### PR TITLE
@orta => [WKWebView] Don’t use deceleration rate bug workaround on iOS 8.

### DIFF
--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+* Fix crash on iOS 8 when trying to workaround WKWebKit scroll deceleration bug. - alloy
+
 ### 2.3.0 (2015.10.08)
 
 * Fixes post-bidding bug on iPad, return to native artwork view instead of Force view - jorystiefel


### PR DESCRIPTION
![](http://media1.giphy.com/media/8vFzjw6chfqsU/giphy.gif)