### PR TITLE
@alloy => [auctions+trial] Add support for reloading web views not done loading

### DIFF
--- a/Artsy/View_Controllers/Web_Browsing/ARExternalWebBrowserViewController.h
+++ b/Artsy/View_Controllers/Web_Browsing/ARExternalWebBrowserViewController.h
@@ -5,6 +5,7 @@
 
 @property (readonly, nonatomic, strong) WKWebView *webView;
 @property (readonly, nonatomic, strong) UIScrollView *scrollView;
+@property (nonatomic, readonly, strong) NSURL *initialURL;
 
 - (instancetype)initWithURL:(NSURL *)url;
 

--- a/Artsy/View_Controllers/Web_Browsing/ARExternalWebBrowserViewController.m
+++ b/Artsy/View_Controllers/Web_Browsing/ARExternalWebBrowserViewController.m
@@ -5,7 +5,6 @@
 
 @interface ARExternalWebBrowserViewController () <UIGestureRecognizerDelegate, UIScrollViewDelegate>
 @property (nonatomic, readonly, strong) UIGestureRecognizer *gesture;
-@property (nonatomic, readonly, strong) NSURL *initialURL;
 @end
 
 

--- a/Artsy/View_Controllers/Web_Browsing/ARInternalMobileWebViewController.m
+++ b/Artsy/View_Controllers/Web_Browsing/ARInternalMobileWebViewController.m
@@ -6,7 +6,6 @@
 
 static void *ARProgressContext = &ARProgressContext;
 
-
 @interface ARInternalMobileWebViewController () <UIAlertViewDelegate, WKNavigationDelegate>
 @property (nonatomic, assign) BOOL loaded;
 @property (nonatomic, strong) ARInternalShareValidator *shareValidator;
@@ -178,7 +177,8 @@ static void *ARProgressContext = &ARProgressContext;
 
 - (void)userDidSignUp
 {
-    [self.webView loadRequest:[self requestWithURL:self.webView.URL]];
+    NSURL *url = self.webView.URL ?: self.initialURL;
+    [self.webView loadRequest:[self requestWithURL:url]];
 }
 
 - (NSURLRequest *)requestWithURL:(NSURL *)URL


### PR DESCRIPTION
Fixes : https://github.com/artsy/eigen/issues/898

So problem is:

* Trial user opens page
* Before page has had chance to load, it is stopped so we can do a log in prompt for bidding
* The web view doesn't have a URL, thus reloading does nothing.

``` objc
- (void)userDidSignUp
{
    [self.webView loadRequest:[self requestWithURL:self.webView.URL]];
}
```