### PR TITLE
@orta => [Router] Fix error with disallowed chars in User-Agent.

### DIFF
--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -93,8 +93,7 @@ static NSSet *artsyHosts = nil;
 
     AFHTTPRequestSerializer *serializer = [[AFHTTPRequestSerializer alloc] init];
     NSString *userAgent = serializer.HTTPRequestHeaders[@"User-Agent"];
-    NSString *deviceName = [[UIDevice currentDevice] name];
-    NSString *agentString = [NSString stringWithFormat:@"Mozilla/5.0 Artsy-Mobile/%@ Eigen/%@ Device: %@", version, build, deviceName];
+    NSString *agentString = [NSString stringWithFormat:@"Mozilla/5.0 Artsy-Mobile/%@ Eigen/%@", version, build];
     userAgent = [userAgent stringByReplacingOccurrencesOfString:@"Artsy" withString:agentString];
     userAgent = [userAgent stringByAppendingString:@"AppleWebKit/601.1.46 (KHTML, like Gecko)"];
 

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -88,14 +88,16 @@ static NSSet *artsyHosts = nil;
     NSString *version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
     NSString *build = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"];
 
-    // Take the default from AFNetworking, and extend them all to include code names
-    // and individual build numbers
+    // Take the default from AFNetworking, and extend them all to include:
+    // * code names
+    // * version information
+    // * include big browser engine names so that scripts like that of fast.fonts.net WKWebView will load
 
     AFHTTPRequestSerializer *serializer = [[AFHTTPRequestSerializer alloc] init];
     NSString *userAgent = serializer.HTTPRequestHeaders[@"User-Agent"];
     NSString *agentString = [NSString stringWithFormat:@"Mozilla/5.0 Artsy-Mobile/%@ Eigen/%@", version, build];
     userAgent = [userAgent stringByReplacingOccurrencesOfString:@"Artsy" withString:agentString];
-    userAgent = [userAgent stringByAppendingString:@"AppleWebKit/601.1.46 (KHTML, like Gecko)"];
+    userAgent = [userAgent stringByAppendingString:@" AppleWebKit/601.1.46 (KHTML, like Gecko)"];
 
     [[NSUserDefaults standardUserDefaults] registerDefaults:@{ @"UserAgent" : userAgent }];
     [self setHTTPHeader:@"User-Agent" value:userAgent];

--- a/Artsy_Tests/Networking_Tests/ARRouterTests.m
+++ b/Artsy_Tests/Networking_Tests/ARRouterTests.m
@@ -127,10 +127,6 @@ describe(@"User-Agent", ^{
         expect(userAgent).to.contain([[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"]);
     });
 
-    it(@"preserves simulator information", ^{
-        expect(userAgent).to.contain(@"iPhone Simulator");
-    });
-
     it(@"is contained in requests sent out from router", ^{
 
         Artwork *artwork = [Artwork modelWithJSON:@{ @"id": @"artwork_id" }];

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+* No longer encode the device’s name into the User-Agent as it might contain characters outside the allowed character set which may lead to encoding errors on the backend. - alloy
+
 ### 2.3.0 (2015.10.15)
 
 * Reduce memory consumption while indexing all of the user’s favourites. - alloy


### PR DESCRIPTION
I don’t know why there was a test that checked for the device name being included, I don’t see a need for it.

When including the device name, it could contain characters outside the allowed character set, which could lead to encoding issues on the backend. E.g.

```
Mozilla/5.0 Artsy-Mobile/2.3.0 Eigen/2015.10.15 Device: Eloy Durán’s iPod/2.3.0 (iPod touch; iOS 8.4.1; Scale/2.00)AppleWebKit/601.1.46 (KHTML, like Gecko)
```

Includes a unicode `’` and results in the following error on the `https://stagingapi.artsy.net/api/v1/me/bidder_position` endpoint:

_[Full error](https://gist.github.com/alloy/3785563548fa0d02302e)_

```
irb(main):005:0> puts bt.reject { |s| s.include?('gems') }
/srv/www/gravity/releases/20151015140557/app/api/v1/me_bidder_positions_endpoint.rb:63:in `block (3 levels) in <class:MeBidderPositionsEndpoint>'
/srv/www/gravity/releases/20151015140557/lib/tale.rb:13:in `call'
/srv/www/gravity/releases/20151015140557/app/api/middleware/logger_middleware.rb:22:in `block in call'
/srv/www/gravity/releases/20151015140557/app/api/middleware/logger_middleware.rb:21:in `call'
/home/deploy/.bundler/gravity/ruby/2.0.0/bin/unicorn_rails:23:in `load'
/home/deploy/.bundler/gravity/ruby/2.0.0/bin/unicorn_rails:23:in `<main>'
```

/cc @mzikherman