### PR TITLE
replace removeConstraints with deactivateConstraints in ARArtworkPreviewImageView

### DIFF
--- a/Artsy/Views/Artwork/ARArtworkPreviewImageView.m
+++ b/Artsy/Views/Artwork/ARArtworkPreviewImageView.m
@@ -39,7 +39,7 @@
 {
     _artwork = artwork;
     [self updateWithArtwork:artwork];
-   @_weakify(self);
+    @_weakify(self);
     [artwork onArtworkUpdate:^{
         @_strongify(self);
         [self updateWithArtwork:artwork];
@@ -114,21 +114,24 @@
 
 - (void)setAspectRatioConstraintWithImage:(UIImage *)image
 {
-    CGFloat oldRatio = 0;
-    if (self.image) {
-        oldRatio = self.image.size.height / self.image.size.width;
-    }
 
-    CGFloat newRatio = image.size.height / image.size.width;
+    BOOL imageSizeChanged = !(self.image && CGSizeEqualToSize(self.image.size, image.size)
 
-    if (oldRatio != newRatio) {
+    if (imageSizeChanged) {
         if (self.imageConstraints) {
             // removeConstraints is scheduled for deprication. Apparently you're
             // supposed to `deactivate` constraints instead of removing them.
             [NSLayoutConstraint deactivateConstraints:self.imageConstraints];
         }
 
-        if (newRatio != 0) {
+        CGFloat newImageWidth = CGRectGetWidth(image.size);
+        CGFloat newImageHeight = CGRectGetHeight(image.size);
+        BOOL sizeIsNotZero = (newImageWidth > 0 && newImageHeight > 0);
+
+        // Unlikely that an image would have a width or height of zero, but just in case
+        // let's prevent a crash.
+        if (sizeIsNotZero) {
+            CGFloat newRatio = newImageHeight / newImageWidth;
             [self createConstraintsWithRatio:newRatio];
         }
     }

--- a/Artsy/Views/Artwork/ARArtworkPreviewImageView.m
+++ b/Artsy/Views/Artwork/ARArtworkPreviewImageView.m
@@ -158,10 +158,8 @@
 
     constraint2.priority = 1000;
 
-    [self addConstraint:constraint1];
-    [self addConstraint:constraint2];
-
-    _imageConstraints = @[ constraint1, constraint2 ];
+    self.imageConstraints = @[ constraint1, constraint2 ];
+    [NSLayoutConstraint activateConstraints:self.imageConstraints];
 }
 
 - (CGSize)intrinsicContentSize

--- a/Artsy/Views/Artwork/ARArtworkPreviewImageView.m
+++ b/Artsy/Views/Artwork/ARArtworkPreviewImageView.m
@@ -114,8 +114,7 @@
 
 - (void)setAspectRatioConstraintWithImage:(UIImage *)image
 {
-
-    BOOL imageSizeChanged = !(self.image && CGSizeEqualToSize(self.image.size, image.size)
+    BOOL imageSizeChanged = !(self.image && CGSizeEqualToSize(self.image.size, image.size));
 
     if (imageSizeChanged) {
         if (self.imageConstraints) {
@@ -124,8 +123,8 @@
             [NSLayoutConstraint deactivateConstraints:self.imageConstraints];
         }
 
-        CGFloat newImageWidth = CGRectGetWidth(image.size);
-        CGFloat newImageHeight = CGRectGetHeight(image.size);
+        CGFloat newImageWidth = image.size.width;
+        CGFloat newImageHeight = image.size.height;
         BOOL sizeIsNotZero = (newImageWidth > 0 && newImageHeight > 0);
 
         // Unlikely that an image would have a width or height of zero, but just in case

--- a/Artsy/Views/Artwork/ARArtworkPreviewImageView.m
+++ b/Artsy/Views/Artwork/ARArtworkPreviewImageView.m
@@ -3,6 +3,7 @@
 
 
 @interface ARArtworkPreviewImageView ()
+@property (nonatomic, strong, readwrite) NSArray *imageConstraints;
 @end
 
 
@@ -93,13 +94,12 @@
     NSURL *imageURL = [NSURL URLWithString:artwork.defaultImage.baseImageURL];
     UIImage *image;
     image = [ARFeedImageLoader bestAvailableCachedImageForBaseURL:imageURL];
-    //    Temporarily disable this to see if it’s related to https://github.com/artsy/eigen/issues/526.
-    //    if (!image) {
-    //        // Multiply by 1000 to preserve precision because the image's dimensions get rounded to whole numbers.
-    //        CGFloat aspectRatio = artwork.aspectRatio ?: 1;
-    //        CGSize size = CGSizeMake(aspectRatio * 1000, 1000);
-    //        image = [UIImage imageFromColor:[UIColor artsyLightGrey] withSize:size];
-    //    }
+    if (!image) {
+        // Multiply by 1000 to preserve precision because the image's dimensions get rounded to whole numbers.
+        CGFloat aspectRatio = artwork.aspectRatio ?: 1;
+        CGSize size = CGSizeMake(aspectRatio * 1000, 1000);
+        image = [UIImage imageFromColor:[UIColor artsyLightGrey] withSize:size];
+    }
     return image;
 }
 
@@ -114,8 +114,28 @@
 
 - (void)setAspectRatioConstraintWithImage:(UIImage *)image
 {
-    [self removeConstraints:self.constraints];
-    CGFloat ratio = image.size.height / image.size.width;
+    CGFloat oldRatio = 0;
+    if (self.image) {
+        oldRatio = self.image.size.height / self.image.size.width;
+    }
+
+    CGFloat newRatio = image.size.height / image.size.width;
+
+    if (oldRatio != newRatio) {
+        if (self.imageConstraints) {
+            // removeConstraints is scheduled for deprication. Apparently you're
+            // supposed to `deactivate` constraints instead of removing them.
+            [NSLayoutConstraint deactivateConstraints:self.imageConstraints];
+        }
+
+        if (newRatio != 0) {
+            [self createConstraintsWithRatio:newRatio];
+        }
+    }
+}
+
+- (void)createConstraintsWithRatio:(CGFloat)ratio
+{
     NSLayoutConstraint *constraint1 = [NSLayoutConstraint
         constraintWithItem:self
                  attribute:NSLayoutAttributeHeight
@@ -124,6 +144,7 @@
                  attribute:NSLayoutAttributeWidth
                 multiplier:ratio
                   constant:0];
+
     constraint1.priority = 750;
 
     NSLayoutConstraint *constraint2 = [NSLayoutConstraint
@@ -134,10 +155,13 @@
                  attribute:NSLayoutAttributeWidth
                 multiplier:ratio
                   constant:0];
+
     constraint2.priority = 1000;
 
     [self addConstraint:constraint1];
     [self addConstraint:constraint2];
+
+    _imageConstraints = @[ constraint1, constraint2 ];
 }
 
 - (CGSize)intrinsicContentSize

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -7,6 +7,7 @@
 * Reload notifications view whenever notifications come in or have been polled. - alloy
 * Mark notifications as seen once the new notifications view has been loaded and was visible. - alloy
 * Move search button from tab bar to navigation bar. - alloy
+* Replace add/removeConstraint with activate/deactivateConstraints in ARArtworkPreviewImage View in hopes of fixing autolayout crash - 1aurabrown
 
 ## 2.1.0 (2015.07.04)
 


### PR DESCRIPTION
¯\\\_(ツ)_/¯ hoping that this fixes https://github.com/artsy/eigen/issues/526

Is this new? 
```
@interface UIView (UIConstraintBasedLayoutInstallingConstraints)

- (NSArray *)constraints NS_AVAILABLE_IOS(6_0);


- (void)addConstraint:(NSLayoutConstraint *)constraint NS_AVAILABLE_IOS(6_0); // This method will be deprecated in a future release and should be avoided.  Instead, set NSLayoutConstraint's active property to YES.
- (void)addConstraints:(NSArray *)constraints NS_AVAILABLE_IOS(6_0); // This method will be deprecated in a future release and should be avoided.  Instead use +[NSLayoutConstraint activateConstraints:].
- (void)removeConstraint:(NSLayoutConstraint *)constraint NS_AVAILABLE_IOS(6_0); // This method will be deprecated in a future release and should be avoided.  Instead set NSLayoutConstraint's active property to NO.
- (void)removeConstraints:(NSArray *)constraints NS_AVAILABLE_IOS(6_0); // This method will be deprecated in a future release and should be avoided.  Instead use +[NSLayoutConstraint deactivateConstraints:].
@end
```