### PR TITLE
Fix the snapshot feedback mechanism

### DIFF
--- a/Artsy/App/ARHockeyFeedbackDelegate.swift
+++ b/Artsy/App/ARHockeyFeedbackDelegate.swift
@@ -11,8 +11,8 @@ class ARHockeyFeedbackDelegate: NSObject {
         notifications.addObserverForName(UIApplicationUserDidTakeScreenshotNotification, object: nil, queue: mainQueue) { notification in
             // When I looked at how Hockey did this, I found that they would delay by a second
             // presumably it can take a second to have the image saved in the asset store before
-            // we can pull it out again.
-            ar_dispatch_after(1, self.showFeedbackWithRecentScreenshot)
+            // we can pull it out again. We might be able to get away with 0.5.
+            ar_dispatch_after(0.5, self.showFeedbackWithRecentScreenshot)
         }
     }
 
@@ -46,7 +46,9 @@ class ARHockeyFeedbackDelegate: NSObject {
             return
         }
 
-        PHImageManager.defaultManager().requestImageForAsset(result, targetSize: UIScreen.mainScreen().bounds.size, contentMode: .AspectFit, options: nil) { image, info in
+        let options = PHImageRequestOptions()
+        options.synchronous = true
+        PHImageManager.defaultManager().requestImageForAsset(result, targetSize: UIScreen.mainScreen().bounds.size, contentMode: .AspectFit, options: options) { image, info in
             self.showFeedback(image)
         }
     }

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,7 +3,7 @@ upcoming:
   details: Ideally a small release for iOS8 + Push fixes.
   dev:
     - Updated Danger - orta
-    - Use Hockey for feedback, take a screenshot in app or use the admin menu to trigger - orta
+    - Use Hockey for feedback, take a screenshot in app or use the admin menu to trigger the feedback mechanism - orta
 
   notes:
     - Remove x-callback support now that it's part of the OS - orta


### PR DESCRIPTION
I think if `PHImageManager` is left async it will send multiple results, which we took to imply sending multiple feedback managers. We only need the one, so I've made is synchronous, and done some device testing 0.5 seconds is working for me. 