### PR TITLE
@alloy => [Search] Don't push search view controller before fully dismissed

### DIFF
--- a/Artsy/View_Controllers/Util/ARNavigationController.m
+++ b/Artsy/View_Controllers/Util/ARNavigationController.m
@@ -471,8 +471,11 @@ ShouldHideItem(UIViewController *viewController, SEL itemSelector, ...)
         self.searchViewController = [ARAppSearchViewController sharedSearchViewController];
     }
     UINavigationController *navigationController = self.ar_innermostTopViewController.navigationController;
-    [navigationController pushViewController:self.searchViewController
-                                    animated:ARPerformWorkAsynchronously];
+
+    if (navigationController.topViewController != self.searchViewController) {
+        [navigationController pushViewController:self.searchViewController
+                                        animated:ARPerformWorkAsynchronously];
+    }
 }
 
 @end

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Fix crash related to search icon being pressed again before search view was fully dismissed - jorystiefel
+
 ## 2.2.0 (2015.8.21)
 
 * Fix "Contact for Price" not showing on artworks - jorystiefel


### PR DESCRIPTION
Fixes #725.

I could only duplicate this by rapidly pressing the Search/Close buttons a bunch of times, so adding a simple check to make sure the Search VC is not already shown.