### PR TITLE
@ashfurrow => [ArtworkView] Don't have any block retain self.

### DIFF
--- a/Artsy/Classes/Views/ARArtworkView.m
+++ b/Artsy/Classes/Views/ARArtworkView.m
@@ -94,6 +94,7 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
     };
 
     [self.artwork onArtworkUpdate:^{
+        @strongify(self);
         // A nil value shouldn't be classed as unpublished
         if (self.artwork.isPublished && self.artwork.isPublished.boolValue == NO) {
             [self addUnpublishedBanner];


### PR DESCRIPTION
Related to #203

One block was still referencing `self` in a strong fashion.

----

Based on this, I’m not a fan of the `weakify` and `strongify` macros. They do not clearly communicate what's going on in the full scope. It seems to me that making it explicit would make it easier to catch these issues when reading the code:

```objc
__weak __typeof__(self) weakSelf = self;
[self.artwork onArtworkUpdate:^{
    __strong __typeof__(weakSelf) strongSelf = weakSelf;
    [strongSelf addUnpublishedBanner];
}];
```

The main communication point is about using `weakSelf` and `strongSelf`, so the dance to make these variables can probably be hidden by some simple macros.

@orta @1aurabrown @ashfurrow Thoughts?