### PR TITLE
@orta => when creating an order, infer edition_set_id if artwork has only one edition

### DIFF
--- a/Artsy Tests/ARArtworkViewControllerTests.m
+++ b/Artsy Tests/ARArtworkViewControllerTests.m
@@ -1,5 +1,11 @@
 #import "ARArtworkViewController.h"
 #import "ARArtworkView.h"
+#import "ARRouter.h"
+
+@interface ARArtworkViewController (Tests)
+- (void)tappedBuyButton:(UIButton *)sender;
+- (void)tappedContactGallery:(UIButton *)sender;
+@end
 
 SpecBegin(ARArtworkViewController)
 
@@ -9,6 +15,105 @@ __block ARArtworkViewController *vc;
 after(^{
     [OHHTTPStubs removeAllStubs];
     vc = nil;
+});
+
+describe(@"buy button", ^{
+    __block id routerMock;
+    __block id vcMock;
+    before(^{
+        routerMock = [OCMockObject mockForClass:[ARRouter class]];
+    });
+
+    after(^{
+        [routerMock stopMocking];
+        [vcMock stopMocking];
+    });
+
+    it(@"posts order if artwork has no edition sets", ^{
+        Artwork *artwork = [Artwork modelWithJSON:@{
+            @"id" : @"artwork-id",
+            @"title" : @"Artwork Title",
+            @"availability" : @"for sale",
+            @"acquireable" : @YES
+        }];
+        vc = [[ARArtworkViewController alloc] initWithArtwork:artwork fair:nil];
+        vcMock = [OCMockObject partialMockForObject:vc];
+        [[vcMock reject] tappedContactGallery:OCMOCK_ANY];
+
+        [[[[routerMock expect] andForwardToRealObject] classMethod] newPendingOrderWithArtworkID:@"artwork-id" editionSetID:[OCMArg isNil]];
+        [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/me/orders" withResponse:@[]];
+
+        [vc tappedBuyButton:nil];
+        [routerMock verify];
+        [vcMock verify];
+    });
+
+    it(@"posts order if artwork has 1 edition set", ^{
+        Artwork *artwork = [Artwork modelWithJSON:@{
+            @"id" : @"artwork-id",
+            @"title" : @"Artwork Title",
+            @"availability" : @"for sale",
+            @"acquireable" : @YES,
+            @"edition_sets" : @[
+                @{ @"id": @"set-1"}
+            ]
+        }];
+
+        vc = [[ARArtworkViewController alloc] initWithArtwork:artwork fair:nil];
+        vcMock = [OCMockObject partialMockForObject:vc];
+        [[vcMock reject] tappedContactGallery:OCMOCK_ANY];
+
+        [[[[routerMock expect] andForwardToRealObject] classMethod] newPendingOrderWithArtworkID:@"artwork-id" editionSetID:@"set-1"];
+        [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/me/orders" withResponse:@[]];
+
+        [vc tappedBuyButton:nil];
+        [routerMock verify];
+        [vcMock verify];
+    });
+
+    it(@"displays inquiry form if artwork has multiple sets", ^{
+        Artwork *artwork = [Artwork modelWithJSON:@{
+                                                    @"id" : @"artwork-id",
+                                                    @"title" : @"Artwork Title",
+                                                    @"availability" : @"for sale",
+                                                    @"acquireable" : @YES,
+                                                    @"edition_sets" : @[
+                                                            @{ @"id": @"set-1"},
+                                                            @{ @"id": @"set-2"}
+                                                            ]
+                                                    }];
+
+        vc = [[ARArtworkViewController alloc] initWithArtwork:artwork fair:nil];
+        vcMock = [OCMockObject partialMockForObject:vc];
+        [[vcMock expect] tappedContactGallery:OCMOCK_ANY];
+
+        [[[routerMock reject] classMethod] newPendingOrderWithArtworkID:OCMOCK_ANY editionSetID:OCMOCK_ANY];
+        [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/me/orders" withResponse:@[]];
+
+        [vc tappedBuyButton:nil];
+        [routerMock verify];
+        [vcMock verify];
+    });
+
+    it(@"displays inquiry form if request fails", ^{
+        Artwork *artwork = [Artwork modelWithJSON:@{
+            @"id" : @"artwork-id",
+            @"title" : @"Artwork Title",
+            @"availability" : @"for sale",
+            @"acquireable" : @YES,
+        }];
+
+        vc = [[ARArtworkViewController alloc] initWithArtwork:artwork fair:nil];
+        vcMock = [OCMockObject partialMockForObject:vc];
+        [[vcMock expect] tappedContactGallery:OCMOCK_ANY];
+
+        [[[[routerMock expect] andForwardToRealObject]classMethod] newPendingOrderWithArtworkID:OCMOCK_ANY editionSetID:OCMOCK_ANY];
+        [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/me/orders" withResponse:@[] andStatusCode:400];
+
+        [vc tappedBuyButton:nil];
+        [routerMock verify];
+        [vcMock verifyWithDelay:2.0];
+    });
 });
 
 describe(@"no related data", ^{

--- a/Artsy/Classes/Networking/ARRouter.h
+++ b/Artsy/Classes/Networking/ARRouter.h
@@ -134,5 +134,5 @@
 
 + (NSURLRequest *)newSystemTimeRequest;
 
-+ (NSURLRequest *)newPendingOrderWithArtworkID:(NSString *)artworkID;
++ (NSURLRequest *)newPendingOrderWithArtworkID:(NSString *)artworkID editionSetID:(NSString *)editionSetID;
 @end

--- a/Artsy/Classes/Networking/ARRouter.m
+++ b/Artsy/Classes/Networking/ARRouter.m
@@ -834,13 +834,16 @@ static NSSet *artsyHosts = nil;
     return [staticHTTPClient requestWithMethod:@"GET" path:ARSystemTimeURL parameters:nil];
 }
 
-+ (NSURLRequest *)newPendingOrderWithArtworkID:(NSString *)artworkID
++ (NSURLRequest *)newPendingOrderWithArtworkID:(NSString *)artworkID editionSetID:(NSString *)editionSetID
 {
-    NSDictionary *params = @{
+    NSMutableDictionary *params = [NSMutableDictionary dictionaryWithDictionary:@{
       @"artwork_id": artworkID,
       @"replace_order": @YES,
       @"session_id": [[NSUUID UUID] UUIDString] // TODO: preserve across session?
-    };
+    }];
+    if (editionSetID != nil) {
+        [params addEntriesFromDictionary:@{@"edition_set_id": editionSetID}];
+    }
 
     return [staticHTTPClient requestWithMethod:@"POST" path:ARCreatePendingOrderURL parameters:params];
 }

--- a/Artsy/Classes/View Controllers/ARArtworkViewController+ButtonActions.m
+++ b/Artsy/Classes/View Controllers/ARArtworkViewController+ButtonActions.m
@@ -100,8 +100,21 @@
         return;
     }
 
+    // We currently don't have a UI for a user to select from multiple editions. Instead, send the user
+    // to the inquiry form.
+    if (self.artwork.hasMultipleEditions) {
+        [self tappedContactGallery:sender];
+        return;
+    }
+
+    // If the artwork has only 1 edition, use that edition id. Otherwise our POST request will fail.
+    NSString *editionSetID = nil;
+    if (self.artwork.editionSets.count > 0) {
+        editionSetID = [[self.artwork.editionSets objectAtIndex:0] valueForKey:@"id"];
+    }
+
     // create a new order
-    NSURLRequest *request = [ARRouter newPendingOrderWithArtworkID:self.artwork.artworkID];
+    NSURLRequest *request = [ARRouter newPendingOrderWithArtworkID:self.artwork.artworkID editionSetID:editionSetID];
 
     @weakify(self);
     AFJSONRequestOperation *op = [AFJSONRequestOperation JSONRequestOperationWithRequest:request


### PR DESCRIPTION
Partially fixes https://github.com/artsy/eigen/issues/27
Artworks that are "acquireable" may be purchased immediately using the martsy order form, rather than inquiring via the inquiry form. These works may have 0, 1 or many "edition sets."

If an artwork has any edition sets, you must provide an edition_set_id when creating an order for that artwork. Until now, we weren't providing this parameter when creating orders, which was resulting in failed POST requests for all works that have editions.

* If an artwork has no edition sets, we won't include the edition_set_id when creating the order.
* If an artwork has one edition set, we can safely assume that we should use the id of that edition set.
* If an artwork has many edition sets, we don't currently have any UI that supports picking which set you'd like to order from, so we should direct the user to the inquiry form. There's no need to even attempt the order POST, as it will fail without the edition_set_id parameter.