### PR TITLE
@orta => [iPad] skip onboarding when signing-up when trying to bid.

### DIFF
--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.0</string>
+	<string>2.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -66,15 +66,15 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2015.10.15</string>
+	<string>2015.10.16</string>
 	<key>FacebookAppID</key>
 	<string>308278682573501</string>
 	<key>FacebookDisplayName</key>
 	<string>Artsy</string>
 	<key>GITCommitRev</key>
-	<string>bd48327</string>
+	<string>2c7c74c</string>
 	<key>GITCommitSha</key>
-	<string>bd483270b1a0cb9b277c888415535ad3ff95430d</string>
+	<string>2c7c74cf940ee8ef4d63cb9fb6dcc39b4e8b8185</string>
 	<key>GITRemoteOriginURL</key>
 	<string></string>
 	<key>LSRequiresIPhoneOS</key>

--- a/Artsy/View_Controllers/Auction_Results/ARAuctionWebViewController.m
+++ b/Artsy/View_Controllers/Auction_Results/ARAuctionWebViewController.m
@@ -50,20 +50,40 @@
     return self;
 }
 
+- (ARTrialContext)trialContextForRequestURL:(NSURL *)requestURL;
+{
+    for (NSString *param in [requestURL.query componentsSeparatedByString:@"&"]) {
+        NSArray *pair = [param componentsSeparatedByString:@"="];
+        // On Force when tapping a ‘bid’ button from an auction overview.
+        if ([pair[0] isEqualToString:@"redirect_uri"] && [pair[1] isEqualToString:self.initialURL.path]) {
+            return ARTrialContextAuctionBid;
+        }
+    }
+    return [super trialContextForRequestURL:requestURL];
+}
+
 - (WKNavigationActionPolicy)shouldLoadNavigationAction:(WKNavigationAction *)navigationAction;
 {
-    if (navigationAction.navigationType == WKNavigationTypeOther
-        && ([navigationAction.request.URL.fragment isEqualToString:@"confirm-bid"]
-            || [navigationAction.request.URL.lastPathComponent isEqualToString:@"confirm-bid"])) {
-        [self bidHasBeenConfirmed];
-        return WKNavigationActionPolicyCancel;
-    } else if (navigationAction.navigationType == WKNavigationTypeOther
-        && [navigationAction.request.URL.lastPathComponent isEqualToString:@"confirm-registration"]) {
-        [self registrationHasBeenConfirmed];
-        return WKNavigationActionPolicyCancel;
-    } else {
-        return [super shouldLoadNavigationAction:navigationAction];
+    if (navigationAction.navigationType == WKNavigationTypeOther) {
+        NSURL *URL = navigationAction.request.URL;
+        // martsy uses the fragment, force uses a path component
+        if ([URL.fragment isEqualToString:@"confirm-bid"] || [URL.lastPathComponent isEqualToString:@"confirm-bid"]) {
+            [self bidHasBeenConfirmed];
+            return WKNavigationActionPolicyCancel;
+        }
+        if ([URL.lastPathComponent isEqualToString:@"confirm-registration"]) {
+            [self registrationHasBeenConfirmed];
+            return WKNavigationActionPolicyCancel;
+        }
+        if ([UIDevice isPad] && [User isTrialUser]) {
+            // On Force when tapping the ‘register to bid’ button.
+            if ([URL.path isEqualToString:[NSString stringWithFormat:@"/auction-registration/%@", self.auctionID]]) {
+                [self startLoginOrSignupWithTrialContext:ARTrialContextAuctionBid];
+                return WKNavigationActionPolicyCancel;
+            }
+        }
     }
+    return [super shouldLoadNavigationAction:navigationAction];
 }
 
 // On Force you can directly bid on a work from the auction overview. If that’s the case, then insert the artwork view

--- a/Artsy/View_Controllers/Auction_Results/ARAuctionWebViewController.m
+++ b/Artsy/View_Controllers/Auction_Results/ARAuctionWebViewController.m
@@ -55,7 +55,8 @@
     for (NSString *param in [requestURL.query componentsSeparatedByString:@"&"]) {
         NSArray *pair = [param componentsSeparatedByString:@"="];
         // On Force when tapping a ‘bid’ button from an auction overview.
-        if ([pair[0] isEqualToString:@"redirect_uri"] && [pair[1] isEqualToString:self.initialURL.path]) {
+        if (pair.count == 2
+                && [pair[0] isEqualToString:@"redirect_uri"] && [pair[1] isEqualToString:self.initialURL.path]) {
             return ARTrialContextAuctionBid;
         }
     }

--- a/Artsy/View_Controllers/Web_Browsing/ARInternalMobileWebViewController.h
+++ b/Artsy/View_Controllers/Web_Browsing/ARInternalMobileWebViewController.h
@@ -1,8 +1,11 @@
 #import "ARExternalWebBrowserViewController.h"
-
+#import "ARTrialController.h"
 
 @interface ARInternalMobileWebViewController : ARExternalWebBrowserViewController <UIScrollViewDelegate>
 
 @property (nonatomic, strong) Fair *fair;
+
+- (void)startLoginOrSignupWithTrialContext:(ARTrialContext)context;
+- (ARTrialContext)trialContextForRequestURL:(NSURL *)requestURL;
 
 @end

--- a/Artsy/View_Controllers/Web_Browsing/ARInternalMobileWebViewController.m
+++ b/Artsy/View_Controllers/Web_Browsing/ARInternalMobileWebViewController.m
@@ -124,6 +124,23 @@ static void *ARProgressContext = &ARProgressContext;
     [self hideLoading];
 }
 
+- (ARTrialContext)trialContextForRequestURL:(NSURL *)requestURL;
+{
+    return ARTrialContextNotTrial;
+}
+
+- (void)startLoginOrSignup:(NSURL *)requestURL;
+{
+    [self startLoginOrSignupWithTrialContext:[self trialContextForRequestURL:requestURL]];
+}
+
+- (void)startLoginOrSignupWithTrialContext:(ARTrialContext)context;
+{
+    [ARTrialController presentTrialWithContext:context success:^(BOOL newUser) {
+        [self userDidSignUp];
+    }];
+}
+
 // Load a new internal web VC for each link we can do
 
 - (WKNavigationActionPolicy)shouldLoadNavigationAction:(WKNavigationAction *)navigationAction;
@@ -138,11 +155,8 @@ static void *ARProgressContext = &ARProgressContext;
     BOOL urlIsLoginOrSignUp = [URL.path isEqual:@"/log_in"] || [URL.path isEqual:@"/sign_up"];
     if ([ARRouter isInternalURL:URL] && (urlIsLoginOrSignUp)) {
         if ([User isTrialUser]) {
-            [ARTrialController presentTrialWithContext:ARTrialContextNotTrial success:^(BOOL newUser) {
-                [self userDidSignUp];
-            }];
+            [self startLoginOrSignup:URL];
         }
-        
         ARActionLog(@"Martsy URL: Denied - %@ - %@", URL, @(navigationAction.navigationType));
         return WKNavigationActionPolicyCancel;
     }

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,4 +1,4 @@
-### Unreleased
+### 2.3.1 (2015.10.16)
 
 * No longer encode the device’s name into the User-Agent as it might contain characters outside the allowed character set which may lead to encoding errors on the backend. - alloy
 * Reload auction webview that had not yet finished loading when the user chose to sign up/in. - orta

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -2,3 +2,4 @@
 
 * No longer encode the device’s name into the User-Agent as it might contain characters outside the allowed character set which may lead to encoding errors on the backend. - alloy
 * Reload auction webview that had not yet finished loading when the user chose to sign up/in. - orta
+* On iPad skip onboarding when signing-up when trying to bid. - alloy


### PR DESCRIPTION
Fixes #687 & #899.

Untested on iPhone as currently martsy won't load the auctions views. (See Slack.)