### PR TITLE
Update BETA_CHANGELOG.md

### DIFF
--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2014.12.24
 
 * Fix iOS 8 status bar in onboarding - ash
-* Fixes Fixes blinking map on fair guide - ash
+* Fixes blinking map on fair guide - ash
 * Revised UI for Show Views to match Artist in Fair - orta
 * Support Logged In only Featured links on the main feed - orta
 * Allow for more textual content in fair map callout view. - alloy


### PR DESCRIPTION
Removes double use of the word `Fixes` (assuming that was a typo(?))
:see_no_evil: 

---

![photo on 16-2-15 at 19 25](https://cloud.githubusercontent.com/assets/2642850/6221969/8861d682-b611-11e4-928a-0c593e13dbbb.jpg)
