### PR TITLE
@1aurabrown => deal with setupCallbackCrashes

### DIFF
--- a/Artsy/Classes/Views/ARArtworkView.m
+++ b/Artsy/Classes/Views/ARArtworkView.m
@@ -100,7 +100,7 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
 
     [self.artwork onFairUpdate:^(Fair *fair) {
         if (!self) return;
-        
+
         @strongify(self);
         [self.metadataView updateWithFair:fair];
         [self.stackView layoutIfNeeded];

--- a/Artsy/Classes/Views/ARArtworkView.m
+++ b/Artsy/Classes/Views/ARArtworkView.m
@@ -99,6 +99,8 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
     }];
 
     [self.artwork onFairUpdate:^(Fair *fair) {
+        if (!self) return;
+        
         @strongify(self);
         [self.metadataView updateWithFair:fair];
         [self.stackView layoutIfNeeded];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 1.6.2 (30/01/2015)
+
+* Fix iOS7 Search crash - orta
+* Fix artwork view crash  - orta
+* Set correct sign up context for purchasable works - 1aurabrown
+* Tapping a map can hide a callout - orta
+* Fix our usages of th/nd/st in dates - orta
+* Reset search when you leave the navigation tab - orta
+* Buy Now artworks with Editions will see inquiry forms instead of a failed order then the inquiry - 1aurabrown
+
+--- Open Sourced Jan 22 2015 ---
+
+
+## 1.6.1 (16/01/2015)
+
+* Facebook Auth Fixes - 1aurabrown
+
+
 ## 1.6.0 (05/01/2015)
 
 * New Fair Guide view - ashfurrow


### PR DESCRIPTION
I've taken a look into both https://github.com/artsy/eigen/issues/64 and https://github.com/artsy/eigen/issues/58

They revolve around this crashing:
```
-[UIScrollView _getDelegateZoomView] + 76
or
-[UIScrollView _offsetForCenterOfPossibleZoomView:withIncomingBoundsSize:] + 42
```

Which revolve around object accessing in `onFairUpdate` that doesn't exist. My guess is that an dealloc'd artwork view is being referenced but that one of it's container stacks is still alive and that this layoutIfNeeded is triggering delegate methods on the scrollview. It's a push, but it feels pretty reasonable.


![selfie-0](http://i.imgur.com/hGl7clg.gif)
