### PR TITLE
@1aurabrown => Pre-caches Hero Unit images.

### DIFF
--- a/Artsy/Classes/View Controllers/ARHeroUnitViewController.m
+++ b/Artsy/Classes/View Controllers/ARHeroUnitViewController.m
@@ -2,6 +2,8 @@
 #import "ARSiteHeroUnitView.h"
 #import "ARHeroUnitsNetworkModel.h"
 
+#import <SDWebImage/SDWebImagePrefetcher.h>
+
 const static CGFloat ARHeroUnitDotsHeight = 30;
 const static CGFloat ARCarouselDelay = 10;
 
@@ -83,6 +85,13 @@ const static CGFloat ARCarouselDelay = 10;
 
         self.view.userInteractionEnabled = YES;
         [self updateViewWithHeroUnits:heroUnits];
+
+        // Grab all but the first and try to pre-download them.
+        NSArray *urls = [[heroUnits subarrayWithRange:NSMakeRange(1, heroUnits.count-1)] map:^id(SiteHeroUnit *unit) {
+            return unit.preferredImageURL;
+        }];
+        [SDWebImagePrefetcher.sharedImagePrefetcher prefetchURLs:urls];
+
         [self startTimer];
 
     } failure:^(NSError *error) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Pre-caches hero unit images — @ashfurrow
+
 ## 1.7.1 (06/03/2015)
 
 * Add previously missing fair editorial content - alloy


### PR DESCRIPTION
Pretty simple fix – when we get the hero units, download their images.

I've opened a [related issue](https://github.com/rs/SDWebImage/issues/1064) on SDWebImage, our image-caching library.

Fixes #251.