### PR TITLE
@jorystiefel => [Authentication] Add support for Shared Web Credentials.

### DIFF
--- a/Artsy/Networking/API_Modules/ARUserManager.h
+++ b/Artsy/Networking/API_Modules/ARUserManager.h
@@ -38,6 +38,14 @@ extern NSString *const ARUserSessionStartedNotification;
     authenticationFailure:(void (^)(NSError *error))authenticationFailure
            networkFailure:(void (^)(NSError *error))networkFailure;
 
+- (void)loginWithUsername:(NSString *)username
+                 password:(NSString *)password
+   successWithCredentials:(void (^)(NSString *accessToken, NSDate *expirationDate))credentials
+                  gotUser:(void (^)(User *currentUser))gotUser
+    authenticationFailure:(void (^)(NSError *error))authenticationFailure
+           networkFailure:(void (^)(NSError *error))networkFailure
+ saveSharedWebCredentials:(BOOL)saveSharedWebCredentials;
+
 - (void)loginWithFacebookToken:(NSString *)token
         successWithCredentials:(void (^)(NSString *accessToken, NSDate *expirationDate))credentials
                        gotUser:(void (^)(User *currentUser))gotUser
@@ -51,10 +59,34 @@ extern NSString *const ARUserSessionStartedNotification;
         authenticationFailure:(void (^)(NSError *error))authenticationFailure
                networkFailure:(void (^)(NSError *error))networkFailure;
 
-- (void)createUserWithName:(NSString *)name email:(NSString *)email password:(NSString *)password success:(void (^)(User *user))success failure:(void (^)(NSError *error, id JSON))failure;
-- (void)createUserViaFacebookWithToken:(NSString *)token email:(NSString *)email name:(NSString *)name success:(void (^)(User *user))success failure:(void (^)(NSError *error, id JSON))failure;
-- (void)createUserViaTwitterWithToken:(NSString *)token secret:(NSString *)secret email:(NSString *)email name:(NSString *)name success:(void (^)(User *user))success failure:(void (^)(NSError *error, id JSON))failure;
+- (void)createUserWithName:(NSString *)name
+                     email:(NSString *)email
+                  password:(NSString *)password
+                   success:(void (^)(User *user))success
+                   failure:(void (^)(NSError *error, id JSON))failure;
 
-- (void)sendPasswordResetForEmail:(NSString *)email success:(void (^)(void))success failure:(void (^)(NSError *error))failure;
+- (void)createUserWithName:(NSString *)name
+                     email:(NSString *)email
+                  password:(NSString *)password
+                   success:(void (^)(User *))success
+                   failure:(void (^)(NSError *error, id JSON))failure
+  saveSharedWebCredentials:(BOOL)saveSharedWebCredentials;
+
+- (void)createUserViaFacebookWithToken:(NSString *)token
+                                 email:(NSString *)email
+                                  name:(NSString *)name
+                               success:(void (^)(User *user))success
+                               failure:(void (^)(NSError *error, id JSON))failure;
+
+- (void)createUserViaTwitterWithToken:(NSString *)token
+                               secret:(NSString *)secret
+                                email:(NSString *)email
+                                 name:(NSString *)name
+                              success:(void (^)(User *user))success
+                              failure:(void (^)(NSError *error, id JSON))failure;
+
+- (void)sendPasswordResetForEmail:(NSString *)email
+                          success:(void (^)(void))success
+                          failure:(void (^)(NSError *error))failure;
 
 @end

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/3_-_Sign_Up_+_Log_In/ARLoginViewController.h
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/3_-_Sign_Up_+_Log_In/ARLoginViewController.h
@@ -13,5 +13,5 @@ typedef NS_ENUM(NSInteger, ARLoginViewControllerLoginType) {
 
 @property (nonatomic, weak) id<AROnboardingStepsDelegate, ARLoginSignupDelegate> delegate;
 @property (nonatomic, assign) BOOL hideDefaultValues;
-
+@property (nonatomic, assign) BOOL skipSharedWebCredentials;
 @end

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/3_-_Sign_Up_+_Log_In/ARLoginViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/3_-_Sign_Up_+_Log_In/ARLoginViewController.m
@@ -313,6 +313,25 @@
 #endif
 
     [super viewDidAppear:animated];
+
+    if (!self.skipSharedWebCredentials) {
+        SecRequestSharedWebCredential(NULL, NULL, ^(CFArrayRef credentials, CFErrorRef error) {
+            if (error) {
+                ARErrorLog(@"Unable to fetch Shared Web Credentials: %@", (__bridge NSError *)error);
+            } else {
+                NSDictionary *account = [(__bridge NSArray *)credentials firstObject];
+                if (account) {
+                    ar_dispatch_main_queue(^{
+                        self.emailTextField.text = account[(__bridge NSString *)kSecAttrAccount];
+                        self.passwordTextField.secureTextEntry = YES;
+                        self.passwordTextField.text = account[(__bridge NSString *)kSecSharedPassword];
+                        self.passwordTextField.secureTextEntry = NO;
+                        [self textFieldDidChange:nil];
+                    });
+                }
+            }
+        });
+    }
 }
 
 - (void)autoLogIn:(id)sender
@@ -415,7 +434,8 @@
         networkFailure:^(NSError *error) {
         @_strongify(self);
         [self networkFailure:error];
-        }];
+        }
+        saveSharedWebCredentials:!self.skipSharedWebCredentials];
 }
 
 - (void)authenticationFailure

--- a/Artsy_Tests/Networking_Tests/API_Modules/ARUserManagerTests.m
+++ b/Artsy_Tests/Networking_Tests/API_Modules/ARUserManagerTests.m
@@ -282,7 +282,7 @@ describe(@"createUserWithName", ^{
         } failure:^(NSError *error, id JSON) {
             XCTFail(@"createUserWithName: %@", error);
             done = YES;
-        }];
+        } saveSharedWebCredentials:NO];
 
         while(!done) {
             [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];

--- a/Artsy_Tests/Stubs/ARUserManager+Stubs.m
+++ b/Artsy_Tests/Stubs/ARUserManager+Stubs.m
@@ -77,7 +77,8 @@
              networkFailure(error);
          }
          done = YES;
-        }];
+        }
+        saveSharedWebCredentials:NO];
 
     while (!done) {
         [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];

--- a/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/ARLoginViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/ARLoginViewControllerTests.m
@@ -34,6 +34,7 @@ describe(@"login view controller", ^{
     describe(@"snapshots", ^{
         beforeEach(^{
             controller = [[ARLoginViewController alloc] init];
+            controller.skipSharedWebCredentials = YES;
             controller.hideDefaultValues = YES;
         });
                    
@@ -55,6 +56,7 @@ describe(@"login view controller", ^{
     describe(@"initWithEmail", ^{
         beforeEach(^{
             controller = [[ARLoginViewController alloc] initWithEmail:[ARUserManager stubUserEmail]];
+            controller.skipSharedWebCredentials = YES;
             [controller view]; // loads view and calls viewDidLoad
         });
 
@@ -67,6 +69,7 @@ describe(@"login view controller", ^{
     describe(@"login", ^{
         beforeEach(^{
             controller = [[ARLoginViewController alloc] init];
+            controller.skipSharedWebCredentials = YES;
             [controller view]; // loads view and calls viewDidLoad
         });
 
@@ -212,6 +215,7 @@ describe(@"login view controller", ^{
     describe(@"forgot password", ^{
         beforeEach(^{
             controller = [[ARLoginViewController alloc] init];
+            controller.skipSharedWebCredentials = YES;
             [controller view]; // loads view and calls viewDidLoad
         });
 

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+* Add support for Shared Web Credentials. Available credentials are shown on the login view and entered/created credentials are saved for web use. - alloy
+
 ## 2.3.0 (2015.09.25)
 
 * Improved Spotlight support for favorites. - alloy


### PR DESCRIPTION
![](http://media1.giphy.com/media/oROnWZd9XvSEw/giphy.gif)

This will show the available credentials on the login view, if there are any credentials available. It takes a second or two for the alert to show, so that’s a slight UX downer :-/ /cc @katarinabatina 

![img_7073](https://cloud.githubusercontent.com/assets/2320/10110608/9623157c-63ce-11e5-81a4-69b12d172602.PNG)
