### PR TITLE
Set the header's size to fit to be CGSizeZero

### DIFF
--- a/Artsy/View_Controllers/Feed_VCs/ARSimpleShowFeedViewController.m
+++ b/Artsy/View_Controllers/Feed_VCs/ARSimpleShowFeedViewController.m
@@ -134,7 +134,7 @@ static NSString *ARShowCellIdentifier = @"ARShowCellIdentifier";
 
     [stack updateConstraints];
     wrapper.frame = (CGRect){
-        .size = [stack systemLayoutSizeFittingSize:self.view.bounds.size],
+        .size = [stack systemLayoutSizeFittingSize:CGSizeZero],
         .origin = CGPointZero};
 
     stack.frame = wrapper.bounds;

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.3.3
+
+* Fixes extra whitespace when we have no feed links on the show feed - orta
+
 ### 2.3.2 (2015.12.01)
 
 * Allow touch events to pass through shows feed to hero units. - alloy
@@ -14,4 +18,3 @@
 * Total Re-write for the show feed - orta
 * Adds local downloading of the shows feed for instant loading on the next run - orta
 * Fix crash due to `nil` in analytics data. - alloy
-


### PR DESCRIPTION
Fixes #965 

When there was no size context for the ShowFeeds's header stackview's height, it would default to the one provided by `systemLayoutSizeFittingSize` which is a full screen. Defaulting to 0,0 makes it fit to the smallest possible value.