### PR TITLE
@orta => Release related fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ set_git_properties:
 	$(PLIST_BUDDY) -c "Set GITRemoteOriginURL $(GIT_REMOTE_ORIGIN_URL)" $(APP_PLIST)
 
 set_targeted_device_family:
-	perl -pi -w -e "s{TARGETED_DEVICE_FAMILY = .*}{TARGETED_DEVICE_FAMILY = $(TARGETED_DEVICE_FAMILY);}g" Artsy.xcodeproj/project.pbxproj
+	perl -pi -w -e "s{TARGETED_DEVICE_FAMILY = \"?[1,2]+\"?;}{TARGETED_DEVICE_FAMILY = $(TARGETED_DEVICE_FAMILY);}g" Artsy.xcodeproj/project.pbxproj
 
 distribute:
 	./config/generate_changelog_short.rb

--- a/docs/deploy_to_app_store.md
+++ b/docs/deploy_to_app_store.md
@@ -29,27 +29,31 @@ See [certs.md](certs.md) for more info on certificates.
 ### Prepare in iTunes Connect
 
 1. You need to have copy for the next release, for minor releases this is just a list of notable changes.
-1. Log in to [iTunes Connect](https://itunesconnect.apple.com) as it@artsymail.com ( team _Art.sy Inc_ ).
-1. Manage Your Apps > Which-ever app > Add new version.
-1. Fill in the copy.
-1. Go back in to the new version and in the top right hit _Mark for Upload_.
+2. Log in to [iTunes Connect](https://itunesconnect.apple.com) as it@artsymail.com ( team _Art.sy Inc_ ).
+3. Manage Your Apps > Which-ever app > Add new version.
+4. Fill in the copy for each localization.
 
 ### Release to AppStore
 
 1. Install HockeyApp from http://hockeyapp.net/apps and run it.
-1. In Xcode, change the target device to _iOS Device_.
-1. In Xcode, hold alt (`⌥`) and go to the menu, hit _Product_ and then _Archive..._.
-1. Check that the Build Configuration is set to _Store_.
-1. Hit _Archive_.
-1. Hit _Distribute_, it will run validations and submit.
+2. In Xcode, change the target device to _iOS Device_.
+3. In Xcode, hold alt (`⌥`) and go to the menu, hit _Product_ and then _Archive..._.
+4. Check that the Build Configuration is set to _Store_.
+5. Hit _Archive_.
+6. Hit _Distribute_, it will run validations and submit.
 
 ### Upon Successful Submission
 
-1. HockeyApp will automatically see your new archive. Push Archived build to HockeyApp as a live build.
-1. Make a git tag for the version with `git tag x.y.z`. Push the tags to `artsy/eigen` with `git push --tags`.
+1. Return to iTunes Connect and click ‘Submit for Review’. Then answer the subequent questions as follows:
+  * Have you added or made changes to encryption features since your last submission of this app?: NO
+  * Does your app contain, display, or access third-party content?: YES
+  * Do you have all necessary rights to that content […]?: YES
+  * Does this app use the Advertising Identifier (IDFA)?: NO
+3. HockeyApp will automatically see your new archive. Push Archived build to HockeyApp as a live build.
+4. Make a git tag for the version with `git tag x.y.z`. Push the tags to `artsy/eigen` with `git push --tags`.
 
 ### Prepare for the Next Release
 
 1. Run `make next`. This runs `pod install` and prompts for the next version number.
-1. Add a new section to CHANGELOG called _Next_.
-1. Add and commit the changed files, typically with `-m "Preparing for development, version X.Y.Z."`.
+2. Add a new section to CHANGELOG called _Next_.
+3. Add and commit the changed files, typically with `-m "Preparing for development, version X.Y.Z."`.


### PR DESCRIPTION
Updates the docs for deploying to the App Store and a fix so that `make next` doesn’t break the Watch target by changing the device to iPhone/iPad.