### PR TITLE
@alloy => Bring back background fetch

### DIFF
--- a/Artsy/App/ARAppBackgroundFetchDelegate.m
+++ b/Artsy/App/ARAppBackgroundFetchDelegate.m
@@ -35,13 +35,13 @@
         NSURLSession *session = [NSURLSession sharedSession];
         NSURLSessionDataTask *task = [session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
             id JSON = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:nil];
-            if ([JSON isKindOfClass:[NSDictionary class]]) {
+            if ([JSON isKindOfClass:NSDictionary.class]) {
 
                 // Save the downloaded JSON to a known place for ARShowFeed to grab
                 // when the app is opened
 
                 NSString *path = [self.class pathForDownloadedShowFeed];
-                [NSKeyedArchiver archiveRootObject:JSON toFile:path];
+                [data writeToFile:path atomically:YES];
 
                 ARActionLog(@"Downloaded show feed in the background");
 

--- a/Artsy/App/ARAppBackgroundFetchDelegate.m
+++ b/Artsy/App/ARAppBackgroundFetchDelegate.m
@@ -1,12 +1,16 @@
 #import "ARAppBackgroundFetchDelegate.h"
+#import "ARRouter.h"
+#import "ARNetworkConstants.h"
+#import "ArtsyWatchAPI.h"
 #import "ARFileUtils.h"
+#import "ArtsyAPI+Private.h"
 
 
 @implementation ARAppBackgroundFetchDelegate
 
 + (void)load
 {
-    //[JSDecoupledAppDelegate sharedAppDelegate].backgroundFetchDelegate = [[self alloc] init];
+    [JSDecoupledAppDelegate sharedAppDelegate].backgroundFetchDelegate = [[self alloc] init];
 }
 
 + (NSString *)pathForDownloadedShowFeed
@@ -18,28 +22,59 @@
 {
     ARActionLog(@"Fetching show feed in the background.");
 
-    [ArtsyAPI getFeedResultsForShowsWithCursor:nil pageSize:10 success:^(NSDictionary *JSON) {
-        if ([JSON isKindOfClass:[NSDictionary class]]) {
+    [ArtsyAPI getXappTokenWithCompletion:^(NSString *xappToken, NSDate *expirationDate) {
 
-            NSString *path = [self.class pathForDownloadedShowFeed];
-            [NSKeyedArchiver archiveRootObject:JSON toFile:path];
+        // Do not trust that we can use the keychain like we can normally with ARRouter
+        NSMutableURLRequest *request = [[ARRouter newShowFeedRequestWithCursor:nil pageSize:5] mutableCopy];
+        [request setValue:xappToken forHTTPHeaderField:ARXappHeader];
 
-            ARActionLog(@"Downloaded show feed in the background");
+        // Use a unique URL client to grab the data, this bypasses all our security
+        // around logging in/out, we have a unique xappToken either by having access
+        // to the local one or by grabbing a new one.
 
-            if (completionHandler) {
-                completionHandler(UIBackgroundFetchResultNewData);
+        NSURLSession *session = [NSURLSession sharedSession];
+        NSURLSessionDataTask *task = [session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+            id JSON = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:nil];
+            if ([JSON isKindOfClass:[NSDictionary class]]) {
+
+                // Save the downloaded JSON to a known place for ARShowFeed to grab
+                // when the app is opened
+
+                NSString *path = [self.class pathForDownloadedShowFeed];
+                [NSKeyedArchiver archiveRootObject:JSON toFile:path];
+
+                ARActionLog(@"Downloaded show feed in the background");
+
+                // Try be smart around whether  we needed to do our parsing
+                // to quote runkeeper "don't DDOS yourself" we keep track of
+                // the cursor that would be needed next time
+
+                NSString *cursorDefault = @"ARBackgroundFetchCursor";
+                NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+                NSString *cursor = JSON[@"next"];
+
+                BOOL sameCursor = [[defaults stringForKey:cursorDefault] isEqualToString:cursor];
+                if (completionHandler && !sameCursor) {
+                    [defaults setObject:cursor forKey:cursorDefault];
+                    [defaults synchronize];
+
+                    completionHandler(UIBackgroundFetchResultNewData);
+
+                } else if (completionHandler && sameCursor){
+                    completionHandler(UIBackgroundFetchResultNoData);
+                }
+                return;
             }
 
-            return;
-        }
-
-        ARErrorLog(@"Error feed is in an unexpected format");
-        if (completionHandler) {
-            completionHandler(UIBackgroundFetchResultFailed);
-        }
+            ARErrorLog(@"Error feed is in an unexpected format");
+            if (completionHandler) {
+                completionHandler(UIBackgroundFetchResultFailed);
+            }
+        }];
+        [task resume];
 
     } failure:^(NSError *error) {
-        ARErrorLog(@"Error downloading feed from the background : %@", error.localizedDescription);
+        ARErrorLog(@"Could not get an xapp token for background fetch");
         if (completionHandler) {
             completionHandler(UIBackgroundFetchResultFailed);
         }

--- a/Artsy/App/ARAppDelegate.m
+++ b/Artsy/App/ARAppDelegate.m
@@ -109,6 +109,15 @@ static ARAppDelegate *_sharedInstance = nil;
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+    UIApplicationState state = application.applicationState;
+    if (state == UIApplicationStateBackground) {
+        // App is doing a background fetch
+        return YES;
+    }
+
+    [application setMinimumBackgroundFetchInterval:UIApplicationBackgroundFetchIntervalMinimum];
+
+
     _landingURLRepresentation = self.landingURLRepresentation ?: @"https://artsy.net";
 
     [[ARLogger sharedLogger] startLogging];

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -116,6 +116,7 @@
 	</array>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>fetch</string>
 		<string>remote-notification</string>
 	</array>
 	<key>UILaunchStoryboardName</key>

--- a/Artsy/Models/Feed_Timelines/ARFeedSubclasses.h
+++ b/Artsy/Models/Feed_Timelines/ARFeedSubclasses.h
@@ -4,7 +4,7 @@
 
 
 @interface ARFileFeed : ARFeed
-- (instancetype)initWithNamedFile:(NSString *)fileName;
+- (instancetype)initWithFileAtPath:(NSString *)fileName;
 @end
 
 

--- a/Artsy/Models/Feed_Timelines/ARFeedTimeline.h
+++ b/Artsy/Models/Feed_Timelines/ARFeedTimeline.h
@@ -9,13 +9,15 @@
 
 @interface ARFeedTimeline : NSObject
 
-- (id)initWithFeed:(ARFeed *)feed;
+- (instancetype)initWithFeed:(ARFeed *)feed;
 - (ARFeedItem *)itemAtIndex:(NSInteger)index;
+
 - (void)getNewItems:(void (^)(NSArray *items))success failure:(void (^)(NSError *error))failure;
 - (void)getNextPage:(void (^)(NSArray *items))success failure:(void (^)(NSError *error))failure completion:(void (^)())completion;
 - (void)removeAllItems;
 
-@property (nonatomic, assign) BOOL hasNext;
-@property (nonatomic, assign) NSInteger numberOfItems;
-@property (nonatomic, assign, getter=isLoading) BOOL loading;
+@property (nonatomic, strong, readonly) NSMutableOrderedSet *items;
+@property (nonatomic, assign, readonly) BOOL hasNext;
+@property (nonatomic, assign, readonly) NSInteger numberOfItems;
+@property (nonatomic, assign, readonly, getter=isLoading) BOOL loading;
 @end

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -66,7 +66,10 @@ static NSSet *artsyHosts = nil;
     }];
 
     // Ensure the keychain is empty incase you've uninstalled and cleared user data
-    if (![[ARUserManager sharedManager] hasExistingAccount]) {
+    // but make sure that this is not a slip-up due to background fetch downloading
+
+    UIApplicationState state = [[UIApplication sharedApplication] applicationState];
+    if (![[ARUserManager sharedManager] hasExistingAccount] && state != UIApplicationStateBackground) {
         [UICKeyChainStore removeItemForKey:AROAuthTokenDefault];
         [UICKeyChainStore removeItemForKey:ARXAppTokenKeychainKey];
     }

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuNavigationDataSource.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuNavigationDataSource.m
@@ -6,6 +6,7 @@
 #import "ARHeroUnitViewController.h"
 #import "ARTopMenuInternalMobileWebViewController.h"
 #import <SDWebImage/SDWebImagePrefetcher.h>
+#import "ARAppBackgroundFetchDelegate.h"
 
 static ARNavigationController *
 WebViewNavigationControllerWithPath(NSString *path)
@@ -49,7 +50,8 @@ WebViewNavigationControllerWithPath(NSString *path)
         _badgeCounts[i] = 0;
     }
 
-    ARShowFeed *showFeed = [[ARShowFeed alloc] init];
+    NSString *filePath = [ARAppBackgroundFetchDelegate pathForDownloadedShowFeed];
+    ARShowFeed *showFeed = [[ARShowFeed alloc] initWithFileAtPath:filePath];
     ARFeedTimeline *showFeedTimeline = [[ARFeedTimeline alloc] initWithFeed:showFeed];
     _showFeedViewController = [[ARSimpleShowFeedViewController alloc] initWithFeedTimeline:showFeedTimeline];
     _showFeedViewController.heroUnitVC.heroUnitNetworkModel = [[ARHeroUnitsNetworkModel alloc] init];

--- a/Artsy/View_Controllers/Feed_VCs/ARSimpleShowFeedViewController.m
+++ b/Artsy/View_Controllers/Feed_VCs/ARSimpleShowFeedViewController.m
@@ -92,6 +92,11 @@ static NSString *ARShowCellIdentifier = @"ARShowCellIdentifier";
     }];
 
     _section = [[ARSectionData alloc] init];
+
+    /// Deal with background cached'd data
+    for (ARPartnerShowFeedItem *show in self.feedTimeline.items) {
+        [self addShowToTable:show];
+    }
     self.tableViewData = [[ARTableViewData alloc] initWithSectionDataArray:@[ self.section ]];
 }
 

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -4,3 +4,12 @@
 * Layout fixes for the Auction Results for an Artwork - orta
 * Potential fix for seeing no API requests get through - orta
 * Total Re-write for the show feed - orta
+* Change onboarding callback to use a block rather then a delegate message. - 1aurabrown
+* Migrated to frameworks under the hood. This is a massive change to a lot
+  of the foundations of the app. Most importantly it required making breaking 
+  changes to facebook that are more or lesss impossible to test automatically. - orta
+* Load all artworks in an artwork's show in the "artwork related artworks" view. - 1aurabrown
+* Fixes auctions route. – ashfurrow
+* Fix crash that could easily occur when the user would navigate back from a martsy view before it was fully done loading. - alloy
+* Remove opaque background from Search keyboard. - 1aurabrown
+* Adds local downloading of the shows feed for instant loading on the next run - orta

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -13,3 +13,4 @@
 * Fix crash that could easily occur when the user would navigate back from a martsy view before it was fully done loading. - alloy
 * Remove opaque background from Search keyboard. - 1aurabrown
 * Adds local downloading of the shows feed for instant loading on the next run - orta
+* Total Re-write for the show feed - orta


### PR DESCRIPTION
**This should be merged during the next sprint, it is not a trivial feature / bug fix**

So, there isn't much in my life I feel guilty about. However, every time I open the app, I feel a little pang of guilt. I made background fetch a long time ago, and haven't gone back to remedy my original implementation. IMO, it's pretty essential.

The original problem was that it used our router, and API clients to grab data which depending on the locked-ness of your iPhone could totally log you out. I've fixed this by giving the fetch-er it's own NSURLSession setup, and totally obviated any work that our internal networking stack does. Just to be paranoid, I've added extra precautions everywhere. From file serialisation, to keychain.
 
On the plus side, I did [some reading](http://www.slideshare.net/moliver816/background-fetch) that it's definitely worth letting apple know that it wasn't worth updating that time. So I've improved the original implementation to check that the feed cursor has changed. The cursor is a unique string that represents the "page" when going through a moving data set. If a new item has been added since then it would be different.