### PR TITLE
Remove $(DEVICE_HOST) from build command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ CIRCLE_TEST_REPORTS ?= $(TMPDIR)
 all: ci
 
 build:
-	set -o pipefail && xcodebuild -workspace $(WORKSPACE) -scheme $(SCHEME) -configuration '$(CONFIGURATION)' -sdk iphonesimulator -destination $(DEVICE_HOST) build | tee $(CIRCLE_ARTIFACTS)/xcode_build_raw.log | bundle exec xcpretty -c
+	set -o pipefail && xcodebuild -workspace $(WORKSPACE) -scheme $(SCHEME) -configuration '$(CONFIGURATION)' -sdk iphonesimulator build | tee $(CIRCLE_ARTIFACTS)/xcode_build_raw.log | bundle exec xcpretty -c
 
 clean:
 	xcodebuild -workspace $(WORKSPACE) -scheme $(SCHEME) -configuration '$(CONFIGURATION)' clean


### PR DESCRIPTION
This makes it possible to build with different versions of Xcode and it wasn't really needed, anyways.