### PR TITLE
@orta => [Web Fonts] add missing browser agent strings for compatibility

### DIFF
--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -94,8 +94,9 @@ static NSSet *artsyHosts = nil;
     AFHTTPRequestSerializer *serializer = [[AFHTTPRequestSerializer alloc] init];
     NSString *userAgent = serializer.HTTPRequestHeaders[@"User-Agent"];
     NSString *deviceName = [[UIDevice currentDevice] name];
-    NSString *agentString = [NSString stringWithFormat:@"Mozilla/5.0 Artsy-Mobile/%@ Eigen/%@ Device: %@ AppleWebKit/601.1.46 (KHTML, like Gecko)", version, build, deviceName];
+    NSString *agentString = [NSString stringWithFormat:@"Mozilla/5.0 Artsy-Mobile/%@ Eigen/%@ Device: %@", version, build, deviceName];
     userAgent = [userAgent stringByReplacingOccurrencesOfString:@"Artsy" withString:agentString];
+    userAgent = [userAgent stringByAppendingString:@"AppleWebKit/601.1.46 (KHTML, like Gecko)"];
 
     [[NSUserDefaults standardUserDefaults] registerDefaults:@{ @"UserAgent" : userAgent }];
     [self setHTTPHeader:@"User-Agent" value:userAgent];

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -94,7 +94,7 @@ static NSSet *artsyHosts = nil;
     AFHTTPRequestSerializer *serializer = [[AFHTTPRequestSerializer alloc] init];
     NSString *userAgent = serializer.HTTPRequestHeaders[@"User-Agent"];
     NSString *deviceName = [[UIDevice currentDevice] name];
-    NSString *agentString = [NSString stringWithFormat:@"Artsy-Mobile/%@ Eigen/%@ Device: %@", version, build, deviceName];
+    NSString *agentString = [NSString stringWithFormat:@"Mozilla/5.0 Artsy-Mobile/%@ Eigen/%@ Device: %@ AppleWebKit/601.1.46 (KHTML, like Gecko)", version, build, deviceName];
     userAgent = [userAgent stringByReplacingOccurrencesOfString:@"Artsy" withString:agentString];
 
     [[NSUserDefaults standardUserDefaults] registerDefaults:@{ @"UserAgent" : userAgent }];

--- a/Artsy_Tests/Networking_Tests/ARRouterTests.m
+++ b/Artsy_Tests/Networking_Tests/ARRouterTests.m
@@ -107,7 +107,12 @@ describe(@"User-Agent", ^{
     __block NSString *userAgent = [[NSUserDefaults standardUserDefaults] valueForKey:@"UserAgent"];
 
     it(@"uses Artsy-Mobile hard-coded in Microgravity", ^{
-        expect(userAgent).to.beginWith(@"Artsy-Mobile/");
+        expect(userAgent).to.contain(@"Artsy-Mobile/");
+    });
+    
+    it(@"contains compatibility strings", ^{
+        expect(userAgent).to.contain(@"AppleWebKit/");
+        expect(userAgent).to.contain(@"KHTML");
     });
 
     it(@"uses Eigen", ^{

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -6,6 +6,7 @@
 * Improve the use of Shared Web Credentials by trying it as early as possible, before even asking the user to sign-in. - alloy
 * Fix crash by disabling network logging in release mode completely. - alloy
 * Clean-up all compiler warnings for Xcode 7 / iOS 9 SDK. - alloy
+* Adding compatibility strings to User-Agent to fix web fonts loading - jorystiefel
 
 ## 2.3.0 (2015.09.26)
 


### PR DESCRIPTION
The problem comes down to our `User-Agent` not identifying itself as any specific type of browser. Adding in these compatibility strings `Mozilla/5.0` and `AppleWebKit/601.1.46 (KHTML, like Gecko)` fixes the font loading issue.

The only minor issue is that I have not found anyway to access the actual `AppleWebKit` version number, so that is hardcoded in the string. Open to suggestions.

Fixes #815.