### PR TITLE
@orta => [Internal WebView] Don’t show stuck progress indicators or broken pages.

### DIFF
--- a/Artsy/View_Controllers/Web_Browsing/ARInternalMobileWebViewController.m
+++ b/Artsy/View_Controllers/Web_Browsing/ARInternalMobileWebViewController.m
@@ -72,6 +72,13 @@
     return self;
 }
 
+- (void)viewDidLoad;
+{
+    [super viewDidLoad];
+    // This is where TSMiniWebBrowser will initially load the URL, so show the initial progress indicator from here.
+    [self showLoading];
+}
+
 - (void)removeContentLoadStateTimer;
 {
     [self.contentLoadStateTimer invalidate];
@@ -89,12 +96,17 @@
 // A full reload, not just a webView.reload, which only refreshes the view without re-requesting data.
 - (void)userDidLoginOrSignUp
 {
-    [self.webView loadRequest:[self requestWithURL:self.currentURL]];
+    [self reload];
 }
 
 - (NSURLRequest *)requestWithURL:(NSURL *)url
 {
     return [ARRouter requestForURL:url];
+}
+
+- (void)reload;
+{
+    [self.webView loadRequest:[self requestWithURL:self.currentURL]];
 }
 
 #pragma mark - UIViewController
@@ -105,7 +117,7 @@
 
     // As we initially show the loading, we don't want this to appear when you do a back or when a modal covers this view.
     if (!self.loaded) {
-        [self showLoading];
+        [self reload];
     }
 }
 

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,3 +1,8 @@
+## Next
+
+* Don’t show a progress indicator when navigating back to a web view that was not yet fully done loading. - alloy
+* Reload a web view that was not fully done loading when the user navigated away, ensuring the user doesn’t get to see broken pages. - alloy
+
 ## 2.2.0 (2015.9.3)
 
 * Show price in artwork grid views - jorystiefel


### PR DESCRIPTION
Fixes #738.

![](http://www.columbia.edu/~bcy2101/progress_bar_dog.gif)