### PR TITLE
@orta => fix missing thumbnails in auction results

### DIFF
--- a/Artsy/Classes/Models/AuctionLot.h
+++ b/Artsy/Classes/Models/AuctionLot.h
@@ -11,8 +11,8 @@
 @property (nonatomic, copy) NSString *dates;
 @property (nonatomic, copy) NSString *auctionDateText;
 @property (nonatomic, copy) NSString *organization;
-@property (nonatomic, copy) NSURL *imageURL;
+@property (nonatomic, copy) NSDictionary *imageURLs;
 @property (nonatomic, copy) NSURL *externalURL;
 @property (nonatomic, strong) NSDate *auctionDate;
-
+-(NSURL *)imageURL;
 @end

--- a/Artsy/Classes/Models/AuctionLot.m
+++ b/Artsy/Classes/Models/AuctionLot.m
@@ -13,13 +13,9 @@
         @"dates" : @"dates_text",
         @"auctionDate" : @"auction_date",
         @"auctionDateText" : @"auction_dates_text",
-        @"imageURL" : @"image_url",
+        @"imageURLs" : @"image_urls",
         @"externalURL" : @"external_url",
     };
-}
-
-+ (NSValueTransformer *)imageURLJSONTransformer {
-    return [NSValueTransformer valueTransformerForName:MTLURLValueTransformerName];
 }
 
 + (NSValueTransformer *)externalURLJSONTransformer {
@@ -44,6 +40,23 @@
 - (NSUInteger)hash
 {
     return self.auctionLotID.hash;
+}
+
+- (NSURL *)imageURL
+{
+    NSString *imageURL = nil;
+    if (self.imageURLs.count > 0){
+        if ([self.imageURLs objectForKey:@"thumbnail"]) {
+            imageURL  = [self.imageURLs objectForKey:@"thumbnail"];
+        } else {
+            NSArray *values = [self.imageURLs allValues];
+            imageURL = [values objectAtIndex:0];
+        }
+        return [NSURL URLWithString:imageURL];
+    } else {
+        return nil;
+    }
+
 }
 
 @end


### PR DESCRIPTION
fixes https://github.com/artsy/eigen/issues/210. We were using `image_url` to get the image for the auction result without doing anything to replace `:version` in the image URL string.

`image_url` and `image_versions` have been deprecated anyway, in favor of the newer `image_urls` hash, so I made the switch to using that instead. I noticed that a few thumbnail images are still not loading -- this is because they actually don't have any image versions, not due to a code issue. This can be seen in the api response. (I'm using https://api.artsy.net/api/v1/artwork/fernando-botero-family-on-a-beach/comparable_sales since that was the piece used in the original github issue)