### PR TITLE
@orta -> auction results warning rotates on ipad

### DIFF
--- a/Artsy/Classes/View Controllers/ARAuctionArtworkResultsViewController.m
+++ b/Artsy/Classes/View Controllers/ARAuctionArtworkResultsViewController.m
@@ -38,12 +38,11 @@ static const NSInteger ARArtworkIndex = 0;
 
 - (UIView *)createWarningView
 {
-    CGFloat bottomMargin = 12;
-    UIView *container = [[UIView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.view.bounds), 88 + bottomMargin)];
-    UILabel *warning = [[ARWarningView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.view.bounds), 88)];
-    warning.text = @"Note: Auction results are an \nexperimental feature with\n limited data.";
+    UIView *container = [[UIView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.view.bounds), 100)];
+    UILabel *warning = [[ARWarningView alloc] initWithFrame:CGRectZero];
+    warning.text = @"Note: Auction results are an experimental feature with limited data.";
     [container addSubview:warning];
-    [warning alignToView:container];
+    [warning alignTop:@"0" leading:@"0" bottom:@"-12" trailing:@"0" toView:container];
 
     return container;
 }

--- a/Artsy/Classes/Views/ARCustomEigenLabels.m
+++ b/Artsy/Classes/Views/ARCustomEigenLabels.m
@@ -60,4 +60,10 @@
     self.backgroundColor = [UIColor artsyAttention];
 }
 
+- (void)drawTextInRect:(CGRect)rect
+{
+    UIEdgeInsets insets = {0, 60, 0, 60};
+    [super drawTextInRect:UIEdgeInsetsInsetRect(rect, insets)];
+}
+
 @end


### PR DESCRIPTION
i also made the line-wrapping for the label automatic, rather than hard coded because the text was fixed at iphone-width on ipad.

fixes https://github.com/artsy/eigen/issues/131

![screen shot 2015-04-10 at 2 37 31 pm](https://cloud.githubusercontent.com/assets/3171662/7094431/21f74cf4-df8f-11e4-981a-ca2abc93fc13.png)