### PR TITLE
@orta => [Makefile] Use `git-credential` to determine the username.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ beta: stamp_date deploy
 
 
 LOCAL_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
-BRANCH := $(shell whoami)-$(shell git rev-parse --abbrev-ref HEAD)
+BRANCH := $(shell echo host=github.com | git credential fill | sed -E 'N; s/.*username=(.+)\n?.*/\1/')-$(shell git rev-parse --abbrev-ref HEAD)
 
 pr: 
 	if [ "$(BRANCH)" == "master" ]; then echo "In master, not PRing"; else git push upstream "$(LOCAL_BRANCH):$(BRANCH)"; open -a "Google Chrome" "https://github.com/artsy/eigen/pull/new/artsy:master...$(BRANCH)"; fi


### PR DESCRIPTION
When using `whoami` this would yield `eloy` on my machine, but that’s not my GitHub username. So switched to using git’s source instead.

![](http://media.tumblr.com/tumblr_mb74ucR1IB1rr159v.gif)