### PR TITLE
@everybody -> [WIP] fix rotation of masonry views by injecting orientation

### DIFF
--- a/Artsy Tests/ARArtworkRelatedArtworksViewTests.m
+++ b/Artsy Tests/ARArtworkRelatedArtworksViewTests.m
@@ -242,10 +242,8 @@ describe(@"concerning layout", ^{
         });
 
         it(@"returns correct layout for orientation", ^{
-//            expect([relatedView masonryLayoutForPadWithOrientation:UIInterfaceOrientationLandscapeLeft]).to.equal(ARArtworkMasonryLayout4Column);
-//            expect([relatedView masonryLayoutForPadWithOrientation:UIInterfaceOrientationLandscapeRight]).to.equal(ARArtworkMasonryLayout4Column);
-//            expect([relatedView masonryLayoutForPadWithOrientation:UIInterfaceOrientationPortrait]).to.equal(ARArtworkMasonryLayout3Column);
-//            expect([relatedView masonryLayoutForPadWithOrientation:UIInterfaceOrientationPortraitUpsideDown]).to.equal(ARArtworkMasonryLayout3Column);
+            expect([relatedView masonryLayoutForPadWithSize:CGSizeMake(400, 300)]).to.equal(ARArtworkMasonryLayout4Column);
+            expect([relatedView masonryLayoutForPadWithSize:CGSizeMake(300, 400)]).to.equal(ARArtworkMasonryLayout3Column);
         });
     });
 });

--- a/Artsy Tests/ARArtworkRelatedArtworksViewTests.m
+++ b/Artsy Tests/ARArtworkRelatedArtworksViewTests.m
@@ -242,10 +242,10 @@ describe(@"concerning layout", ^{
         });
 
         it(@"returns correct layout for orientation", ^{
-            expect([relatedView masonryLayoutForPadWithOrientation:UIInterfaceOrientationLandscapeLeft]).to.equal(ARArtworkMasonryLayout4Column);
-            expect([relatedView masonryLayoutForPadWithOrientation:UIInterfaceOrientationLandscapeRight]).to.equal(ARArtworkMasonryLayout4Column);
-            expect([relatedView masonryLayoutForPadWithOrientation:UIInterfaceOrientationPortrait]).to.equal(ARArtworkMasonryLayout3Column);
-            expect([relatedView masonryLayoutForPadWithOrientation:UIInterfaceOrientationPortraitUpsideDown]).to.equal(ARArtworkMasonryLayout3Column);
+//            expect([relatedView masonryLayoutForPadWithOrientation:UIInterfaceOrientationLandscapeLeft]).to.equal(ARArtworkMasonryLayout4Column);
+//            expect([relatedView masonryLayoutForPadWithOrientation:UIInterfaceOrientationLandscapeRight]).to.equal(ARArtworkMasonryLayout4Column);
+//            expect([relatedView masonryLayoutForPadWithOrientation:UIInterfaceOrientationPortrait]).to.equal(ARArtworkMasonryLayout3Column);
+//            expect([relatedView masonryLayoutForPadWithOrientation:UIInterfaceOrientationPortraitUpsideDown]).to.equal(ARArtworkMasonryLayout3Column);
         });
     });
 });

--- a/Artsy Tests/AREmbeddedModelsViewControllerTests.m
+++ b/Artsy Tests/AREmbeddedModelsViewControllerTests.m
@@ -2,7 +2,7 @@
 #import "ARArtworkMasonryModule.h"
 
 @interface ARArtworkMasonryModule (Private)
-+ (CGFloat)dimensionForlayout:(ARArtworkMasonryLayout)layout;
++ (CGFloat)dimensionForlayout:(ARArtworkMasonryLayout)layout useLandscapeValues:(BOOL)useLandscapeValues;
 @end
 
 static CGFloat
@@ -13,7 +13,7 @@ AspectRatioForMultiplier(CGFloat multiplier, ARArtworkMasonryLayout layout) {
         case ARArtworkMasonryLayout3Column:
         case ARArtworkMasonryLayout4Column:
             {
-                CGFloat dimension = [ARArtworkMasonryModule dimensionForlayout:layout];
+                CGFloat dimension = [ARArtworkMasonryModule dimensionForlayout:layout useLandscapeValues:NO];
                 return dimension / (dimension * multiplier);
             }
 

--- a/Artsy/Classes/View Controllers/ARArtistViewController.m
+++ b/Artsy/Classes/View Controllers/ARArtistViewController.m
@@ -207,6 +207,9 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
+
+    // Ensure that the related artists VC has the correct dimensions to lay out its content BEFORE it appears.
+    [self.relatedArtistsVC.view layoutIfNeeded];
     [self setArtworksHeight];
 }
 
@@ -296,9 +299,9 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
     }
 }
 
-- (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
-    [super willAnimateRotationToInterfaceOrientation:toInterfaceOrientation duration:duration];
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
     [self setArtworksHeight];
 }
 

--- a/Artsy/Classes/View Controllers/ARArtworkFlowModule.m
+++ b/Artsy/Classes/View Controllers/ARArtworkFlowModule.m
@@ -39,7 +39,6 @@
     return layout;
 }
 
-
 - (CGSize)intrinsicSize
 {
     return [self.class intrinsicSizeWithlayout:self.layout andArtworks:self.items];

--- a/Artsy/Classes/View Controllers/ARArtworkMasonryModule.h
+++ b/Artsy/Classes/View Controllers/ARArtworkMasonryModule.h
@@ -14,7 +14,7 @@ typedef NS_ENUM(NSInteger, ARArtworkMasonryLayout){
 
 // A protocol to standardize the way we provide different layout styles to the module.
 @protocol ARArtworkMasonryLayoutProvider <NSObject>
-- (enum ARArtworkMasonryLayout)masonryLayoutForPadWithOrientation:(UIInterfaceOrientation)orientation;
+- (enum ARArtworkMasonryLayout)masonryLayoutForPadWithSize:(CGSize)size;
 @end
 
 @interface ARArtworkMasonryModule : ARModelCollectionViewModule <ARCollectionViewMasonryLayoutDelegate>
@@ -25,8 +25,13 @@ typedef NS_ENUM(NSInteger, ARArtworkMasonryLayout){
 /// Designated initializer. Creates a masonry module with a specific artwork style
 + (instancetype)masonryModuleWithLayout:(enum ARArtworkMasonryLayout)layout andStyle:(enum AREmbeddedArtworkPresentationStyle)style;
 
+
+// Call this method to make the module query it's layout provider for a new layout -- particularly when rotating.
+// You shouldn't really HAVE to do this as the embedded models VC will call this method for you.
+- (void)updateLayoutForSize:(CGSize)size;
+
 /// Get the height of the collection view for a horizontal layout
-+ (CGFloat)intrinsicHeightForHorizontalLayout:(ARArtworkMasonryLayout)layout;
++ (CGFloat)intrinsicHeightForHorizontalLayout:(ARArtworkMasonryLayout)layout useLandscapeValues:(BOOL)useLandscapeValues;
 
 /// Gets the intrinsic property from an existing instance
 - (CGSize)intrinsicSize;

--- a/Artsy/Classes/View Controllers/ARArtworkMasonryModule.m
+++ b/Artsy/Classes/View Controllers/ARArtworkMasonryModule.m
@@ -2,13 +2,14 @@
 #import "ARReusableLoadingView.h"
 #import "ARItemThumbnailViewCell.h"
 #import "ARArtworkWithMetadataThumbnailCell.h"
-
+#import "UIViewController+InnermostTopViewController.h"
 
 @interface ARArtworkMasonryModule()
 @property (nonatomic, strong) ARCollectionViewMasonryLayout *moduleLayout;
 @property (nonatomic, assign) enum AREmbeddedArtworkPresentationStyle style;
 @property (nonatomic, assign, getter = isHorizontal) BOOL horizontalOrientation;
 @property (nonatomic, readonly, strong) ARReusableLoadingView *loadingView;
+@property (nonatomic, readwrite) BOOL useLandscapeValues;
 @end
 
 @implementation ARArtworkMasonryModule
@@ -19,9 +20,8 @@
 
     module.layout = layout;
     module.style = style;
-    if ([UIDevice isPad]) {
-        [[NSNotificationCenter defaultCenter] addObserver:module selector:@selector(orientationChanged:) name:UIDeviceOrientationDidChangeNotification object:nil];
-    }
+    CGRect currentVCFrame = [[ARTopMenuViewController sharedController].rootNavigationController ar_innermostTopViewController].view.frame;
+    module.useLandscapeValues = CGRectGetWidth(currentVCFrame) > CGRectGetHeight(currentVCFrame);
     return module;
 }
 
@@ -31,10 +31,10 @@
     return [self masonryModuleWithLayout:layout andStyle:AREmbeddedArtworkPresentationStyleArtworkOnly];
 }
 
-+ (CGFloat)intrinsicHeightForHorizontalLayout:(ARArtworkMasonryLayout)layout
++ (CGFloat)intrinsicHeightForHorizontalLayout:(ARArtworkMasonryLayout)layout useLandscapeValues:(BOOL)useLandscapeValues
 {
     NSAssert([self.class layoutIsHorizontal:layout], @"intrinsicHeightForHorizontalLayout must be given a horizontal layout.");
-    CGFloat height = [self dimensionForlayout:layout];
+    CGFloat height = [self dimensionForlayout:layout useLandscapeValues:useLandscapeValues];
     CGFloat margin = [self itemMarginsforLayout:layout].height;
     CGFloat rank = [self rankForlayout:layout];
     height = (rank * height) + ((rank - 1) * margin);
@@ -75,7 +75,7 @@
     }
 }
 
-+ (CGFloat)dimensionForlayout:(ARArtworkMasonryLayout)layout
++ (CGFloat)dimensionForlayout:(ARArtworkMasonryLayout)layout useLandscapeValues:(BOOL)useLandscapeValues
 {
     CGRect screenRect = [[UIScreen mainScreen] bounds];
     CGFloat width = CGRectGetWidth(screenRect);
@@ -91,8 +91,7 @@
         case ARArtworkMasonryLayout3Column:
             // The 3-column layout is only used on iPad.
             NSAssert([UIDevice isPad], @"ARARtworkMasonryLayout3Column is intended for use with iPad");
-            UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
-            if (UIInterfaceOrientationIsLandscape(orientation)) {
+            if (useLandscapeValues) {
                 return 280;
             } else {
                 return 200;
@@ -105,10 +104,10 @@
 
         case ARArtworkMasonryLayout2Row:
             if ([UIDevice isPad]) {
-                if (UIInterfaceOrientationIsPortrait([[UIApplication sharedApplication] statusBarOrientation])) {
-                    return 134;
-                } else {
+                if (useLandscapeValues) {
                     return 184;
+                } else {
+                    return 134;
                 }
             } else {
                 return 120;
@@ -143,34 +142,35 @@
 }
 
 
-- (void)orientationChanged:(id)sender
+- (void)updateLayoutForSize:(CGSize)size
 {
+    self.useLandscapeValues = size.width > size.height;
+
     // Only called if current device is an iPad
     if (self.layoutProvider) {
-        self.layout = [self.layoutProvider masonryLayoutForPadWithOrientation:[[UIApplication sharedApplication] statusBarOrientation]];
+        self.layout = [self.layoutProvider masonryLayoutForPadWithSize:size];
     } else {
-        [self setup];
+        [self setupWithLandscapeOrientation:self.useLandscapeValues];
     }
 }
 
 - (void)setLayout:(enum ARArtworkMasonryLayout)layout
 {
     _layout = layout;
-    [self setup];
+    [self setupWithLandscapeOrientation:self.useLandscapeValues];
 }
 
 - (CGSize)intrinsicSize
 {
-    UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
     CGSize screenSize = [[UIScreen mainScreen] bounds].size;
-    CGFloat width = UIInterfaceOrientationIsLandscape(orientation) ? screenSize.height : screenSize.width;
+    CGFloat width = screenSize.width;
     CGFloat height;
     if ([self.class layoutIsHorizontal:self.layout]) {
-        height = [self.class intrinsicHeightForHorizontalLayout:self.layout];
+        height = [self.class intrinsicHeightForHorizontalLayout:self.layout useLandscapeValues:self.useLandscapeValues];
     } else {
         NSMutableArray *lengths = [NSMutableArray array];
         for (Artwork *artwork in self.items) {
-            CGFloat itemLength = [self.class variableDimensionForItem:artwork style:self.style layout:self.layout];
+            CGFloat itemLength = [self.class variableDimensionForItem:artwork style:self.style layout:self.layout useLandscapeValues:self.useLandscapeValues];
             [lengths addObject:@( itemLength )];
         }
 
@@ -190,7 +190,7 @@
     }
 }
 
-- (void)setup
+- (void)setupWithLandscapeOrientation:(BOOL)useLandscapeValues
 {
     self.horizontalOrientation = [self.class layoutIsHorizontal:self.layout];
 
@@ -200,19 +200,19 @@
 
     self.moduleLayout.itemMargins = [self.class itemMarginsforLayout:self.layout];
     self.moduleLayout.rank = [self.class rankForlayout:self.layout];
-    self.moduleLayout.dimensionLength = [self.class dimensionForlayout:self.layout];
+    self.moduleLayout.dimensionLength = [self.class dimensionForlayout:self.layout useLandscapeValues:useLandscapeValues];
     self.moduleLayout.contentInset = [self.class edgeInsetsForlayout:self.layout];
 }
 
 - (CGFloat)collectionView:(UICollectionView *)collectionView layout:(ARCollectionViewMasonryLayout *)collectionViewLayout variableDimensionForItemAtIndexPath:(NSIndexPath *)indexPath
 {
     Artwork *item = self.items[indexPath.row];
-    return [[self class] variableDimensionForItem:item style:self.style layout:self.layout];
+    return [[self class] variableDimensionForItem:item style:self.style layout:self.layout useLandscapeValues:self.useLandscapeValues];
 }
 
-+ (CGFloat)variableDimensionForItem:(Artwork *)item style:(AREmbeddedArtworkPresentationStyle)style layout:(ARArtworkMasonryLayout)layout
++ (CGFloat)variableDimensionForItem:(Artwork *)item style:(AREmbeddedArtworkPresentationStyle)style layout:(ARArtworkMasonryLayout)layout useLandscapeValues:(BOOL)useLandscapeValues
 {
-    CGFloat staticDimension = [self.class dimensionForlayout:layout];
+    CGFloat staticDimension = [self.class dimensionForlayout:layout useLandscapeValues:useLandscapeValues];
     CGFloat variableDimension = 0;
 
     // Set the artwork height/width for the artwork based on the layout

--- a/Artsy/Classes/View Controllers/ARArtworkViewController.m
+++ b/Artsy/Classes/View Controllers/ARArtworkViewController.m
@@ -104,8 +104,8 @@
     // When we get back from zoom / VIR allow the preview to do trigger zoom
     self.view.metadataView.userInteractionEnabled = YES;
     [super viewDidAppear:self.shouldAnimate && animated];
-    CGSize size = self.view.frame.size;
-    [self.view.metadataView updateConstraintsIsLandscape:size.width > size.height];
+    CGRect frame = self.view.frame;
+    [self.view.metadataView updateConstraintsIsLandscape:CGRectGetWidth(frame) > CGRectGetHeight(frame)];
 }
 
 - (void)viewDidDisappear:(BOOL)animated

--- a/Artsy/Classes/View Controllers/AREmbeddedModelsViewController.h
+++ b/Artsy/Classes/View Controllers/AREmbeddedModelsViewController.h
@@ -17,7 +17,7 @@
 /// This message gets passed if the edge is reached. Currently
 /// unimplemented, may be moved to a block property.
 - (void)embeddedModelsViewControllerDidScrollPastEdge:(AREmbeddedModelsViewController *)controller;
-
+- (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath;
 @end
 
 

--- a/Artsy/Classes/View Controllers/AREmbeddedModelsViewController.m
+++ b/Artsy/Classes/View Controllers/AREmbeddedModelsViewController.m
@@ -37,6 +37,19 @@
     self.collectionView.frame = self.view.bounds;
 }
 
+
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
+{
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+        [self.view setNeedsUpdateConstraints];
+
+    } completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+
+    }];
+}
+
 - (UICollectionView *)createCollectionView
 {
     // Because the collection view is lazily created at view will appear

--- a/Artsy/Classes/View Controllers/AREmbeddedModelsViewController.m
+++ b/Artsy/Classes/View Controllers/AREmbeddedModelsViewController.m
@@ -42,12 +42,15 @@
 {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
 
+    if ([self.activeModule isKindOfClass:[ARArtworkMasonryModule class]]) {
+        [(ARArtworkMasonryModule *)self.activeModule updateLayoutForSize:size];
+    }
+
+    [self.view setNeedsUpdateConstraints];
+
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
-        [self.view setNeedsUpdateConstraints];
-
-    } completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
-
-    }];
+        [self.view layoutIfNeeded];
+    } completion:nil];
 }
 
 - (UICollectionView *)createCollectionView
@@ -161,11 +164,7 @@
     [super updateViewConstraints];
 
     if (self.heightConstraint) {
-        if (self.collectionView.contentSize.height != 0) {
-            self.heightConstraint.constant = self.collectionView.contentSize.height;
-        } else {
             self.heightConstraint.constant = self.activeModule.intrinsicSize.height;
-        }
     }
 }
 

--- a/Artsy/Classes/View Controllers/AREmbeddedModelsViewController.m
+++ b/Artsy/Classes/View Controllers/AREmbeddedModelsViewController.m
@@ -164,7 +164,7 @@
     [super updateViewConstraints];
 
     if (self.heightConstraint) {
-            self.heightConstraint.constant = self.activeModule.intrinsicSize.height;
+        self.heightConstraint.constant = self.activeModule.intrinsicSize.height;
     }
 }
 
@@ -283,6 +283,15 @@
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout referenceSizeForFooterInSection:(NSInteger)section
 {
     return self.showTrailingLoadingIndicator ? CGSizeMake(CGRectGetWidth(self.collectionView.bounds), 44) : CGSizeZero;
+}
+
+- (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewFlowLayout *)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath
+{
+    if ([self.delegate respondsToSelector:@selector(collectionView:layout:sizeForItemAtIndexPath:)]) {
+        return [self.delegate collectionView:collectionView layout:collectionViewLayout sizeForItemAtIndexPath:indexPath];
+    } else {
+        return collectionViewLayout.itemSize;
+    }
 }
 
 #pragma mark ARCollectionViewMasonryLayoutDelegate Methods

--- a/Artsy/Classes/View Controllers/ARFavoriteItemModule.m
+++ b/Artsy/Classes/View Controllers/ARFavoriteItemModule.m
@@ -10,10 +10,6 @@
     UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
     CGFloat sideMargin = [UIDevice isPad] ? 50 : 20;
     layout.sectionInset = UIEdgeInsetsMake(20, sideMargin, 20, sideMargin);
-    UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
-    CGFloat width = [ARFavoriteItemViewCell widthForCellWithOrientation:orientation];
-    CGFloat height = [ARFavoriteItemViewCell heightForCellWithOrientation:orientation];
-    layout.itemSize = (CGSize){ width, height };
     _moduleLayout = layout;
     return self;
 }

--- a/Artsy/Classes/View Controllers/ARFavoritesViewController.m
+++ b/Artsy/Classes/View Controllers/ARFavoritesViewController.m
@@ -108,7 +108,7 @@
     _artistFavoritesNetworkModel = [[ARArtistFavoritesNetworkModel alloc] init];
     _geneFavoritesNetworkModel = [[ARGeneFavoritesNetworkModel alloc] init];
 
-    ARArtworkMasonryLayout layout = [UIDevice isPad] ? [self masonryLayoutForPadWithOrientation:[[UIApplication sharedApplication] statusBarOrientation]] : ARArtworkMasonryLayout2Column;
+    ARArtworkMasonryLayout layout = [UIDevice isPad] ? [self masonryLayoutForPadWithSize:self.view.frame.size] : ARArtworkMasonryLayout2Column;
     _artworksModule = [ARArtworkMasonryModule masonryModuleWithLayout:layout andStyle:AREmbeddedArtworkPresentationStyleArtworkMetadata];
     _artworksModule.layoutProvider = self;
     _artistsModule = [[ARFavoriteItemModule alloc] init];

--- a/Artsy/Classes/View Controllers/ARFavoritesViewController.m
+++ b/Artsy/Classes/View Controllers/ARFavoritesViewController.m
@@ -72,6 +72,8 @@
 
 - (void)viewDidLoad
 {
+    [super viewDidLoad];
+
     self.embeddedItemsVC.delegate = self;
     self.embeddedItemsVC.showTrailingLoadingIndicator = YES;
 
@@ -118,11 +120,9 @@
 
     self.embeddedItemsVC.scrollDelegate = [ARScrollNavigationChief chief];
 
-    [self setModuleItemSizesForOrientation:[UIApplication sharedApplication].statusBarOrientation];
     [self.embeddedItemsVC.headerView updateConstraints];
     self.collectionView.scrollsToTop = YES;
 
-    [super viewDidLoad];
 }
 
 - (UICollectionView *)collectionView
@@ -135,24 +135,15 @@
     return [UIDevice isPad] ? 193 : 127;
 }
 
-- (ARArtworkMasonryLayout)masonryLayoutForPadWithOrientation:(UIInterfaceOrientation)orientation
+- (ARArtworkMasonryLayout)masonryLayoutForPadWithSize:(CGSize)size
 {
-    return UIInterfaceOrientationIsLandscape(orientation) ? ARArtworkMasonryLayout4Column : ARArtworkMasonryLayout3Column;
+    return (size.width > size.height) ? ARArtworkMasonryLayout4Column : ARArtworkMasonryLayout3Column;
 }
 
-- (void)setModuleItemSizesForOrientation:(UIInterfaceOrientation)orientation
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
-    CGFloat width = [ARFavoriteItemViewCell widthForCellWithOrientation:orientation];
-    CGFloat height = [ARFavoriteItemViewCell heightForCellWithOrientation:orientation];
-
-    self.genesModule.moduleLayout.itemSize = (CGSize){ width, height };
-    self.artistsModule.moduleLayout.itemSize = (CGSize){ width, height };
-}
-
-- (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
-{
-    [super willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
-    [self setModuleItemSizesForOrientation:(UIInterfaceOrientation)toInterfaceOrientation];
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    [self.embeddedItemsVC.collectionView.collectionViewLayout invalidateLayout];
 }
 
 - (void)viewWillDisappear:(BOOL)animated
@@ -161,6 +152,12 @@
     self.embeddedItemsVC.scrollDelegate = nil;
 
     [super viewWillDisappear:animated];
+}
+
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+    [self.embeddedItemsVC.collectionView.collectionViewLayout invalidateLayout];
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -318,6 +315,15 @@
 - (void)embeddedModelsViewControllerDidScrollPastEdge:(AREmbeddedModelsViewController *)embeddedModelsViewController
 {
     [self getNextItemSet];
+}
+
+- (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)layout sizeForItemAtIndexPath:(NSIndexPath *)indexPath
+{
+    if (layout == self.genesModule.moduleLayout || layout == self.artistsModule.moduleLayout) {
+        return [ARFavoriteItemViewCell sizeForCellwithSize:self.view.frame.size];
+    } else {
+        return CGSizeZero;
+    }
 }
 
 #pragma mark - ARSwitchViewDelegate

--- a/Artsy/Classes/View Controllers/ARFeedViewController.m
+++ b/Artsy/Classes/View Controllers/ARFeedViewController.m
@@ -20,6 +20,7 @@
 @property (nonatomic, readonly) BOOL shouldRefreshFeed;
 @property (nonatomic, readwrite, assign) NSInteger refreshFeedInterval;
 @property (nonatomic, readonly, assign) BOOL loading;
+@property (nonatomic, readwrite) BOOL useLandscapeValues;
 @end
 
 @implementation ARFeedViewController
@@ -60,6 +61,11 @@
 
     [tableView alignToView:self.view];
     self.tableView = tableView;
+}
+
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
+{
+    self.useLandscapeValues = size.width > size.height;
 }
 
 - (Class)classForTableView
@@ -129,7 +135,7 @@
         return [ARFeedStatusIndicatorTableViewCell heightForFeedItemWithState:_footerState];
     } else {
         ARFeedItem *item = [self.feedTimeline itemAtIndex:indexPath.row];
-        return [ARModernPartnerShowTableViewCell heightForItem:item];
+        return [ARModernPartnerShowTableViewCell heightForItem:item useLandscapeValues:self.useLandscapeValues];
     }
 }
 

--- a/Artsy/Classes/View Controllers/ARRelatedArtistsViewController.m
+++ b/Artsy/Classes/View Controllers/ARRelatedArtistsViewController.m
@@ -1,7 +1,7 @@
 #import "ARRelatedArtistsViewController.h"
 #import "ARFavoriteItemViewCell.h"
 
-@interface ARRelatedArtistsViewController () <UICollectionViewDataSource, UICollectionViewDelegate>
+@interface ARRelatedArtistsViewController () <UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout>
 
 @property (nonatomic, strong) UICollectionView *view;
 
@@ -41,24 +41,27 @@
     }
 }
 
-- (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
-    [self setItemSizeForOrientation:toInterfaceOrientation];
-    [self updateHeightConstraint];
-    [super willAnimateRotationToInterfaceOrientation:toInterfaceOrientation duration:duration];
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    [self.view.collectionViewLayout invalidateLayout];
+
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+        [self updateHeightConstraint];
+    } completion:nil];
 }
 
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    [self setItemSizeForOrientation:[UIApplication sharedApplication].statusBarOrientation];
+    [self.view.collectionViewLayout invalidateLayout];
     [self updateHeightConstraint];
 }
 
 - (void) loadView
 {
     UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
-    CGFloat sideMargin = [UIDevice isPad] ?  50 : 20;
+    CGFloat sideMargin = [UIDevice isPad] ? 50 : 20;
     layout.sectionInset = UIEdgeInsetsMake(20, sideMargin, 20, sideMargin);
     UICollectionView *collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
 
@@ -70,16 +73,13 @@
     self.view = collectionView;
 }
 
-- (void)setItemSizeForOrientation:(UIInterfaceOrientation)orientation
-{
-    UICollectionViewFlowLayout *layout = (UICollectionViewFlowLayout *)self.view.collectionViewLayout;
-    layout.itemSize = (CGSize){ [ARFavoriteItemViewCell widthForCellWithOrientation:orientation], [ARFavoriteItemViewCell heightForCellWithOrientation:orientation] };
-    [self.view.collectionViewLayout invalidateLayout];
-    [self.view layoutIfNeeded];
-}
-
 #pragma mark -
 #pragma mark Related artist delegate/datasource
+
+- (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath
+{
+    return [ARFavoriteItemViewCell sizeForCellwithSize:self.parentViewController.view.frame.size];
+}
 
 - (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section;
 {

--- a/Artsy/Classes/View Controllers/ARShowViewController.m
+++ b/Artsy/Classes/View Controllers/ARShowViewController.m
@@ -348,7 +348,7 @@ static const NSInteger ARFairShowMaximumNumberOfHeadlineImages = 5;
 
     ARArtworkMasonryLayout layout;
     if ([UIDevice isPad]) {
-        layout = [self masonryLayoutForPadWithOrientation:[[UIApplication sharedApplication] statusBarOrientation]];
+        layout = [self masonryLayoutForPadWithSize:self.view.frame.size];
     } else {
         layout = ARArtworkMasonryLayout2Column;
     }
@@ -538,9 +538,9 @@ static const NSInteger ARFairShowMaximumNumberOfHeadlineImages = 5;
 }
 
 #pragma mark - ARArtworkMasonryLayoutProvider
-- (ARArtworkMasonryLayout)masonryLayoutForPadWithOrientation:(UIInterfaceOrientation)orientation
+- (ARArtworkMasonryLayout)masonryLayoutForPadWithSize:(CGSize)size
 {
-    return UIInterfaceOrientationIsLandscape(orientation) ? ARArtworkMasonryLayout3Column : ARArtworkMasonryLayout2Column;
+    return size.width > size.height ? ARArtworkMasonryLayout3Column : ARArtworkMasonryLayout2Column;
 }
 
 @end

--- a/Artsy/Classes/View Controllers/ARTopMenuViewController.m
+++ b/Artsy/Classes/View Controllers/ARTopMenuViewController.m
@@ -127,9 +127,11 @@ static const CGFloat ARSearchMenuButtonDimension = 46;
     }];
 }
 
-- (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
     [self.view layoutSubviews];
+
 }
 
 - (void)viewWillLayoutSubviews

--- a/Artsy/Classes/Views/ARArtworkRelatedArtworksView.m
+++ b/Artsy/Classes/Views/ARArtworkRelatedArtworksView.m
@@ -209,7 +209,7 @@
 
     ARArtworkMasonryLayout layout = ARArtworkMasonryLayout2Column;
     if ([UIDevice isPad]) {
-        layout = [self masonryLayoutForPadWithOrientation:[[UIApplication sharedApplication] statusBarOrientation]];
+        layout = [self masonryLayoutForPadWithSize:self.parentViewController.view.frame.size];
     }
     ARArtworkMasonryModule *module = [ARArtworkMasonryModule masonryModuleWithLayout:layout
                                                                             andStyle:AREmbeddedArtworkPresentationStyleArtworkMetadata];
@@ -254,9 +254,9 @@
 
 #pragma mark - ARArtworkMasonryLayoutProvider
 
-- (ARArtworkMasonryLayout)masonryLayoutForPadWithOrientation:(UIInterfaceOrientation)orientation
+- (ARArtworkMasonryLayout)masonryLayoutForPadWithSize:(CGSize)size
 {
-    return UIInterfaceOrientationIsLandscape(orientation) ? ARArtworkMasonryLayout4Column : ARArtworkMasonryLayout3Column;
+    return size.width > size.height ? ARArtworkMasonryLayout4Column : ARArtworkMasonryLayout3Column;
 }
 
 #pragma mark - AREmbeddedModelsDelegate

--- a/Artsy/Classes/Views/ARFavoriteItemViewCell.h
+++ b/Artsy/Classes/Views/ARFavoriteItemViewCell.h
@@ -1,7 +1,6 @@
 @interface ARFavoriteItemViewCell : UICollectionViewCell
 
-+ (CGFloat)heightForCellWithOrientation:(UIInterfaceOrientation)orientation;
-+ (CGFloat)widthForCellWithOrientation:(UIInterfaceOrientation)orientation;
++ (CGSize)sizeForCellwithSize:(CGSize)size;
 - (void)setupWithRepresentedObject:(id)object;
 
 @end

--- a/Artsy/Classes/Views/ARFavoriteItemViewCell.m
+++ b/Artsy/Classes/Views/ARFavoriteItemViewCell.m
@@ -18,41 +18,20 @@ static const CGFloat ARFavoriteCellLabelHeight = 34;
     self.imageView.image = [ARFeedImageLoader defaultPlaceholder];
 }
 
-+ (CGFloat)heightForCellWithOrientation:(UIInterfaceOrientation)orientation
++ (CGSize)sizeForCellwithSize:(CGSize)size
 {
-    return ARFavoriteCellLabelHeight + ARFavoriteCellMetadataMargin + [self heightForImageWithOrientation:orientation];
-}
-
-+ (CGFloat)heightForImageWithOrientation:(UIInterfaceOrientation)orientation
-{
-    CGRect screenRect = [[UIScreen mainScreen] bounds];
-    CGFloat width = CGRectGetWidth(screenRect);
-
+    CGFloat width;
+    CGFloat height;
     if ([UIDevice isPad]) {
-        if (UIInterfaceOrientationIsLandscape(orientation)) {
-            return 184;
-        } else {
-            return 134;
-        }
+        BOOL landscape = size.width > size.height;
+        width = landscape ? 276 : 201;
+        height = landscape ? 184 : 134;
     } else {
-        return width/2 - 70;
+        width = 130;
+        height = 90;
     }
-}
-
-+ (CGFloat)widthForCellWithOrientation:(UIInterfaceOrientation)orientation
-{
-    CGRect screenRect = [[UIScreen mainScreen] bounds];
-    CGFloat width = CGRectGetWidth(screenRect);
-
-    if ([UIDevice isPad]) {
-        if (UIInterfaceOrientationIsLandscape(orientation)) {
-            return 276;
-        } else {
-            return 201;
-        }
-    } else {
-        return width/2 - 30;
-    }
+    height += (ARFavoriteCellMetadataMargin + ARFavoriteCellLabelHeight);
+    return CGSizeMake(width, height);
 }
 
 - (void)setupWithRepresentedObject:(id)object

--- a/Artsy/Classes/Views/ARGeneViewController.m
+++ b/Artsy/Classes/Views/ARGeneViewController.m
@@ -252,13 +252,9 @@
 
 #pragma mark - ARArtworkMasonryLayoutProvider
 
--(ARArtworkMasonryLayout)masonryLayoutForPadWithOrientation:(UIInterfaceOrientation)orientation
+-(ARArtworkMasonryLayout)masonryLayoutForPadWithSize:(CGSize)size
 {
-    if (UIInterfaceOrientationIsLandscape(orientation)) {
-        return ARArtworkMasonryLayout4Column;
-    } else {
-        return ARArtworkMasonryLayout3Column;
-    }
+    return (size.width > size.height) ? ARArtworkMasonryLayout4Column : ARArtworkMasonryLayout3Column;
 }
 #pragma mark - AREmbeddedModelsDelegate
 

--- a/Artsy/Classes/Views/ARGeneViewController.m
+++ b/Artsy/Classes/Views/ARGeneViewController.m
@@ -137,7 +137,7 @@
 
 - (void)createGeneArtworksViewController
 {
-    ARArtworkMasonryLayout layout = [UIDevice isPad] ? [self masonryLayoutForPadWithOrientation:[UIApplication sharedApplication].statusBarOrientation] : ARArtworkMasonryLayout2Column;
+    ARArtworkMasonryLayout layout = [UIDevice isPad] ? [self masonryLayoutForPadWithSize:self.view.frame.size] : ARArtworkMasonryLayout2Column;
 
     ARArtworkMasonryModule *module = [ARArtworkMasonryModule masonryModuleWithLayout:layout andStyle:AREmbeddedArtworkPresentationStyleArtworkMetadata];
 

--- a/Artsy/Classes/Views/Table View Cells/iPhone Feed Items/ARModernPartnerShowTableViewCell.h
+++ b/Artsy/Classes/Views/Table View Cells/iPhone Feed Items/ARModernPartnerShowTableViewCell.h
@@ -18,7 +18,7 @@
 @interface ARModernPartnerShowTableViewCell : UITableViewCell
 
 /// Get the pre-generated height for the table view cell
-+ (CGFloat)heightForItem:(ARFeedItem *)feedItem;
++ (CGFloat)heightForItem:(ARFeedItem *)feedItem useLandscapeValues:(BOOL)useLandscapeValues;
 
 /// Configure the cell with the feed item
 - (void)configureWithFeedItem:(ARFeedItem *)feedItem;

--- a/Artsy/Classes/Views/Table View Cells/iPhone Feed Items/ARModernPartnerShowTableViewCell.m
+++ b/Artsy/Classes/Views/Table View Cells/iPhone Feed Items/ARModernPartnerShowTableViewCell.m
@@ -97,7 +97,7 @@ static CGFloat ARPartnerShowCellSideMargin;
     return item.ausstellungsdauerAndLocation;
 }
 
-+ (CGFloat)heightForItem:(ARPartnerShowFeedItem *)feedItem
++ (CGFloat)heightForItem:(ARPartnerShowFeedItem *)feedItem useLandscapeValues:(BOOL)useLandscapeValues
 {
     CGFloat height = 0;
     PartnerShow *item = feedItem.show;
@@ -123,7 +123,7 @@ static CGFloat ARPartnerShowCellSideMargin;
     BOOL useMasonry = [self shouldUseMultipleRowsForItem:feedItem.show];
 
     ARArtworkMasonryLayout layout = (useMasonry) ? ARArtworkMasonryLayout2Row : ARArtworkMasonryLayout1Row;
-    artworkHeight = [ARArtworkMasonryModule intrinsicHeightForHorizontalLayout:layout];
+    artworkHeight = [ARArtworkMasonryModule intrinsicHeightForHorizontalLayout:layout useLandscapeValues:useLandscapeValues];
     height += (artworkHeight + ARPartnerShowCellBottomMargin);
     if (pregeneratedMargins == 0) {
         NSArray *verticalMargins = @[

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -12,6 +12,7 @@
 * Remove progress indicator from martsy views as soon as the state of the webview is at DOMContentLoaded - alloy
 * Really only show artworks that are for sale on an artist’s ‘for sale’ tab - alloy
 * Fixes iPad sharing hijacking - ash
+* Improve masonry/collection view layout changes when rotation occurs using iOS8 API - 1aurabrown
 
 ## 2015.04.23
 


### PR DESCRIPTION
the masonry module was previously subscribed to orientation notifications from the notification center. this isn't very elegant. It should be able to respond to size change methods from the VC that it belongs to, and it should be able to calculate its dimensions before the rotation actually has occured (ie as the result of something you call in `viewWillTransitionToSize`), rather than querying the _current_ device orientation

This fixes https://github.com/artsy/eigen/issues/368 and probably will make it easier going forward, especially when it comes to multiple screen sizes. We could easily change this dependency injection to accept arbitrary sizes instead of just a BOOL indicating whether it should lay itself out for landscape vs portrait.

Don't merge yet, I need to update tests and there might be weird things in here where I tried something out, changed my mind, and forgot to delete something. Just wanted everyone's thoughts.