### PR TITLE
Use master branch for build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Artsy Eigen
 
-[![Build Status](https://travis-ci.org/artsy/eigen.svg)](https://travis-ci.org/artsy/eigen)
+[![Build Status](https://travis-ci.org/artsy/eigen.svg?branch=master)](https://travis-ci.org/artsy/eigen)
 
 
 <a href="http://iphone.artsy.net"><img src ="https://raw.githubusercontent.com/artsy/eigen/master/docs/screenshots/overview.jpg"></a>


### PR DESCRIPTION
Just a small thing but I was just checking out the README and thought it would make sense to have the Build Status badge displaying the master branch instead of the latest build (which might be failing). Please close if intentional.