### PR TITLE
@1aurabrown => [Artwork] Fix a crash when swiping between artworks.

### DIFF
--- a/Artsy/Classes/View Controllers/ARArtworkViewController.m
+++ b/Artsy/Classes/View Controllers/ARArtworkViewController.m
@@ -85,11 +85,6 @@
 
 - (void)viewDidAppear:(BOOL)animated
 {
-    self.view.delegate = self;
-    self.view.metadataView.delegate = self;
-    self.view.artworkBlurbView.delegate = self;
-    self.postsVC.delegate = self;
-  
     // When we get back from zoom / VIR allow the preview to do trigger zoom
     self.view.metadataView.userInteractionEnabled = YES;
     [super viewDidAppear:self.shouldAnimate && animated];
@@ -99,14 +94,6 @@
 {
     [self.view.relatedArtworksView cancel];
     self.view.scrollsToTop = NO;
-
-    // See https://github.com/artsy/eigen/issues/103
-    self.view.delegate = nil;
-    // And nill-ify these as well, for good measure.
-    self.view.metadataView.delegate = nil;
-    self.view.artworkBlurbView.delegate = nil;
-    self.postsVC.delegate = nil;
-  
     [super viewDidDisappear:self.shouldAnimate && animated];
 }
 

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,3 +1,7 @@
+## Master
+
+* Fix a crash when swiping between artworks. - alloy
+
 ## 2014.12.24
 
 * Fix iOS 8 status bar in onboarding - ash


### PR DESCRIPTION
Fixes #214.

This was a regression introduced by too paranoiacally nullifying the
scrollview's delegate in 0e06018, which has since been properly
fixed at the root cause in 8db7b1e.