### PR TITLE
@alloy => [Bidding] Return to native artwork view on iPad after bid

### DIFF
--- a/Artsy/View_Controllers/Auction_Results/ARAuctionWebViewController.m
+++ b/Artsy/View_Controllers/Auction_Results/ARAuctionWebViewController.m
@@ -51,7 +51,8 @@
 - (WKNavigationActionPolicy)shouldLoadNavigationAction:(WKNavigationAction *)navigationAction;
 {
     if (navigationAction.navigationType == WKNavigationTypeOther
-            && [navigationAction.request.URL.fragment isEqualToString:@"confirm-bid"]) {
+        && ([navigationAction.request.URL.fragment isEqualToString:@"confirm-bid"]
+            || [navigationAction.request.URL.lastPathComponent isEqualToString:@"confirm-bid"])) {
         [self bidHasBeenConfirmed];
         return WKNavigationActionPolicyCancel;
     } else if (navigationAction.navigationType == WKNavigationTypeOther

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* Fixes post-bidding bug on iPad, return to native artwork view instead of Force view - jorystiefel
 * Added "Not for Sale" to the Artwork's price information - orta
 * Workaround bug in WKWebKit that makes it impossible to fix the scrollview’s deceleration rate through public API. - alloy
 * Fixed Peek/Pop issue where items from a view lower in the stack would get previewed. - orta


### PR DESCRIPTION
Fixes issue of iPad bidding returning you to a Force web view instead of the native artwork view