### PR TITLE
@orta => Removes XApp check for trial user condition.

### DIFF
--- a/Artsy Tests/ARArtworkViewControllerTests.m
+++ b/Artsy Tests/ARArtworkViewControllerTests.m
@@ -1,5 +1,6 @@
 #import "ARArtworkViewController.h"
 #import "ARArtworkView.h"
+#import "ARUserManager+Stubs.h"
 #import "ARRouter.h"
 
 @interface ARArtworkViewController (Tests)
@@ -28,6 +29,15 @@ describe(@"buy button", ^{
         [routerMock stopMocking];
         [vcMock stopMocking];
     });
+
+    beforeEach(^{
+        [ARUserManager stubAndLoginWithUsername];
+    });
+
+    afterEach(^{
+        [ARUserManager clearUserData];
+    });
+
 
     it(@"posts order if artwork has no edition sets", ^{
         Artwork *artwork = [Artwork modelWithJSON:@{

--- a/Artsy/Classes/Models/User.m
+++ b/Artsy/Classes/Models/User.m
@@ -10,7 +10,7 @@
 + (BOOL)isTrialUser
 {
     ARUserManager *userManager = [ARUserManager sharedManager];
-    return (userManager.currentUser == nil) && userManager.hasValidXAppToken;
+    return userManager.currentUser == nil;
 }
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey


### PR DESCRIPTION
See discussion [here](https://github.com/artsy/eigen/issues/463#issuecomment-106519283). Before we were requiring two conditions to be considered a "trial user":

- Not be logged in.
- Have a valid XApp token. 

Now we only require the first. 

A larger discussions could be had about renaming `isTrialUser` to be the more accurate `isLoggedOut`. 

Fixes #463.