### PR TITLE
@orta => [Martsy] Fix crash due to NSTimer based retain cycle.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
-gem 'cocoapods', :git => "https://github.com/cocoapods/cocoapods.git", :branch => "seg-embed-frameworks-quotes"
-gem "cocoapods-keys", :git => 'https://github.com/alloy/cocoapods-keys.git', :branch => 'retrieve-keys-from-env'
-gem "cocoapods-stats"
-gem "cocoapods-deintegrate"
+gem 'cocoapods', :git => 'https://github.com/cocoapods/cocoapods.git', :branch => 'seg-embed-frameworks-quotes'
+gem 'cocoapods-keys'
+gem 'cocoapods-stats'
+gem 'cocoapods-deintegrate'
 
 group :development do
   gem 'houston'
@@ -12,7 +12,7 @@ end
 group :test do
   gem 'fui'
   gem 'xcpretty'
-  gem 'second_curtain', :git => "https://github.com/ashfurrow/second_curtain.git", :branch => "improved_parse"
+  gem 'second_curtain', :git => 'https://github.com/ashfurrow/second_curtain.git', :branch => 'improved_parse'
 end
 
 group :distribution do

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 group :test do
   gem 'fui'
   gem 'xcpretty'
-  gem 'second_curtain', :git => "git@github.com:ashfurrow/second_curtain.git", :branch => "improved_parse"
+  gem 'second_curtain', :git => "https://github.com/ashfurrow/second_curtain.git", :branch => "improved_parse"
 end
 
 group :distribution do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,19 @@
 GIT
-  remote: git@github.com:ashfurrow/second_curtain.git
-  revision: 2f388f5aca8496c14c4c72ac5a726529b7dedb80
-  branch: improved_parse
-  specs:
-    second_curtain (0.4.0)
-      aws-sdk-v1 (~> 1.52)
-      mustache (~> 0.99)
-
-GIT
   remote: https://github.com/alloy/cocoapods-keys.git
   revision: 60a23f0b3b3ef7c055386417d94111795a2ec456
   branch: retrieve-keys-from-env
   specs:
     cocoapods-keys (1.2.0)
       osx_keychain
+
+GIT
+  remote: https://github.com/ashfurrow/second_curtain.git
+  revision: 2f388f5aca8496c14c4c72ac5a726529b7dedb80
+  branch: improved_parse
+  specs:
+    second_curtain (0.4.0)
+      aws-sdk-v1 (~> 1.52)
+      mustache (~> 0.99)
 
 GIT
   remote: https://github.com/cocoapods/cocoapods.git

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/alloy/cocoapods-keys.git
-  revision: 60a23f0b3b3ef7c055386417d94111795a2ec456
-  branch: retrieve-keys-from-env
-  specs:
-    cocoapods-keys (1.2.0)
-      osx_keychain
-
-GIT
   remote: https://github.com/ashfurrow/second_curtain.git
   revision: 2f388f5aca8496c14c4c72ac5a726529b7dedb80
   branch: improved_parse
@@ -17,7 +9,7 @@ GIT
 
 GIT
   remote: https://github.com/cocoapods/cocoapods.git
-  revision: c7e261c93575751149b62c49fea74254e652647e
+  revision: 119c8c7659418991ababcd227297fe9eee800b50
   branch: seg-embed-frameworks-quotes
   specs:
     cocoapods (0.38.0.beta.1)
@@ -26,6 +18,7 @@ GIT
       cocoapods-core (= 0.38.0.beta.1)
       cocoapods-downloader (~> 0.9.1)
       cocoapods-plugins (~> 0.4.2)
+      cocoapods-stats (~> 0.5.0)
       cocoapods-trunk (~> 0.6.1)
       cocoapods-try (~> 0.4.5)
       colored (~> 1.2)
@@ -59,7 +52,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    cert (0.2.0)
+    cert (0.2.1)
       fastlane_core (>= 0.7.2)
     certified (1.0.0)
     claide (0.8.2)
@@ -71,9 +64,11 @@ GEM
     cocoapods-deintegrate (0.2.1)
       cocoapods (~> 0.34)
     cocoapods-downloader (0.9.1)
+    cocoapods-keys (1.4.0)
+      osx_keychain
     cocoapods-plugins (0.4.2)
       nap
-    cocoapods-stats (0.5.0)
+    cocoapods-stats (0.5.3)
       nap (~> 0.8)
     cocoapods-trunk (0.6.1)
       nap (>= 0.8)
@@ -82,11 +77,11 @@ GEM
     colored (1.2)
     commander (4.3.4)
       highline (~> 1.7.2)
-    credentials_manager (0.4.0)
+    credentials_manager (0.6.0)
       colored
       highline (>= 1.7.1)
       security
-    cupertino (1.3.3)
+    cupertino (1.3.4)
       certified (~> 1.0.0)
       commander (~> 4.3)
       highline (>= 1.7.1)
@@ -95,18 +90,17 @@ GEM
       security (~> 0.1.2)
       term-ansicolor (~> 1.0.7)
       terminal-table (~> 1.4.5)
-    deliver (0.10.0)
+    deliver (0.12.1)
       credentials_manager (>= 0.3.0)
       excon
       fastimage (~> 1.6.3)
       fastlane_core (>= 0.7.2)
       nokogiri (~> 1.6.5)
       plist (~> 3.1.0)
-      prawn
       rubyzip (~> 1.1.6)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.0.1)
+    dotenv (2.0.2)
     escape (0.0.4)
     excon (0.45.3)
     faraday (0.8.9)
@@ -115,45 +109,46 @@ GEM
       faraday (>= 0.7.4, < 0.10)
     fastimage (1.6.8)
       addressable (~> 2.3, >= 2.3.5)
-    fastlane (1.0.2)
+    fastlane (1.3.2)
       aws-sdk (~> 1.0)
-      cert (>= 0.2.0)
+      cert (>= 0.2.1)
       cupertino (>= 1.3.3)
-      deliver (>= 0.9.4)
-      fastlane_core (>= 0.7.2)
-      frameit (>= 1.0.1)
+      deliver (>= 0.11.0)
+      fastlane_core (>= 0.7.5)
+      frameit (>= 2.0.0)
       krausefx-shenzhen (= 0.14.2)
       nokogiri (~> 1.6)
-      pem (>= 0.5.5)
+      pbxplorer (~> 1.0.0)
+      pem (>= 0.6.1)
       produce (>= 0.2.1)
-      sigh (>= 0.5.1)
+      sigh (>= 0.5.2)
       slack-notifier (~> 1.0)
-      snapshot (>= 0.8.0)
+      snapshot (>= 0.9.0)
       terminal-notifier (~> 1.6.2)
       terminal-table (~> 1.4.5)
       xcodeproj (~> 0.20)
       xcpretty (~> 0.1)
-    fastlane_core (0.7.2)
+    fastlane_core (0.8.0)
       babosa
       capybara (~> 2.4.3)
       colored
       commander (>= 4.3.4)
-      credentials_manager (>= 0.4.0)
+      credentials_manager (>= 0.6.0)
       excon (~> 0.45.0)
       highline (>= 1.7.2)
       json
       multi_json
       phantomjs (~> 1.9.8)
       poltergeist (~> 1.5.1)
-    frameit (1.0.1)
+    frameit (2.0.1)
       deliver (> 0.3)
       fastimage (~> 1.6.3)
-      fastlane_core (>= 0.5.0)
+      fastlane_core (>= 0.7.2)
       mini_magick (~> 4.0.2)
     fui (0.3.0)
       gli
     fuzzy_match (2.0.4)
-    gli (2.13.0)
+    gli (2.13.1)
     highline (1.7.2)
     houston (2.2.3)
       commander (~> 4.1)
@@ -186,7 +181,8 @@ GEM
     mini_portile (0.6.2)
     minitest (5.7.0)
     molinillo (0.2.3)
-    multi_json (1.11.0)
+    multi_json (1.11.1)
+    multi_xml (0.5.5)
     multipart-post (1.2.0)
     mustache (0.99.8)
     nap (0.8.0)
@@ -201,9 +197,9 @@ GEM
     ntlm-http (0.1.1)
     osx_keychain (1.0.1)
       RubyInline (~> 3)
-    pdf-core (0.5.1)
-    pem (0.5.5)
-      fastlane_core (>= 0.6.0)
+    pbxplorer (1.0.0)
+    pem (0.6.4)
+      fastlane_core (>= 0.7.2)
     phantomjs (1.9.8.0)
     plist (3.1.0)
     poltergeist (1.5.1)
@@ -211,17 +207,14 @@ GEM
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
-    prawn (2.0.1)
-      pdf-core (~> 0.5.1)
-      ttfunk (~> 1.4.0)
     produce (0.2.1)
       fastlane_core (>= 0.5.0)
-    rack (1.6.1)
+    rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
     rubyzip (1.1.7)
     security (0.1.3)
-    shenzhen (0.14.1)
+    shenzhen (0.14.2)
       aws-sdk (~> 1.0)
       commander (~> 4.3)
       dotenv (>= 0.7)
@@ -234,18 +227,24 @@ GEM
       rubyzip (~> 1.1)
       security (~> 0.1.3)
       terminal-table (~> 1.4.5)
-    sigh (0.5.1)
-      fastlane_core (>= 0.7.2)
+    sigh (0.6.0)
+      fastlane_core (>= 0.7.6)
       plist (~> 3.1.0)
-    slack-notifier (1.2.0)
-    snapshot (0.8.0)
+      spaceship (>= 0.0.8)
+    slack-notifier (1.2.1)
+    snapshot (0.9.0)
       fastimage (~> 1.6.3)
-      fastlane_core (>= 0.5.0)
+      fastlane_core (>= 0.7.2)
+    spaceship (0.0.8)
+      credentials_manager (>= 0.5.0)
+      faraday (~> 0.8.9)
+      faraday_middleware (~> 0.9)
+      multi_xml (~> 0.5)
+      plist (~> 3.1)
     term-ansicolor (1.0.7)
     terminal-notifier (1.6.3)
     terminal-table (1.4.5)
     thread_safe (0.3.5)
-    ttfunk (1.4.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     unf (0.1.4)
@@ -268,7 +267,7 @@ PLATFORMS
 DEPENDENCIES
   cocoapods!
   cocoapods-deintegrate
-  cocoapods-keys!
+  cocoapods-keys
   cocoapods-stats
   fastlane
   fui

--- a/Podfile
+++ b/Podfile
@@ -54,6 +54,7 @@ target 'Artsy' do
   pod 'ARCollectionViewMasonryLayout', '~> 2.1', '>= 2.1.2'
   pod 'ARGenericTableViewController', '1.0.2'
   pod 'FLKAutoLayout', '0.1.1'
+  pod 'TPDWeakProxy', '1.1.0'
 
   # X-Callback-Url support
   pod 'InterAppCommunication'

--- a/Podfile
+++ b/Podfile
@@ -1,3 +1,13 @@
+class Pod::Project
+  def predictabilize_uuids
+    # no-op to ensure we can use this branch, but without the, currently for us broken, persistant UUID change in Xcodeproj:
+    # https://github.com/CocoaPods/CocoaPods/tree/seg-embed-frameworks-quotes
+    #
+    # Remove this and change Gemfile to latest CP once this is fixed:
+    # https://github.com/CocoaPods/CocoaPods/issues/3763
+  end
+end
+
 source 'https://github.com/artsy/Specs.git'
 source 'https://github.com/CocoaPods/Specs.git'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -107,6 +107,7 @@ PODS:
     - SDWebImage/Core (= 3.7.1)
   - SDWebImage/Core (3.7.1)
   - Specta (0.5.0)
+  - TPDWeakProxy (1.1.0)
   - TRVSDictionaryWithCaseInsensitivity (0.0.2)
   - TSMiniWebBrowser@dblock (HEAD based on 1.1)
   - UIAlertView+Blocks (0.8)
@@ -165,6 +166,7 @@ DEPENDENCIES:
   - ReactiveCocoa (= 2.3)
   - SDWebImage (= 3.7.1)
   - Specta
+  - TPDWeakProxy (= 1.1.0)
   - TSMiniWebBrowser@dblock (HEAD)
   - UIAlertView+Blocks (= 0.8)
   - UICKeyChainStore (= 1.0.5)
@@ -268,6 +270,7 @@ SPEC CHECKSUMS:
   RSSwizzle: d561958f595028bfcef98c7d55c318b3878a61c6
   SDWebImage: ed3095af2ff88b436426037444979b917f6c5575
   Specta: eb90708ed77569bbda089f8ead10bb99b8e9489e
+  TPDWeakProxy: 2ee6754e401aad6a67cc1d59c9fedddae7815abf
   TRVSDictionaryWithCaseInsensitivity: 51d2ccf52c6d645d27b63467a98fa02c556e01b0
   TSMiniWebBrowser@dblock: 6eb565b44cc2e5cd5eee7660ee5c21f8afae415c
   UIAlertView+Blocks: 6b408d63507287b22c6e631a2b25ca26f96fb609

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -150,7 +150,7 @@ DEPENDENCIES:
   - ISO8601DateFormatter (HEAD)
   - JLRoutes (= 1.5)
   - JSDecoupledAppDelegate (= 1.1.0)
-  - Keys (from `Pods/CocoaPodsKeys/`)
+  - Keys (from `Pods/CocoaPodsKeys`)
   - KSDeferred (= 0.2.0)
   - libextobjc/EXTKeyPathCoding (= 0.4)
   - libextobjc/EXTScope (= 0.4)
@@ -190,7 +190,7 @@ EXTERNAL SOURCES:
   FODFormKit:
     :git: https://github.com/1aurabrown/FODFormKit.git
   Keys:
-    :path: Pods/CocoaPodsKeys/
+    :path: Pods/CocoaPodsKeys
   NAMapKit:
     :commit: 62275386978db91b0e7ed8de755d15cef3e793b4
     :git: https://github.com/neilang/NAMapKit

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -6,3 +6,4 @@
   changes to facebook that are more or lesss impossible to test automatically. - orta
 * Load all artworks in an artwork's show in the "artwork related artworks" view. - 1aurabrown
 * Fixes auctions route. – ashfurrow
+* Fix crash that could easily occur when the user would navigate back from a martsy view before it was fully done loading. - alloy


### PR DESCRIPTION
If a user would navigate back before the webview fully finished loading,
the VC would be retained by the timer and released once the timer was
invalidated, which in turn would lead to a crash if the VC was
referenced after invalidating the timer.

Fixes #557. (See there for more details.)

Tested on :iphone: