### PR TITLE
[Push Notification] Fix blank view issue with ‘works for you’.

### DIFF
--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -45,9 +45,9 @@ static const CGFloat ARMenuButtonDimension = 46;
     [super viewDidLoad];
 
     self.view.backgroundColor = [UIColor blackColor];
-    _selectedTabIndex = -1;
+    self.selectedTabIndex = -1;
 
-    _navigationDataSource = _navigationDataSource ?: [[ARTopMenuNavigationDataSource alloc] init];
+    self.navigationDataSource = _navigationDataSource ?: [[ARTopMenuNavigationDataSource alloc] init];
 
     // TODO: Turn into custom view?
 
@@ -151,8 +151,7 @@ static const CGFloat ARMenuButtonDimension = 46;
 
     for (NSNumber *tabIndex in menuToPaths.keyEnumerator) {
         [switchboard registerPathCallbackAtPath:menuToPaths[tabIndex] callback:^id _Nullable(NSDictionary *_Nullable parameters) {
-            [self.tabContentView setCurrentViewIndex:tabIndex.integerValue animated:NO];
-            return self.rootNavigationController.topViewController;
+            return [self rootNavigationControllerAtIndex:tabIndex.integerValue].rootViewController;
         }];
     }
 }
@@ -329,7 +328,7 @@ static const CGFloat ARMenuButtonDimension = 46;
     NSAssert(viewController != nil, @"Attempt to push a nil view controller.");
     NSInteger index = [self indexOfRootViewController:viewController];
     if (index != NSNotFound) {
-        [self presentRootViewControllerAtIndex:index animated:animated];
+        [self presentRootViewControllerAtIndex:index animated:(animated && index != self.selectedTabIndex)];
     } else {
         [self.rootNavigationController pushViewController:viewController animated:animated];
     }
@@ -379,7 +378,7 @@ static const CGFloat ARMenuButtonDimension = 46;
 
 - (void)tabContentView:(ARTabContentView *)tabContentView didChangeSelectedIndex:(NSInteger)index
 {
-    _selectedTabIndex = index;
+    self.selectedTabIndex = index;
 }
 
 - (BOOL)tabContentView:(ARTabContentView *)tabContentView shouldChangeToIndex:(NSInteger)index
@@ -398,7 +397,7 @@ static const CGFloat ARMenuButtonDimension = 46;
         return NO;
     }
 
-    if (index == _selectedTabIndex) {
+    if (index == self.selectedTabIndex) {
         ARNavigationController *controller = (id)[tabContentView currentNavigationController];
 
         if (controller.viewControllers.count == 1) {

--- a/Artsy_Tests/View_Controller_Tests/App_Menu/ARTopMenuViewControllerSpec.m
+++ b/Artsy_Tests/View_Controller_Tests/App_Menu/ARTopMenuViewControllerSpec.m
@@ -10,6 +10,7 @@
 #import "ARBrowseViewController.h"
 #import <JSBadgeView/JSBadgeView.h>
 #import "ARSwitchBoard.h"
+#import "ARFavoritesViewController.h"
 
 
 @interface ARTopMenuNavigationDataSource (Test)
@@ -252,12 +253,11 @@ describe(@"navigation", ^{
             ARSwitchBoard *switchboard = [ARSwitchBoard sharedInstance];
             for (NSNumber *tabIndex in menuToPaths.keyEnumerator) {
                 id viewcontroller = [switchboard loadPath:menuToPaths[tabIndex]];
-                expect(viewcontroller).to.beTruthy();
-                NSLog(@"VC: %@ %@", tabIndex, viewcontroller);
-                if (tabIndex.integerValue != [ARTopMenuViewController sharedController].selectedTabIndex) {
-
+                if (tabIndex.integerValue == ARTopTabControllerIndexFavorites) {
+                    expect(viewcontroller).to.beAKindOf(ARFavoritesViewController.class);
+                } else {
+                    expect(viewcontroller).to.equal([[ARTopMenuViewController sharedController] rootNavigationControllerAtIndex:tabIndex.integerValue].rootViewController);
                 }
-                expect([ARTopMenuViewController sharedController].selectedTabIndex).to.equal(tabIndex.integerValue);
             }
         });
     });

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,5 +1,5 @@
 upcoming:
-  version: 2.5.0
+  version: 2.4.0
   notes:
     - Added Dangerfile to the repo, updated to 0.2.1 - orta
     - Added Dangerfile to the repo - orta
@@ -11,6 +11,7 @@ upcoming:
     - Remove x-callback support now that it's part of the OS - orta
     - New (native) auction banner view - ash
     - Use artworks/filter for the genes artworks - orta
+    - Fixes issue opening ‘works for you’ from a push notification - alloy
 
 releases:
 - version: 2.3.3


### PR DESCRIPTION
The previous code was presenting the top menu VC during routing, whereas it should’ve only returned it. This was leading to a blank web view being shown when tapping a “works for you” push notification.

Why the blank web view is being shown I’m not certain of, but as the initial cause for it being shown is faulty logic, I didn’t spend more time chasing that.