### PR TITLE
@ashfurrow => Add more paranoid nillifying of delegates.

### DIFF
--- a/Artsy/Classes/View Controllers/ARExternalWebBrowserViewController.m
+++ b/Artsy/Classes/View Controllers/ARExternalWebBrowserViewController.m
@@ -11,6 +11,11 @@
 
 @implementation ARExternalWebBrowserViewController
 
+- (void)dealloc;
+{
+    self.scrollView.delegate = nil;
+}
+
 - (instancetype)initWithURL:(NSURL *)url
 {
     self = [super initWithURL:url];
@@ -60,7 +65,7 @@
 
 - (UIScrollView *)scrollView
 {
-    return  self.webView.scrollView;
+    return self.webView.scrollView;
 }
 
 #pragma mark UIScrollViewDelegate

--- a/Artsy/Classes/View Controllers/ARInternalMobileWebViewController.m
+++ b/Artsy/Classes/View Controllers/ARInternalMobileWebViewController.m
@@ -20,6 +20,16 @@
 
 - (void)dealloc;
 {
+    // This is already done in -[TSMiniWebBrowser dealloc], but still it seems we're getting UIWebViewDelegate messages
+    // after this object has been deallocated.
+    //
+    // It could also have been due to ARExternalWebBrowserViewController
+    // hijacking the webview’s scrollview delegate and maybe the webview doing something funky, like retrieving its
+    // delegate from the scrollview. If so, then the nillifying of the scrollview that's now done in
+    // -[ARExternalWebBrowserViewController dealloc] should be enough, but that's all just conjecture.
+    //
+    self.webView.delegate = nil;
+
     [self removeContentLoadStateTimer];
 }
 


### PR DESCRIPTION
![](http://media4.giphy.com/media/LIgVC2ZiQbpQs/giphy.gif)

This is an effort to try to fix #527 (https://rink.hockeyapp.net/manage/apps/37029/app_versions/34/crash_reasons/37717442)

It looks like your typical ‘delegate messages send to an already deallocated object’ crash,
and indeed the `UIWebView.delegate` property is of type `assign`, but the superclass `TSMiniBrowser` is already nillifying the delegate in its dealloc implementation… So I don’t understand how this can occur.

These changes just add a few more explicit nillifications in hopes that it fixes this somehow, but if it does then I’m currently unsure why it does.

