### PR TITLE
@alloy -> paginate when page controller is tapped

### DIFF
--- a/Artsy Tests/ARHeroUnitTests.m
+++ b/Artsy Tests/ARHeroUnitTests.m
@@ -4,6 +4,8 @@
 #import "SiteHeroUnit.h"
 
 @interface ARSiteHeroUnitViewController : UIViewController
+@property (nonatomic, assign) NSInteger index;
+@property (nonatomic, assign) SiteHeroUnit *heroUnit;
 @end
 
 @interface ARHeroUnitViewController (Test)
@@ -13,6 +15,7 @@
 - (void)startTimer;
 - (void)updateViewWithHeroUnits:(NSArray *)heroUnits;
 - (ARSiteHeroUnitViewController *)currentViewController;
+- (void)pageControlTapped:(id)sender;
 @end
 
 @interface ARHeroUnitsNetworkModel (Test)
@@ -90,6 +93,17 @@ describe(@"with three hero units", ^{
             expect(heroVC.pageControl.numberOfPages).to.equal(3);
         });
 
+        it(@"responds to page control", ^{
+            expect([heroVC currentViewController].index).to.equal(0);
+            expect([heroVC currentViewController].heroUnit).to.equal(heroUnits[0]);
+
+            heroVC.pageControl.currentPage = 1;
+            [heroVC pageControlTapped:heroVC.pageControl];
+
+            expect([heroVC currentViewController].index).to.equal(1);
+            expect([heroVC currentViewController].heroUnit).to.equal(heroUnits[1]);
+        });
+
         it(@"sets the first view controller", ^{
             expect(heroVC.pageViewController.viewControllers.count).to.equal(1);
         });
@@ -152,8 +166,6 @@ describe(@"with one hero unit", ^{
             expect(currentViewController).to.beKindOf([ARSiteHeroUnitViewController class]);
         });
     });
-
-
 
     it(@"startTimer doesn't set timer for page turn", ^{
         sharedBefore();

--- a/Artsy/Classes/View Controllers/ARHeroUnitViewController.m
+++ b/Artsy/Classes/View Controllers/ARHeroUnitViewController.m
@@ -51,6 +51,8 @@ const static CGFloat ARCarouselDelay = 10;
     self.pageControl.pageIndicatorTintColor = [UIColor colorWithWhite:1 alpha:0.5];
     self.pageControl.currentPageIndicatorTintColor = [UIColor whiteColor];
 
+    [self.pageControl addTarget:self action:@selector(pageControlTapped:) forControlEvents:UIControlEventValueChanged];
+
     CAGradientLayer *shadowLayer = [CAGradientLayer layer];
     shadowLayer.colors = @[(id)[UIColor colorWithWhite:0 alpha:.4].CGColor,
                            (id)[UIColor colorWithWhite:0 alpha:.12].CGColor,
@@ -82,6 +84,13 @@ const static CGFloat ARCarouselDelay = 10;
 
         if (timerEnabled) { [self startTimer]; }
     }];
+}
+
+- (void)pageControlTapped:(UIPageControl *)sender
+{
+    NSInteger newIndex = sender.currentPage;
+    UIPageViewControllerNavigationDirection direction = newIndex < [self currentViewController].index ? UIPageViewControllerNavigationDirectionReverse : UIPageViewControllerNavigationDirectionForward;
+    [self goToHeroUnit:[self viewControllerForIndex:newIndex] withDirection:direction];
 }
 
 - (void)viewDidLayoutSubviews
@@ -136,17 +145,22 @@ const static CGFloat ARCarouselDelay = 10;
     }
 }
 
--(void)goToNextHeroUnit
+-(void)goToHeroUnit:(UIViewController *)vc withDirection:(UIPageViewControllerNavigationDirection)direction
 {
     self.pageViewController.view.userInteractionEnabled = NO;
-    UIViewController *nextVC = [self pageViewController:self.pageViewController viewControllerAfterViewController:[self currentViewController]];
     @weakify(self);
-    [self.pageViewController setViewControllers:@[nextVC] direction:UIPageViewControllerNavigationDirectionForward animated:YES completion:^(BOOL finished) {
+    [self.pageViewController setViewControllers:@[vc] direction:direction animated:YES completion:^(BOOL finished) {
         @strongify(self);
         [self.pageControl setCurrentPage:[self currentViewController].index];
         self.pageViewController.view.userInteractionEnabled = YES;
 
     }];
+}
+
+-(void)goToNextHeroUnit
+{
+    UIViewController *nextVC = [self pageViewController:self.pageViewController viewControllerAfterViewController:[self currentViewController]];
+    [self goToHeroUnit:nextVC withDirection:UIPageViewControllerNavigationDirectionForward];
 }
 
 #pragma mark - UIPageViewControllerDataSource

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add a fair network model to improve testing - 1aurabrown
 * Add top rule to main nav to separate it from black content - 1aurabrown
 * Fix buttons that have a partial underlined title on iOS 8.0, 8.1, and 8.2 - alloy
+* Add ability to paginate left and right by tapping hero unit page control - 1aurabrown
 
 ## 2015.04.23
 


### PR DESCRIPTION
fixes https://github.com/artsy/eigen/issues/369

UIPageControl is not built to handle skipping to a specific page, but rather just to move right or left depending which side you tap on. So that's all I added -- moving forward or backward by one page when tapped.