### PR TITLE
@orta => Reload root webviews

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -211,6 +211,7 @@
 		49F45188176A71B50041A4B4 /* ARArtworkSetViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4917819E176A6B22001E751E /* ARArtworkSetViewController.m */; };
 		5122D69A1A89E5F800DA2704 /* ARFairMapAnnotationViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5122D6991A89E5F800DA2704 /* ARFairMapAnnotationViewTests.m */; };
 		513483551AADD0A10062E624 /* PSPDFKitImproveRecursiveDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 513483541AADD0A10062E624 /* PSPDFKitImproveRecursiveDescription.m */; };
+		5144331B1AD68D8400FBBCE5 /* ARTopMenuInternalMobileWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5144331A1AD68D8400FBBCE5 /* ARTopMenuInternalMobileWebViewController.m */; };
 		5174A03B1A859E2C006CD337 /* ARFairMapView.m in Sources */ = {isa = PBXBuildFile; fileRef = 5174A03A1A859E2C006CD337 /* ARFairMapView.m */; };
 		540262C618A0FAFB00844AE1 /* ARButtonWithImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 540262C518A0FAFB00844AE1 /* ARButtonWithImage.m */; };
 		54289FEE18AA7F4E00681E49 /* UINavigationController_InnermostTopViewControllerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 54289FED18AA7F4E00681E49 /* UINavigationController_InnermostTopViewControllerSpec.m */; };
@@ -951,6 +952,8 @@
 		49F0C67E17B972F200721244 /* ARSlideshowView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARSlideshowView.m; sourceTree = "<group>"; };
 		5122D6991A89E5F800DA2704 /* ARFairMapAnnotationViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARFairMapAnnotationViewTests.m; sourceTree = "<group>"; };
 		513483541AADD0A10062E624 /* PSPDFKitImproveRecursiveDescription.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PSPDFKitImproveRecursiveDescription.m; sourceTree = "<group>"; };
+		514433191AD68D8400FBBCE5 /* ARTopMenuInternalMobileWebViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARTopMenuInternalMobileWebViewController.h; sourceTree = "<group>"; };
+		5144331A1AD68D8400FBBCE5 /* ARTopMenuInternalMobileWebViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTopMenuInternalMobileWebViewController.m; sourceTree = "<group>"; };
 		5174A0391A859E2C006CD337 /* ARFairMapView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARFairMapView.h; sourceTree = "<group>"; };
 		5174A03A1A859E2C006CD337 /* ARFairMapView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARFairMapView.m; sourceTree = "<group>"; };
 		540262C418A0FAFB00844AE1 /* ARButtonWithImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARButtonWithImage.h; path = "Table View Cells/ARButtonWithImage.h"; sourceTree = "<group>"; };
@@ -3479,6 +3482,8 @@
 				60647C741A94F71600A45247 /* AREndOfLineInternalMobileWebViewController.m */,
 				60A309A61AC999DE000783C1 /* ARInternalShareValidator.h */,
 				60A309A71AC999DE000783C1 /* ARInternalShareValidator.m */,
+				514433191AD68D8400FBBCE5 /* ARTopMenuInternalMobileWebViewController.h */,
+				5144331A1AD68D8400FBBCE5 /* ARTopMenuInternalMobileWebViewController.m */,
 			);
 			name = "Web Browsing";
 			sourceTree = "<group>";
@@ -4370,6 +4375,7 @@
 				062C202116DD76C90095A7EC /* ARZoomView.m in Sources */,
 				E6A3500518AAEBFF0075398F /* NSKeyedUnarchiver+ErrorLogging.m in Sources */,
 				3CCCC89B18996DD4008015DD /* Post.m in Sources */,
+				5144331B1AD68D8400FBBCE5 /* ARTopMenuInternalMobileWebViewController.m in Sources */,
 				609F985F1AC1054D0079FE21 /* PartnerShowCoordinates.m in Sources */,
 				3CEE0B6818A16F9000FEA6E6 /* ArtsyAPI+Genes.m in Sources */,
 				60F1C51B17C11303000938F7 /* ARGeneViewController.m in Sources */,

--- a/Artsy/Classes/View Controllers/ARInternalMobileWebViewController.m
+++ b/Artsy/Classes/View Controllers/ARInternalMobileWebViewController.m
@@ -12,7 +12,6 @@
 @interface ARInternalMobileWebViewController() <UIAlertViewDelegate, TSMiniWebBrowserDelegate>
 @property (nonatomic, assign) BOOL loaded;
 @property (nonatomic, readonly, strong) ARInternalShareValidator *shareValidator;
-
 @end
 
 @implementation ARInternalMobileWebViewController
@@ -95,7 +94,7 @@
 {
     [super webViewDidFinishLoad:aWebView];
     [self hideLoading];
-    _loaded = YES;
+    self.loaded = YES;
 }
 
 - (void)hideLoading
@@ -125,7 +124,7 @@
     } else if ([ARRouter isInternalURL:request.URL] && ([request.URL.path isEqual:@"/log_in"] || [request.URL.path isEqual:@"/sign_up"])) {
         // hijack AJAX requests
         if ([User isTrialUser]) {
-            [ARTrialController presentTrialWithContext:ARTrialContextNotTrial fromTarget:self selector:@selector(reload)];
+            [ARTrialController presentTrialWithContext:ARTrialContextNotTrial fromTarget:self selector:@selector(userDidSignUp)];
         }
         return NO;
     }
@@ -135,7 +134,7 @@
 
 // A full reload, not just a webView.reload, which only refreshes the view without re-requesting data.
 
-- (void)reload
+- (void)userDidSignUp
 {
     [self.webView loadRequest:[self requestWithURL:self.currentURL]];
 }

--- a/Artsy/Classes/View Controllers/ARInternalMobileWebViewController.m
+++ b/Artsy/Classes/View Controllers/ARInternalMobileWebViewController.m
@@ -10,7 +10,7 @@
 @end
 
 @interface ARInternalMobileWebViewController() <UIAlertViewDelegate, TSMiniWebBrowserDelegate>
-@property (nonatomic, readonly, assign) BOOL loaded;
+@property (nonatomic, assign) BOOL loaded;
 @property (nonatomic, readonly, strong) ARInternalShareValidator *shareValidator;
 
 @end
@@ -57,6 +57,13 @@
 
     ARInfoLog(@"Initialized with URL %@", url);
     return self;
+}
+
+- (void)loadURL:(NSURL *)url
+{
+    self.loaded = NO;
+    [self showLoading];
+    [super loadURL:url];
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Artsy/Classes/View Controllers/ARTopMenuInternalMobileWebViewController.h
+++ b/Artsy/Classes/View Controllers/ARTopMenuInternalMobileWebViewController.h
@@ -1,0 +1,6 @@
+#import "ARInternalMobileWebViewController.h"
+
+@interface ARTopMenuInternalMobileWebViewController : ARInternalMobileWebViewController
+@property (nonatomic, readonly) BOOL shouldBeReloaded;
+- (void)reload;
+@end

--- a/Artsy/Classes/View Controllers/ARTopMenuInternalMobileWebViewController.m
+++ b/Artsy/Classes/View Controllers/ARTopMenuInternalMobileWebViewController.m
@@ -1,0 +1,73 @@
+#import "ARTopMenuInternalMobileWebViewController.h"
+
+#define MAX_AGE 3600 // 1 hour
+
+@interface ARTopMenuInternalMobileWebViewController ()
+@property (nonatomic, assign) BOOL hasSuccessfullyLoadedLastRequest;
+@property (nonatomic, strong) NSDate *lastRequestLoadedAt;
+@end
+
+@implementation ARTopMenuInternalMobileWebViewController
+
+- (void)reload;
+{
+    [self loadURL:self.currentURL];
+}
+
+// If the currently visible view is the root webview, reload it. This ensures that an existing view hierachy isn't
+// thrown out every time the user changes tabs, but that the user also has a way to effectively ‘reload’ a webview.
+// This is needed because there could have been a connectivity/server error at the time of loading and also because
+// content needs to be refreshable.
+//
+- (BOOL)shouldBeReloaded;
+{
+    return !self.hasSuccessfullyLoadedLastRequest || (self.isCurrentlyVisibleViewController && self.isContentStale);
+}
+
+- (BOOL)isCurrentlyVisibleViewController;
+{
+    return self.navigationController.visibleViewController == self;
+}
+
+- (BOOL)isContentStale;
+{
+    return self.lastRequestLoadedAt.timeIntervalSinceNow < -MAX_AGE;
+}
+
+#pragma mark - Overrides
+
+- (instancetype)initWithURL:(NSURL *)url;
+{
+    if ((self = [super initWithURL:url])) {
+        _hasSuccessfullyLoadedLastRequest = YES;
+    }
+    return self;
+}
+
+- (void)loadURL:(NSURL *)url
+{
+    self.lastRequestLoadedAt = nil;
+    [super loadURL:url];
+}
+
+- (void)webViewDidFinishLoad:(UIWebView *)webView;
+{
+    [super webViewDidFinishLoad:webView];
+
+    NSCachedURLResponse *urlResponse = [[NSURLCache sharedURLCache] cachedResponseForRequest:webView.request];
+    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)urlResponse.response;
+    NSInteger statusCode = httpResponse.statusCode;
+    self.hasSuccessfullyLoadedLastRequest = statusCode >= 200 && statusCode < 300;
+
+    if (self.hasSuccessfullyLoadedLastRequest) {
+        self.lastRequestLoadedAt = [NSDate date];
+    }
+}
+
+- (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error;
+{
+    [super webView:webView didFailLoadWithError:error];
+    self.hasSuccessfullyLoadedLastRequest = NO;
+}
+
+@end

--- a/Artsy/Classes/View Controllers/ARTopMenuNavigationDataSource.m
+++ b/Artsy/Classes/View Controllers/ARTopMenuNavigationDataSource.m
@@ -4,27 +4,22 @@
 #import "ARFavoritesViewController.h"
 #import "ARAppSearchViewController.h"
 #import "ARHeroUnitsNetworkModel.h"
-#import "ARInternalMobileWebViewController.h"
+#import "ARTopMenuInternalMobileWebViewController.h"
 #import <SDWebImage/SDWebImagePrefetcher.h>
 
 static ARNavigationController *
-InternalWebViewNavigationControllerWithPath(NSString *path) {
+WebViewNavigationControllerWithPath(NSString *path) {
     NSURL *URL = [NSURL URLWithString:path];
-    ARInternalMobileWebViewController *viewController = [[ARInternalMobileWebViewController alloc] initWithURL:URL];
+    ARTopMenuInternalMobileWebViewController *viewController = [[ARTopMenuInternalMobileWebViewController alloc] initWithURL:URL];
     return [[ARNavigationController alloc] initWithRootViewController:viewController];
 }
 
-// If the currently visible view is the root webview, reload it. This ensures that an existing view hierachy isn't
-// thrown out every time the user changes tabs, but that the user also has a way to effectively ‘reload’ a webview.
-// This is needed because there could have been a connectivity/server error at the time of loading and also because
-// content needs to be refreshable.
-//
 static ARNavigationController *
 RefreshedWebViewNavigationController(ARNavigationController *navigationController) {
     NSArray *viewControllers = navigationController.viewControllers;
-    ARInternalMobileWebViewController *rootViewController = (ARInternalMobileWebViewController *)viewControllers[0];
-    if (navigationController.visibleViewController == rootViewController) {
-        [rootViewController loadURL:rootViewController.currentURL];
+    ARTopMenuInternalMobileWebViewController *viewController = (ARTopMenuInternalMobileWebViewController *)viewControllers[0];
+    if (viewController.shouldBeReloaded) {
+        [viewController reload];
     }
     return navigationController;
 }
@@ -59,13 +54,13 @@ RefreshedWebViewNavigationController(ARNavigationController *navigationControlle
     _showFeedViewController.heroUnitDatasource = [[ARHeroUnitsNetworkModel alloc] init];
     _feedNavigationController = [[ARNavigationController alloc] initWithRootViewController:_showFeedViewController];
 
-    _showsNavigationController = InternalWebViewNavigationControllerWithPath(@"/shows");
+    _showsNavigationController = WebViewNavigationControllerWithPath(@"/shows");
 
     _browseViewController = [[ARBrowseViewController alloc] init];
     _browseViewController.networkModel = [[ARBrowseNetworkModel alloc] init];
     _browseNavigationController = [[ARNavigationController alloc] initWithRootViewController:_browseViewController];
 
-    _magazineNavigationController = InternalWebViewNavigationControllerWithPath(@"/magazine");
+    _magazineNavigationController = WebViewNavigationControllerWithPath(@"/magazine");
 
     return self;
 }


### PR DESCRIPTION
They are now reloaded when you make their tab active, they are the currently visible view controller (so maintain existing deep view hierarchy), and the previous request was unsuccessful _or_ 1 hour has passed since the last load.

I wanted to touch the existing code as little as possible, as to not introduce any regressions, but the reload implementation in `ARInternalMobileWebViewController` and `ARTopMenuInternalMobileWebViewController` could most probably be shared.