### PR TITLE
@alloy => Hero units offline loading

### DIFF
--- a/Artsy/Models/Feed_Timelines/ARHeroUnitsNetworkModel.m
+++ b/Artsy/Models/Feed_Timelines/ARHeroUnitsNetworkModel.m
@@ -31,7 +31,7 @@ static NSString *ARHeroUnitsDataSourceItemsKey = @"ARHeroUnitsDataSourceItemsKey
     }
 
     self.isLoading = YES;
-   @_weakify(self);
+    @_weakify(self);
 
     // This is generally one of the first networking calls, lets make sure it comes through.
 
@@ -41,15 +41,14 @@ static NSString *ARHeroUnitsDataSourceItemsKey = @"ARHeroUnitsDataSourceItemsKey
             @_strongify(self);
             self.isLoading = NO;
 
-            if (success) {
-                NSArray *filteredHeroUnits = [heroUnits select:^BOOL(SiteHeroUnit *unit) {
-                    return unit.isCurrentlyActive;
-                }];
-                self.heroUnits = filteredHeroUnits;
+            NSArray *filteredHeroUnits = [heroUnits select:^BOOL(SiteHeroUnit *unit) {
+                return unit.isCurrentlyActive;
+            }];
 
-                ar_dispatch_main_queue(^{
-                    success(self.heroUnits);
-                });
+            self.heroUnits = filteredHeroUnits;
+
+            if (success) {
+                success(self.heroUnits);
             }
 
         } failure:^(NSError *error) {

--- a/Artsy/Networking/ArtsyAPI.m
+++ b/Artsy/Networking/ArtsyAPI.m
@@ -12,13 +12,12 @@
     __weak AFJSONRequestOperation *performOperation = nil;
     performOperation = [AFJSONRequestOperation JSONRequestOperationWithRequest:request success:^(NSURLRequest *request, NSHTTPURLResponse *response, id JSON) {
         success(JSON);
-    }
-        failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON) {
-       if (failure) {
-           [ArtsyAPI handleXappTokenError:error];
-           failure(request, response, error);
-       }
-        }];
+    } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON) {
+        if (failure) {
+            [ArtsyAPI handleXappTokenError:error];
+            failure(request, response, error);
+        }
+    }];
 
     [performOperation start];
     return performOperation;
@@ -53,13 +52,14 @@
                 success(object);
             });
         }
-    }
-        failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON) {
+    } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON) {
         [ArtsyAPI handleXappTokenError:error];
         if (failure) {
             failure(error);
         }
-        }];
+    }];
+
+    // Use a background queue so JSON results are parsed off the UI thread. We'll dispatch back to main queue on success.
     getOperation.successCallbackQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
     [getOperation start];
     return getOperation;
@@ -96,13 +96,14 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             success(returnArray);
         });
-    }
-        failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON) {
+    } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON) {
         [ArtsyAPI handleXappTokenError:error];
         if (failure) {
             failure(error);
         }
-        }];
+    }];
+
+    // Use a background queue so JSON results are parsed off the UI thread. We'll dispatch back to main queue on success.
     getOperation.successCallbackQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
     [getOperation start];
     return getOperation;
@@ -127,13 +128,14 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             success(returnArray);
         });
-    }
-        failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON) {
+    } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON) {
        [ArtsyAPI handleXappTokenError:error];
        if (failure) {
            failure(error);
        }
-        }];
+    }];
+
+    // Use a background queue so JSON results are parsed off the UI thread. We'll dispatch back to main queue on success.
     getOperation.successCallbackQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
     [getOperation start];
     return getOperation;

--- a/Artsy/View_Controllers/Feed_VCs/ARShowFeedViewController.m
+++ b/Artsy/View_Controllers/Feed_VCs/ARShowFeedViewController.m
@@ -163,6 +163,7 @@ static CGFloat ARFeaturedShowsTitleHeightPhone = 40;
             [self.tableView reloadData];
             [self hideLoadingView];
             [self hideOfflineView];
+            [self loadHeroUnits];
             [self loadNextFeedPage];
             [ARAnalytics finishTimingEvent:ARAnalyticsInitialFeedLoadTime];
 
@@ -175,6 +176,11 @@ static CGFloat ARFeaturedShowsTitleHeightPhone = 40;
     } failure:^(NSError *error) {
         [self.offlineView refreshFailed];
     }];
+}
+
+- (void)loadHeroUnits
+{
+    [self.heroUnitDatasource getHeroUnitsWithSuccess:nil failure:nil];
 }
 
 - (void)setHeroUnitDatasource:(ARHeroUnitsNetworkModel *)heroUnitDatasource

--- a/Artsy_Tests/Model_Tests/Feed_Timeline_Tests/ARHeroUnitsNetworkModelTests.m
+++ b/Artsy_Tests/Model_Tests/Feed_Timeline_Tests/ARHeroUnitsNetworkModelTests.m
@@ -17,23 +17,33 @@ describe(@"heros", ^{
         [OHHTTPStubs removeAllStubs];
     });
 
-    it(@"only retrieves active hero units", ^{
-        waitUntil(^(DoneCallback done) {
+    describe(@"with stubbed data", ^{
+        beforeEach(^{
             [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/xapp_token" withResponse:@{ @"xapp_token": @"23123123", @"expires_in": @"2035-01-02T21:42:21-0500" }];
-            [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/site_hero_units"
-                                     withParams: @{ @"mobile" : @"true", @"enabled" : @"true" }
-                                   withResponse:@[
-                                                  @{ @"id": @"past", @"enabled" : @YES, @"display_on_mobile" : @YES, @"start_at" : @"1976-01-27T05:00:00+00:00", @"end_at" : @"1976-01-27T05:00:00+00:00" },
-                                                  @{ @"id": @"future", @"enabled" : @YES, @"display_on_mobile" : @YES, @"start_at" : @"2099-01-27T05:00:00+00:00", @"end_at" : @"2099-01-27T05:00:00+00:00" },
-                                                  @{ @"id": @"current", @"enabled" : @YES, @"display_on_mobile" : @YES, @"start_at" : @"1976-01-27T05:00:00+00:00", @"end_at" : @"2099-01-27T05:00:00+00:00" }
+                [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/site_hero_units"
+                    withParams: @{ @"mobile" : @"true", @"enabled" : @"true" }
+                    withResponse:@[
+                        @{ @"id": @"past", @"enabled" : @YES, @"display_on_mobile" : @YES, @"start_at" : @"1976-01-27T05:00:00+00:00", @"end_at" : @"1976-01-27T05:00:00+00:00" },
+                        @{ @"id": @"future", @"enabled" : @YES, @"display_on_mobile" : @YES, @"start_at" : @"2099-01-27T05:00:00+00:00", @"end_at" : @"2099-01-27T05:00:00+00:00" },
+                        @{ @"id": @"current", @"enabled" : @YES, @"display_on_mobile" : @YES, @"start_at" : @"1976-01-27T05:00:00+00:00", @"end_at" : @"2099-01-27T05:00:00+00:00" }
             ]];
+        });
 
-            [_dataSource getHeroUnitsWithSuccess:^(NSArray *heroUnits){
-                expect([_dataSource.heroUnits isEqualToArray:heroUnits]).to.beTruthy();
-                expect([_dataSource.heroUnits count]).to.equal(1);
-                expect([[_dataSource.heroUnits firstObject] siteHeroUnitID]).to.equal(@"current");
-                done();
-            } failure:nil];
+        it(@"only retrieves active hero units", ^{
+            waitUntil(^(DoneCallback done) {
+                [_dataSource getHeroUnitsWithSuccess:^(NSArray *heroUnits){
+                    expect([_dataSource.heroUnits isEqualToArray:heroUnits]).to.beTruthy();
+                    expect([_dataSource.heroUnits count]).to.equal(1);
+                    expect([[_dataSource.heroUnits firstObject] siteHeroUnitID]).to.equal(@"current");
+                    done();
+                } failure:nil];
+            });
+        });
+
+        it(@"sets heroUnits property even if success black is nil", ^{
+            [_dataSource getHeroUnitsWithSuccess:nil failure:nil];
+
+            expect([_dataSource.heroUnits.firstObject siteHeroUnitID]).will.equal(@"current");
         });
     });
 });

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -3,6 +3,7 @@
 * Do not show the search navigation button in VIR mode. - alloy
 * Adds Adjust SDK to the app. - orta
 * Add back analytics page view event for Search and add Bell. - alloy
+* Hero units load when app connects to internet after offline start. - ash
 
 ## 2.1.0 (2015.07.18)
 


### PR DESCRIPTION
Noticed a related problem in the network model where the model only sets its `heroUnits` property if a non-`nil` success block has been passed. This breaks use of the model with KVO, which is how its used. In fact, the method is only called with a success block once, and never with a failure block. Worth entertaining simplifying its API. 

Fixes #669.