### PR TITLE
Use size classes instead of isPad now that we're post iOS7

### DIFF
--- a/Artsy/Resources/Artsy-Bridging-Header.h
+++ b/Artsy/Resources/Artsy-Bridging-Header.h
@@ -7,7 +7,6 @@
 
 #import "ARScrollNavigationChief.h"
 #import "ARWhitespaceGobbler.h"
-#import "UIDevice-Hardware.h"
 #import "ARCountdownView.h"
 
 // Models. Importing Models.h is a no-go, since each header implicitly relies on a bunch of stuff imported from the PCH.

--- a/Artsy/Resources/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Artsy/Resources/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -65,6 +65,11 @@
       "idiom" : "ipad",
       "filename" : "Icon-76@2x.png",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/Artsy/Views/Auction/AuctionBannerView.swift
+++ b/Artsy/Views/Auction/AuctionBannerView.swift
@@ -52,7 +52,7 @@ extension AuctionBannerView {
         logoImageView.constrainHeight("70")
 
         // Device-specific layout for logo & countdown views.
-        if UIDevice.isPad() {
+        if traitCollection.horizontalSizeClass == .Regular {
             // Bottom lefthand corner with 40pt margin.
             logoImageView.alignLeadingEdgeWithView(self, predicate: "40")
             logoImageView.alignBottomEdgeWithView(self, predicate: "-40")


### PR DESCRIPTION
In terms of trying to keep the seams smaller between swift/objc - we can remove the isPad check with a size class check. This makes life much easier if we ever decide to do real work surrounding the split screen stuff that we do support already.