### PR TITLE
Fix update application badge issue

### DIFF
--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuNavigationDataSource.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuNavigationDataSource.m
@@ -127,6 +127,11 @@ WebViewNavigationControllerWithPath(NSString *path)
 - (UINavigationController *)viewControllerForTabContentView:(ARTabContentView *)tabContentView atIndex:(NSInteger)index
 {
     _currentIndex = index;
+    
+    // When a tab is clicked, remove it's badge and update application badge,
+    // fixes https://github.com/artsy/eigen/issues/724
+    [self setBadgeNumber:0 forTabAtIndex:index];
+    
     return [self navigationControllerAtIndex:index];
 }
 


### PR DESCRIPTION
Update badge count of a tab to 0 (tab is visited) every time we click on a tab. This way we calculate and update application badge based on which tab you have visited.

This one was hard to repro on my device since I've already lost the update, but it did fix my badge issue first time I ran it. So hopefully this is the fix :)

fixes #724