### PR TITLE
Show messages about failing inquiries if you're an admin

### DIFF
--- a/Artsy_Tests/View_Controller_Tests/Contact/ARInquireForArtworkViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Contact/ARInquireForArtworkViewControllerTests.m
@@ -4,11 +4,14 @@
 
 @interface ARInquireForArtworkViewController (Testing)
 
+@property (nonatomic, strong) User *user;
+
 @property (nonatomic, strong, readonly) UITextField *emailInput;
 @property (nonatomic, strong, readonly) UITextField *nameInput;
 
 @property (nonatomic, strong, readonly) UILabel *messageTitleLabel;
 @property (nonatomic, strong, readonly) UILabel *messageBodyLabel;
+@property (nonatomic, strong, readonly) UILabel *userSignature;
 
 @property (nonatomic, strong, readonly) UIButton *failureDismissButton;
 @property (nonatomic, strong, readonly) UIButton *failureTryAgainButton;
@@ -86,6 +89,15 @@ describe(@"logged in", ^{
         ARInquireForArtworkViewController *vc = [[ARInquireForArtworkViewController alloc] initWithAdminInquiryForArtwork:museumGallery fair:nil];
         [vc ar_presentWithFrame:[[UIScreen mainScreen] bounds]];
         return vc;
+    });
+});
+
+describe(@"as an admin", ^{
+    it(@"shows a warning in the user signature about failing", ^{
+        ARInquireForArtworkViewController *vc = [[ARInquireForArtworkViewController alloc] initWithPartnerInquiryForArtwork:museumGallery fair:nil];
+        vc.user = [User modelWithJSON:@{ @"email" : @"orta@artsymail.net" }];
+        [vc ar_presentWithFrame:[[UIScreen mainScreen] bounds]];
+        expect(vc.userSignature.text).to.contain(@"will fail");
     });
 });
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,6 +3,7 @@ upcoming:
   notes:
     - Added Dangerfile to the repo - orta
     - Send dsym to hockey - orta
+    - Users with Artsy emails get a warning that their inquiry may fail - orta
     - Converted CHANGELOG to yaml - orta
     - New (native) auction banner view - ash
 


### PR DESCRIPTION
You're an admin, you go test a bug report. Ten minutes later you find yourself seeing this JSON: 

```
Printing description of JSON:
{
    detail =     {
        inquirer =         (
            "cannot be an admin"
        );
    };
    message = "Inquirer cannot be an admin.";
    type = "param_error";
}
```

This changes the name section on an inquiry to let you know it will fail if you are using an artsy email address as a user.