### PR TITLE
@alloy => Use the keychain for checking the authentication token - fixes #939

### DIFF
--- a/Artsy/App/ARAppActivityContinuationDelegate.m
+++ b/Artsy/App/ARAppActivityContinuationDelegate.m
@@ -40,9 +40,13 @@ static BOOL IsSpotlightActionTypeAvailable = NO;
     if ([[ARUserManager sharedManager] hasExistingAccount]) {
         showViewController();
     } else {
+
         // This is (hopefully) an edge-case where the user did not launch the app yet since installing it, in which case
         // we skip on-boarding and sign in as trial user.
-        [[ARUserManager sharedManager] startTrial:showViewController failure:^(NSError *error) {
+        [ArtsyAPI getXappTokenWithCompletion:^(NSString *xappToken, NSDate *expirationDate) {
+            showViewController();
+
+        } failure:^(NSError *error) {
             // Don’t leave the user with an app in a broken state, so start on-boarding after all.
             [(ARAppDelegate *)[[JSDecoupledAppDelegate sharedAppDelegate] appStateDelegate] showTrialOnboarding];
         }];

--- a/Artsy/Constants/ARDefaults.h
+++ b/Artsy/Constants/ARDefaults.h
@@ -4,7 +4,7 @@ extern NSString *const ARUseStagingDefault;
 extern NSString *const AROAuthTokenDefault;
 extern NSString *const AROAuthTokenExpiryDateDefault;
 
-extern NSString *const ARXAppTokenDefault;
+extern NSString *const ARXAppTokenKeychainKey;
 extern NSString *const ARXAppTokenExpiryDateDefault;
 
 #pragma mark -

--- a/Artsy/Constants/ARDefaults.m
+++ b/Artsy/Constants/ARDefaults.m
@@ -9,7 +9,9 @@ NSString *const ARUseStagingDefault = @"ARUseStagingDefault";
 NSString *const AROAuthTokenDefault = @"AROAuthToken";
 NSString *const AROAuthTokenExpiryDateDefault = @"AROAuthTokenExpiryDate";
 
-NSString *const ARXAppTokenDefault = @"ARXAppTokenDefault";
+// Yes, there's inconsitency here. We migrated this to keychain, but wanted
+// to keep backwards compatability.
+NSString *const ARXAppTokenKeychainKey = @"ARXAppTokenDefault";
 NSString *const ARXAppTokenExpiryDateDefault = @"ARXAppTokenExpiryDateDefault";
 
 NSString *const AROnboardingSkipPersonalizeDefault = @"eigen-onboard-skip-personalize";

--- a/Artsy/Networking/API_Modules/ARUserManager.h
+++ b/Artsy/Networking/API_Modules/ARUserManager.h
@@ -31,8 +31,6 @@ extern NSString *const ARUserSessionStartedNotification;
 - (void)disableSharedWebCredentials;
 - (void)tryLoginWithSharedWebCredentials:(void (^)(NSError *error))completion;
 
-- (void)startTrial:(void (^)())callback failure:(void (^)(NSError *error))failure;
-
 - (void)loginWithUsername:(NSString *)username
                  password:(NSString *)password
    successWithCredentials:(void (^)(NSString *accessToken, NSDate *expirationDate))credentials

--- a/Artsy/Networking/API_Modules/ARUserManager.m
+++ b/Artsy/Networking/API_Modules/ARUserManager.m
@@ -12,6 +12,7 @@
 #import "ARCollectorStatusViewController.h"
 #import "ARKeychainable.h"
 #import "AFHTTPRequestOperation+JSON.h"
+#import <UICKeychainStore/UICKeychainStore.h>
 
 NSString *const ARUserSessionStartedNotification = @"ARUserSessionStarted";
 
@@ -121,7 +122,7 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
 
 - (BOOL)hasValidXAppToken
 {
-    NSString *xapp = [[NSUserDefaults standardUserDefaults] objectForKey:ARXAppTokenDefault];
+    NSString *xapp = [UICKeyChainStore stringForKey:ARXAppTokenKeychainKey];
     NSDate *expiryDate = [[NSUserDefaults standardUserDefaults] objectForKey:ARXAppTokenExpiryDateDefault];
 
     BOOL tokenValid = expiryDate && [[[ARSystemTime date] GMTDate] earlierDate:expiryDate] != expiryDate;
@@ -140,7 +141,7 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     [defaults setObject:expiryDate forKey:AROAuthTokenExpiryDateDefault];
 
-    [defaults removeObjectForKey:ARXAppTokenDefault];
+    [defaults removeObjectForKey:ARXAppTokenKeychainKey];
     [defaults removeObjectForKey:ARXAppTokenExpiryDateDefault];
     [defaults synchronize];
 }
@@ -355,7 +356,7 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
     [self.keychain removeKeychainStringForKey:AROAuthTokenDefault];
 
     [ArtsyAPI getXappTokenWithCompletion:^(NSString *xappToken, NSDate *expirationDate) {
-        [[NSUserDefaults standardUserDefaults] setObject:xappToken forKey:ARXAppTokenDefault];
+        [[NSUserDefaults standardUserDefaults] setObject:xappToken forKey:ARXAppTokenKeychainKey];
         [[NSUserDefaults standardUserDefaults] setObject:expirationDate forKey:ARXAppTokenExpiryDateDefault];
         [[NSUserDefaults standardUserDefaults] synchronize];
         callback();
@@ -554,7 +555,7 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
     [ARDefaults resetDefaults];
 
     [manager.keychain removeKeychainStringForKey:AROAuthTokenDefault];
-    [manager.keychain removeKeychainStringForKey:ARXAppTokenDefault];
+    [manager.keychain removeKeychainStringForKey:ARXAppTokenKeychainKey];
 
     [manager deleteHTTPCookies];
     [ARRouter setAuthToken:nil];

--- a/Artsy/Networking/API_Modules/ARUserManager.m
+++ b/Artsy/Networking/API_Modules/ARUserManager.m
@@ -136,12 +136,11 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
 
 - (void)saveUserOAuthToken:(NSString *)token expiryDate:(NSDate *)expiryDate
 {
-    [self.keychain setKeychainStringForKey:AROAuthTokenDefault value:token];
-
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    [self.keychain setKeychainStringForKey:AROAuthTokenDefault value:token];
     [defaults setObject:expiryDate forKey:AROAuthTokenExpiryDateDefault];
 
-    [defaults removeObjectForKey:ARXAppTokenKeychainKey];
+    [self.keychain removeKeychainStringForKey:ARXAppTokenKeychainKey];
     [defaults removeObjectForKey:ARXAppTokenExpiryDateDefault];
     [defaults synchronize];
 }
@@ -349,18 +348,6 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
         }];
 
     [op start];
-}
-
-- (void)startTrial:(void (^)())callback failure:(void (^)(NSError *error))failure
-{
-    [self.keychain removeKeychainStringForKey:AROAuthTokenDefault];
-
-    [ArtsyAPI getXappTokenWithCompletion:^(NSString *xappToken, NSDate *expirationDate) {
-        [[NSUserDefaults standardUserDefaults] setObject:xappToken forKey:ARXAppTokenKeychainKey];
-        [[NSUserDefaults standardUserDefaults] setObject:expirationDate forKey:ARXAppTokenExpiryDateDefault];
-        [[NSUserDefaults standardUserDefaults] synchronize];
-        callback();
-    } failure:failure];
 }
 
 - (void)createUserWithName:(NSString *)name

--- a/Artsy/Networking/API_Modules/ArtsyAPI+Private.h
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+Private.h
@@ -21,7 +21,5 @@
 /// Performs a series of requests then runs the success block
 + (void)getRequests:(NSArray *)requests success:(void (^)(NSArray *operations))completed;
 
-+ (void)getXappTokenWithCompletion:(void (^)(NSString *xappToken, NSDate *expirationDate))callback;
-+ (void)getXappTokenWithCompletion:(void (^)(NSString *xappToken, NSDate *expirationDate))callback failure:(void (^)(NSError *error))failure;
 + (void)handleXappTokenError:(NSError *)error;
 @end

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -68,7 +68,7 @@ static NSSet *artsyHosts = nil;
     // Ensure the keychain is empty incase you've uninstalled and cleared user data
     if (![[ARUserManager sharedManager] hasExistingAccount]) {
         [UICKeyChainStore removeItemForKey:AROAuthTokenDefault];
-        [UICKeyChainStore removeItemForKey:ARXAppTokenDefault];
+        [UICKeyChainStore removeItemForKey:ARXAppTokenKeychainKey];
     }
 
     NSString *token = [UICKeyChainStore stringForKey:AROAuthTokenDefault];
@@ -78,7 +78,7 @@ static NSSet *artsyHosts = nil;
 
     } else {
         ARActionLog(@"Found trial XApp token in keychain");
-        NSString *xapp = [UICKeyChainStore stringForKey:ARXAppTokenDefault];
+        NSString *xapp = [UICKeyChainStore stringForKey:ARXAppTokenKeychainKey];
         [ARRouter setXappToken:xapp];
     }
 }

--- a/Artsy/Networking/ArtsyAPI.h
+++ b/Artsy/Networking/ArtsyAPI.h
@@ -2,6 +2,13 @@
 
 
 @interface ArtsyAPI : NSObject
+
+/// Gets a temporary Xapp token asyncronously, or if the user has one will run syncronously
++ (void)getXappTokenWithCompletion:(void (^)(NSString *xappToken, NSDate *expirationDate))callback;
+
+/// Gets a temporary Xapp token asyncronously, or if the user has one will run syncronously
++ (void)getXappTokenWithCompletion:(void (^)(NSString *xappToken, NSDate *expirationDate))callback failure:(void (^)(NSError *error))failure;
+
 @end
 
 #import "ArtsyAPI+Artworks.h"

--- a/Artsy/Networking/ArtsyAPI.m
+++ b/Artsy/Networking/ArtsyAPI.m
@@ -165,8 +165,6 @@
 
     }
     failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON) {
-        [UICKeyChainStore removeItemForKey:ARXAppTokenKeychainKey];
-        [ARRouter setXappToken:nil];
 
         //TODO: handle this less stupid
         ARErrorLog(@"Couldn't get an Xapp token.");

--- a/Artsy/Networking/ArtsyAPI.m
+++ b/Artsy/Networking/ArtsyAPI.m
@@ -83,7 +83,7 @@
         
         if ([recoverySuggestion[@"error"] isEqualToString:@"Unauthorized"] && [recoverySuggestion[@"text"] isEqualToString:@"The XAPP token is invalid or has expired."]) {
             ARActionLog(@"Resetting XAPP token after error: %@", error.localizedDescription);
-            [UICKeyChainStore removeItemForKey:ARXAppTokenDefault];
+            [UICKeyChainStore removeItemForKey:ARXAppTokenKeychainKey];
             [ARRouter setXappToken:nil];
         }
     }
@@ -127,7 +127,7 @@
     // Check if we already have a token for xapp or oauth and run the block
 
     NSDate *date = [[NSUserDefaults standardUserDefaults] objectForKey:ARXAppTokenExpiryDateDefault];
-    NSString *xappToken = [UICKeyChainStore stringForKey:ARXAppTokenDefault];
+    NSString *xappToken = [UICKeyChainStore stringForKey:ARXAppTokenKeychainKey];
     NSString *oauthToken = [UICKeyChainStore stringForKey:AROAuthTokenDefault];
 
     if (date && (xappToken || oauthToken)) {
@@ -146,7 +146,7 @@
         ISO8601DateFormatter *dateFormatter = [[ISO8601DateFormatter alloc] init];
         NSDate *expiryDate = [dateFormatter dateFromString:date];
 
-        NSString *oldxToken = [UICKeyChainStore stringForKey:ARXAppTokenDefault];
+        NSString *oldxToken = [UICKeyChainStore stringForKey:ARXAppTokenKeychainKey];
         if (oldxToken) {
             if (callback) {
                 callback(token, expiryDate);
@@ -155,7 +155,7 @@
         }
 
         [ARRouter setXappToken:token];
-        [UICKeyChainStore setString:token forKey:ARXAppTokenDefault];
+        [UICKeyChainStore setString:token forKey:ARXAppTokenKeychainKey];
         [[NSUserDefaults standardUserDefaults] setObject:expiryDate forKey:ARXAppTokenExpiryDateDefault];
         [[NSUserDefaults standardUserDefaults] synchronize];
 
@@ -165,6 +165,8 @@
 
     }
     failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON) {
+        [UICKeyChainStore removeItemForKey:ARXAppTokenKeychainKey];
+        [ARRouter setXappToken:nil];
 
         //TODO: handle this less stupid
         ARErrorLog(@"Couldn't get an Xapp token.");

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/2_-_Calls_to_Action/ARSignUpSplashViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/2_-_Calls_to_Action/ARSignUpSplashViewController.m
@@ -3,6 +3,7 @@
 #import "ARCrossfadingImageView.h"
 #import "ARUserManager.h"
 #import "UIView+HitTestExpansion.h"
+#import "ArtsyAPI+Private.h"
 
 #import <UIAlertView+Blocks/UIAlertView+Blocks.h>
 
@@ -280,11 +281,11 @@
 {
     [self setFormEnabled:NO animated:YES];
 
-    [ARTrialController startTrialWithCompletion:^{
+    [ArtsyAPI getXappTokenWithCompletion:^(NSString *xappToken, NSDate *expirationDate) {
         // Load normal app
         [self.delegate dismissOnboardingWithVoidAnimation:YES];
-    }
-        failure:^(NSError *error) {
+
+    } failure:^(NSError *error) {
         [UIAlertView showWithTitle:@"Couldn’t Reach Artsy"
                            message:error.localizedDescription
                  cancelButtonTitle:@"Retry"
@@ -292,7 +293,7 @@
                           tapBlock:^(UIAlertView *alertView, NSInteger buttonIndex) {
                               [self performSelector:@selector(enableForm) withObject:nil];
                           }];
-        }];
+    }];
 }
 
 - (void)enableForm

--- a/Artsy/View_Controllers/Util/ARTrialController.h
+++ b/Artsy/View_Controllers/Util/ARTrialController.h
@@ -20,9 +20,6 @@ typedef NS_ENUM(NSInteger, ARTrialContext) {
 /// Shows the sign up, with optional completion block to be triggered after signup or login.
 + (void)presentTrialWithContext:(enum ARTrialContext)context success:(void (^)(BOOL newUser))success;
 
-/// Get the guest authentication token and run the completion block
-+ (void)startTrialWithCompletion:(void (^)(void))completion failure:(void (^)(NSError *error))failure;
-
 /// No-op if you didn't have a trial account before signing up
 /// otherwise will run the "favorite" artwork or whatever started the splash
 

--- a/Artsy/View_Controllers/Util/ARTrialController.m
+++ b/Artsy/View_Controllers/Util/ARTrialController.m
@@ -112,11 +112,6 @@ static ARTrialController *instance;
     }
 }
 
-+ (void)startTrialWithCompletion:(void (^)(void))completion failure:(void (^)(NSError *error))failure
-{
-    [[ARUserManager sharedManager] startTrial:completion failure:failure];
-}
-
 + (void)extendTrial
 {
     [instance extendTrial];

--- a/Artsy_Tests/Networking_Tests/API_Modules/ARUserManagerTests.m
+++ b/Artsy_Tests/Networking_Tests/API_Modules/ARUserManagerTests.m
@@ -256,7 +256,7 @@ describe(@"startTrial", ^{
     });
 
     it(@"sets an xapp token", ^{
-        NSString *xapp = [[NSUserDefaults standardUserDefaults] objectForKey:ARXAppTokenDefault];
+        NSString *xapp = [[NSUserDefaults standardUserDefaults] objectForKey:ARXAppTokenKeychainKey];
         expect([ARUserManager stubXappToken]).to.equal(xapp);
     });
 

--- a/Artsy_Tests/Networking_Tests/API_Modules/ARUserManagerTests.m
+++ b/Artsy_Tests/Networking_Tests/API_Modules/ARUserManagerTests.m
@@ -244,33 +244,6 @@ describe(@"clearUserData", ^{
     });
 });
 
-describe(@"startTrial", ^{
-    beforeEach(^{
-        [ARUserManager stubXappToken:[ARUserManager stubXappToken] expiresIn:[ARUserManager stubXappTokenExpiresIn]];
-
-        [[ARUserManager sharedManager] startTrial:^{
-
-        } failure:^(NSError *error) {
-            failure(@"startTrial should not fail");
-        }];
-    });
-
-    it(@"sets an xapp token", ^{
-        NSString *xapp = [[NSUserDefaults standardUserDefaults] objectForKey:ARXAppTokenKeychainKey];
-        expect([ARUserManager stubXappToken]).to.equal(xapp);
-    });
-
-    // Right now the Xapp call in tests is a stub that just returns a string straight away
-    // so it doesn't set an expiry date
-
-    pending(@"sets expiry date", ^{
-        ISO8601DateFormatter *dateFormatter = [[ISO8601DateFormatter alloc] init];
-        NSDate *expiryDate = [dateFormatter dateFromString:[ARUserManager stubXappTokenExpiresIn]];
-
-        expect([expiryDate isEqualToDate:[[NSUserDefaults standardUserDefaults] objectForKey:ARXAppTokenExpiryDateDefault]]).to.beTruthy();
-    });
-});
-
 describe(@"createUserWithName", ^{
     beforeEach(^{
         [ARUserManager stubXappToken:[ARUserManager stubXappToken] expiresIn:[ARUserManager stubXappTokenExpiresIn]];

--- a/Artsy_Tests/Networking_Tests/API_Modules/ArtsyAPI+PrivateTests.m
+++ b/Artsy_Tests/Networking_Tests/API_Modules/ArtsyAPI+PrivateTests.m
@@ -17,14 +17,14 @@ it(@"is always ArtsyOHHTTPAPI in tests", ^{
 describe(@"handleXappTokenError", ^{
 
     it(@"doesn't reset XAPP token on non-401 errors", ^{
-        [UICKeyChainStore setString:@"xapp token" forKey:ARXAppTokenDefault];
+        [UICKeyChainStore setString:@"xapp token" forKey:ARXAppTokenKeychainKey];
         NSError *error = [[NSError alloc] initWithDomain:NSURLErrorDomain code:302 userInfo:@{}];
         [ArtsyAPI handleXappTokenError:error];
-        expect([UICKeyChainStore stringForKey:ARXAppTokenDefault]).to.equal(@"xapp token");
+        expect([UICKeyChainStore stringForKey:ARXAppTokenKeychainKey]).to.equal(@"xapp token");
     });
 
     it(@"resets XAPP token on error", ^{
-        [UICKeyChainStore setString:@"value" forKey:ARXAppTokenDefault];
+        [UICKeyChainStore setString:@"value" forKey:ARXAppTokenKeychainKey];
         id mock = [OCMockObject mockForClass:[ARRouter class]];
         [[mock expect] setXappToken:nil];
 
@@ -37,7 +37,7 @@ describe(@"handleXappTokenError", ^{
         [ArtsyAPI handleXappTokenError:error];
         [mock verify];
         [mock stopMocking];
-        expect([UICKeyChainStore stringForKey:ARXAppTokenDefault]).to.beNil();
+        expect([UICKeyChainStore stringForKey:ARXAppTokenKeychainKey]).to.beNil();
     });
 });
 

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -4,3 +4,4 @@
 
 
 * Layout fixes for the Auction Results for an Artwork - orta
+* Potential fix for seeing no API requests get through - orta


### PR DESCRIPTION
I've renamed the key to make it more obvious what should be happening, ideally though we should be moving to our ArtsyAuthentication lib for this kind of stuff.