### PR TITLE
@orta => unify synchronous setting

### DIFF
--- a/Artsy/Categories/Apple/UIImageView+AsyncImageLoading.m
+++ b/Artsy/Categories/Apple/UIImageView+AsyncImageLoading.m
@@ -14,7 +14,7 @@
     }
 
     // This will save a lot of async calls sometime, this exists in Energy.
-    //    if ([ARDispatchManager sharedManager].useSyncronousDispatches) {
+    //    if (ARPerformWorkSynchronously) {
     //        self.image = [UIImage imageWithData:[NSData dataWithContentsOfURL:url]];
     //        return;
     //    }

--- a/Artsy/Constants/ARAppConstants.h
+++ b/Artsy/Constants/ARAppConstants.h
@@ -20,3 +20,5 @@ typedef NS_OPTIONS(NSUInteger, ARAuctionState) {
     ARAuctionStateUserIsBidder = 1 << 4,
     ARAuctionStateUserIsHighBidder = 1 << 5
 };
+
+extern BOOL ARPerformWorkAsynchronously;

--- a/Artsy/Constants/ARAppConstants.m
+++ b/Artsy/Constants/ARAppConstants.m
@@ -14,3 +14,5 @@ const NSString *AROAuthTokenKey = @"access_token";
 
 NSString *const ARNetworkAvailableNotification = @"network_available_notification";
 NSString *const ARNetworkUnavailableNotification = @"network_unavailable_notification";
+
+BOOL ARPerformWorkAsynchronously = NO;

--- a/Artsy/Tooling/ARDispatchManager.h
+++ b/Artsy/Tooling/ARDispatchManager.h
@@ -1,8 +1,11 @@
+
+/// Dispatches asynchronously when ARPerformWorkAsynchronously is set to true, and synchronously otherwise
 extern void ar_dispatch_async(dispatch_block_t block);
 
+/// Dispatches to the main queue unless ARPerformWorkAsynchronously is set to false
 extern void ar_dispatch_main_queue(dispatch_block_t block);
 
-// Dispatches to a queue unless ARPerformWorkAsynchronously is set to false
+/// Dispatches to a queue unless ARPerformWorkAsynchronously is set to false
 extern void ar_dispatch_on_queue(dispatch_queue_t queue, dispatch_block_t block);
 
 extern void ar_dispatch_after_on_queue(float seconds, dispatch_queue_t queue, dispatch_block_t block);

--- a/Artsy/Tooling/ARDispatchManager.h
+++ b/Artsy/Tooling/ARDispatchManager.h
@@ -1,10 +1,8 @@
-// Dispatches asyncronously unless ARPerformWorkSynchronously is set on the shared dispatch manager
 extern void ar_dispatch_async(dispatch_block_t block);
 
-// Dispatches to the main queue unless ARPerformWorkSynchronously is set on the shared dispatch manager
 extern void ar_dispatch_main_queue(dispatch_block_t block);
 
-// Dispatches to a queue unless ARPerformWorkSynchronously is set on the shared dispatch manager
+// Dispatches to a queue unless ARPerformWorkAsynchronously is set to false
 extern void ar_dispatch_on_queue(dispatch_queue_t queue, dispatch_block_t block);
 
 extern void ar_dispatch_after_on_queue(float seconds, dispatch_queue_t queue, dispatch_block_t block);

--- a/Artsy/Tooling/ARDispatchManager.h
+++ b/Artsy/Tooling/ARDispatchManager.h
@@ -1,10 +1,10 @@
-// Dispatches asyncronously unless useSyncronousDispatches is set on the shared dispatch manager
+// Dispatches asyncronously unless ARPerformWorkSynchronously is set on the shared dispatch manager
 extern void ar_dispatch_async(dispatch_block_t block);
 
-// Dispatches to the main queue unless useSyncronousDispatches is set on the shared dispatch manager
+// Dispatches to the main queue unless ARPerformWorkSynchronously is set on the shared dispatch manager
 extern void ar_dispatch_main_queue(dispatch_block_t block);
 
-// Dispatches to a queue unless useSyncronousDispatches is set on the shared dispatch manager
+// Dispatches to a queue unless ARPerformWorkSynchronously is set on the shared dispatch manager
 extern void ar_dispatch_on_queue(dispatch_queue_t queue, dispatch_block_t block);
 
 extern void ar_dispatch_after_on_queue(float seconds, dispatch_queue_t queue, dispatch_block_t block);
@@ -15,8 +15,5 @@ extern void ar_dispatch_after(float seconds, dispatch_block_t block);
 @interface ARDispatchManager : NSObject
 
 + (instancetype)sharedManager;
-
-// Useful in tests
-@property (readwrite, nonatomic, assign) BOOL useSyncronousDispatches;
 
 @end

--- a/Artsy/Tooling/ARDispatchManager.m
+++ b/Artsy/Tooling/ARDispatchManager.m
@@ -10,7 +10,7 @@ void ar_dispatch_main_queue(dispatch_block_t block)
 
 void ar_dispatch_on_queue(dispatch_queue_t queue, dispatch_block_t block)
 {
-    if ([ARDispatchManager sharedManager].useSyncronousDispatches) {
+    if (!ARPerformWorkAsynchronously) {
         if ([NSThread isMainThread]) {
             block();
         } else {
@@ -23,7 +23,7 @@ void ar_dispatch_on_queue(dispatch_queue_t queue, dispatch_block_t block)
 
 void ar_dispatch_after_on_queue(float seconds, dispatch_queue_t queue, dispatch_block_t block)
 {
-    if ([ARDispatchManager sharedManager].useSyncronousDispatches) {
+    if (!ARPerformWorkAsynchronously) {
         block();
     } else {
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, seconds * NSEC_PER_SEC), queue, block);

--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController+ButtonActions.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController+ButtonActions.m
@@ -23,7 +23,7 @@
 {
     ARZoomArtworkImageViewController *zoomImageVC = [[ARZoomArtworkImageViewController alloc] initWithImage:self.artwork.defaultImage];
     zoomImageVC.suppressZoomViewCreation = (self.fair == nil);
-    [self.navigationController pushViewController:zoomImageVC animated:self.shouldAnimate];
+    [self.navigationController pushViewController:zoomImageVC animated:ARPerformWorkAsynchronously];
 }
 
 #pragma mark - ARArtworkPreviewActionsViewDelegate
@@ -68,7 +68,7 @@
 - (void)tappedArtworkViewInRoom
 {
     ARViewInRoomViewController *viewInRoomVC = [[ARViewInRoomViewController alloc] initWithArtwork:self.artwork];
-    [self.navigationController pushViewController:viewInRoomVC animated:self.shouldAnimate];
+    [self.navigationController pushViewController:viewInRoomVC animated:ARPerformWorkAsynchronously];
 }
 
 - (void)tappedArtworkViewInMap
@@ -76,7 +76,7 @@
     [ArtsyAPI getShowsForArtworkID:self.artwork.artworkID inFairID:self.fair.fairID success:^(NSArray *shows) {
         if (shows.count > 0) {
             ARFairMapViewController *viewController = [[ARSwitchBoard sharedInstance] loadMapInFair:self.fair title:self.artwork.partner.name selectedPartnerShows:shows];
-            [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
+            [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
         }
     } failure:^(NSError *error){
         // ignore
@@ -130,7 +130,7 @@
 
     UIViewController *viewController = [ARSwitchBoard.sharedInstance loadBidUIForArtwork:self.artwork.artworkID
                                                                                   inSale:saleArtwork.auction.saleID];
-    [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
+    [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
 }
 
 - (void)tappedBuyersPremium
@@ -138,7 +138,7 @@
     [self.artwork onSaleArtworkUpdate:^(SaleArtwork *saleArtwork) {
         NSString *path = [NSString stringWithFormat:@"/auction/%@/buyers-premium", saleArtwork.auction.saleID];
         UIViewController *viewController = [ARSwitchBoard.sharedInstance loadPath:path fair:self.fair];
-        [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
+        [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
 
     } failure:^(NSError *error) {
         ARErrorLog(@"Can't get sale to bid for artwork %@. Error: %@", self.artwork.artworkID, error.localizedDescription);

--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.h
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.h
@@ -12,7 +12,6 @@
 /// The artwork this VC represents
 @property (nonatomic, strong, readonly) Artwork *artwork;
 @property (nonatomic, strong, readonly) Fair *fair;
-@property (nonatomic, assign, readwrite) BOOL shouldAnimate;
 
 /// The index in the current set of artworks
 @property (nonatomic, assign) NSInteger index;

--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
@@ -33,16 +33,6 @@
     }
 }
 
-- (instancetype)init
-{
-    self = [super init];
-    if (!self) {
-        return nil;
-    }
-    _shouldAnimate = YES;
-    return self;
-}
-
 - (instancetype)initWithArtworkID:(NSString *)artworkID fair:(Fair *)fair
 {
     Artwork *artwork = [[Artwork alloc] initWithArtworkID:artworkID];
@@ -81,14 +71,14 @@
 - (void)viewDidLoad
 {
     if (self.artwork.title == nil) {
-        [self ar_removeIndeterminateLoadingIndicatorAnimated:self.shouldAnimate];
+        [self ar_removeIndeterminateLoadingIndicatorAnimated:ARPerformWorkAsynchronously];
     }
 
-   @_weakify(self);
+    @_weakify(self);
 
     void (^completion)(void) = ^{
         @_strongify(self);
-        [self ar_removeIndeterminateLoadingIndicatorAnimated:self.shouldAnimate];
+        [self ar_removeIndeterminateLoadingIndicatorAnimated:ARPerformWorkAsynchronously];
     };
 
     [self.artwork onArtworkUpdate:^{
@@ -109,7 +99,7 @@
 {
     // When we get back from zoom / VIR allow the preview to do trigger zoom
     self.view.metadataView.userInteractionEnabled = YES;
-    [super viewDidAppear:self.shouldAnimate && animated];
+    [super viewDidAppear:ARPerformWorkAsynchronously && animated];
     CGRect frame = self.view.frame;
     [self.view.metadataView updateConstraintsIsLandscape:CGRectGetWidth(frame) > CGRectGetHeight(frame)];
 }
@@ -118,7 +108,7 @@
 {
     self.view.scrollsToTop = NO;
     [self.view.relatedArtworksView cancelRequests];
-    [super viewDidDisappear:self.shouldAnimate && animated];
+    [super viewDidDisappear:ARPerformWorkAsynchronously && animated];
 }
 
 - (void)setHasFinishedScrolling
@@ -139,7 +129,7 @@
 
 - (void)getRelatedPosts
 {
-   @_weakify(self);
+    @_weakify(self);
     [self.artwork getRelatedPosts:^(NSArray *posts) {
         @_strongify(self);
         [self updateWithRelatedPosts:posts];
@@ -150,7 +140,7 @@
 {
     if (posts.count > 0) {
         self.postsVC.posts = posts;
-        [UIView animateIf:self.shouldAnimate duration:ARAnimationDuration:^{
+        [UIView animateIf:ARPerformWorkAsynchronously duration:ARAnimationDuration:^{
             self.postsVC.view.alpha = 1;
         }];
     } else {
@@ -219,14 +209,14 @@
 
 - (void)artworkBlurView:(ARArtworkBlurbView *)blurbView shouldPresentViewController:(UIViewController *)viewController
 {
-    [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
+    [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
 }
 
 #pragma mark - ARArtworkDetailViewDelegate
 
 - (void)artworkDetailView:(ARArtworkDetailView *)detailView shouldPresentViewController:(UIViewController *)viewController
 {
-    [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
+    [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
 }
 
 - (void)didUpdateArtworkDetailView:(id)detailView
@@ -246,20 +236,20 @@
 
 - (void)postViewController:(ARPostsViewController *)postViewController shouldShowViewController:(UIViewController *)viewController
 {
-    [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
+    [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
 }
 
 #pragma mark - ARArtworkRelatedArtworksViewParentViewController
 
 - (void)relatedArtworksView:(ARArtworkRelatedArtworksView *)view shouldShowViewController:(UIViewController *)viewController
 {
-    [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
+    [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
 }
 
 - (void)relatedArtworksView:(ARArtworkRelatedArtworksView *)view didAddSection:(UIView *)section;
 {
     section.alpha = 0;
-    [UIView animateTwoStepIf:self.shouldAnimate
+    [UIView animateTwoStepIf:ARPerformWorkAsynchronously
         duration:ARAnimationDuration *
         2:^{
             [self.view.stackView setNeedsLayout];

--- a/Artsy/View_Controllers/Contact/ARInquireForArtworkViewController.m
+++ b/Artsy/View_Controllers/Contact/ARInquireForArtworkViewController.m
@@ -60,22 +60,10 @@ typedef NS_ENUM(NSInteger, ARInquireFormState) {
 // Private Access
 @property (nonatomic, strong, readwrite) Fair *fair;
 
-@property (nonatomic, assign, readwrite) BOOL shouldAnimate;
-
 @end
 
 
 @implementation ARInquireForArtworkViewController
-
-- (instancetype)init
-{
-    self = [super init];
-    if (!self) {
-        return nil;
-    }
-    _shouldAnimate = YES;
-    return self;
-}
 
 - (instancetype)initWithAdminInquiryForArtwork:(Artwork *)artwork fair:(Fair *)fair
 {
@@ -240,7 +228,7 @@ typedef NS_ENUM(NSInteger, ARInquireFormState) {
 {
     float fromValue = makeVisible ? 0.0 : 0.5;
     float toValue = makeVisible ? 0.5 : 0.0;
-    if (self.shouldAnimate) {
+    if (ARPerformWorkAsynchronously) {
         CABasicAnimation *fade = [CABasicAnimation animationWithKeyPath:@"opacity"];
         fade.duration = ARAnimationDuration;
         fade.fromValue = [NSNumber numberWithFloat:fromValue];
@@ -308,7 +296,7 @@ typedef NS_ENUM(NSInteger, ARInquireFormState) {
 
     // Show Keyboard
     self.keyboardPositionConstraint.constant = -height;
-    [UIView animateIf:self.shouldAnimate duration:duration:^{
+    [UIView animateIf:ARPerformWorkAsynchronously duration:duration:^{
         [self.view layoutIfNeeded];
     }];
 }
@@ -319,7 +307,7 @@ typedef NS_ENUM(NSInteger, ARInquireFormState) {
 
     CGFloat duration = [[[notification userInfo] objectForKey:UIKeyboardAnimationDurationUserInfoKey] doubleValue];
 
-    [UIView animateIf:self.shouldAnimate duration:duration:^{
+    [UIView animateIf:ARPerformWorkAsynchronously duration:duration:^{
         [self.view layoutIfNeeded];
     }];
 }
@@ -650,7 +638,7 @@ typedef NS_ENUM(NSInteger, ARInquireFormState) {
     self.hideInquiryConstraint.priority = 1;
     self.inquiryFormView.userInteractionEnabled = YES;
     self.textView.editable = YES;
-    [UIView animateIf:self.shouldAnimate duration:ARAnimationDuration:^{
+    [UIView animateIf:ARPerformWorkAsynchronously duration:ARAnimationDuration:^{
         [self.view layoutIfNeeded];
     }];
 }
@@ -660,7 +648,7 @@ typedef NS_ENUM(NSInteger, ARInquireFormState) {
     self.hideInquiryConstraint.priority = 999;
     self.inquiryFormView.userInteractionEnabled = NO;
     self.textView.editable = NO;
-    [UIView animateIf:self.shouldAnimate duration:ARAnimationDuration:^{
+    [UIView animateIf:ARPerformWorkAsynchronously duration:ARAnimationDuration:^{
         [self.view layoutIfNeeded];
     }];
 }
@@ -707,7 +695,7 @@ typedef NS_ENUM(NSInteger, ARInquireFormState) {
 
 - (void)getCurrentAdmin
 {
-   @_weakify(self);
+    @_weakify(self);
     [ArtsyAPI getInquiryContact:^(User *contactStub) {
         @_strongify(self);
         self.specialistNameLabel.text = contactStub.name;
@@ -794,7 +782,7 @@ typedef NS_ENUM(NSInteger, ARInquireFormState) {
 
 - (UIColor *)inputTintColor
 {
-    return self.shouldAnimate ? [UIColor artsyPurple] : [UIColor whiteColor];
+    return ARPerformWorkAsynchronously ? [UIColor artsyPurple] : [UIColor whiteColor];
 }
 
 - (void)inquiryCompleted:(NSString *)message
@@ -854,7 +842,7 @@ typedef NS_ENUM(NSInteger, ARInquireFormState) {
     _emailValidator = [ALPValidator validatorWithType:ALPValidatorTypeString];
     [self.emailValidator addValidationToEnsureValidEmailWithInvalidMessage:NSLocalizedString(@"Please enter a valid email", nil)];
 
-   @_weakify(self);
+    @_weakify(self);
     self.emailValidator.validatorStateChangedHandler = ^(ALPValidatorState newState) {
         @_strongify(self);
         self.sendButton.enabled = self.emailValidator.isValid;

--- a/Artsy/View_Controllers/Core/ARArtistViewController.m
+++ b/Artsy/View_Controllers/Core/ARArtistViewController.m
@@ -64,23 +64,12 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
 
 @property (nonatomic, strong) ARPostsViewController *postsVC;
 
-@property (nonatomic, assign, readwrite) BOOL shouldAnimate;
 @end
 
 
 @implementation ARArtistViewController
 
 @dynamic view;
-
-- (instancetype)init
-{
-    self = [super init];
-    if (!self) {
-        return nil;
-    }
-    _shouldAnimate = YES;
-    return self;
-}
 
 - (instancetype)initWithArtistID:(NSString *)artistID
 {
@@ -158,7 +147,7 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
     [favoriteButton addTarget:self action:@selector(toggleFollowingArtist:) forControlEvents:UIControlEventTouchUpInside];
 
     [self.networkModel getFollowState:^(ARHeartStatus status) {
-        [favoriteButton setStatus:status animated:self.shouldAnimate];
+        [favoriteButton setStatus:status animated:ARPerformWorkAsynchronously];
     } failure:^(NSError *error) {
         [favoriteButton setStatus:ARHeartStatusNo];
     }];
@@ -172,7 +161,6 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
 
     self.switchView = [[ARSwitchView alloc] initWithButtonTitles:[ARSwitchView artistButtonTitlesArray]];
     [self.switchView constrainWidth:@"280"];
-    self.switchView.shouldAnimate = self.shouldAnimate;
     self.switchView.delegate = self;
     self.switchView.tag = ARArtistViewArtworksToggle;
     [self.view.stackView addSubview:self.switchView withTopMargin:@"20" sideMargin:NSStringWithFormat(@">=%@", [self sideMarginString])];
@@ -289,7 +277,7 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
     [noWorksLabel alignTopEdgeWithView:self.artworkVC.view predicate:@"0"];
     [noWorksLabel alignCenterXWithView:self.artworkVC.view predicate:nil];
 
-    [self.artworkVC ar_removeIndeterminateLoadingIndicatorAnimated:self.shouldAnimate];
+    [self.artworkVC ar_removeIndeterminateLoadingIndicatorAnimated:ARPerformWorkAsynchronously];
 }
 
 - (void)setArtworksHeight
@@ -318,7 +306,7 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
     }
 
     BOOL hearted = !sender.hearted;
-    [sender setHearted:hearted animated:self.shouldAnimate];
+    [sender setHearted:hearted animated:ARPerformWorkAsynchronously];
 
     @_weakify(self);
     [self.networkModel setFavoriteStatus:sender.isHearted
@@ -327,7 +315,7 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
         failure:^(NSError *error) {
         @_strongify(self);
         [ARNetworkErrorManager presentActiveError:error withMessage:@"Failed to follow artist."];
-        [sender setHearted:!hearted animated:self.shouldAnimate];
+        [sender setHearted:!hearted animated:ARPerformWorkAsynchronously];
         }];
 }
 
@@ -335,12 +323,12 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
 
 - (void)allArtworksTapped
 {
-    [self switchToDisplayMode:ARArtistArtworksDisplayAll animated:self.shouldAnimate];
+    [self switchToDisplayMode:ARArtistArtworksDisplayAll animated:ARPerformWorkAsynchronously];
 }
 
 - (void)forSaleOnlyArtworksTapped
 {
-    [self switchToDisplayMode:ARArtistArtworksDisplayForSale animated:self.shouldAnimate];
+    [self switchToDisplayMode:ARArtistArtworksDisplayForSale animated:ARPerformWorkAsynchronously];
 }
 
 - (void)switchToDisplayMode:(ARArtistArtworksDisplayMode)displayMode animated:(BOOL)animated
@@ -351,7 +339,7 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
 
     NSOrderedSet *artworks = [self artworksForDisplayMode:displayMode];
     if (![artworks isEqualToOrderedSet:[self artworksForDisplayMode:oldDisplayMode]]) {
-        [UIView animateTwoStepIf:self.shouldAnimate && animated duration:ARAnimationDuration * 1.5:^{
+        [UIView animateTwoStepIf:ARPerformWorkAsynchronously && animated duration:ARAnimationDuration * 1.5:^{
             self.artworkVC.view.alpha = 0;
         } midway:^{
             self.artworkVC.collectionView.contentOffset = CGPointZero;
@@ -362,7 +350,7 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
             if (artworks.count > 0) {
                 [self.artworkVC appendItems:artworks.array];
             } else {
-                [self.artworkVC ar_presentIndeterminateLoadingIndicatorAnimated:self.shouldAnimate];
+                [self.artworkVC ar_presentIndeterminateLoadingIndicatorAnimated:ARPerformWorkAsynchronously];
             }
 
             // Ensure that the user can never get to see any stale cells from the previous tab. E.g. if we ever
@@ -375,7 +363,7 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
 
         } completion:^(BOOL finished) {
             if (artworks.count > 0) {
-                [self.artworkVC ar_removeIndeterminateLoadingIndicatorAnimated:self.shouldAnimate];
+                [self.artworkVC ar_removeIndeterminateLoadingIndicatorAnimated:ARPerformWorkAsynchronously];
             }
             [self.view setNeedsUpdateConstraints];
         }];
@@ -405,13 +393,13 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
     @_weakify(self);
     [self.networkModel getArtistArtworksAtPage:lastPage + 1 params:params success:^(NSArray *artworks) {
         @_strongify(self);
-        [self.artworkVC ar_removeIndeterminateLoadingIndicatorAnimated:self.shouldAnimate];
+        [self.artworkVC ar_removeIndeterminateLoadingIndicatorAnimated:ARPerformWorkAsynchronously];
         [self handleFetchedArtworks:artworks displayMode:self.displayMode];
         [self checkForAdditionalArtworksToFillView];
     } failure:^(NSError *error) {
         @_strongify(self);
         ARErrorLog(@"Could not get Artist Artworks: %@", error.localizedDescription);
-        [self.artworkVC ar_removeIndeterminateLoadingIndicatorAnimated:self.shouldAnimate];
+        [self.artworkVC ar_removeIndeterminateLoadingIndicatorAnimated:ARPerformWorkAsynchronously];
         [self setIsGettingArtworks:NO displayMode:displayMode];
     }];
 }
@@ -529,7 +517,7 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
 - (void)loadBioViewController
 {
     ARArtistBiographyViewController *artistBioVC = [[ARArtistBiographyViewController alloc] initWithArtist:self.artist];
-    [self.navigationController pushViewController:artistBioVC animated:self.shouldAnimate];
+    [self.navigationController pushViewController:artistBioVC animated:ARPerformWorkAsynchronously];
 }
 
 - (BOOL)shouldAutorotate
@@ -569,7 +557,7 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
     [self.networkModel getRelatedArtists:^(NSArray *artists) {
         @_strongify(self);
         if (artists.count > 0 ) {
-            [UIView animateIf:self.shouldAnimate duration:ARAnimationDuration :^{
+            [UIView animateIf:ARPerformWorkAsynchronously duration:ARAnimationDuration :^{
                 self.relatedTitle.alpha = 1;
             }];
             artists = [artists filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"publishedArtworksCount != 0"]];
@@ -594,13 +582,13 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
 
 - (void)embeddedModelsViewController:(AREmbeddedModelsViewController *)controller shouldPresentViewController:(UIViewController *)viewController
 {
-    [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
+    [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
 }
 
 - (void)embeddedModelsViewController:(AREmbeddedModelsViewController *)controller didTapItemAtIndex:(NSUInteger)index
 {
     ARArtworkSetViewController *viewController = [ARSwitchBoard.sharedInstance loadArtworkSet:self.artworkVC.items inFair:nil atIndex:index];
-    [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
+    [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
 }
 
 - (void)embeddedModelsViewControllerDidScrollPastEdge:(AREmbeddedModelsViewController *)controller
@@ -612,7 +600,7 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
 
 - (void)postViewController:(ARPostsViewController *)postViewController shouldShowViewController:(UIViewController *)viewController
 {
-    [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
+    [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
 }
 
 #pragma mark - ARSwitchViewDelegate

--- a/Artsy/View_Controllers/Embedded/Generics/AREmbeddedModelsViewController.h
+++ b/Artsy/View_Controllers/Embedded/Generics/AREmbeddedModelsViewController.h
@@ -57,8 +57,6 @@
 
 @property (nonatomic, strong, readonly) Fair *fair;
 
-@property (nonatomic, assign, readwrite) BOOL shouldAnimate;
-
 - (BOOL)currentContentFillsView;
 
 @end

--- a/Artsy/View_Controllers/Embedded/Generics/AREmbeddedModelsViewController.m
+++ b/Artsy/View_Controllers/Embedded/Generics/AREmbeddedModelsViewController.m
@@ -298,7 +298,7 @@
         if (view.subviews.count == 0) {
             ARReusableLoadingView *loadingView = [[ARReusableLoadingView alloc] init];
             [view addSubview:loadingView];
-            [loadingView startIndeterminateAnimated:self.shouldAnimate];
+            [loadingView startIndeterminateAnimated:ARPerformWorkAsynchronously];
             [loadingView alignTop:@"0" leading:@"0" bottom:nil trailing:@"0" toView:view];
         }
         return view;

--- a/Artsy/View_Controllers/Fair/ARFairArtistViewController.m
+++ b/Artsy/View_Controllers/Fair/ARFairArtistViewController.m
@@ -30,7 +30,6 @@ typedef NS_ENUM(NSInteger, ARFairArtistViewIndex) {
 @property (nonatomic, strong, readonly) NSArray *partnerShows;
 @property (nonatomic, strong, readwrite) Fair *fair;
 @property (nonatomic, strong, readonly) NSString *header;
-@property (nonatomic, assign, readwrite) BOOL shouldAnimate;
 @end
 
 
@@ -42,7 +41,6 @@ typedef NS_ENUM(NSInteger, ARFairArtistViewIndex) {
 {
     self = [super init];
     _fair = fair;
-    _shouldAnimate = YES;
     _artist = [[Artist alloc] initWithArtistID:artistID];
     _networkModel = [[ARFairArtistNetworkModel alloc] init];
     return self;
@@ -55,7 +53,7 @@ typedef NS_ENUM(NSInteger, ARFairArtistViewIndex) {
     self.view.stackView.bottomMarginHeight = 20;
     self.view.delegate = [ARScrollNavigationChief chief];
 
-   @_weakify(self);
+    @_weakify(self);
     [self.networkModel getArtistForArtistID:self.artist.artistID success:^(Artist *artist) {
         @_strongify(self);
         if (!self) { return; }
@@ -85,7 +83,7 @@ typedef NS_ENUM(NSInteger, ARFairArtistViewIndex) {
 
     [self addSubtitle];
 
-   @_weakify(self);
+    @_weakify(self);
     [self.networkModel getShowsForArtistID:self.artist.artistID inFairID:self.fair.fairID success:^(NSArray *shows) {
         @_strongify(self);
         if (!self) { return; }
@@ -114,7 +112,7 @@ typedef NS_ENUM(NSInteger, ARFairArtistViewIndex) {
     button.tag = ARFairArtistOnArtsy;
     button.onTap = ^(UIButton *tappedButton) {
         UIViewController *viewController = [[ARSwitchBoard sharedInstance] loadArtistWithID:self.artist.artistID inFair:nil];
-        [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
+        [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
     };
     [self.view.stackView addSubview:button withTopMargin:@"20" sideMargin:@"40"];
 }
@@ -139,7 +137,7 @@ typedef NS_ENUM(NSInteger, ARFairArtistViewIndex) {
     button.tag = tag;
     button.onTap = ^(UIButton *tappedButton) {
         UIViewController *viewController = [[ARSwitchBoard sharedInstance] loadShow:show fair:self.fair];
-        [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
+        [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
     };
     [self.view.stackView addSubview:button withTopMargin:@"0" sideMargin:@"40"];
 }
@@ -158,7 +156,7 @@ typedef NS_ENUM(NSInteger, ARFairArtistViewIndex) {
 
 - (void)addMapButton
 {
-   @_weakify(self);
+    @_weakify(self);
     [self.fair getFairMaps:^(NSArray *maps) {
         @_strongify(self);
 
@@ -185,11 +183,11 @@ typedef NS_ENUM(NSInteger, ARFairArtistViewIndex) {
 
 - (void)mapButtonTapped:(id)mapButtonTapped
 {
-   @_weakify(self);
+    @_weakify(self);
     [self.fair getFairMaps:^(NSArray *maps) {
         @_strongify(self);
         ARFairMapViewController *viewController = [[ARSwitchBoard sharedInstance] loadMapInFair:self.fair title:self.header selectedPartnerShows:self.partnerShows];
-        [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
+        [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
     }];
 }
 
@@ -227,13 +225,13 @@ typedef NS_ENUM(NSInteger, ARFairArtistViewIndex) {
 
 - (void)embeddedModelsViewController:(AREmbeddedModelsViewController *)controller shouldPresentViewController:(UIViewController *)viewController
 {
-    [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
+    [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
 }
 
 - (void)embeddedModelsViewController:(AREmbeddedModelsViewController *)controller didTapItemAtIndex:(NSUInteger)index
 {
     ARArtworkSetViewController *viewController = [ARSwitchBoard.sharedInstance loadArtwork:controller.items[index] inFair:self.fair];
-    [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
+    [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
 }
 
 @end

--- a/Artsy/View_Controllers/Fair/ARShowViewController.m
+++ b/Artsy/View_Controllers/Fair/ARShowViewController.m
@@ -156,10 +156,9 @@ self.actionButtonsView.actionButtonDescriptions = descriptions;
         ARActionButtonImageKey : @"MapButtonAction",
         ARActionButtonHandlerKey : ^(ARCircularActionButton *sender){
             @_strongify(self);
-    [self handleMapButtonPress:sender];
-}
-}
-;
+            [self handleMapButtonPress:sender];
+        }
+    };
 }
 
 - (void)handleMapButtonPress:(ARCircularActionButton *)sender

--- a/Artsy/View_Controllers/Fair/ARShowViewController.m
+++ b/Artsy/View_Controllers/Fair/ARShowViewController.m
@@ -40,7 +40,6 @@ static const NSInteger ARFairShowMaximumNumberOfHeadlineImages = 5;
 @property (nonatomic, strong, readonly) AREmbeddedModelsViewController *showArtworksViewController;
 @property (nonatomic, strong, readonly) ARActionButtonsView *actionButtonsView;
 @property (nonatomic, strong, readwrite) Fair *fair;
-@property (nonatomic, assign, readwrite) BOOL shouldAnimate;
 
 @property (nonatomic, strong) NSLayoutConstraint *followButtonWidthConstraint;
 @property (nonatomic, strong) NSLayoutConstraint *headerImageHeightConstraint;
@@ -69,16 +68,6 @@ static const NSInteger ARFairShowMaximumNumberOfHeadlineImages = 5;
     } else {
         return size.width > size.height ? 511 : 413;
     }
-}
-
-- (instancetype)init
-{
-    self = [super init];
-    if (!self) {
-        return nil;
-    }
-    _shouldAnimate = YES;
-    return self;
 }
 
 - (instancetype)initWithShowID:(NSString *)showID fair:(Fair *)fair
@@ -123,7 +112,7 @@ static const NSInteger ARFairShowMaximumNumberOfHeadlineImages = 5;
     [self addMapPreview];
     [self addFairArtworksToStack];
 
-    [self ar_removeIndeterminateLoadingIndicatorAnimated:self.shouldAnimate];
+    [self ar_removeIndeterminateLoadingIndicatorAnimated:ARPerformWorkAsynchronously];
 
     // Create a "be full screen with a low priority" constraint
     CGFloat height = CGRectGetHeight(self.parentViewController.parentViewController.view.bounds);
@@ -167,9 +156,10 @@ self.actionButtonsView.actionButtonDescriptions = descriptions;
         ARActionButtonImageKey : @"MapButtonAction",
         ARActionButtonHandlerKey : ^(ARCircularActionButton *sender){
             @_strongify(self);
-            [self handleMapButtonPress:sender];
-        }
-    };
+    [self handleMapButtonPress:sender];
+}
+}
+;
 }
 
 - (void)handleMapButtonPress:(ARCircularActionButton *)sender
@@ -178,7 +168,7 @@ self.actionButtonsView.actionButtonDescriptions = descriptions;
     [self.showNetworkModel getFairMaps:^(NSArray *maps) {
         @_strongify(self);
         ARFairMapViewController *viewController = [[ARSwitchBoard sharedInstance] loadMapInFair:self.fair title:self.show.title selectedPartnerShows:@[self.show]];
-        [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
+        [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
     }];
 }
 
@@ -220,7 +210,7 @@ self.actionButtonsView.actionButtonDescriptions = descriptions;
 {
     [super viewDidLoad];
 
-    [self ar_presentIndeterminateLoadingIndicatorAnimated:self.shouldAnimate];
+    [self ar_presentIndeterminateLoadingIndicatorAnimated:ARPerformWorkAsynchronously];
 
     @_weakify(self);
     [self.showNetworkModel getShowInfo:^(PartnerShow *show) {
@@ -347,7 +337,7 @@ self.actionButtonsView.actionButtonDescriptions = descriptions;
 - (void)openShowFair:(id)sender
 {
     UIViewController *viewController = [ARSwitchBoard.sharedInstance routeProfileWithID:self.show.fair.organizer.profileID];
-    [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
+    [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
 }
 
 - (void)addFairArtworksToStack
@@ -482,7 +472,7 @@ self.actionButtonsView.actionButtonDescriptions = descriptions;
 {
     Partner *partner = self.show.partner;
     UIViewController *viewController = [ARSwitchBoard.sharedInstance loadPartnerWithID:partner.profileID];
-    [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
+    [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
 }
 
 - (BOOL)shouldAutorotate
@@ -510,13 +500,13 @@ self.actionButtonsView.actionButtonDescriptions = descriptions;
 
 - (void)embeddedModelsViewController:(AREmbeddedModelsViewController *)controller shouldPresentViewController:(UIViewController *)viewController
 {
-    [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
+    [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
 }
 
 - (void)embeddedModelsViewController:(AREmbeddedModelsViewController *)controller didTapItemAtIndex:(NSUInteger)index
 {
     ARArtworkSetViewController *viewController = [ARSwitchBoard.sharedInstance loadArtworkSet:self.showArtworksViewController.items inFair:self.fair atIndex:index];
-    [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
+    [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
 }
 
 #pragma mark - Public Methods

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/2_-_Calls_to_Action/ARSignUpActiveUserViewController.h
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/2_-_Calls_to_Action/ARSignUpActiveUserViewController.h
@@ -12,5 +12,4 @@
 @property (strong, nonatomic) IBOutlet UIView *bottomView;
 @property (nonatomic, strong) IBOutlet ARSerifLineHeightLabel *bodyCopyLabel;
 
-@property (nonatomic) BOOL shouldAnimate;
 @end

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/2_-_Calls_to_Action/ARSignUpActiveUserViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/2_-_Calls_to_Action/ARSignUpActiveUserViewController.m
@@ -10,16 +10,6 @@
 
 @implementation ARSignUpActiveUserViewController
 
-- (instancetype)init
-{
-    self = [super init];
-    if (!self) {
-        return nil;
-    }
-    _shouldAnimate = YES;
-    return self;
-}
-
 - (void)setTrialContext:(enum ARTrialContext)context
 {
     _trialContext = context;

--- a/Artsy/View_Controllers/Search/ARSearchViewController.m
+++ b/Artsy/View_Controllers/Search/ARSearchViewController.m
@@ -9,7 +9,6 @@
 @property (readonly, nonatomic) UITableView *resultsView;
 @property (readonly, nonatomic) UIView *contentView;
 @property (readonly, nonatomic) AFJSONRequestOperation *searchRequest;
-@property (nonatomic, readwrite, assign) BOOL shouldAnimate;
 @end
 
 
@@ -23,7 +22,6 @@
     _searchDataSource = [[ARSearchResultsDataSource alloc] init];
     _fontSize = 16;
     _noResultsInfoLabelText = @"No results found.";
-    _shouldAnimate = YES;
 
     return self;
 }
@@ -174,7 +172,7 @@
 
 - (void)setSearchQuery:(NSString *)text
 {
-    [self setSearchQuery:text animated:self.shouldAnimate];
+    [self setSearchQuery:text animated:ARPerformWorkAsynchronously];
 }
 
 - (void)setSearchQuery:(NSString *)text animated:(BOOL)animated
@@ -206,7 +204,7 @@
 
 - (void)fetchSearchResults:(NSString *)text replace:(BOOL)replaceResults
 {
-   @_weakify(self);
+    @_weakify(self);
     _searchRequest = [self searchWithQuery:text success:^(NSArray *results) {
         @_strongify(self);
         [self addResults:results replace:replaceResults];
@@ -226,7 +224,7 @@
     if (self.searchDataSource.searchResults.count == 0) {
         [self presentNoResults];
     } else {
-        [self showInfoLabel:NO animated:self.shouldAnimate];
+        [self showInfoLabel:NO animated:ARPerformWorkAsynchronously];
     }
 }
 
@@ -235,15 +233,15 @@
     if (replaceResults) {
         self.searchDataSource.searchResults = [NSOrderedSet orderedSetWithArray:results];
         if (results.count == 0) {
-            [self removeResultsViewAnimated:self.shouldAnimate];
+            [self removeResultsViewAnimated:ARPerformWorkAsynchronously];
         } else {
-            [self presentResultsViewAnimated:self.shouldAnimate];
+            [self presentResultsViewAnimated:ARPerformWorkAsynchronously];
         }
     } else {
         NSMutableOrderedSet *searchResults = [NSMutableOrderedSet orderedSetWithOrderedSet:self.searchDataSource.searchResults];
         [searchResults addObjectsFromArray:results];
         self.searchDataSource.searchResults = searchResults;
-        [self presentResultsViewAnimated:self.shouldAnimate];
+        [self presentResultsViewAnimated:ARPerformWorkAsynchronously];
     }
 
     [self.resultsView reloadData];
@@ -272,7 +270,7 @@
 
 - (void)removeResultsViewAnimated:(BOOL)animated
 {
-   @_weakify(self);
+    @_weakify(self);
 
     [UIView animateIf:animated duration:0.15:^{
         @_strongify(self);
@@ -289,7 +287,7 @@
 {
     [self resetResults];
     [self setNoResultsInfoLabelText];
-    [self showInfoLabel:YES animated:self.shouldAnimate];
+    [self showInfoLabel:YES animated:ARPerformWorkAsynchronously];
     [self stopSearching];
 }
 

--- a/Artsy/View_Controllers/Util/ARBrowseCategoriesViewController.m
+++ b/Artsy/View_Controllers/Util/ARBrowseCategoriesViewController.m
@@ -5,23 +5,12 @@
 
 
 @interface ARBrowseCategoriesViewController () <ARBrowseFeaturedLinksCollectionViewControllerDelegate>
-@property (nonatomic, assign, readwrite) BOOL shouldAnimate;
 @end
 
 
 @implementation ARBrowseCategoriesViewController
 
 @dynamic view;
-
-- (instancetype)init
-{
-    self = [super init];
-    if (!self) {
-        return nil;
-    }
-    _shouldAnimate = YES;
-    return self;
-}
 
 #pragma mark - UIViewController
 
@@ -36,7 +25,7 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    [self ar_presentIndeterminateLoadingIndicatorAnimated:self.shouldAnimate];
+    [self ar_presentIndeterminateLoadingIndicatorAnimated:ARPerformWorkAsynchronously];
 
     [self.view.stackView addPageTitleWithString:@"Featured Categories"];
 
@@ -46,10 +35,10 @@
 
     [ArtsyAPI getFeaturedLinksForGenesWithSuccess:^(NSArray *genes) {
         featureCollectionVC.featuredLinks = genes;
-        [self ar_removeIndeterminateLoadingIndicatorAnimated:self.shouldAnimate];
+        [self ar_removeIndeterminateLoadingIndicatorAnimated:ARPerformWorkAsynchronously];
 
     } failure:^(NSError *error) {
-        [self ar_removeIndeterminateLoadingIndicatorAnimated:self.shouldAnimate];
+        [self ar_removeIndeterminateLoadingIndicatorAnimated:ARPerformWorkAsynchronously];
     }];
 
     [ArtsyAPI getFeaturedLinkCategoriesForGenesWithSuccess:^(NSArray *orderedSets) {
@@ -82,7 +71,7 @@
 
 - (void)viewWillAppear:(BOOL)animated
 {
-    [super viewWillAppear:animated && self.shouldAnimate];
+    [super viewWillAppear:animated && ARPerformWorkAsynchronously];
     self.view.delegate = [ARScrollNavigationChief chief];
 }
 
@@ -90,7 +79,7 @@
 {
     self.view.delegate = nil;
 
-    [super viewWillDisappear:animated && self.shouldAnimate];
+    [super viewWillDisappear:animated && ARPerformWorkAsynchronously];
 }
 
 #pragma mark - ARBrowseFeaturedLinksCollectionViewControllerDelegate
@@ -99,7 +88,7 @@
 {
     UIViewController *viewController = [ARSwitchBoard.sharedInstance loadPath:featuredLink.href];
     if (viewController) {
-        [self.navigationController pushViewController:viewController animated:self.shouldAnimate];
+        [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
     }
 }
 

--- a/Artsy/View_Controllers/Util/ARBrowseViewController.m
+++ b/Artsy/View_Controllers/Util/ARBrowseViewController.m
@@ -23,21 +23,10 @@
 
 @interface ARBrowseViewController () <UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout>
 @property (nonatomic, strong, readonly) NSArray *menuLinks;
-@property (nonatomic, assign, readwrite) BOOL shouldAnimate;
 @end
 
 
 @implementation ARBrowseViewController
-
-- (instancetype)init
-{
-    self = [super init];
-    if (!self) {
-        return nil;
-    }
-    _shouldAnimate = YES;
-    return self;
-}
 
 - (void)viewDidLoad
 {

--- a/Artsy/View_Controllers/Util/ARNavigationController.m
+++ b/Artsy/View_Controllers/Util/ARNavigationController.m
@@ -472,7 +472,7 @@ ShouldHideItem(UIViewController *viewController, SEL itemSelector, ...)
     }
     UINavigationController *navigationController = self.ar_innermostTopViewController.navigationController;
     [navigationController pushViewController:self.searchViewController
-                                    animated:![ARDispatchManager sharedManager].useSyncronousDispatches];
+                                    animated:ARPerformWorkAsynchronously];
 }
 
 @end

--- a/Artsy/Views/Artwork/ARArtworkRelatedArtworksView.m
+++ b/Artsy/Views/Artwork/ARArtworkRelatedArtworksView.m
@@ -79,7 +79,7 @@
     self.artwork = artwork;
     self.hasRequested = YES;
 
-   @_weakify(self);
+    @_weakify(self);
 
     // TODO: refactor these callbacks to return so we can use
     // results from the values array in a `when`
@@ -133,7 +133,7 @@
 
 - (void)addSectionsForFair:(Fair *)fair;
 {
-   @_weakify(self);
+    @_weakify(self);
     [self addRelatedArtworkRequest:[self.artwork getFeaturedShowsAtFair:fair success:^(NSArray *shows) {
         @_strongify(self);
         for (PartnerShow *show in shows) {
@@ -156,7 +156,7 @@
 
 - (void)addSectionsForAuction:(Sale *)auction;
 {
-   @_weakify(self);
+    @_weakify(self);
     [self addRelatedArtworkRequest:[auction getArtworks:^(NSArray *artworks) {
         @_strongify(self);
         [self addSectionWithTag:ARRelatedArtworksSameAuction artworks:artworks heading:@"Other works in auction"];
@@ -165,7 +165,7 @@
 
 - (void)addSectionWithOtherArtworksInShow:(PartnerShow *)show;
 {
-   @_weakify(self);
+    @_weakify(self);
     [self getArtworksInShow:show atPage:1 success:^(NSArray *artworks) {
         @_strongify(self);
         ARArtworkRelatedArtworksContentView *view = [self addSectionWithTag:ARRelatedArtworksSameShow artworks:artworks heading:@"Other works in show"];
@@ -175,7 +175,7 @@
 
 - (void)addArtworksInShow:(PartnerShow *)show atPage:(NSInteger)page toView:(ARArtworkRelatedArtworksContentView *)view
 {
-   @_weakify(self);
+    @_weakify(self);
     [self getArtworksInShow:show atPage:page success:^(NSArray *artworks) {
         if (!artworks.count > 0) { return; }
         @_strongify(self);
@@ -195,7 +195,7 @@
         return;
     }
 
-   @_weakify(self);
+    @_weakify(self);
     [self addRelatedArtworkRequest:[self.artwork.artist getArtworksAtPage:1 andParams:nil success:^(NSArray *artworks) {
         @_strongify(self);
         [self addSectionWithTag:ARRelatedArtworksArtistArtworks
@@ -206,7 +206,7 @@
 
 - (void)addSectionWithRelatedArtworks;
 {
-   @_weakify(self);
+    @_weakify(self);
     [self addRelatedArtworkRequest:[self.artwork getRelatedArtworks:^(NSArray *artworks) {
         @_strongify(self);
         [self addSectionWithTag:ARRelatedArtworks artworks:artworks heading:@"Related artworks"];
@@ -239,7 +239,6 @@
                                                                                                    artworks:artworks
                                                                                                     heading:heading];
 
-    section.artworksVC.shouldAnimate = self.parentViewController.shouldAnimate;
     section.artworksVC.delegate = self;
 
     // `-[ORStackView addViewController:toParent:withTopMargin:]` is a bit of a problem with unit-testing, because it

--- a/Artsy/Views/Artwork/ARArtworkView.m
+++ b/Artsy/Views/Artwork/ARArtworkView.m
@@ -53,7 +53,7 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
     self.artworkBlurbView = artworkBlurbView;
 
     ARSpinner *spinner = [[ARSpinner alloc] initWithFrame:CGRectMake(0, 0, 44, 44)];
-    [spinner fadeInAnimated:self.parentViewController.shouldAnimate];
+    [spinner fadeInAnimated:ARPerformWorkAsynchronously];
     spinner.tag = ARArtworkSpinner;
     self.spinner = spinner;
     [spinner constrainHeight:@"100"];
@@ -96,11 +96,11 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
 
 - (void)setUpCallbacks
 {
-   @_weakify(self);
+    @_weakify(self);
 
     void (^completion)(void) = ^{
         @_strongify(self);
-        [self.spinner fadeOutAnimated:self.parentViewController.shouldAnimate];
+        [self.spinner fadeOutAnimated:ARPerformWorkAsynchronously];
         [self.stackView removeSubview:self.spinner];
     };
 
@@ -126,7 +126,7 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
         if (saleArtwork.auctionState & ARAuctionStateUserIsBidder) {
             [ARAnalytics setUserProperty:@"has_placed_bid" toValue:@"true"];
             self.banner.auctionState = saleArtwork.auctionState;
-            [UIView animateIf:self.parentViewController.shouldAnimate duration:ARAnimationDuration :^{
+            [UIView animateIf:ARPerformWorkAsynchronously duration:ARAnimationDuration :^{
                 [self.banner updateHeightConstraint];
                 [self.stackView layoutIfNeeded];
             }];

--- a/Artsy/Views/Collection_Views/ARGeneViewController.h
+++ b/Artsy/Views/Collection_Views/ARGeneViewController.h
@@ -7,6 +7,5 @@
 - (instancetype)initWithGene:(Gene *)gene;
 
 @property (nonatomic, strong, readonly) Gene *gene;
-@property (nonatomic) BOOL shouldAnimate;
 
 @end

--- a/Artsy/Views/Collection_Views/ARGeneViewController.m
+++ b/Artsy/Views/Collection_Views/ARGeneViewController.m
@@ -31,16 +31,6 @@
     return [self initWithGene:gene];
 }
 
-- (instancetype)init
-{
-    self = [super init];
-    if (!self) {
-        return nil;
-    }
-    _shouldAnimate = YES;
-    return self;
-}
-
 - (instancetype)initWithGene:(Gene *)gene
 {
     self = [self init];
@@ -59,7 +49,7 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    [self ar_presentIndeterminateLoadingIndicatorAnimated:self.shouldAnimate];
+    [self ar_presentIndeterminateLoadingIndicatorAnimated:ARPerformWorkAsynchronously];
 
     [self createGeneArtworksViewController];
 
@@ -100,7 +90,7 @@
     @_weakify(self);
     [self.gene updateGene:^{
         @_strongify(self);
-        [self ar_removeIndeterminateLoadingIndicatorAnimated:self.shouldAnimate];
+        [self ar_removeIndeterminateLoadingIndicatorAnimated:ARPerformWorkAsynchronously];
         [self updateBody];
 
         if (self.gene.geneDescription.length == 0) {
@@ -126,7 +116,7 @@
     [actionsWrapper addSubview:favoriteButton];
 
     [self.gene getFollowState:^(ARHeartStatus status) {
-        [favoriteButton setStatus:status animated:self.shouldAnimate];
+        [favoriteButton setStatus:status animated:ARPerformWorkAsynchronously];
     } failure:^(NSError *error) {
         [favoriteButton setStatus:ARHeartStatusNo];
     }];
@@ -144,7 +134,6 @@
 
     module.layoutProvider = self;
     self.artworksViewController = [[AREmbeddedModelsViewController alloc] init];
-    self.artworksViewController.shouldAnimate = self.shouldAnimate;
     self.artworksViewController.activeModule = module;
     self.artworksViewController.delegate = self;
     self.artworksViewController.showTrailingLoadingIndicator = YES;
@@ -188,13 +177,13 @@
     }
 
     BOOL hearted = !sender.hearted;
-    [sender setHearted:hearted animated:self.shouldAnimate];
+    [sender setHearted:hearted animated:ARPerformWorkAsynchronously];
 
     [ArtsyAPI setFavoriteStatus:sender.isHearted forGene:self.gene success:^(id response) {
     }
         failure:^(NSError *error) {
         [ARNetworkErrorManager presentActiveError:error withMessage:@"Failed to follow category."];
-        [sender setHearted:!hearted animated:self.shouldAnimate];
+        [sender setHearted:!hearted animated:ARPerformWorkAsynchronously];
         }];
 }
 

--- a/Artsy/Views/Utilities/ARSwitchView.h
+++ b/Artsy/Views/Utilities/ARSwitchView.h
@@ -22,6 +22,4 @@
 @property (nonatomic, assign, readwrite) NSInteger selectedIndex;
 - (void)setSelectedIndex:(NSInteger)index animated:(BOOL)animated;
 
-@property (nonatomic, assign, readwrite) BOOL shouldAnimate;
-
 @end

--- a/Artsy/Views/Utilities/ARSwitchView.m
+++ b/Artsy/Views/Utilities/ARSwitchView.m
@@ -15,16 +15,6 @@
 // Light grey = background, visible by the buttons being a bit smaller than full size
 // black bit that moves = uiviews
 
-- (instancetype)init
-{
-    self = [super init];
-    if (!self) {
-        return nil;
-    }
-    _shouldAnimate = YES;
-    return self;
-}
-
 - (instancetype)initWithButtonTitles:(NSArray *)buttonTitlesArray
 {
     self = [self init];
@@ -97,7 +87,7 @@
 - (void)selectedButton:(UIButton *)sender
 {
     NSInteger buttonIndex = [self.buttons indexOfObject:sender];
-    [self setSelectedIndex:buttonIndex animated:self.shouldAnimate];
+    [self setSelectedIndex:buttonIndex animated:ARPerformWorkAsynchronously];
 }
 
 - (UIButton *)createButtonWithTitle:(NSString *)title
@@ -141,7 +131,7 @@
 
 - (void)setSelectedIndex:(NSInteger)index animated:(BOOL)animated
 {
-    [UIView animateIf:self.shouldAnimate && animated duration:ARAnimationQuickDuration options:UIViewAnimationOptionCurveEaseOut:^{
+    [UIView animateIf:ARPerformWorkAsynchronously && animated duration:ARAnimationQuickDuration options:UIViewAnimationOptionCurveEaseOut:^{
         UIButton *button = self.buttons[index];
 
         [self.buttons each:^(UIButton *button) {
@@ -156,7 +146,7 @@
         [self layoutIfNeeded];
     }];
 
-    [self.delegate switchView:self didPressButtonAtIndex:index animated:self.shouldAnimate && animated];
+    [self.delegate switchView:self didPressButtonAtIndex:index animated:ARPerformWorkAsynchronously && animated];
 }
 
 - (void)highlightButton:(UIButton *)button highlighted:(BOOL)highlighted
@@ -177,7 +167,7 @@
 {
     NSAssert(enabledStates.count == self.buttons.count, @"Need to have a consistent number of enabled states for buttons");
 
-    [UIView animateIf:self.shouldAnimate && animated duration:ARAnimationQuickDuration:^{
+    [UIView animateIf:ARPerformWorkAsynchronously && animated duration:ARAnimationQuickDuration:^{
         for (NSInteger i = 0; i < self.enabledStates.count; i++) {
             UIButton *button = self.buttons[i];
             BOOL enabled = [self.enabledStates[i] boolValue];

--- a/Artsy_Tests/Supporting_Files/ARAppDelegate+Testing.m
+++ b/Artsy_Tests/Supporting_Files/ARAppDelegate+Testing.m
@@ -42,7 +42,7 @@
 
 - (BOOL)swizzled_application:(id)app willFinishLaunchingWithOptions:(id)opts
 {
-    [ARDispatchManager sharedManager].useSyncronousDispatches = YES;
+    ARPerformWorkAsynchronously = NO;
     [ARRouter setup];
 
     /// Never run in tests

--- a/Artsy_Tests/Supporting_Files/ARTestHelper.m
+++ b/Artsy_Tests/Supporting_Files/ARTestHelper.m
@@ -13,6 +13,8 @@
     NSAssert([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPhone && CGSizeEqualToSize(nativeResolution, CGSizeMake(750, 1334)),
              @"The tests should be run on an iPhone 6, not a device with native resolution %@",
              NSStringFromCGSize(nativeResolution));
+
+    ARPerformWorkAsynchronously = YES;
 }
 
 @end

--- a/Artsy_Tests/Supporting_Files/ARTestHelper.m
+++ b/Artsy_Tests/Supporting_Files/ARTestHelper.m
@@ -14,7 +14,7 @@
              @"The tests should be run on an iPhone 6, not a device with native resolution %@",
              NSStringFromCGSize(nativeResolution));
 
-    ARPerformWorkAsynchronously = YES;
+    ARPerformWorkAsynchronously = NO;
 }
 
 @end

--- a/Artsy_Tests/View_Controller_Tests/App_Menu/ARAppSearchViewControllerSpec.m
+++ b/Artsy_Tests/View_Controller_Tests/App_Menu/ARAppSearchViewControllerSpec.m
@@ -3,7 +3,6 @@
 
 
 @interface ARAppSearchViewController (Testing)
-@property (readwrite, nonatomic) BOOL shouldAnimate;
 - (void)clearTapped:(id)sender;
 - (void)closeSearch:(id)sender;
 @end
@@ -15,7 +14,6 @@ __block ARAppSearchViewController *sut;
 
 dispatch_block_t sharedBefore = ^{
     sut = [[ARAppSearchViewController alloc] init];
-    sut.shouldAnimate = NO;
     [sut ar_presentWithFrame:[UIScreen mainScreen].bounds];
 
     [sut beginAppearanceTransition:YES animated:NO];
@@ -111,7 +109,6 @@ context(@"searching", ^{
 it(@"clears search", ^{
     // custom clear button for dark color scheme
     sut = [[ARAppSearchViewController alloc] init];
-    sut.shouldAnimate = NO;
     [sut ar_presentWithFrame:[UIScreen mainScreen].bounds];
     sut.textField.text = @"s";
     [sut clearTapped:nil];
@@ -123,7 +120,6 @@ it(@"closes search", ^{
     sut = [[ARAppSearchViewController alloc] init];
     UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:sut];
     OCMockObject *navigationControllerMock = [OCMockObject partialMockForObject:navigationController];
-    sut.shouldAnimate = NO;
     [sut ar_presentWithFrame:[UIScreen mainScreen].bounds];
     [[navigationControllerMock expect] popViewControllerAnimated:YES];
     [sut closeSearch:nil];

--- a/Artsy_Tests/View_Controller_Tests/App_Menu/ARSearchViewControllerSpec.m
+++ b/Artsy_Tests/View_Controller_Tests/App_Menu/ARSearchViewControllerSpec.m
@@ -2,7 +2,6 @@
 
 
 @interface ARSearchViewController (Testing)
-@property (readwrite, nonatomic) BOOL shouldAnimate;
 - (void)presentResultsViewAnimated:(BOOL)animated;
 @end
 
@@ -14,7 +13,6 @@ __block id sutMock;
 context(@"add results", ^{
     before(^{
         sut = [[ARSearchViewController alloc] init];
-        sut.shouldAnimate = NO;
         sutMock = [OCMockObject partialMockForObject:sut];
         [[[sutMock expect] ignoringNonObjectArgs] presentResultsViewAnimated:NO];
     });

--- a/Artsy_Tests/View_Controller_Tests/Artist/ARArtistViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Artist/ARArtistViewControllerTests.m
@@ -5,7 +5,6 @@
 
 
 @interface ARArtistViewController (Tests)
-@property (nonatomic, assign, readwrite) BOOL shouldAnimate;
 @property (nonatomic, strong) id<ARArtistNetworkModelable> networkModel;
 @property (nonatomic, strong) AREmbeddedModelsViewController *artworkVC;
 

--- a/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
@@ -142,7 +142,6 @@ describe(@"no related data", ^{
     it(@"shows artwork on iPhone", ^{
         window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
         vc = [[ARArtworkViewController alloc] initWithArtworkID:@"some-artwork" fair:nil];
-        vc.shouldAnimate = NO;
 
         window.rootViewController = vc;
         expect(vc.view).willNot.beNil();
@@ -156,7 +155,6 @@ describe(@"no related data", ^{
             [ARTestContext stubDevice:ARDeviceTypePad];
             window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
             vc = [[ARArtworkViewController alloc] initWithArtworkID:@"some-artwork" fair:nil];
-            vc.shouldAnimate = NO;
 
             window.rootViewController = vc;
             expect(vc.view).willNot.beNil();
@@ -191,7 +189,6 @@ describe(@"with related artworks", ^{
 
             window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
             vc = [[ARArtworkViewController alloc] initWithArtworkID:@"some-artwork" fair:nil];
-            vc.shouldAnimate = NO;
         });
 
         it(@"displays related artworks", ^{
@@ -233,7 +230,6 @@ describe(@"with related artworks", ^{
             [ARTestContext stubDevice:ARDeviceTypePad];
             window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
             vc = [[ARArtworkViewController alloc] initWithArtworkID:@"some-artwork" fair:nil];
-            vc.shouldAnimate = NO;
         });
 
         after(^{
@@ -289,7 +285,6 @@ it(@"shows an upublished banner", ^{
     [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/related/layer/synthetic/main/artworks" withResponse:@{}];
     
     vc = [[ARArtworkViewController alloc] initWithArtwork:artwork fair:nil];
-    vc.shouldAnimate = NO;
 
     window.rootViewController = vc;
     expect(vc.view).willNot.beNil();
@@ -347,7 +342,6 @@ describe(@"at a closed auction", ^{
             [ARTestContext stubDevice:ARDeviceTypePhone6];
             window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
             vc = [[ARArtworkViewController alloc] initWithArtworkID:@"some-artwork" fair:nil];
-            vc.shouldAnimate = NO;
 
             [vc.imageView removeFromSuperview];
             window.rootViewController = vc;
@@ -370,7 +364,6 @@ describe(@"at a closed auction", ^{
             [ARTestContext stubDevice:ARDeviceTypePad];
             window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
             vc = [[ARArtworkViewController alloc] initWithArtworkID:@"some-artwork" fair:nil];
-            vc.shouldAnimate = NO;
 
             window.rootViewController = vc;
             expect(vc.view).willNot.beNil();

--- a/Artsy_Tests/View_Controller_Tests/Browse/ARBrowseCategoriesViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Browse/ARBrowseCategoriesViewControllerTests.m
@@ -4,10 +4,6 @@
 #import "ARUserManager+Stubs.h"
 
 
-@interface ARBrowseCategoriesViewController (Tests)
-@property (nonatomic, assign, readwrite) BOOL shouldAnimate;
-@end
-
 SpecBegin(ARBrowseCategoriesViewController);
 
 __block ARBrowseCategoriesViewController *viewController;
@@ -54,7 +50,6 @@ before(^{
      ];
     
     viewController = [[ARBrowseCategoriesViewController alloc] init];
-    viewController.shouldAnimate = NO;
 });
 
 it(@"presents featured categories and genes", ^{

--- a/Artsy_Tests/View_Controller_Tests/Browse/ARBrowseViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Browse/ARBrowseViewControllerTests.m
@@ -3,7 +3,6 @@
 
 
 @interface ARBrowseViewController (Tests)
-@property (nonatomic, assign, readwrite) BOOL shouldAnimate;
 @property (nonatomic, strong, readonly) NSArray *menuLinks;
 @property (nonatomic, strong, readonly) ARBrowseNetworkModel *networkModel;
 - (void)fetchMenuItems;
@@ -23,7 +22,6 @@ before(^{
 
     viewController = [[ARBrowseViewController alloc] init];
     viewController.networkModel = networkModel;
-    viewController.shouldAnimate = NO;
 });
 
 it(@"sets its menu items", ^{

--- a/Artsy_Tests/View_Controller_Tests/Contact/ARInquireForArtworkViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Contact/ARInquireForArtworkViewControllerTests.m
@@ -4,8 +4,6 @@
 
 @interface ARInquireForArtworkViewController (Testing)
 
-@property (nonatomic, assign, readwrite) BOOL shouldAnimate;
-
 @property (nonatomic, strong, readonly) UITextField *emailInput;
 @property (nonatomic, strong, readonly) UITextField *nameInput;
 
@@ -74,21 +72,18 @@ describe(@"logged in", ^{
 
     itHasAsyncronousSnapshotsForDevicesWithName(@"displays Contact Gallery when seller is a gallery", ^{
         ARInquireForArtworkViewController *vc = [[ARInquireForArtworkViewController alloc] initWithPartnerInquiryForArtwork:galleryArtwork fair:nil];
-        vc.shouldAnimate = NO;
         [vc ar_presentWithFrame:[[UIScreen mainScreen] bounds]];
         return vc;
     });
 
     itHasAsyncronousSnapshotsForDevicesWithName(@"displays Contact Seller when seller is not a gallery", ^{
         ARInquireForArtworkViewController *vc = [[ARInquireForArtworkViewController alloc] initWithPartnerInquiryForArtwork:museumGallery fair:nil];
-        vc.shouldAnimate = NO;
         [vc ar_presentWithFrame:[[UIScreen mainScreen] bounds]];
         return vc;
     });
 
     itHasAsyncronousSnapshotsForDevicesWithName(@"logged out, displays artsy specialist", ^{
         ARInquireForArtworkViewController *vc = [[ARInquireForArtworkViewController alloc] initWithAdminInquiryForArtwork:museumGallery fair:nil];
-        vc.shouldAnimate = NO;
         [vc ar_presentWithFrame:[[UIScreen mainScreen] bounds]];
         return vc;
     });
@@ -109,14 +104,12 @@ describe(@"logged out", ^{
 
         itHasAsyncronousSnapshotsForDevicesWithName(@"displays contact gallery", ^{
             ARInquireForArtworkViewController *vc = [[ARInquireForArtworkViewController alloc] initWithPartnerInquiryForArtwork:galleryArtwork fair:nil];
-            vc.shouldAnimate = NO;
             [vc ar_presentWithFrame:[[UIScreen mainScreen] bounds]];
             return vc;
         });
 
         itHasAsyncronousSnapshotsForDevicesWithName(@"displays artsy specialist", ^{
             ARInquireForArtworkViewController *vc = [[ARInquireForArtworkViewController alloc] initWithAdminInquiryForArtwork:museumGallery fair:nil];
-            vc.shouldAnimate = NO;
             [vc ar_presentWithFrame:[[UIScreen mainScreen] bounds]];
             return vc;
         });
@@ -124,7 +117,6 @@ describe(@"logged out", ^{
         itHasAsyncronousSnapshotsForDevicesWithName(@"works for an artwork without a title", ^{
             museumGallery.title = nil;
             ARInquireForArtworkViewController *vc = [[ARInquireForArtworkViewController alloc] initWithPartnerInquiryForArtwork:museumGallery fair:nil];
-            vc.shouldAnimate = NO;
             [vc ar_presentWithFrame:[[UIScreen mainScreen] bounds]];
             return vc;
         });
@@ -148,7 +140,6 @@ describe(@"logged out", ^{
             [ARUserManager sharedManager].trialUserEmail = @"invalidEmail";
             
             ARInquireForArtworkViewController *vc = [[ARInquireForArtworkViewController alloc] initWithAdminInquiryForArtwork:museumGallery fair:nil];
-            vc.shouldAnimate = NO;
             [vc ar_presentWithFrame:[[UIScreen mainScreen] bounds]];
             return vc;
         });
@@ -157,7 +148,6 @@ describe(@"logged out", ^{
             [ARUserManager sharedManager].trialUserEmail = @"validemail@gmail.com";
 
             ARInquireForArtworkViewController *vc = [[ARInquireForArtworkViewController alloc] initWithAdminInquiryForArtwork:museumGallery fair:nil];
-            vc.shouldAnimate = NO;
             [vc ar_presentWithFrame:[[UIScreen mainScreen] bounds]];
             return vc;
         });
@@ -166,7 +156,6 @@ describe(@"logged out", ^{
             [ARUserManager sharedManager].trialUserEmail = nil;
             
             ARInquireForArtworkViewController *vc = [[ARInquireForArtworkViewController alloc] initWithAdminInquiryForArtwork:museumGallery fair:nil];
-            vc.shouldAnimate = NO;
             [vc ar_presentWithFrame:[[UIScreen mainScreen] bounds]];
             return vc;
         });
@@ -175,7 +164,6 @@ describe(@"logged out", ^{
             [ARUserManager sharedManager].trialUserEmail = nil;
             
             ARInquireForArtworkViewController *vc = [[ARInquireForArtworkViewController alloc] initWithAdminInquiryForArtwork:museumGallery fair:nil];
-            vc.shouldAnimate = NO;
             [vc ar_presentWithFrame:[[UIScreen mainScreen] bounds]];
             
             vc.emailInput.text = @"validemail@gmail.com";
@@ -187,7 +175,6 @@ describe(@"logged out", ^{
             [ARUserManager sharedManager].trialUserEmail = nil;
             
             ARInquireForArtworkViewController *vc = [[ARInquireForArtworkViewController alloc] initWithAdminInquiryForArtwork:museumGallery fair:nil];
-            vc.shouldAnimate = NO;
             [vc ar_presentWithFrame:[[UIScreen mainScreen] bounds]];
             
             vc.emailInput.text = @"validemail@gmail.com";
@@ -211,7 +198,6 @@ describe(@"sending", ^{
         [[[[userMock stub] classMethod] andReturnValue:OCMOCK_VALUE(YES)] isTrialUser];
 
         vc = [[ARInquireForArtworkViewController alloc] initWithPartnerInquiryForArtwork:galleryArtwork fair:nil];
-        vc.shouldAnimate = NO;
         [vc ar_presentWithFrame:[[UIScreen mainScreen] bounds]];
     });
     

--- a/Artsy_Tests/View_Controller_Tests/Fair/ARFairArtistViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/ARFairArtistViewControllerTests.m
@@ -3,7 +3,6 @@
 #import "ARFairArtistNetworkModel.h"
 
 // @interface ARFairArtistViewController (Tests)
-// @property (nonatomic, assign, readwrite) BOOL shouldAnimate;
 // @property (nonatomic, strong, readwrite) NSObject <FairArtistNeworkModel> *networkModel;
 // @end
 //

--- a/Artsy_Tests/View_Controller_Tests/Fair/ARFairViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/ARFairViewControllerTests.m
@@ -28,10 +28,6 @@
 @end
 
 
-@interface ARFairSearchViewController (Testing)
-@property (nonatomic, readwrite, assign) BOOL shouldAnimate;
-@end
-
 SpecBegin(ARFairViewController);
 
 it(@"maps bindings correctly", ^{
@@ -226,7 +222,6 @@ context(@"with a map", ^{
     
     it(@"search view looks correct", ^{
         [fairVC searchFieldButtonWasPressed:nil];
-        fairVC.searchVC.shouldAnimate = NO;
         [fairVC.searchVC beginAppearanceTransition:YES animated:NO];
         [fairVC.searchVC endAppearanceTransition];
         expect(fairVC.view).to.haveValidSnapshot();

--- a/Artsy_Tests/View_Controller_Tests/Fair/ARShowViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/ARShowViewControllerTests.m
@@ -7,7 +7,6 @@
 @interface ARShowViewController ()
 
 - (void)addMapPreview;
-@property (nonatomic, assign, readwrite) BOOL shouldAnimate;
 @property (nonatomic, strong) ARShowNetworkModel *showNetworkModel;
 
 @end

--- a/Artsy_Tests/View_Controller_Tests/Gene/ARGeneViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Gene/ARGeneViewControllerTests.m
@@ -30,7 +30,6 @@ pending(@"with long desciption", ^{ // This works, but on Travis we get a weird 
 
     UIWindow *window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     vc = [[ARGeneViewController alloc] initWithGeneID:@"painting"];
-    vc.shouldAnimate = NO;
     window.rootViewController = vc;
     expect(vc.view).willNot.beNil();
     [window makeKeyAndVisible];

--- a/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/ARSignUpActiveUserViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/ARSignUpActiveUserViewControllerTests.m
@@ -6,7 +6,6 @@ __block ARSignUpActiveUserViewController *vc;
 
 dispatch_block_t sharedBefore = ^{
     vc = [[ARSignUpActiveUserViewController alloc] init];
-    vc.shouldAnimate = NO;
 };
 
 describe(@"sign up after app launch", ^{

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+* Unify way to set whether to perform work asynchronously with ARPerformWorkAsynchronously - jorystiefel
 * Skip onboarding flow when registering to bid on iPhone - jorystiefel
 * Adds a web view admin gesture to get information. Do a long press on a blank space on any web view - orta
 * Fix artwork zoom bug and only zoom if we have a big enough tiled image for iPad screen - 1aurabrown


### PR DESCRIPTION
Closes #658.

After some discussion, @Orta and I decided to use the variable name `ARPerformWorkAsynchronously` instead of the mentioned `ARPerformWorkSynchronously`, for this reason:

```objc
[sender setHearted:!hearted animated:ARPerformWorkAsynchronously];
```
Is more readable and less prone to mistakes than:
```objc
[sender setHearted:!hearted animated:!ARPerformWorkSynchronously];
````
This saves us a lot of !s.