### PR TITLE
@ashfurrow => [ARTextView] Fix a crash related to NSAttributedString+HTML content.

### DIFF
--- a/Artsy Tests/ARArtistViewControllerTests.m
+++ b/Artsy Tests/ARArtistViewControllerTests.m
@@ -105,7 +105,7 @@ itHasSnapshotsForDevices(@"two-rows artworks masonry", ^{
     return vc;
 });
 
-itHasSnapshotsForDevices(@"with a bio", ^{
+itHasAsyncronousSnapshotsForDevices(@"with a bio", ^{
 
     ARArtistViewController *vc = [[ARArtistViewController alloc] initWithArtistID:@"some-artist"];
     networkModel = [[ARStubbedArtistNetworkModel alloc] initWithArtist:vc.artist];

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2015.04.01.1642
+
+* Fix a crash when swiping through artworks that have Markdown content - alloy
+
 ## 2015.04.01
 
 * Update the display of show header images to fit instead of fill - 1aurabrown

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2015.04.01.1642
 
 * Fix a crash when swiping through artworks that have Markdown content - alloy
+* Fix the formatting of title strings when title is absent but date is present - 1aurabrown
 
 ## 2015.04.01
 
@@ -10,7 +11,6 @@
 * Show the ‘YOU’ tab after tapping it and signing-in - alloy
 * Maintain shows and magazine view hierarchies when navigating to other tabs - alloy
 * Logout and switching servers now completely exits app - 1aurabrown
-* fix the formatting of title strings when title is absent but date is present - 1aurabrown
 
 ## 2015.03.31
 


### PR DESCRIPTION
It looks like WebKit is running into some internal cache issues,
which is why deferring to the next runloop iteration fixes it.

In addition, Markdown parsing is now performed on a background thread.

Fixes #348.