### PR TITLE
[iPad] Fix crash when presenting an alert regarding external URL.

### DIFF
--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -202,7 +202,7 @@
     messsage = [messsage stringByReplacingOccurrencesOfString:@"https://" withString:@""];
 
     ARTopMenuViewController *presentationVC = [ARTopMenuViewController sharedController];
-    UIAlertController *controller = [UIAlertController alertControllerWithTitle:title message:messsage preferredStyle:UIAlertControllerStyleActionSheet];
+    UIAlertController *controller = [UIAlertController alertControllerWithTitle:title message:messsage preferredStyle:UIAlertControllerStyleAlert];
 
     [controller addAction:[UIAlertAction actionWithTitle:@"Open" style:UIAlertActionStyleDefault handler:^(UIAlertAction *_Nonnull action) {
         [[UIApplication sharedApplication] openURL:url];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -12,6 +12,7 @@ upcoming:
     - New (native) auction banner view - ash
     - Use artworks/filter for the genes artworks - orta
     - Fixes issue opening ‘works for you’ from a push notification - alloy
+    - Fixes crash on iPad when presenting an alert about opening an external URL - alloy
 
 releases:
 - version: 2.3.3


### PR DESCRIPTION
https://rink.hockeyapp.net/manage/apps/37029/app_versions/49/crash_reasons/102830998?type=overview

![simulator screen shot 22 jan 2016 23 05 52](https://cloud.githubusercontent.com/assets/2320/12524417/2c096d66-c15d-11e5-984b-8ed02e149c4e.png)

![simulator screen shot 22 jan 2016 23 06 55](https://cloud.githubusercontent.com/assets/2320/12524416/2c0743d8-c15d-11e5-9f1a-a75420b3bd2e.png)

----

If you really do prefer a sheet on iPhone, we’ll have to add a device conditional, because a sheet in a popover on iPad has to point to a location and there really is none to point to:

![simulator screen shot 22 jan 2016 23 03 53](https://cloud.githubusercontent.com/assets/2320/12524430/4e59b830-c15d-11e5-9998-a4039c2b8a81.png)
