### PR TITLE
Don't wait three seconds between re-tries for failed networking

### DIFF
--- a/Artsy/View_Controllers/Feed_VCs/ARSimpleShowFeedViewController.m
+++ b/Artsy/View_Controllers/Feed_VCs/ARSimpleShowFeedViewController.m
@@ -154,8 +154,9 @@ static NSString *ARShowCellIdentifier = @"ARShowCellIdentifier";
 
 - (void)refreshFeedItems
 {
+    // This will get overwritten on event next refresh, so no need to cancel
     [ARAnalytics startTimingEvent:ARAnalyticsInitialFeedLoadTime];
-    __weak typeof (self) wself = self;
+    __weak typeof(self) wself = self;
 
     [ArtsyAPI getXappTokenWithCompletion:^(NSString *xappToken, NSDate *expirationDate) {
         [self.feedTimeline getNewItems:^(NSArray *items) {
@@ -180,10 +181,10 @@ static NSString *ARShowCellIdentifier = @"ARShowCellIdentifier";
             [sself.networkStatus.offlineView refreshFailed];
             [sself.networkStatus showOfflineViewIfNeeded];
             
-            [sself performSelector:@selector(refreshFeedItems) withObject:nil afterDelay:3];
+            [sself performSelector:@selector(refreshFeedItems) withObject:nil afterDelay:1];
             [ARAnalytics finishTimingEvent:ARAnalyticsInitialFeedLoadTime];
         }];
-        
+
     } failure:^(NSError *error) {
         [self.networkStatus.offlineView refreshFailed];
     }];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-### 2.3.3
-
-* [dev] Converted all `@weakify`/`@strongify` to use `sself` and `wself` instead. - orta
-* If a user changes their password on the web, provide a log out button on the feed - orta
 
 ### 2.3.2
 

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -1,20 +1,7 @@
 ### 2.3.3
 
 * Fixes extra whitespace when we have no feed links on the show feed - orta
-
-### 2.3.2 (2015.12.01)
-
-* Allow touch events to pass through shows feed to hero units. - alloy
-
-### 2.3.2 (2015.11.30)
-
-* Don’t scroll hero units on shows feed. - alloy
-
-### 2.3.2 (2015.11.20)
-
-* Caches website content from martsy/force, vastly speeding up hybrid pages - orta
-* Layout fixes for the Auction Results for an Artwork - orta
-* Potential fix for seeing no API requests get through - orta
-* Total Re-write for the show feed - orta
-* Adds local downloading of the shows feed for instant loading on the next run - orta
-* Fix crash due to `nil` in analytics data. - alloy
+*  Converted all `@weakify`/`@strongify` to use `sself` and `wself` instead. - orta
+* Reduced the time for networking retries on the show feed - orta
+* Hidden the inquire button for inquirable artworks which are not for sale - orta
+* If a user changes their password on the web, provide a log out button on the feed - orta


### PR DESCRIPTION
Decreases the time before attempting another reconnect, if they're failing then they're probably taking less than a second to show, plus who waits for 3 seconds for anything nowadays?