### PR TITLE
@ashfurrow => support analytics URLs in the ARPersonalizeWebViewController

### DIFF
--- a/Artsy Tests/ARPersonalizeWebViewControllerTests.m
+++ b/Artsy Tests/ARPersonalizeWebViewControllerTests.m
@@ -1,0 +1,26 @@
+#import "ARPersonalizeWebViewController.h"
+
+SpecBegin(ARPersonalizeWebViewController)
+
+__block ARPersonalizeWebViewController *sut;
+
+before(^{
+    sut = [[ARPersonalizeWebViewController alloc] init];
+});
+
+it(@"allows goole urls to pass", ^{
+    NSURL *url = [NSURL URLWithString:@"https://google.com/hi"];
+    NSURLRequest *request = [NSURLRequest requestWithURL:url];
+    BOOL allowed = [sut webView:nil shouldStartLoadWithRequest:request navigationType:UIWebViewNavigationTypeOther];
+    expect(allowed).to.beTruthy();
+});
+
+it(@"returns no on artsy root urls", ^{
+    NSURL *url = [NSURL URLWithString:@"https://staging.artsy.net/"];
+    NSURLRequest *request = [NSURLRequest requestWithURL:url];
+    BOOL allowed = [sut webView:nil shouldStartLoadWithRequest:request navigationType:UIWebViewNavigationTypeOther];
+    expect(allowed).to.beFalsy();
+});
+
+
+SpecEnd

--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -375,6 +375,7 @@
 		60CEA78119B6254800CC3A91 /* ARStubbedArtistNetworkModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 60CEA78019B6254800CC3A91 /* ARStubbedArtistNetworkModel.m */; };
 		60CF97FC17BE9303005ED59B /* ARShadowView.m in Sources */ = {isa = PBXBuildFile; fileRef = 60CF97FB17BE9303005ED59B /* ARShadowView.m */; };
 		60CF980817BF79CA005ED59B /* ARArtistBiographyViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 60CF980717BF79CA005ED59B /* ARArtistBiographyViewController.m */; };
+		60D7FB731AC35F5600F5043A /* ARPersonalizeWebViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 60D7FB721AC35F5600F5043A /* ARPersonalizeWebViewControllerTests.m */; };
 		60D83DE8189EAB82001672E9 /* ARFairShowMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 60D83DE7189EAB82001672E9 /* ARFairShowMapper.m */; };
 		60D83DEE189EE679001672E9 /* ARFairGuideViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 60D83DED189EE679001672E9 /* ARFairGuideViewController.m */; };
 		60D8E63B18D256BB0040BEFD /* ARDemoSplashViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 60D8E63918D256BB0040BEFD /* ARDemoSplashViewController.m */; };
@@ -1194,6 +1195,7 @@
 		60CF97FB17BE9303005ED59B /* ARShadowView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARShadowView.m; sourceTree = "<group>"; };
 		60CF980617BF79CA005ED59B /* ARArtistBiographyViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARArtistBiographyViewController.h; sourceTree = "<group>"; };
 		60CF980717BF79CA005ED59B /* ARArtistBiographyViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARArtistBiographyViewController.m; sourceTree = "<group>"; };
+		60D7FB721AC35F5600F5043A /* ARPersonalizeWebViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARPersonalizeWebViewControllerTests.m; sourceTree = "<group>"; };
 		60D83DE6189EAB82001672E9 /* ARFairShowMapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARFairShowMapper.h; path = models/ARFairShowMapper.h; sourceTree = "<group>"; };
 		60D83DE7189EAB82001672E9 /* ARFairShowMapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ARFairShowMapper.m; path = models/ARFairShowMapper.m; sourceTree = "<group>"; };
 		60D83DEC189EE679001672E9 /* ARFairGuideViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARFairGuideViewController.h; sourceTree = "<group>"; };
@@ -2014,6 +2016,7 @@
 				3CB97D8E1887099E008C44FE /* ARLoginViewControllerTests.m */,
 				3CF144B718E9E00400B1A764 /* ARSignUpSplashViewControllerTests.m */,
 				E6F84D011A0AB40500BF99A3 /* ARSignUpActiveUserViewControllerTests.m */,
+				60D7FB721AC35F5600F5043A /* ARPersonalizeWebViewControllerTests.m */,
 			);
 			name = "Login and Onboarding";
 			sourceTree = "<group>";
@@ -4133,6 +4136,7 @@
 				E6BC2C3E197EDC950063ED3C /* ARBrowseCategoriesViewControllerTests.m in Sources */,
 				3CBB03A8192BA94C00689F89 /* ARFairArtistViewControllerTests.m in Sources */,
 				3CF144B618E4802400B1A764 /* ARSystemTimeTests.m in Sources */,
+				60D7FB731AC35F5600F5043A /* ARPersonalizeWebViewControllerTests.m in Sources */,
 				E6F111A018A2A7CB00D33C3E /* ARBrowseFeaturedLinksCollectionViewTests.m in Sources */,
 				3C7A7FA718C6EDAB00E8D336 /* ArtworkTests.m in Sources */,
 				E67E1DB219475642004252E0 /* ARAnimatedTickViewTest.m in Sources */,

--- a/Artsy/Classes/View Controllers/ARPersonalizeWebViewController.m
+++ b/Artsy/Classes/View Controllers/ARPersonalizeWebViewController.m
@@ -35,11 +35,17 @@
     
     if (shouldLoad && [ARRouter isInternalURL:request.URL] && [path isEqualToString:ARPersonalizePath]) {
         return YES;
-    } else {
 
-        // Force onboarding is all push-state. A new request to load a page indicates that onboarding is complete.
+    } else if ([ARRouter isInternalURL:request.URL] && [path isEqualToString:@"/"]) {
+
+        // Force onboarding is all push-state.
+        // A new request to load the root page indicates that onboarding is complete.
+
         [self.delegate dismissOnboardingWithVoidAnimation:YES];
         return NO;
+
+    } else {
+        return YES;
     }
 }
 


### PR DESCRIPTION
I think since this was created we now do some analytics stuff on force, they were causing our request handler to run finishing the personalize.

Now we whitelist specifically for the root before finishing.