### PR TITLE
@alloy => [Crash] attempt to fix search crash

### DIFF
--- a/Artsy/View_Controllers/Util/ARNavigationController.m
+++ b/Artsy/View_Controllers/Util/ARNavigationController.m
@@ -467,15 +467,22 @@ ShouldHideItem(UIViewController *viewController, SEL itemSelector, ...)
 
 - (IBAction)search:(id)sender;
 {
+    // Attempt to fix problem of crash https://rink.hockeyapp.net/manage/apps/37029/app_versions/41/crash_reasons/46749845?type=overview
+    // If you rapidly press the search/close buttons, you will get a crash pushing the same VC twice
+    self.searchButton.enabled = NO;
+
     if (self.searchViewController == nil) {
         self.searchViewController = [ARAppSearchViewController sharedSearchViewController];
     }
     UINavigationController *navigationController = self.ar_innermostTopViewController.navigationController;
 
-    if (navigationController.topViewController != self.searchViewController) {
-        [navigationController pushViewController:self.searchViewController
-                                        animated:ARPerformWorkAsynchronously];
-    }
+    [CATransaction begin];
+    [navigationController pushViewController:self.searchViewController
+                                    animated:ARPerformWorkAsynchronously];
+    [CATransaction setCompletionBlock:^{
+        self.searchButton.enabled = YES;
+    }];
+    [CATransaction commit];
 }
 
 @end

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -3,6 +3,7 @@
 * Reduce memory consumption while indexing all of the user’s favourites. - alloy
 * On iPad, ensure a native artwork view is shown after making a bid directly from the auction overview. - alloy
 * Update ‘How Bidding Works’ link. - alloy
+* Another attempt at eliminating crashes due to the search view controller being presented twice in the same stack. - jorystiefel
 
 ### 2.3.0 (2015.10.09)
 


### PR DESCRIPTION
Closes #850.

Disable the Search button and re-enable it once the view controller has transitioned to the search view, in attempt to prevent rapidly pressing the search button from trying to push the same VC twice.