### PR TITLE
@1aurabrown => Removes ability to disable back button.

### DIFF
--- a/Artsy/Classes/View Controllers/ARMenuAwareViewController.h
+++ b/Artsy/Classes/View Controllers/ARMenuAwareViewController.h
@@ -7,6 +7,5 @@
 
 @optional
 @property (readonly, nonatomic, assign) BOOL hidesStatusBarBackground;
-@property (readonly, nonatomic, assign) BOOL enableMenuButtons;
 
 @end

--- a/Artsy/Classes/View Controllers/ARNavigationController.m
+++ b/Artsy/Classes/View Controllers/ARNavigationController.m
@@ -65,11 +65,6 @@ static void * ARNavigationControllerScrollingChiefContext = &ARNavigationControl
     [self observeViewController:NO];
 }
 
-- (void)setEnableNavigationButtons:(BOOL)enabled
-{
-    self.backButton.enabled = enabled;
-}
-
 #pragma mark - Properties
 
 - (void)setDelegate:(id<UINavigationControllerDelegate>)delegate
@@ -164,8 +159,6 @@ static void * ARNavigationControllerScrollingChiefContext = &ARNavigationControl
 
 - (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated
 {
-    [self setEnableNavigationButtons:NO];
-
     // If it is a non-interactive transition, we fade the buttons in or out
     // ourselves. Otherwise, we'll leave it to the interactive transition.
     if (self.interactiveTransitionHandler == nil) {
@@ -180,8 +173,6 @@ static void * ARNavigationControllerScrollingChiefContext = &ARNavigationControl
 
 - (void)navigationController:(UINavigationController *)navigationController didShowViewController:(UIViewController *)viewController animated:(BOOL)animated
 {
-    [self setEnableNavigationButtons:YES];
-
     if ([viewController conformsToProtocol:@protocol(ARMenuAwareViewController)]) {
         self.observedViewController = (UIViewController<ARMenuAwareViewController> *)viewController;
     } else {
@@ -357,8 +348,7 @@ static void * ARNavigationControllerScrollingChiefContext = &ARNavigationControl
 
     NSArray *keyPaths = @[
         @keypath(vc, hidesBackButton),
-        @keypath(vc, hidesToolbarMenu),
-        @keypath(vc, enableMenuButtons)
+        @keypath(vc, hidesToolbarMenu)
     ];
 
     [keyPaths each:^(NSString *keyPath) {
@@ -381,10 +371,6 @@ static void * ARNavigationControllerScrollingChiefContext = &ARNavigationControl
 
         if ([vc respondsToSelector:@selector(hidesToolbarMenu)]) {
             [[ARTopMenuViewController sharedController] hideToolbar:vc.hidesToolbarMenu animated:YES];
-        }
-
-        if ([vc respondsToSelector:@selector(enableMenuButtons)]) {
-            self.backButton.enabled = vc.enableMenuButtons;
         }
 
     } else if (context == ARNavigationControllerScrollingChiefContext) {


### PR DESCRIPTION
This PR does a few things:

1. Removes per-view controller ability to disable nav buttons (a holdover from our old navigation paradigm, which were unused anyway).
1. Stops the disable/re-enable dance when showing a view controller.

I don't see any need to disable the back button during a view controller transition. As far as I know, iOS disables interaction with view controllers during push/pop transitions anyway. 

Fixes #466.