### PR TITLE
@orta => [Tabs] Fix route used for the magazine, which is now called 'articles'.

### DIFF
--- a/Artsy/Classes/View Controllers/ARTopMenuNavigationDataSource.m
+++ b/Artsy/Classes/View Controllers/ARTopMenuNavigationDataSource.m
@@ -50,7 +50,7 @@
     _browseViewController.networkModel = [[ARBrowseNetworkModel alloc] init];
     _browseNavigationController = [[ARNavigationController alloc] initWithRootViewController:_browseViewController];
 
-    _magazineNavigationController = [self.class internalWebViewNavigationController:@"/magazine"];
+    _magazineNavigationController = [self.class internalWebViewNavigationController:@"/articles"];
 
     return self;
 }


### PR DESCRIPTION
https://github.com/artsy/force/pull/2415

Is there a better way that you’d normally guard against such routes breaking for released versions?