### PR TITLE
@orta => Fix xcode 6.4 warnings

### DIFF
--- a/Artsy/App/Artsy-Prefix.pch
+++ b/Artsy/App/Artsy-Prefix.pch
@@ -36,7 +36,8 @@
     @import ObjectiveSugar;
 
     // Need to use this to ensure the legacy macros are not enabled.
-    #import <CocoaLumberjack/CocoaLumberjack.h>
+    #define DD_LEGACY_MACROS 0
+    #import <CocoaLumberjack/DDLog.h>
 
     #import <ORStackView/ORStackScrollView.h>
     #import <ORStackView/ORTagBasedAutoStackView.h>

--- a/Artsy/App/Artsy-Prefix.pch
+++ b/Artsy/App/Artsy-Prefix.pch
@@ -26,7 +26,6 @@
     @import AFNetworkActivityLogger;
     @import ObjectiveSugar;
     @import FLKAutoLayout;
-    @import CocoaLumberjack;
     @import ORStackView;
     @import ReactiveCocoa;
     @import NAMapKit;
@@ -35,6 +34,9 @@
     @import UIView_BooleanAnimations;
     @import Artsy_UIButtons;
     @import ObjectiveSugar;
+
+    // Need to use this to ensure the legacy macros are not enabled.
+    #import <CocoaLumberjack/CocoaLumberjack.h>
 
     #import <ORStackView/ORStackScrollView.h>
     #import <ORStackView/ORTagBasedAutoStackView.h>

--- a/Artsy/App/Artsy-Prefix.pch
+++ b/Artsy/App/Artsy-Prefix.pch
@@ -24,6 +24,7 @@
     @import Mantle;
     @import Mantle.metamacros;
     @import AFNetworkActivityLogger;
+    @import CocoaLumberjack;
     @import ObjectiveSugar;
     @import FLKAutoLayout;
     @import ORStackView;
@@ -34,10 +35,6 @@
     @import UIView_BooleanAnimations;
     @import Artsy_UIButtons;
     @import ObjectiveSugar;
-
-    // Need to use this to ensure the legacy macros are not enabled.
-    #define DD_LEGACY_MACROS 0
-    #import <CocoaLumberjack/DDLog.h>
 
     #import <ORStackView/ORStackScrollView.h>
     #import <ORStackView/ORTagBasedAutoStackView.h>

--- a/Artsy/App/Watch/ArtsyWatchAPI.m
+++ b/Artsy/App/Watch/ArtsyWatchAPI.m
@@ -8,7 +8,7 @@
 
 @implementation ArtsyWatchAPI
 
-+ (void)getRequest:(NSURLRequest *)request parseToArrayOfClass:(Class)klass:(void (^)(NSArray *objects, NSURLResponse *response, NSError *error))completionHandler
++ (void)getRequest:(NSURLRequest *)request parseToArrayOfClass:(Class)klass :(void (^)(NSArray *objects, NSURLResponse *response, NSError *error))completionHandler
 {
     NSURLSession *session = [NSURLSession sharedSession];
 

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -714,8 +714,7 @@ static NSSet *artsyHosts = nil;
 
 + (NSURLRequest *)newFairMapRequestWithFair:(Fair *)fair
 {
-    NSString *url = [NSString stringWithFormat:ARNewFairMapURL];
-    return [self requestWithMethod:@"GET" path:url parameters:@{ @"fair_id" : fair.fairID }];
+    return [self requestWithMethod:@"GET" path:ARNewFairMapURL parameters:@{ @"fair_id" : fair.fairID }];
 }
 
 + (NSURLRequest *)newFollowArtistRequest

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.h
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.h
@@ -59,7 +59,7 @@
 
 /// Returns the index of the tab that holds the given view controller at the root of the navigation stack or
 /// `NSNotFound` in case it’s not a root view controller.
-- (ARTopTabControllerIndex)indexOfRootViewController:(UIViewController *)viewController;
+- (NSInteger)indexOfRootViewController:(UIViewController *)viewController;
 
 /// Update the badge number on the data source for the navigation root view controller at the specified tab index.
 - (void)setNotificationCount:(NSUInteger)number forControllerAtIndex:(ARTopTabControllerIndex)index;

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -138,7 +138,7 @@ static const CGFloat ARMenuButtonDimension = 46;
     // Ensure it's created now and started listening for keyboard changes.
     // TODO Ideally this pod would start listening from launch of the app, so we don't need to rely on this one but can
     // be assured that any VCs guide can be trusted.
-    self.keyboardLayoutGuide;
+    (void)self.keyboardLayoutGuide;
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Artsy/View_Controllers/Debug/Quicksilver/ARQuicksilverViewController.m
+++ b/Artsy/View_Controllers/Debug/Quicksilver/ARQuicksilverViewController.m
@@ -47,7 +47,10 @@
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self.searchDisplayController.searchResultsTableView reloadData];
+#pragma clang diagnostic pop
     [self.searchBar becomeFirstResponder];
 
     [self setHighlight:YES forCellAtIndex:self.selectedIndex];
@@ -81,7 +84,10 @@
 - (void)setHighlight:(BOOL)highlight forCellAtIndex:(NSInteger)index
 {
     NSIndexPath *path = [NSIndexPath indexPathForRow:index inSection:0];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     UITableViewCell *cell = [self.searchDisplayController.searchResultsTableView cellForRowAtIndexPath:path];
+#pragma clang diagnostic pop
 
     UIColor *background = highlight ? [UIColor darkGrayColor] : [UIColor blackColor];
     [cell setBackgroundColor:background];
@@ -97,7 +103,10 @@
         return;
     }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     UITableView *tableView = self.searchDisplayController.searchResultsTableView;
+#pragma clang diagnostic pop
     NSIndexPath *path = [NSIndexPath indexPathForRow:self.selectedIndex inSection:0];
     UITableViewCell *cell = [tableView cellForRowAtIndexPath:path];
     [cell setBackgroundColor:[UIColor grayColor]];
@@ -118,7 +127,7 @@
 - (void)searchDisplayController:(UISearchDisplayController *)controller didHideSearchResultsTableView:(UITableView *)tableView
 {
     // We need to prevent the resultsTable from hiding if the search is still active
-    if (self.searchDisplayController.active == YES) {
+    if (controller.active == YES) {
         tableView.hidden = NO;
     }
 }

--- a/Artsy/View_Controllers/Fair/ARFairPopupViewController.m
+++ b/Artsy/View_Controllers/Fair/ARFairPopupViewController.m
@@ -64,7 +64,7 @@
     }];
 }
 
-- (void)animateOut:(BOOL)animated:(void (^)())completion
+- (void)animateOut:(BOOL)animated :(void (^)())completion
 {
     NSParameterAssert(completion);
 
@@ -79,7 +79,7 @@
 
 - (void)dismissPopover
 {
-    [self animateOut:YES:^{
+    [self animateOut:YES :^{
         [self.presentingViewController dismissViewControllerAnimated:NO completion:nil];
     }];
 }

--- a/Artsy/View_Controllers/Login_and_Onboarding/ARPersonalizeWebViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/ARPersonalizeWebViewController.m
@@ -16,8 +16,6 @@
 
 @implementation ARPersonalizeWebViewController
 
-@dynamic delegate;
-
 - (void)viewDidLoad
 {
     [super viewDidLoad];

--- a/Artsy/View_Controllers/Util/Logging/ARLogger.h
+++ b/Artsy/View_Controllers/Util/Logging/ARLogger.h
@@ -1,3 +1,5 @@
+#import <CocoaLumberjack/DDLogMacros.h>
+
 // If you update this enum, update `contextMap` in the implementation too please
 typedef NS_ENUM(NSInteger, ARLogContext) {
     // starting at 1 because 0 is the default

--- a/Artsy/View_Controllers/Util/Logging/ARLogger.h
+++ b/Artsy/View_Controllers/Util/Logging/ARLogger.h
@@ -19,16 +19,7 @@ typedef NS_ENUM(NSInteger, ARLogContext) {
 #pragma mark -
 #pragma mark Context specific macros
 
-// ARLogContextRequestOperation context is specifically for logging http responses directly from the
-// server. To log specifically formatted text errors after a failed request, use ARLogContextNetwork
-// logs. These macros are used by ARHTTPRequestOperationLogger. This logger has its own log level so
-// that you may log only failed requests without affecting the global log level of ARLogger.
+#define ARLogInfo(frmt, ...) LOG_MAYBE(NO, LOG_LEVEL_DEF, DDLogFlagInfo, ARLogContextInfo, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define ARActionLog(frmt, ...) LOG_MAYBE(LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, DDLogFlagDebug, ARLogContextAction, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
 
-#define ARHTTPRequestOperationDebugLog(frmt, ...) LOG_OBJC_MAYBE(YES, ddLogLevel, LOG_FLAG_DEBUG, ARLogContextRequestOperation, frmt, ##__VA_ARGS__)
-#define ARHTTPRequestOperationSuccessLog(frmt, ...) LOG_OBJC_MAYBE(YES, ddLogLevel, LOG_FLAG_INFO, ARLogContextRequestOperation, frmt, ##__VA_ARGS__)
-#define ARHTTPRequestOperationFailureLog(frmt, ...) LOG_OBJC_MAYBE(YES, ddLogLevel, LOG_FLAG_ERROR, ARLogContextRequestOperation, frmt, ##__VA_ARGS__)
-
-#define ARLogInfo(frmt, ...) LOG_OBJC_MAYBE(NO LOG_LEVEL_DEF, (DDLogFlag)ARLogContextInfo, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-#define ARActionLog(frmt, ...) LOG_OBJC_MAYBE(LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, (DDLogFlag)ARLogContextAction, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-
-#define ARErrorLog(frmt, ...) LOG_OBJC_MAYBE(LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, (DDLogFlag)ARLogContextError, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define ARErrorLog(frmt, ...) LOG_MAYBE(LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, DDLogFlagError, ARLogContextError, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,13 @@
 source 'https://rubygems.org'
 
-gem 'cocoapods', :git => 'https://github.com/cocoapods/cocoapods.git', :branch => 'seg-embed-frameworks-quotes'
+gem 'cocoapods'
 gem 'cocoapods-keys'
-gem 'cocoapods-stats'
 gem 'cocoapods-deintegrate'
 
 group :development do
   gem 'houston'
-  gem 'synx', :git => "https://github.com/orta/synx", :branch => "spaces_to-underscores"
+  # Depends on older xcodeproj gem that is incompatible with current CocoaPods.
+  #gem 'synx', :git => "https://github.com/orta/synx", :branch => "spaces_to-underscores"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,52 +7,22 @@ GIT
       aws-sdk-v1 (~> 1.52)
       mustache (~> 0.99)
 
-GIT
-  remote: https://github.com/cocoapods/cocoapods.git
-  revision: 119c8c7659418991ababcd227297fe9eee800b50
-  branch: seg-embed-frameworks-quotes
-  specs:
-    cocoapods (0.38.0.beta.1)
-      activesupport (>= 3.2.15)
-      claide (~> 0.8.2)
-      cocoapods-core (= 0.38.0.beta.1)
-      cocoapods-downloader (~> 0.9.1)
-      cocoapods-plugins (~> 0.4.2)
-      cocoapods-stats (~> 0.5.0)
-      cocoapods-trunk (~> 0.6.1)
-      cocoapods-try (~> 0.4.5)
-      colored (~> 1.2)
-      escape (~> 0.0.4)
-      molinillo (~> 0.2.3)
-      nap (~> 0.8)
-      xcodeproj (~> 0.25.0)
-
-GIT
-  remote: https://github.com/orta/synx
-  revision: ebf1f2d88d5a0262e408e70bac0364fcbc306d6c
-  branch: spaces_to-underscores
-  specs:
-    synx (0.0.61)
-      clamp (~> 0.6)
-      colorize (~> 0.7)
-      xcodeproj (~> 0.25.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
     RubyInline (3.12.4)
       ZenTest (~> 4.3)
     ZenTest (4.11.0)
-    activesupport (4.2.3)
+    activesupport (4.2.4)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    aws-sdk (1.64.0)
-      aws-sdk-v1 (= 1.64.0)
-    aws-sdk-v1 (1.64.0)
+    aws-sdk (1.65.0)
+      aws-sdk-v1 (= 1.65.0)
+    aws-sdk-v1 (1.65.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
     babosa (1.0.2)
@@ -65,31 +35,43 @@ GEM
     cert (0.2.1)
       fastlane_core (>= 0.7.2)
     certified (1.0.0)
-    claide (0.8.2)
-    clamp (0.6.5)
+    claide (0.9.1)
     cliver (0.3.2)
-    cocoapods-core (0.38.0.beta.1)
+    cocoapods (0.38.2)
+      activesupport (>= 3.2.15)
+      claide (~> 0.9.1)
+      cocoapods-core (= 0.38.2)
+      cocoapods-downloader (~> 0.9.1)
+      cocoapods-plugins (~> 0.4.2)
+      cocoapods-stats (~> 0.5.3)
+      cocoapods-trunk (~> 0.6.1)
+      cocoapods-try (~> 0.4.5)
+      colored (~> 1.2)
+      escape (~> 0.0.4)
+      molinillo (~> 0.3.1)
+      nap (~> 0.8)
+      xcodeproj (~> 0.26.3)
+    cocoapods-core (0.38.2)
       activesupport (>= 3.2.15)
       fuzzy_match (~> 2.0.4)
       nap (~> 0.8.0)
     cocoapods-deintegrate (0.2.1)
       cocoapods (~> 0.34)
-    cocoapods-downloader (0.9.1)
+    cocoapods-downloader (0.9.3)
     cocoapods-keys (1.4.0)
       osx_keychain
     cocoapods-plugins (0.4.2)
       nap
     cocoapods-stats (0.5.3)
       nap (~> 0.8)
-    cocoapods-trunk (0.6.1)
-      nap (>= 0.8)
+    cocoapods-trunk (0.6.4)
+      nap (>= 0.8, < 2.0)
       netrc (= 0.7.8)
     cocoapods-try (0.4.5)
     colored (1.2)
-    colorize (0.7.7)
-    commander (4.3.4)
+    commander (4.3.5)
       highline (~> 1.7.2)
-    credentials_manager (0.6.0)
+    credentials_manager (0.7.4)
       colored
       highline (>= 1.7.1)
       security
@@ -102,22 +84,22 @@ GEM
       security (~> 0.1.2)
       term-ansicolor (~> 1.0.7)
       terminal-table (~> 1.4.5)
-    deliver (0.12.1)
+    deliver (0.13.3)
       credentials_manager (>= 0.3.0)
       excon
       fastimage (~> 1.6.3)
-      fastlane_core (>= 0.7.2)
+      fastlane_core (>= 0.15.1)
       nokogiri (~> 1.6.5)
-      plist (~> 3.1.0)
+      plist (~> 3.1)
       rubyzip (~> 1.1.6)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.0.2)
     escape (0.0.4)
-    excon (0.45.3)
-    faraday (0.8.9)
+    excon (0.45.4)
+    faraday (0.8.10)
       multipart-post (~> 1.2.0)
-    faraday_middleware (0.9.1)
+    faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
     fastimage (1.6.8)
       addressable (~> 2.3, >= 2.3.5)
@@ -140,19 +122,21 @@ GEM
       terminal-table (~> 1.4.5)
       xcodeproj (~> 0.20)
       xcpretty (~> 0.1)
-    fastlane_core (0.8.0)
+    fastlane_core (0.15.2)
       babosa
       capybara (~> 2.4.3)
       colored
-      commander (>= 4.3.4)
-      credentials_manager (>= 0.6.0)
+      commander (>= 4.3.5)
+      credentials_manager (>= 0.7.2)
       excon (~> 0.45.0)
       highline (>= 1.7.2)
       json
       multi_json
       phantomjs (~> 1.9.8)
+      plist (~> 3.1)
       poltergeist (~> 1.5.1)
-    frameit (2.0.1)
+      rubyzip (~> 1.1.6)
+    frameit (2.2.0)
       deliver (> 0.3)
       fastimage (~> 1.6.3)
       fastlane_core (>= 0.7.2)
@@ -160,8 +144,8 @@ GEM
     fui (0.3.0)
       gli
     fuzzy_match (2.0.4)
-    gli (2.13.1)
-    highline (1.7.2)
+    gli (2.13.2)
+    highline (1.7.3)
     houston (2.2.3)
       commander (~> 4.1)
       json
@@ -191,9 +175,9 @@ GEM
     mime-types (1.25.1)
     mini_magick (4.0.4)
     mini_portile (0.6.2)
-    minitest (5.7.0)
-    molinillo (0.2.3)
-    multi_json (1.11.1)
+    minitest (5.8.0)
+    molinillo (0.3.1)
+    multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (1.2.0)
     mustache (0.99.8)
@@ -244,7 +228,7 @@ GEM
       plist (~> 3.1.0)
       spaceship (>= 0.0.8)
     slack-notifier (1.2.1)
-    snapshot (0.9.0)
+    snapshot (0.9.2)
       fastimage (~> 1.6.3)
       fastlane_core (>= 0.7.2)
     spaceship (0.0.8)
@@ -263,13 +247,14 @@ GEM
       unf_ext
     unf_ext (0.0.7.1)
     webrobots (0.1.1)
-    websocket-driver (0.5.4)
+    websocket-driver (0.6.2)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
-    xcodeproj (0.25.1)
+    xcodeproj (0.26.3)
       activesupport (>= 3)
+      claide (~> 0.9.1)
       colored (~> 1.2)
-    xcpretty (0.1.10)
+    xcpretty (0.1.11)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -277,17 +262,15 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods!
+  cocoapods
   cocoapods-deintegrate
   cocoapods-keys
-  cocoapods-stats
   fastlane
   fui
   houston
   second_curtain!
   shenzhen
-  synx!
   xcpretty
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/Podfile
+++ b/Podfile
@@ -1,13 +1,3 @@
-class Pod::Project
-  def predictabilize_uuids
-    # no-op to ensure we can use this branch, but without the, currently for us broken, persistant UUID change in Xcodeproj:
-    # https://github.com/CocoaPods/CocoaPods/tree/seg-embed-frameworks-quotes
-    #
-    # Remove this and change Gemfile to latest CP once this is fixed:
-    # https://github.com/CocoaPods/CocoaPods/issues/3763
-  end
-end
-
 source 'https://github.com/artsy/Specs.git'
 source 'https://github.com/CocoaPods/Specs.git'
 

--- a/Podfile
+++ b/Podfile
@@ -39,7 +39,7 @@ target 'Artsy' do
   # Core
   pod 'ALPValidator'
   pod 'ARGenericTableViewController'
-  pod 'CocoaLumberjack'
+  pod 'CocoaLumberjack', :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack.git' # Unreleased > 2.0.1 version has a CP modulemap fix
   pod 'FLKAutoLayout', :git => 'https://github.com/alloy/FLKAutoLayout.git', :branch => 'add-support-for-layout-guides-take-2'
   pod 'FXBlurView'
   pod 'iRate'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -65,13 +65,13 @@ PODS:
   - Bolts/AppLinks (1.2.0):
     - Bolts/Tasks
   - Bolts/Tasks (1.2.0)
-  - CocoaLumberjack (2.0.0):
-    - CocoaLumberjack/Default (= 2.0.0)
-    - CocoaLumberjack/Extensions (= 2.0.0)
-  - CocoaLumberjack/Core (2.0.0)
-  - CocoaLumberjack/Default (2.0.0):
+  - CocoaLumberjack (2.0.1):
+    - CocoaLumberjack/Default (= 2.0.1)
+    - CocoaLumberjack/Extensions (= 2.0.1)
+  - CocoaLumberjack/Core (2.0.1)
+  - CocoaLumberjack/Default (2.0.1):
     - CocoaLumberjack/Core
-  - CocoaLumberjack/Extensions (2.0.0):
+  - CocoaLumberjack/Extensions (2.0.1):
     - CocoaLumberjack/Default
   - DHCShakeNotifier (0.2.0)
   - DRKonamiCode (1.1.0)
@@ -161,7 +161,7 @@ DEPENDENCIES:
   - Artsy+UIFonts (from `https://github.com/artsy/Artsy-UIFonts.git`, branch `old_fonts_new_lib`)
   - Artsy+UILabels (>= 1.3.2)
   - Artsy-UIButtons
-  - CocoaLumberjack
+  - CocoaLumberjack (from `https://github.com/CocoaLumberjack/CocoaLumberjack.git`)
   - DHCShakeNotifier
   - DRKonamiCode
   - Expecta
@@ -212,6 +212,8 @@ EXTERNAL SOURCES:
   Artsy+UIFonts:
     :branch: old_fonts_new_lib
     :git: https://github.com/artsy/Artsy-UIFonts.git
+  CocoaLumberjack:
+    :git: https://github.com/CocoaLumberjack/CocoaLumberjack.git
   FLKAutoLayout:
     :branch: add-support-for-layout-guides-take-2
     :git: https://github.com/alloy/FLKAutoLayout.git
@@ -235,6 +237,9 @@ CHECKOUT OPTIONS:
   Artsy+UIFonts:
     :commit: 39f47deebf947aa4c07727fdf2b69e2feff17428
     :git: https://github.com/artsy/Artsy-UIFonts.git
+  CocoaLumberjack:
+    :commit: a09dd37888d9f51159c4926d4280794f915d726c
+    :git: https://github.com/CocoaLumberjack/CocoaLumberjack.git
   FLKAutoLayout:
     :commit: dd2cd4fe901ff5dcfc47c2c29c7746779fc12b64
     :git: https://github.com/alloy/FLKAutoLayout.git
@@ -265,7 +270,7 @@ SPEC CHECKSUMS:
   Artsy+UILabels: 7efedaf4487a2545c750beaa29cb74db5de39d7f
   Artsy-UIButtons: 6f67de2a5285f18acb5d0e2919d1b17188acbc27
   Bolts: d176cb1e0012175589e389a9db49b85e27787576
-  CocoaLumberjack: a6f77d987d65dc7ba86b0f84db7d0b9084f77bcb
+  CocoaLumberjack: 27ae9abcd376c3e4ee726ecd4adfd7b093ddef3f
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   DRKonamiCode: 94439de24e8264b4f553c775f055e964675af4b6
   EDColor: 89d19a013279a5604d61650721c15f20fefaaf00
@@ -310,4 +315,4 @@ SPEC CHECKSUMS:
   VCRURLConnection: accd771ebd4be11183a3e4d5a4403f180a9a235e
   XCTest+OHHTTPStubSuiteCleanUp: 4469ec8863c6bc022c5089a9b94233eb3416c5ee
 
-COCOAPODS: 0.38.0.beta.1
+COCOAPODS: 0.38.2


### PR DESCRIPTION
Closes #695.

There’s a whole bunch of iOS 9 warnings with Xcode 7, but some of those can’t be fixed without breaking it on Xcode 6 or having to resort to ugly additional macros, so I’m not bothering with that for now until Xcode 7 is GM.

Can you please review this commit specifically, as it’s related to changes you made updating CocoaLumberjack and AFNetworking https://github.com/artsy/eigen/commit/4c209c5884b2fad1fde24c430c51f3b11c404a2b