### PR TITLE
Cleanup the changelog + Remove hockey from deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ Artsy.xcodeproj/project.xcworkspace/xcshareddata/
 vendor/
 Artsy.app.dSYM.zip
 Artsy.ipa
-CHANGELOG_SHORT.md
 fastlane/report.xml
 fastlane/Preview.html
 

--- a/Artsy.xcodeproj/xcshareddata/xcschemes/Artsy.xcscheme
+++ b/Artsy.xcodeproj/xcshareddata/xcschemes/Artsy.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0700"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
@@ -143,23 +143,5 @@
    <ArchiveAction
       buildConfiguration = "Store"
       revealArchiveInOrganizer = "YES">
-      <PostActions>
-         <ExecutionAction
-            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
-            <ActionContent
-               title = "Run Script"
-               scriptText = "open -a HockeyApp &quot;${ARCHIVE_PATH}&quot;">
-               <EnvironmentBuildable>
-                  <BuildableReference
-                     BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "49BA7DFE1655ABE600C06572"
-                     BuildableName = "Artsy.app"
-                     BlueprintName = "Artsy"
-                     ReferencedContainer = "container:Artsy.xcodeproj">
-                  </BuildableReference>
-               </EnvironmentBuildable>
-            </ActionContent>
-         </ExecutionAction>
-      </PostActions>
    </ArchiveAction>
 </Scheme>

--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,7 @@ ipa: set_git_properties change_version_to_date
 	bundle exec gym
 
 distribute:
-	./config/generate_changelog_short.rb
-	bundle exec pilot upload -i build/Artsy.ipa --changelog "$(shell cat CHANGELOG_SHORT.md)"
+	bundle exec pilot upload -i build/Artsy.ipa --changelog "$(shell ./config/generate_changelog_short.rb)"
 
 ### General Xcode tooling
 

--- a/config/generate_changelog_short.rb
+++ b/config/generate_changelog_short.rb
@@ -7,4 +7,4 @@ mini_readme = readme.split("\n## ")[0..1].join("\n## ")
 generated_changelog = beta_readme + "\n\n-------\n" + mini_readme
 # Don't want to break the shell command passing this into pilot
 generated_changelog = generated_changelog.gsub('"', "'").gsub('`', "'")
-File.open("CHANGELOG_SHORT.md", 'w') { |f| f.write(generated_changelog) }
+puts generated_changelog


### PR DESCRIPTION
Removes the side-effect of creating the changelog_short by capturing `puts` directly from ruby.
Removes the scheme actin that was opening hockey when it doesn't need it.