### PR TITLE
@ashfurrow => Update Keys, and add a Makefile command for PRing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ CHANGELOG_SHORT = CHANGELOG_SHORT.md
 IPA = Artsy.ipa
 DSYM = Artsy.app.dSYM.zip
 
-.PHONY: all build ci clean pods test lint oss
+.PHONY: all build ci clean pods test lint oss pr
 
 all: ci
 
@@ -127,6 +127,12 @@ alpha: stamp_date deploy
 beta: BUNDLE_NAME = 'Artsy β'
 beta: NOTIFY = 1
 beta: stamp_date deploy
+
+
+BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+
+pr: 
+	if [ "$(BRANCH)" == "master" ]; then echo "In master, not PRing"; else git push upstream "$(BRANCH)"; open -a "Google Chrome" "https://github.com/artsy/eigen/pull/new/artsy:master...$(BRANCH)"; fi
 
 setup:
 	mkdir -p .git/hooks

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ lint:
 	bundle exec fui --path Artsy find
 
 oss:
-	bundle exec pod keys set "ArtsyAPIClientSecret" "1ef4f2c9d0b8fe7872e2837cd3d32394" Artsy
-	bundle exec pod keys set "ArtsyAPIClientKey" "47ac83ba1572052cc0ac"
+	bundle exec pod keys set "ArtsyAPIClientSecret" "e750db60ac506978fc70" Artsy
+	bundle exec pod keys set "ArtsyAPIClientKey" "3a33d2085cbd1176153f99781bbce7c6"
 	bundle exec pod keys set "HockeyProductionSecret" "-"
 	bundle exec pod keys set "HockeyBetaSecret" "-"
 	bundle exec pod keys set "MixpanelProductionAPIClientKey" "-"


### PR DESCRIPTION
You can now run `make pr` to push to an artsy branch and open a chrome browser with the PR. 

Now, I know what you're thinking, you're thinking "who would use Chrome [nowadays](http://www.huffingtonpost.com/2014/05/06/nsa-google_n_5273437.html)" but I couldn't successfully port Github Selfies to Safari. So Deal with it.

![Giphy](http://media4.giphy.com/media/16KdaesKdaAI8/giphy.gif)