### PR TITLE
@orta => Favorites logged out

### DIFF
--- a/Artsy/Classes/View Controllers/ARTopMenuNavigationDataSource.h
+++ b/Artsy/Classes/View Controllers/ARTopMenuNavigationDataSource.h
@@ -11,8 +11,6 @@ NS_ENUM(NSInteger, ARTopTabControllerIndex){
 
 @interface ARTopMenuNavigationDataSource : NSObject <ARTabViewDataSource>
 
-- (ARNavigationController *)currentNavigationController;
-
 @property (readwrite, nonatomic, strong) ARShowFeedViewController *showFeedViewController;
 
 @end

--- a/Artsy/Classes/View Controllers/ARTopMenuNavigationDataSource.m
+++ b/Artsy/Classes/View Controllers/ARTopMenuNavigationDataSource.m
@@ -58,12 +58,6 @@
     return self.favoritesNavigationController;
 }
 
-
-- (ARNavigationController *)currentNavigationController
-{
-    return (id)[self viewControllerForTabContentView:nil atIndex:self.currentIndex];
-}
-
 #pragma mark ARTabViewDataSource
 
 - (UINavigationController *)viewControllerForTabContentView:(ARTabContentView *)tabContentView atIndex:(NSInteger)index

--- a/Artsy/Classes/View Controllers/ARTopMenuViewController.m
+++ b/Artsy/Classes/View Controllers/ARTopMenuViewController.m
@@ -137,7 +137,7 @@ static const CGFloat ARSearchMenuButtonDimension = 46;
 
 - (ARNavigationController *)rootNavigationController
 {
-    return self.navigationDataSource.currentNavigationController;
+    return (ARNavigationController *)[self.tabContentView currentNavigationController];
 }
 
 #pragma mark - ARMenuAwareViewController
@@ -260,11 +260,15 @@ static const CGFloat ARSearchMenuButtonDimension = 46;
 
 - (BOOL)tabContentView:(ARTabContentView *)tabContentView shouldChangeToIndex:(NSInteger)index
 {
+    if (index == ARTopTabControllerIndexFavorites && [User isTrialUser]) {
+        [ARTrialController presentTrialWithContext:ARTrialContextShowingFavorites fromTarget:self selector:_cmd];
+        return NO;
+    }
     if (index == _selectedTabIndex) {
         ARNavigationController *controller = (id)[tabContentView currentNavigationController];
         if (controller.viewControllers.count == 1) {
             if (index == ARTopTabControllerIndexSearch) {
-                [tabContentView returnToPreviousViewIndex];
+                [self returnToPreviousTab];
             } else {
                 UIScrollView *scrollView = nil;
                 if (index == ARTopTabControllerIndexFeed) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.7.0
+## 1.7.0 (16/2/2015)
 
 * Fair Map will zoom to show annotations on first double tap - 1aurabrown
 * Fix iOS 8 status bar in onboarding - ash

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,6 +1,13 @@
-## Master
+## Next
 
 * Fix a crash when swiping between artworks. - alloy
+* Tapping YOU as a Trial User invokes signup - 1aurabrown
+* Share URLs always use desktop, not martsy, urls -- 1aurabrown
+* Added works by artists you follow to fair guide Works section - 1aurabrown
+* Minor changes to some buttons - 1aurabrown
+* Featured categories removed from fair guide - 1aurabrown
+* Fix missing thumbnail images on auction results - 1aurabrown
+* Automatically invoke keyboard in email sign in on iPad - 1aurabrown
 
 ## 2014.12.24
 


### PR DESCRIPTION
When you are logged out and you tap the YOU section, we will show the sign in modal on top of whatever your current view is, instead of taking you to an empty YOU section. 
fixes https://github.com/artsy/eigen/issues/108.

Also includes a bunch of changelog updates.