### PR TITLE
@ashfurrow -> include works by artists you follow in personalized fair guides 'works' section

### DIFF
--- a/Artsy Tests/ARFairFavoritesNetworkModelTests.m
+++ b/Artsy Tests/ARFairFavoritesNetworkModelTests.m
@@ -44,12 +44,10 @@ it(@"ignores artworks without a partner", ^{
         ];
         
         ARFairFavoritesNetworkModel *favoritesNetworkModel = [[ARFairFavoritesNetworkModel alloc] init];
-        [favoritesNetworkModel getFavoritesForNavigationsButtonsForFair:fair artwork:^(NSArray *work) {
+        [favoritesNetworkModel getFavoritesForNavigationsButtonsForFair:fair artworks:^(NSArray *work) {
             expect(work.count).to.equal(2);
             done();
-        } exhibitors:^(NSArray *exhibitors) {
-        } artists:^(NSArray *artists) {
-        } failure:nil];
+        } artworksByArtists:nil exhibitors:nil artists:nil failure:nil];
     });
 });
 
@@ -91,15 +89,13 @@ describe(@"when downloading exhibitor data", ^{
             }] failure:OCMOCK_ANY];
             
             ARFairFavoritesNetworkModel *favoritesNetworkModel = [[ARFairFavoritesNetworkModel alloc] init];
-            [favoritesNetworkModel getFavoritesForNavigationsButtonsForFair:fairMock artwork:^(NSArray *work) {
-            } exhibitors:^(NSArray *exhibitors) {
+            [favoritesNetworkModel getFavoritesForNavigationsButtonsForFair:fairMock artworks:nil artworksByArtists:nil exhibitors:^(NSArray *exhibitors) {
                 expect(exhibitors.count).to.equal(1);
                 NSDictionary *button = exhibitors.firstObject;
                 expect(button[@"ARNavigationButtonPropertiesKey"][@"title"]).to.equal(@"Leila Heller Gallery in New York City");
                 expect(button[@"ARNavigationButtonPropertiesKey"][@"subtitle"]).to.equal(@"Pier 1, Booth 2, Section 3, Floor 5");
                 done();
-            } artists:^(NSArray *artists) {
-            } failure:nil];
+            } artists:nil failure:nil];
         });
     });
     
@@ -129,15 +125,13 @@ describe(@"when downloading exhibitor data", ^{
             }] failure:OCMOCK_ANY];
             
             ARFairFavoritesNetworkModel *favoritesNetworkModel = [[ARFairFavoritesNetworkModel alloc] init];
-            [favoritesNetworkModel getFavoritesForNavigationsButtonsForFair:fairMock artwork:^(NSArray *work) {
-            } exhibitors:^(NSArray *exhibitors) {
+            [favoritesNetworkModel getFavoritesForNavigationsButtonsForFair:fairMock artworks:nil artworksByArtists:nil exhibitors:^(NSArray *exhibitors) {
                 expect(exhibitors.count).to.equal(1);
                 NSDictionary *button = exhibitors.firstObject;
                 expect(button[@"ARNavigationButtonPropertiesKey"][@"title"]).to.equal(@"Leila Heller Gallery in New York City");
                 expect(button[@"ARNavigationButtonPropertiesKey"][@"subtitle"]).to.equal(@"Pier 1, Booth 2, Section 3, Floor 5");
                 done();
-            } artists:^(NSArray *artists) {
-            } failure:nil];
+            } artists:nil failure:nil];
         });
     });
 });

--- a/Artsy/Classes/Models/Profile.m
+++ b/Artsy/Classes/Models/Profile.m
@@ -159,7 +159,7 @@
     }
 
     [ArtsyAPI checkFollowProfile:self success:^(BOOL status) {
-        success(ARHeartStatusYes);
+        success(status);
     } failure:failure];
 }
 

--- a/Artsy/Classes/Networking/Network Models/ARFairFavoritesNetworkModel.h
+++ b/Artsy/Classes/Networking/Network Models/ARFairFavoritesNetworkModel.h
@@ -11,12 +11,11 @@
 @interface ARFairFavoritesNetworkModel : NSObject
 
 - (void)getFavoritesForNavigationsButtonsForFair:(Fair *)fair
-                                         artwork:(void (^)(NSArray *artworks))work
-                                      exhibitors:(void (^)(NSArray *exhibitorsArray))exhibitors
-                                         artists:(void (^)(NSArray *artistsArray))artists
+                                        artworks:(void (^)(NSArray *artworks))artworksBlock
+                               artworksByArtists:(void (^)(NSArray *artworks))appendArtistArtworksBlock
+                                      exhibitors:(void (^)(NSArray *exhibitors))exhibitorsBlock
+                                         artists:(void (^)(NSArray *artists))artistsBlock
                                          failure:(void (^)(NSError *error))failure;
-
-@property (readonly, nonatomic, assign) BOOL isDownloading;
 
 @property (nonatomic, weak) id<ARFairFavoritesNetworkModelDelegate> delegate;
 

--- a/Artsy/Classes/View Controllers/ARFairGuideViewController.m
+++ b/Artsy/Classes/View Controllers/ARFairGuideViewController.m
@@ -251,8 +251,11 @@ typedef NS_ENUM(NSInteger, ARFairGuideSelectedTab) {
 
 - (void)addUserContent
 {
+
     [self.fairFavorites getFavoritesForNavigationsButtonsForFair:self.fair
-        artwork:^(NSArray *workArray) {
+        artworks:^(NSArray *workArray) {
+            [self.workViewController addButtonDescriptions:workArray unique:YES];
+        } artworksByArtists:^(NSArray *workArray) {
             [self.workViewController addButtonDescriptions:workArray unique:YES];
         } exhibitors:^(NSArray *exhibitorsArray) {
             [self.exhibitorsViewController addButtonDescriptions:exhibitorsArray unique:YES];


### PR DESCRIPTION
The artworks sections of the personalized fair guide should include both works at the fair that you've favorited AND all works by artists you follow who are exhibiting at the fair.

This accomplishes what I want, but has some not so great nested success callbacks. There's probably an elegant way. There's a little bit of existing RAC in this network model, maybe we can make it leverage RAC some more. I'd also like the API to allow you to fetch any of the 3 types of data (works, artists, exhibitors) separately, say when you switch tabs. Needs tests.