### PR TITLE
@alloy -> Onboarding callback

### DIFF
--- a/Artsy Tests/ARFairGuideViewControllerTests.m
+++ b/Artsy Tests/ARFairGuideViewControllerTests.m
@@ -4,48 +4,48 @@
 
 @interface ARFairGuideViewController (Testing)
 
-- (void)userDidSignUp;
+- (void)userDidLoginOrSignUp;
 @property (nonatomic, assign) NSInteger selectedTabIndex;
 @property (nonatomic, strong) User *currentUser;
 @end
 
 SpecBegin(ARFairGuideViewController)
 
-__block ARFairGuideViewController *_fairGuideVC = nil;
+__block ARFairGuideViewController *fairGuideVC = nil;
 
 beforeEach(^{
     Fair *fair = [Fair modelWithJSON:@{ @"id" : @"fair-id", @"name" : @"The Armory Show", @"organizer" : @{ @"profile_id" : @"fair-profile-id" } }];
-    _fairGuideVC = [[ARFairGuideViewController alloc] initWithFair:fair];
+    fairGuideVC = [[ARFairGuideViewController alloc] initWithFair:fair];
 });
 
 it(@"looks correct with a logged in user", ^{
-    _fairGuideVC.currentUser = [User modelWithJSON:@{ @"name" : @"User Name"}];
-    _fairGuideVC.view.frame = CGRectMake(0, 0, 320, 480);
-    [_fairGuideVC fairDidLoad];
-    expect(_fairGuideVC).to.haveValidSnapshot();
+    fairGuideVC.currentUser = [User modelWithJSON:@{ @"name" : @"User Name"}];
+    fairGuideVC.view.frame = CGRectMake(0, 0, 320, 480);
+    [fairGuideVC fairDidLoad];
+    expect(fairGuideVC).to.haveValidSnapshot();
 });
 
 it(@"looks correct with a trial user", ^{
-    _fairGuideVC.currentUser = (id)[NSNull null];
-    _fairGuideVC.view.frame = CGRectMake(0, 0, 320, 480);
-    [_fairGuideVC fairDidLoad];
-    expect(_fairGuideVC).to.haveValidSnapshot();
+    fairGuideVC.currentUser = (id)[NSNull null];
+    fairGuideVC.view.frame = CGRectMake(0, 0, 320, 480);
+    [fairGuideVC fairDidLoad];
+    expect(fairGuideVC).to.haveValidSnapshot();
 });
 
 it(@"adds a top border", ^{
-    _fairGuideVC.currentUser = [User modelWithJSON:@{ @"name" : @"User Name"}];
-    _fairGuideVC.view.frame = CGRectMake(0, 0, 320, 480);
-    _fairGuideVC.showTopBorder = YES;
-    [_fairGuideVC fairDidLoad];
-    expect(_fairGuideVC).to.haveValidSnapshot();
+    fairGuideVC.currentUser = [User modelWithJSON:@{ @"name" : @"User Name"}];
+    fairGuideVC.view.frame = CGRectMake(0, 0, 320, 480);
+    fairGuideVC.showTopBorder = YES;
+    [fairGuideVC fairDidLoad];
+    expect(fairGuideVC).to.haveValidSnapshot();
 });
 
 it(@"calls the appropriate delegate method upon user change", ^{
     id delegateMock = [OCMockObject mockForProtocol:@protocol(ARFairGuideViewControllerDelegate)];
     [[delegateMock expect] fairGuideViewControllerDidChangeUser:OCMOCK_ANY];
     
-    [_fairGuideVC userDidSignUp];
-    expect(_fairGuideVC.selectedTabIndex).to.equal(-1);
+    [fairGuideVC userDidLoginOrSignUp];
+    expect(fairGuideVC.selectedTabIndex).to.equal(-1);
 });
 
 SpecEnd

--- a/Artsy Tests/ARInternalMobileWebViewControllerTests.m
+++ b/Artsy Tests/ARInternalMobileWebViewControllerTests.m
@@ -155,7 +155,7 @@ describe(@"authenticated", ^{
             [[[mockUser stub] andReturnValue:OCMOCK_VALUE(NO)] isTrialUser];
 
             id mock = [OCMockObject partialMockForObject:[ARTrialController instance]];
-            [[mock reject] presentTrialWithContext:ARTrialContextNotTrial fromTarget:[OCMArg any] selector:[OCMArg anySelector]];
+            [[mock reject] presentTrialWithContext:ARTrialContextNotTrial success:[OCMArg any]];
 
             id switchboardMock = [OCMockObject partialMockForObject:ARSwitchBoard.sharedInstance];
             [[switchboardMock reject] loadURL:[OCMArg any] fair:[OCMArg any]];
@@ -216,7 +216,7 @@ describe(@"unauthenticated", ^{
             [[[mockUser stub] andReturnValue:OCMOCK_VALUE(YES)] isTrialUser];
 
             id mock = [OCMockObject partialMockForObject:[ARTrialController instance]];
-            [[mock expect] presentTrialWithContext:ARTrialContextNotTrial fromTarget:[OCMArg any] selector:[OCMArg anySelector]];
+            [[mock expect] presentTrialWithContext:ARTrialContextNotTrial success:[OCMArg any]];
 
             id switchboardMock = [OCMockObject partialMockForObject:ARSwitchBoard.sharedInstance];
             [[switchboardMock reject] loadURL:[OCMArg any] fair:[OCMArg any]];
@@ -237,7 +237,7 @@ describe(@"unauthenticated", ^{
             [[[mockUser stub] andReturnValue:OCMOCK_VALUE(YES)] isTrialUser];
 
             id mock = [OCMockObject partialMockForObject:[ARTrialController instance]];
-            [[mock expect] presentTrialWithContext:ARTrialContextNotTrial fromTarget:[OCMArg any] selector:[OCMArg anySelector]];
+            [[mock expect] presentTrialWithContext:ARTrialContextNotTrial success:[OCMArg any]];
 
             id switchboardMock = [OCMockObject partialMockForObject:ARSwitchBoard.sharedInstance];
             [[switchboardMock reject] loadURL:[OCMArg any] fair:[OCMArg any]];

--- a/Artsy Tests/AROnboardingViewControllerTests.m
+++ b/Artsy Tests/AROnboardingViewControllerTests.m
@@ -29,7 +29,7 @@ describe(@"signup splash", ^{
             [ARTestContext stubDevice:ARDeviceTypePad];
             [[mock reject] presentCollectorLevel];
             [[mock expect] presentWebOnboarding];
-            [vc signupDone];
+            [vc didSignUpAndLogin];
             [mock verify];
         });
 
@@ -37,7 +37,7 @@ describe(@"signup splash", ^{
             [ARTestContext stubDevice:ARDeviceTypePhone5];
             [[mock reject] presentWebOnboarding];
             [[mock expect] presentCollectorLevel];
-            [vc signupDone];
+            [vc didSignUpAndLogin];
             [mock verify];
         });
     });

--- a/Artsy Tests/ARTopMenuViewControllerSpec.m
+++ b/Artsy Tests/ARTopMenuViewControllerSpec.m
@@ -15,7 +15,7 @@
 @end
 
 @interface ARTrialController (Testing)
-- (void)presentTrialWithContext:(enum ARTrialContext)context fromTarget:(id)target selector:(SEL)selector;
+- (void)presentTrialWithContext:(enum ARTrialContext)context success:(void (^)(BOOL newUser))success;
 @end
 
 @interface ARTopMenuViewController(Testing) <ARTabViewDelegate>
@@ -160,7 +160,7 @@ describe(@"navigation", ^{
 
             it(@"invokes signup popover", ^{
                 id mock = [OCMockObject niceMockForClass:[ARTrialController class]];
-                [[mock expect] presentTrialWithContext:0 fromTarget:[OCMArg any] selector:[OCMArg anyPointer]] ;
+                [[mock expect] presentTrialWithContext:0 success:[OCMArg any]];
             });
         });
 

--- a/Artsy Tests/ARUserManagerTests.m
+++ b/Artsy Tests/ARUserManagerTests.m
@@ -43,6 +43,8 @@ describe(@"login", ^{
         });
 
         it(@"sets current user", ^{
+            expect([ARUserManager didCreateAccountThisSession]).to.beFalsy();
+
             User *currentUser = [[ARUserManager sharedManager] currentUser];
             expect(currentUser).toNot.beNil();
             expect(currentUser.userID).to.equal(ARUserManager.stubUserID);
@@ -285,6 +287,8 @@ describe(@"createUserWithName", ^{
     });
 
     it(@"sets current user", ^{
+        expect([ARUserManager didCreateAccountThisSession]).to.beTruthy();
+
         User *currentUser = [[ARUserManager sharedManager] currentUser];
         expect(currentUser).toNot.beNil();
         expect(currentUser.userID).to.equal(ARUserManager.stubUserID);
@@ -312,6 +316,8 @@ describe(@"createUserViaFacebookWithToken", ^{
     });
 
     it(@"sets current user", ^{
+        expect([ARUserManager didCreateAccountThisSession]).to.beTruthy();
+
         User *currentUser = [[ARUserManager sharedManager] currentUser];
         expect(currentUser).toNot.beNil();
         expect(currentUser.userID).to.equal(ARUserManager.stubUserID);
@@ -339,6 +345,8 @@ describe(@"createUserViaTwitterWithToken", ^{
     });
 
     it(@"sets current user", ^{
+        expect([ARUserManager didCreateAccountThisSession]).to.beTruthy();
+
         User *currentUser = [[ARUserManager sharedManager] currentUser];
         expect(currentUser).toNot.beNil();
         expect(currentUser.userID).to.equal(ARUserManager.stubUserID);

--- a/Artsy/Classes/ARAppDelegate+Analytics.m
+++ b/Artsy/Classes/ARAppDelegate+Analytics.m
@@ -956,7 +956,7 @@
                     ARAnalyticsDetails: @[
                         @{
                             ARAnalyticsEventName: ARAnalyticsShowTrialSplash,
-                            ARAnalyticsSelectorName: NSStringFromSelector(@selector(presentTrialWithContext:fromTarget:selector:)),
+                            ARAnalyticsSelectorName: NSStringFromSelector(@selector(presentTrialWithContext:success:)),
                             ARAnalyticsProperties: ^NSDictionary*(ARTrialController *controller, NSArray *parameters){
                                 enum ARTrialContext context = [parameters.first integerValue];
                                 return @{

--- a/Artsy/Classes/ARAppDelegate+Analytics.m
+++ b/Artsy/Classes/ARAppDelegate+Analytics.m
@@ -18,6 +18,8 @@
 #import "ARInquireForArtworkViewController.h"
 #import "ARArtworkViewController.h"
 #import "AROnboardingArtistTableController.h"
+#import "ARInternalMobileWebViewController.h"
+#import "ARSignUpSplashViewController.h"
 #import "ARLoginViewController.h"
 #import "ARSignUpActiveUserViewController.h"
 #import "ARSignupViewController.h"

--- a/Artsy/Classes/ARAppDelegate.m
+++ b/Artsy/Classes/ARAppDelegate.m
@@ -150,13 +150,21 @@ static ARAppDelegate *_sharedInstance = nil;
 - (void)finishOnboardingAnimated:(BOOL)animated didCancel:(BOOL)cancelledSignIn;
 {
     [[UIApplication sharedApplication] setStatusBarHidden:NO withAnimation:UIStatusBarAnimationFade];
-    [[ARTopMenuViewController sharedController] moveToInAppAnimated:animated];
+
+    ARTopMenuViewController *topVC = ARTopMenuViewController.sharedController;
+    if (topVC.presentedViewController) {
+        topVC.presentedViewController.transitioningDelegate = topVC;
+        [topVC.presentedViewController dismissViewControllerAnimated:animated completion:^{
+            [ARTrialController performCompletionNewUser:[ARUserManager didCreateAccountThisSession]];
+        }];
+    }
 
     if (!cancelledSignIn) {
         dispatch_async(dispatch_get_main_queue(), ^{
             [self registerForDeviceNotifications];
         });
     }
+
 }
 
 - (void)showTrialOnboardingWithState:(enum ARInitialOnboardingState)state andContext:(enum ARTrialContext)context

--- a/Artsy/Classes/Networking/ARUserManager.h
+++ b/Artsy/Classes/Networking/ARUserManager.h
@@ -6,6 +6,7 @@
 + (void)logout;
 + (void)logoutAndSetUseStaging:(BOOL)useStaging;
 + (void)clearUserData;
++ (BOOL)didCreateAccountThisSession;
 
 + (void)identifyAnalyticsUser;
 

--- a/Artsy/Classes/Networking/ARUserManager.m
+++ b/Artsy/Classes/Networking/ARUserManager.m
@@ -16,6 +16,7 @@ NSString *ARTrialUserUUID = @"ARTrialUserUUID";
 
 @interface ARUserManager()
 @property (nonatomic, strong) User *currentUser;
+@property (nonatomic, readonly) BOOL didCreateAccountThisSession;
 @end
 
 @implementation ARUserManager
@@ -28,6 +29,11 @@ NSString *ARTrialUserUUID = @"ARTrialUserUUID";
         _sharedManager = [[self alloc] init];
     });
     return _sharedManager;
+}
+
++ (BOOL)didCreateAccountThisSession
+{
+    return [self.class sharedManager].didCreateAccountThisSession;
 }
 
 + (void)identifyAnalyticsUser
@@ -334,7 +340,8 @@ NSString *ARTrialUserUUID = @"ARTrialUserUUID";
                  failure(error, JSON);
                  return;
              }
-             
+
+             self->_didCreateAccountThisSession = YES;
              self.currentUser = user;
              [self storeUserData];
              
@@ -368,6 +375,8 @@ NSString *ARTrialUserUUID = @"ARTrialUserUUID";
                  failure(error, JSON);
                  return;
              }
+
+             self->_didCreateAccountThisSession = YES;
              self.currentUser = user;
              [self storeUserData];
 
@@ -400,6 +409,8 @@ NSString *ARTrialUserUUID = @"ARTrialUserUUID";
                  failure(error, JSON);
                  return;
              }
+
+             self->_didCreateAccountThisSession = YES;
              self.currentUser = user;
              [self storeUserData];
              

--- a/Artsy/Classes/Utils/ARTrialController.h
+++ b/Artsy/Classes/Utils/ARTrialController.h
@@ -15,17 +15,16 @@ typedef NS_ENUM(NSInteger, ARTrialContext){
 
 @interface ARTrialController : NSObject
 
-/// Shows the sign up, with an optional target / selector to re-trigger the
-/// original action after we've logged in.
-
-+ (void)presentTrialWithContext:(enum ARTrialContext)context fromTarget:(id)target selector:(SEL)selector;
+/// Shows the sign up, with optional completion block to be triggered after signup or login.
++ (void)presentTrialWithContext:(enum ARTrialContext)context success:(void (^)(BOOL newUser))success;
 
 /// Get the guest authentication token and run the completion block
 + (void)startTrialWithCompletion:(void (^)(void))completion failure:(void (^)(NSError *error))failure;
 
 /// No-op if you didn't have a trial account before signing up
 /// otherwise will run the "favorite" artwork or whatever started the splash
-+ (void)performPostSignupEvent;
+
++ (void)performCompletionNewUser:(BOOL)newUser;
 
 /// Adds one to the number of view controllers shown before showing the splash
 + (void)shownAViewController;

--- a/Artsy/Classes/View Controllers/ARArtistViewController.m
+++ b/Artsy/Classes/View Controllers/ARArtistViewController.m
@@ -308,7 +308,9 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
 - (void)toggleFollowingArtist:(ARHeartButton *)sender
 {
     if ([User isTrialUser]) {
-        [ARTrialController presentTrialWithContext:ARTrialContextFavoriteArtist fromTarget:self selector:_cmd];
+        [ARTrialController presentTrialWithContext:ARTrialContextFavoriteArtist success:^(BOOL newUser){
+            [self toggleFollowingArtist:sender];
+        }];
         return;
     }
 

--- a/Artsy/Classes/View Controllers/ARArtworkViewController+ButtonActions.m
+++ b/Artsy/Classes/View Controllers/ARArtworkViewController+ButtonActions.m
@@ -30,7 +30,9 @@
 - (void)tappedArtworkFavorite:(ARHeartButton *)sender
 {
     if ([User isTrialUser]) {
-        [ARTrialController presentTrialWithContext:ARTrialContextFavoriteArtwork fromTarget:self selector:_cmd];
+        [ARTrialController presentTrialWithContext:ARTrialContextFavoriteArtwork success:^(BOOL newUser){
+            [self tappedArtworkFavorite:sender];
+        }];
         return;
     }
 
@@ -109,7 +111,9 @@
 - (void)tappedBidButton
 {
     if ([User isTrialUser]) {
-        [ARTrialController presentTrialWithContext:ARTrialContextAuctionBid fromTarget:self selector:_cmd];
+        [ARTrialController presentTrialWithContext:ARTrialContextAuctionBid success:^(BOOL newUser){
+            [self tappedBidButton];
+        }];
         return;
     }
     [self.artwork onSaleArtworkUpdate:^(SaleArtwork *saleArtwork) {
@@ -143,7 +147,9 @@
 - (void)tappedBuyButton
 {
     if ([User isTrialUser]) {
-        [ARTrialController presentTrialWithContext:ARTrialContextArtworkOrder fromTarget:self selector:_cmd];
+        [ARTrialController presentTrialWithContext:ARTrialContextArtworkOrder success:^(BOOL newUser){
+            [self tappedBuyButton];
+        }];
         return;
     }
 

--- a/Artsy/Classes/View Controllers/ARCreateAccountViewController.m
+++ b/Artsy/Classes/View Controllers/ARCreateAccountViewController.m
@@ -19,7 +19,6 @@
 @property (nonatomic) ARSpinner *loadingSpinner;
 @property (nonatomic, strong) UIView *containerView;
 @property (nonatomic, strong) NSLayoutConstraint *keyboardConstraint;
-
 @end
 
 @implementation ARCreateAccountViewController

--- a/Artsy/Classes/View Controllers/ARCreateAccountViewController.m
+++ b/Artsy/Classes/View Controllers/ARCreateAccountViewController.m
@@ -192,7 +192,9 @@
     @weakify(self);
     [[ARUserManager sharedManager] createUserWithName:self.name.text email:username password:password success:^(User *user) {
         @strongify(self);
-        [self loginWithUserCredentials];
+        [self loginWithUserCredentialsWithSuccess:^{
+            [self.delegate didSignUpAndLogin];
+        }];
     } failure:^(NSError *error, id JSON) {
         @strongify(self);
         if (JSON
@@ -215,7 +217,7 @@
     }];
 }
 
-- (void)loginWithUserCredentials
+- (void)loginWithUserCredentialsWithSuccess:(void(^)())success
 {
     NSString *username = self.email.text;
     NSString *password = self.password.text;
@@ -223,8 +225,7 @@
     @weakify(self);
    [[ARUserManager sharedManager] loginWithUsername:username password:password successWithCredentials:nil
      gotUser:^(User *currentUser) {
-        @strongify(self);
-        [self.delegate signupDone];
+         success();
     } authenticationFailure:^(NSError *error) {
         @strongify(self);
         [self setFormEnabled:YES];

--- a/Artsy/Classes/View Controllers/ARFairArtistViewController.m
+++ b/Artsy/Classes/View Controllers/ARFairArtistViewController.m
@@ -208,7 +208,9 @@ NS_ENUM(NSInteger, ARFairArtistViewIndex){
 - (void)toggleFollowArtist:(id)sender
 {
     if ([User isTrialUser]) {
-        [ARTrialController presentTrialWithContext:ARTrialContextFavoriteArtist fromTarget:self selector:_cmd];
+        [ARTrialController presentTrialWithContext:ARTrialContextFavoriteArtist success:^(BOOL newUser){
+            [self toggleFollowArtist:sender];
+        }];
         return;
     }
     self.followableNetwork.following = !self.followableNetwork.following;

--- a/Artsy/Classes/View Controllers/ARFairGuideViewController.m
+++ b/Artsy/Classes/View Controllers/ARFairGuideViewController.m
@@ -234,11 +234,13 @@ NS_ENUM(NSInteger, ARFairGuideViewOrder) {
 - (void)signupForArtsy:(id)sender
 {
     if ([User isTrialUser]) {
-        [ARTrialController presentTrialWithContext:ARTrialContextFairGuide fromTarget:self selector:@selector(userDidSignUp)];
+        [ARTrialController presentTrialWithContext:ARTrialContextFairGuide success:^(BOOL newUser){
+            [self userDidLoginOrSignUp];
+        }];
     }
 }
 
-- (void)userDidSignUp
+- (void)userDidLoginOrSignUp
 {
     [self.delegate fairGuideViewControllerDidChangeUser:self];
     _selectedTabIndex = ARFairGuideSelectedTabUndefined;

--- a/Artsy/Classes/View Controllers/ARInternalMobileWebViewController.m
+++ b/Artsy/Classes/View Controllers/ARInternalMobileWebViewController.m
@@ -80,7 +80,7 @@
 }
 
 // A full reload, not just a webView.reload, which only refreshes the view without re-requesting data.
-- (void)userDidSignUp
+- (void)userDidLoginOrSignUp
 {
     [self.webView loadRequest:[self requestWithURL:self.currentURL]];
 }
@@ -181,7 +181,9 @@
     } else if ([ARRouter isInternalURL:request.URL] && ([request.URL.path isEqual:@"/log_in"] || [request.URL.path isEqual:@"/sign_up"])) {
         // hijack AJAX requests
         if ([User isTrialUser]) {
-            [ARTrialController presentTrialWithContext:ARTrialContextNotTrial fromTarget:self selector:@selector(userDidSignUp)];
+            [ARTrialController presentTrialWithContext:ARTrialContextNotTrial success:^(BOOL newUser){
+                [self userDidLoginOrSignUp];
+            }];
         }
         return NO;
 

--- a/Artsy/Classes/View Controllers/ARLoginViewController.h
+++ b/Artsy/Classes/View Controllers/ARLoginViewController.h
@@ -1,4 +1,5 @@
-#import "AROnboardingViewController.h"
+@protocol AROnboardingStepsDelegate;
+@protocol ARLoginSignupDelegate;
 
 typedef NS_ENUM(NSInteger, ARLoginViewControllerLoginType) {
     ARLoginViewControllerLoginTypeTwitter = 0,
@@ -10,7 +11,7 @@ typedef NS_ENUM(NSInteger, ARLoginViewControllerLoginType) {
 
 - (instancetype)initWithEmail:(NSString *)email;
 
-@property (nonatomic, weak) AROnboardingViewController *delegate;
+@property (nonatomic, weak) id<AROnboardingStepsDelegate, ARLoginSignupDelegate> delegate;
 @property (nonatomic, assign) BOOL hideDefaultValues;
 
 @end

--- a/Artsy/Classes/View Controllers/ARLoginViewController.h
+++ b/Artsy/Classes/View Controllers/ARLoginViewController.h
@@ -1,5 +1,4 @@
-@protocol AROnboardingStepsDelegate;
-@protocol ARLoginSignupDelegate;
+#import "AROnboardingViewController.h"
 
 typedef NS_ENUM(NSInteger, ARLoginViewControllerLoginType) {
     ARLoginViewControllerLoginTypeTwitter = 0,

--- a/Artsy/Classes/View Controllers/ARLoginViewController.m
+++ b/Artsy/Classes/View Controllers/ARLoginViewController.m
@@ -7,6 +7,7 @@
 #import "ARTextFieldWithPlaceholder.h"
 #import "ARSecureTextFieldWithPlaceholder.h"
 #import "UIView+HitTestExpansion.h"
+#import "AROnboardingViewController.h"
 
 #define SPINNER_TAG 0x555
 

--- a/Artsy/Classes/View Controllers/ARLoginViewController.m
+++ b/Artsy/Classes/View Controllers/ARLoginViewController.m
@@ -7,7 +7,6 @@
 #import "ARTextFieldWithPlaceholder.h"
 #import "ARSecureTextFieldWithPlaceholder.h"
 #import "UIView+HitTestExpansion.h"
-#import "AROnboardingViewController.h"
 
 #define SPINNER_TAG 0x555
 

--- a/Artsy/Classes/View Controllers/AROnboardingMoreInfoViewController.m
+++ b/Artsy/Classes/View Controllers/AROnboardingMoreInfoViewController.m
@@ -216,7 +216,7 @@
                                                                  name:self.nameField.text
                                                               success:^(User *user) {
             @strongify(self);
-            [self loginWithFacebookCredential:NO];
+            [self loginWithFacebookCredential];
         } failure:^(NSError *error, id JSON) {
             @strongify(self);
             if (JSON && [JSON isKindOfClass:[NSDictionary class]]) {
@@ -249,7 +249,7 @@
                                                                  name:self.nameField.text
                                                               success:^(User *user) {
             @strongify(self);
-            [self loginWithTwitterCredential:NO];
+            [self loginWithTwitterCredential];
       } failure:^(NSError *error, id JSON) {
           @strongify(self);
           if (JSON && [JSON isKindOfClass:[NSDictionary class]]) {
@@ -296,8 +296,7 @@
     [alert show];
 }
 
-/// skipAhead to pass over the rest of onboarding
-- (void)loginWithTwitterCredential:(BOOL)skipAhead
+- (void)loginWithTwitterCredential
 {
     [self ar_presentIndeterminateLoadingIndicatorAnimated:YES];
     @weakify(self);
@@ -307,7 +306,7 @@
                                   successWithCredentials:nil
      gotUser:^(User *currentUser) {
          @strongify(self);
-         [self loginCompletedForLoginType:AROnboardingMoreInfoViewControllerLoginTypeTwitter skipAhead:skipAhead];
+         [self loginCompletedForLoginType:AROnboardingMoreInfoViewControllerLoginTypeTwitter];
     } authenticationFailure:^(NSError *error) {
         @strongify(self);
         [self ar_removeIndeterminateLoadingIndicatorAnimated:YES];
@@ -321,8 +320,7 @@
     }];
 }
 
-/// skipAhead to pass over the rest of onboarding
-- (void)loginWithFacebookCredential:(BOOL)skipAhead
+- (void)loginWithFacebookCredential
 {
     [self ar_presentIndeterminateLoadingIndicatorAnimated:YES];
     @weakify(self);
@@ -330,7 +328,7 @@
     [[ARUserManager sharedManager] loginWithFacebookToken:self.token successWithCredentials:nil
       gotUser:^(User *currentUser) {
           @strongify(self);
-          [self loginCompletedForLoginType:AROnboardingMoreInfoViewControllerLoginTypeFacebook skipAhead:skipAhead];
+          [self loginCompletedForLoginType:AROnboardingMoreInfoViewControllerLoginTypeFacebook];
       } authenticationFailure:^(NSError *error) {
           @strongify(self);
           [self ar_removeIndeterminateLoadingIndicatorAnimated:YES];
@@ -349,22 +347,22 @@
     //let's go ahead and log them in
     switch (loginType) {
         case AROnboardingMoreInfoViewControllerLoginTypeFacebook:
-            [self loginWithFacebookCredential:YES];
+            [self loginWithFacebookCredential];
             break;
         case AROnboardingMoreInfoViewControllerLoginTypeTwitter:
-            [self loginWithTwitterCredential:YES];
+            [self loginWithTwitterCredential];
             break;
     }
 }
 
-- (void)loginCompletedForLoginType:(AROnboardingMoreInfoViewControllerLoginType)loginType skipAhead:(BOOL)skipAhead
+- (void)loginCompletedForLoginType:(AROnboardingMoreInfoViewControllerLoginType)loginType
 {
     [self ar_removeIndeterminateLoadingIndicatorAnimated:YES];
     
-    if (skipAhead) {
-        [self.delegate dismissOnboardingWithVoidAnimation:YES];
+    if ([ARUserManager didCreateAccountThisSession]) {
+        [self.delegate didSignUpAndLogin];
     } else {
-        [self.delegate signupDone];
+        [self.delegate dismissOnboardingWithVoidAnimation:YES];
     }
 }
 

--- a/Artsy/Classes/View Controllers/AROnboardingViewController.h
+++ b/Artsy/Classes/View Controllers/AROnboardingViewController.h
@@ -1,7 +1,21 @@
-#import "ARSignUpSplashViewController.h"
 #import "ARNavigationController.h"
 #import "ARTrialController.h"
-#import "ARPersonalizeWebViewController.h"
+
+@class ARSignUpSplashViewController;
+
+@protocol AROnboardingStepsDelegate <NSObject>
+- (void)personalizeDone;
+- (void)splashDone:(ARSignUpSplashViewController *)sender;
+- (void)splashDoneWithLogin:(ARSignUpSplashViewController *)sender;
+- (void)collectorLevelDone:(ARCollectorLevel)level;
+- (void)slideshowDone;
+- (void)setPriceRangeDone:(NSInteger)range;
+@end
+
+@protocol ARLoginSignupDelegate <NSObject>
+- (void)didSignUpAndLogin;
+- (void)dismissOnboardingWithVoidAnimation:(BOOL)animated;
+@end
 
 typedef NS_ENUM(NSInteger, ARInitialOnboardingState){
     ARInitialOnboardingStateSlideShow,
@@ -10,7 +24,7 @@ typedef NS_ENUM(NSInteger, ARInitialOnboardingState){
 
 /// A state-machine based VC that implements the app onboarding process
 
-@interface AROnboardingViewController : UINavigationController <ARPersonalizeWebViewControllerDelegate>
+@interface AROnboardingViewController : UINavigationController <ARLoginSignupDelegate, AROnboardingStepsDelegate>
 
 - (instancetype)initWithState:(enum ARInitialOnboardingState)state;
 
@@ -19,20 +33,7 @@ typedef NS_ENUM(NSInteger, ARInitialOnboardingState){
 - (void)signUpWithFacebook;
 - (void)signUpWithTwitter;
 - (void)signUpWithEmail;
-
 - (void)logInWithEmail:(NSString *)email;
-
-- (void)slideshowDone;
-
-- (void)splashDone:(ARSignUpSplashViewController *)sender;
-- (void)splashDoneWithLogin:(ARSignUpSplashViewController *)sender;
-
-- (void)signupDone;
-- (void)collectorLevelDone:(ARCollectorLevel)level;
-- (void)setPriceRangeDone:(NSInteger)range;
-- (void)personalizeDone;
-- (void)webOnboardingDone;
-
 - (void)showTermsAndConditions;
 - (void)showPrivacyPolicy;
 

--- a/Artsy/Classes/View Controllers/AROnboardingViewController.m
+++ b/Artsy/Classes/View Controllers/AROnboardingViewController.m
@@ -2,7 +2,6 @@
 
 #import "ARAppDelegate.h"
 #import "ARUserManager.h"
-
 #import "AROnboardingTransition.h"
 #import "AROnboardingViewControllers.h"
 #import "ARNetworkConstants.h"
@@ -13,6 +12,7 @@
 #import "ARAuthProviders.h"
 #import "UIViewController+FullScreenLoading.h"
 #import "AROnboardingMoreInfoViewController.h"
+#import "ARPersonalizeWebViewController.h"
 #import "ARParallaxEffect.h"
 #import "NSString+StringCase.h"
 #import "ArtsyAPI+Private.h"
@@ -203,7 +203,7 @@ typedef NS_ENUM(NSInteger, AROnboardingStage) {
     self.state = AROnboardingStageEmailPassword;
 }
 
-- (void)signupDone
+- (void)presentOnboarding
 {
     if ([UIDevice isPad]) {
         [self presentWebOnboarding];
@@ -213,6 +213,11 @@ typedef NS_ENUM(NSInteger, AROnboardingStage) {
         }];
         [self presentCollectorLevel];
     }
+}
+
+- (void)didSignUpAndLogin
+{
+    [self presentOnboarding];
 }
 
 
@@ -225,11 +230,6 @@ typedef NS_ENUM(NSInteger, AROnboardingStage) {
     ARPersonalizeWebViewController *viewController = [[ARPersonalizeWebViewController alloc] initWithURL:url];
     viewController.personalizeDelegate = self;
     [self pushViewController:viewController animated:YES];
-}
-
-- (void)webOnboardingDone
-{
-    [self dismissOnboardingWithVoidAnimation:YES];
 }
 
 #pragma mark -

--- a/Artsy/Classes/View Controllers/ARPersonalizeViewController.h
+++ b/Artsy/Classes/View Controllers/ARPersonalizeViewController.h
@@ -1,11 +1,11 @@
-@class AROnboardingViewController;
+@protocol AROnboardingStepsDelegate;
 @class AROnboardingGeneTableController;
 @class AROnboardingArtistTableController;
 
 @interface ARPersonalizeViewController : UIViewController
 
 - (instancetype)initWithGenes:(NSArray *)genes;
-@property (nonatomic, weak) AROnboardingViewController *delegate;
+@property (nonatomic, weak) id<AROnboardingStepsDelegate> delegate;
 
 @property (nonatomic, assign, readonly) NSInteger followedThisSession;
 @property (nonatomic, readonly) AROnboardingGeneTableController *geneController;

--- a/Artsy/Classes/View Controllers/ARPersonalizeViewController.h
+++ b/Artsy/Classes/View Controllers/ARPersonalizeViewController.h
@@ -1,4 +1,5 @@
-@protocol AROnboardingStepsDelegate;
+#import "AROnboardingViewController.h"
+
 @class AROnboardingGeneTableController;
 @class AROnboardingArtistTableController;
 

--- a/Artsy/Classes/View Controllers/ARPersonalizeViewController.m
+++ b/Artsy/Classes/View Controllers/ARPersonalizeViewController.m
@@ -3,7 +3,6 @@
 #import "AROnboardingArtistTableController.h"
 #import "AROnboardingSearchField.h"
 #import "AROnboardingFollowableTableViewCell.h"
-#import "AROnboardingViewController.h"
 
 static NSString *SearchCellId = @"OnboardingSearchCell";
 

--- a/Artsy/Classes/View Controllers/ARPersonalizeWebViewController.h
+++ b/Artsy/Classes/View Controllers/ARPersonalizeWebViewController.h
@@ -1,10 +1,6 @@
 #import "ARInternalMobileWebViewController.h"
-
-@protocol ARPersonalizeWebViewControllerDelegate <NSObject>
-- (void)dismissOnboardingWithVoidAnimation:(BOOL)createdAccount;
-- (void)webOnboardingDone;
-@end
+#import "AROnboardingViewController.h"
 
 @interface ARPersonalizeWebViewController : ARInternalMobileWebViewController
-@property (atomic, weak) id <ARPersonalizeWebViewControllerDelegate> personalizeDelegate;
+@property (atomic, weak) id<ARLoginSignupDelegate> personalizeDelegate;
 @end

--- a/Artsy/Classes/View Controllers/ARPersonalizeWebViewController.m
+++ b/Artsy/Classes/View Controllers/ARPersonalizeWebViewController.m
@@ -43,7 +43,7 @@
         // Force onboarding is all push-state.
         // A new request to load the root page indicates that onboarding is complete.
 
-        [self.personalizeDelegate dismissOnboardingWithVoidAnimation:YES];
+        [self exitOnboarding];
         return NO;
 
     } else {
@@ -58,7 +58,7 @@
 
 - (void)exitOnboarding
 {
-    [self.personalizeDelegate webOnboardingDone];
+    [self.personalizeDelegate dismissOnboardingWithVoidAnimation:YES];
 }
 
 - (void)showLoading

--- a/Artsy/Classes/View Controllers/ARShowViewController.m
+++ b/Artsy/Classes/View Controllers/ARShowViewController.m
@@ -436,7 +436,9 @@ static const NSInteger ARFairShowMaximumNumberOfHeadlineImages = 5;
 - (void)toggleFollowShow:(id)sender
 {
     if ([User isTrialUser]) {
-        [ARTrialController presentTrialWithContext:ARTrialContextFavoriteProfile fromTarget:self selector:_cmd];
+        [ARTrialController presentTrialWithContext:ARTrialContextFavoriteProfile success:^(BOOL newUser){
+            [self toggleFollowShow:sender];
+        }];
         return;
     }
 

--- a/Artsy/Classes/View Controllers/ARSignUpActiveUserViewController.m
+++ b/Artsy/Classes/View Controllers/ARSignUpActiveUserViewController.m
@@ -138,7 +138,6 @@
         self.bottomView.alpha = 0;
     }];
     [self.delegate dismissOnboardingWithVoidAnimation:NO didCancel:YES];
-
 }
 
 @end

--- a/Artsy/Classes/View Controllers/ARSignUpSplashViewController.h
+++ b/Artsy/Classes/View Controllers/ARSignUpSplashViewController.h
@@ -1,8 +1,7 @@
-@class AROnboardingViewController;
+@protocol AROnboardingStepsDelegate;
 
 @interface ARSignUpSplashViewController : UIViewController
-
-@property (nonatomic, weak) AROnboardingViewController *delegate;
+@property (nonatomic, weak) id<AROnboardingStepsDelegate> delegate;
 
 @property (nonatomic, strong) UIImage *backgroundImage;
 

--- a/Artsy/Classes/View Controllers/ARSignUpSplashViewController.h
+++ b/Artsy/Classes/View Controllers/ARSignUpSplashViewController.h
@@ -1,7 +1,7 @@
-@protocol AROnboardingStepsDelegate;
+#import "AROnboardingViewController.h"
 
 @interface ARSignUpSplashViewController : UIViewController
-@property (nonatomic, weak) id<AROnboardingStepsDelegate> delegate;
+@property (nonatomic, weak) id<AROnboardingStepsDelegate, ARLoginSignupDelegate> delegate;
 
 @property (nonatomic, strong) UIImage *backgroundImage;
 

--- a/Artsy/Classes/View Controllers/ARTopMenuViewController.h
+++ b/Artsy/Classes/View Controllers/ARTopMenuViewController.h
@@ -35,9 +35,6 @@
 /// Hides the toolbar
 - (void)hideToolbar:(BOOL)hideToolbar animated:(BOOL)animated;
 
-/// Removes the Onboarding overlay
-- (void)moveToInAppAnimated:(BOOL)animated;
-
 /// Used in search to exit out of search and back into a previous tab.
 - (void)returnToPreviousTab;
 

--- a/Artsy/Classes/View Controllers/ARTopMenuViewController.m
+++ b/Artsy/Classes/View Controllers/ARTopMenuViewController.m
@@ -196,18 +196,6 @@ static const CGFloat ARSearchMenuButtonDimension = 46;
     self.divider.frame = CGRectMake(tabHeight, tabHeight * .25, 1, tabHeight * .5);
 }
 
-- (void)moveToInAppAnimated:(BOOL)animated
-{
-    if (self.presentedViewController) {
-        self.presentedViewController.transitioningDelegate = self;
-        [self.presentedViewController dismissViewControllerAnimated:animated completion:^{
-            if ([User currentUser]) {
-                [ARTrialController performPostSignupEvent];
-            }
-        }];
-    }
-}
-
 #pragma mark - Pushing VCs
 
 - (void)loadFeed
@@ -266,11 +254,6 @@ static const CGFloat ARSearchMenuButtonDimension = 46;
     [self.tabContentView returnToPreviousViewIndex];
 }
 
-- (void)userDidSignUp
-{
-    [self.tabContentView setCurrentViewIndex:ARTopTabControllerIndexFavorites animated:NO];
-}
-
 #pragma mark - ARTabViewDelegate
 
 - (void)tabContentView:(ARTabContentView *)tabContentView didChangeSelectedIndex:(NSInteger)index
@@ -289,7 +272,13 @@ static const CGFloat ARSearchMenuButtonDimension = 46;
 - (BOOL)tabContentView:(ARTabContentView *)tabContentView shouldChangeToIndex:(NSInteger)index
 {
     if (index == ARTopTabControllerIndexFavorites && [User isTrialUser]) {
-        [ARTrialController presentTrialWithContext:ARTrialContextShowingFavorites fromTarget:self selector:@selector(userDidSignUp)];
+        [ARTrialController presentTrialWithContext:ARTrialContextShowingFavorites success:^(BOOL newUser) {
+            if(newUser) {
+                [self.tabContentView setCurrentViewIndex:ARTopTabControllerIndexFeed animated:NO];
+            } else {
+                [self.tabContentView setCurrentViewIndex:ARTopTabControllerIndexFavorites animated:NO];
+            }
+        }];
         return NO;
     }
 

--- a/Artsy/Classes/Views/ARGeneViewController.m
+++ b/Artsy/Classes/Views/ARGeneViewController.m
@@ -178,7 +178,9 @@
 - (void)toggleFollowingGene:(ARHeartButton *)sender
 {
     if ([User isTrialUser]) {
-        [ARTrialController presentTrialWithContext:ARTrialContextFavoriteGene fromTarget:self selector:_cmd];
+        [ARTrialController presentTrialWithContext:ARTrialContextFavoriteGene success:^(BOOL newUser){
+            [self toggleFollowingGene:sender];
+        }];
         return;
     }
 


### PR DESCRIPTION
we want the ability to keep track of whether the user created a new account or logged in without creating a new account, regardless of which of the multiple sign in/log in points of entry they go through, and to pass this bit of information to whatever callback is specified after onboarding/login is completed.

closes https://github.com/artsy/eigen/issues/481