### PR TITLE
@alloy => Hides back button when presenting VIR on iPhone via rotation

### DIFF
--- a/Artsy/View_Controllers/Util/ARNavigationController.m
+++ b/Artsy/View_Controllers/Util/ARNavigationController.m
@@ -398,12 +398,13 @@ ShouldHideItem(UIViewController *viewController, SEL itemSelector, ...)
 
 #pragma mark - KVO
 
-- (void)observeViewController:(BOOL)observe;
+- (void)observeViewController:(BOOL)observe
 {
     UIViewController<ARMenuAwareViewController> *vc = self.observedViewController;
 
     NSArray *keyPaths = @[
         @keypath(vc, hidesNavigationButtons),
+        @keypath(vc, hidesBackButton),
         @keypath(vc, hidesToolbarMenu)
     ];
 

--- a/Artsy_Tests/View_Controller_Tests/Util/ARNavigationControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Util/ARNavigationControllerTests.m
@@ -5,6 +5,16 @@
 #import "ARTopMenuViewController.h"
 #import "ARAppSearchViewController.h"
 
+@interface ARTestingHidesBackButtonViewController : UIViewController <ARMenuAwareViewController>
+@property (readwrite, nonatomic, assign) BOOL hidesBackButton;
+@end
+
+@interface ARTestingHidesNavigationButtonsViewController : UIViewController <ARMenuAwareViewController>
+@property (readwrite, nonatomic, assign) BOOL hidesNavigationButtons;
+@end
+
+@implementation ARTestingHidesNavigationButtonsViewController @end
+@implementation ARTestingHidesBackButtonViewController @end
 
 @interface ARNavigationController (Testing)
 - (IBAction)back:(id)sender;
@@ -12,11 +22,23 @@
 @property (readwrite, nonatomic, strong) ARAppSearchViewController *searchViewController;
 @end
 
+@implementation ARNavigationController (PrivateTesting)
+
+-(void)callDidShowVCDelegateMethod
+{
+    // For some reason, this is not called during tests unless the actual view hierarchy is rendered.
+    [(id<UINavigationControllerDelegate>)self navigationController:self
+                                             didShowViewController:self.topViewController
+                                                          animated:NO];
+}
+
+@end
+
 SpecBegin(ARNavigationController);
 
 __block ARNavigationController *navigationController;
 
-before(^{
+beforeEach(^{
     UIViewController *viewController = [[UIViewController alloc] init];
     navigationController = [[ARNavigationController alloc] initWithRootViewController:viewController];
 });
@@ -136,10 +158,7 @@ describe(@"search", ^{
 
     it(@"presents the search VC", ^{
         [navigationController search:nil];
-        // This is normally only called when on-screen
-        [(id<UINavigationControllerDelegate>)navigationController navigationController:navigationController
-                                                                 didShowViewController:navigationController.searchViewController
-                                                                              animated:NO];
+        [navigationController callDidShowVCDelegateMethod];
         expect(navigationController.topViewController).to.equal(navigationController.searchViewController);
     });
 
@@ -147,10 +166,7 @@ describe(@"search", ^{
         [navigationController search:nil];
         UIViewController *other = [UIViewController new];
         [navigationController pushViewController:other animated:NO];
-        // This is normally only called when on-screen
-        [(id<UINavigationControllerDelegate>)navigationController navigationController:navigationController
-                                                                 didShowViewController:other
-                                                                              animated:NO];
+        [navigationController callDidShowVCDelegateMethod];
         expect(navigationController.viewControllers).to.equal(@[navigationController.rootViewController, other]);
     });
 
@@ -159,6 +175,54 @@ describe(@"search", ^{
         [navigationController search:nil];
         expect(navigationController.searchViewController.navigationController).to.equal(navigationController);
         expect(other.viewControllers).to.beEmpty();
+    });
+});
+
+describe(@"back button", ^{
+    it(@"should hide back", ^{
+        ARTestingHidesBackButtonViewController *viewController = [[ARTestingHidesBackButtonViewController alloc] init];
+        viewController.hidesBackButton = YES;
+        [navigationController pushViewController:viewController animated:NO];
+
+        [navigationController callDidShowVCDelegateMethod];
+
+        viewController.hidesBackButton = NO;
+        expect(navigationController.backButton.layer.opacity).to.equal(1);
+    });
+
+    it(@"should show back", ^{
+        ARTestingHidesBackButtonViewController *viewController = [[ARTestingHidesBackButtonViewController alloc] init];
+        viewController.hidesBackButton = NO;
+        [navigationController pushViewController:viewController animated:NO];
+
+        [navigationController callDidShowVCDelegateMethod];
+
+        viewController.hidesBackButton = YES;
+        expect(navigationController.backButton.layer.opacity).to.equal(0);
+    });
+
+    describe(@"hidesBackButton not implemented", ^{
+        it(@"falls back to hidesNavigationButtons to show back button ", ^{
+            ARTestingHidesNavigationButtonsViewController *viewController = [[ARTestingHidesNavigationButtonsViewController alloc] init];
+            viewController.hidesNavigationButtons = NO;
+            [navigationController pushViewController:viewController animated:NO];
+
+            [navigationController callDidShowVCDelegateMethod];
+
+            viewController.hidesNavigationButtons = YES;
+            expect(navigationController.backButton.layer.opacity).to.equal(0);
+        });
+
+        it(@"falls back to hidesNavigationButtons to hide back button ", ^{
+            ARTestingHidesNavigationButtonsViewController *viewController = [[ARTestingHidesNavigationButtonsViewController alloc] init];
+            viewController.hidesNavigationButtons = YES;
+            [navigationController pushViewController:viewController animated:NO];
+
+            [navigationController callDidShowVCDelegateMethod];
+
+            viewController.hidesNavigationButtons = NO;
+            expect(navigationController.backButton.layer.opacity).to.equal(1);
+        });
     });
 });
 

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -6,6 +6,7 @@
   loaded before the end of the tab switch animation, which was prone to breakage on slow connections. - alloy
 * Fix a crash caused by not guarding against `nil` values in show/partner analytics data. - alloy
 * Add more breadcrumbs in order to fix my nemesis crasher in ARTiledImageView. - alloy
+* Fixes a problem with view-in-room showing the back button when it was initially rotated into. - ash
 
 ## 2.1.0 (2015.07.20)
 


### PR DESCRIPTION
The bug appears to have been introduced [here](https://github.com/artsy/eigen/commit/5132299bf86569ab39e4c1aff47c9e9d0690e577#diff-4fa974736d8e8c4f6ac97956648e6f5aL360) and is fixed by observing the `hidesBackButton` key value on the observed view controller. 

Fixes #681.