### PR TITLE
Support iOS again, and support gracefully deprecating the platform when we choose 

### DIFF
--- a/Artsy/App/ARAppDelegate.m
+++ b/Artsy/App/ARAppDelegate.m
@@ -156,6 +156,7 @@ static ARAppDelegate *_sharedInstance = nil;
 
     [ARWebViewCacheHost startup];
     [self registerNewSessionOpened];
+    [self checkForiOS8Deprecation];
 }
 
 - (void)registerNewSessionOpened
@@ -388,6 +389,36 @@ static ARAppDelegate *_sharedInstance = nil;
 
     [[NSUserDefaults standardUserDefaults] setInteger:numberOfRuns forKey:ARAnalyticsAppUsageCountProperty];
     [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
+- (void)checkForiOS8Deprecation
+
+{
+    // To totally deprecate all iOS8 devices
+    // set the "iOS8 Redirection URL" featured link's HREF to something like /404/ios8
+    // https://admin.artsy.net/set/54e4aab97261692d085a1c00
+
+    // This was added in iOS9
+    if (&UIApplicationOpenURLOptionsAnnotationKey != NULL) {
+        return;
+    }
+
+    [ArtsyAPI getOrderedSetWithKey:@"eigen-ios-deprecation-featured-links" success:^(OrderedSet *set) {
+        [set getItems:^(NSArray *items) {
+            FeaturedLink *link = [items detect:^BOOL(FeaturedLink *link) {
+                return [link.title isEqualToString:@"iOS8 Redirection URL"];
+            }];
+
+            // By default it be 0 length
+            if (link.href.length) {
+                UINavigationController *navigationController = ARTopMenuViewController.sharedController.rootNavigationController;
+                NSURL *url = [NSURL URLWithString:link.href relativeToURL:[ARRouter baseWebURL]];
+                UIViewController *martsyWarning = [[AREndOfLineInternalMobileWebViewController alloc] initWithURL:url];
+                [navigationController setViewControllers:@[martsyWarning] animated:NO];
+            }
+
+        }];
+    } failure:nil];
 }
 
 @end

--- a/Artsy/Tooling/ARWebViewCacheHost.m
+++ b/Artsy/Tooling/ARWebViewCacheHost.m
@@ -60,7 +60,10 @@
 - (WKWebView *)spawnWebview
 {
     WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
-    config.requiresUserActionForMediaPlayback = NO;
+    // iOS9 only
+    if ([config respondsToSelector:@selector(setRequiresUserActionForMediaPlayback:)]) {
+        config.requiresUserActionForMediaPlayback = NO;
+    }
     config.processPool = [ARWebViewCacheHost sharedInstance].processPool;
 
     CGRect deviceBounds = [UIScreen mainScreen].bounds;

--- a/Artsy/Tooling/ARWebViewCacheHost.m
+++ b/Artsy/Tooling/ARWebViewCacheHost.m
@@ -60,7 +60,7 @@
 - (WKWebView *)spawnWebview
 {
     WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
-    // iOS9 only
+    // iOS8 doesn't support this
     if ([config respondsToSelector:@selector(setRequiresUserActionForMediaPlayback:)]) {
         config.requiresUserActionForMediaPlayback = NO;
     }

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
     - Added Dangerfile to the repo, updated to 0.2.1 - orta
     - Added Dangerfile to the repo - orta
     - Add support for iOS9 facebook - orta
+    - Support deprecating iOS8 - orta
     - Send dsym to hockey - orta
     - Converted CHANGELOG to yaml - orta
     - Remove x-callback support now that it's part of the OS - orta


### PR DESCRIPTION
fixes #1048 
fixes #1047 

Adds the same support we added for iOS7 back in #198 