### PR TITLE
@orta -> artwork changes

### DIFF
--- a/Artsy/Classes/Categories/Apple/UIImage+ImageFromColor.h
+++ b/Artsy/Classes/Categories/Apple/UIImage+ImageFromColor.h
@@ -2,4 +2,5 @@
 
 @interface UIImage (ImageWithColor)
 + (UIImage *)imageFromColor:(UIColor *)color;
++ (UIImage *)imageFromColor:(UIColor *)color withSize:(CGSize)size;
 @end

--- a/Artsy/Classes/Categories/Apple/UIImage+ImageFromColor.m
+++ b/Artsy/Classes/Categories/Apple/UIImage+ImageFromColor.m
@@ -7,6 +7,11 @@ static NSCache *imageCache;
 
 + (UIImage *)imageFromColor:(UIColor *)color
 {
+    return [self.class imageFromColor:color withSize:CGSizeMake(1, 1)];
+}
+
++ (UIImage *)imageFromColor:(UIColor *)color withSize:(CGSize)size
+{
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         imageCache = [[NSCache alloc] init];
@@ -17,7 +22,7 @@ static NSCache *imageCache;
         return image;
     }
 
-    CGRect rect = CGRectMake(0, 0, 1, 1);
+    CGRect rect = CGRectMake(0, 0, size.width, size.height);
     UIGraphicsBeginImageContext(rect.size);
     CGContextRef context = UIGraphicsGetCurrentContext();
     CGContextSetFillColorWithColor(context, [color CGColor]);

--- a/Artsy/Classes/View Controllers/ARArtworkPreviewImageView.m
+++ b/Artsy/Classes/View Controllers/ARArtworkPreviewImageView.m
@@ -88,7 +88,15 @@
 - (UIImage *)placeholderImageForArtwork:(Artwork *)artwork
 {
     NSURL *imageURL = [NSURL URLWithString:artwork.defaultImage.baseImageURL];
-    return [ARFeedImageLoader bestAvailableCachedImageForBaseURL:imageURL];
+    UIImage *image;
+    image = [ARFeedImageLoader bestAvailableCachedImageForBaseURL:imageURL];
+    if (!image) {
+        // Multiply by 1000 to preserve precision because the image's dimensions get rounded to whole numbers.
+        CGFloat aspectRatio = artwork.aspectRatio ?: 1;
+        CGSize size = CGSizeMake(aspectRatio * 1000, 1000);
+        image = [UIImage imageFromColor:[UIColor artsyLightGrey] withSize:size];
+    }
+    return image;
 }
 
 - (void)setImage:(UIImage *)image

--- a/Artsy/Classes/View Controllers/ARArtworkViewController.m
+++ b/Artsy/Classes/View Controllers/ARArtworkViewController.m
@@ -214,14 +214,7 @@
 
 - (void)artworkMetadataView:(ARArtworkMetadataView *)metadataView didUpdateArtworkActionsView:(ARArtworkActionsView *)actionsView
 {
-    [metadataView layoutIfNeeded];
-
-    [UIView animateTwoStepIf:self.shouldAnimate
-        duration:ARAnimationDuration * 2 :^{
-            [self.view.stackView layoutIfNeeded];
-        } midway:^{
-            actionsView.alpha = 1;
-        } completion:nil];
+    [self.view.stackView layoutIfNeeded];
 }
 
 #pragma mark - ARPostsViewControllerDelegate

--- a/Artsy/Classes/Views/ARArtworkMetadataView.m
+++ b/Artsy/Classes/Views/ARArtworkMetadataView.m
@@ -33,7 +33,6 @@
     ARArtworkPreviewActionsView *previewActionsView = [[ARArtworkPreviewActionsView alloc] initWithArtwork:artwork andFair:fair];
     ARArtworkDetailView *artworkDetailView = [[ARArtworkDetailView alloc] initWithArtwork:artwork andFair:fair];
     ARArtworkActionsView *artworkActionsView = [[ARArtworkActionsView alloc] initWithArtwork:artwork];
-    artworkActionsView.alpha = 0;
     self.artworkPreview = artworkPreview;
     self.actionsView = artworkActionsView;
     self.artworkPreviewActions = previewActionsView;
@@ -191,6 +190,7 @@
 -(void)didUpdateArtworkActionsView:(ARArtworkActionsView *)actionsView
 {
     [self.delegate artworkMetadataView:self didUpdateArtworkActionsView:actionsView];
+    [self layoutIfNeeded];
 }
 
 #pragma mark - ARArtworkDetailViewDelegate


### PR DESCRIPTION
don't animate the appearance of the action buttons

also use the artwork's aspectRatio to make the grey placeholder image if no cached image is available for the artwork (flawed because this number is sometimes incorrect in the json response)
