### PR TITLE
@orta => reset search

### DIFF
--- a/Artsy.xcworkspace/xcshareddata/Artsy.xccheckout
+++ b/Artsy.xcworkspace/xcshareddata/Artsy.xccheckout
@@ -10,7 +10,7 @@
 	<string>Artsy</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>0B1CB3A2D81D8FD5BBD2FD17F27A95AB88A2DEE2</key>
+		<key>0D236AB02938F7EBBEA0219F472EED729CF6BE0C</key>
 		<string>https://github.com/orta/eigen.git</string>
 		<key>1E01CC43-5AFE-43BF-95A0-B3371CC7E3C3</key>
 		<string>file:///Users/orta/Library/Caches/CocoaPods/GitHub/b13734b3f7530db77cfbf57ab7084df18dcb2cac/</string>
@@ -31,7 +31,7 @@
 	<string>Artsy.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>0B1CB3A2D81D8FD5BBD2FD17F27A95AB88A2DEE2</key>
+		<key>0D236AB02938F7EBBEA0219F472EED729CF6BE0C</key>
 		<string>..</string>
 		<key>1E01CC43-5AFE-43BF-95A0-B3371CC7E3C3</key>
 		<string>../Pods/JLRoutes</string>
@@ -53,7 +53,7 @@
 	<key>IDESourceControlProjectVersion</key>
 	<integer>111</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>0B1CB3A2D81D8FD5BBD2FD17F27A95AB88A2DEE2</string>
+	<string>0D236AB02938F7EBBEA0219F472EED729CF6BE0C</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
@@ -84,7 +84,7 @@
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>0B1CB3A2D81D8FD5BBD2FD17F27A95AB88A2DEE2</string>
+			<string>0D236AB02938F7EBBEA0219F472EED729CF6BE0C</string>
 			<key>IDESourceControlWCCName</key>
 			<string>eigen</string>
 		</dict>

--- a/Artsy/Classes/View Controllers/ARAppSearchViewController.m
+++ b/Artsy/Classes/View Controllers/ARAppSearchViewController.m
@@ -93,7 +93,6 @@
 
 - (void)closeSearch:(id)sender
 {
-    [super closeSearch:sender];
     [[ARTopMenuViewController sharedController] returnToPreviousTab];
 }
 


### PR DESCRIPTION
I didn't realize you'd already fixed the bug, but additionally, calling super here means that search gets reset both in `super closeSearch` AND the next time you open up search, which is redundant.