### PR TITLE
[Favorites] Make gene images show-up in list again.

### DIFF
--- a/Artsy/Classes/Models/Gene.m
+++ b/Artsy/Classes/Models/Gene.m
@@ -28,7 +28,7 @@
 
 - (NSURL *)largeImageURL
 {
-    return [NSURL URLWithString:[self.urlFormatString stringByReplacingOccurrencesOfString:@":version" withString:@"square"]];
+    return [NSURL URLWithString:[self.urlFormatString stringByReplacingOccurrencesOfString:@":version" withString:@"square500"]];
 }
 
 - (NSURL *)smallImageURL


### PR DESCRIPTION
Fixes #90.

Because of time constraints I decided to fix this the easy way for now and delay a possibly more proper fix to #172.