### PR TITLE
@1aurabrown => [Sharing] Fix crash on iPad.

### DIFF
--- a/Artsy Tests/ARSharingControllerTests.m
+++ b/Artsy Tests/ARSharingControllerTests.m
@@ -5,15 +5,15 @@
 
 @interface ARSharingController (Testing)
 - (NSString *)message;
-- (NSString *)objectID;
+// - (NSString *)objectID;
 - (NSArray *)activityItems;
 @property (nonatomic, strong) id <ARShareableObject> object;
-@property (nonatomic, strong) ARURLItemProvider *urlProvider;
-@property (nonatomic, strong) ARImageItemProvider *imageProvider;
-@property (nonatomic, strong) ARMessageItemProvider *messageProvider;
-- (void)shareWithThumbnailImageURL:(NSURL *)thumbnailImageURL image:(UIImage *)image;
-- (instancetype)initWithObject:(id)object;
-- (void)presentActivityViewController;
+// @property (nonatomic, strong) ARURLItemProvider *urlProvider;
+// @property (nonatomic, strong) ARImageItemProvider *imageProvider;
+// @property (nonatomic, strong) ARMessageItemProvider *messageProvider;
+// - (void)shareWithThumbnailImageURL:(NSURL *)thumbnailImageURL image:(UIImage *)image;
+// - (instancetype)initWithObject:(id)object;
+// - (void)presentActivityViewController;
 @end
 
 SpecBegin(ARSharingController)
@@ -77,50 +77,13 @@ describe(@"sharing", ^{
     });
 
     describe(@"activityItems", ^{
-        __block ARMessageItemProvider *messageProvider;
-        __block ARURLItemProvider *urlProvider;
-
-        before(^{
-            sharingController = [ARSharingController new];
-            messageProvider = [ARMessageItemProvider new];
-            urlProvider = [ARURLItemProvider new];
-        });
-
         it(@"orders items", ^{
-            [sharingController shareWithThumbnailImageURL:nil image:nil];
+            sharingController = [ARSharingController sharingControllerWithObject:nil thumbnailImageURL:nil image:nil];
             NSArray *activityItems = [sharingController activityItems];
             expect([activityItems count]).to.equal(3);
             expect(activityItems[0]).to.beKindOf([ARMessageItemProvider class]);
             expect(activityItems[1]).to.beKindOf([ARURLItemProvider class]);
             expect(activityItems[2]).to.beKindOf([ARImageItemProvider class]);
-        });
-    });
-
-    describe(@"initWithObject", ^{
-        it(@"sets object", ^{
-            Artist *artistObject = [Artist new];
-            sharingController = [[ARSharingController alloc] initWithObject:artistObject];
-            expect(sharingController.object).to.equal(artistObject);
-        });
-    });
-
-    describe(@"sharewithImage", ^{
-        before(^{
-            sharingController = [ARSharingController new];
-        });
-
-        it(@"sets all providers", ^{
-            [sharingController shareWithThumbnailImageURL:nil image:nil];
-            expect(sharingController.messageProvider).notTo.beNil();
-            expect(sharingController.urlProvider).notTo.beNil();
-            expect(sharingController.imageProvider).notTo.beNil();
-        });
-
-        it(@"triggers the View Controller", ^{
-            id mock = [OCMockObject partialMockForObject:sharingController];
-            [[mock expect] presentActivityViewController];
-            [sharingController shareWithThumbnailImageURL:nil image:nil];
-            [mock verify];
         });
     });
 });

--- a/Artsy Tests/ARSharingControllerTests.m
+++ b/Artsy Tests/ARSharingControllerTests.m
@@ -5,15 +5,8 @@
 
 @interface ARSharingController (Testing)
 - (NSString *)message;
-// - (NSString *)objectID;
 - (NSArray *)activityItems;
 @property (nonatomic, strong) id <ARShareableObject> object;
-// @property (nonatomic, strong) ARURLItemProvider *urlProvider;
-// @property (nonatomic, strong) ARImageItemProvider *imageProvider;
-// @property (nonatomic, strong) ARMessageItemProvider *messageProvider;
-// - (void)shareWithThumbnailImageURL:(NSURL *)thumbnailImageURL image:(UIImage *)image;
-// - (instancetype)initWithObject:(id)object;
-// - (void)presentActivityViewController;
 @end
 
 SpecBegin(ARSharingController)

--- a/Artsy/Classes/Utils/ARSharingController.h
+++ b/Artsy/Classes/Utils/ARSharingController.h
@@ -6,7 +6,7 @@
 + (instancetype)sharingControllerWithObject:(id)object thumbnailImageURL:(NSURL *)thumbnailImageURL image:(UIImage *)image;
 
 - (NSString *)objectID;
-- (void)presentActivityViewControllerFromView:(UIView *)view;
+- (void)presentActivityViewControllerFromButton:(UIButton *)button;
 
 @property (nonatomic, readonly) id <ARShareableObject> object;
 

--- a/Artsy/Classes/Utils/ARSharingController.h
+++ b/Artsy/Classes/Utils/ARSharingController.h
@@ -6,7 +6,7 @@
 + (instancetype)sharingControllerWithObject:(id)object thumbnailImageURL:(NSURL *)thumbnailImageURL image:(UIImage *)image;
 
 - (NSString *)objectID;
-- (void)presentActivityViewControllerOverViewController:(UIViewController *)presentingViewController fromView:(UIView *)view;
+- (void)presentActivityViewControllerFromView:(UIView *)view;
 
 @property (nonatomic, readonly) id <ARShareableObject> object;
 

--- a/Artsy/Classes/Utils/ARSharingController.h
+++ b/Artsy/Classes/Utils/ARSharingController.h
@@ -2,12 +2,12 @@
 
 @interface ARSharingController : NSObject
 
-+ (void)shareObject:(id)object;
-+ (void)shareObject:(id)object withThumbnailImageURL:(NSURL *)thumbnailImageURL;
-+ (void)shareObject:(id)object withThumbnailImageURL:(NSURL *)thumbnailImageURL withImage:(UIImage *)image;
++ (instancetype)sharingControllerWithObject:(id)object thumbnailImageURL:(NSURL *)thumbnailImageURL;
++ (instancetype)sharingControllerWithObject:(id)object thumbnailImageURL:(NSURL *)thumbnailImageURL image:(UIImage *)image;
 
 - (NSString *)objectID;
+- (void)presentActivityViewControllerOverViewController:(UIViewController *)presentingViewController fromView:(UIView *)view;
 
-@property (nonatomic, strong, readonly) id <ARShareableObject> object;
+@property (nonatomic, readonly) id <ARShareableObject> object;
 
 @end

--- a/Artsy/Classes/Utils/ARSharingController.m
+++ b/Artsy/Classes/Utils/ARSharingController.m
@@ -4,7 +4,7 @@
 #import "ARMessageItemProvider.h"
 #import <UIAlertView+Blocks/UIAlertView+Blocks.h>
 
-@interface ARSharingController () <UIPopoverControllerDelegate>
+@interface ARSharingController ()
 @property (nonatomic, strong) id <ARShareableObject> object;
 @property (nonatomic, strong) NSURL *thumbnailImageURL;
 @property (nonatomic, strong) UIImage *image;
@@ -32,7 +32,7 @@
     return self;
 }
 
-- (void)presentActivityViewControllerOverViewController:(UIViewController *)presentingViewController fromView:(UIView *)view;
+- (void)presentActivityViewControllerFromView:(UIView *)view;
 {
     if (ARIsRunningInDemoMode) {
         [UIAlertView showWithTitle:nil message:@"Feature not enabled for this demo" cancelButtonTitle:@"OK" otherButtonTitles:nil tapBlock:nil];
@@ -55,11 +55,11 @@
     UIPopoverController *popover = nil;
 
     if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
-        [presentingViewController presentViewController:activityVC animated:YES completion:nil];
+        [[ARTopMenuViewController sharedController] presentViewController:activityVC animated:YES completion:nil];
     } else {
         UIPopoverController *popover = [[UIPopoverController alloc] initWithContentViewController:activityVC];
-        [popover presentPopoverFromRect:[view convertRect:view.bounds toView:presentingViewController.view]
-                                 inView:presentingViewController.view
+        [popover presentPopoverFromRect:view.bounds
+                                 inView:view
                permittedArrowDirections:UIPopoverArrowDirectionAny
                                animated:YES];
     }

--- a/Artsy/Classes/View Controllers/ARArtistViewController.m
+++ b/Artsy/Classes/View Controllers/ARArtistViewController.m
@@ -491,7 +491,7 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
 {
     ARSharingController *sharingController = [ARSharingController sharingControllerWithObject:self.artist
                                                                             thumbnailImageURL:self.artist.squareImageURL];
-    [sharingController presentActivityViewControllerFromView:sender];
+    [sharingController presentActivityViewControllerFromButton:sender];
 }
 
 - (void)loadBioViewController

--- a/Artsy/Classes/View Controllers/ARArtistViewController.m
+++ b/Artsy/Classes/View Controllers/ARArtistViewController.m
@@ -491,7 +491,7 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
 {
     ARSharingController *sharingController = [ARSharingController sharingControllerWithObject:self.artist
                                                                             thumbnailImageURL:self.artist.squareImageURL];
-    [sharingController presentActivityViewControllerOverViewController:self fromView:sender];
+    [sharingController presentActivityViewControllerFromView:sender];
 }
 
 - (void)loadBioViewController

--- a/Artsy/Classes/View Controllers/ARArtistViewController.m
+++ b/Artsy/Classes/View Controllers/ARArtistViewController.m
@@ -145,7 +145,7 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
 
     UIView *actionsWrapper = [[UIView alloc] init];
     UIButton *shareButton = [[ARCircularActionButton alloc] initWithImageName:@"Artwork_Icon_Share"];
-    [shareButton addTarget:self action:@selector(shareArtist) forControlEvents:UIControlEventTouchUpInside];
+    [shareButton addTarget:self action:@selector(shareArtist:) forControlEvents:UIControlEventTouchUpInside];
     [actionsWrapper addSubview:shareButton];
 
     ARHeartButton *favoriteButton = [[ARHeartButton alloc] init];
@@ -487,9 +487,11 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
     return 0;
 }
 
-- (void)shareArtist
+- (void)shareArtist:(UIButton *)sender
 {
-    [ARSharingController shareObject:self.artist withThumbnailImageURL:self.artist.squareImageURL];
+    ARSharingController *sharingController = [ARSharingController sharingControllerWithObject:self.artist
+                                                                            thumbnailImageURL:self.artist.squareImageURL];
+    [sharingController presentActivityViewControllerOverViewController:self fromView:sender];
 }
 
 - (void)loadBioViewController

--- a/Artsy/Classes/View Controllers/ARArtworkViewController+ButtonActions.m
+++ b/Artsy/Classes/View Controllers/ARArtworkViewController+ButtonActions.m
@@ -54,7 +54,7 @@
     ARSharingController *sharingController = [ARSharingController sharingControllerWithObject:self.artwork
                                                                             thumbnailImageURL:thumbnailImageURL
                                                                                         image:image];
-    [sharingController presentActivityViewControllerOverViewController:self fromView:sender];
+    [sharingController presentActivityViewControllerFromView:sender];
 }
 
 

--- a/Artsy/Classes/View Controllers/ARArtworkViewController+ButtonActions.m
+++ b/Artsy/Classes/View Controllers/ARArtworkViewController+ButtonActions.m
@@ -41,15 +41,20 @@
     }];
 }
 
-- (void)tappedArtworkShare:(id)sender
+- (void)tappedArtworkShare:(UIButton *)sender
 {
+    NSURL *thumbnailImageURL = nil;
+    UIImage *image = nil;
     if (self.artwork.defaultImage.downloadable) {
-        [ARSharingController shareObject:self.artwork withThumbnailImageURL:self.artwork.defaultImage.urlForThumbnailImage withImage:self.imageView.image];
+      thumbnailImageURL = self.artwork.defaultImage.urlForThumbnailImage;
+      image = self.imageView.image;
     } else if (self.artwork.canShareImage) {
-        [ARSharingController shareObject:self.artwork withThumbnailImageURL:self.artwork.defaultImage.urlForThumbnailImage];
-    } else {
-        [ARSharingController shareObject:self.artwork];
+      thumbnailImageURL = self.artwork.defaultImage.urlForThumbnailImage;
     }
+    ARSharingController *sharingController = [ARSharingController sharingControllerWithObject:self.artwork
+                                                                            thumbnailImageURL:thumbnailImageURL
+                                                                                        image:image];
+    [sharingController presentActivityViewControllerOverViewController:self fromView:sender];
 }
 
 

--- a/Artsy/Classes/View Controllers/ARArtworkViewController+ButtonActions.m
+++ b/Artsy/Classes/View Controllers/ARArtworkViewController+ButtonActions.m
@@ -54,7 +54,7 @@
     ARSharingController *sharingController = [ARSharingController sharingControllerWithObject:self.artwork
                                                                             thumbnailImageURL:thumbnailImageURL
                                                                                         image:image];
-    [sharingController presentActivityViewControllerFromView:sender];
+    [sharingController presentActivityViewControllerFromButton:sender];
 }
 
 

--- a/Artsy/Classes/View Controllers/ARShowViewController.m
+++ b/Artsy/Classes/View Controllers/ARShowViewController.m
@@ -137,7 +137,9 @@ static const NSInteger ARFairShowMaximumNumberOfHeadlineImages = 5;
             if (self.imagePageViewController.images.count) {
                 imageURL = [(Image *)self.imagePageViewController.images[0] urlForThumbnailImage];
             }
-            [ARSharingController shareObject:self.show withThumbnailImageURL:imageURL];
+            ARSharingController *sharingController = [ARSharingController sharingControllerWithObject:self.show
+                                                                                    thumbnailImageURL:imageURL];
+            [sharingController presentActivityViewControllerOverViewController:self fromView:sender];
         }
     }];
 

--- a/Artsy/Classes/View Controllers/ARShowViewController.m
+++ b/Artsy/Classes/View Controllers/ARShowViewController.m
@@ -139,7 +139,7 @@ static const NSInteger ARFairShowMaximumNumberOfHeadlineImages = 5;
             }
             ARSharingController *sharingController = [ARSharingController sharingControllerWithObject:self.show
                                                                                     thumbnailImageURL:imageURL];
-            [sharingController presentActivityViewControllerFromView:sender];
+            [sharingController presentActivityViewControllerFromButton:sender];
         }
     }];
 

--- a/Artsy/Classes/View Controllers/ARShowViewController.m
+++ b/Artsy/Classes/View Controllers/ARShowViewController.m
@@ -139,7 +139,7 @@ static const NSInteger ARFairShowMaximumNumberOfHeadlineImages = 5;
             }
             ARSharingController *sharingController = [ARSharingController sharingControllerWithObject:self.show
                                                                                     thumbnailImageURL:imageURL];
-            [sharingController presentActivityViewControllerOverViewController:self fromView:sender];
+            [sharingController presentActivityViewControllerFromView:sender];
         }
     }];
 

--- a/Artsy/Classes/Views/ARGeneViewController.m
+++ b/Artsy/Classes/Views/ARGeneViewController.m
@@ -211,9 +211,11 @@
     [self getNextGeneArtworks];
 }
 
-- (void)shareGene:(id)sender
+- (void)shareGene:(UIButton *)sender
 {
-    [ARSharingController shareObject:self.gene withThumbnailImageURL:self.gene.smallImageURL];
+    ARSharingController *sharingController = [ARSharingController sharingControllerWithObject:self.gene
+                                                                            thumbnailImageURL:self.gene.smallImageURL];
+    [sharingController presentActivityViewControllerOverViewController:self fromView:sender];
 }
 
 -(BOOL)shouldAutorotate

--- a/Artsy/Classes/Views/ARGeneViewController.m
+++ b/Artsy/Classes/Views/ARGeneViewController.m
@@ -215,7 +215,7 @@
 {
     ARSharingController *sharingController = [ARSharingController sharingControllerWithObject:self.gene
                                                                             thumbnailImageURL:self.gene.smallImageURL];
-    [sharingController presentActivityViewControllerOverViewController:self fromView:sender];
+    [sharingController presentActivityViewControllerFromView:sender];
 }
 
 -(BOOL)shouldAutorotate

--- a/Artsy/Classes/Views/ARGeneViewController.m
+++ b/Artsy/Classes/Views/ARGeneViewController.m
@@ -215,7 +215,7 @@
 {
     ARSharingController *sharingController = [ARSharingController sharingControllerWithObject:self.gene
                                                                             thumbnailImageURL:self.gene.smallImageURL];
-    [sharingController presentActivityViewControllerFromView:sender];
+    [sharingController presentActivityViewControllerFromButton:sender];
 }
 
 -(BOOL)shouldAutorotate

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -190,7 +190,7 @@ SPEC CHECKSUMS:
   AFHTTPRequestOperationLogger: 890afab1adb178314d33c4de9d2aa5a42cc594b9
   AFNetworking: 80c4e0652b08eb34e25b9c0ff3c82556fe5967b4
   AFOAuth1Client: 53c76d9cadd73142a9f73854456d5d970bdc147a
-  ALPValidator: 33ec78108e2389b903f066179973dbb1679d82c1
+  ALPValidator: 13bc680ecba56a5385ade37137d7cc75a16e5504
   ARAnalytics: 4626cd58b4ab08ca4857da8ecf02e47c6f6bdefa
   ARASCIISwizzle: 01fc71ffac975f18079a249b0608c9769a9fc4b6
   ARCollectionViewMasonryLayout: 164b82010cf8ec99bc7a38cffe59a179d7e5a116

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Fix a crash when sharing from an iPad. - alloy
 * Fix a crash when swiping between artworks. - alloy
 * Tapping YOU as a Trial User invokes signup - 1aurabrown
 * Share URLs always use desktop, not martsy, urls -- 1aurabrown


### PR DESCRIPTION
On iPad a UIActivityViewController has to be shown in a UIPopoverController.

I chose a somewhat unusual route to not have to retain the popover, because doing so would mean that the callers would have to also retain the ARSharingController and then there would also have to be a delegate for when it can all be released. As it seems that on iOS 8 the popover is retained by the system and we’re moving away from iOS 7 soon anyways, this seemed like a good compromise.

Fixes #239