### PR TITLE
@orta -> always use desktop web urls when sharing

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -1299,6 +1299,7 @@
 		D37E4CF91A92AC5A00023E2C /* ARAnnotatedMapView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARAnnotatedMapView.h; sourceTree = "<group>"; };
 		D37E4CFA1A92AC5A00023E2C /* ARAnnotatedMapView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARAnnotatedMapView.m; sourceTree = "<group>"; };
 		D37E4CFC1A92B29F00023E2C /* ARAnnotatedMapViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARAnnotatedMapViewTests.m; sourceTree = "<group>"; };
+		D3AC809B1A9E9493000CB97A /* ARRouter+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ARRouter+Private.h"; sourceTree = "<group>"; };
 		E2C583DC5F5EBC24D3CC3B76 /* Pods.demo.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.demo.xcconfig; path = "Pods/Target Support Files/Pods/Pods.demo.xcconfig"; sourceTree = "<group>"; };
 		E60673B119BE4E8C00EF05EB /* full_logo_white_small@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "full_logo_white_small@2x.png"; sourceTree = "<group>"; };
 		E611846F18D78068000FE4C9 /* ARMessageItemProviderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARMessageItemProviderTests.m; sourceTree = "<group>"; };
@@ -3190,6 +3191,7 @@
 				60A49F5E1676559200B9B95D /* ARNetworkConstants.h */,
 				60A49F5F1676559300B9B95D /* ARNetworkConstants.m */,
 				601C317616582BA30013E061 /* ARRouter.h */,
+				D3AC809B1A9E9493000CB97A /* ARRouter+Private.h */,
 				601C317716582BA30013E061 /* ARRouter.m */,
 				60B6F13716638785007C9587 /* ArtsyAPI.h */,
 				CB9E243F17CBC36F00773A9A /* ARAuthProviders.h */,

--- a/Artsy/Classes/Networking/ARNetworkConstants.h
+++ b/Artsy/Classes/Networking/ARNetworkConstants.h
@@ -1,4 +1,4 @@
-extern NSString *const ARBaseWebURL;
+extern NSString *const ARBaseDesktopWebURL;
 extern NSString *const ARBaseMobileWebURL;
 extern NSString *const ARBaseApiURL;
 extern NSString *const ARStagingBaseWebURL;

--- a/Artsy/Classes/Networking/ARNetworkConstants.m
+++ b/Artsy/Classes/Networking/ARNetworkConstants.m
@@ -1,4 +1,4 @@
-NSString *const ARBaseWebURL = @"https://artsy.net/";
+NSString *const ARBaseDesktopWebURL = @"https://artsy.net/";
 NSString *const ARBaseMobileWebURL = @"https://m.artsy.net/";
 NSString *const ARBaseApiURL = @"https://api.artsy.net/";
 

--- a/Artsy/Classes/Networking/ARRouter+Private.h
+++ b/Artsy/Classes/Networking/ARRouter+Private.h
@@ -1,0 +1,6 @@
+#import "ARRouter.h"
+
+@interface ARRouter (Private)
++ (NSURL *)baseMobileWebURL;
++ (NSURL *)baseDesktopWebURL;
+@end

--- a/Artsy/Classes/Networking/ARRouter.m
+++ b/Artsy/Classes/Networking/ARRouter.m
@@ -1,5 +1,6 @@
 #import "ARNetworkConstants.h"
 #import "ARRouter.h"
+#import "ARRouter+Private.h"
 #import "ARUserManager.h"
 #import <UICKeyChainStore/UICKeyChainStore.h>
 #import <CocoaPods-Keys/ArtsyKeys.h>
@@ -34,11 +35,17 @@ static NSSet *artsyHosts = nil;
 
 + (NSURL *)baseWebURL
 {
-    if ([AROptions boolForOption:ARUseStagingDefault]) {
-        return [NSURL URLWithString:[UIDevice isPad] ? ARStagingBaseWebURL : ARStagingBaseMobileWebURL];
-    } else {
-        return [NSURL URLWithString:[UIDevice isPad] ? ARBaseWebURL : ARBaseMobileWebURL];
-    }
+    return [UIDevice isPad] ? [self baseDesktopWebURL] : [self baseMobileWebURL];
+}
+
++ (NSURL *)baseDesktopWebURL
+{
+    return [NSURL URLWithString:[AROptions boolForOption:ARUseStagingDefault] ? ARStagingBaseWebURL : ARBaseDesktopWebURL];
+}
+
++ (NSURL *)baseMobileWebURL
+{
+    return [NSURL URLWithString:[AROptions boolForOption:ARUseStagingDefault] ? ARStagingBaseMobileWebURL : ARBaseMobileWebURL];
 }
 
 + (void)setupWithBaseApiURL:(NSURL *)baseApiURL

--- a/Artsy/Classes/Utils/ARURLItemProvider.m
+++ b/Artsy/Classes/Utils/ARURLItemProvider.m
@@ -1,11 +1,12 @@
 #import "ARURLItemProvider.h"
 #import "ARFileUtils.h"
+#import "ARRouter+Private.h"
 
 @implementation ARURLItemProvider
 
 - (instancetype)initWithMessage:(NSString *)message path:(NSString *)path thumbnailImageURL:(NSURL *)thumbnailImageURL
 {
-    NSURL *shareableURL = [ARSwitchBoard.sharedInstance resolveRelativeUrl:path];
+    NSURL *shareableURL = [NSURL URLWithString:path relativeToURL:[ARRouter baseDesktopWebURL]];
 
     // sharing the URL built with URLWithString:relativeToURL via AirDrop: fails with a declined error message
     self = [super initWithPlaceholderItem:[NSURL URLWithString:shareableURL.absoluteString]];


### PR DESCRIPTION
fixes https://github.com/artsy/eigen/issues/161

I guess another solution would be to add meta tags on m.artsy.net, but personally I think it's weird and ugly when people tweet/post mobile links. If somebody happens to visit a force link on a phone as a result of a share, they'll just get redirected to mobile anyway.