### PR TITLE
@orta => [Fair Map] Don't hide annotations when they’re selected.

### DIFF
--- a/Artsy Tests/ARFairMapAnnotationViewTests.m
+++ b/Artsy Tests/ARFairMapAnnotationViewTests.m
@@ -1,0 +1,31 @@
+#import "ARFairMapAnnotationView.h"
+
+@interface ARFairMapAnnotationView (Testing)
+@property (nonatomic, readonly) UILabel *primaryTitleLabel;
+@end
+
+SpecBegin(ARFairMapAnnotationView)
+
+__block ARFairMapAnnotationView *annotationView = nil;
+
+describe(@"reduceToPoint, on a default feature", ^{
+    beforeEach(^{
+      annotationView = [ARFairMapAnnotationView new];
+      annotationView.mapFeatureType = ARMapFeatureTypeDefault;
+      annotationView.displayTitle = @"Jackson Pollock";
+    });
+
+    it(@"hides the complete annotation", ^{
+      [annotationView reduceToPoint];
+      expect(annotationView.isHidden).to.equal(YES);
+    });
+
+    it(@"only hides the annotation’s label", ^{
+      annotationView.highlighted = YES;
+      [annotationView reduceToPoint];
+      expect(annotationView.isHidden).to.equal(NO);
+      expect(annotationView.primaryTitleLabel.isHidden).to.equal(YES);
+    });
+});
+
+SpecEnd

--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -209,6 +209,7 @@
 		49EF164716C568EA00460BD7 /* Profile.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EF164616C568EA00460BD7 /* Profile.m */; };
 		49F0C67B17B9706000721244 /* AROnboardingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 49F0C67A17B9706000721244 /* AROnboardingViewController.m */; };
 		49F45188176A71B50041A4B4 /* ARArtworkSetViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4917819E176A6B22001E751E /* ARArtworkSetViewController.m */; };
+		5122D69A1A89E5F800DA2704 /* ARFairMapAnnotationViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5122D6991A89E5F800DA2704 /* ARFairMapAnnotationViewTests.m */; };
 		5174A03B1A859E2C006CD337 /* ARFairMapView.m in Sources */ = {isa = PBXBuildFile; fileRef = 5174A03A1A859E2C006CD337 /* ARFairMapView.m */; };
 		540262C618A0FAFB00844AE1 /* ARButtonWithImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 540262C518A0FAFB00844AE1 /* ARButtonWithImage.m */; };
 		54289FEE18AA7F4E00681E49 /* UINavigationController_InnermostTopViewControllerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 54289FED18AA7F4E00681E49 /* UINavigationController_InnermostTopViewControllerSpec.m */; };
@@ -871,6 +872,7 @@
 		49F0C67A17B9706000721244 /* AROnboardingViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AROnboardingViewController.m; sourceTree = "<group>"; };
 		49F0C67D17B972F200721244 /* ARSlideshowView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARSlideshowView.h; sourceTree = "<group>"; };
 		49F0C67E17B972F200721244 /* ARSlideshowView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARSlideshowView.m; sourceTree = "<group>"; };
+		5122D6991A89E5F800DA2704 /* ARFairMapAnnotationViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARFairMapAnnotationViewTests.m; sourceTree = "<group>"; };
 		5174A0391A859E2C006CD337 /* ARFairMapView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARFairMapView.h; sourceTree = "<group>"; };
 		5174A03A1A859E2C006CD337 /* ARFairMapView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARFairMapView.m; sourceTree = "<group>"; };
 		540262C418A0FAFB00844AE1 /* ARButtonWithImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARButtonWithImage.h; path = "Table View Cells/ARButtonWithImage.h"; sourceTree = "<group>"; };
@@ -1951,6 +1953,7 @@
 				5EB33E73197EBDE200706EB1 /* ARParallaxHeaderViewControllerTests.m */,
 				5EB33E75197EBFEB00706EB1 /* wide.jpg */,
 				5EB33E76197EBFEB00706EB1 /* square.png */,
+				5122D6991A89E5F800DA2704 /* ARFairMapAnnotationViewTests.m */,
 			);
 			name = Fair;
 			sourceTree = "<group>";
@@ -4090,6 +4093,7 @@
 				E611847218D7B4C4000FE4C9 /* ARSharingControllerTests.m in Sources */,
 				3CA0A17D18EF633900C361E5 /* ARArtistViewControllerTests.m in Sources */,
 				608EE3DB19954CEB001F4FE0 /* UIViewController+PresentWithFrame.m in Sources */,
+				5122D69A1A89E5F800DA2704 /* ARFairMapAnnotationViewTests.m in Sources */,
 				342F9E0892E99A2F66657964 /* Artwork+Extensions.m in Sources */,
 				342F9715E899AC7D24E70734 /* ORStackViewArtsyCategoriesTests.m in Sources */,
 				342F925E34CAC3E5DB8E5F52 /* ARFairMapViewControllerTests.m in Sources */,

--- a/Artsy/Classes/View Controllers/ARFairMapAnnotationView.m
+++ b/Artsy/Classes/View Controllers/ARFairMapAnnotationView.m
@@ -111,7 +111,7 @@ static CGFloat ARHorizontalOffsetFromIcon = 4;
         return;
     }
 
-    if (self.mapFeatureType != ARMapFeatureTypeDefault) {
+    if (self.isHighlighted || self.mapFeatureType != ARMapFeatureTypeDefault) {
         self.primaryTitleLabel.hidden = YES;
     } else {
         self.hidden = YES;

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2014.12.24
 
+* Fix fair map annotation view disappearing once selected. - alloy
 * Fix fair map callout view disappearing on iOS 8. - alloy
 * Remove open map button from fair artist view - alloy
 * Update birth place/year subtitle on fair artist view - alloy


### PR DESCRIPTION
Fixes #126.

This makes it so that annotations that are highlighted will only have their label hidden. Because there didn’t appear to be any snapshot tests for maps, I added unit tests instead.

![](http://a.dilcdn.com/bl/wp-content/uploads/sites/2/2013/07/Cheshire-Cat-GIF.gif)