### PR TITLE
@1aurabrown => Fixes crash caused by assumption that there’s always an artist.

### DIFF
--- a/Artsy Tests/ARArtworkRelatedArtworksViewTests.m
+++ b/Artsy Tests/ARArtworkRelatedArtworksViewTests.m
@@ -170,6 +170,12 @@ describe(@"concerning an artwork at an auction", ^{
 });
 
 describe(@"concerning an artwork at a show", ^{
+    it(@"does not add a section with other works by the same artist if the artwork has no associated artist", ^{
+        relatedView.artwork.artist = nil;
+        [relatedView addSectionsForShow:show];
+        expect([relatedView viewWithTag:ARRelatedArtworksArtistArtworks]).will.beNil();
+    });
+
     __block NSDictionary *otherWorkByArtistJSON = nil;
     __block Artwork *otherWorkByArtist = nil;
 
@@ -191,13 +197,13 @@ describe(@"concerning an artwork at a show", ^{
         expect([relatedView titlesOfArtworksInSectionWithTag:ARRelatedArtworksSameShow]).to.equal(@[otherShowArtwork.title]);
     });
 
-    it(@"adds a section with other works by the same artist (not in the same show?)", ^{
+    it(@"adds a section with other works by the same artist", ^{
         expect([relatedView viewWithTag:ARRelatedArtworksArtistArtworks]).willNot.beNil();
         expect([relatedView titleForSectionWithTag:ARRelatedArtworksArtistArtworks]).to.equal(@"OTHER WORKS BY EL ANATSUI");
         expect([relatedView titlesOfArtworksInSectionWithTag:ARRelatedArtworksArtistArtworks]).to.equal(@[otherWorkByArtist.title]);
     });
 
-    it(@"adds a section with related works (not in the same show?)", ^{
+    it(@"adds a section with related works", ^{
         expect([relatedView viewWithTag:ARRelatedArtworks]).willNot.beNil();
         expect([relatedView titleForSectionWithTag:ARRelatedArtworks]).to.equal(@"RELATED ARTWORKS");
         expect([relatedView titlesOfArtworksInSectionWithTag:ARRelatedArtworks]).to.equal(@[relatedArtwork.title]);

--- a/Artsy/Classes/Models/Artwork.h
+++ b/Artsy/Classes/Models/Artwork.h
@@ -35,6 +35,7 @@ typedef NS_ENUM(NSInteger, ARDimensionMetric) {
 @property (nonatomic, copy) NSString *dimensionsCM;
 @property (nonatomic, copy) NSString *dimensionsInches;
 
+// The artist that created the artwork. This may be `nil`.
 @property (nonatomic, strong) Artist *artist;
 @property (nonatomic, copy) NSString *imageFormatAddress;
 

--- a/Artsy/Classes/Views/ARArtworkRelatedArtworksView.m
+++ b/Artsy/Classes/Views/ARArtworkRelatedArtworksView.m
@@ -169,6 +169,10 @@
 
 - (void)addSectionWithArtistArtworks;
 {
+    if (!self.artwork.artist) {
+        return;
+    }
+
     @weakify(self);
     [self addRelatedArtworkRequest:[self.artwork.artist getArtworksAtPage:1 andParams:nil success:^(NSArray *artworks) {
         @strongify(self);

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Next
+
+* Fix a crash caused by the assumption that an artwork will always have a artist - alloy
 * Browse renamed to Explore - 1aurabrown
 
 ## 2015.03.20


### PR DESCRIPTION
Related to #277.

Alas the crash is no longer visible on hockey app, as I removed the 1.7.2 beta that was using the incorrect profile, which was the one I had.

![](http://i.imgur.com/gvD8bjO.gif)