### PR TITLE
@alloy => Add support for using the URL to figure the fair in an Fair Artist 

### DIFF
--- a/Artsy/Classes/Utils/ARSwitchBoard.m
+++ b/Artsy/Classes/Utils/ARSwitchBoard.m
@@ -69,8 +69,8 @@
     if ([UIDevice isPad]) {
         [self.routes addRoute:@"/:profile_id/artist/:id" handler:^BOOL(NSDictionary *parameters) {
             @strongify(self)
-            Fair *fair = [parameters[@"fair"] isKindOfClass:Fair.class] ? parameters[@"fair"] : nil;
 
+            Fair *fair = [parameters[@"fair"] isKindOfClass:Fair.class] ? parameters[@"fair"] : nil;
             ARArtistViewController *viewController = (id)[self loadArtistWithID:parameters[@"id"] inFair:fair];
             [[ARTopMenuViewController sharedController] pushViewController:viewController];
             return YES;
@@ -106,10 +106,8 @@
 
         @strongify(self);
 
-        id context = parameters[@"fair"];
-        NSAssert(context != nil, @"Fair guide routing attempt with no context. ");
-
-        UIViewController *viewController = [self loadFairGuideWithFair:context];
+        Fair *fair = [parameters[@"fair"] isKindOfClass:Fair.class] ? parameters[@"fair"] : nil;
+        UIViewController *viewController = [self loadFairGuideWithFair:fair];
         [[ARTopMenuViewController sharedController] pushViewController:viewController];
 
         return YES;
@@ -120,8 +118,8 @@
         if ([UIDevice isPad]) { return NO; }
 
         @strongify(self)
-
-        UIViewController *viewController = [self loadArtistInFairWithID:parameters[@"id"] fair:parameters[@"fair"]];
+        Fair *fair = parameters[@"fair"] ?: [[Fair alloc] initWithFairID:parameters[@"profile_id"]];
+        UIViewController *viewController = [self loadArtistInFairWithID:parameters[@"id"] fair:fair];
         [[ARTopMenuViewController sharedController] pushViewController:viewController];
         return YES;
     }];
@@ -249,7 +247,7 @@
 
 - (UIViewController<ARFairAwareObject> *)loadArtistWithID:(NSString *)artistID inFair:(Fair *)fair
 {
-    if(fair){
+    if (fair) {
         ARFairArtistViewController *viewController = [[ARFairArtistViewController alloc] initWithArtistID:artistID fair:fair];
         return viewController;
     } else {

--- a/Artsy/Classes/View Controllers/ARFairArtistViewController.m
+++ b/Artsy/Classes/View Controllers/ARFairArtistViewController.m
@@ -77,7 +77,7 @@ NS_ENUM(NSInteger, ARFairArtistViewIndex){
 
 - (void)artistDidLoad
 {
-    _header = NSStringWithFormat(@"%@ at %@", self.artist.name, self.fair.name);
+    _header = NSStringWithFormat(@"%@ at %@", self.artist.name, self.fair.name ?: self.fair.fairID);
 
     [self.view.stackView addPageTitleWithString:self.header tag:ARFairArtistTitle];
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* Fair Artists links in Martsy outside of a fair will resolve correctly to their fair - orta
+
 ## 2.0.0 (05/06/2015)
 
 * Add iPad support - 1aurabrown


### PR DESCRIPTION
If you link to an artist browse in the fair page from an internal web view there is no fair context provided, so we can pull out the fair ID from it's route and use that.