### PR TITLE
@alloy => Remove the full modal spinner, there is already one for the fe…

### DIFF
--- a/Artsy/View_Controllers/Feed_VCs/ARShowFeedViewController.m
+++ b/Artsy/View_Controllers/Feed_VCs/ARShowFeedViewController.m
@@ -151,10 +151,6 @@ static CGFloat ARFeaturedShowsTitleHeightPhone = 40;
 - (void)refreshFeedItems
 {
     [ARAnalytics startTimingEvent:ARAnalyticsInitialFeedLoadTime];
-    if (!self.showingOfflineView) {
-        [self presentLoadingView];
-    }
-
     @weakify(self);
 
     [ArtsyAPI getXappTokenWithCompletion:^(NSString *xappToken, NSDate *expirationDate) {


### PR DESCRIPTION
There is already a spinner on the page, so adding a full screen spinner briefly doesn't make sense. Would happily accept a version that checks if it's not the first time it's doing it work if needs be, but this is a UI annoyance on every launch.