### PR TITLE
@orta => [Fair Map] Fix disappearing callout view on iOS 8.

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -209,6 +209,7 @@
 		49EF164716C568EA00460BD7 /* Profile.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EF164616C568EA00460BD7 /* Profile.m */; };
 		49F0C67B17B9706000721244 /* AROnboardingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 49F0C67A17B9706000721244 /* AROnboardingViewController.m */; };
 		49F45188176A71B50041A4B4 /* ARArtworkSetViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4917819E176A6B22001E751E /* ARArtworkSetViewController.m */; };
+		5174A03B1A859E2C006CD337 /* ARFairMapView.m in Sources */ = {isa = PBXBuildFile; fileRef = 5174A03A1A859E2C006CD337 /* ARFairMapView.m */; };
 		540262C618A0FAFB00844AE1 /* ARButtonWithImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 540262C518A0FAFB00844AE1 /* ARButtonWithImage.m */; };
 		54289FEE18AA7F4E00681E49 /* UINavigationController_InnermostTopViewControllerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 54289FED18AA7F4E00681E49 /* UINavigationController_InnermostTopViewControllerSpec.m */; };
 		5435192E18A8E9420060F31E /* UIView+OldSchoolSnapshots.m in Sources */ = {isa = PBXBuildFile; fileRef = 5435192D18A8E9420060F31E /* UIView+OldSchoolSnapshots.m */; };
@@ -870,6 +871,8 @@
 		49F0C67A17B9706000721244 /* AROnboardingViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AROnboardingViewController.m; sourceTree = "<group>"; };
 		49F0C67D17B972F200721244 /* ARSlideshowView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARSlideshowView.h; sourceTree = "<group>"; };
 		49F0C67E17B972F200721244 /* ARSlideshowView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARSlideshowView.m; sourceTree = "<group>"; };
+		5174A0391A859E2C006CD337 /* ARFairMapView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARFairMapView.h; sourceTree = "<group>"; };
+		5174A03A1A859E2C006CD337 /* ARFairMapView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARFairMapView.m; sourceTree = "<group>"; };
 		540262C418A0FAFB00844AE1 /* ARButtonWithImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARButtonWithImage.h; path = "Table View Cells/ARButtonWithImage.h"; sourceTree = "<group>"; };
 		540262C518A0FAFB00844AE1 /* ARButtonWithImage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ARButtonWithImage.m; path = "Table View Cells/ARButtonWithImage.m"; sourceTree = "<group>"; };
 		54289FED18AA7F4E00681E49 /* UINavigationController_InnermostTopViewControllerSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UINavigationController_InnermostTopViewControllerSpec.m; sourceTree = "<group>"; };
@@ -1482,6 +1485,8 @@
 		342F93B0E900CB6BC98011DE /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				5174A0391A859E2C006CD337 /* ARFairMapView.h */,
+				5174A03A1A859E2C006CD337 /* ARFairMapView.m */,
 				342F995897B0B106E59A39A0 /* ARFairMapAnnotationView.h */,
 				342F9559FD6EB9419E3CEE68 /* ARFairMapAnnotationView.m */,
 				5EFF52B81976CA6C00E2A563 /* ARSearchFieldButton.h */,
@@ -3739,6 +3744,7 @@
 				60B79B89182C54CE00945FFF /* ARQuicksilverSearchBar.m in Sources */,
 				49EC62181778AF100020D648 /* PartnerShow.m in Sources */,
 				E61446AF195A1CDC00BFB7C3 /* ARFairFavoritesNetworkModel.m in Sources */,
+				5174A03B1A859E2C006CD337 /* ARFairMapView.m in Sources */,
 				60B6F13916638785007C9587 /* ArtsyAPI.m in Sources */,
 				60B6F13E16638815007C9587 /* Artwork.m in Sources */,
 				49473F3617C1907F004BF082 /* ARCreateAccountViewController.m in Sources */,

--- a/Artsy/Classes/View Controllers/ARFairMapView.h
+++ b/Artsy/Classes/View Controllers/ARFairMapView.h
@@ -1,0 +1,12 @@
+#import "NATiledImageMapView.h"
+
+// This custom subclass moves the subviews into a single content view so that we can safely use a
+// mix of both frame and Auto Layout code, as described under ‘Mixed approach’ here:
+//
+//   https://developer.apple.com/library/ios/releasenotes/General/RN-iOSSDK-6_0/index.html
+//
+// It does this by overriding the UIView subview APIs (that we currently use), so that the existing
+// code can remain the same and no immediate changes are needed to the NAMapView library.
+//
+@interface ARFairMapView : NATiledImageMapView
+@end

--- a/Artsy/Classes/View Controllers/ARFairMapView.m
+++ b/Artsy/Classes/View Controllers/ARFairMapView.m
@@ -1,0 +1,43 @@
+#import "ARFairMapView.h"
+
+@interface ARFairMapView ()
+@property (nonatomic, readonly) UIView *contentView;
+@end
+
+@implementation ARFairMapView
+
+@synthesize contentView = _contentView;
+
+- (UIView *)contentView;
+{
+    if (!_contentView) {
+        _contentView = [[UIView alloc] initWithFrame:self.bounds];
+        [super addSubview:_contentView];
+    }
+    return _contentView;
+}
+
+- (void)setContentSize:(CGSize)size;
+{
+    CGRect frame = self.contentView.frame;
+    frame.size = size;
+    self.contentView.frame = frame;
+    [super setContentSize:size];
+}
+
+- (void)addSubview:(UIView *)subview;
+{
+    [self.contentView addSubview:subview];
+}
+
+- (void)bringSubviewToFront:(UIView *)subview;
+{
+    [self.contentView bringSubviewToFront:subview];
+}
+
+- (void)insertSubview:(UIView *)view belowSubview:(UIView *)siblingSubview;
+{
+    [self.contentView insertSubview:view belowSubview:siblingSubview];
+}
+
+@end

--- a/Artsy/Classes/View Controllers/ARFairMapViewController.m
+++ b/Artsy/Classes/View Controllers/ARFairMapViewController.m
@@ -1,5 +1,6 @@
 #import "ARFairMapViewController.h"
 #import "ARTiledImageDataSourceWithImage.h"
+#import "ARFairMapView.h"
 #import "ARFairMapZoomManager.h"
 #import "ARFairShowMapper.h"
 #import "ARFairShowViewController.h"
@@ -12,7 +13,7 @@
 
 @interface ARFairMapViewController () <NAMapViewDelegate, ARFairSearchViewControllerDelegate, ARSearchFieldButtonDelegate>
 @property (nonatomic, strong) UILabel *titleLabel;
-@property (nonatomic, strong, readwrite) NATiledImageMapView *mapView;
+@property (nonatomic, strong, readwrite) ARFairMapView *mapView;
 @property (nonatomic, strong) ARSearchFieldButton *searchButton;
 @property (nonatomic, strong, readwrite) ARTiledImageDataSourceWithImage *mapDataSource;
 @property (nonatomic, strong, readwrite) ARFairSearchViewController *searchVC;
@@ -60,7 +61,7 @@
 
 - (void)viewDidLoad
 {
-    NATiledImageMapView *mapView = [[NATiledImageMapView alloc] initWithFrame:self.view.frame tiledImageDataSource:self.mapDataSource];
+    ARFairMapView *mapView = [[ARFairMapView alloc] initWithFrame:self.view.frame tiledImageDataSource:self.mapDataSource];
     mapView.mapViewDelegate = self;
     mapView.zoomStep = 2.5;
     mapView.showsVerticalScrollIndicator = NO;

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2014.12.24
 
+* Fix fair map callout view disappearing on iOS 8. - alloy
 * Remove open map button from fair artist view - alloy
 * Update birth place/year subtitle on fair artist view - alloy
 * Show auction lot on the artwork view - orta


### PR DESCRIPTION
Separate the various map subviews that use a mix of frame
and Auto Layout code from the scroll view, by moving them
all into a single container view, as per:

https://developer.apple.com/library/ios/releasenotes/General/RN-iOSSDK-6_0/index.html

Fixes #40.

----

Because I’m not sure if it makes sense to _always_ use a container view and because it would break the API, I did not yet move this into NAMapKit. Any thoughts on this?