### PR TITLE
@orta -> fix shows view not using proper masonry layout

### DIFF
--- a/Artsy Tests/ARArtworkRelatedArtworksViewTests.m
+++ b/Artsy Tests/ARArtworkRelatedArtworksViewTests.m
@@ -225,6 +225,11 @@ describe(@"concerning layout", ^{
             ARArtworkMasonryLayout layout = [(ARArtworkMasonryModule *)section.artworksVC.activeModule layout];
             expect(layout).to.equal(ARArtworkMasonryLayout2Column);
         });
+
+        it(@"returns correct layout for orientation", ^{
+            expect([relatedView masonryLayoutForSize:CGSizeMake(400, 300)]).to.equal(ARArtworkMasonryLayout2Column);
+            expect([relatedView masonryLayoutForSize:CGSizeMake(300, 400)]).to.equal(ARArtworkMasonryLayout2Column);
+        });
     });
 
     describe(@"iPad", ^{
@@ -242,8 +247,8 @@ describe(@"concerning layout", ^{
         });
 
         it(@"returns correct layout for orientation", ^{
-            expect([relatedView masonryLayoutForPadWithSize:CGSizeMake(400, 300)]).to.equal(ARArtworkMasonryLayout4Column);
-            expect([relatedView masonryLayoutForPadWithSize:CGSizeMake(300, 400)]).to.equal(ARArtworkMasonryLayout3Column);
+            expect([relatedView masonryLayoutForSize:CGSizeMake(400, 300)]).to.equal(ARArtworkMasonryLayout4Column);
+            expect([relatedView masonryLayoutForSize:CGSizeMake(300, 400)]).to.equal(ARArtworkMasonryLayout3Column);
         });
     });
 });

--- a/Artsy Tests/ARTabContentViewSpec.m
+++ b/Artsy Tests/ARTabContentViewSpec.m
@@ -50,9 +50,10 @@ describe(@"correctly shows a navigation controller", ^{
 
 it(@"correctly sets the child view controller", ^{
     expect(outerController.childViewControllers).to.contain(innerController1);
+    expect(outerController.childViewControllers).toNot.contain(innerController2);
     [sut setCurrentViewIndex:1 animated:NO];
-        expect(outerController.childViewControllers).to.contain(innerController2);
-
+    expect(outerController.childViewControllers).to.contain(innerController1);
+    expect(outerController.childViewControllers).to.contain(innerController2);
 });
 
 SpecEnd

--- a/Artsy/Classes/View Controllers/ARArtworkInfoViewController.m
+++ b/Artsy/Classes/View Controllers/ARArtworkInfoViewController.m
@@ -78,7 +78,7 @@
 
 -(BOOL)shouldAutorotate
 {
-    return NO;
+    return [UIDevice isPad];
 }
 
 @end

--- a/Artsy/Classes/View Controllers/ARArtworkMasonryModule.h
+++ b/Artsy/Classes/View Controllers/ARArtworkMasonryModule.h
@@ -12,9 +12,12 @@ typedef NS_ENUM(NSInteger, ARArtworkMasonryLayout){
 
 @class ARArtworkMasonryModule;
 
-// A protocol to standardize the way we provide different layout styles to the module.
+/// A protocol to standardize the way we provide different layout styles to the module.
+/// If you do not use a layout provider, the masonry module will use the layout in
+/// its `layout` property regardless of size.
+
 @protocol ARArtworkMasonryLayoutProvider <NSObject>
-- (enum ARArtworkMasonryLayout)masonryLayoutForPadWithSize:(CGSize)size;
+- (enum ARArtworkMasonryLayout)masonryLayoutForSize:(CGSize)size;
 @end
 
 @interface ARArtworkMasonryModule : ARModelCollectionViewModule <ARCollectionViewMasonryLayoutDelegate>
@@ -24,11 +27,6 @@ typedef NS_ENUM(NSInteger, ARArtworkMasonryLayout){
 
 /// Designated initializer. Creates a masonry module with a specific artwork style
 + (instancetype)masonryModuleWithLayout:(enum ARArtworkMasonryLayout)layout andStyle:(enum AREmbeddedArtworkPresentationStyle)style;
-
-
-// Call this method to make the module query it's layout provider for a new layout -- particularly when rotating.
-// You shouldn't really HAVE to do this as the embedded models VC will call this method for you.
-- (void)updateLayoutForSize:(CGSize)size;
 
 /// Get the height of the collection view for a horizontal layout
 + (CGFloat)intrinsicHeightForHorizontalLayout:(ARArtworkMasonryLayout)layout useLandscapeValues:(BOOL)useLandscapeValues;
@@ -41,6 +39,8 @@ typedef NS_ENUM(NSInteger, ARArtworkMasonryLayout){
 @property (nonatomic, readonly) ARCollectionViewMasonryLayout *moduleLayout;
 
 /// The specific layout
+/// If you have set a layout provider, the layout will be set using the `masonryLayoutForSize` delegate method,
+/// not by assigning this property. If you are not using a provider, you can assign a layout to this property.
 @property (nonatomic, assign, readwrite) enum ARArtworkMasonryLayout layout;
 
 @property (nonatomic, weak, readwrite) id<ARArtworkMasonryLayoutProvider> layoutProvider;

--- a/Artsy/Classes/View Controllers/ARArtworkMasonryModule.m
+++ b/Artsy/Classes/View Controllers/ARArtworkMasonryModule.m
@@ -21,7 +21,6 @@
     module.layout = layout;
     module.style = style;
     CGRect currentVCFrame = [[ARTopMenuViewController sharedController].rootNavigationController ar_innermostTopViewController].view.frame;
-    module.useLandscapeValues = CGRectGetWidth(currentVCFrame) > CGRectGetHeight(currentVCFrame);
     return module;
 }
 
@@ -141,17 +140,10 @@
     }
 }
 
-
 - (void)updateLayoutForSize:(CGSize)size
 {
     self.useLandscapeValues = size.width > size.height;
-
-    // Only called if current device is an iPad
-    if (self.layoutProvider) {
-        self.layout = [self.layoutProvider masonryLayoutForPadWithSize:size];
-    } else {
-        [self setupWithLandscapeOrientation:self.useLandscapeValues];
-    }
+    self.layout = (self.layoutProvider) ? [self.layoutProvider masonryLayoutForSize:size] : self.layout;
 }
 
 - (void)setLayout:(enum ARArtworkMasonryLayout)layout

--- a/Artsy/Classes/View Controllers/AREmbeddedModelsViewController.m
+++ b/Artsy/Classes/View Controllers/AREmbeddedModelsViewController.m
@@ -2,6 +2,11 @@
 #import "ARItemThumbnailViewCell.h"
 #import "ARReusableLoadingView.h"
 
+
+@interface ARArtworkMasonryModule (Private)
+- (void)updateLayoutForSize:(CGSize)size;
+@end
+
 @interface AREmbeddedModelsViewController() <ARCollectionViewMasonryLayoutDelegate>
 
 @property (nonatomic, strong) UICollectionView *collectionView;
@@ -34,19 +39,30 @@
 
 - (void)viewDidLayoutSubviews
 {
+    [super viewDidLayoutSubviews];
     self.collectionView.frame = self.view.bounds;
 }
 
-
-- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
+- (void)updateForSize:(CGSize)size
 {
-    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
-
     if ([self.activeModule isKindOfClass:[ARArtworkMasonryModule class]]) {
         [(ARArtworkMasonryModule *)self.activeModule updateLayoutForSize:size];
     }
 
     [self.view setNeedsUpdateConstraints];
+}
+
+- (void)didMoveToParentViewController:(UIViewController *)parent
+{
+    if (!parent) { return; }
+    [self updateForSize:parent.view.frame.size];
+}
+
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
+{
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+
+    [self updateForSize:size];
 
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
         [self.view layoutIfNeeded];

--- a/Artsy/Classes/View Controllers/ARFavoritesViewController.m
+++ b/Artsy/Classes/View Controllers/ARFavoritesViewController.m
@@ -110,7 +110,7 @@
     _artistFavoritesNetworkModel = [[ARArtistFavoritesNetworkModel alloc] init];
     _geneFavoritesNetworkModel = [[ARGeneFavoritesNetworkModel alloc] init];
 
-    ARArtworkMasonryLayout layout = [UIDevice isPad] ? [self masonryLayoutForPadWithSize:self.view.frame.size] : ARArtworkMasonryLayout2Column;
+    ARArtworkMasonryLayout layout = [self masonryLayoutForSize:self.view.frame.size];
     _artworksModule = [ARArtworkMasonryModule masonryModuleWithLayout:layout andStyle:AREmbeddedArtworkPresentationStyleArtworkMetadata];
     _artworksModule.layoutProvider = self;
     _artistsModule = [[ARFavoriteItemModule alloc] init];
@@ -135,9 +135,13 @@
     return [UIDevice isPad] ? 193 : 127;
 }
 
-- (ARArtworkMasonryLayout)masonryLayoutForPadWithSize:(CGSize)size
+- (ARArtworkMasonryLayout)masonryLayoutForSize:(CGSize)size
 {
-    return (size.width > size.height) ? ARArtworkMasonryLayout4Column : ARArtworkMasonryLayout3Column;
+    if ([UIDevice isPad] ) {
+        return (size.width > size.height) ? ARArtworkMasonryLayout4Column : ARArtworkMasonryLayout3Column;
+    } else {
+        return ARArtworkMasonryLayout2Column;
+    }
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator

--- a/Artsy/Classes/Views/ARArtworkRelatedArtworksView.m
+++ b/Artsy/Classes/Views/ARArtworkRelatedArtworksView.m
@@ -207,11 +207,7 @@
         [self invalidateIntrinsicContentSize];
     }
 
-    ARArtworkMasonryLayout layout = ARArtworkMasonryLayout2Column;
-    if ([UIDevice isPad]) {
-        layout = [self masonryLayoutForPadWithSize:self.parentViewController.view.frame.size];
-    }
-    ARArtworkMasonryModule *module = [ARArtworkMasonryModule masonryModuleWithLayout:layout
+    ARArtworkMasonryModule *module = [ARArtworkMasonryModule masonryModuleWithLayout:[self masonryLayoutForSize:self.parentViewController.view.frame.size]
                                                                             andStyle:AREmbeddedArtworkPresentationStyleArtworkMetadata];
     module.layoutProvider = self;
 
@@ -254,9 +250,13 @@
 
 #pragma mark - ARArtworkMasonryLayoutProvider
 
-- (ARArtworkMasonryLayout)masonryLayoutForPadWithSize:(CGSize)size
+- (ARArtworkMasonryLayout)masonryLayoutForSize:(CGSize)size
 {
-    return size.width > size.height ? ARArtworkMasonryLayout4Column : ARArtworkMasonryLayout3Column;
+    if ([UIDevice isPad]) {
+        return size.width > size.height ? ARArtworkMasonryLayout4Column : ARArtworkMasonryLayout3Column;
+    } else {
+        return ARArtworkMasonryLayout2Column;
+    }
 }
 
 #pragma mark - AREmbeddedModelsDelegate

--- a/Artsy/Classes/Views/ARGeneViewController.m
+++ b/Artsy/Classes/Views/ARGeneViewController.m
@@ -137,9 +137,7 @@
 
 - (void)createGeneArtworksViewController
 {
-    ARArtworkMasonryLayout layout = [UIDevice isPad] ? [self masonryLayoutForPadWithSize:self.view.frame.size] : ARArtworkMasonryLayout2Column;
-
-    ARArtworkMasonryModule *module = [ARArtworkMasonryModule masonryModuleWithLayout:layout andStyle:AREmbeddedArtworkPresentationStyleArtworkMetadata];
+    ARArtworkMasonryModule *module = [ARArtworkMasonryModule masonryModuleWithLayout:[self masonryLayoutForSize:self.view.frame.size] andStyle:AREmbeddedArtworkPresentationStyleArtworkMetadata];
 
     module.layoutProvider = self;
     self.artworksViewController = [[AREmbeddedModelsViewController alloc] init];
@@ -252,10 +250,15 @@
 
 #pragma mark - ARArtworkMasonryLayoutProvider
 
--(ARArtworkMasonryLayout)masonryLayoutForPadWithSize:(CGSize)size
+-(ARArtworkMasonryLayout)masonryLayoutForSize:(CGSize)size
 {
-    return (size.width > size.height) ? ARArtworkMasonryLayout4Column : ARArtworkMasonryLayout3Column;
+    if ([UIDevice isPad] ) {
+        return (size.width > size.height) ? ARArtworkMasonryLayout4Column : ARArtworkMasonryLayout3Column;
+    } else {
+        return ARArtworkMasonryLayout2Column;
+    }
 }
+
 #pragma mark - AREmbeddedModelsDelegate
 
 -(void)embeddedModelsViewController:(AREmbeddedModelsViewController *)controller shouldPresentViewController:(UIViewController *)viewController

--- a/Artsy/Classes/Views/ARTabContentView.m
+++ b/Artsy/Classes/Views/ARTabContentView.m
@@ -154,10 +154,12 @@ static BOOL ARTabViewDirectionRight = YES;
     _currentNavigationController = [self navigationControllerForIndex:index];
     self.currentNavigationController.view.frame = nextViewInitialFrame;
 
-    // Add the new ViewController our view's host
-    [self.currentNavigationController willMoveToParentViewController:self.hostViewController];
-    [self.hostViewController addChildViewController:self.currentNavigationController];
-    [self.currentNavigationController didMoveToParentViewController:_hostViewController];
+    if (!self.currentNavigationController.parentViewController) {
+        // Add the new ViewController our view's host
+        [self.currentNavigationController willMoveToParentViewController:self.hostViewController];
+        [self.hostViewController addChildViewController:self.currentNavigationController];
+        [self.currentNavigationController didMoveToParentViewController:_hostViewController];
+    }
 
     void (^animationBlock)();
     animationBlock = ^{
@@ -167,12 +169,6 @@ static BOOL ARTabViewDirectionRight = YES;
 
     void (^completionBlock)(BOOL finished);
     completionBlock = ^(BOOL finished) {
-        // Remove the old one
-        [oldViewController willMoveToParentViewController:nil];
-
-        [oldViewController removeFromParentViewController];
-        [oldViewController.view removeFromSuperview];
-        
         if ([self.delegate respondsToSelector:@selector(tabContentView:didChangeSelectedIndex:)]) {
             [self.delegate tabContentView:self didChangeSelectedIndex:index];
         }


### PR DESCRIPTION
I noticed that when switching tabs, rotating, then switching back, the view that is about to appear still had the old frame size. This is because we were removing navigation controllers from their host when at tab is deselected. If you DON'T remove them and maintain each tab's navigation controller in the VC hierarchy, each tab can respond to rotation/size change events even when they are not visible, and they will also already have the correct view size when they are reselected.

Let me know if you think there would be other problems with doing this. It makes rotation a whole lot easier to keep all the Nav Controllers in the hierarchy even when deselected.