### PR TITLE
@ashfurrow => Route to /auction/ when tapping on a bid button

### DIFF
--- a/Artsy/Classes/Utils/ARSwitchBoard.m
+++ b/Artsy/Classes/Utils/ARSwitchBoard.m
@@ -182,7 +182,7 @@
 
 - (UIViewController *)loadBidUIForArtwork:(NSString *)artworkID inSale:(NSString *)saleID
 {
-    NSString *path = [NSString stringWithFormat:@"/feature/%@/bid/%@", saleID, artworkID];
+    NSString *path = [NSString stringWithFormat:@"/auctions/%@/bid/%@", saleID, artworkID];
     return [self loadURL:[NSURL URLWithString:path]];
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* Tapping bid button on an artwork uses new /auctions/ route - orta
+
 ## 2.0.0 (05/06/2015)
 
 * Add iPad support - 1aurabrown


### PR DESCRIPTION
Fixes: https://github.com/artsy/eigen/issues/529