### PR TITLE
@orta => add semicolon to SpecEnd

### DIFF
--- a/Artsy_Tests/App_Tests/ARAppNotificationsDelegateTests.m
+++ b/Artsy_Tests/App_Tests/ARAppNotificationsDelegateTests.m
@@ -175,4 +175,4 @@ describe(@"receiveRemoteNotification", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/App_Tests/ARDeveloperOptionsSpec.m
+++ b/Artsy_Tests/App_Tests/ARDeveloperOptionsSpec.m
@@ -11,4 +11,4 @@ it(@"transforms the correct syntax to options", ^{
     expect(sut[@"test"]).to.equal(@"data");
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
+++ b/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
@@ -364,4 +364,4 @@ describe(@"ARSwitchboard", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Model_Tests/ARImageTests.m
+++ b/Artsy_Tests/Model_Tests/ARImageTests.m
@@ -26,4 +26,4 @@ describe(@"canZoom", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Model_Tests/ArtworkTests.m
+++ b/Artsy_Tests/Model_Tests/ArtworkTests.m
@@ -101,4 +101,4 @@ describe(@"defaultImage", ^{
 });
 
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Model_Tests/FairTests.m
+++ b/Artsy_Tests/Model_Tests/FairTests.m
@@ -104,4 +104,4 @@ describe(@"getting image URL string", ^{
 
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Model_Tests/Feed_Timeline_Tests/ARHeroUnitsNetworkModelTests.m
+++ b/Artsy_Tests/Model_Tests/Feed_Timeline_Tests/ARHeroUnitsNetworkModelTests.m
@@ -48,4 +48,4 @@ describe(@"heros", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Model_Tests/MapFeatureTests.m
+++ b/Artsy_Tests/Model_Tests/MapFeatureTests.m
@@ -6,4 +6,4 @@ it(@"maps every feature type to an image", ^{
     }
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Model_Tests/OrderedSetTests.m
+++ b/Artsy_Tests/Model_Tests/OrderedSetTests.m
@@ -61,4 +61,4 @@ it(@"getItems raises an exception when retrieving items of an unsupported time",
     }).to.raiseWithReason(@"NSInternalInconsistencyException", @"Unsupported item type: Invalid");
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Model_Tests/PartnerTests.m
+++ b/Artsy_Tests/Model_Tests/PartnerTests.m
@@ -22,4 +22,4 @@ describe(@"defaultImage", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Model_Tests/ProfileTests.m
+++ b/Artsy_Tests/Model_Tests/ProfileTests.m
@@ -165,4 +165,4 @@ describe(@"imageURL", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Model_Tests/SaleArtworkTests.m
+++ b/Artsy_Tests/Model_Tests/SaleArtworkTests.m
@@ -136,4 +136,4 @@ describe(@"artwork for sale", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Model_Tests/SaleTests.m
+++ b/Artsy_Tests/Model_Tests/SaleTests.m
@@ -51,4 +51,4 @@ describe(@"propertiess", ^{
 });
 
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Model_Tests/SiteHeroUnitTests.m
+++ b/Artsy_Tests/Model_Tests/SiteHeroUnitTests.m
@@ -39,4 +39,4 @@ describe(@"alignment", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Model_Tests/SystemTimeTests.m
+++ b/Artsy_Tests/Model_Tests/SystemTimeTests.m
@@ -27,4 +27,4 @@ it(@"converts date", ^{
     expect(components.day).to.equal(24);
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Model_Tests/UserTests.m
+++ b/Artsy_Tests/Model_Tests/UserTests.m
@@ -40,4 +40,4 @@ it(@"loads model version 1", ^{
     expect(deserializedUser.email).to.equal(@"dblock@dblock.org");
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Networking_Tests/API_Modules/ARUserManagerTests.m
+++ b/Artsy_Tests/Networking_Tests/API_Modules/ARUserManagerTests.m
@@ -414,4 +414,4 @@ describe(@"trialUserUUID", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Networking_Tests/API_Modules/ArtsyAPI+ArtworksTests.m
+++ b/Artsy_Tests/Networking_Tests/API_Modules/ArtsyAPI+ArtworksTests.m
@@ -49,4 +49,4 @@ describe(@"relatedFairs", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Networking_Tests/API_Modules/ArtsyAPI+ErrorHandlers.m
+++ b/Artsy_Tests/Networking_Tests/API_Modules/ArtsyAPI+ErrorHandlers.m
@@ -103,4 +103,4 @@ describe(@"handleHTTPErrors", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Networking_Tests/API_Modules/ArtsyAPI+PrivateTests.m
+++ b/Artsy_Tests/Networking_Tests/API_Modules/ArtsyAPI+PrivateTests.m
@@ -27,4 +27,4 @@ describe(@"handleXappTokenError", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Networking_Tests/API_Modules/ArtsyAPI+SystemTimeTests.m
+++ b/Artsy_Tests/Networking_Tests/API_Modules/ArtsyAPI+SystemTimeTests.m
@@ -39,4 +39,4 @@ it(@"retrieves system time", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Networking_Tests/ARRouterTests.m
+++ b/Artsy_Tests/Networking_Tests/ARRouterTests.m
@@ -166,4 +166,4 @@ describe(@"baseWebURL", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Networking_Tests/ARSystemTimeTests.m
+++ b/Artsy_Tests/Networking_Tests/ARSystemTimeTests.m
@@ -63,4 +63,4 @@ describe(@"in sync", ^{
 });
 
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Networking_Tests/Collection/ARGeneArtworksNetworkModelTests.m
+++ b/Artsy_Tests/Networking_Tests/Collection/ARGeneArtworksNetworkModelTests.m
@@ -93,10 +93,9 @@ describe(@"networking", ^{
     });
 });
 
-SpecEnd
+SpecEnd;
 
-    void
-    stubNetworkingForPartialGeneAtPageWithArray(id gene, NSInteger page, NSArray *content)
+void stubNetworkingForPartialGeneAtPageWithArray(id gene, NSInteger page, NSArray *content)
 {
     [[[gene stub] andDo:^(NSInvocation *invocation) {
         void (^successBlock)(NSArray *) = nil;

--- a/Artsy_Tests/Networking_Tests/Networking_Models/ARArtworkFavoritesNetworkModelTests.m
+++ b/Artsy_Tests/Networking_Tests/Networking_Models/ARArtworkFavoritesNetworkModelTests.m
@@ -118,4 +118,4 @@ describe(@"getFavorites", ^{
 });
 
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Networking_Tests/Networking_Models/ARFairFavoritesNetworkModelTests.m
+++ b/Artsy_Tests/Networking_Tests/Networking_Models/ARFairFavoritesNetworkModelTests.m
@@ -131,4 +131,4 @@ describe(@"when downloading exhibitor data", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Networking_Tests/Networking_Models/ARFairNetworkModelTests.m
+++ b/Artsy_Tests/Networking_Tests/Networking_Models/ARFairNetworkModelTests.m
@@ -209,4 +209,4 @@ describe(@"getMapInfo", ^{
 });
 
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Networking_Tests/Networking_Models/ARShowNetworkModelTests.m
+++ b/Artsy_Tests/Networking_Tests/Networking_Models/ARShowNetworkModelTests.m
@@ -116,4 +116,4 @@ describe(@"network access", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Theming_Tests/ARThemeTests.m
+++ b/Artsy_Tests/Theming_Tests/ARThemeTests.m
@@ -19,4 +19,4 @@ it(@"loads layout", ^{
     expect([ARTheme defaultTheme].layout).notTo.beNil();
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Util_Tests/ARBackButtonCallbackManagerTests.m
+++ b/Artsy_Tests/Util_Tests/ARBackButtonCallbackManagerTests.m
@@ -78,4 +78,4 @@ describe(@"handleBackForViewController:", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Util_Tests/ARDefaultsTests.m
+++ b/Artsy_Tests/Util_Tests/ARDefaultsTests.m
@@ -9,4 +9,4 @@ it(@"rests user defaults", ^{
     expect([[NSUserDefaults standardUserDefaults] valueForKey:@"Test Value"]).to.beNil();
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Util_Tests/Enumerations/UIApplicationStateEnumTests.m
+++ b/Artsy_Tests/Util_Tests/Enumerations/UIApplicationStateEnumTests.m
@@ -23,4 +23,4 @@ describe(@"toString", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Util_Tests/NSDate+RangeTests.m
+++ b/Artsy_Tests/Util_Tests/NSDate+RangeTests.m
@@ -10,4 +10,4 @@ it(@"ordinals correctly", ^{
     expect([NSDate ordinalForDay:11]).to.equal(@"th");
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Util_Tests/Sharing_Tests/ARImageItemProviderTests.m
+++ b/Artsy_Tests/Util_Tests/Sharing_Tests/ARImageItemProviderTests.m
@@ -29,4 +29,4 @@ describe(@"image provider item", ^{
 
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Util_Tests/Sharing_Tests/ARMessageItemProviderTests.m
+++ b/Artsy_Tests/Util_Tests/Sharing_Tests/ARMessageItemProviderTests.m
@@ -75,4 +75,4 @@ describe(@"message provider", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Util_Tests/Sharing_Tests/ARSharingControllerTests.m
+++ b/Artsy_Tests/Util_Tests/Sharing_Tests/ARSharingControllerTests.m
@@ -82,4 +82,4 @@ describe(@"sharing", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Util_Tests/Sharing_Tests/ARURLItemProviderTests.m
+++ b/Artsy_Tests/Util_Tests/Sharing_Tests/ARURLItemProviderTests.m
@@ -198,4 +198,4 @@ describe(@"url and image thumbnail", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/Util_Tests/UINavigationController_InnermostTopViewControllerSpec.m
+++ b/Artsy_Tests/Util_Tests/UINavigationController_InnermostTopViewControllerSpec.m
@@ -46,4 +46,4 @@ it(@"returns the inner most top view controller if there is multiple levels of n
     expect(rootNavigationController.ar_innermostTopViewController).to.equal(viewController);
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/App_Menu/ARAppSearchViewControllerSpec.m
+++ b/Artsy_Tests/View_Controller_Tests/App_Menu/ARAppSearchViewControllerSpec.m
@@ -126,4 +126,4 @@ it(@"closes search", ^{
     [navigationControllerMock verify];
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/App_Menu/ARSearchViewControllerSpec.m
+++ b/Artsy_Tests/View_Controller_Tests/App_Menu/ARSearchViewControllerSpec.m
@@ -95,4 +95,4 @@ context(@"add results", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/App_Menu/ARTabContentViewSpec.m
+++ b/Artsy_Tests/View_Controller_Tests/App_Menu/ARTabContentViewSpec.m
@@ -56,4 +56,4 @@ it(@"correctly sets the child view controller", ^{
     expect(outerController.childViewControllers).to.contain(innerController2);
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/App_Menu/ARTopMenuNavigationDataSourceSpec.m
+++ b/Artsy_Tests/View_Controller_Tests/App_Menu/ARTopMenuNavigationDataSourceSpec.m
@@ -69,4 +69,4 @@ it(@"reinstantiates favorites vc", ^{
     expect(newRootVC).notTo.equal(rootVC);
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/App_Menu/ARTopMenuViewControllerSpec.m
+++ b/Artsy_Tests/View_Controller_Tests/App_Menu/ARTopMenuViewControllerSpec.m
@@ -231,4 +231,4 @@ describe(@"navigation", ^{
    });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Artist/ARArtistViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Artist/ARArtistViewControllerTests.m
@@ -216,4 +216,4 @@ it(@"does not try to load more artworks if the artworks view is full", ^{
     [subjectMock verify];
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkInfoViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkInfoViewControllerTests.m
@@ -38,4 +38,4 @@ describe(@"more info", ^{
 
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkSetViewControllerSpec.m
+++ b/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkSetViewControllerSpec.m
@@ -23,4 +23,4 @@ describe(@"setting the index", ^{
 
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerBuyButtonTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerBuyButtonTests.m
@@ -3,6 +3,7 @@
 #import "ARUserManager+Stubs.h"
 #import "ARNetworkConstants.h"
 
+
 @interface ARArtworkViewController (Tests)
 - (void)tappedBuyButton;
 - (void)tappedContactGallery;
@@ -118,4 +119,4 @@ describe(@"buy button", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
@@ -115,7 +115,7 @@ it(@"shows an upublished banner", ^{
 
 describe(@"at a closed auction", ^{
     before(^{
-        [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/related/sales" withResponse:@[ @{
+        [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/related/sales" withResponse:@[@{
             @"id": @"some-auction",
             @"name": @"Some Auction",
             @"is_auction": @YES,
@@ -177,4 +177,4 @@ describe(@"at a closed auction", ^{
 
 pending(@"at a fair");
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Browse/ARBrowseCategoriesViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Browse/ARBrowseCategoriesViewControllerTests.m
@@ -82,4 +82,4 @@ describe(@"looks correct", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Browse/ARBrowseViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Browse/ARBrowseViewControllerTests.m
@@ -52,4 +52,4 @@ itHasSnapshotsForDevicesWithName(@"looks correct", ^{
     return viewController;
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Contact/ARInquireForArtworkViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Contact/ARInquireForArtworkViewControllerTests.m
@@ -271,4 +271,4 @@ describe(@"sending", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Embedded/AREmbeddedModelsViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Embedded/AREmbeddedModelsViewControllerTests.m
@@ -186,4 +186,4 @@ describe(@"masonry layout", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Embedded/ARNavigationButtonsViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Embedded/ARNavigationButtonsViewControllerTests.m
@@ -115,4 +115,4 @@ describe(@"creating buttons", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Fair/ARFairArtistViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/ARFairArtistViewControllerTests.m
@@ -62,4 +62,4 @@
 //     itBehavesLike(@"looks correct", @{@"mapsJSON": @[] });
 // });
 //
-// SpecEnd
+// SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Fair/ARFairGuideContainerViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/ARFairGuideContainerViewControllerTests.m
@@ -109,4 +109,4 @@ it(@"handles a changed user correct", ^{
     [fairGuideMock verify];
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Fair/ARFairGuideViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/ARFairGuideViewControllerTests.m
@@ -53,4 +53,4 @@ it(@"calls the appropriate delegate method upon user change", ^{
     expect(fairGuideVC.selectedTabIndex).to.equal(-1);
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Fair/ARFairMapAnnotationViewTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/ARFairMapAnnotationViewTests.m
@@ -39,4 +39,4 @@ describe(@"expandToFull", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Fair/ARFairPopupViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/ARFairPopupViewControllerTests.m
@@ -12,4 +12,4 @@ describe(@"visuals", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Fair/ARFairPostsViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/ARFairPostsViewControllerTests.m
@@ -59,4 +59,4 @@ describe(@"rendered", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Fair/ARFairSearchViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/ARFairSearchViewControllerTests.m
@@ -101,4 +101,4 @@ describe(@"init", ^{
 
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Fair/ARFairViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/ARFairViewControllerTests.m
@@ -228,4 +228,4 @@ context(@"with a map", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Fair/ARParallaxHeaderViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/ARParallaxHeaderViewControllerTests.m
@@ -128,4 +128,4 @@ describe(@"with new banner urls", ^{
 });
 
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Fair/ARPendingOperationViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/ARPendingOperationViewControllerTests.m
@@ -35,4 +35,4 @@ it(@"binds message to the label's text", ^{
     expect(viewController.label.text).to.equal(message);
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Fair/ARProfileViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/ARProfileViewControllerTests.m
@@ -280,4 +280,4 @@ describe(@"showViewController:", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Fair/ARShowViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/ARShowViewControllerTests.m
@@ -282,4 +282,4 @@ describe(@"not at a fair", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Fair/Maps/ARFairMapViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/Maps/ARFairMapViewControllerTests.m
@@ -286,4 +286,4 @@ describe(@"on init", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Fair/Views/ARSearchFieldButtonTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/Views/ARSearchFieldButtonTests.m
@@ -7,4 +7,4 @@ it(@"has a valid snapshot", ^{
     expect(button).to.haveValidSnapshot();
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Favorites/ARFavoritesViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Favorites/ARFavoritesViewControllerTests.m
@@ -274,4 +274,4 @@ describe(@"genes", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Gene/ARGeneViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Gene/ARGeneViewControllerTests.m
@@ -36,4 +36,4 @@ pending(@"with long desciption", ^{ // This works, but on Travis we get a weird 
     return vc;
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Hero_Unit/ARHeroUnitTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Hero_Unit/ARHeroUnitTests.m
@@ -405,4 +405,4 @@ describe(@"alignment on iPad", ^{
 });
 
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Image/ARTiledImageDataSourceWithImageTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Image/ARTiledImageDataSourceWithImageTests.m
@@ -57,4 +57,4 @@ describe(@"init", ^{
 
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/ARCollectorStatusViewControllerSpec.m
+++ b/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/ARCollectorStatusViewControllerSpec.m
@@ -13,4 +13,4 @@ itHasSnapshotsForDevicesWithName(@"looks correct", ^{
     return sut;
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/ARCreateAccountViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/ARCreateAccountViewControllerTests.m
@@ -79,10 +79,9 @@ describe(@"warning view", ^{
 
 });
 
-SpecEnd
+SpecEnd;
 
-    BOOL
-    checkViewControllerHasWarningWithMessage(UIViewController *vc, NSString *msg)
+BOOL checkViewControllerHasWarningWithMessage(UIViewController *vc, NSString *msg)
 {
     for (UIView *child in vc.view.subviews) {
         if ([child isKindOfClass:ARWarningView.class]) {

--- a/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/ARLoginViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/ARLoginViewControllerTests.m
@@ -278,4 +278,4 @@ describe(@"login view controller", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/AROnboardingMoreInfoViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/AROnboardingMoreInfoViewControllerTests.m
@@ -80,4 +80,4 @@ describe(@"canSubmit", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/AROnboardingViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/AROnboardingViewControllerTests.m
@@ -56,4 +56,4 @@ describe(@"signup splash", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/ARPersonalizeWebViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/ARPersonalizeWebViewControllerTests.m
@@ -30,4 +30,4 @@ it(@"is positioned correctly", ^{
 });
 
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/ARSignUpActiveUserViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/ARSignUpActiveUserViewControllerTests.m
@@ -94,4 +94,4 @@ describe(@"sign up after app launch", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/ARSignUpSplashViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/ARSignUpSplashViewControllerTests.m
@@ -32,4 +32,4 @@ describe(@"signup splash", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Util/ARFileUtilsTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Util/ARFileUtilsTests.m
@@ -61,4 +61,4 @@ describe(@"logged in user documents folder", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Util/ARNavigationControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Util/ARNavigationControllerTests.m
@@ -5,16 +5,24 @@
 #import "ARTopMenuViewController.h"
 #import "ARAppSearchViewController.h"
 
+
 @interface ARTestingHidesBackButtonViewController : UIViewController <ARMenuAwareViewController>
 @property (readwrite, nonatomic, assign) BOOL hidesBackButton;
 @end
+
 
 @interface ARTestingHidesNavigationButtonsViewController : UIViewController <ARMenuAwareViewController>
 @property (readwrite, nonatomic, assign) BOOL hidesNavigationButtons;
 @end
 
-@implementation ARTestingHidesNavigationButtonsViewController @end
-@implementation ARTestingHidesBackButtonViewController @end
+
+@implementation ARTestingHidesNavigationButtonsViewController
+@end
+
+
+@implementation ARTestingHidesBackButtonViewController
+@end
+
 
 @interface ARNavigationController (Testing)
 - (IBAction)back:(id)sender;
@@ -22,9 +30,10 @@
 @property (readwrite, nonatomic, strong) ARAppSearchViewController *searchViewController;
 @end
 
+
 @implementation ARNavigationController (PrivateTesting)
 
--(void)callDidShowVCDelegateMethod
+- (void)callDidShowVCDelegateMethod
 {
     // For some reason, this is not called during tests unless the actual view hierarchy is rendered.
     [(id<UINavigationControllerDelegate>)self navigationController:self
@@ -226,4 +235,4 @@ describe(@"back button", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Util/ARValueTransformerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Util/ARValueTransformerTests.m
@@ -31,4 +31,4 @@ describe(@"without default", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Web_Browsing/ARExternalWebBrowserViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Web_Browsing/ARExternalWebBrowserViewControllerTests.m
@@ -34,4 +34,4 @@ it(@"forwards `scrollViewDidScroll` to scroll chief", ^{
     [chiefMock verify];
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Web_Browsing/ARInternalMobileWebViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Web_Browsing/ARInternalMobileWebViewControllerTests.m
@@ -283,4 +283,4 @@ describe(@"sharing", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/Web_Browsing/ARInternalShareValidatorTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Web_Browsing/ARInternalShareValidatorTests.m
@@ -69,4 +69,4 @@ describe(@"correctly pulls out the address", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Tests/ARAnimatedTickViewTest.m
+++ b/Artsy_Tests/View_Tests/ARAnimatedTickViewTest.m
@@ -39,4 +39,4 @@ describe(@"ARTickViewFrontLayer layer", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Tests/ARAnnotatedMapViewTests.m
+++ b/Artsy_Tests/View_Tests/ARAnnotatedMapViewTests.m
@@ -46,4 +46,4 @@ describe(@"nextZoomScale", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Tests/ARArtworkActionsViewTests.m
+++ b/Artsy_Tests/View_Tests/ARArtworkActionsViewTests.m
@@ -378,4 +378,4 @@ describe(@"mocked artwork promises", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Tests/ARArtworkDetailViewTests.m
+++ b/Artsy_Tests/View_Tests/ARArtworkDetailViewTests.m
@@ -45,4 +45,4 @@ it(@"shows auction data", ^{
 });
 
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Tests/ARArtworkPreviewActionsViewTests.m
+++ b/Artsy_Tests/View_Tests/ARArtworkPreviewActionsViewTests.m
@@ -66,4 +66,4 @@ describe(@"with a delegate set", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Tests/ARArtworkRelatedArtworksViewTests.m
+++ b/Artsy_Tests/View_Tests/ARArtworkRelatedArtworksViewTests.m
@@ -273,4 +273,4 @@ describe(@"concerning layout", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Tests/ARAspectRatioImageViewTests.m
+++ b/Artsy_Tests/View_Tests/ARAspectRatioImageViewTests.m
@@ -32,4 +32,4 @@ describe(@"intrinsicContentSize", ^{
 
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Tests/ARBrowseFeaturedLinksCollectionViewControllerTests.m
+++ b/Artsy_Tests/View_Tests/ARBrowseFeaturedLinksCollectionViewControllerTests.m
@@ -172,4 +172,4 @@ describe(@"reuseIdentifier", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Tests/ARCollapsableTextViewTests.m
+++ b/Artsy_Tests/View_Tests/ARCollapsableTextViewTests.m
@@ -80,4 +80,4 @@ describe(@"text is taller than collapsed height", ^{
 
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Tests/ARCustomEigenLabelTests.m
+++ b/Artsy_Tests/View_Tests/ARCustomEigenLabelTests.m
@@ -53,4 +53,4 @@ describe(@"ARWarningView", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Tests/ARFairMapAnnotationCallOutViewTests.m
+++ b/Artsy_Tests/View_Tests/ARFairMapAnnotationCallOutViewTests.m
@@ -70,4 +70,4 @@ it(@"long title with arrow", ^{
     expect(view).to.haveValidSnapshotNamed(@"longTitleWithArrow");
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Tests/ARPostFeedItemLinkViewTests.m
+++ b/Artsy_Tests/View_Tests/ARPostFeedItemLinkViewTests.m
@@ -15,4 +15,4 @@ it(@"targetURL", ^{
     expect([view targetPath]).to.equal(@"/post/post_id");
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Tests/ARSwitchViewTests.m
+++ b/Artsy_Tests/View_Tests/ARSwitchViewTests.m
@@ -34,4 +34,4 @@ it(@"adjusts buttons to any switch width", ^{
     expect(switchView).to.haveValidSnapshot();
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Tests/Buttons/ARBidButtonTests.m
+++ b/Artsy_Tests/View_Tests/Buttons/ARBidButtonTests.m
@@ -28,4 +28,4 @@ it(@"bidding closed", ^{
     expect(_button).will.haveValidSnapshotNamed(@"testBiddingClosedState");
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Tests/Buttons/ARFollowableButtonTests.m
+++ b/Artsy_Tests/View_Tests/Buttons/ARFollowableButtonTests.m
@@ -17,4 +17,4 @@ describe(@"ARFollowableButton", ^{
     });
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Tests/Buttons/ARHeartButtonTests.m
+++ b/Artsy_Tests/View_Tests/Buttons/ARHeartButtonTests.m
@@ -68,4 +68,4 @@ describe(@"hearted", ^{
 });
 
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Tests/Buttons/ARNavigationButtonTests.m
+++ b/Artsy_Tests/View_Tests/Buttons/ARNavigationButtonTests.m
@@ -89,4 +89,4 @@ describe(@"ARSerifNavigationButton", ^{
 
 });
 
-SpecEnd
+SpecEnd;

--- a/Artsy_Tests/View_Tests/ORStackViewArtsyCategoriesTests.m
+++ b/Artsy_Tests/View_Tests/ORStackViewArtsyCategoriesTests.m
@@ -82,4 +82,4 @@ describe(@"when adding an alt page title and subtitle", ^{
 });
 
 
-SpecEnd
+SpecEnd;


### PR DESCRIPTION
The fixes an issue of Space Commander adding strange whitespace to C functions that come after the `SpecEnd` command.

Example of strange formatting:
```c
    void
    stubNetworkingForPartialGeneAtPageWithArray(id gene, NSInteger page, NSArray *content)
{
...
}
```

After fix:
```c
void stubNetworkingForPartialGeneAtPageWithArray(id gene, NSInteger page, NSArray *content)
{
...
}
```