### PR TITLE
@1aurabrown => [Fair] Show editorial content.

### DIFF
--- a/Artsy/Classes/View Controllers/ARFairViewController.m
+++ b/Artsy/Classes/View Controllers/ARFairViewController.m
@@ -33,6 +33,7 @@ NSString * const ARFairHighlightFavoritePartnersKey = @"ARFairHighlightFavoriteP
 @property (nonatomic, strong) ARNavigationButtonsViewController *primaryNavigationVC;
 @property (nonatomic, strong) ARFairSectionViewController *categoryCollectionVC;
 @property (nonatomic, strong) ARNavigationButtonsViewController *curatorVC;
+@property (nonatomic, strong) ARNavigationButtonsViewController *editorialVC;
 @property (nonatomic, strong) ARFairPostsViewController *fairPostsVC;
 @property (nonatomic, strong) NSLayoutConstraint *searchConstraint;
 
@@ -121,6 +122,12 @@ NSString * const ARFairHighlightFavoritePartnersKey = @"ARFairHighlightFavoriteP
     self.primaryNavigationVC.view.hidden = YES;
     [self.stackView.stackView addSubview:self.primaryNavigationVC.view withTopMargin:@"12" sideMargin:@"20"];
 
+    self.editorialVC = [[ARNavigationButtonsViewController alloc] init];
+    [(ORStackView *)self.editorialVC.view addPageTitleWithString:@"Fair Highlights"];
+    [(ORStackView *)self.editorialVC.view addGenericSeparatorWithSideMargin: @"20"];
+    self.editorialVC.view.hidden = YES;
+    [self.stackView.stackView addSubview:self.editorialVC.view withTopMargin:@"60" sideMargin:@"20"];
+
     self.curatorVC = [[ARNavigationButtonsViewController alloc] init];
     [(ORStackView *)self.curatorVC.view addPageTitleWithString:@"Insider's Picks"];
     [(ORStackView *)self.curatorVC.view addGenericSeparatorWithSideMargin: @"20"];
@@ -160,6 +167,21 @@ NSString * const ARFairHighlightFavoritePartnersKey = @"ARFairHighlightFavoriteP
                 break;
             };
 
+            for (OrderedSet *curatorSet in orderedSets[@"editorial"]) {
+              [curatorSet getItems:^(NSArray *items) {
+                @strongify(self);
+                self.editorialVC.buttonDescriptions = [[items select:displayOnMobile] map:^(FeaturedLink *link) {
+                  return [self buttonDescriptionForFeaturedLink:link buttonClass:[ARButtonWithImage class]];
+                }];
+                self.editorialVC.view.hidden = NO;
+                if (self.editorialVC.buttonDescriptions.count == 0) {
+                  [self.stackView.stackView removeSubview:self.editorialVC.view];
+                }
+              }];
+              // TODO why always break after the first set and not just get the first set?
+              break;
+            }
+
             for (OrderedSet *curatorSet in orderedSets[@"curator"]) {
                 [curatorSet getItems:^(NSArray *items) {
                     @strongify(self);
@@ -174,6 +196,7 @@ NSString * const ARFairHighlightFavoritePartnersKey = @"ARFairHighlightFavoriteP
 
                 break;
             }
+
         }];
     }];
 

--- a/Artsy/Classes/Views/Table View Cells/ARButtonWithImage.m
+++ b/Artsy/Classes/Views/Table View Cells/ARButtonWithImage.m
@@ -1,6 +1,8 @@
 #import "ARButtonWithImage.h"
 #import "ARFeedImageLoader.h"
 
+const CGFloat TitlesMargin = 5;
+
 @interface ARButtonWithImage ()
 
 @property (readonly, nonatomic, strong) UIView *contentView;
@@ -10,6 +12,7 @@
 @property (readonly, nonatomic, strong) UIView *labelContainer;
 @property (readonly, nonatomic, strong) UILabel *actualTitleLabel;
 @property (readonly, nonatomic, strong) UILabel *subtitleLabel;
+@property (readonly, nonatomic, strong) NSLayoutConstraint *titlesMarginConstraint;
 
 @property (readonly, nonatomic, strong) UIImageView *buttonArrowView;
 
@@ -71,9 +74,8 @@
     self.buttonImageView.contentMode = UIViewContentModeScaleAspectFill;
     self.buttonImageView.clipsToBounds = YES;
 
+    [self.buttonImageView alignCenterYWithView:self.contentView predicate:nil];
     [self.buttonImageView alignLeadingEdgeWithView:self.contentView predicate:@"10"];
-    [self.buttonImageView alignTopEdgeWithView:self.contentView predicate:@"12"];
-    [self.contentView alignBottomEdgeWithView:self.buttonImageView predicate:@"13"];
 
     [self.labelContainer constrainLeadingSpaceToView:self.buttonImageView predicate:@"20"];
     [self.labelContainer alignCenterYWithView:self.contentView predicate:nil];
@@ -81,15 +83,20 @@
     [self.labelContainer alignTopEdgeWithView:self.actualTitleLabel predicate:nil];
     [self.actualTitleLabel alignLeadingEdgeWithView:self.labelContainer predicate:nil];
     [self.actualTitleLabel alignTrailingEdgeWithView:self.labelContainer predicate:nil];
+    _titlesMarginConstraint = [[self.subtitleLabel constrainTopSpaceToView:self.actualTitleLabel predicate:@"0"] lastObject];
     [self.subtitleLabel alignBottomEdgeWithView:self.labelContainer predicate:nil];
-
-    [self.subtitleLabel constrainTopSpaceToView:self.actualTitleLabel predicate:@"5"];
 
     [UIView alignLeadingAndTrailingEdgesOfViews:@[ self.actualTitleLabel, self.subtitleLabel, self.labelContainer ]];
 
     [self.buttonArrowView alignCenterYWithView:self.contentView predicate:nil];
     [self.buttonArrowView alignTrailingEdgeWithView:self.contentView predicate:@"-15@1000"];
     [self.buttonArrowView constrainLeadingSpaceToView:self.labelContainer predicate:@">=8@800"];
+
+    // Constrain size of contentView to content
+    [self.contentView alignTopEdgeWithView:self.buttonImageView predicate:@"<=-12"];
+    [self.contentView alignBottomEdgeWithView:self.buttonImageView predicate:@">=13"];
+    [self.contentView alignTopEdgeWithView:self.labelContainer predicate:@"<=-12"];
+    [self.contentView alignBottomEdgeWithView:self.labelContainer predicate:@">=13"];
 
     return self;
 }
@@ -108,6 +115,8 @@
     _subtitle = [subtitle copy];
 
     self.subtitleLabel.text = subtitle;
+
+    self.titlesMarginConstraint.constant = subtitle.length > 0 ? TitlesMargin : 0;
 }
 
 - (void)setImageURL:(NSURL *)imageURL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.1
+
+* Add previously missing fair editorial content - alloy
+
 ## 1.7.0 (16/2/2015)
 
 * Fair Map will zoom to show annotations on first double tap - 1aurabrown


### PR DESCRIPTION
Fixes #256 & #257.

Makes the rows have variable height, defined by the textual content. Because this slightly changes how the `ARButtonWithImage` layout is calculated, it would be great if you can do a quick check through the app to see if any places are negatively affected.

![ios simulator screen shot 05 mar 2015 19 58 50](https://cloud.githubusercontent.com/assets/2320/6512264/d7fd8c4a-c372-11e4-80d5-aef018247476.png)

![ios simulator screen shot 05 mar 2015 19 58 59](https://cloud.githubusercontent.com/assets/2320/6512267/da700048-c372-11e4-93c9-2d24c073c4f1.png)
