### PR TITLE
@ashfurrow => [Fair Map] Only allow portrait orientation on iPhone.

### DIFF
--- a/Artsy/Classes/View Controllers/ARFairMapViewController.m
+++ b/Artsy/Classes/View Controllers/ARFairMapViewController.m
@@ -153,9 +153,14 @@
     [super viewDidAppear:animated];
 }
 
-- (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
+- (BOOL)shouldAutorotate
 {
-    [self.mapZoomManager setMaxMinZoomScalesForCurrentBounds];
+    return NO;
+}
+
+- (NSUInteger)supportedInterfaceOrientations
+{
+    return UIInterfaceOrientationMaskPortrait;
 }
 
 - (void)setTitleHidden:(BOOL)titleHidden

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2014.12.24
 
+* Only allow the portrait orientation for the fair map view on iPhone. - alloy
 * Fix fair map annotation view disappearing once selected. - alloy
 * Fix fair map callout view disappearing on iOS 8. - alloy
 * Remove open map button from fair artist view - alloy


### PR DESCRIPTION
On the iPhone only the artwork view should be rotatable.

![](http://www.digitalhilarity.com/wp-content/uploads/2013/03/owl-rotate.gif)