### PR TITLE
@orta => Temp disable placeholder images at right size in effort to debug crash.

### DIFF
--- a/Artsy/Classes/View Controllers/ARArtworkPreviewImageView.m
+++ b/Artsy/Classes/View Controllers/ARArtworkPreviewImageView.m
@@ -90,12 +90,13 @@
     NSURL *imageURL = [NSURL URLWithString:artwork.defaultImage.baseImageURL];
     UIImage *image;
     image = [ARFeedImageLoader bestAvailableCachedImageForBaseURL:imageURL];
-    if (!image) {
-        // Multiply by 1000 to preserve precision because the image's dimensions get rounded to whole numbers.
-        CGFloat aspectRatio = artwork.aspectRatio ?: 1;
-        CGSize size = CGSizeMake(aspectRatio * 1000, 1000);
-        image = [UIImage imageFromColor:[UIColor artsyLightGrey] withSize:size];
-    }
+//    Temporarily disable this to see if it’s related to https://github.com/artsy/eigen/issues/526.
+//    if (!image) {
+//        // Multiply by 1000 to preserve precision because the image's dimensions get rounded to whole numbers.
+//        CGFloat aspectRatio = artwork.aspectRatio ?: 1;
+//        CGSize size = CGSizeMake(aspectRatio * 1000, 1000);
+//        image = [UIImage imageFromColor:[UIColor artsyLightGrey] withSize:size];
+//    }
     return image;
 }
 


### PR DESCRIPTION
This is ugly, but will get reverted as soon as the 2.0.1 bugfix release
has been released. It should at least give us some insight into whether
or not this code is in any way related to, as of yet, unreproducible
issue https://github.com/artsy/eigen/issues/526.