### PR TITLE
Add edge antialiasing to .plist

### DIFF
--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -139,5 +139,7 @@
 			</dict>
 		</dict>
 	</array>
+	<key>UIViewEdgeAntialiasing</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Add "Renders with edge antialiasing" to Artsy-Info.plist to reduce pixelation on the black rectangle loading animation.