### PR TITLE
@alloy => Ensure that the keychain always works through access groups

### DIFF
--- a/Artsy Tests/ARUserManagerTests.m
+++ b/Artsy Tests/ARUserManagerTests.m
@@ -5,7 +5,8 @@
 #import "ARDefaults.h"
 
 @interface ARUserManager (Testing)
-+ (void)clearUserDataAndSetUseStaging:(id)useStaging;
++ (void)clearUserData;
++ (void)clearUserData:(ARUserManager *)manager useStaging:(id)useStaging;
 @end
 
 SpecBegin(ARUserManager)
@@ -163,7 +164,7 @@ describe(@"clearUserData", ^{
         it(@"explicitly sets staging default to yes", ^{
             expect([[NSUserDefaults standardUserDefaults] valueForKey:ARUseStagingDefault]).to.beNil();
             expect([[NSUserDefaults standardUserDefaults] valueForKey:@"TestKey"]).to.equal(@"test value");
-            [ARUserManager clearUserDataAndSetUseStaging:@(YES)];
+            [ARUserManager clearUserData:[ARUserManager sharedManager] useStaging:@(YES)];
             expect([[NSUserDefaults standardUserDefaults] valueForKey:ARUseStagingDefault]).to.beTruthy();
             expect([[NSUserDefaults standardUserDefaults] valueForKey:@"TestKey"]).to.beNil();
         });
@@ -171,7 +172,7 @@ describe(@"clearUserData", ^{
         it(@"explicitly sets staging default to no", ^{
             expect([[NSUserDefaults standardUserDefaults] valueForKey:ARUseStagingDefault]).to.beNil();
             expect([[NSUserDefaults standardUserDefaults] valueForKey:@"TestKey"]).to.equal(@"test value");
-            [ARUserManager clearUserDataAndSetUseStaging:@(NO)];
+            [ARUserManager clearUserData:[ARUserManager sharedManager] useStaging:@(NO)];
             expect([[NSUserDefaults standardUserDefaults] valueForKey:ARUseStagingDefault]).to.beFalsy();
             expect([[NSUserDefaults standardUserDefaults] valueForKey:@"TestKey"]).to.beNil();
         });
@@ -179,7 +180,7 @@ describe(@"clearUserData", ^{
         it(@"does not set staging value passed is nil", ^{
             expect([[NSUserDefaults standardUserDefaults] valueForKey:ARUseStagingDefault]).to.beNil();
             expect([[NSUserDefaults standardUserDefaults] valueForKey:@"TestKey"]).to.equal(@"test value");
-            [ARUserManager clearUserDataAndSetUseStaging:nil];
+            [ARUserManager clearUserData:[ARUserManager sharedManager] useStaging:nil];
             expect([[NSUserDefaults standardUserDefaults] valueForKey:ARUseStagingDefault]).to.beNil();
             expect([[NSUserDefaults standardUserDefaults] valueForKey:@"TestKey"]).to.beNil();
         });

--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -322,6 +322,7 @@
 		6088B75417D1DBAC00E4BB67 /* ARAnalyticsConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 6088B75317D1DBAC00E4BB67 /* ARAnalyticsConstants.m */; };
 		6088B75917D20A0A00E4BB67 /* ARSlideshowView.m in Sources */ = {isa = PBXBuildFile; fileRef = 49F0C67E17B972F200721244 /* ARSlideshowView.m */; };
 		608920C3178C682A00989A10 /* ARItemThumbnailViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 608920C2178C682A00989A10 /* ARItemThumbnailViewCell.m */; };
+		608AABDC1B3884C600855A1C /* ARKeychainable.m in Sources */ = {isa = PBXBuildFile; fileRef = 608AABDB1B3884C600855A1C /* ARKeychainable.m */; };
 		608B2F5E1657D0500046956C /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 608B2F5D1657D0500046956C /* main.m */; };
 		608B2F621657D1500046956C /* ARDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 608B2F611657D1500046956C /* ARDefaults.m */; };
 		608B2F6F1657D1D10046956C /* User.m in Sources */ = {isa = PBXBuildFile; fileRef = 608B2F6E1657D1D10046956C /* User.m */; };
@@ -1177,6 +1178,8 @@
 		6089243217F617140023D1AC /* ARArtworkMetadataView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARArtworkMetadataView.m; sourceTree = "<group>"; };
 		60892CEC16B9A849004C1B47 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 		60892CEE16B9A871004C1B47 /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
+		608AABDA1B3884C600855A1C /* ARKeychainable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARKeychainable.h; sourceTree = "<group>"; };
+		608AABDB1B3884C600855A1C /* ARKeychainable.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARKeychainable.m; sourceTree = "<group>"; };
 		608B2F5D1657D0500046956C /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = Artsy/App/main.m; sourceTree = SOURCE_ROOT; };
 		608B2F601657D1500046956C /* ARDefaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARDefaults.h; sourceTree = "<group>"; };
 		608B2F611657D1500046956C /* ARDefaults.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARDefaults.m; sourceTree = "<group>"; };
@@ -3478,6 +3481,8 @@
 				3CF144AD18E460EF00B1A764 /* ArtsyAPI+SystemTime.m */,
 				3CB37D95192246B500089A1D /* ArtsyAPI+ErrorHandlers.h */,
 				3CB37D96192246B500089A1D /* ArtsyAPI+ErrorHandlers.m */,
+				608AABDA1B3884C600855A1C /* ARKeychainable.h */,
+				608AABDB1B3884C600855A1C /* ARKeychainable.m */,
 			);
 			name = "API Modules";
 			sourceTree = "<group>";
@@ -4250,6 +4255,7 @@
 				49BA7E141655ABE600C06572 /* ARAppDelegate.m in Sources */,
 				B375E5F418121EEA005FC680 /* Sale.m in Sources */,
 				608B2F5E1657D0500046956C /* main.m in Sources */,
+				608AABDC1B3884C600855A1C /* ARKeychainable.m in Sources */,
 				608B2F621657D1500046956C /* ARDefaults.m in Sources */,
 				600415C917C4ECE2003C7974 /* ArtsyAPI+RelatedModels.m in Sources */,
 				3CF144A718E45F6C00B1A764 /* SystemTime.m in Sources */,
@@ -4828,6 +4834,8 @@
 				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = NO;
 				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = NO;
 				CODE_SIGN_ENTITLEMENTS = Artsy/Artsy.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4855,6 +4863,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				INFOPLIST_FILE = "Artsy/App/Artsy-Info.plist";
 				PRODUCT_NAME = Artsy;
+				PROVISIONING_PROFILE = "";
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4879,6 +4888,8 @@
 				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = NO;
 				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = NO;
 				CODE_SIGN_ENTITLEMENTS = Artsy/Artsy.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4906,6 +4917,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				INFOPLIST_FILE = "Artsy/App/Artsy-Info.plist";
 				PRODUCT_NAME = Artsy;
+				PROVISIONING_PROFILE = "";
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5282,6 +5294,8 @@
 				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = NO;
 				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = NO;
 				CODE_SIGN_ENTITLEMENTS = Artsy/Artsy.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -5311,6 +5325,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				INFOPLIST_FILE = "Artsy/App/Artsy-Info.plist";
 				PRODUCT_NAME = Artsy;
+				PROVISIONING_PROFILE = "";
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5398,6 +5413,8 @@
 				CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK = NO;
 				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = NO;
 				CODE_SIGN_ENTITLEMENTS = Artsy/Artsy.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -5426,6 +5443,7 @@
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				INFOPLIST_FILE = "Artsy/App/Artsy-Info.plist";
 				PRODUCT_NAME = Artsy;
+				PROVISIONING_PROFILE = "";
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Artsy.xcodeproj/xcshareddata/xcschemes/Artsy.xcscheme
+++ b/Artsy.xcodeproj/xcshareddata/xcschemes/Artsy.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "4D830D885CE3DB20472E230A"
+               BlueprintIdentifier = "7B6F3179CDD265E55DF25EFE"
                BuildableName = "libPods.a"
                BlueprintName = "Pods"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">

--- a/Artsy/Artsy.entitlements
+++ b/Artsy/Artsy.entitlements
@@ -7,6 +7,7 @@
 		<string>$(AppIdentifierPrefix)net.artsy.artsy.dev</string>
 		<string>$(AppIdentifierPrefix)net.artsy.artsy.beta</string>
 		<string>$(AppIdentifierPrefix)net.artsy.artsy</string>
+		<string>$(AppIdentifierPrefix)net.artsy.artsy.demo</string>
 	</array>
 </dict>
 </plist>

--- a/Artsy/Classes/ARAppDelegate.m
+++ b/Artsy/Classes/ARAppDelegate.m
@@ -38,6 +38,8 @@
 #import <VCRURLConnection/VCR.h>
 #endif
 
+#import <UICKeyChainStore/UICKeyChainStore.h>
+
 // demo
 #import "ARDemoSplashViewController.h"
 #import "ARShowFeedViewController.h"
@@ -64,6 +66,7 @@ static ARAppDelegate *_sharedInstance = nil;
 }
 
 // These methods are swizzled during unit tests. See ARAppDelegate(Testing).
+
 
 - (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {

--- a/Artsy/Classes/Networking/ARKeychainable.h
+++ b/Artsy/Classes/Networking/ARKeychainable.h
@@ -1,0 +1,18 @@
+/// A protocol that sets/edits strings in the keychain
+
+@protocol ARKeychainable <NSObject>
+
+- (void)removeKeychainStringForKey:(NSString *)key;
+- (NSString *)keychainStringForKey:(NSString *)key;
+- (void)setKeychainStringForKey:(NSString *)key value:(NSString *)value;
+
+@end
+
+/// Provides an API for the Keychain with correct access groups
+@interface ARKeychain : NSObject <ARKeychainable>
+@end
+
+/// Provides a stubbed API that is easily inspected
+@interface ARDictionaryBackedKeychain : NSObject <ARKeychainable>
+@property (nonatomic, copy) NSMutableDictionary *dict;
+@end

--- a/Artsy/Classes/Networking/ARKeychainable.m
+++ b/Artsy/Classes/Networking/ARKeychainable.m
@@ -1,0 +1,62 @@
+#import <UICKeyChainStore/UICKeyChainStore.h>
+
+#import "ARKeychainable.h"
+
+@implementation ARKeychain
+
+- (void)removeKeychainStringForKey:(NSString *)key
+{
+    NSString *service = [UICKeyChainStore defaultService];
+    NSString *appBundle = [[NSBundle mainBundle] bundleIdentifier];
+    NSString *accessGroup = [@"group." stringByAppendingString:appBundle];
+
+    [UICKeyChainStore removeItemForKey:key service:service accessGroup:accessGroup];
+}
+
+- (NSString *)keychainStringForKey:(NSString *)key
+{
+    NSString *service = [UICKeyChainStore defaultService];
+    NSString *appBundle = [[NSBundle mainBundle] bundleIdentifier];
+    NSString *accessGroup = [@"group." stringByAppendingString:appBundle];
+
+    return [UICKeyChainStore stringForKey:key service:service accessGroup:accessGroup];
+}
+
+- (void)setKeychainStringForKey:(NSString *)key value:(NSString *)value
+{
+    NSString *service = [UICKeyChainStore defaultService];
+    NSString *appBundle = [[NSBundle mainBundle] bundleIdentifier];
+    NSString *accessGroup = [@"group." stringByAppendingString:appBundle];
+
+    [UICKeyChainStore setString:value forKey:key service:service accessGroup:accessGroup];
+}
+
+@end
+
+@implementation ARDictionaryBackedKeychain
+
+- (instancetype)init
+{
+    self = [super init];
+    if (!self) { return nil; }
+
+    _dict = [NSMutableDictionary dictionary];
+    return self;
+}
+
+- (NSString *)keychainStringForKey:(NSString *)key
+{
+    return self.dict[key];
+}
+
+- (void)removeKeychainStringForKey:(NSString *)key
+{
+    [self.dict removeObjectForKey:key];
+}
+
+- (void)setKeychainStringForKey:(NSString *)key value:(NSString *)value
+{
+    [self.dict setObject:value forKey:key];
+}
+
+@end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* Ensure consistent access to the keychain throughout the ARUserManager - orta
+
 ## 2.0.0 (05/06/2015)
 
 * Add iPad support - 1aurabrown

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,3 +247,6 @@ DEPENDENCIES
   second_curtain
   shenzhen
   xcpretty
+
+BUNDLED WITH
+   1.10.3


### PR DESCRIPTION
My Watch App introduced some bugs that are only apparent when using the app store build on a device. Sigh. 

So I've gone and re-created our eigen certs, and ensured that we have consistent access groups between all the apps. In started to work on the tests I ended up in the bushes a bit and created https://github.com/artsy/eigen/issues/533 as I realized that this is outside of the current scope. 

fixes https://github.com/artsy/eigen/issues/530
