### PR TITLE
@alloy => Fixes #44.

### DIFF
--- a/Artsy/Classes/View Controllers/ARFairGuideContainerViewController.m
+++ b/Artsy/Classes/View Controllers/ARFairGuideContainerViewController.m
@@ -242,16 +242,15 @@ const CGFloat kClosedMapHeight = 180.0f;
         [self.view setNeedsLayout];
     };
 
-    // Collapsing
-    if (oldTopHeight > 0 && self.topHeight < kClosedMapHeight) {
+    if (oldTopHeight > 0 && self.topHeight < kClosedMapHeight) { // Collapsing to map preview
         CGFloat heightRatio = ((1.0 - self.topHeight/kClosedMapHeight) + 1.0) / 2.0;
         [self.fairMapViewController centerMap:heightRatio inFrameOfHeight:kClosedMapHeight animated:NO];
         self.fairBackgroundViewTopLayoutConstraint.constant = self.topHeight;
         updateConstraints();
         scrollView.contentOffset = contentOffset.y > 0 ? CGPointZero : contentOffset;
 
-        // Expanding
-    } else if (contentOffset.y < 0) {
+    } else if (contentOffset.y < 0 && oldTopHeight != 0) { // Expanding to fullscreen map
+        // We check for oldTopHeight != 0 to prevent the controller from executing this branch when beginning to scroll down from contentOffset.y ~= 0. 
         CGFloat heightRatio = ((contentOffset.y + kClosedMapHeight)/kClosedMapHeight) / 2.0;
         [self.fairMapViewController centerMap:heightRatio inFrameOfHeight:kClosedMapHeight animated:NO];
         self.fairBackgroundViewTopLayoutConstraint.constant = fabsf(contentOffset.y) + kClosedMapHeight;


### PR DESCRIPTION
The problem was involved in the container view controller, which manages a few different things, including the map view controller, the guide view controller, and a white background view. It was this background view that was being misconstrained. 

In `scrollViewDidScroll:`, I noticed a problem where for a single invocation, the controller thought the map was expanding (that is, it thought the user had pulled down enough so that if they let go, the map would become full screen). It updated the constraints on the white background view accordingly. The solution was to limit that conditional branch by forcing it to check if the `oldTopHeight` (the height of the old constrain) was not zero. It is only equal to zero when the scroll view is first pull from the state where `contentOffset.y` is zero(ish). 

![](http://media.tumblr.com/71b157eed14b7ed58b0a0f58d3827304/tumblr_inline_n4z26w5mQu1s71nq7.gif)