### PR TITLE
@alloy => Fix failing network crash

### DIFF
--- a/Artsy/View_Controllers/Web_Browsing/ARTopMenuInternalMobileWebViewController.m
+++ b/Artsy/View_Controllers/Web_Browsing/ARTopMenuInternalMobileWebViewController.m
@@ -119,10 +119,6 @@
 
 - (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error
 {
-    [super webView:webView didFailNavigation:navigation withError:error];
-
-    self.hasSuccessfullyLoadedLastRequest = NO;
-
     // This happens when we cancel loading the request and route internally from ARInternalMobileWebViewController.
     if (error.code != NSURLErrorCancelled) {
         self.hasSuccessfullyLoadedLastRequest = NO;


### PR DESCRIPTION
The old behavior would fall back to [ARInternalWebViewController](https://github.com/artsy/eigen/blob/2.2.1/Artsy/View_Controllers/Web_Browsing/ARInternalMobileWebViewController.m#L186) which would then stop the timer for the "should I remove the spinner?"

We don't use that anymore so the `super` call doesn't need to exist.