### PR TITLE
@alloy => warnings + Podfile cleanup

### DIFF
--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -59,9 +59,9 @@
 
     _routes = [[JLRoutes alloc] init];
 
-    @weakify(self);
+   @_weakify(self);
     [self.routes addRoute:@"/artist/:id" handler:^BOOL(NSDictionary *parameters) {
-        @strongify(self)
+        @_strongify(self)
         ARArtistViewController *viewController = [self loadArtistWithID:parameters[@"id"]];
         [[ARTopMenuViewController sharedController] pushViewController:viewController];
         return YES;
@@ -72,7 +72,7 @@
 
     if ([UIDevice isPad]) {
         [self.routes addRoute:@"/:profile_id/artist/:id" handler:^BOOL(NSDictionary *parameters) {
-            @strongify(self)
+            @_strongify(self)
 
             Fair *fair = [parameters[@"fair"] isKindOfClass:Fair.class] ? parameters[@"fair"] : nil;
             ARArtistViewController *viewController = (id)[self loadArtistWithID:parameters[@"id"] inFair:fair];
@@ -82,7 +82,7 @@
     }
 
     [self.routes addRoute:@"/artwork/:id" handler:^BOOL(NSDictionary *parameters) {
-        @strongify(self)
+        @_strongify(self)
         Fair *fair = [parameters[@"fair"] isKindOfClass:Fair.class] ? parameters[@"fair"] : nil;
         ARArtworkSetViewController *viewController = [self loadArtworkWithID:parameters[@"id"] inFair:fair];
         [[ARTopMenuViewController sharedController] pushViewController:viewController];
@@ -90,7 +90,7 @@
     }];
 
     [self.routes addRoute:@"/gene/:id" handler:^BOOL(NSDictionary *parameters) {
-        @strongify(self)
+        @_strongify(self)
         ARGeneViewController *viewController = [self loadGeneWithID:parameters[@"id"]];
         [[ARTopMenuViewController sharedController] pushViewController:viewController];
         return YES;
@@ -98,7 +98,7 @@
 
 
     [self.routes addRoute:@"/show/:id" handler:^BOOL(NSDictionary *parameters) {
-        @strongify(self)
+        @_strongify(self)
         ARShowViewController *viewController = [self loadShowWithID:parameters[@"id"]];
         [[ARTopMenuViewController sharedController] pushViewController:viewController];
         return YES;
@@ -108,7 +108,7 @@
 
         if ([UIDevice isPad]) { return NO; }
 
-        @strongify(self);
+        @_strongify(self);
 
         Fair *fair = [parameters[@"fair"] isKindOfClass:Fair.class] ? parameters[@"fair"] : nil;
         UIViewController *viewController = [self loadFairGuideWithFair:fair];
@@ -121,7 +121,7 @@
 
         if ([UIDevice isPad]) { return NO; }
 
-        @strongify(self)
+        @_strongify(self)
         Fair *fair = parameters[@"fair"] ?: [[Fair alloc] initWithFairID:parameters[@"profile_id"]];
         UIViewController *viewController = [self loadArtistInFairWithID:parameters[@"id"] fair:fair];
         [[ARTopMenuViewController sharedController] pushViewController:viewController];
@@ -152,7 +152,7 @@
     }];
 
     [self.routes addRoute:@"/:profile_id" handler:^BOOL(NSDictionary *parameters) {
-        @strongify(self);
+        @_strongify(self);
         UIViewController *viewController = [self routeProfileWithID: parameters[@"profile_id"]];
         [[ARTopMenuViewController sharedController] pushViewController:viewController];
         return YES;

--- a/Artsy/App/Artsy-Prefix.pch
+++ b/Artsy/App/Artsy-Prefix.pch
@@ -73,6 +73,14 @@
     #import "ARLogger.h"
 #endif
 
+// Given that we don't see eye to eye with the GitHub team
+// on dependency management, we can't use frameworks without
+// getting ambiguous warning when Mantle+RAC and @weakify
+// as they just throw it all in together.
+
+// We can work around this for now by having our own commands
+// but a more realistic approach is to migrate away from the APIs.
+
 #define _weakify(...) \
     autoreleasepool {} \
     metamacro_foreach_cxt(rac_weakify_,, __weak, __VA_ARGS__)

--- a/Artsy/App/Artsy-Prefix.pch
+++ b/Artsy/App/Artsy-Prefix.pch
@@ -8,31 +8,36 @@
 
 #import <Availability.h>
 
-#ifndef __IPHONE_5_0
-#warning "This project uses features only available in iOS SDK 4.0 and later."
+#ifndef __IPHONE_8_3
+#warning "This project uses features only available in iOS SDK 8.3 and later."
 #endif
 
 #ifdef __OBJC__
-    #import <UIKit/UIKit.h>
-    #import <Foundation/Foundation.h>
-    #import <SystemConfiguration/SystemConfiguration.h>
-    #import <MobileCoreServices/MobileCoreServices.h>
+    @import UIKit;
+    @import Foundation;
+    @import SystemConfiguration;
+    @import MobileCoreServices;
 
     #import "Constants.h"
 
-    #import <AFNetworking/AFNetworking.h>
-    #import <AFHTTPRequestOperationLogger/AFHTTPRequestOperationLogger.h>
-    #import <Mantle/Mantle.h>
-    #import <ObjectiveSugar/ObjectiveSugar.h>
-    #import <FLKAutoLayout/UIView+FLKAutoLayout.h>
-    #import <CocoaLumberjack/CocoaLumberjack.h>
+    @import AFNetworking;
+    @import Mantle;
+    @import Mantle.metamacros;
+    @import AFHTTPRequestOperationLogger;
+    @import ObjectiveSugar;
+    @import FLKAutoLayout;
+    @import CocoaLumberjack;
+    @import ORStackView;
+    @import ReactiveCocoa;
+    @import NAMapKit;
+    @import EDColor;
+    @import libextobjc;
+    @import UIView_BooleanAnimations;
+    @import Artsy_UIButtons;
+    @import ObjectiveSugar;
+
     #import <ORStackView/ORStackScrollView.h>
     #import <ORStackView/ORTagBasedAutoStackView.h>
-    #import <ReactiveCocoa/ReactiveCocoa.h>
-    #import <NAMapKit/NAMapView.h>
-    #import <EDColor/UIColor+Hex.h>
-    #import <UIView_BooleanAnimations/UIView+BooleanAnimations.h>
-    #import <Artsy_UIButtons/ARButtonSubclasses.h>
 
     #import "ArtsyAPI.h"
     #import "Models.h"
@@ -46,13 +51,10 @@
     #import "ARTopMenuViewController.h"
     #import "ARScrollNavigationChief.h"
     #import "ARSystemTime.h"
-    @import ObjectiveSugar;
     #import "ARDispatchManager.h"
     #import "ARDeveloperOptions.h"
     #import "ARAutoLayoutDebugging.h"
 
-    #import <libextobjc/EXTKeyPathCoding.h>
-    #import <libextobjc/EXTScope.h>
 
     #ifdef DEBUG
     static const int ddLogLevel = DDLogLevelVerbose;
@@ -69,13 +71,15 @@
     #endif
 
     #import "ARLogger.h"
-
 #endif
 
-#ifndef __FEATURES
-#define __FEATURES
+#define _weakify(...) \
+    autoreleasepool {} \
+    metamacro_foreach_cxt(rac_weakify_,, __weak, __VA_ARGS__)
 
-// define here all the features you want on
-//#define STUBBED_FEED
-
-#endif
+#define _strongify(...) \
+    try {} @finally {} \
+    _Pragma("clang diagnostic push") \
+    _Pragma("clang diagnostic ignored \"-Wshadow\"") \
+    metamacro_foreach(rac_strongify_,, __VA_ARGS__) \
+    _Pragma("clang diagnostic pop")

--- a/Artsy/App/Watch/ARAppWatchCommunicator.m
+++ b/Artsy/App/Watch/ARAppWatchCommunicator.m
@@ -50,9 +50,9 @@
         case ARWatchMessageRequestBid: {
             WatchBiddingDetails *details = [[WatchBiddingDetails alloc] initWithDictionary:incoming.referenceObject];
 
-            @weakify(self);
+           @_weakify(self);
             [ARWatchBidNetworkModel bidWithDetails:details:^(BidderPosition *position) {
-                @strongify(self);
+                @_strongify(self);
                 [self validateTopBidderWithDetails:details completion:reply];
 
             } failure:^(NSError *error) {

--- a/Artsy/App/Watch/ARWatchBidNetworkModel.h
+++ b/Artsy/App/Watch/ARWatchBidNetworkModel.h
@@ -4,8 +4,8 @@
 
 @interface ARWatchBidNetworkModel : NSObject
 
-+ (void)bidWithDetails:(WatchBiddingDetails *)details:(void (^)(BidderPosition *))success failure:(void (^)(NSError *))failure;
++ (void)bidWithDetails:(WatchBiddingDetails *)details :(void (^)(BidderPosition *))success failure:(void (^)(NSError *))failure;
 
-+ (void)validateIsTopBidderForDetails:(WatchBiddingDetails *)details:(void (^)())success failure:(void (^)(NSError *))failure;
++ (void)validateIsTopBidderForDetails:(WatchBiddingDetails *)details :(void (^)())success failure:(void (^)(NSError *))failure;
 
 @end

--- a/Artsy/App/Watch/ARWatchBidNetworkModel.m
+++ b/Artsy/App/Watch/ARWatchBidNetworkModel.m
@@ -3,12 +3,12 @@
 
 @implementation ARWatchBidNetworkModel
 
-+ (void)bidWithDetails:(WatchBiddingDetails *)details:(void (^)(BidderPosition *))success failure:(void (^)(NSError *))failure
++ (void)bidWithDetails:(WatchBiddingDetails *)details :(void (^)(BidderPosition *))success failure:(void (^)(NSError *))failure
 {
     success(nil);
 }
 
-+ (void)validateIsTopBidderForDetails:(WatchBiddingDetails *)details:(void (^)())success failure:(void (^)(NSError *))failure
++ (void)validateIsTopBidderForDetails:(WatchBiddingDetails *)details :(void (^)())success failure:(void (^)(NSError *))failure
 {
     sleep(1);
     success();

--- a/Artsy/App/Watch/ArtsyWatchAPI.h
+++ b/Artsy/App/Watch/ArtsyWatchAPI.h
@@ -3,6 +3,6 @@
 
 @interface ArtsyWatchAPI : NSObject
 
-+ (void)getRequest:(NSURLRequest *)request parseToArrayOfClass:(Class)klass:(void (^)(NSArray *objects, NSURLResponse *response, NSError *error))completionHandler;
++ (void)getRequest:(NSURLRequest *)request parseToArrayOfClass:(Class)klass :(void (^)(NSArray *objects, NSURLResponse *response, NSError *error))completionHandler;
 
 @end

--- a/Artsy/Models/API_Models/Artwork_Metadata/Gene.m
+++ b/Artsy/Models/API_Models/Artwork_Metadata/Gene.m
@@ -53,9 +53,9 @@
 
 - (void)updateGene:(void (^)(void))success
 {
-    @weakify(self);
+   @_weakify(self);
     [ArtsyAPI getGeneForGeneID:self.geneID success:^(id gene) {
-        @strongify(self);
+        @_strongify(self);
         [self mergeValuesForKeysFromModel:gene];
         success();
     } failure:^(NSError *error) {
@@ -85,15 +85,15 @@
 
 - (void)setFollowState:(BOOL)state success:(void (^)(id))success failure:(void (^)(NSError *))failure
 {
-    @weakify(self);
+   @_weakify(self);
     [ArtsyAPI setFavoriteStatus:state forGene:self success:^(id response) {
-        @strongify(self);
+        @_strongify(self);
         self.followed = state;
         if (success) {
             success(response);
         }
     } failure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         self.followed = !state;
         if (failure) {
             failure(error);
@@ -108,9 +108,9 @@
         return;
     }
 
-    @weakify(self);
+   @_weakify(self);
     [ArtsyAPI checkFavoriteStatusForGene:self success:^(BOOL result) {
-        @strongify(self);
+        @_strongify(self);
         self.followed = result;
         success(result ? ARHeartStatusYes : ARHeartStatusNo);
     } failure:failure];

--- a/Artsy/Models/API_Models/Fair/Fair.m
+++ b/Artsy/Models/API_Models/Fair/Fair.m
@@ -113,7 +113,7 @@
 
 - (void)downloadShows
 {
-    @weakify(self);
+   @_weakify(self);
 
     NSString *path = self.pathForLocalShowStorage;
 
@@ -121,7 +121,7 @@
         NSMutableSet *shows = [[NSKeyedUnarchiver unarchiveObjectWithFile:path] mutableCopy];
 
         ar_dispatch_main_queue(^{
-            @strongify(self);
+            @_strongify(self);
             if (!self) { return; }
 
             [self willChangeValueForKey:@keypath(Fair.new, shows)];
@@ -157,11 +157,11 @@
         _showsFeed = [[ARFairShowFeed alloc] initWithFair:self];
     }
 
-    @weakify(self);
+   @_weakify(self);
 
     [self.networkModel getShowFeedItems:self.showsFeed success:^(NSOrderedSet *items) {
 
-        @strongify(self);
+        @_strongify(self);
         if(items.count > 0) {
             [self addFeedItemsToShows:items];
             [self downloadPastShowSet];
@@ -171,7 +171,7 @@
 
     } failure:^(NSError *error) {
 
-        @strongify(self);
+        @_strongify(self);
         ARErrorLog(@"failed to get shows %@", error.localizedDescription);
         [self performSelector:@selector(downloadPastShowSet) withObject:nil afterDelay:0.5];
     }];
@@ -204,9 +204,9 @@
 {
     [self willChangeValueForKey:@keypath(Fair.new, shows)];
 
-    @weakify(self);
+   @_weakify(self);
     [feedItems enumerateObjectsUsingBlock:^(ARPartnerShowFeedItem *feedItem, NSUInteger idx, BOOL *stop) {
-        @strongify(self);
+        @_strongify(self);
         if (!self) { return; }
 
         // So, you're asking, why is there C++ in my Obj-C?

--- a/Artsy/Models/API_Models/Partner_Metadata/Artist.m
+++ b/Artsy/Models/API_Models/Partner_Metadata/Artist.m
@@ -69,15 +69,15 @@
 
 - (void)setFollowState:(BOOL)state success:(void (^)(id))success failure:(void (^)(NSError *))failure
 {
-    @weakify(self);
+   @_weakify(self);
     [ArtsyAPI setFavoriteStatus:state forArtist:self success:^(id response) {
-        @strongify(self);
+        @_strongify(self);
         self.followed = state;
         if (success) {
             success(response);
         }
     } failure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         self.followed = !state;
         if (failure) {
             failure(error);
@@ -92,9 +92,9 @@
         return;
     }
 
-    @weakify(self);
+   @_weakify(self);
     [ArtsyAPI checkFavoriteStatusForArtist:self success:^(BOOL result) {
-        @strongify(self);
+        @_strongify(self);
         self.followed = result;
         success(result ? ARHeartStatusYes : ARHeartStatusNo);
     } failure:failure];

--- a/Artsy/Models/API_Models/Partner_Metadata/Artwork.m
+++ b/Artsy/Models/API_Models/Partner_Metadata/Artwork.m
@@ -257,13 +257,13 @@
 
 - (void)updateArtwork
 {
-    @weakify(self);
+   @_weakify(self);
     __weak KSDeferred *deferred = _artworkUpdateDeferred;
 
     ar_dispatch_async(^{
         [ArtsyAPI getArtworkInfo:self.artworkID success:^(id artwork) {
             ar_dispatch_main_queue(^{
-                @strongify(self);
+                @_strongify(self);
                 [self mergeValuesForKeysFromModel:artwork];
                 [deferred resolveWithValue:self];
             });
@@ -282,7 +282,7 @@
 
 - (KSPromise *)onArtworkUpdate:(void (^)(void))success failure:(void (^)(NSError *error))failure
 {
-    @weakify(self);
+   @_weakify(self);
 
     if (!_artworkUpdateDeferred) {
         _artworkUpdateDeferred = [KSDeferred defer];
@@ -295,7 +295,7 @@
     } error:^id(NSError *error) {
         if (failure) { failure(error); }
 
-        @strongify(self);
+        @_strongify(self);
         ARErrorLog(@"Failed fetching full JSON for artwork %@. Error: %@", self.artworkID, error.localizedDescription);
         return error;
     }];
@@ -311,7 +311,7 @@
 
 - (void)updateSaleArtwork
 {
-    @weakify(self);
+   @_weakify(self);
 
     KSDeferred *deferred = [self deferredSaleArtworkUpdate];
 
@@ -327,13 +327,13 @@
         }
 
         if (auction) {
-            @strongify(self);
+            @_strongify(self);
             [ArtsyAPI getAuctionArtworkWithSale:auction.saleID artwork:self.artworkID success:^(SaleArtwork *saleArtwork) {
                 saleArtwork.auction = auction;
                 [deferred resolveWithValue:saleArtwork];
 
             } failure:^(NSError *error) {
-                @strongify(self);
+                @_strongify(self);
                 ARErrorLog(@"Error fetching auction details for artwork %@: %@", self.artworkID, error.localizedDescription);
                 [deferred rejectWithError:error];
             }];
@@ -342,7 +342,7 @@
         }
 
     } failure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         [deferred rejectWithError:error];
         ARErrorLog(@"Error fetching sales for artwork %@: %@", self.artworkID, error.localizedDescription);
     }];
@@ -374,17 +374,17 @@
 
 - (void)updateFair
 {
-    @weakify(self);
+   @_weakify(self);
 
     KSDeferred *deferred = [self deferredFairUpdate];
     [ArtsyAPI getFairsForArtwork:self success:^(NSArray *fairs) {
-        @strongify(self);
+        @_strongify(self);
         // we're not checking for count > 0 cause we wanna fulfill with nil if no fairs
         Fair *fair = [fairs firstObject];
         self.fair = fair;
         [deferred resolveWithValue:fair];
     } failure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         [deferred rejectWithError:error];
         ARErrorLog(@"Couldn't get fairs for artwork %@. Error: %@", self.artworkID, error.localizedDescription);
     }];
@@ -429,7 +429,7 @@
 
 - (void)updatePartnerShow;
 {
-    @weakify(self);
+   @_weakify(self);
 
     KSDeferred *deferred = [self deferredPartnerShowUpdate];
     [ArtsyAPI getShowsForArtworkID:self.artworkID inFairID:nil success:^(NSArray *shows) {
@@ -437,7 +437,7 @@
         PartnerShow *show = [shows firstObject];
         [deferred resolveWithValue:show];
     } failure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         [deferred rejectWithError:error];
         ARErrorLog(@"Couldn't get shows for artwork %@. Error: %@", self.artworkID, error.localizedDescription);
     }];
@@ -445,9 +445,9 @@
 
 - (void)setFollowState:(BOOL)state success:(void (^)(id))success failure:(void (^)(NSError *))failure
 {
-    @weakify(self);
+   @_weakify(self);
     [ArtsyAPI setFavoriteStatus:state forArtwork:self success:^(id response) {
-        @strongify(self);
+        @_strongify(self);
         if (!self) { return; }
 
         self->_heartStatus = state? ARHeartStatusYes : ARHeartStatusNo;
@@ -456,7 +456,7 @@
             success(response);
         }
     } failure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         if (!self) { return; }
 
         self->_heartStatus = ARHeartStatusNo;
@@ -476,12 +476,12 @@
         return;
     }
 
-    @weakify(self);
+   @_weakify(self);
 
     if (!_favDeferred) {
         KSDeferred *deferred = [KSDeferred defer];
         [ArtsyAPI checkFavoriteStatusForArtwork:self success:^(BOOL status) {
-            @strongify(self);
+            @_strongify(self);
             if (!self) { return; }
 
             self->_heartStatus = status ? ARHeartStatusYes : ARHeartStatusNo;
@@ -495,7 +495,7 @@
     }
 
     [_favDeferred.promise then:^(id value) {
-        @strongify(self);
+        @_strongify(self);
 
         success(self.heartStatus);
         return self;

--- a/Artsy/Models/API_Models/Social/Profile.m
+++ b/Artsy/Models/API_Models/Social/Profile.m
@@ -57,11 +57,11 @@
 
 - (void)updateProfile:(void (^)(void))success
 {
-    @weakify(self);
+   @_weakify(self);
 
     if (self.profileID) {
         [ArtsyAPI getProfileForProfileID:self.profileID success:^(Profile *profile) {
-            @strongify(self);
+            @_strongify(self);
 
             [self mergeValuesForKeysFromModel:profile];
             success();

--- a/Artsy/Models/Feed_Timelines/ARFeedSubclasses.m
+++ b/Artsy/Models/Feed_Timelines/ARFeedSubclasses.m
@@ -65,7 +65,7 @@
 
 - (void)getFeedItemsWithCursor:(NSString *)cursor success:(void (^)(NSOrderedSet *))success failure:(void (^)(NSError *))failure
 {
-    @weakify(self);
+   @_weakify(self);
     if (self.JSON) {
         // We may get asked multiple times before we finished extracting the data
 
@@ -78,7 +78,7 @@
         // If we've background fetch'd a copy of the feed, we should use that on the first grab of show data
 
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-            @strongify(self);
+            @_strongify(self);
             NSOrderedSet *items = [self parseItemsFromJSON:self.JSON];
 
             dispatch_async(dispatch_get_main_queue(), ^{
@@ -95,7 +95,7 @@
     NSInteger pageSize = (cursor) ? 4 : 1;
     [ArtsyAPI getFeedResultsForShowsWithCursor:cursor pageSize:pageSize success:^(id JSON) {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-            @strongify(self);
+            @_strongify(self);
             NSOrderedSet *items = [self parseItemsFromJSON:JSON];
             dispatch_async(dispatch_get_main_queue(), ^{
                 success(items);
@@ -131,9 +131,9 @@
 
 - (void)getFeedItemsWithCursor:(NSString *)cursor success:(void (^)(NSOrderedSet *))success failure:(void (^)(NSError *))failure
 {
-    @weakify(self);
+   @_weakify(self);
     [ArtsyAPI getFeedResultsForProfile:self.profile withCursor:cursor success:^(id JSON) {
-        @strongify(self);
+        @_strongify(self);
         success([self parseItemsFromJSON:JSON]);
     } failure:failure];
 }
@@ -164,10 +164,10 @@
 
 - (void)getFeedItemsWithCursor:(NSString *)cursor success:(void (^)(NSOrderedSet *))success failure:(void (^)(NSError *))failure
 {
-    @weakify(self);
+   @_weakify(self);
     [ArtsyAPI getFeedResultsForFairOrganizer:self.fairOrganizer withCursor:cursor success:^(id JSON) {
         ar_dispatch_async(^{
-            @strongify(self);
+            @_strongify(self);
             NSOrderedSet *items = [self parseItemsFromJSON:JSON];
 
             ar_dispatch_main_queue(^{
@@ -210,11 +210,11 @@
 
 - (void)getFeedItemsWithCursor:(NSString *)cursor success:(void (^)(NSOrderedSet *))success failure:(void (^)(NSError *))failure
 {
-    @weakify(self);
+   @_weakify(self);
 
     [ArtsyAPI getFeedResultsForFairShows:self.fair partnerID:self.partner.partnerID withCursor:cursor success:^(id JSON) {
         ar_dispatch_async(^{
-            @strongify(self);
+            @_strongify(self);
 
             NSOrderedSet *items = [self parseItemsFromJSON:JSON];
 

--- a/Artsy/Models/Feed_Timelines/ARFeedTimeline.m
+++ b/Artsy/Models/Feed_Timelines/ARFeedTimeline.m
@@ -34,9 +34,9 @@
 
 - (void)getNewItems:(void (^)())success failure:(void (^)(NSError *error))failure
 {
-    @weakify(self);
+   @_weakify(self);
     [_currentFeed getFeedItemsWithCursor:nil success:^(NSOrderedSet *parsedItems) {
-        @strongify(self);
+        @_strongify(self);
 
         NSIndexSet *indexSet = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, [parsedItems count])];
         NSArray *newItems = [parsedItems array];
@@ -58,9 +58,9 @@
 
     self.currentlyLoadingCursor = self.currentFeed.cursor;
 
-    @weakify(self);
+   @_weakify(self);
     void (^successBlock)(id) = ^(NSOrderedSet *parsedItems) {
-        @strongify(self);
+        @_strongify(self);
         if (parsedItems.count) {
             [self.items addObjectsFromArray:[parsedItems array]];
             if (success) {
@@ -74,7 +74,7 @@
     };
 
     void (^failureBlock)(NSError *) = ^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         self.currentlyLoadingCursor = nil;
         if (failure) {
             failure(error);

--- a/Artsy/Models/Feed_Timelines/ARHeroUnitsNetworkModel.m
+++ b/Artsy/Models/Feed_Timelines/ARHeroUnitsNetworkModel.m
@@ -31,14 +31,14 @@ static NSString *ARHeroUnitsDataSourceItemsKey = @"ARHeroUnitsDataSourceItemsKey
     }
 
     self.isLoading = YES;
-    @weakify(self);
+   @_weakify(self);
 
     // This is generally one of the first networking calls, lets make sure it comes through.
 
     [ArtsyAPI getXappTokenWithCompletion:^(NSString *xappToken, NSDate *expirationDate) {
         [ArtsyAPI getSiteHeroUnits:^(NSArray *heroUnits) {
 
-            @strongify(self);
+            @_strongify(self);
             self.isLoading = NO;
 
             if (success) {
@@ -53,7 +53,7 @@ static NSString *ARHeroUnitsDataSourceItemsKey = @"ARHeroUnitsDataSourceItemsKey
             }
 
         } failure:^(NSError *error) {
-            @strongify(self);
+            @_strongify(self);
             ARErrorLog(@"There was an error getting Hero Units: %@", error.localizedDescription);
             self.isLoading = NO;
             if (failure) {
@@ -61,7 +61,7 @@ static NSString *ARHeroUnitsDataSourceItemsKey = @"ARHeroUnitsDataSourceItemsKey
             }
         }];
     } failure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         ARErrorLog(@"There was an error getting Hero Units: %@", error.localizedDescription);
         self.isLoading = NO;
         if (failure) {

--- a/Artsy/Networking/API_Modules/ArtsyAPI+SiteFunctions.m
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+SiteFunctions.m
@@ -18,11 +18,11 @@ NSString *const ArtsyAPIInquiryAnalyticsLandingURL = @"ArtsyAPIInquiryAnalyticsL
                   failure:(void (^)(NSError *error))failure
 {
     NSParameterAssert(success);
-    @weakify(self);
+   @_weakify(self);
 
     NSURLRequest *request = [ARRouter newOnDutyRepresentativeRequest];
     [self performRequest:request success:^(NSArray *results) {
-        @strongify(self);
+        @_strongify(self);
         if ([results count] == 0) {
             success(nil);
         } else {

--- a/Artsy/Networking/ArtworkSources/ARGeneArtworksNetworkModel.m
+++ b/Artsy/Networking/ArtworkSources/ARGeneArtworksNetworkModel.m
@@ -31,10 +31,10 @@
 
     self.downloadLock = YES;
 
-    @weakify(self);
+   @_weakify(self);
 
     [self.gene getArtworksAtPage:self.currentPage success:^(NSArray *artworks) {
-        @strongify(self);
+        @_strongify(self);
         if (!self) { return; }
 
         self.currentPage++;

--- a/Artsy/Networking/Network_Models/ARBrowseNetworkModel.m
+++ b/Artsy/Networking/Network_Models/ARBrowseNetworkModel.m
@@ -5,9 +5,9 @@
 
 - (void)getBrowseFeaturedLinks:(void (^)(NSArray *links))success failure:(void (^)(NSError *error))failure;
 {
-    @weakify(self);
+   @_weakify(self);
     [ArtsyAPI getBrowseMenuFeedLinksWithSuccess:^(NSArray *links) {
-        @strongify(self);
+        @_strongify(self);
         self->_links = links;
         success(self.links);
     } failure:failure];

--- a/Artsy/Networking/Network_Models/ARFairFavoritesNetworkModel.m
+++ b/Artsy/Networking/Network_Models/ARFairFavoritesNetworkModel.m
@@ -112,7 +112,7 @@ const NSInteger ARFairFavoritesNetworkModelMaxRandomExhibitors = 10;
     // avoid having to lookup a partner -> show server-side when possible
     PartnerShow *show = [fair findShowForPartner:partner];
 
-    @weakify(self);
+   @_weakify(self);
     return @{
         ARNavigationButtonClassKey : ARButtonWithImage.class,
         ARNavigationButtonPropertiesKey : @{
@@ -122,7 +122,7 @@ const NSInteger ARFairFavoritesNetworkModelMaxRandomExhibitors = 10;
             @keypath(ARButtonWithImage.new, imageURL) : (show ? [show imageURLWithFormatName:@"square"] : [NSNull null]) ?: [NSNull null]
         },
         ARNavigationButtonHandlerKey : ^(ARButtonWithImage *sender){
-            @strongify(self);
+            @_strongify(self);
     if (show) {
         [self handleShowButtonPress:show fair:fair];
     } else {
@@ -137,7 +137,7 @@ const NSInteger ARFairFavoritesNetworkModelMaxRandomExhibitors = 10;
 
 - (id)navigationButtonForArtwork:(Artwork *)artwork inFair:(Fair *)fair
 {
-    @weakify(self);
+   @_weakify(self);
     return @{
         ARNavigationButtonClassKey : ARButtonWithImage.class,
         ARNavigationButtonPropertiesKey : @{
@@ -148,7 +148,7 @@ const NSInteger ARFairFavoritesNetworkModelMaxRandomExhibitors = 10;
             @keypath(ARButtonWithImage.new, subtitleFont) : [UIFont sansSerifFontWithSize:12]
         },
         ARNavigationButtonHandlerKey : ^(ARButtonWithImage *sender){
-            @strongify(self);
+            @_strongify(self);
     [self handleArtworkButtonPress:artwork fair:fair];
 }
 }
@@ -159,7 +159,7 @@ const NSInteger ARFairFavoritesNetworkModelMaxRandomExhibitors = 10;
 
 - (id)navigationButtonForArtist:(Artist *)artist inFair:(Fair *)fair
 {
-    @weakify(self);
+   @_weakify(self);
     return @{
         ARNavigationButtonClassKey : ARButtonWithImage.class,
         ARNavigationButtonPropertiesKey : @{
@@ -170,7 +170,7 @@ const NSInteger ARFairFavoritesNetworkModelMaxRandomExhibitors = 10;
             @keypath(ARButtonWithImage.new, subtitleFont) : [UIFont serifFontWithSize:12]
         },
         ARNavigationButtonHandlerKey : ^(ARButtonWithImage *sender){
-            @strongify(self);
+            @_strongify(self);
     [self handleArtistButtonPress:artist fair:fair];
 }
 }
@@ -180,9 +180,9 @@ const NSInteger ARFairFavoritesNetworkModelMaxRandomExhibitors = 10;
 - (void)handlePartnerButtonPress:(Partner *)partner fair:(Fair *)fair
 {
     ARFairShowFeed *feed = [[ARFairShowFeed alloc] initWithFair:fair partner:partner];
-    @weakify(self);
+   @_weakify(self);
     [feed getFeedItemsWithCursor:feed.cursor success:^(NSOrderedSet *parsed) {
-        @strongify(self);
+        @_strongify(self);
         ARPartnerShowFeedItem *showFeedItem = parsed.firstObject;
         if (feed && showFeedItem) { // check feed to retain it
             UIViewController *viewController = [[ARSwitchBoard sharedInstance] loadShow:showFeedItem.show fair:fair];

--- a/Artsy/Networking/Network_Models/ARFavoritesNetworkModel.m
+++ b/Artsy/Networking/Network_Models/ARFavoritesNetworkModel.m
@@ -26,10 +26,10 @@
     }
 
     _downloadLock = YES;
-    @weakify(self);
+   @_weakify(self);
 
     [self performNetworkRequestAtPage:self.currentPage withSuccess:^(NSArray *items) {
-        @strongify(self);
+        @_strongify(self);
         if (!self) { return; }
 
         self.currentPage++;
@@ -42,7 +42,7 @@
         if(success) success(items);
 
     } failure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         if (!self) { return; }
 
         self->_allDownloaded = YES;

--- a/Artsy/Networking/Network_Models/ARFollowableNetworkModel.m
+++ b/Artsy/Networking/Network_Models/ARFollowableNetworkModel.m
@@ -16,9 +16,9 @@
 
     _representedObject = representedObject;
 
-    @weakify(self);
+   @_weakify(self);
     [self.representedObject getFollowState:^(ARHeartStatus status) {
-        @strongify(self);
+        @_strongify(self);
         if (!self) { return; }
 
         [self willChangeValueForKey:@"following"];
@@ -35,17 +35,17 @@
 {
     if (following == _following) return;
 
-    @weakify(self);
+   @_weakify(self);
     if (following) {
         [_representedObject followWithSuccess:nil failure:^(NSError *error) {
-            @strongify(self);
+            @_strongify(self);
             ARErrorLog(@"Error following %@ - %@", self.representedObject, error.localizedDescription);
             [self _setFollowing:NO];
         }];
 
     } else {
         [_representedObject unfollowWithSuccess:nil failure:^(NSError *error) {
-            @strongify(self);
+            @_strongify(self);
             ARErrorLog(@"Error following %@ - %@", self.representedObject, error.localizedDescription);
             [self _setFollowing:YES];
         }];

--- a/Artsy/Networking/Network_Models/ARGeneFavoritesNetworkModel.m
+++ b/Artsy/Networking/Network_Models/ARGeneFavoritesNetworkModel.m
@@ -6,10 +6,10 @@
 - (void)performNetworkRequestAtPage:(NSInteger)page withSuccess:(void (^)(NSArray *artists))success failure:(void (^)(NSError *error))failure
 {
     if (self.useSampleFavorites) {
-        @weakify(self);
+       @_weakify(self);
 
         [ArtsyAPI getOrderedSetWithKey:@"favorites:suggested-genes" success:^(OrderedSet *set) {
-            @strongify(self);
+            @_strongify(self);
             if (!self) { return; }
 
             [ArtsyAPI getOrderedSetItems:set.orderedSetID.copy atPage:page withType:Gene.class success:success failure:failure];

--- a/Artsy/Networking/Network_Models/ARShowNetworkModel.m
+++ b/Artsy/Networking/Network_Models/ARShowNetworkModel.m
@@ -26,9 +26,9 @@
 
 - (void)getShowInfo:(void (^)(PartnerShow *))success failure:(void (^)(NSError *))failure
 {
-    @weakify(self);
+   @_weakify(self);
     [ArtsyAPI getShowInfo:_show success:^(PartnerShow *show) {
-        @strongify(self);
+        @_strongify(self);
 
         if (!self.fair) {
             self.fair = show.fair;

--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController+ButtonActions.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController+ButtonActions.m
@@ -170,7 +170,7 @@
     // create a new order
     NSURLRequest *request = [ARRouter newPendingOrderWithArtworkID:self.artwork.artworkID editionSetID:editionSetID];
 
-    @weakify(self);
+   @_weakify(self);
     AFJSONRequestOperation *op = [AFJSONRequestOperation JSONRequestOperationWithRequest:request
         success:^(NSURLRequest *request, NSHTTPURLResponse *response, id JSON) {
             NSString *orderID = [JSON valueForKey:@"id"];
@@ -181,7 +181,7 @@
 
         }
         failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON) {
-            @strongify(self);
+            @_strongify(self);
             ARErrorLog(@"Creating a new order failed. Error: %@,\nJSON: %@", error.localizedDescription, JSON);
             [self tappedContactGallery];
         }];

--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
@@ -84,10 +84,10 @@
         [self ar_removeIndeterminateLoadingIndicatorAnimated:self.shouldAnimate];
     }
 
-    @weakify(self);
+   @_weakify(self);
 
     void (^completion)(void) = ^{
-        @strongify(self);
+        @_strongify(self);
         [self ar_removeIndeterminateLoadingIndicatorAnimated:self.shouldAnimate];
     };
 
@@ -139,9 +139,9 @@
 
 - (void)getRelatedPosts
 {
-    @weakify(self);
+   @_weakify(self);
     [self.artwork getRelatedPosts:^(NSArray *posts) {
-        @strongify(self);
+        @_strongify(self);
         [self updateWithRelatedPosts:posts];
     }];
 }

--- a/Artsy/View_Controllers/Artwork/ARZoomArtworkImageViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARZoomArtworkImageViewController.m
@@ -66,9 +66,9 @@
     // throttle: is necessary to push this to the next runloop invocation.
     // Well, technically we need to delay it at least 2 invocations, at least on iOS 7.
     // Since it's not good to rely on iOS implementation details, this inperceptable delay will do.
-    @weakify(zoomView);
+   @_weakify(zoomView);
     [[[viewFrameSignal skip:1] throttle:0.01] subscribeNext:^(id x) {
-        @strongify(zoomView);
+        @_strongify(zoomView);
         
         CGRect frame = [x CGRectValue];
         CGSize size = frame.size;

--- a/Artsy/View_Controllers/Auction_Results/ARAuctionArtworkResultsViewController.m
+++ b/Artsy/View_Controllers/Auction_Results/ARAuctionArtworkResultsViewController.m
@@ -25,9 +25,9 @@ static const NSInteger ARArtworkIndex = 0;
 
     _artwork = artwork;
 
-    @weakify(self);
+   @_weakify(self);
     [_artwork getRelatedAuctionResults:^(NSArray *auctionResults) {
-        @strongify(self);
+        @_strongify(self);
         self.auctionResults = auctionResults;
     }];
 

--- a/Artsy/View_Controllers/Contact/ARInquireForArtworkViewController.m
+++ b/Artsy/View_Controllers/Contact/ARInquireForArtworkViewController.m
@@ -706,18 +706,18 @@ typedef NS_ENUM(NSInteger, ARInquireFormState) {
 
 - (void)getCurrentAdmin
 {
-    @weakify(self);
+   @_weakify(self);
     [ArtsyAPI getInquiryContact:^(User *contactStub) {
-        @strongify(self);
+        @_strongify(self);
         self.specialistNameLabel.text = contactStub.name;
 
     } withProfile:^(Profile *contactProfile) {
-        @strongify(self);
+        @_strongify(self);
         // Use a white BG because the square to circle looks ugly
         [self.specialistHeadImage ar_setImageWithURL:[NSURL URLWithString:contactProfile.iconURL] placeholderImage:[UIImage imageFromColor:[UIColor whiteColor]]];
 
     } failure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         ARErrorLog(@"Couldn't get an inquiry contact. %@", error.localizedDescription);
         [self performSelector:@selector(getCurrentAdmin) withObject:nil afterDelay:2];
     }];
@@ -853,9 +853,9 @@ typedef NS_ENUM(NSInteger, ARInquireFormState) {
     _emailValidator = [ALPValidator validatorWithType:ALPValidatorTypeString];
     [self.emailValidator addValidationToEnsureValidEmailWithInvalidMessage:NSLocalizedString(@"Please enter a valid email", nil)];
 
-    @weakify(self);
+   @_weakify(self);
     self.emailValidator.validatorStateChangedHandler = ^(ALPValidatorState newState) {
-        @strongify(self);
+        @_strongify(self);
         self.sendButton.enabled = self.emailValidator.isValid;
       // We can also use newState to determine what to do in more complex situations. Validator states include:
       // ALPValidatorValidationStateValid, ALPValidatorValidationStateInvalid, ALPValidatorValidationStateWaitingForRemote

--- a/Artsy/View_Controllers/Core/ARArtistViewController.m
+++ b/Artsy/View_Controllers/Core/ARArtistViewController.m
@@ -112,10 +112,10 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
 
 - (void)updateArtistInfo
 {
-    @weakify(self);
+   @_weakify(self);
     [self.networkModel getArtistInfoWithSuccess:^(Artist *artist) {
 
-        @strongify(self);
+        @_strongify(self);
         if (!self) { return; }
 
         if (!artist) {
@@ -128,7 +128,7 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
         [self artistIsReady];
 
     } failure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         ARErrorLog(@"Could not update artist information: %@", error.localizedDescription);
         [self setIsGettingArtworks:NO displayMode:self.displayMode];
     }];
@@ -319,12 +319,12 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
     BOOL hearted = !sender.hearted;
     [sender setHearted:hearted animated:self.shouldAnimate];
 
-    @weakify(self);
+   @_weakify(self);
     [self.networkModel setFavoriteStatus:sender.isHearted success:^(id response) {
     }
         failure:^(NSError *error) {
 
-         @strongify(self);
+         @_strongify(self);
         [ARNetworkErrorManager presentActiveErrorModalWithError:error];
         [sender setHearted:!hearted animated:self.shouldAnimate];
         }];
@@ -392,14 +392,14 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
     BOOL showingForSale = (displayMode == ARArtistArtworksDisplayForSale);
     NSDictionary *params = (showingForSale) ? @{ @"filter[]" : @"for_sale" } : nil;
 
-    @weakify(self);
+   @_weakify(self);
     [self.networkModel getArtistArtworksAtPage:lastPage + 1 params:params success:^(NSArray *artworks) {
-        @strongify(self);
+        @_strongify(self);
         [self.artworkVC ar_removeIndeterminateLoadingIndicatorAnimated:self.shouldAnimate];
         [self handleFetchedArtworks:artworks displayMode:self.displayMode];
         [self checkForAdditionalArtworksToFillView];
     } failure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         ARErrorLog(@"Could not get Artist Artworks: %@", error.localizedDescription);
         [self.artworkVC ar_removeIndeterminateLoadingIndicatorAnimated:self.shouldAnimate];
         [self setIsGettingArtworks:NO displayMode:displayMode];
@@ -555,9 +555,9 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
 
 - (void)getRelatedArtists
 {
-    @weakify(self);
+   @_weakify(self);
     [self.artist getRelatedArtists:^(NSArray *artists) {
-        @strongify(self);
+        @_strongify(self);
         if (artists.count > 0 ) {
             [UIView animateIf:self.shouldAnimate duration:ARAnimationDuration :^{
                 self.relatedTitle.alpha = 1;
@@ -570,9 +570,9 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
 
 - (void)getRelatedPosts
 {
-    @weakify(self);
+   @_weakify(self);
     [self.artist getRelatedPosts:^(NSArray *posts) {
-        @strongify(self);
+        @_strongify(self);
         if (posts.count > 0) {
             self.postsVC.posts = posts;
             [self.view.stackView addSubview:self.postsVC.view withTopMargin:@"20" sideMargin:@"40"];

--- a/Artsy/View_Controllers/Core/ARFeedLinkUnitViewController.m
+++ b/Artsy/View_Controllers/Core/ARFeedLinkUnitViewController.m
@@ -16,11 +16,11 @@
         return;
     }
 
-    @weakify(self);
+   @_weakify(self);
 
     // edit set here: http://admin.artsy.net/set/52277573c9dc24da5b00020c
     [ArtsyAPI getOrderedSetItemsWithKey:@"eigen:feed-links" success:^(NSArray *items) {
-        @strongify(self);
+        @_strongify(self);
         [self addButtonDescriptions:[self phoneNavigationForFeaturedLinks:items]];
         completion();
     } failure:^(NSError *error) {
@@ -30,7 +30,7 @@
     // edit set here: https://admin.artsy.net/set/54e255e9726169752bbb1b00
     if ([User currentUser]) {
         [ArtsyAPI getOrderedSetItemsWithKey:@"eigen:logged-in-feed-links" success:^(NSArray *items) {
-            @strongify(self);
+            @_strongify(self);
             [self addButtonDescriptions:[self phoneNavigationForFeaturedLinks:items]];
             completion();
         } failure:^(NSError *error) {
@@ -42,7 +42,7 @@
     if ([bundleID containsString:@".dev"] || [bundleID containsString:@".beta"]) {
         // edit set here: http://admin.artsy.net/set/5308e7be9c18db75fd000343
         [ArtsyAPI getOrderedSetItemsWithKey:@"eigen:beta-feed-links" success:^(NSArray *items) {
-            @strongify(self);
+            @_strongify(self);
             [self addButtonDescriptions:[self phoneNavigationForFeaturedLinks:items]];
             completion();
         } failure:^(NSError *error) {
@@ -53,7 +53,7 @@
 
 - (NSArray *)phoneNavigationForFeaturedLinks:(NSArray *)featuredLinks
 {
-    @weakify(self);
+   @_weakify(self);
     NSMutableArray *phoneNavigation = [NSMutableArray array];
     for (FeaturedLink *featuredLink in featuredLinks) {
         [phoneNavigation addObject:@{
@@ -63,7 +63,7 @@
                 @keypath(ARSerifNavigationButton.new, subtitle): featuredLink.subtitle
             },
             ARNavigationButtonHandlerKey: ^(UIButton *sender) {
-                @strongify(self);
+                @_strongify(self);
                 UIViewController *viewController = [ARSwitchBoard.sharedInstance loadPath:featuredLink.href];
                 [self.navigationController pushViewController:viewController animated:YES];
     }

--- a/Artsy/View_Controllers/Core/ARHeroUnitViewController.m
+++ b/Artsy/View_Controllers/Core/ARHeroUnitViewController.m
@@ -162,9 +162,9 @@ const static CGFloat ARCarouselDelay = 10;
 - (void)goToHeroUnit:(UIViewController *)vc withDirection:(UIPageViewControllerNavigationDirection)direction
 {
     self.pageViewController.view.userInteractionEnabled = NO;
-    @weakify(self);
+   @_weakify(self);
     [self.pageViewController setViewControllers:@[ vc ] direction:direction animated:YES completion:^(BOOL finished) {
-        @strongify(self);
+        @_strongify(self);
         [self.pageControl setCurrentPage:[self currentViewController].index];
         self.pageViewController.view.userInteractionEnabled = YES;
 

--- a/Artsy/View_Controllers/Debug/Quicksilver/ARQuicksilverViewController.m
+++ b/Artsy/View_Controllers/Debug/Quicksilver/ARQuicksilverViewController.m
@@ -142,9 +142,9 @@
     } else {
         [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
 
-        @weakify(self);
+       @_weakify(self);
         _searchRequest = [ArtsyAPI searchWithQuery:query success:^(NSArray *results) {
-            @strongify(self);
+            @_strongify(self);
             self.searchResults = [results copy];
             self.selectedIndex = 0;
 
@@ -179,11 +179,11 @@
 
     UIImage *placeholder = [UIImage imageNamed:@"SearchThumb_LightGray"];
 
-    @weakify(cell);
+   @_weakify(cell);
     [cell.imageView setImageWithURLRequest:result.imageRequest placeholderImage:placeholder
 
                                    success:^(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image) {
-         @strongify(cell);
+         @_strongify(cell);
          cell.imageView.image = image;
          [cell layoutSubviews];
 

--- a/Artsy/View_Controllers/Fair/ARFairArtistViewController.m
+++ b/Artsy/View_Controllers/Fair/ARFairArtistViewController.m
@@ -54,14 +54,14 @@ NS_ENUM(NSInteger, ARFairArtistViewIndex){
     self.view.stackView.bottomMarginHeight = 20;
     self.view.delegate = [ARScrollNavigationChief chief];
 
-    @weakify(self);
+   @_weakify(self);
     [self.networkModel getArtistForArtistID:self.artist.artistID success:^(Artist *artist) {
-        @strongify(self);
+        @_strongify(self);
         if (!self) { return; }
         self->_artist = artist;
         [self artistDidLoad];
     } failure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         [self artistDidLoad];
     }];
 }
@@ -84,9 +84,9 @@ NS_ENUM(NSInteger, ARFairArtistViewIndex){
 
     [self addSubtitle];
 
-    @weakify(self);
+   @_weakify(self);
     [self.networkModel getShowsForArtistID:self.artist.artistID inFairID:self.fair.fairID success:^(NSArray *shows) {
-        @strongify(self);
+        @_strongify(self);
         if (!self) { return; }
 
         self->_partnerShows = shows;
@@ -157,9 +157,9 @@ NS_ENUM(NSInteger, ARFairArtistViewIndex){
 
 - (void)addMapButton
 {
-    @weakify(self);
+   @_weakify(self);
     [self.fair getFairMaps:^(NSArray *maps) {
-        @strongify(self);
+        @_strongify(self);
 
         Map *map = maps.firstObject;
         if (!map) { return; }
@@ -184,9 +184,9 @@ NS_ENUM(NSInteger, ARFairArtistViewIndex){
 
 - (void)mapButtonTapped:(id)mapButtonTapped
 {
-    @weakify(self);
+   @_weakify(self);
     [self.fair getFairMaps:^(NSArray *maps) {
-        @strongify(self);
+        @_strongify(self);
         ARFairMapViewController *viewController = [[ARSwitchBoard sharedInstance] loadMapInFair:self.fair title:self.header selectedPartnerShows:self.partnerShows];
         [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
     }];

--- a/Artsy/View_Controllers/Fair/ARFairPostsViewController.m
+++ b/Artsy/View_Controllers/Fair/ARFairPostsViewController.m
@@ -12,9 +12,9 @@
         return nil;
     }
 
-    @weakify(self);
+   @_weakify(self);
     [fair getPosts:^(ARFeedTimeline *feedTimeline) {
-        @strongify(self);
+        @_strongify(self);
         [self setFeedTimeline:feedTimeline];
     }];
 

--- a/Artsy/View_Controllers/Fair/ARFairViewController.m
+++ b/Artsy/View_Controllers/Fair/ARFairViewController.m
@@ -86,10 +86,10 @@ NSString *const ARFairHighlightFavoritePartnersKey = @"ARFairHighlightFavoritePa
     self.stackView.delegate = [ARScrollNavigationChief chief];
 
     [self ar_presentIndeterminateLoadingIndicatorAnimated:YES];
-    @weakify(self);
+   @_weakify(self);
 
     [_fair updateFair:^{
-        @strongify(self);
+        @_strongify(self);
         [self fairDidLoad];
     }];
 
@@ -142,12 +142,12 @@ NSString *const ARFairHighlightFavoritePartnersKey = @"ARFairHighlightFavoritePa
         return link.displayOnMobile;
     };
 
-    @weakify(self)
+   @_weakify(self)
         [self.fair getFairMaps:^(NSArray *maps) {
         [self.fair getOrderedSets:^(NSMutableDictionary *orderedSets) {
             for (OrderedSet *primarySet in orderedSets[@"primary"]) {
                 [primarySet getItems:^(NSArray *items) {
-                    @strongify(self);
+                    @_strongify(self);
                     NSArray *buttonDescriptions = [[items ?: @[]
                         select:displayOnMobile]
                         map:^(FeaturedLink *link) {
@@ -173,7 +173,7 @@ NSString *const ARFairHighlightFavoritePartnersKey = @"ARFairHighlightFavoritePa
 
             for (OrderedSet *curatorSet in orderedSets[@"editorial"]) {
               [curatorSet getItems:^(NSArray *items) {
-                @strongify(self);
+                @_strongify(self);
                 self.editorialVC.buttonDescriptions = [[items select:displayOnMobile] map:^(FeaturedLink *link) {
                   return [self buttonDescriptionForFeaturedLink:link buttonClass:[ARButtonWithImage class]];
                 }];
@@ -188,7 +188,7 @@ NSString *const ARFairHighlightFavoritePartnersKey = @"ARFairHighlightFavoritePa
 
             for (OrderedSet *curatorSet in orderedSets[@"curator"]) {
                 [curatorSet getItems:^(NSArray *items) {
-                    @strongify(self);
+                    @_strongify(self);
                     self.curatorVC.buttonDescriptions = [[items select:displayOnMobile] map:^(FeaturedLink *link) {
                         return [self buttonDescriptionForFeaturedLink:link buttonClass:[ARButtonWithCircularImage class]];
                     }];
@@ -223,7 +223,7 @@ NSString *const ARFairHighlightFavoritePartnersKey = @"ARFairHighlightFavoritePa
 
 - (NSDictionary *)buttonDescriptionForMapLink
 {
-    @weakify(self);
+   @_weakify(self);
     return @{
         ARNavigationButtonClassKey : [ARButtonWithImage class],
         ARNavigationButtonPropertiesKey : @{
@@ -232,7 +232,7 @@ NSString *const ARFairHighlightFavoritePartnersKey = @"ARFairHighlightFavoritePa
             @keypath(ARButtonWithImage.new, image) : [UIImage imageNamed:@"MapIcon"]
         },
         ARNavigationButtonHandlerKey : ^(ARButtonWithImage *button){
-            @strongify(self);
+            @_strongify(self);
     ARFairMapViewController *viewController = [[ARSwitchBoard sharedInstance] loadMapInFair:self.fair];
     [self.navigationController pushViewController:viewController animated:YES];
 }
@@ -242,7 +242,7 @@ NSString *const ARFairHighlightFavoritePartnersKey = @"ARFairHighlightFavoritePa
 
 - (NSDictionary *)buttonDescriptionForFeaturedLink:(FeaturedLink *)featuredLink buttonClass:(Class)buttonClass
 {
-    @weakify(self);
+   @_weakify(self);
     return @{
         ARNavigationButtonClassKey : buttonClass,
         ARNavigationButtonPropertiesKey : @{
@@ -252,7 +252,7 @@ NSString *const ARFairHighlightFavoritePartnersKey = @"ARFairHighlightFavoritePa
             @keypath(ARButtonWithImage.new, targetURL) : [NSURL URLWithString:featuredLink.href] ?: NSNull.null
         },
         ARNavigationButtonHandlerKey : ^(UIButton *button){
-            @strongify(self);
+            @_strongify(self);
     if ([button isKindOfClass:[ARButtonWithImage class]]) {
         ARButtonWithImage *buttonWithImage = (ARButtonWithImage *)button;
         [self buttonPressed:buttonWithImage];

--- a/Artsy/View_Controllers/Fair/ARProfileViewController.m
+++ b/Artsy/View_Controllers/Fair/ARProfileViewController.m
@@ -38,10 +38,10 @@
 {
     [super viewDidLoad];
 
-    @weakify(self)
+   @_weakify(self)
         // On the first viewWillAppear:
         [[[self rac_signalForSelector:@selector(viewWillAppear:)] take:1] subscribeNext:^(id _) {
-        @strongify(self);
+        @_strongify(self);
         [self loadProfile];
         }];
 }

--- a/Artsy/View_Controllers/Fair/ARShowViewController.m
+++ b/Artsy/View_Controllers/Fair/ARShowViewController.m
@@ -159,22 +159,21 @@ self.actionButtonsView.actionButtonDescriptions = descriptions;
 
 - (NSDictionary *)descriptionForMapButton
 {
-    @weakify(self);
+   @_weakify(self);
     return @{
         ARActionButtonImageKey : @"MapButtonAction",
         ARActionButtonHandlerKey : ^(ARCircularActionButton *sender){
-            @strongify(self);
-    [self handleMapButtonPress:sender];
-}
-}
-;
+            @_strongify(self);
+            [self handleMapButtonPress:sender];
+        }
+    };
 }
 
 - (void)handleMapButtonPress:(ARCircularActionButton *)sender
 {
-    @weakify(self);
+   @_weakify(self);
     [self.showNetworkModel getFairMaps:^(NSArray *maps) {
-        @strongify(self);
+        @_strongify(self);
         ARFairMapViewController *viewController = [[ARSwitchBoard sharedInstance] loadMapInFair:self.fair title:self.show.title selectedPartnerShows:@[self.show]];
         [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
     }];
@@ -220,9 +219,9 @@ self.actionButtonsView.actionButtonDescriptions = descriptions;
 
     [self ar_presentIndeterminateLoadingIndicatorAnimated:self.shouldAnimate];
 
-    @weakify(self);
+   @_weakify(self);
     [self.showNetworkModel getShowInfo:^(PartnerShow *show) {
-        @strongify(self);
+        @_strongify(self);
         if (!self) { return; }
 
         [self.show mergeValuesForKeysFromModel:show];
@@ -233,7 +232,7 @@ self.actionButtonsView.actionButtonDescriptions = descriptions;
 
         [self showDidLoad];
     } failure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
 
         [self showDidLoad];
     }];
@@ -369,9 +368,9 @@ self.actionButtonsView.actionButtonDescriptions = descriptions;
     self.showArtworksViewController.showTrailingLoadingIndicator = YES;
     [self.view.stackView addViewController:self.showArtworksViewController toParent:self withTopMargin:@"0" sideMargin:nil];
 
-    @weakify(self);
+   @_weakify(self);
     [self getArtworksAtPage:1 onArtworks:^(NSArray *artworks) {
-        @strongify(self);
+        @_strongify(self);
         if (artworks.count > 0) {
             if (whitespaceGobbler) {
                 [self.view.stackView removeSubview:whitespaceGobbler];
@@ -391,9 +390,9 @@ self.actionButtonsView.actionButtonDescriptions = descriptions;
 {
     NSParameterAssert(onArtworks);
 
-    @weakify(self);
+   @_weakify(self);
     [self.showNetworkModel getArtworksAtPage:page success:^(NSArray *artworks) {
-        @strongify(self);
+        @_strongify(self);
         onArtworks(artworks);
         if (artworks.count > 0) {
             [self getArtworksAtPage:page + 1 onArtworks:onArtworks];
@@ -422,9 +421,9 @@ self.actionButtonsView.actionButtonDescriptions = descriptions;
 
 - (void)addMapPreview
 {
-    @weakify(self);
+   @_weakify(self);
     [self.showNetworkModel getFairMaps:^(NSArray *maps) {
-        @strongify(self);
+        @_strongify(self);
 
         Map *map = maps.firstObject;
         if (!map) { return; }

--- a/Artsy/View_Controllers/Fair/Guides/ARFairGuideContainerViewController.m
+++ b/Artsy/View_Controllers/Fair/Guides/ARFairGuideContainerViewController.m
@@ -58,21 +58,21 @@ const CGFloat kClosedMapHeight = 180.0f;
 
     self.view.backgroundColor = [UIColor whiteColor];
 
-    @weakify(self);
+   @_weakify(self);
     [[[self rac_signalForSelector:@selector(viewWillAppear:)] take:1] subscribeNext:^(id _) {
-        @strongify(self);
+        @_strongify(self);
         [self downloadContent];
     }];
 
     [[RACSignal combineLatest:@[ RACObserve(self, mapsLoaded), RACObserve(self, fairLoaded) ]] subscribeNext:^(id x) {
-        @strongify(self);
+        @_strongify(self);
         [self checkForDataLoaded];
     }];
 
     // Every time the mapCollapsed property changes, we want to setup the constraints.
     // We skip the first time because we don't want to fire immediately.
     [[[RACObserve(self, mapCollapsed) skip:1] distinctUntilChanged] subscribeNext:^(id _) {
-        @strongify(self);
+        @_strongify(self);
 
         CGFloat height = 0;
         if (self.mapCollapsed) {

--- a/Artsy/View_Controllers/Fair/Guides/ARFairMapViewController.m
+++ b/Artsy/View_Controllers/Fair/Guides/ARFairMapViewController.m
@@ -123,9 +123,9 @@
     RAC(self.mapShowMapper, expandAnnotations) = RACObserve(self, expandAnnotations);
 
     // Due to a problem in the custom UIViewController transitions API (when the VC's view is a scrollview subclass)
-    @weakify(self);
+   @_weakify(self);
     [[self rac_signalForSelector:@selector(viewWillDisappear:)] subscribeNext:^(id x) {
-        @strongify(self);
+        @_strongify(self);
 
         CGPoint contentOffset = self.mapView.contentOffset;
 

--- a/Artsy/View_Controllers/Fair/Network_Models/ARFairNetworkModel.m
+++ b/Artsy/View_Controllers/Fair/Network_Models/ARFairNetworkModel.m
@@ -44,10 +44,10 @@
 
 - (void)getMapInfoForFair:(Fair *)fair success:(void (^)(NSArray *))success failure:(void (^)(NSError *))failure
 {
-    @weakify(fair);
+   @_weakify(fair);
 
     [ArtsyAPI getMapInfoForFair:fair success:^(NSArray *maps) {
-        @strongify(fair);
+        @_strongify(fair);
         if (!fair) { return; }
         fair.maps = maps;
         if (success) {

--- a/Artsy/View_Controllers/Fair/Utils/ARFairShowMapper.m
+++ b/Artsy/View_Controllers/Fair/Utils/ARFairShowMapper.m
@@ -247,9 +247,9 @@
 
 - (void)rebuildPartnerToShowsMap
 {
-    @weakify(self);
+   @_weakify(self);
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0), ^{
-        @strongify(self);
+        @_strongify(self);
 
         NSMapTable *result = [NSMapTable strongToStrongObjectsMapTable];
         for(PartnerShow *show in self.shows) {

--- a/Artsy/View_Controllers/Fair/Views/ARParallaxHeaderViewController.m
+++ b/Artsy/View_Controllers/Fair/Views/ARParallaxHeaderViewController.m
@@ -118,9 +118,9 @@ const CGFloat ARParallaxHeaderViewIconImageViewDimension = 80.0f;
     }
 
     if (![self hasNewStyledBanner] && [self hasIconImage]) {
-        @weakify(self);
+       @_weakify(self);
         [self.iconImageView ar_setImageWithURL:[NSURL URLWithString:[self.profile iconURL]] completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *imageURL) {
-            @strongify(self);
+            @_strongify(self);
             if (image) {
                 [self.iconImageView alignBottomEdgeWithView:self.view predicate:@"0"];
                 [self.iconImageView alignLeadingEdgeWithView:self.view predicate:@"20"];

--- a/Artsy/View_Controllers/Fair/Views/ARSearchFieldButton.m
+++ b/Artsy/View_Controllers/Fair/Views/ARSearchFieldButton.m
@@ -42,9 +42,9 @@
     [self.label alignTop:@"2" bottom:@"0" toView:self];
 
     UITapGestureRecognizer *recognizer = [[UITapGestureRecognizer alloc] init];
-    @weakify(self);
+   @_weakify(self);
     [recognizer.rac_gestureSignal subscribeNext:^(id _) {
-        @strongify(self);
+        @_strongify(self);
         [self.delegate searchFieldButtonWasPressed:self];
     }];
     [self addGestureRecognizer:recognizer];

--- a/Artsy/View_Controllers/Favorites/ARFavoritesViewController.m
+++ b/Artsy/View_Controllers/Favorites/ARFavoritesViewController.m
@@ -289,10 +289,10 @@
     if (networkModel.allDownloaded) {
         return;
     };
-    @weakify(self);
+   @_weakify(self);
     dispatch_async(self.artworkPageQueue, ^{
         [self.activeNetworkModel getFavorites:^(NSArray *items){
-            @strongify(self);
+            @_strongify(self);
             [self addItems:items toModule:module];
         } failure:nil];
     });

--- a/Artsy/View_Controllers/Feed_VCs/ARFeedViewController.m
+++ b/Artsy/View_Controllers/Feed_VCs/ARFeedViewController.m
@@ -116,10 +116,10 @@
 
 - (void)refreshFeedItems
 {
-    @weakify(self)
+   @_weakify(self)
         [ArtsyAPI getXappTokenWithCompletion:^(NSString *xappToken, NSDate *expirationDate) {
         [self.feedTimeline getNewItems:^{
-            @strongify(self);
+            @_strongify(self);
             [self hideLoadingView];
             [self.tableView reloadData];
         } failure:^(NSError *error) {
@@ -168,11 +168,11 @@
     _loading = YES;
     [self setFooterStatus:ARFeedStatusStateLoading];
 
-    @weakify(self)
+   @_weakify(self)
         NSInteger oldCount = self.feedTimeline.numberOfItems;
 
     [self.feedTimeline getNextPage:^{
-        @strongify(self);
+        @_strongify(self);
         if (!self) { return; }
 
         NSMutableArray *indexPaths = [NSMutableArray array];
@@ -184,7 +184,7 @@
         self->_loading = NO;
     }
         failure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         if (!self) { return; }
 
         // add a "network error, retry?" state to footer
@@ -193,7 +193,7 @@
         self->_loading = NO;
         }
         completion:^{
-        @strongify(self);
+        @_strongify(self);
         if (!self) { return; }
 
         [self setFooterStatus:ARFeedStatusStateEndOfFeed];

--- a/Artsy/View_Controllers/Feed_VCs/ARShowFeedViewController.m
+++ b/Artsy/View_Controllers/Feed_VCs/ARShowFeedViewController.m
@@ -51,10 +51,10 @@ static CGFloat ARFeaturedShowsTitleHeightPhone = 40;
 
     _heroUnitVC = [[ARHeroUnitViewController alloc] init];
 
-    @weakify(self);
+   @_weakify(self);
     NSNotificationCenter *defaultCenter = [NSNotificationCenter defaultCenter];
     self.networkNotificationObserver = [defaultCenter addObserverForName:ARNetworkUnavailableNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
-        @strongify(self);
+        @_strongify(self);
         if (self.feedTimeline.numberOfItems == 0) {
             // The offline view will be hidden when we load content.
             [self showOfflineView];
@@ -130,10 +130,10 @@ static CGFloat ARFeaturedShowsTitleHeightPhone = 40;
     [ARAnalytics startTimingEvent:ARAnalyticsInitialFeedLoadTime];
     [self presentLoadingView];
 
-    @weakify(self)
+   @_weakify(self)
         [ArtsyAPI getXappTokenWithCompletion:^(NSString *xappToken, NSDate *expirationDate) {
         [self.feedTimeline getNewItems:^{
-            @strongify(self);
+            @_strongify(self);
             [self.tableView reloadData];
             [self hideLoadingView];
             [self hideOfflineView];
@@ -207,10 +207,10 @@ static CGFloat ARFeaturedShowsTitleHeightPhone = 40;
 
     } else {
         self.feedLinkVC = [[ARFeedLinkUnitViewController alloc] init];
-        @weakify(self);
+       @_weakify(self);
         [ArtsyAPI getXappTokenWithCompletion:^(NSString *xappToken, NSDate *expirationDate) {
             [self.feedLinkVC fetchLinks:^{
-                @strongify(self);
+                @_strongify(self);
                 if (![UIDevice isPad]) { [self layoutFeedLinks]; }
             }];
         }];

--- a/Artsy/View_Controllers/Login_and_Onboarding/AROnboardingViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/AROnboardingViewController.m
@@ -79,14 +79,14 @@ typedef NS_ENUM(NSInteger, AROnboardingStage) {
     self.screenSwipeGesture.edges = UIRectEdgeLeft;
     [self.view addGestureRecognizer:self.screenSwipeGesture];
 
-    @weakify(self);
+   @_weakify(self);
 
     [ArtsyAPI getXappTokenWithCompletion:^(NSString *xappToken, NSDate *expirationDate) {
-        @strongify(self);
+        @_strongify(self);
 
-        @weakify(self);
+       @_weakify(self);
         [ArtsyAPI getPersonalizeGenesWithSuccess:^(NSArray *genes) {
-            @strongify(self);
+            @_strongify(self);
             self.genesForPersonalize = genes;
         } failure:^(NSError *error) {
             ARErrorLog(@"Couldn't get personalize genes. Error: %@", error.localizedDescription);
@@ -324,9 +324,9 @@ typedef NS_ENUM(NSInteger, AROnboardingStage) {
 {
     self.backgroundWidthConstraint.constant = 0;
     self.backgroundHeightConstraint.constant = 0;
-    @weakify(self);
+   @_weakify(self);
     [UIView animateIf:animated duration:ARAnimationQuickDuration:^{
-        @strongify(self);
+        @_strongify(self);
         [self.backgroundView layoutIfNeeded];
         self.backgroundView.alpha = 1;
         self.backgroundView.backgroundColor = [UIColor clearColor];
@@ -370,10 +370,10 @@ typedef NS_ENUM(NSInteger, AROnboardingStage) {
 
 - (void)signUpWithFacebook
 {
-    @weakify(self);
+   @_weakify(self);
     [self ar_presentIndeterminateLoadingIndicatorAnimated:YES];
     [ARAuthProviders getTokenForFacebook:^(NSString *token, NSString *email, NSString *name) {
-        @strongify(self);
+        @_strongify(self);
 
         AROnboardingMoreInfoViewController *more = [[AROnboardingMoreInfoViewController alloc] initForFacebookWithToken:token email:email name:name];
         more.delegate = self;
@@ -381,7 +381,7 @@ typedef NS_ENUM(NSInteger, AROnboardingStage) {
         [self pushViewController:more animated:YES];
 
     } failure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
 
         [self ar_removeIndeterminateLoadingIndicatorAnimated:YES];
 
@@ -396,9 +396,9 @@ typedef NS_ENUM(NSInteger, AROnboardingStage) {
 {
     [self ar_presentIndeterminateLoadingIndicatorAnimated:YES];
 
-    @weakify(self);
+   @_weakify(self);
     [ARAuthProviders getReverseAuthTokenForTwitter:^(NSString *token, NSString *secret) {
-        @strongify(self);
+        @_strongify(self);
 
         AROnboardingMoreInfoViewController *more = [[AROnboardingMoreInfoViewController alloc]
                                                     initForTwitterWithToken:token andSecret:secret];
@@ -407,7 +407,7 @@ typedef NS_ENUM(NSInteger, AROnboardingStage) {
         [self pushViewController:more animated:YES];
 
     } failure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
 
         [self ar_removeIndeterminateLoadingIndicatorAnimated:YES];
         [self twitterError];
@@ -547,9 +547,9 @@ typedef NS_ENUM(NSInteger, AROnboardingStage) {
 
     self.backgroundWidthConstraint.constant = offset * 2;
     self.backgroundHeightConstraint.constant = offset * 2;
-    @weakify(self);
+   @_weakify(self);
     [UIView animateIf:animated duration:ARAnimationQuickDuration:^{
-        @strongify(self);
+        @_strongify(self);
         [self.backgroundView layoutIfNeeded];
         self.backgroundView.image = blurImage;
         self.backgroundView.alpha = 0.3;

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/3_-_Sign_Up_+_Log_In/ARCreateAccountViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/3_-_Sign_Up_+_Log_In/ARCreateAccountViewController.m
@@ -188,14 +188,14 @@
     NSString *username = self.email.text;
     NSString *password = self.password.text;
 
-    @weakify(self);
+   @_weakify(self);
     [[ARUserManager sharedManager] createUserWithName:self.name.text email:username password:password success:^(User *user) {
-        @strongify(self);
+        @_strongify(self);
         [self loginWithUserCredentialsWithSuccess:^{
             [self.delegate didSignUpAndLogin];
         }];
     } failure:^(NSError *error, id JSON) {
-        @strongify(self);
+        @_strongify(self);
         if (JSON
             && [JSON isKindOfClass:[NSDictionary class]]
             && ([JSON[@"error"] isEqualToString:@"User Already Exists"]
@@ -221,20 +221,20 @@
     NSString *username = self.email.text;
     NSString *password = self.password.text;
 
-    @weakify(self);
+   @_weakify(self);
     [[ARUserManager sharedManager] loginWithUsername:username password:password successWithCredentials:nil
         gotUser:^(User *currentUser) {
          success();
         }
         authenticationFailure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         [self setFormEnabled:YES];
         UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Couldn’t Log In" message:@"Please check your email and password." delegate:nil cancelButtonTitle:@"Dismiss" otherButtonTitles:nil];
         [alert show];
 
         }
         networkFailure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         [self setFormEnabled:YES];
         [self performSelector:_cmd withObject:self afterDelay:3];
         [ARNetworkErrorManager presentActiveErrorModalWithError:error];

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/3_-_Sign_Up_+_Log_In/ARLoginViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/3_-_Sign_Up_+_Log_In/ARLoginViewController.m
@@ -163,7 +163,7 @@
 - (void)twitter:(id)sender
 {
     [self hideKeyboard];
-    @weakify(self);
+   @_weakify(self);
 
     [self ar_presentIndeterminateLoadingIndicatorAnimated:YES];
 
@@ -172,20 +172,20 @@
             secret:secret
             successWithCredentials:nil
             gotUser:^(User *currentUser) {
-                @strongify(self);
+                @_strongify(self);
                 [self loggedInWithType:ARLoginViewControllerLoginTypeTwitter user:currentUser];
             } authenticationFailure:^(NSError *error) {
-                @strongify(self);
+                @_strongify(self);
                 [self ar_removeIndeterminateLoadingIndicatorAnimated:YES];
                 [self twitterError];
 
             } networkFailure:^(NSError *error) {
-                @strongify(self);
+                @_strongify(self);
                 [self failedToLoginToTwitter];
             }];
 
     } failure:^(NSError *error) {
-             @strongify(self);
+             @_strongify(self);
              [self ar_removeIndeterminateLoadingIndicatorAnimated:YES];
              [self twitterError];
     }];
@@ -209,14 +209,14 @@
     [self hideKeyboard];
     [self ar_presentIndeterminateLoadingIndicatorAnimated:YES];
 
-    @weakify(self);
+   @_weakify(self);
     [ARAuthProviders getTokenForFacebook:^(NSString *token, NSString *email, NSString *name) {
         [[ARUserManager sharedManager] loginWithFacebookToken:token
            successWithCredentials:nil gotUser:^(User *currentUser) {
-               @strongify(self);
+               @_strongify(self);
                 [self loggedInWithType:ARLoginViewControllerLoginTypeFacebook user:currentUser];
            } authenticationFailure:^(NSError *error) {
-               @strongify(self);
+               @_strongify(self);
 
                [self ar_removeIndeterminateLoadingIndicatorAnimated:YES];
 
@@ -229,11 +229,11 @@
                }
 
            } networkFailure:^(NSError *error) {
-               @strongify(self);
+               @_strongify(self);
                [self failedToLoginToFacebook];
            }];
     } failure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
 
         [self ar_removeIndeterminateLoadingIndicatorAnimated:YES];
         [self fbError];
@@ -400,22 +400,22 @@
 
     self.loginButton.alpha = 0.5;
 
-    @weakify(self);
+   @_weakify(self);
     [[ARUserManager sharedManager] loginWithUsername:username
         password:password
         successWithCredentials:nil
         gotUser:^(User *currentUser) {
-        @strongify(self);
+        @_strongify(self);
         [self loggedInWithType:ARLoginViewControllerLoginTypeEmail user:currentUser];
         }
 
         authenticationFailure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         [self authenticationFailure];
         }
 
         networkFailure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         [self networkFailure:error];
         }];
 }

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/3_-_Sign_Up_+_Log_In/AROnboardingMoreInfoViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/3_-_Sign_Up_+_Log_In/AROnboardingMoreInfoViewController.m
@@ -210,18 +210,18 @@
         return;
     }
 
-    @weakify(self);
+   @_weakify(self);
     [self setFormEnabled:NO];
     if (self.provider == ARAuthProviderFacebook) {
         [[ARUserManager sharedManager] createUserViaFacebookWithToken:self.token
             email:self.emailField.text
             name:self.nameField.text
             success:^(User *user) {
-            @strongify(self);
+            @_strongify(self);
             [self loginWithFacebookCredential];
             }
             failure:^(NSError *error, id JSON) {
-            @strongify(self);
+            @_strongify(self);
             if (JSON && [JSON isKindOfClass:[NSDictionary class]]) {
                 if ([JSON[@"error"] containsString:@"Another Account Already Linked"]) {
                     ARErrorLog(@"Facebook account already linked");
@@ -239,9 +239,9 @@
 
             ARErrorLog(@"Couldn't link Facebook account. Error: %@. The server said: %@", error.localizedDescription, JSON);
             NSString *errorString = [NSString stringWithFormat:@"Server replied saying '%@'.", JSON[@"error"] ?: JSON[@"message"] ?: error.localizedDescription];
-            @weakify(self);
+           @_weakify(self);
             [UIAlertView showWithTitle:@"Error Creating\na New Artsy Account" message:errorString cancelButtonTitle:@"Close" otherButtonTitles:nil tapBlock:^(UIAlertView *alertView, NSInteger buttonIndex) {
-                @strongify(self);
+                @_strongify(self);
                 [self setFormEnabled:YES];
             }];
             }];
@@ -251,11 +251,11 @@
             email:self.emailField.text
             name:self.nameField.text
             success:^(User *user) {
-            @strongify(self);
+            @_strongify(self);
             [self loginWithTwitterCredential];
             }
             failure:^(NSError *error, id JSON) {
-          @strongify(self);
+          @_strongify(self);
           if (JSON && [JSON isKindOfClass:[NSDictionary class]]) {
               if ([JSON[@"error"] containsString:@"Another Account Already Linked"]) {
                   ARErrorLog(@"Twitter account already linked");
@@ -273,9 +273,9 @@
 
           ARErrorLog(@"Couldn't link Twitter account. Error: %@. The server said: %@", error.localizedDescription, JSON);
           NSString *errorString = [NSString stringWithFormat:@"Server replied saying '%@'.", JSON[@"error"] ?: JSON[@"message"] ?: error.localizedDescription];
-          @weakify(self);
+         @_weakify(self);
           [UIAlertView showWithTitle:@"Error Creating\na New Artsy Account" message:errorString cancelButtonTitle:@"Close" otherButtonTitles:nil tapBlock:^(UIAlertView *alertView, NSInteger buttonIndex) {
-              @strongify(self);
+              @_strongify(self);
               [self setFormEnabled:YES];
           }];
             }];
@@ -303,23 +303,23 @@
 - (void)loginWithTwitterCredential
 {
     [self ar_presentIndeterminateLoadingIndicatorAnimated:YES];
-    @weakify(self);
+   @_weakify(self);
 
     [[ARUserManager sharedManager] loginWithTwitterToken:self.token
         secret:self.secret
         successWithCredentials:nil
         gotUser:^(User *currentUser) {
-         @strongify(self);
+         @_strongify(self);
          [self loginCompletedForLoginType:AROnboardingMoreInfoViewControllerLoginTypeTwitter];
         }
         authenticationFailure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         [self ar_removeIndeterminateLoadingIndicatorAnimated:YES];
           //TODO: handle me
 
         }
         networkFailure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         [self setFormEnabled:YES];
         [self ar_removeIndeterminateLoadingIndicatorAnimated:YES];
         [ARNetworkErrorManager presentActiveErrorModalWithError:error];
@@ -329,21 +329,21 @@
 - (void)loginWithFacebookCredential
 {
     [self ar_presentIndeterminateLoadingIndicatorAnimated:YES];
-    @weakify(self);
+   @_weakify(self);
 
     [[ARUserManager sharedManager] loginWithFacebookToken:self.token successWithCredentials:nil
         gotUser:^(User *currentUser) {
-          @strongify(self);
+          @_strongify(self);
           [self loginCompletedForLoginType:AROnboardingMoreInfoViewControllerLoginTypeFacebook];
         }
         authenticationFailure:^(NSError *error) {
-          @strongify(self);
+          @_strongify(self);
           [self ar_removeIndeterminateLoadingIndicatorAnimated:YES];
           //TODO: handle me
 
         }
         networkFailure:^(NSError *error) {
-          @strongify(self);
+          @_strongify(self);
           [self ar_removeIndeterminateLoadingIndicatorAnimated:YES];
           [self setFormEnabled:YES];
           [ARNetworkErrorManager presentActiveErrorModalWithError:error];

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/AROnboardingGeneTableController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/AROnboardingGeneTableController.m
@@ -78,13 +78,13 @@ static NSString *CellId = @"OnboardingGeneFollow";
 
     self.numberOfFollowedGenes += newState ? 1 : -1;
 
-    @weakify(gene);
+   @_weakify(gene);
     [gene setFollowState:newState success:^(id response) {
-        @strongify(gene);
+        @_strongify(gene);
         ARActionLog(@"%@ gene %@", newState ? @"Followed" : @"Unfollowed" , gene.geneID);
 
     } failure:^(NSError *error) {
-        @strongify(gene);
+        @_strongify(gene);
         [cell toggleFollowState];
         ARErrorLog(@"Error %@ gene %@. Error: %@", newState ? @"following" : @"unfollowing", gene, error.localizedDescription);
     }];

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/ARPersonalizeViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/ARPersonalizeViewController.m
@@ -133,9 +133,9 @@ static NSString *SearchCellId = @"OnboardingSearchCell";
     self.artistTableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     self.artistTableView.scrollEnabled = NO;
 
-    @weakify(self);
+   @_weakify(self);
     [self.artistController setPostRemoveBlock:^{
-        @strongify(self);
+        @_strongify(self);
         [self updateArtistTableViewAnimated:YES];
     }];
 

--- a/Artsy/View_Controllers/Menu/Settings/ARUserSettingsViewController.m
+++ b/Artsy/View_Controllers/Menu/Settings/ARUserSettingsViewController.m
@@ -166,16 +166,16 @@
     [super switchValueChangedTo:newValue userInfo:userInfo];
     FODFormRow *row = (FODFormRow *)userInfo;
 
-    @weakify(row);
+   @_weakify(row);
     [ArtsyAPI updateCurrentUserProperty:[User JSONKeyPathsByPropertyKey][row.key]
         toValue:row.workingValue
         success:^(User *user) {
-            @strongify(row);
+            @_strongify(row);
             [[User currentUser] setValue:[user valueForKey:row.key] forKey:row.key];
             [[ARUserManager sharedManager] storeUserData];
         }
         failure:^(NSError *error) {
-            @strongify(row);
+            @_strongify(row);
             row.workingValue = row.initialValue;
             [self.tableView reloadRowsAtIndexPaths:@[row.indexPath] withRowAnimation:UITableViewRowAnimationNone];
         }];
@@ -190,15 +190,15 @@
         return;
     }
 
-    @weakify(row);
+   @_weakify(row);
     [ArtsyAPI updateCurrentUserProperty:[User JSONKeyPathsByPropertyKey][row.key] toValue:row.workingValue
         success:^(User *user) {
-            @strongify(row);
+            @_strongify(row);
             [[User currentUser] setValue:[user valueForKey:row.key] forKey:row.key];
             [[ARUserManager sharedManager] storeUserData];
         }
         failure:^(NSError *error) {
-            @strongify(row);
+            @_strongify(row);
             row.workingValue = row.initialValue;
             [self.tableView reloadRowsAtIndexPaths:@[row.indexPath] withRowAnimation:UITableViewRowAnimationNone];
         }];

--- a/Artsy/View_Controllers/Search/ARSearchResultsDataSource.m
+++ b/Artsy/View_Controllers/Search/ARSearchResultsDataSource.m
@@ -34,10 +34,10 @@
 
     cell.textLabel.textColor = self.textColor ?: [UIColor whiteColor];
 
-    @weakify(cell);
+   @_weakify(cell);
     [cell.imageView setImageWithURLRequest:result.imageRequest placeholderImage:self.placeholderImage
                                    success:^(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image) {
-       @strongify(cell);
+       @_strongify(cell);
        cell.imageView.image = image;
        [cell layoutSubviews];
 

--- a/Artsy/View_Controllers/Search/ARSearchViewController.m
+++ b/Artsy/View_Controllers/Search/ARSearchViewController.m
@@ -206,9 +206,9 @@
 
 - (void)fetchSearchResults:(NSString *)text replace:(BOOL)replaceResults
 {
-    @weakify(self);
+   @_weakify(self);
     _searchRequest = [self searchWithQuery:text success:^(NSArray *results) {
-        @strongify(self);
+        @_strongify(self);
         [self addResults:results replace:replaceResults];
         [self finishSearching];
     } failure:^(NSError *error) {
@@ -272,13 +272,13 @@
 
 - (void)removeResultsViewAnimated:(BOOL)animated
 {
-    @weakify(self);
+   @_weakify(self);
 
     [UIView animateIf:animated duration:0.15:^{
-        @strongify(self);
+        @_strongify(self);
         self.resultsView.alpha = 0;
     } completion:^(BOOL finished) {
-        @strongify(self);
+        @_strongify(self);
         if (!self) { return; }
 
         self.resultsView.hidden = YES;

--- a/Artsy/View_Controllers/Util/ARNavigationController.m
+++ b/Artsy/View_Controllers/Util/ARNavigationController.m
@@ -327,10 +327,10 @@ static void *ARNavigationControllerScrollingChiefContext = &ARNavigationControll
     }
     [self ar_addModernChildViewController:self.pendingOperationViewController];
 
-    @weakify(self);
+   @_weakify(self);
 
     return [[RACCommand alloc] initWithSignalBlock:^RACSignal *(id input) {
-        @strongify(self);
+        @_strongify(self);
         RACSubject *completionSubject = [RACSubject subject];
 
         [UIView animateIf:self.animatesLayoverChanges duration:ARAnimationDuration :^{

--- a/Artsy/View_Controllers/Util/ARNavigationController.m
+++ b/Artsy/View_Controllers/Util/ARNavigationController.m
@@ -254,7 +254,7 @@ static void *ARNavigationControllerScrollingChiefContext = &ARNavigationControll
     if (animated) {
         CABasicAnimation *fade = [CABasicAnimation animation];
         fade.keyPath = @keypath(self.backButton.layer, opacity);
-        fade.fromValue = @([self.backButton.layer.presentationLayer opacity]);
+        fade.fromValue = @([(CALayer *)self.backButton.layer.presentationLayer opacity]);
         fade.toValue = @(toValue);
         fade.duration = ARAnimationDuration;
 

--- a/Artsy/View_Controllers/Util/Logging/ARLogger.h
+++ b/Artsy/View_Controllers/Util/Logging/ARLogger.h
@@ -28,6 +28,7 @@ typedef NS_ENUM(NSInteger, ARLogContext) {
 #define ARHTTPRequestOperationSuccessLog(frmt, ...) LOG_OBJC_MAYBE(YES, ddLogLevel, LOG_FLAG_INFO, ARLogContextRequestOperation, frmt, ##__VA_ARGS__)
 #define ARHTTPRequestOperationFailureLog(frmt, ...) LOG_OBJC_MAYBE(YES, ddLogLevel, LOG_FLAG_ERROR, ARLogContextRequestOperation, frmt, ##__VA_ARGS__)
 
-#define ARLogInfo(frmt, ...) LOG_MAYBE(NO LOG_LEVEL_DEF, ARLogContextInfo, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-#define ARActionLog(frmt, ...) LOG_MAYBE(LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, ARLogContextAction, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-#define ARErrorLog(frmt, ...) LOG_MAYBE(LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, ARLogContextError, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define ARLogInfo(frmt, ...) LOG_OBJC_MAYBE(NO LOG_LEVEL_DEF, (DDLogFlag)ARLogContextInfo, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define ARActionLog(frmt, ...) LOG_OBJC_MAYBE(LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, (DDLogFlag)ARLogContextAction, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+
+#define ARErrorLog(frmt, ...) LOG_OBJC_MAYBE(LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, (DDLogFlag)ARLogContextError, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)

--- a/Artsy/Views/Artwork/ARArtworkActionsView.m
+++ b/Artsy/Views/Artwork/ARArtworkActionsView.m
@@ -42,16 +42,16 @@
 - (void)setDelegate:(id<ARArtworkActionsViewDelegate, ARArtworkActionsViewButtonDelegate>)delegate
 {
     _delegate = delegate;
-    @weakify(self);
+   @_weakify(self);
 
     KSPromise *artworkPromise = [self.artwork onArtworkUpdate:nil failure:nil];
     KSPromise *saleArtworkPromise = [self.artwork onSaleArtworkUpdate:^(SaleArtwork *saleArtwork) {
-        @strongify(self);
+        @_strongify(self);
         self.saleArtwork = saleArtwork;
     } failure:nil];
 
     [[KSPromise when:@[ artworkPromise, saleArtworkPromise ]] then:^id(id value) {
-        @strongify(self);
+        @_strongify(self);
         id returnable = nil;
         [self updateUI];
         return returnable;

--- a/Artsy/Views/Artwork/ARArtworkBlurbView.m
+++ b/Artsy/Views/Artwork/ARArtworkBlurbView.m
@@ -2,7 +2,6 @@
 #import "ARTextView.h"
 #import "ORStackView+ArtsyViews.h"
 
-
 @interface ARArtworkBlurbView () <ARTextViewDelegate>
 @property (nonatomic, strong) UILabel *aboutHeading;
 @property (nonatomic, strong) ARTextView *blurbTextView;

--- a/Artsy/Views/Artwork/ARArtworkBlurbView.m
+++ b/Artsy/Views/Artwork/ARArtworkBlurbView.m
@@ -18,10 +18,10 @@
         return nil;
     }
 
-    @weakify(self);
+   @_weakify(self);
 
     [artwork onArtworkUpdate:^{
-        @strongify(self);
+        @_strongify(self);
         [self updateWithArtwork:artwork];
     } failure:nil];
 

--- a/Artsy/Views/Artwork/ARArtworkDetailView.m
+++ b/Artsy/Views/Artwork/ARArtworkDetailView.m
@@ -40,15 +40,15 @@ NS_ENUM(NSInteger, ARDetailSubViewOrder){
 - (void)setDelegate:(id<ARArtworkDetailViewDelegate, ARArtworkDetailViewButtonDelegate>)delegate
 {
     _delegate = delegate;
-    @weakify(self);
+   @_weakify(self);
     [self.artwork onArtworkUpdate:^{
-        @strongify(self);
+        @_strongify(self);
         [self updateWithArtwork:self.artwork];
     } failure:nil];
     [self updateWithArtwork:self.artwork];
 
     [self.artwork onSaleArtworkUpdate:^(SaleArtwork *saleArtwork) {
-        @strongify(self);
+        @_strongify(self);
         [self updateWithSaleArtwork:saleArtwork];
     } failure:nil];
 }

--- a/Artsy/Views/Artwork/ARArtworkPreviewActionsView.m
+++ b/Artsy/Views/Artwork/ARArtworkPreviewActionsView.m
@@ -34,17 +34,17 @@ const CGFloat ARArtworkActionButtonSpacing = 8;
     _shareButton = [self newShareButton];
     _favoriteButton = [self newFavoriteButton];
 
-    @weakify(self);
+   @_weakify(self);
     [artwork getFavoriteStatus:^(ARHeartStatus status) {
-        @strongify(self);
+        @_strongify(self);
         [self.favoriteButton setStatus:status animated:YES];
     } failure:^(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         [self.favoriteButton setStatus:ARHeartStatusNo animated:YES];
     }];
 
     [artwork onArtworkUpdate:^{
-        @strongify(self);
+        @_strongify(self);
         [self updateWithArtwork:artwork andFair:fair];
     } failure:nil];
 

--- a/Artsy/Views/Artwork/ARArtworkPreviewImageView.m
+++ b/Artsy/Views/Artwork/ARArtworkPreviewImageView.m
@@ -38,9 +38,9 @@
 {
     _artwork = artwork;
     [self updateWithArtwork:artwork];
-    @weakify(self);
+   @_weakify(self);
     [artwork onArtworkUpdate:^{
-        @strongify(self);
+        @_strongify(self);
         [self updateWithArtwork:artwork];
     } failure:nil];
 }

--- a/Artsy/Views/Artwork/ARArtworkRelatedArtworksView.m
+++ b/Artsy/Views/Artwork/ARArtworkRelatedArtworksView.m
@@ -79,7 +79,7 @@
     self.artwork = artwork;
     self.hasRequested = YES;
 
-    @weakify(self);
+   @_weakify(self);
 
     // TODO: refactor these callbacks to return so we can use
     // results from the values array in a `when`
@@ -94,7 +94,7 @@
     } failure:nil];
 
     [[KSPromise when:@[ salePromise, fairPromise, partnerShowPromise ]] then:^id(id value) {
-        @strongify(self);
+        @_strongify(self);
 
         if (show) {
             [self addSectionsForShow:show];
@@ -117,7 +117,7 @@
         return nil;
 
     } error:^id(NSError *error) {
-        @strongify(self);
+        @_strongify(self);
         ARErrorLog(@"Error fetching sale/fair for %@. Error: %@", self.artwork.artworkID, error.localizedDescription);
         [self addSectionWithRelatedArtworks];
         return error;
@@ -133,15 +133,15 @@
 
 - (void)addSectionsForFair:(Fair *)fair;
 {
-    @weakify(self);
+   @_weakify(self);
     [self addRelatedArtworkRequest:[self.artwork getFeaturedShowsAtFair:fair success:^(NSArray *shows) {
-        @strongify(self);
+        @_strongify(self);
         for (PartnerShow *show in shows) {
             [self addSectionWithOtherArtworksInShow:show];
         }
     }]];
     [self addRelatedArtworkRequest:[self.artwork getRelatedFairArtworks:fair success:^(NSArray *artworks) {
-        @strongify(self);
+        @_strongify(self);
         [self addSectionWithTag:ARRelatedArtworksSameFair artworks:artworks heading:@"Other works in fair"];
     }]];
 }
@@ -155,18 +155,18 @@
 
 - (void)addSectionsForAuction:(Sale *)auction;
 {
-    @weakify(self);
+   @_weakify(self);
     [self addRelatedArtworkRequest:[auction getArtworks:^(NSArray *artworks) {
-        @strongify(self);
+        @_strongify(self);
         [self addSectionWithTag:ARRelatedArtworksSameAuction artworks:artworks heading:@"Other works in auction"];
     }]];
 }
 
 - (void)addSectionWithOtherArtworksInShow:(PartnerShow *)show;
 {
-    @weakify(self);
+   @_weakify(self);
     [self getArtworksInShow:show atPage:1 success:^(NSArray *artworks) {
-        @strongify(self);
+        @_strongify(self);
         ARArtworkRelatedArtworksContentView *view = [self addSectionWithTag:ARRelatedArtworksSameShow artworks:artworks heading:@"Other works in show"];
         [self addArtworksInShow:show atPage:2 toView:view];
     }];
@@ -174,10 +174,10 @@
 
 - (void)addArtworksInShow:(PartnerShow *)show atPage:(NSInteger)page toView:(ARArtworkRelatedArtworksContentView *)view
 {
-    @weakify(self);
+   @_weakify(self);
     [self getArtworksInShow:show atPage:page success:^(NSArray *artworks) {
         if (!artworks.count > 0) { return; }
-        @strongify(self);
+        @_strongify(self);
         [view.artworksVC appendItems:artworks];
         [self addArtworksInShow:show atPage:page+1 toView:view];
     }];
@@ -194,9 +194,9 @@
         return;
     }
 
-    @weakify(self);
+   @_weakify(self);
     [self addRelatedArtworkRequest:[self.artwork.artist getArtworksAtPage:1 andParams:nil success:^(NSArray *artworks) {
-        @strongify(self);
+        @_strongify(self);
         [self addSectionWithTag:ARRelatedArtworksArtistArtworks
                        artworks:artworks
                         heading:[NSString stringWithFormat:@"Other works by %@", self.artwork.artist.name]];
@@ -205,9 +205,9 @@
 
 - (void)addSectionWithRelatedArtworks;
 {
-    @weakify(self);
+   @_weakify(self);
     [self addRelatedArtworkRequest:[self.artwork getRelatedArtworks:^(NSArray *artworks) {
-        @strongify(self);
+        @_strongify(self);
         [self addSectionWithTag:ARRelatedArtworks artworks:artworks heading:@"Related artworks"];
     }]];
 }

--- a/Artsy/Views/Artwork/ARArtworkView.m
+++ b/Artsy/Views/Artwork/ARArtworkView.m
@@ -96,16 +96,16 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
 
 - (void)setUpCallbacks
 {
-    @weakify(self);
+   @_weakify(self);
 
     void (^completion)(void) = ^{
-        @strongify(self);
+        @_strongify(self);
         [self.spinner fadeOutAnimated:self.parentViewController.shouldAnimate];
         [self.stackView removeSubview:self.spinner];
     };
 
     [self.artwork onArtworkUpdate:^{
-        @strongify(self);
+        @_strongify(self);
         [self artworkUpdated];
 
         completion();
@@ -114,7 +114,7 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
     }];
 
     [self.artwork onFairUpdate:^(Fair *fair) {
-        @strongify(self);
+        @_strongify(self);
         if (!self || !fair) return;
 
         [self.metadataView updateWithFair:fair];
@@ -122,7 +122,7 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
     } failure:nil];
 
     [self.artwork onSaleArtworkUpdate:^(SaleArtwork *saleArtwork) {
-        @strongify(self);
+        @_strongify(self);
         if (saleArtwork.auctionState & ARAuctionStateUserIsBidder) {
             [ARAnalytics setUserProperty:@"has_placed_bid" toValue:@"true"];
             self.banner.auctionState = saleArtwork.auctionState;

--- a/Artsy/Views/Collection_Views/ARGeneViewController.m
+++ b/Artsy/Views/Collection_Views/ARGeneViewController.m
@@ -97,9 +97,9 @@
 
 - (void)loadGene
 {
-    @weakify(self);
+   @_weakify(self);
     [self.gene updateGene:^{
-        @strongify(self);
+        @_strongify(self);
         [self ar_removeIndeterminateLoadingIndicatorAnimated:self.shouldAnimate];
         [self updateBody];
 

--- a/Artsy/Views/Styled_Subclasses/Buttons/ARHeartButton.m
+++ b/Artsy/Views/Styled_Subclasses/Buttons/ARHeartButton.m
@@ -88,9 +88,9 @@
 
     _status = status;
 
-    @weakify(self);
+   @_weakify(self);
     void (^animation)() = ^() {
-        @strongify(self);
+        @_strongify(self);
         if (status == ARHeartStatusYes) {
             [self.backView removeFromSuperview];
             [self addSubview:self.frontView];

--- a/Artsy/Views/Utilities/ARSiteHeroUnitView.m
+++ b/Artsy/Views/Utilities/ARSiteHeroUnitView.m
@@ -143,9 +143,9 @@ static CGFloat ARHeroUnitDescriptionFont;
 - (UIImageView *)createTitleImageWithImageURL:(NSURL *)titleImageURL
 {
     UIImageView *titleImageView = [[UIImageView alloc] init];
-    @weakify(titleImageView);
+   @_weakify(titleImageView);
     [titleImageView ar_setImageWithURL:titleImageURL completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *imageURL) {
-            @strongify(titleImageView);
+            @_strongify(titleImageView);
             titleImageView.image = [UIImage imageWithCGImage:image.CGImage scale:2.58 orientation:image.imageOrientation];
     }];
     if (self.alignment == ARHeroUnitAlignmentRight) {

--- a/Podfile
+++ b/Podfile
@@ -21,8 +21,6 @@ use_frameworks!
 local_podfile = "Podfile.local"
 eval(File.open(local_podfile).read) if File.exist? local_podfile
 
-# Include my pods in the install stats
-plugin 'cocoapods-stats'
 plugin 'cocoapods-keys', {
     :project => "Artsy",
     :target => "Artsy",
@@ -40,40 +38,55 @@ plugin 'cocoapods-keys', {
 }
 
 target 'Artsy' do
-  # Core
 
-  pod 'Mantle', '1.5.3'
+  # Networking
   pod 'AFNetworking', :git => 'https://github.com/orta/AFNetworking', :branch => 'no_ifdefs'
-  pod 'AFHTTPRequestOperationLogger', '1.0.0'
-  pod 'SDWebImage', '3.7.1'
-  pod 'JLRoutes', '1.5'
+  pod 'AFOAuth1Client', :git => "https://github.com/orta/AFOAuth1Client", :branch => "patch-1"
+  pod 'AFHTTPRequestOperationLogger'
+  pod 'SDWebImage'
+
+  # Core
+  pod 'ALPValidator'
+  pod 'ARGenericTableViewController'
+  pod 'CocoaLumberjack'
+  pod 'FLKAutoLayout'
+  pod 'FXBlurView'
+  pod 'iRate'
   pod 'ISO8601DateFormatter', :head
-  pod 'KSDeferred', '0.2.0'
-  pod 'JSDecoupledAppDelegate', '1.1.0'
-  pod 'CocoaLumberjack', '~> 2.0'
-  pod 'FXBlurView', '1.6.1'
-  pod 'MMMarkdown', '0.4'
-  pod 'UIAlertView+Blocks', '0.8'
-  pod 'iRate', '1.10.2'
-  pod 'MultiDelegate', '0.0.2'
-  pod 'ReactiveCocoa', '2.3'
-  pod 'ALPValidator', '0.0.3'
-  pod 'ORKeyboardReactingApplication', '0.5.3'
-  pod 'ORStackView', :git => 'https://github.com/1aurabrown/ORStackView.git'
+  pod 'JLRoutes'
+  pod 'JSDecoupledAppDelegate'
+  pod 'Mantle'
+  pod 'MMMarkdown'
+  pod 'ReactiveCocoa'
+  pod 'UICKeyChainStore'
+
+  # Core owned by Artsy
   pod 'ARTiledImageView', :git => 'https://github.com/dblock/ARTiledImageView', :commit => '1a31b864d1d56b1aaed0816c10bb55cf2e078bb8'
-  pod 'ARCollectionViewMasonryLayout', '~> 2.1', '>= 2.1.2'
-  pod 'ARGenericTableViewController', '1.0.2'
-  pod 'FLKAutoLayout', '0.1.1'
-  pod 'TPDWeakProxy', '1.1.0'
+  pod 'ARCollectionViewMasonryLayout'
+  pod 'ORStackView', :git => 'https://github.com/1aurabrown/ORStackView.git'
+  pod 'UIView+BooleanAnimations'
+  pod 'NAMapKit', :git => 'https://github.com/neilang/NAMapKit', :commit => '62275386978db91b0e7ed8de755d15cef3e793b4'
+
+  # Deprecated:
+  # UIAlertView is deprecated for iOS8 APIs
+  pod 'UIAlertView+Blocks'
+  # Code isn't used, and should be removed
+  pod 'FODFormKit', :git => 'https://github.com/1aurabrown/FODFormKit.git'
+
+  # Language Enhancments
+  pod 'KSDeferred'
+  pod 'libextobjc/EXTKeyPathCoding'
+  pod 'MultiDelegate'
+  pod 'ObjectiveSugar'
+  pod 'TPDWeakProxy'
 
   # X-Callback-Url support
   pod 'InterAppCommunication'
 
   # Artsy Spec repo stuff
-  pod 'Artsy+UILabels', :head
+  pod 'Artsy-UIButtons'
   pod 'Artsy+UIColors'
-  pod 'Artsy-UIButtons', '~> 1.4'
-  pod 'UIView+BooleanAnimations'
+  pod 'Artsy+UILabels'
 
   if %w(orta ash artsy laura eloy sarahscott).include?(ENV['USER']) || ENV['CI'] == 'true'
     pod 'Artsy+UIFonts', :git => "https://github.com/artsy/Artsy-UIFonts.git", :branch => "old_fonts_new_lib"
@@ -81,51 +94,32 @@ target 'Artsy' do
     pod 'Artsy+OSSUIFonts'
   end
 
-  # Auth
-  pod 'FBSDKCoreKit', '~> 4.2'
-  pod 'FBSDKLoginKit', '~> 4.2'
+  # Facebook
+  pod 'FBSDKCoreKit'
+  pod 'FBSDKLoginKit'
 
-  pod 'AFOAuth1Client', :git => "https://github.com/orta/AFOAuth1Client", :branch => "patch-1"
-
-  # Language niceities
-  pod 'ObjectiveSugar', '1.1.0'
-
-  # libextobjc
-  pod 'libextobjc/EXTKeyPathCoding', '0.4'
-  pod 'libextobjc/EXTScope', '0.4'
-
-  # Martsy
+  # Martsy / Force integration
   pod 'TSMiniWebBrowser@dblock', :head
 
-  # Table View simplification
-  pod 'FODFormKit', :git => 'https://github.com/1aurabrown/FODFormKit.git'
-
   # Analytics
-  pod 'HockeySDK-Source', '~> 3.7'
   pod 'ARAnalytics', '>= 3.6.2', :subspecs => ["Segmentio", "HockeyApp", "DSL"]
-  pod 'UICKeyChainStore', '1.0.5'
-
-  # Fairs
-  pod 'NAMapKit', :git => 'https://github.com/neilang/NAMapKit', :commit => '62275386978db91b0e7ed8de755d15cef3e793b4'
 
   # Developer Pods
-  pod 'VCRURLConnection', '0.2.0'
-  pod 'DHCShakeNotifier', '0.2.0'
+  pod 'DHCShakeNotifier'
+  pod 'ORKeyboardReactingApplication'
+  pod 'VCRURLConnection'
 
   # Easter Eggs
-  pod 'ARASCIISwizzle', '1.1.0'
-  pod 'DRKonamiCode', '1.1.0'
+  pod 'ARASCIISwizzle'
+  pod 'DRKonamiCode'
 end
 
 target 'Artsy Tests' do
   pod 'FBSnapshotTestCase'
-  pod 'Expecta+Snapshots', '1.3.4'
-  pod 'OHHTTPStubs', '3.1.2'
-  pod 'XCTest+OHHTTPStubSuiteCleanUp', '1.0.0'
+  pod 'Expecta+Snapshots'
+  pod 'OHHTTPStubs'
+  pod 'XCTest+OHHTTPStubSuiteCleanUp'
   pod 'Specta'
   pod 'Expecta'
-  pod 'OCMock', '2.2.4'
+  pod 'OCMock'
 end
-
-# Yep.
-inhibit_all_warnings!

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - Artsy+UIColors (1.0.0):
     - EDColor (~> 0.4)
   - Artsy+UIFonts (1.1.0)
-  - Artsy+UILabels (HEAD based on 1.3.1):
+  - Artsy+UILabels (1.3.1):
     - Artsy+UIColors
   - Artsy-UIButtons (1.4.0):
     - Artsy+UIColors
@@ -78,8 +78,6 @@ PODS:
   - KSDeferred (0.2.0)
   - libextobjc/EXTKeyPathCoding (0.4):
     - libextobjc/RuntimeExtensions
-  - libextobjc/EXTScope (0.4):
-    - libextobjc/RuntimeExtensions
   - libextobjc/RuntimeExtensions (0.4)
   - Mantle (1.5.3):
     - Mantle/extobjc (= 1.5.3)
@@ -118,61 +116,59 @@ PODS:
     - OHHTTPStubs
 
 DEPENDENCIES:
-  - AFHTTPRequestOperationLogger (= 1.0.0)
+  - AFHTTPRequestOperationLogger
   - AFNetworking (from `https://github.com/orta/AFNetworking`, branch `no_ifdefs`)
   - AFOAuth1Client (from `https://github.com/orta/AFOAuth1Client`, branch `patch-1`)
-  - ALPValidator (= 0.0.3)
+  - ALPValidator
   - ARAnalytics/DSL (>= 3.6.2)
   - ARAnalytics/HockeyApp (>= 3.6.2)
   - ARAnalytics/Segmentio (>= 3.6.2)
-  - ARASCIISwizzle (= 1.1.0)
-  - ARCollectionViewMasonryLayout (>= 2.1.2, ~> 2.1)
-  - ARGenericTableViewController (= 1.0.2)
+  - ARASCIISwizzle
+  - ARCollectionViewMasonryLayout
+  - ARGenericTableViewController
   - ARTiledImageView (from `https://github.com/dblock/ARTiledImageView`, commit `1a31b864d1d56b1aaed0816c10bb55cf2e078bb8`)
   - Artsy+UIColors
   - Artsy+UIFonts (from `https://github.com/artsy/Artsy-UIFonts.git`, branch `old_fonts_new_lib`)
-  - Artsy+UILabels (HEAD)
-  - Artsy-UIButtons (~> 1.4)
-  - CocoaLumberjack (~> 2.0)
-  - DHCShakeNotifier (= 0.2.0)
-  - DRKonamiCode (= 1.1.0)
+  - Artsy+UILabels
+  - Artsy-UIButtons
+  - CocoaLumberjack
+  - DHCShakeNotifier
+  - DRKonamiCode
   - Expecta
-  - Expecta+Snapshots (= 1.3.4)
-  - FBSDKCoreKit (~> 4.2)
-  - FBSDKLoginKit (~> 4.2)
+  - Expecta+Snapshots
+  - FBSDKCoreKit
+  - FBSDKLoginKit
   - FBSnapshotTestCase
-  - FLKAutoLayout (= 0.1.1)
+  - FLKAutoLayout
   - FODFormKit (from `https://github.com/1aurabrown/FODFormKit.git`)
-  - FXBlurView (= 1.6.1)
-  - HockeySDK-Source (~> 3.7)
+  - FXBlurView
   - InterAppCommunication
-  - iRate (= 1.10.2)
+  - iRate
   - ISO8601DateFormatter (HEAD)
-  - JLRoutes (= 1.5)
-  - JSDecoupledAppDelegate (= 1.1.0)
+  - JLRoutes
+  - JSDecoupledAppDelegate
   - Keys (from `Pods/CocoaPodsKeys`)
-  - KSDeferred (= 0.2.0)
-  - libextobjc/EXTKeyPathCoding (= 0.4)
-  - libextobjc/EXTScope (= 0.4)
-  - Mantle (= 1.5.3)
-  - MMMarkdown (= 0.4)
-  - MultiDelegate (= 0.0.2)
+  - KSDeferred
+  - libextobjc/EXTKeyPathCoding
+  - Mantle
+  - MMMarkdown
+  - MultiDelegate
   - NAMapKit (from `https://github.com/neilang/NAMapKit`, commit `62275386978db91b0e7ed8de755d15cef3e793b4`)
-  - ObjectiveSugar (= 1.1.0)
-  - OCMock (= 2.2.4)
-  - OHHTTPStubs (= 3.1.2)
-  - ORKeyboardReactingApplication (= 0.5.3)
+  - ObjectiveSugar
+  - OCMock
+  - OHHTTPStubs
+  - ORKeyboardReactingApplication
   - ORStackView (from `https://github.com/1aurabrown/ORStackView.git`)
-  - ReactiveCocoa (= 2.3)
-  - SDWebImage (= 3.7.1)
+  - ReactiveCocoa
+  - SDWebImage
   - Specta
-  - TPDWeakProxy (= 1.1.0)
+  - TPDWeakProxy
   - TSMiniWebBrowser@dblock (HEAD)
-  - UIAlertView+Blocks (= 0.8)
+  - UIAlertView+Blocks
   - UICKeyChainStore (= 1.0.5)
   - UIView+BooleanAnimations
-  - VCRURLConnection (= 0.2.0)
-  - XCTest+OHHTTPStubSuiteCleanUp (= 1.0.0)
+  - VCRURLConnection
+  - XCTest+OHHTTPStubSuiteCleanUp
 
 EXTERNAL SOURCES:
   AFNetworking:


### PR DESCRIPTION
So, a few points:

* Looks like I messed up slightly WRT to the ARLoggers, they needed to be `OBJC_` loggers:

``` diff
-#define ARLogInfo(frmt, ...) LOG_MAYBE(NO LOG_LEVEL_DEF, ARLogContextInfo, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define ARLogInfo(frmt, ...) LOG_OBJC_MAYBE(NO LOG_LEVEL_DEF, (DDLogFlag)ARLogContextInfo, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
```
* And we needed to cast the log level.
* Next the migration to frameworks has exposed an annoyance with the way that Mantle/RAC vend their common library `libextobjc`, I don't expect improvements on this front, so for now in-app `@weakify`/`@strongify` has an underscore. I'd also like to see us migrate away from this. Now it's easy to find.

* Removed specific versions from the Podfile. Leaving the `Podfile.lock` to do it's thing. @1aurabrown - be careful with `pod update`.
 * I've added a few more categories in the Podfile, and ordered them alphabetically internally.