### PR TITLE
@alloy => Make changelogs use a union merge

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+CHANGELOG.md merge=union
+docs/BETA_CHANGELOG.md merge=union


### PR DESCRIPTION
For everyone else: https://about.gitlab.com/2015/02/10/gitlab-reduced-merge-conflicts-by-90-percent-with-changelog-placeholders/

and https://twitter.com/orta/status/619139230162362368