### PR TITLE
@orta => [Navigation] Remove all KVO registrations on view controllers before dealloc.

### DIFF
--- a/Artsy/Classes/View Controllers/ARTopMenuNavigationDataSource.m
+++ b/Artsy/Classes/View Controllers/ARTopMenuNavigationDataSource.m
@@ -44,8 +44,6 @@
 
     _browseViewController = [[ARBrowseViewController alloc] init];
     _browseViewController.networkModel = [[ARBrowseNetworkModel alloc] init];
-
-    
     _browseNavigationController = [[ARNavigationController alloc] initWithRootViewController:_browseViewController];
 
     return self;

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2015.03.27
 
+* Ensure navigation controllers properly cleanup and can’t lead to crashes - alloy
 * Ensure web views properly cleanup and can’t lead to crashes - alloy
 * Ensure labels don’t overlap with chevrons - alloy
 * Add shows and magazine to available tabs - alloy


### PR DESCRIPTION
Fix for https://rink.hockeyapp.net/manage/apps/37020/app_versions/149/crash_reasons/31300472.

The child view controller is released without removing all KVO registrations. This is a guesstimated fix, though, and as this seems to be the first time this crash occurred, it’s kinda fishy, but let’s see if @orta can still reproduce the crash after applying this.