### PR TITLE
@alloy -> re-fetch hero units when hero VC will appear

### DIFF
--- a/Artsy Tests/ARHeroUnitTests.m
+++ b/Artsy Tests/ARHeroUnitTests.m
@@ -14,6 +14,7 @@
 @property (nonatomic, strong) NSTimer *timer;
 - (void)startTimer;
 - (void)updateViewWithHeroUnits:(NSArray *)heroUnits;
+- (void)handleHeroUnits:(NSArray *)heroUnits;
 - (ARSiteHeroUnitViewController *)currentViewController;
 - (void)pageControlTapped:(id)sender;
 @end
@@ -82,6 +83,16 @@ describe(@"with three hero units", ^{
         }]];
     });
 
+    describe(@"handleHeroUnits", ^{
+        it(@"updates the view", ^{
+            sharedBefore();
+            id mock = [OCMockObject partialMockForObject:heroVC];
+            [[mock expect] updateViewWithHeroUnits:heroUnits];
+            [heroVC handleHeroUnits:heroUnits];
+            [mock verify];
+        });
+    });
+
     describe(@"updateViewWithHeroUnits", ^{
         before(^{
             sharedBefore();
@@ -145,6 +156,16 @@ describe(@"with one hero unit", ^{
         }]];
     });
 
+    describe(@"handleHeroUnits", ^{
+        it(@"updates the view", ^{
+            sharedBefore();
+            id mock = [OCMockObject partialMockForObject:heroVC];
+            [[mock expect] updateViewWithHeroUnits:heroUnits];
+            [heroVC handleHeroUnits:heroUnits];
+            [mock verify];
+        });
+    });
+
     describe(@"updateViewWithHeroUnits", ^{
         before(^{
             sharedBefore();
@@ -180,10 +201,102 @@ describe(@"with one hero unit", ^{
     });
 });
 
+describe(@"viewWillAppear", ^{
+    __block id mock;
+    __block id networkModelMock;
+    before(^{
+        mock = [OCMockObject partialMockForObject:heroVC];
+        heroUnits = @[[SiteHeroUnit modelWithJSON:@{
+            @"id": @"art-basel1",
+            @"name": @"Art Basel1",
+            @"heading": @"Exclusive Preview",
+            @"mobile_description": @"Discover some artworks.",
+            @"mobile_title": @"Art Basel",
+            @"display_on_mobile": @true,
+            @"position": @1,
+            @"link":@"/art-basel1",
+            @"link_text":@"Explore",
+            @"credit_line":@"Artsy artsy artsy"
+        }], [SiteHeroUnit modelWithJSON:@{
+            @"id": @"art-basel2",
+            @"name": @"Art Basel2",
+            @"heading": @"Exclusive Preview",
+            @"mobile_description": @"Discover some artworks.",
+            @"mobile_title": @"Art Basel",
+            @"display_on_mobile": @true,
+            @"position": @2,
+            @"link":@"/art-basel2",
+            @"link_text":@"Explore",
+            @"credit_line":@"Artsy artsy artsy"
+        }], [SiteHeroUnit modelWithJSON:@{
+            @"id": @"art-basel3",
+            @"name": @"Art Basel3",
+            @"heading": @"Exclusive Preview",
+            @"mobile_description": @"Discover some artworks.",
+            @"mobile_title": @"Art Basel",
+            @"display_on_mobile": @true,
+            @"position": @3,
+            @"link":@"/art-basel3",
+            @"link_text":@"Explore",
+            @"credit_line":@"Artsy artsy artsy"
+        }]];
+        sharedBefore();
+        networkModelMock = [OCMockObject partialMockForObject:heroVC.heroUnitNetworkModel];
+    });
+
+    it(@"refetches hero units", ^{
+        [[networkModelMock expect] getHeroUnitsWithSuccess:OCMOCK_ANY failure:OCMOCK_ANY];
+        [heroVC viewWillAppear:NO];
+        [networkModelMock verify];
+    });
+
+    it(@"does not update view if they are the same", ^{
+        [[mock reject] updateViewWithHeroUnits:OCMOCK_ANY];
+        [heroVC viewWillAppear:NO];
+        [mock verify];
+    });
+
+    it(@"updates view if units have changed", ^{
+        __block NSArray *units = [heroUnits arrayByAddingObject:[SiteHeroUnit modelWithJSON:@{
+           @"id": @"art-basel4",
+           @"name": @"Art Basel4",
+           @"heading": @"Exclusive Preview",
+           @"mobile_description": @"Discover some artworks.",
+           @"mobile_title": @"Art Basel",
+           @"display_on_mobile": @true,
+           @"position": @3,
+           @"link":@"/art-basel4",
+           @"link_text":@"Explore",
+           @"credit_line":@"Artsy artsy artsy"
+       }]];
+
+        [[[networkModelMock stub] andDo:^(NSInvocation *invocation) {
+            void (^successBlock)(NSArray *) = nil;
+            [invocation getArgument:&successBlock atIndex:2];
+
+            heroVC.heroUnitNetworkModel.heroUnits = units;
+            successBlock(units);
+
+        }] getHeroUnitsWithSuccess:OCMOCK_ANY failure:OCMOCK_ANY];
+
+        [[mock expect] updateViewWithHeroUnits:units];
+
+        [heroVC viewWillAppear:NO];
+    });
+});
+
 describe(@"with no hero units", ^{
     // In practice this should never happen. If there are ever zero hero units, there is a data problem.
     before(^{
         heroUnits = @[];
+    });
+
+    describe(@"handleHeroUnits", ^{
+        sharedBefore();
+        id mock = [OCMockObject partialMockForObject:heroVC];
+        [[mock reject] updateViewWithHeroUnits:OCMOCK_ANY];
+        [heroVC handleHeroUnits:heroUnits];
+        [mock verify];
     });
 
     describe(@"updateViewWithHeroUnits", ^{

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -13,6 +13,7 @@
 * Really only show artworks that are for sale on an artist’s ‘for sale’ tab - alloy
 * Fixes iPad sharing hijacking - ash
 * Improve masonry/collection view layout changes when rotation occurs using iOS8 API - 1aurabrown
+* Re-fetch hero units every time they will appear - 1aurabrown
 
 ## 2015.04.23
 


### PR DESCRIPTION
this is a quick fix and could probably use some tests. There is probably a nicer way to tie this in with the pre-fetching and whatever RAC thing is going on when the view loads, but this is simple enough to just ensure that hero units don't go stale. won't disturb the timer or re-render anything if the hero unit data that we get back isn't any different from what we already have.