### PR TITLE
@ashfurrow => Only show ‘unpublished’ work warning once.

### DIFF
--- a/Artsy/Classes/Views/ARArtworkView.m
+++ b/Artsy/Classes/Views/ARArtworkView.m
@@ -145,11 +145,13 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
 
 - (void)addUnpublishedBanner
 {
-    UILabel *warning = [[ARWarningView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.bounds), 88)];
-    warning.text = @"Artwork is unpublished.";
-    warning.tag = ARArtworkUnpublishedWarning;
-    [warning constrainHeight:@"44"];
-    [self.stackView addSubview:warning withTopMargin:@"0" sideMargin:@"0"];
+    if (![self.stackView viewWithTag:ARArtworkUnpublishedWarning]) {
+        UILabel *warning = [[ARWarningView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.bounds), 88)];
+        warning.text = @"Artwork is unpublished.";
+        warning.tag = ARArtworkUnpublishedWarning;
+        [warning constrainHeight:@"44"];
+        [self.stackView addSubview:warning withTopMargin:@"0" sideMargin:@"0"];
+    }
 }
 
 @end

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Only show ‘unpublished’ work warning once - alloy
 * Show more related artworks on an artwork view - alloy
 
 ## 2015.03.03

--- a/docs/eigen_tips.md
+++ b/docs/eigen_tips.md
@@ -6,6 +6,8 @@ Use Quicksilver
 
 Quickly load any type of our primitives ( shows / artworks / artists etc ) by pressing enter on the keyboard when the app loads, typing in your changes and then pressing enter again.
 
+Be sure to sign-in with an admin account if you wish to see admin only content, such as ‘unpublished’ artworks.
+
 Use your `.eigen` file
 -----------------------
 


### PR DESCRIPTION
Fixes #279 

There’s only one right type of overload and it ain’t warnings… ANIMALS!

![](http://i.imgur.com/QKXKNGU.gif)