### PR TITLE
@ashfurrow => fix nav button placement on rotation

### DIFF
--- a/Artsy/Classes/View Controllers/ARTopMenuViewController.m
+++ b/Artsy/Classes/View Controllers/ARTopMenuViewController.m
@@ -122,9 +122,7 @@ static const CGFloat ARSearchMenuButtonDimension = 46;
         buttonsWidth += button.intrinsicContentSize.width;
     }];
 
-    BOOL isPortrait = UIInterfaceOrientationIsPortrait([UIApplication sharedApplication].statusBarOrientation);
-
-    CGFloat viewWidth = isPortrait ? self.view.frame.size.width : self.view.frame.size.height;
+    CGFloat viewWidth = self.view.frame.size.width;
     CGFloat extraWidth = viewWidth - buttonsWidth;
     CGFloat eachMargin = floorf(extraWidth / (self.tabContentView.buttons.count - 1));
 


### PR DESCRIPTION
fixes https://github.com/artsy/eigen/issues/267

This was originally written for ios7, which didn't swap frame width and height on rotation for some reason. in iOS 8 they fixed that bug, but our code didn't account for the fix. now it does and it ditches the iOS7 way.