### PR TITLE
@alloy => Add support for not raising when downloading the feed from the background

### DIFF
--- a/Artsy/App/ARAppBackgroundFetchDelegate.m
+++ b/Artsy/App/ARAppBackgroundFetchDelegate.m
@@ -34,6 +34,11 @@
 
         NSURLSession *session = [NSURLSession sharedSession];
         NSURLSessionDataTask *task = [session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+            if (!data) {
+                completionHandler(UIBackgroundFetchResultFailed);
+                return;
+            }
+
             id JSON = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:nil];
             if ([JSON isKindOfClass:NSDictionary.class]) {
 

--- a/docs/BETA_CHANGELOG.md
+++ b/docs/BETA_CHANGELOG.md
@@ -3,3 +3,4 @@
 * Converted our routing engine to only handle the creation of view controllers and not showing them - orta
 * Removed the settings view controller that isn't used - orta
 * Removed the direct dependency on `libextobjc` from the app :tada: - orta
+* Background data isn't parsed to JSON if we don't recieve a response - orta


### PR DESCRIPTION
So this is the crasher. Closes #968

Looking into ideas about what would happen if the app was first launched in the background for the odd state.