### PR TITLE
@ashfurrow => use a black background for the show view controller

### DIFF
--- a/Artsy/Classes/View Controllers/ARFairShowViewController.m
+++ b/Artsy/Classes/View Controllers/ARFairShowViewController.m
@@ -46,11 +46,7 @@ static const NSInteger ARFairShowMaximumNumberOfHeadlineImages = 5;
 
 + (CGFloat)followButtonWidthForInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
 {
-    if (UIInterfaceOrientationIsPortrait(interfaceOrientation)) {
-        return 315;
-    } else {
-        return 281;
-    }
+    return UIInterfaceOrientationIsPortrait(interfaceOrientation) ? 315 : 281;
 }
 
 + (CGFloat)headerImageHeightForInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
@@ -58,11 +54,7 @@ static const NSInteger ARFairShowMaximumNumberOfHeadlineImages = 5;
     if ([UIDevice isPhone]) {
         return 213;
     } else {
-        if (UIInterfaceOrientationIsPortrait(interfaceOrientation)) {
-            return 413;
-        } else {
-            return 511;
-        }
+        return UIInterfaceOrientationIsPortrait(interfaceOrientation) ? 413 : 511;
     }
 }
 
@@ -98,7 +90,8 @@ static const NSInteger ARFairShowMaximumNumberOfHeadlineImages = 5;
 - (void)loadView
 {
     self.view = [[ORStackScrollView alloc] initWithStackViewClass:[ORTagBasedAutoStackView class]];
-    self.view.backgroundColor = [UIColor whiteColor];
+    self.view.backgroundColor = [UIColor blackColor];
+    self.view.stackView.backgroundColor = [UIColor whiteColor];
     self.view.delegate = [ARScrollNavigationChief chief];
 }
 
@@ -152,12 +145,12 @@ static const NSInteger ARFairShowMaximumNumberOfHeadlineImages = 5;
 {
     @weakify(self);
     return @{
-         ARActionButtonImageKey: @"MapButtonAction",
-         ARActionButtonHandlerKey: ^(ARCircularActionButton *sender) {
+        ARActionButtonImageKey: @"MapButtonAction",
+        ARActionButtonHandlerKey: ^(ARCircularActionButton *sender) {
             @strongify(self);
             [self handleMapButtonPress:sender];
-         }
-     };
+        }
+    };
 }
 
 - (void)handleMapButtonPress:(ARCircularActionButton *)sender


### PR DESCRIPTION
Some minor code golf-ing WRT those height constants for the top. Wonder if it makes sense to move them to be based on a ratio of screen size. However for now I'm keeping pixel perfect to designs.

Does this when dragging down, instead of being white: 
![2015-01-27 16_57_44](https://cloud.githubusercontent.com/assets/49038/5928041/a65796ee-a645-11e4-9d81-07739ccf6146.gif)
