### PR TITLE
@orta => remove reveal, fix buy button trial context

### DIFF
--- a/Artsy/Classes/View Controllers/ARArtworkViewController+ButtonActions.m
+++ b/Artsy/Classes/View Controllers/ARArtworkViewController+ButtonActions.m
@@ -96,7 +96,7 @@
 - (void)tappedBuyButton:(ARButton *)sender
 {
     if ([User isTrialUser]) {
-        [ARTrialController presentTrialWithContext:ARTrialContextAuctionBid fromTarget:self selector:_cmd];
+        [ARTrialController presentTrialWithContext:ARTrialContextArtworkOrder fromTarget:self selector:_cmd];
         return;
     }
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ CHANGELOG_SHORT = CHANGELOG_SHORT.md
 IPA = Artsy.ipa
 DSYM = Artsy.app.dSYM.zip
 
-.PHONY: all build ci clean pods test lint oss pr
+.PHONY: all build ci clean test lint oss pr
 
 all: ci
 
@@ -54,18 +54,10 @@ oss:
 ci: CONFIGURATION = Debug
 ci: build	
 
-remove_debug_pods:
-	perl -pi -w -e "s{^pod 'Reveal-iOS-SDK'}{# pod 'Reveal-iOS-SDK'}g" Podfile
-
-add_debug_pods:
-	perl -pi -w -e "s{^# pod 'Reveal-iOS-SDK'}{pod 'Reveal-iOS-SDK'}g" Podfile
-
 update_bundle_version:
 	@printf 'What is the new human-readable release version? '; \
 		read HUMAN_VERSION; \
 		$(PLIST_BUDDY) -c "Set CFBundleShortVersionString $$HUMAN_VERSION" $(APP_PLIST)
-
-pods: remove_debug_pods
 
 bundler:
 	gem install bundler
@@ -107,18 +99,18 @@ distribute:
 	 | grep -v "errors"
 
 appstore: TARGETED_DEVICE_FAMILY = 1
-appstore: remove_debug_pods update_bundle_version set_git_properties change_version_to_date set_targeted_device_family
+appstore: update_bundle_version set_git_properties change_version_to_date set_targeted_device_family
 
 appledemo: TARGETED_DEVICE_FAMILY = 1
 appledemo: NOTIFY = 0
 appledemo: CONFIGURATION = "Apple Demo"
-appledemo: set_git_properties change_version_to_date remove_debug_pods set_targeted_device_family
-appledemo: pods ipa distribute
+appledemo: set_git_properties change_version_to_date set_targeted_device_family
+appledemo: ipa distribute
 
 next: TARGETED_DEVICE_FAMILY = \"1,2\"
-next: add_debug_pods update_bundle_version set_git_properties change_version_to_date remove_debug_pods set_targeted_device_family
+next: update_bundle_version set_git_properties change_version_to_date set_targeted_device_family
 
-deploy: pods ipa distribute
+deploy: ipa distribute
 
 alpha: BUNDLE_NAME = 'Artsy α'
 alpha: NOTIFY = 0

--- a/Podfile
+++ b/Podfile
@@ -96,7 +96,6 @@ pod 'UICKeyChainStore', '1.0.5'
 pod 'NAMapKit', :git => 'https://github.com/neilang/NAMapKit', :commit => '62275386978db91b0e7ed8de755d15cef3e793b4'
 
 # Developer Pods
-# pod 'Reveal-iOS-SDK'
 pod 'VCRURLConnection', '0.2.0'
 pod 'DHCShakeNotifier', '0.2.0'
 

--- a/docs/deploy_to_app_store.md
+++ b/docs/deploy_to_app_store.md
@@ -3,7 +3,7 @@
 ### TODOs for anyone before deploying
 
 1. Check out eigen Artsy master.
-1. Run `make appstore`. This removes Reveal, runs `pod install` and prompts for a release version number.
+1. Run `make appstore`. This runs `pod install` and prompts for a release version number.
 1. Update CHANGELOG with the release number.
 1. Add and commit the changed files, typically with `-m "Preparing for the next release, version X.Y.Z."`.
 
@@ -50,6 +50,6 @@ See [certs.md](certs.md) for more info on certificates.
 
 ### Prepare for the Next Release
 
-1. Run `make next`. This re-adds Reveal, runs `pod install` and prompts for the next version number.
+1. Run `make next`. This runs `pod install` and prompts for the next version number.
 1. Add a new section to CHANGELOG called _Next_.
 1. Add and commit the changed files, typically with `-m "Preparing for development, version X.Y.Z."`.


### PR DESCRIPTION
Tapping the buy button as a trial user should present a message about buying, not bidding.

Removing reveal pod. See https://gist.github.com/raven/8553761 on how to use Reveal without it.