### PR TITLE
@ashfurrow => remove auto layout warnings from fair overview VC

### DIFF
--- a/Artsy Tests/ARPostFeedItemLinkViewTests.m
+++ b/Artsy Tests/ARPostFeedItemLinkViewTests.m
@@ -7,11 +7,8 @@ __block ARPostFeedItemLinkView *view = nil;
 __block ARPostFeedItem *postFeedItem = nil;
 
 beforeEach(^{
-    view = [[ARPostFeedItemLinkView alloc] init];
-    postFeedItem = [ARPostFeedItem modelWithJSON:@{
-        @"id" : @"post_id"
-    }];
-    [view updateWithPostFeedItem:postFeedItem];
+    postFeedItem = [ARPostFeedItem modelWithJSON:@{ @"id" : @"post_id" }];
+    view = [[ARPostFeedItemLinkView alloc] initWithPostFeedItem:postFeedItem];
 });
 
 it(@"targetURL", ^{

--- a/Artsy/Classes/View Controllers/ARFairPostsViewController.m
+++ b/Artsy/Classes/View Controllers/ARFairPostsViewController.m
@@ -31,8 +31,7 @@
         [(ORStackView *)self.view addGenericSeparatorWithSideMargin: @"20"];
         for (NSInteger i = 0; i < [[self feedTimeline] numberOfItems]; i++) {
             ARPostFeedItem *postFeedItem = (ARPostFeedItem *) [[self feedTimeline] itemAtIndex:i];
-            ARPostFeedItemLinkView * postLinkView = [[ARPostFeedItemLinkView alloc] init];
-            [postLinkView updateWithPostFeedItem:postFeedItem];
+            ARPostFeedItemLinkView * postLinkView = [[ARPostFeedItemLinkView alloc] initWithPostFeedItem:postFeedItem];
             [self addSubview:postLinkView withTopMargin:nil sideMargin:nil];
         }
     }

--- a/Artsy/Classes/View Controllers/ARPostsViewController.m
+++ b/Artsy/Classes/View Controllers/ARPostsViewController.m
@@ -27,8 +27,7 @@
 
     for(NSInteger i = 0; i < self.posts.count; i++) {
         ARPostFeedItem *post = self.posts[i];
-        ARPostFeedItemLinkView * postLinkView = [[ARPostFeedItemLinkView alloc] init];
-        [postLinkView updateWithPostFeedItem:post];
+        ARPostFeedItemLinkView * postLinkView = [[ARPostFeedItemLinkView alloc] initWithPostFeedItem:post];
         [self.view addSubview:postLinkView withTopMargin:nil sideMargin:nil];
     }
 }

--- a/Artsy/Classes/Views/ARAspectRatioImageView.h
+++ b/Artsy/Classes/Views/ARAspectRatioImageView.h
@@ -1,5 +1,7 @@
 #import <UIKit/UIKit.h>
 
+// A UIImage subclass that returns a content sized based on an existing width or height.
+
 @interface ARAspectRatioImageView : UIImageView
 
 @end

--- a/Artsy/Classes/Views/ARAspectRatioImageView.m
+++ b/Artsy/Classes/Views/ARAspectRatioImageView.m
@@ -12,4 +12,9 @@
     }
 }
 
+-(UIViewContentMode)contentMode
+{
+    return UIViewContentModeScaleAspectFit;
+}
+
 @end

--- a/Artsy/Classes/Views/ARPostFeedItemLinkView.h
+++ b/Artsy/Classes/Views/ARPostFeedItemLinkView.h
@@ -2,8 +2,8 @@
 
 @interface ARPostFeedItemLinkView : UIButton
 
-- (void)updateWithPostFeedItem:(ARPostFeedItem *)postFeedItem;
-- (void)updateWithPostFeedItem:(ARPostFeedItem *)postFeedItem withSeparator:(BOOL)withSeparator;
+// Creates a view that represents a PostFeedItem
+- (id)initWithPostFeedItem:(ARPostFeedItem *)postFeedItem;
 
 @property(nonatomic, strong, readonly) NSString *targetPath;
 

--- a/Artsy/Classes/Views/ARPostFeedItemLinkView.m
+++ b/Artsy/Classes/Views/ARPostFeedItemLinkView.m
@@ -4,22 +4,13 @@
 
 @implementation ARPostFeedItemLinkView
 
-- (id)init
+- (id)initWithPostFeedItem:(ARPostFeedItem *)postFeedItem
 {
     self = [super init];
-    if (self) {
-        [self addTarget:nil action:@selector(tappedPostFeedItemLinkView:) forControlEvents:UIControlEventTouchUpInside];
-    }
-    return self;
-}
+    if (!self) { return nil; }
 
-- (void)updateWithPostFeedItem:(ARPostFeedItem *)postFeedItem
-{
-    [self updateWithPostFeedItem:postFeedItem withSeparator:YES];
-}
+    [self addTarget:nil action:@selector(tappedPostFeedItemLinkView:) forControlEvents:UIControlEventTouchUpInside];
 
-- (void)updateWithPostFeedItem:(ARPostFeedItem *)postFeedItem withSeparator:(BOOL)withSeparator
-{
     ARSeparatorView *separatorView = [[ARSeparatorView alloc] init];
     [self addSubview:separatorView];
 
@@ -44,27 +35,26 @@
     [labelContainer addSubview:postTitleLabel];
 
     // Auto Layout
-
     [separatorView alignTop:nil leading:@"10" bottom:@"0" trailing:@"-10" toView:self];
 
     [imageView constrainWidth:@"120"];
-
     [imageView alignLeadingEdgeWithView:self predicate:@"10"];
     [imageView alignTopEdgeWithView:self predicate:@"20"];
-    [imageView setContentMode:UIViewContentModeScaleAspectFit];
 
     [imageFiller constrainTopSpaceToView:imageView predicate:@"0"];
 
     [labelContainer constrainLeadingSpaceToView:imageView predicate:@"20"];
-
     [labelContainer alignTopEdgeWithView:imageView predicate:@"0"];
     [labelContainer alignTrailingEdgeWithView:self predicate:@"-10"];
-    [postTitleLabel alignTopEdgeWithView:labelContainer predicate:@"0"];\
+
+    [postTitleLabel alignTopEdgeWithView:labelContainer predicate:@"0"];
 
     if (postFeedItem.profile.profileName) {
         UILabel *postAuthorLabel = [ARThemedFactory labelForLinkItemSubtitles];
         postAuthorLabel.text = [postFeedItem.profile.profileName uppercaseString];
+
         [labelContainer addSubview:postAuthorLabel];
+
         [postAuthorLabel constrainTopSpaceToView:postTitleLabel predicate:@"5"];
         [labelContainer alignBottomEdgeWithView:postAuthorLabel predicate:@"0"];
         [UIView alignLeadingAndTrailingEdgesOfViews:@[postTitleLabel, postAuthorLabel, labelContainer]];
@@ -80,13 +70,13 @@
 
     _targetPath = NSStringWithFormat(@"/post/%@", postFeedItem.postID);
 
-    // Layout the view to calculate bounds and frame for the image view before adding the image.
-    [self layoutIfNeeded];
     NSURL *imageUrl = [NSURL URLWithString:postFeedItem.imageURL];
     [imageView ar_setImageWithURL:imageUrl completed:(SDWebImageCompletionBlock)^{
         [self setNeedsLayout];
         [self layoutIfNeeded];
     }];
+
+    return self;
 }
 
 @end


### PR DESCRIPTION
Only one line of code change. Line 84 on `ARPostFeedItemLinkView.m `.

The rest is all refactoring to make the class feel less state-y. ( we always ran update right after init. ) We never used the "hasSeperator" either, so that's gone too [YANG](https://en.wikipedia.org/wiki/You_aren%27t_gonna_need_it). 

My github selfie isn't working. Here's a pug after eating yoghurt instead.

![Anybody else love yogurt?](http://i.imgur.com/ETBoDbF.jpg)