### PR TITLE
@1aurabrown => [Pods] Pin ORStackView to v2, as the API has changed.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -48,7 +48,7 @@ pod 'MultiDelegate', '0.0.2'
 pod 'ReactiveCocoa', '2.3'
 pod 'ALPValidator', '0.0.3'
 pod 'ORKeyboardReactingApplication', '0.5.3'
-pod 'ORStackView', :head
+pod 'ORStackView', '~> 2.0'
 pod 'ARTiledImageView', :git => 'https://github.com/dblock/ARTiledImageView', :commit => '1a31b864d1d56b1aaed0816c10bb55cf2e078bb8'
 pod 'ARCollectionViewMasonryLayout', :git => 'https://github.com/ashfurrow/ARCollectionViewMasonryLayout', :commit => '2ee871f509806af147d0529a36f791906997d4b7'
 pod 'ARGenericTableViewController', '1.0.2'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -73,7 +73,7 @@ PODS:
   - OCMock (2.2.4)
   - OHHTTPStubs (3.1.2)
   - ORKeyboardReactingApplication (0.5.3)
-  - ORStackView (HEAD based on 2.0.0):
+  - ORStackView (2.0.0):
     - FLKAutoLayout (~> 0.1)
   - ReactiveCocoa (2.3):
     - ReactiveCocoa/UI (= 2.3)
@@ -141,7 +141,7 @@ DEPENDENCIES:
   - OCMock (= 2.2.4)
   - OHHTTPStubs (= 3.1.2)
   - ORKeyboardReactingApplication (= 0.5.3)
-  - ORStackView (HEAD)
+  - ORStackView (~> 2.0)
   - ReactiveCocoa (= 2.3)
   - SDWebImage (= 3.7.1)
   - Specta


### PR DESCRIPTION
ORStackView has changed the use of string margin predicates to floats, which is perfectly :+1: imo, but this means that we need to explicitly use v2 atm.

https://github.com/orta/ORStackView/pull/27