### PR TITLE
Get Gene pages working again

### DIFF
--- a/Artsy/Networking/API_Modules/ArtsyAPI+Artworks.m
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+Artworks.m
@@ -27,7 +27,7 @@
 + (AFHTTPRequestOperation *)getArtworksForGene:(Gene *)gene atPage:(NSInteger)page success:(void (^)(NSArray *artworks))success failure:(void (^)(NSError *error))failure
 {
     NSURLRequest *request = [ARRouter newArtworksFromGeneRequest:gene.geneID atPage:page];
-    return [self getRequest:request parseIntoAnArrayOfClass:Artwork.class success:success failure:failure];
+    return [self getRequest:request parseIntoAnArrayOfClass:Artwork.class fromDictionaryWithKey:@"hits" success:success failure:failure];
 }
 
 + (AFHTTPRequestOperation *)getAuctionComparablesForArtwork:(Artwork *)artwork success:(void (^)(NSArray *))success failure:(void (^)(NSError *))failure
@@ -46,12 +46,11 @@
 
 + (void)getAuctionArtworkWithSale:(NSString *)saleID artwork:(NSString *)artworkID success:(void (^)(id auctionArtwork))success failure:(void (^)(NSError *error))failure
 {
-
     NSURLRequest *saleArtworkRequest = [ARRouter saleArtworkRequestForSaleID:saleID artworkID:artworkID];
     NSURLRequest *biddersRequest = [ARRouter biddersRequest];
     NSURLRequest *bidderPositionRequest = [ARRouter bidderPositionsRequestForSaleID:saleID artworkID:artworkID];
 
-    [self getRequests:@[saleArtworkRequest, biddersRequest, bidderPositionRequest] success:^(NSArray *operations) {
+    [self getRequests:@[ saleArtworkRequest, biddersRequest, bidderPositionRequest ] success:^(NSArray *operations) {
 
         // Doing all parsing here since completion blocks fire async per: https://github.com/AFNetworking/AFNetworking/issues/362
         ar_dispatch_async(^{

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -843,7 +843,8 @@ static NSSet *artsyHosts = nil;
 {
     NSDictionary *params = @{
         @"page" : @(page),
-        @"gene_id" : gene
+        @"gene_id" : gene,
+        @"size" : @10
     };
     return [self requestWithMethod:@"GET" path:ARGeneArtworksURL parameters:params];
 }

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -13,7 +13,7 @@ upcoming:
     - New (native) auction refine controls - ash
     - Use artworks/filter for the genes artworks - orta
     - Use Hockey for feedback, take a screenshot in app or use the admin menu to trigger - orta
-
+    - Fix Genome Artworks API - orta
     - Fixes issue opening ‘works for you’ from a push notification - alloy
     - Fixes crash on iPad when presenting an alert about opening an external URL - alloy
 


### PR DESCRIPTION
The API calls for filter come in as a dictionary, with the Artworks being inside `hits` rather than at the root of the array. 

This PR will mean that we need to deploy another build of our current beta 2.3.5.