### PR TITLE
@alloy => [WKWebView] Fix for scroll deceleration assert fail on iPad

### DIFF
--- a/Artsy/View_Controllers/Web_Browsing/ARExternalWebBrowserViewController.m
+++ b/Artsy/View_Controllers/Web_Browsing/ARExternalWebBrowserViewController.m
@@ -2,6 +2,7 @@
 #import "ARExternalWebBrowserViewController.h"
 #import <FLKAutoLayout/UIViewController+FLKAutoLayout.h>
 
+
 @interface ARExternalWebBrowserViewController () <UIGestureRecognizerDelegate, UIScrollViewDelegate>
 @property (nonatomic, readonly, strong) UIGestureRecognizer *gesture;
 @property (nonatomic, readonly, strong) NSURL *initialURL;
@@ -57,8 +58,8 @@
     scrollView.decelerationRate = UIScrollViewDecelerationRateNormal;
     // Work around bug in WKScrollView by setting private ivar directly: http://trac.webkit.org/changeset/188541
     // Once this has been fixed, we can’t completely disable this workaround, only for those OS versions with the fix.
-    NSString *decelerationRateKey = [NSString stringWithFormat:@"%@%@ScrollDecelerationFactor", @"_", @"preferred"];
-    NSAssert([[scrollView valueForKey:decelerationRateKey] doubleValue] < (UIScrollViewDecelerationRateNormal - 0.005),
+    NSString *decelerationRateKey = [NSString stringWithFormat:@"%@%@ollDecelerationFactor", @"_pre", @"ferredScr"];
+    NSAssert([[scrollView valueForKey:decelerationRateKey] doubleValue] < (UIScrollViewDecelerationRateNormal - 0.001),
              @"Expected the private value to not change, maybe this bug has been fixed?");
     [scrollView setValue:@(UIScrollViewDecelerationRateNormal) forKey:decelerationRateKey];
 


### PR DESCRIPTION
Adjust the float delta, this was giving us an `NSAssert` failure on iPad (but not iPhone).