### PR TITLE
@jorystiefel => [Spinner] Fix a bug where the spinner would only rotate 8 times.

### DIFF
--- a/Artsy/Views/Utilities/ARSpinner.m
+++ b/Artsy/Views/Utilities/ARSpinner.m
@@ -73,7 +73,7 @@ CGFloat RotationDuration = 0.9;
 
 - (void)startAnimating
 {
-    [self animate:HUGE_VAL];
+    [self animate:LONG_MAX];
 }
 
 - (void)animate:(NSInteger)times

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Fix an issue where after 8 rotations our progress indicator would stop rotating, making it seem as if the progress was finished when it was actually not. - alloy
+
 ### 2.3.0 (2015.10.05)
 
 * Search hides the statusbar - orta


### PR DESCRIPTION
This appears to be a compiler bug, but also a case where we were
using an incorrect type (double) anyways.

Fixes #838.