### PR TITLE
@orta => [Debug] Add ARFilteredStackTrace helper.

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -211,6 +211,7 @@
 		5122D69A1A89E5F800DA2704 /* ARFairMapAnnotationViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5122D6991A89E5F800DA2704 /* ARFairMapAnnotationViewTests.m */; };
 		513483551AADD0A10062E624 /* PSPDFKitImproveRecursiveDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 513483541AADD0A10062E624 /* PSPDFKitImproveRecursiveDescription.m */; };
 		5144331B1AD68D8400FBBCE5 /* ARTopMenuInternalMobileWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5144331A1AD68D8400FBBCE5 /* ARTopMenuInternalMobileWebViewController.m */; };
+		5168A76E1B46A70500FFBCBF /* ARFilteredStackTrace.m in Sources */ = {isa = PBXBuildFile; fileRef = 5168A76D1B46A70500FFBCBF /* ARFilteredStackTrace.m */; };
 		5174A03B1A859E2C006CD337 /* ARFairMapView.m in Sources */ = {isa = PBXBuildFile; fileRef = 5174A03A1A859E2C006CD337 /* ARFairMapView.m */; };
 		51D141B01AEA52E5000091CF /* AREmbeddedModelsViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 51D141AF1AEA52E5000091CF /* AREmbeddedModelsViewControllerTests.m */; };
 		51D141B71AF0F14B000091CF /* ARTestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 51D141B61AF0F14B000091CF /* ARTestHelper.m */; };
@@ -958,6 +959,8 @@
 		513483541AADD0A10062E624 /* PSPDFKitImproveRecursiveDescription.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PSPDFKitImproveRecursiveDescription.m; sourceTree = "<group>"; };
 		514433191AD68D8400FBBCE5 /* ARTopMenuInternalMobileWebViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARTopMenuInternalMobileWebViewController.h; sourceTree = "<group>"; };
 		5144331A1AD68D8400FBBCE5 /* ARTopMenuInternalMobileWebViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTopMenuInternalMobileWebViewController.m; sourceTree = "<group>"; };
+		5168A76C1B46A70500FFBCBF /* ARFilteredStackTrace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARFilteredStackTrace.h; sourceTree = "<group>"; };
+		5168A76D1B46A70500FFBCBF /* ARFilteredStackTrace.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARFilteredStackTrace.m; sourceTree = "<group>"; };
 		5174A0391A859E2C006CD337 /* ARFairMapView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARFairMapView.h; sourceTree = "<group>"; };
 		5174A03A1A859E2C006CD337 /* ARFairMapView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARFairMapView.m; sourceTree = "<group>"; };
 		51D141AF1AEA52E5000091CF /* AREmbeddedModelsViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AREmbeddedModelsViewControllerTests.m; sourceTree = "<group>"; };
@@ -2825,6 +2828,8 @@
 				513483541AADD0A10062E624 /* PSPDFKitImproveRecursiveDescription.m */,
 				51D141BA1AF2B3CD000091CF /* ARAutoLayoutDebugging.h */,
 				51D141B81AF25DB4000091CF /* ARAutoLayoutDebugging.m */,
+				5168A76C1B46A70500FFBCBF /* ARFilteredStackTrace.h */,
+				5168A76D1B46A70500FFBCBF /* ARFilteredStackTrace.m */,
 			);
 			path = Tooling;
 			sourceTree = "<group>";
@@ -4353,6 +4358,7 @@
 				60B6F0F21662AADF007C9587 /* ARAppConstants.m in Sources */,
 				60B79B89182C54CE00945FFF /* ARQuicksilverSearchBar.m in Sources */,
 				49EC62181778AF100020D648 /* PartnerShow.m in Sources */,
+				5168A76E1B46A70500FFBCBF /* ARFilteredStackTrace.m in Sources */,
 				E61446AF195A1CDC00BFB7C3 /* ARFairFavoritesNetworkModel.m in Sources */,
 				5174A03B1A859E2C006CD337 /* ARFairMapView.m in Sources */,
 				60B6F13916638785007C9587 /* ArtsyAPI.m in Sources */,

--- a/Artsy/Tooling/ARAutoLayoutDebugging.m
+++ b/Artsy/Tooling/ARAutoLayoutDebugging.m
@@ -3,6 +3,8 @@
 // https://github.com/objcio/issue-3-auto-layout-debugging
 //
 
+// TODO This should use ARFilteredStackTrace now that we have frameworks.
+
 #if DEBUG
 
 #import "ARAutoLayoutDebugging.h"

--- a/Artsy/Tooling/ARFilteredStackTrace.h
+++ b/Artsy/Tooling/ARFilteredStackTrace.h
@@ -1,0 +1,55 @@
+#ifdef DEBUG
+
+#import <Foundation/Foundation.h>
+#import <dlfcn.h>
+
+typedef BOOL (^ARFilteredStackTraceBasicBlock)(Dl_info *info);
+typedef BOOL (^ARFilteredStackTraceParsedSymbolBlock)(BOOL blockInvocation,
+                                                      BOOL objcMethod,
+                                                      BOOL classMethod,
+                                                      NSString *className,
+                                                      NSString *methodOrFunctionName);
+
+/// `skip_frames` allows you to skip the calling function(s), where 0 is no skipping.
+///
+/// Both `basicBlock` and `parsedSymbolBlock` are optional blocks that allow filtering of symbols from the stack trace.
+/// A block should return `YES` if it is to be included or `NO` if it is to be excluded.
+///
+NSArray *ARFilteredStackTraceWithOptions(int skip_frames,
+                                         ARFilteredStackTraceBasicBlock basicBlock,
+                                         ARFilteredStackTraceParsedSymbolBlock parsedSymbolBlock);
+
+/// `skip_frames` allows you to skip the calling function(s), where 0 is no skipping.
+///
+/// `whiteList` may specify a list of `NSBundle` instances or `NSString` instances describing images that should be
+/// included. In case of an `NSString` it may be the image’s name or full path.
+///
+/// `parsedSymbolBlock` may optionally be specified to further filter symbols.
+/// It should return `YES` if it is to be included or `NO` if it is to be excluded.
+///
+NSArray *ARFilteredStackTraceWithWhiteList(int skip_frames,
+                                           NSArray *whiteList,
+                                           ARFilteredStackTraceParsedSymbolBlock parsedSymbolBlock);
+
+/// `skip_frames` allows you to skip the calling function(s), where 0 is no skipping.
+///
+/// `blackList` may specify a list of `NSBundle` instances or `NSString` instances describing images that should **not**
+/// be included. In case of an `NSString` it may be the image’s name or full path.
+///
+/// `parsedSymbolBlock` may optionally be specified to further filter symbols.
+/// It should return `YES` if it is to be included or `NO` if it is to be excluded.
+///
+NSArray *ARFilteredStackTraceWithBlackList(int skip_frames,
+                                           NSArray *blackList,
+                                           ARFilteredStackTraceParsedSymbolBlock parsedSymbolBlock);
+
+/// This only allows symbols from the main bundle.
+///
+/// `skip_frames` allows you to skip the calling function(s), where 0 is no skipping.
+///
+/// `parsedSymbolBlock` may optionally be specified to further filter symbols.
+/// It should return `YES` if it is to be included or `NO` if it is to be excluded.
+///
+NSArray *ARFilteredStackTrace(int skip_frames, ARFilteredStackTraceParsedSymbolBlock parsedSymbolBlock);
+
+#endif

--- a/Artsy/Tooling/ARFilteredStackTrace.m
+++ b/Artsy/Tooling/ARFilteredStackTrace.m
@@ -1,0 +1,106 @@
+#ifdef DEBUG
+
+#import "ARFilteredStackTrace.h"
+
+#import <execinfo.h>
+#import <libgen.h>
+#import <mach-o/dyld.h>
+
+NSString *const ARFilteredStackTraceWhiteListedImages = @"WhiteList";
+NSString *const ARFilteredStackTraceBlackListedImages = @"BlackList";
+
+static BOOL
+ARSymbolIsFromAnyImage(Dl_info *info, NSArray *list)
+{
+    NSString *imagePath = [NSString stringWithUTF8String:info->dli_fname];
+    NSString *imageName = [imagePath lastPathComponent];
+    for (id image in list) {
+        if ([image isKindOfClass:[NSBundle class]]) {
+            if ([imagePath isEqualToString:[(NSBundle *)image executablePath]]) {
+                return YES;
+            }
+        } else if ([image isKindOfClass:[NSString class]]) {
+            if ([imagePath isEqualToString:image] || [imageName isEqualToString:image]) {
+                return YES;
+            }
+        } else {
+            NSCAssert(NO, @"Unexpected class, should be either NSBundle or NSString: %@", image);
+        }
+    }
+    return NO;
+}
+
+static BOOL
+ARFilteredStackTracePerformParsedSymbolBlock(Dl_info *info, ARFilteredStackTraceParsedSymbolBlock block)
+{
+    NSString *symbol = [NSString stringWithUTF8String:info->dli_sname];
+    NSScanner *scanner = [NSScanner scannerWithString:symbol];
+
+    // First remove block prefixes
+    BOOL isBlock = [scanner scanString:@"__" intoString:NULL] && [scanner scanInt:NULL];
+    // Then remove class or instance method indicators
+    BOOL isClassMethod = [scanner scanString:@"+[" intoString:NULL];
+    BOOL isInstanceMethod = [scanner scanString:@"-[" intoString:NULL];
+
+    if (isClassMethod || isInstanceMethod) {
+        NSString *className = nil;
+        NSCAssert([scanner scanUpToString:@" " intoString:&className], @"Expected to parse a class name from: %@", scanner.string);
+        NSString *methodName = nil;
+        NSCAssert([scanner scanUpToString:@"]" intoString:&methodName], @"Expected to parse a method name from: %@", scanner.string);
+        return block(isBlock, YES, isClassMethod, className, methodName);
+    } else {
+        return block(isBlock, NO, NO, nil, symbol);
+    }
+}
+
+NSArray *
+ARFilteredStackTraceWithOptions(int skip_frames,
+                                ARFilteredStackTraceBasicBlock basicBlock,
+                                ARFilteredStackTraceParsedSymbolBlock parsedSymbolBlock)
+{
+    void *callstack[128];
+    int callstack_size = backtrace(callstack, 128);
+    NSMutableArray *symbols = [NSMutableArray new];
+    // Always skip this function’s frame
+    skip_frames++;
+
+    for (int i = skip_frames; i < callstack_size; i++) {
+        intptr_t address = (intptr_t)callstack[i];
+        NSString *symbol = nil;
+        Dl_info info;
+        if (dladdr((void *)address, &info) == 0) {
+            symbol = [NSString stringWithFormat:@"%p (unable to retrieve metadata)", (void *)address];
+        } else {
+            if (basicBlock && !basicBlock(&info)) continue;
+            if (parsedSymbolBlock && !ARFilteredStackTracePerformParsedSymbolBlock(&info, parsedSymbolBlock)) continue;
+            char *path = (char *)info.dli_fname;
+            symbol = [NSString stringWithFormat:@"%s: %s (%p)", basename(path), info.dli_sname, (void *)address];
+        }
+        [symbols addObject:symbol];
+    }
+
+    return [symbols copy];
+}
+
+NSArray *
+ARFilteredStackTraceWithWhiteList(int skip_frames, NSArray *whiteList, ARFilteredStackTraceParsedSymbolBlock parsedSymbolBlock)
+{
+    return ARFilteredStackTraceWithOptions(skip_frames + 1, ^BOOL(Dl_info *info) {
+        return ARSymbolIsFromAnyImage(info, whiteList);
+    }, parsedSymbolBlock);
+}
+
+NSArray *
+ARFilteredStackTraceWithBlackList(int skip_frames, NSArray *blackList, ARFilteredStackTraceParsedSymbolBlock parsedSymbolBlock)
+{
+    return ARFilteredStackTraceWithOptions(skip_frames + 1, ^BOOL(Dl_info *info) {
+        return !ARSymbolIsFromAnyImage(info, blackList);
+    }, parsedSymbolBlock);
+}
+
+NSArray *ARFilteredStackTrace(int skip_frames, ARFilteredStackTraceParsedSymbolBlock parsedSymbolBlock)
+{
+    return ARFilteredStackTraceWithWhiteList(skip_frames + 1, @[ [NSBundle mainBundle] ], parsedSymbolBlock);
+}
+
+#endif


### PR DESCRIPTION
I did not include a function that returns a pretty string, I’m leaving that up to you to see if a default version makes sense or if you always want to do that where you’ll be using the stack trace.

----

```objc
NSLog(@"%@", ARFilteredStackTrace(0, nil));
```

```
2015-07-03 15:39:17.477 Artsy[90093:2106250] (
    "Artsy: -[ARAppDelegate application:willFinishLaunchingWithOptions:] (0x100626eaa)",
    "Artsy: main (0x10062ac27)"
)
```

----

```objc
NSLog(@"%@", ARFilteredStackTraceWithWhiteList(0, @[[NSBundle mainBundle], @"UIKit"], nil));
```

```
2015-07-03 15:39:17.479 Artsy[90093:2106250] (
    "Artsy: -[ARAppDelegate application:willFinishLaunchingWithOptions:] (0x100626f63)",
    "UIKit: -[UIApplication _handleDelegateCallbacksWithOptions:isSuspended:restoreState:] (0x102cbe721)",
    "UIKit: -[UIApplication _callInitializationDelegatesForMainScene:transitionContext:] (0x102cbf397)",
    "UIKit: -[UIApplication _runWithMainScene:transitionContext:completion:] (0x102cc21de)",
    "UIKit: -[UIApplication workspaceDidEndTransaction:] (0x102cc10d5)",
    "UIKit: -[UIApplication _run] (0x102cc0b42)",
    "UIKit: UIApplicationMain (0x102cc3900)",
    "Artsy: main (0x10062ac27)"
)
```

----

```objc
NSLog(@"%@", ARFilteredStackTraceWithBlackList(0, @[[NSBundle mainBundle], @"UIKit"], nil));
```

```
2015-07-03 15:39:17.481 Artsy[90093:2106250] (
    "JSDecoupledAppDelegate: -[JSDecoupledAppDelegate application:willFinishLaunchingWithOptions:] (0x100f75c9c)",
    "FrontBoardServices: __31-[FBSSerialQueue performAsync:]_block_invoke_2 (0x1060635e5)",
    "CoreFoundation: __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ (0x10211041c)",
    "CoreFoundation: __CFRunLoopDoBlocks (0x102106165)",
    "CoreFoundation: __CFRunLoopRun (0x102105f25)",
    "CoreFoundation: CFRunLoopRunSpecific (0x102105366)",
    "libdyld.dylib: start (0x104344145)"
)
```

----

```objc
dispatch_async(dispatch_get_main_queue(), ^{
    NSLog(@"%@", ARFilteredStackTrace(0, ^BOOL(BOOL blockInvocation, BOOL objcMethod, BOOL classMethod, NSString *className, NSString *methodOrFunctionName) {
        if (objcMethod) {
            NSLog(@"BLOCK:%@ - CLASS METHOD: %@ - CLASS: %@ - METHOD: %@", blockInvocation ? @"YES" : @"NO", classMethod ? @"YES" : @"NO", className, methodOrFunctionName);
        } else {
            NSLog(@"BLOCK:%@ - FUNCTION: %@", blockInvocation ? @"YES" : @"NO", methodOrFunctionName);
        }
        return YES;
    }));
});
```

```
2015-07-03 15:48:54.922 Artsy[94755:2125168] BLOCK:YES - CLASS METHOD: NO - CLASS: ARAppDelegate - METHOD: application:willFinishLaunchingWithOptions:
2015-07-03 15:48:54.923 Artsy[94755:2125168] BLOCK:NO - FUNCTION: main
2015-07-03 15:48:54.923 Artsy[94755:2125168] (
    "Artsy: __60-[ARAppDelegate application:willFinishLaunchingWithOptions:]_block_invoke (0x10f0de483)",
    "Artsy: main (0x10f0e1c27)"
)
```
