### PR TITLE
@1aurabrown => [Martsy] Show web view as soon as DOMContentLoaded state is reached.

### DIFF
--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix buttons that have a partial underlined title on iOS 8.0, 8.1, and 8.2 - alloy
 * Add ability to paginate left and right by tapping hero unit page control - 1aurabrown
 * Add breadcrumbs to crash reports, especially around ARTiledImageView - alloy
+* Remove progress indicator from martsy views as soon as the state of the webview is at DOMContentLoaded - alloy
 
 ## 2015.04.23
 


### PR DESCRIPTION
Fixes #351.

At least, this fixes it for just the magazines view, as I understood that to be the main problem, but the #351 ticket is about _all_ martsy views, do you want me to just apply it for all martsy views?

Keep in mind that `DOMContentLoaded` means that not all sub-resources have loaded yet, although the way martsy is currently loading this still means that images have already started loading.