### PR TITLE
@anyone => Updates to ARAnalytics 3.0.0 with Snowplow support

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -89,9 +89,9 @@ pod 'FODFormKit', :git => 'https://github.com/1aurabrown/FODFormKit.git'
 # Analytics
 pod 'HockeySDK', '3.5.0'
 pod 'Mixpanel', '2.3.1'
-pod 'ARAnalytics/Mixpanel', :git => 'https://github.com/orta/ARAnalytics.git'
-pod 'ARAnalytics/HockeyApp', :git => 'https://github.com/orta/ARAnalytics.git'
-pod 'ARAnalytics/DSL', :git => 'https://github.com/orta/ARAnalytics.git'
+pod 'ARAnalytics/Mixpanel'
+pod 'ARAnalytics/HockeyApp'
+pod 'ARAnalytics/DSL'
 pod 'UICKeyChainStore', '1.0.5'
 
 # Fairs

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
   - ALPValidator (0.0.3)
   - ARAnalytics/CoreIOS (3.0.0)
   - ARAnalytics/DSL (3.0.0):
-    - ReactiveCocoa (~> 2.0)
+    - ReactiveCocoa (= 2.3)
     - RSSwizzle (~> 0.1.0)
   - ARAnalytics/HockeyApp (3.0.0):
     - ARAnalytics/CoreIOS
@@ -100,9 +100,9 @@ DEPENDENCIES:
   - AFNetworking (= 1.3.4)
   - AFOAuth1Client (= 0.3.3)
   - ALPValidator (= 0.0.3)
-  - ARAnalytics/DSL (from `https://github.com/orta/ARAnalytics.git`)
-  - ARAnalytics/HockeyApp (from `https://github.com/orta/ARAnalytics.git`)
-  - ARAnalytics/Mixpanel (from `https://github.com/orta/ARAnalytics.git`)
+  - ARAnalytics/DSL
+  - ARAnalytics/HockeyApp
+  - ARAnalytics/Mixpanel
   - ARASCIISwizzle (= 1.1.0)
   - ARCollectionViewMasonryLayout (>= 2.1.1, ~> 2.1)
   - ARGenericTableViewController (= 1.0.2)
@@ -152,8 +152,6 @@ DEPENDENCIES:
   - XCTest+OHHTTPStubSuiteCleanUp (= 1.0.0)
 
 EXTERNAL SOURCES:
-  ARAnalytics:
-    :git: https://github.com/orta/ARAnalytics.git
   ARTiledImageView:
     :commit: 1a31b864d1d56b1aaed0816c10bb55cf2e078bb8
     :git: https://github.com/dblock/ARTiledImageView
@@ -166,9 +164,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/neilang/NAMapKit
 
 CHECKOUT OPTIONS:
-  ARAnalytics:
-    :commit: fa35a18caab902f79046c9f079ba490bfcfed931
-    :git: https://github.com/orta/ARAnalytics.git
   ARTiledImageView:
     :commit: 1a31b864d1d56b1aaed0816c10bb55cf2e078bb8
     :git: https://github.com/dblock/ARTiledImageView
@@ -187,7 +182,7 @@ SPEC CHECKSUMS:
   AFNetworking: cf8e418e16f0c9c7e5c3150d019a3c679d015018
   AFOAuth1Client: 7bac5f9f00a2a97d99d4cb9942a09d0812c5e5b7
   ALPValidator: c74ea0d49bbbff0f8a4228f1eb6589b992255cfe
-  ARAnalytics: 952400e88ab11aa631aa4e0a21a3cf7163d3c8f4
+  ARAnalytics: 9669efd110dd9a92c0b3f6e073f01f8eec9a8a21
   ARASCIISwizzle: 4800c50a918bdc06f6304020e348ef8c15c554ee
   ARCollectionViewMasonryLayout: 98a899a3c9ebf9283e993198e12b54bd3615f672
   ARGenericTableViewController: 61a0897ba66c35111b5d1cc3b44884282bd3c1a5


### PR DESCRIPTION
Related to #384.

Ran tests locally; only failures were snapshot-related and therefore (probably) not caused by this change. 