### PR TITLE
Fixes deadlocks.

### DIFF
--- a/Artsy_Tests/Stubs/ARUserManager+Stubs.m
+++ b/Artsy_Tests/Stubs/ARUserManager+Stubs.m
@@ -1,5 +1,6 @@
 #import "ARUserManager+Stubs.h"
 #import <OHHTTPStubs/OHHTTPStubs.h>
+#import <SDWebImage/SDWebImageManager.h>
 
 
 @implementation ARUserManager (Stubs)
@@ -51,6 +52,8 @@
            authenticationFailure:(void (^)(NSError *error))authFail
                   networkFailure:(void (^)(NSError *error))networkFailure
 {
+    [[SDWebImageManager sharedManager] cancelAll];
+
     __block BOOL done = NO;
     [[ARUserManager sharedManager]
         loginWithUsername:[ARUserManager stubUserEmail]


### PR DESCRIPTION
This is a possible fix for #985. According to [other SDWebImage users](https://github.com/rs/SDWebImage/issues/507), there's a problem with deadlocking which is related to a race condition checking if a request is cancelled/finished. 

This solution cancels all downloads whenever we stub the user (which is where we've been deadlocking). Fairly straightforward – ran it a bunch of times locally and it was all good. 