### PR TITLE
@1aurabrown => [AsyncImageLoading] Add request logging and refactor.

### DIFF
--- a/Artsy/Classes/Categories/Apple/UIImageView+AsyncImageLoading.m
+++ b/Artsy/Classes/Categories/Apple/UIImageView+AsyncImageLoading.m
@@ -1,27 +1,72 @@
 #import <SDWebImage/UIImageView+WebCache.h>
+#import <objc/runtime.h>
+#import "ARLogger.h"
+
 
 @implementation UIImageView (AsyncImageLoading)
 
 - (void)ar_setImageWithURL:(NSURL *)url
-{
-    UIImage *placeholder = [UIImage imageFromColor:[UIColor artsyLightGrey]];
-    [self sd_setImageWithURL:url placeholderImage:placeholder];
-}
-
-- (void)ar_setImageWithURL:(NSURL *)url completed:(SDWebImageCompletionBlock)completed
-{
-    UIImage *placeholder = [UIImage imageFromColor:[UIColor artsyLightGrey]];
-    [self sd_setImageWithURL:url placeholderImage:placeholder completed:completed];
-}
-
-- (void)ar_setImageWithURL:(NSURL *)url
           placeholderImage:(UIImage *)placeholder
+                 completed:(SDWebImageCompletionBlock)completionBlock
 {
     if (!placeholder) {
       placeholder = [UIImage imageFromColor:[UIColor artsyLightGrey]];
     }
 
-    [self sd_setImageWithURL:url placeholderImage:placeholder];
+    if ([ARLogger shouldLogNetworkRequests]) {
+        // SDWebImage might not call the callback in case an image view is deallocated in the
+        // meantime, so associate the start date to it so the date's lifetime will be tied to the
+        // image view.
+        static void *ARAsyncImageLoadingStartDate = &ARAsyncImageLoadingStartDate;
+        objc_setAssociatedObject(self, ARAsyncImageLoadingStartDate, [NSDate date], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+        [self sd_setImageWithURL:url
+                placeholderImage:placeholder
+                       completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *imageURL) {
+            NSTimeInterval elapsedTime = [[NSDate date] timeIntervalSinceDate:objc_getAssociatedObject(self, ARAsyncImageLoadingStartDate)];
+            objc_setAssociatedObject(self, ARAsyncImageLoadingStartDate, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            if (error) {
+                // SDWebImage uses -[NSError code] to communicate the HTTP status code.
+                int status = NSURLErrorUnknown;
+                if (error.domain == NSURLErrorDomain) {
+                    if (error.code == NSURLErrorFileDoesNotExist) {
+                        // SDWebImage's cache feature will try to load the image from disk, but if
+                        // the original request failed to load the cached file won't exist either.
+                        // This is not very interesting to show in the logs.
+                        return;
+                    }
+                    if (error.code >= 400 && error.code < 600) {
+                        status = error.code;
+                    }
+                }
+                ARHTTPRequestOperationFailureLog(@"[Error] %d '%@' [%.04f s]: %@", status, imageURL, elapsedTime, error);
+            } else {
+                // This might actually be another 2xx status code, but let's assume 200 for now.
+                ARHTTPRequestOperationSuccessLog(@"[Success] 200 '%@' [%.04f s]", imageURL, elapsedTime);
+            }
+            if (completionBlock) {
+                completionBlock(image, error, cacheType, imageURL);
+            }
+        }];
+    } else {
+      [self sd_setImageWithURL:url placeholderImage:placeholder completed:completionBlock];
+    }
+}
+
+- (void)ar_setImageWithURL:(NSURL *)url
+{
+    [self ar_setImageWithURL:url placeholderImage:nil completed:nil];
+}
+
+- (void)ar_setImageWithURL:(NSURL *)url completed:(SDWebImageCompletionBlock)completionBlock
+{
+    [self ar_setImageWithURL:url placeholderImage:nil completed:completionBlock];
+}
+
+- (void)ar_setImageWithURL:(NSURL *)url
+          placeholderImage:(UIImage *)placeholder
+{
+    [self ar_setImageWithURL:url placeholderImage:placeholder completed:nil];
 }
 
 @end

--- a/Artsy/Classes/Utils/Logging/ARLogger.h
+++ b/Artsy/Classes/Utils/Logging/ARLogger.h
@@ -11,6 +11,7 @@ typedef NS_ENUM(NSInteger, ARLogContext) {
 /// Call this ASAP to get logging up and running
 - (void)startLogging;
 - (void)stopLogging;
++ (BOOL)shouldLogNetworkRequests;
 + (instancetype)sharedLogger;
 @end
 

--- a/Artsy/Classes/Utils/Logging/ARLogger.m
+++ b/Artsy/Classes/Utils/Logging/ARLogger.m
@@ -6,6 +6,11 @@
 
 @implementation ARLogger
 
++ (BOOL)shouldLogNetworkRequests;
+{
+    return ![ARDeveloperOptions options][@"suppress_network_logs"];
+}
+
 + (instancetype)sharedLogger {
     static ARLogger *_sharedLogger = nil;
     static dispatch_once_t onceToken;
@@ -34,7 +39,7 @@
     [DDLog addLogger:[DDTTYLogger sharedInstance]];
     [self addDDFileLogger];
 
-    if (![ARDeveloperOptions options][@"suppress_network_logs"]) {
+    if ([self.class shouldLogNetworkRequests]) {
         [[ARHTTPRequestOperationLogger sharedLogger] startLogging];
     }
 }


### PR DESCRIPTION
![](http://i.imgur.com/Mg4uDl3.gif)

This tries to replicate the format used by AFHTTPRequestLogger for SDWebImage:

```
2015-02-13 20:11:05.063 [NETWORK] | [Success] 200 'https://d32dm0rphc51dk.cloudfront.net/sbk-ujRq86RgJLlDoxiHDQ/tall.jpg' [0.0001 s]

2015-02-13 20:11:08.267 [NETWORK] | [Error] 403 'https://d32dm0rphc51dk.cloudfront.net/Cy1tDMUKkF_H-QN4BIDlDA/square.jpg' [0.5112 s]: Error Domain=NSURLErrorDomain Code=403 "The operation couldn’t be completed. (NSURLErrorDomain error 403.)"
```

I’m wondering if re-using the `NETWORK` category is adding too much noise or not. I can change it to e.g. `IMAGE`, but it _is_ really network… Maybe this is just something to keep an eye on and change it later if needed?

----

In addition it slightly refactors the category by making all methods use 1 single entry point.