### PR TITLE
@alloy -> don't use cached square image unless requested

### DIFF
--- a/Artsy/Categories/Apple/UIImage+ImageFromColor.m
+++ b/Artsy/Categories/Apple/UIImage+ImageFromColor.m
@@ -8,31 +8,31 @@ static NSCache *imageCache;
 
 + (UIImage *)imageFromColor:(UIColor *)color
 {
-    return [self.class imageFromColor:color withSize:CGSizeMake(1, 1)];
-}
-
-+ (UIImage *)imageFromColor:(UIColor *)color withSize:(CGSize)size
-{
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         imageCache = [[NSCache alloc] init];
     });
 
     UIImage *image = [imageCache objectForKey:color];
-    if (image) {
-        return image;
+    if (!image) {
+        image = [self.class imageFromColor:color withSize:CGSizeMake(1, 1)];
+        [imageCache setObject:image forKey:color];
     }
 
+    return image;
+}
+
++ (UIImage *)imageFromColor:(UIColor *)color withSize:(CGSize)size
+{
     CGRect rect = CGRectMake(0, 0, size.width, size.height);
     UIGraphicsBeginImageContext(rect.size);
     CGContextRef context = UIGraphicsGetCurrentContext();
     CGContextSetFillColorWithColor(context, [color CGColor]);
     CGContextFillRect(context, rect);
 
-    image = UIGraphicsGetImageFromCurrentImageContext();
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
 
-    [imageCache setObject:image forKey:color];
     return image;
 }
 

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,10 +1,10 @@
 ## Next
 
 * Constrain size of launch logo to smaller size on iphone - 1aurabrown
-* Force portrait orientation for the admin menu on iPhone, which could be wrong on top of a landscape VIR view. - alloy
 * Make hit test areas of ‘MAG’, ‘YOU’, and ‘bell’ tab buttons wider. - alloy
 * Force the feed view controller to load its content when the network becomes available. - alloy
 * Force portrait orientation for the admin menu on iPhone, which could be wrong on top of a landscape VIR view. - alloy
+* Don't use square placeholder image for artwork image preview. - 1aurabrown
 
 ## 2.1.0 (2015.07.11)
 
@@ -34,4 +34,3 @@
 * Gracefully handle cancellation of sign-in with Twitter (and presumably on device with Facebook). - ashfurrow
 * Adds ‘bell’ notifications tab and shows notification count (currently only on launch and only if already signed-in). - alloy
 * Fix personalize search bar. - 1aurabrown
-* Don't use square placeholder image for artwork image preview. - 1aurabrown

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -34,3 +34,4 @@
 * Gracefully handle cancellation of sign-in with Twitter (and presumably on device with Facebook). - ashfurrow
 * Adds ‘bell’ notifications tab and shows notification count (currently only on launch and only if already signed-in). - alloy
 * Fix personalize search bar. - 1aurabrown
+* Don't use square placeholder image for artwork image preview. - 1aurabrown


### PR DESCRIPTION
![screen shot 2015-07-13 at 2 58 13 pm](https://cloud.githubusercontent.com/assets/3171662/8658106/ce08f32e-296f-11e5-8ab8-08a6c6947c1b.png)

The grey placeholder image was alway square, even when we had an accurate aspect ratio with which to make a properly-sized placeholder. This is because a previously-cached square image was always being used.