### PR TITLE
@alloy => Add ARAnalyticsSignInWebCredentials to note when logging in via web creds

### DIFF
--- a/Artsy/App/ARAnalyticsConstants.h
+++ b/Artsy/App/ARAnalyticsConstants.h
@@ -42,6 +42,7 @@ extern NSString *const ARAnalyticsOnboardingCompleted;
 extern NSString *const ARAnalyticsSignInEmail;
 extern NSString *const ARAnalyticsSignInTwitter;
 extern NSString *const ARAnalyticsSignInFacebook;
+extern NSString *const ARAnalyticsSignInWebCredentials;
 extern NSString *const ARAnalyticsSignInError;
 
 // Sign up

--- a/Artsy/App/ARAnalyticsConstants.m
+++ b/Artsy/App/ARAnalyticsConstants.m
@@ -18,6 +18,7 @@ NSString *const ARAnalyticsTappedLogIn = @"Tapped log in";
 NSString *const ARAnalyticsSignInEmail = @"Login with email";
 NSString *const ARAnalyticsSignInTwitter = @"Login with twitter";
 NSString *const ARAnalyticsSignInFacebook = @"Login with facebook";
+NSString *const ARAnalyticsSignInWebCredentials = @"Login with web credentials";
 NSString *const ARAnalyticsSignInError = @"Login errors";
 
 NSString *const ARAnalyticsSignUpEmail = @"Sign up with email";

--- a/Artsy/App/ARAppDelegate+Analytics.m
+++ b/Artsy/App/ARAppDelegate+Analytics.m
@@ -452,6 +452,13 @@
                     ARAnalyticsClass: ARSignUpActiveUserViewController.class,
                     ARAnalyticsDetails: @[
                         @{
+                            ARAnalyticsEventName: ARAnalyticsSignInWebCredentials,
+                            ARAnalyticsSelectorName: @"loggedInWithSharedCredentials",
+                            ARAnalyticsProperties: ^NSDictionary *(ARSignUpActiveUserViewController *controller, NSArray *_) {
+                                return @{@"active_user": @"true"};
+                            }
+                        },
+                        @{
                             ARAnalyticsEventName: ARAnalyticsTappedLogIn,
                             ARAnalyticsSelectorName: ARAnalyticsSelector(goToLogin:),
                             ARAnalyticsProperties: ^NSDictionary *(ARSignUpActiveUserViewController *controller, NSArray *_) {
@@ -686,6 +693,13 @@
                         @{
                             ARAnalyticsEventName: ARAnalyticsTappedSignUp,
                             ARAnalyticsSelectorName: NSStringFromSelector(@selector(signUp:)),
+                        },
+                        @{
+                            ARAnalyticsEventName: ARAnalyticsSignInWebCredentials,
+                            ARAnalyticsSelectorName: @"loggedInWithSharedCredentials",
+                            ARAnalyticsProperties: ^NSDictionary *(ARSignUpSplashViewController *controller, NSArray *_) {
+                                return @{@"active_user": @"true"};
+                            }
                         },
                         @{
                             ARAnalyticsEventName: ARAnalyticsTryWithoutAccount,

--- a/Artsy/Networking/API_Modules/ARUserManager.m
+++ b/Artsy/Networking/API_Modules/ARUserManager.m
@@ -68,7 +68,7 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
 }
 
 - (instancetype)init
-{
+{   
     self = [super init];
     if (!self) {
         return nil;

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/2_-_Calls_to_Action/ARSignUpActiveUserViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/2_-_Calls_to_Action/ARSignUpActiveUserViewController.m
@@ -92,12 +92,18 @@
                     [self showControls];
                 }];
             } else {
+                [self loggedInWithSharedCredentials];
                 [self.delegate dismissOnboardingWithVoidAnimation:YES];
             }
         });
     }];
 
     [super viewDidAppear:animated];
+}
+
+- (void)loggedInWithSharedCredentials
+{
+    // This is a dummy method for ARAppDelegat+Analytics to hook into.
 }
 
 - (void)showControls;

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/2_-_Calls_to_Action/ARSignUpSplashViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/2_-_Calls_to_Action/ARSignUpSplashViewController.m
@@ -113,12 +113,18 @@
                     [self showControls];
                 }];
             } else {
+                [self loggedInWithSharedCredentials];
                 [self.delegate dismissOnboardingWithVoidAnimation:YES];
             }
         });
     }];
 
     [super viewDidAppear:animated];
+}
+
+- (void)loggedInWithSharedCredentials
+{
+    // This is a dummy method for ARAppDelegat+Analytics to hook into.
 }
 
 - (void)showControls;


### PR DESCRIPTION
Figured it won't need a changelog, but happy to add if you prefer. Might be worth auditing if this will still trigger the normal logged in via email analytics calls too.