### PR TITLE
@orta => Tries to fix #103 and various related tickets.

### DIFF
--- a/Artsy/Classes/View Controllers/ARArtworkViewController.m
+++ b/Artsy/Classes/View Controllers/ARArtworkViewController.m
@@ -85,6 +85,11 @@
 
 - (void)viewDidAppear:(BOOL)animated
 {
+    self.view.delegate = self;
+    self.view.metadataView.delegate = self;
+    self.view.artworkBlurbView.delegate = self;
+    self.postsVC.delegate = self;
+  
     // When we get back from zoom / VIR allow the preview to do trigger zoom
     self.view.metadataView.userInteractionEnabled = YES;
     [super viewDidAppear:self.shouldAnimate && animated];
@@ -95,6 +100,13 @@
     [self.view.relatedArtworksView cancel];
     self.view.scrollsToTop = NO;
 
+    // See https://github.com/artsy/eigen/issues/103
+    self.view.delegate = nil;
+    // And nill-ify these as well, for good measure.
+    self.view.metadataView.delegate = nil;
+    self.view.artworkBlurbView.delegate = nil;
+    self.postsVC.delegate = nil;
+  
     [super viewDidDisappear:self.shouldAnimate && animated];
 }
 

--- a/Artsy/Classes/Views/ARArtworkView.m
+++ b/Artsy/Classes/Views/ARArtworkView.m
@@ -105,9 +105,9 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
     }];
 
     [self.artwork onFairUpdate:^(Fair *fair) {
+        @strongify(self);
         if (!self) return;
 
-        @strongify(self);
         [self.metadataView updateWithFair:fair];
         [self.stackView layoutIfNeeded];
     } failure:nil];


### PR DESCRIPTION
Also does the weak->strong dance in the right order.

As discussed I will be doing a bit more investigating, but I think what's happening is:

- ARArtworkView (a UIScrollView subclass) is being retained _longer_ than its VC (ARArtworkViewController).
- UIScrollView's `delegate` property is `assign` not `weak`.
- The UIScrollView implementation tries to message its delegate when it has already been released.