### PR TITLE
Fixes missing analytics for the tab views

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -512,6 +512,8 @@
 		60E6447617BE424E004486B3 /* ARSwitchView.m in Sources */ = {isa = PBXBuildFile; fileRef = 60E6447517BE424E004486B3 /* ARSwitchView.m */; };
 		60E719FE1B4C6032008948FA /* Launch Screen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 60E719FD1B4C6032008948FA /* Launch Screen.xib */; };
 		60E71A011B4C60AC008948FA /* Artsy_Logo.png in Resources */ = {isa = PBXBuildFile; fileRef = 60E71A001B4C60AC008948FA /* Artsy_Logo.png */; };
+		60E738711C64AB8B00AC381B /* ARStubbedAnalyticsProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 60E738701C64AB8B00AC381B /* ARStubbedAnalyticsProvider.m */; };
+		60E738741C64ACA000AC381B /* ARAppAnalyticsSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 60E738731C64ACA000AC381B /* ARAppAnalyticsSpec.m */; };
 		60EFA6F516CAA8180094AD7C /* ArtsyAPI+Feed.m in Sources */ = {isa = PBXBuildFile; fileRef = 60EFA6F416CAA8180094AD7C /* ArtsyAPI+Feed.m */; };
 		60F1C50E17C0EC6A000938F7 /* ARBrowseCategoriesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 60F1C50D17C0EC6A000938F7 /* ARBrowseCategoriesViewController.m */; };
 		60F1C51217C0EDDB000938F7 /* ARBrowseFeaturedLinksCollectionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 60F1C51117C0EDDB000938F7 /* ARBrowseFeaturedLinksCollectionViewController.m */; };
@@ -1517,6 +1519,10 @@
 		60E6447517BE424E004486B3 /* ARSwitchView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARSwitchView.m; sourceTree = "<group>"; };
 		60E719FD1B4C6032008948FA /* Launch Screen.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = "Launch Screen.xib"; sourceTree = "<group>"; };
 		60E71A001B4C60AC008948FA /* Artsy_Logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Artsy_Logo.png; sourceTree = "<group>"; };
+		60E7386F1C64AB8B00AC381B /* ARStubbedAnalyticsProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARStubbedAnalyticsProvider.h; sourceTree = "<group>"; };
+		60E738701C64AB8B00AC381B /* ARStubbedAnalyticsProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARStubbedAnalyticsProvider.m; sourceTree = "<group>"; };
+		60E738731C64ACA000AC381B /* ARAppAnalyticsSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ARAppAnalyticsSpec.m; path = Analytics_Tests/ARAppAnalyticsSpec.m; sourceTree = "<group>"; };
+		60E738841C64B47300AC381B /* Dangerfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Dangerfile; path = ../Dangerfile; sourceTree = "<group>"; };
 		60EEFE741658547C00F43F00 /* Constants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Constants.h; sourceTree = "<group>"; };
 		60EFA6F316CAA8180094AD7C /* ArtsyAPI+Feed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ArtsyAPI+Feed.h"; sourceTree = "<group>"; };
 		60EFA6F416CAA8180094AD7C /* ArtsyAPI+Feed.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ArtsyAPI+Feed.m"; sourceTree = "<group>"; };
@@ -1797,6 +1803,8 @@
 				3CE0DA3118A13604000E537A /* OHHTTPStubs+Artsy.m */,
 				514207181BB1B5D2000CC01C /* ARStubbedFavoritesNetworkModel.h */,
 				514207191BB1B5D2000CC01C /* ARStubbedFavoritesNetworkModel.m */,
+				60E7386F1C64AB8B00AC381B /* ARStubbedAnalyticsProvider.h */,
+				60E738701C64AB8B00AC381B /* ARStubbedAnalyticsProvider.m */,
 			);
 			path = Stubs;
 			sourceTree = "<group>";
@@ -3909,6 +3917,14 @@
 			name = Launch;
 			sourceTree = "<group>";
 		};
+		60E738721C64AC7C00AC381B /* Analytics Tests */ = {
+			isa = PBXGroup;
+			children = (
+				60E738731C64ACA000AC381B /* ARAppAnalyticsSpec.m */,
+			);
+			name = "Analytics Tests";
+			sourceTree = "<group>";
+		};
 		60F1C50F17C0EDA7000938F7 /* Collection Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -3955,6 +3971,7 @@
 		60FFE3D5188E916C0012B485 /* Documentation */ = {
 			isa = PBXGroup;
 			children = (
+				60E738841C64B47300AC381B /* Dangerfile */,
 				600B8B441C4FCEEC00776F84 /* CHANGELOG.yml */,
 				600B8B3C1C4FCEE000776F84 /* push_notifications.md */,
 				600B8B3D1C4FCEE000776F84 /* welcome_to_eigen_beta.md */,
@@ -4052,6 +4069,7 @@
 		B3ECE82B1819D1E6009F5C5B /* Artsy Tests */ = {
 			isa = PBXGroup;
 			children = (
+				60E738721C64AC7C00AC381B /* Analytics Tests */,
 				3C205B5718900091004280E0 /* App Tests */,
 				0CE0FE251B8E29CC00A921FD /* Stubs */,
 				3C3FEA8B188433CB00E1A16F /* Extensions */,
@@ -4996,6 +5014,7 @@
 			files = (
 				3CB97D8F1887099E008C44FE /* ARLoginViewControllerTests.m in Sources */,
 				3C6AA7CB1885F38D00501F07 /* SaleArtwork+Extensions.m in Sources */,
+				60E738741C64ACA000AC381B /* ARAppAnalyticsSpec.m in Sources */,
 				60F8FFC1197E773E00DC3869 /* ARArtworkSetViewControllerSpec.m in Sources */,
 				5EBDC95119794D840082C514 /* ARSearchFieldButtonTests.m in Sources */,
 				5E0AEB7A19B9EF57009F34DE /* ARShowNetworkModelTests.m in Sources */,
@@ -5049,6 +5068,7 @@
 				5E9A78231906BA3D00734E1B /* OCMArg+ClassChecker.m in Sources */,
 				5E088DB11C58145600C448D7 /* UIViewController+Tests.swift in Sources */,
 				D3C8C2061B66D2FF004CAD7F /* ARImageTests.m in Sources */,
+				60E738711C64AB8B00AC381B /* ARStubbedAnalyticsProvider.m in Sources */,
 				3CE75A0B18B6367F00885355 /* ARValueTransformerTests.m in Sources */,
 				3CA1E820188465F0003C622D /* Sale+Extensions.m in Sources */,
 				E61E773919A7E8D500C55E14 /* ARGeneViewControllerTests.m in Sources */,

--- a/Artsy/App/ARAppDelegate+Analytics.m
+++ b/Artsy/App/ARAppDelegate+Analytics.m
@@ -56,6 +56,7 @@
 #import "ARBrowseViewController.h"
 #import "ARSearchViewController.h"
 #import "ARNavigationController.h"
+#import "ARHeroUnitViewController.h"
 
 // Views
 #import "ARHeartButton.h"
@@ -92,10 +93,13 @@
         environment = ADJEnvironmentSandbox;
     }
 
-    // Skipping ARAnalytics because Adjust has its own expectations
-    // around event names being < 6 chars
-    ADJConfig *adjustConfig = [ADJConfig configWithAppToken:keys.adjustProductionAppToken environment:environment];
-    [Adjust appDidLaunch:adjustConfig];
+    if (ARAppStatus.isRunningTests == NO) {
+        // Skipping ARAnalytics because Adjust has its own expectations
+        // around event names being < 6 chars
+
+        ADJConfig *adjustConfig = [ADJConfig configWithAppToken:keys.adjustProductionAppToken environment:environment];
+        [Adjust appDidLaunch:adjustConfig];
+    }
 
 #if DEBUG
     BITHockeyManager *hockey = [BITHockeyManager sharedHockeyManager];
@@ -760,14 +764,14 @@
                     ]
                 },
                 @{
-                    ARAnalyticsClass: ARSiteHeroUnitView.class,
+                    ARAnalyticsClass: ARSiteHeroUnitViewController.class,
                     ARAnalyticsDetails: @[
                         @{
                             ARAnalyticsEventName: ARAnalyticsTappedHeroUnit,
-                            ARAnalyticsSelectorName: NSStringFromSelector(@selector(tappedView:)),
-                            ARAnalyticsProperties: ^NSDictionary*(ARSiteHeroUnitView *view, NSArray *_){
+                            ARAnalyticsSelectorName: NSStringFromSelector(@selector(tappedUnit:)),
+                            ARAnalyticsProperties: ^NSDictionary*(ARSiteHeroUnitViewController *vc, NSArray *_){
                                 return @{
-                                    @"destination" : view.linkAddress ?: @""
+                                    @"destination" : vc.heroUnit.link ?: @""
                                 };
                             },
                         }

--- a/Artsy/App/ARAppDelegate.m
+++ b/Artsy/App/ARAppDelegate.m
@@ -112,6 +112,11 @@ static ARAppDelegate *_sharedInstance = nil;
     // Temp Fix for: https://github.com/artsy/eigen/issues/602
     [self forceCacheCustomFonts];
 
+    // This cannot be moved after the view setup code, as it
+    // relies on swizzling alloc on new objects, thus should be
+    // one of the first things that happen.
+    [self setupAnalytics];
+
     self.window = [[ARWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     self.viewController = [ARTopMenuViewController sharedController];
     self.window.rootViewController = self.viewController;
@@ -119,7 +124,6 @@ static ARAppDelegate *_sharedInstance = nil;
 
     [self setupAdminTools];
 
-    [self setupAnalytics];
     [self setupRatingTool];
     [self countNumberOfRuns];
 

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.3</string>
+	<string>2.3.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -66,17 +66,24 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2016.01.06</string>
+	<string>2016.02.05</string>
 	<key>FacebookAppID</key>
 	<string>308278682573501</string>
 	<key>FacebookDisplayName</key>
 	<string>Artsy</string>
 	<key>GITCommitRev</key>
-	<string>131e0b6</string>
+	<string>b8559b7</string>
 	<key>GITCommitSha</key>
-	<string>131e0b60ca1001a3334f6d6350f8722101bb6c4f</string>
+	<string>b8559b7f3762c14fa63cb33c4db2468977fd0aae</string>
 	<key>GITRemoteOriginURL</key>
 	<string>https://github.com/artsy/eigen.git</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>fbapi</string>
+		<string>fb-messenger-api</string>
+		<string>fbauth2</string>
+		<string>fbshareextension</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>
@@ -168,12 +175,5 @@
 			</dict>
 		</dict>
 	</array>
-    <key>LSApplicationQueriesSchemes</key>
-    <array>
-        <string>fbapi</string>
-        <string>fb-messenger-api</string>
-        <string>fbauth2</string>
-        <string>fbshareextension</string>
-    </array>
 </dict>
 </plist>

--- a/Artsy/View_Controllers/Core/ARHeroUnitViewController.h
+++ b/Artsy/View_Controllers/Core/ARHeroUnitViewController.h
@@ -10,8 +10,17 @@
 @end
 
 // Class internal to ARHeroUnitViewController - exposed only for analytics
+
+
 @interface ARSiteHeroUnitViewController : UIViewController
 
+/// Init function
+- (instancetype)initWithHeroUnit:(SiteHeroUnit *)heroUnit andIndex:(NSInteger)index;
+
+/// Hero Unit the VC represents
 @property (nonatomic, strong, readonly) SiteHeroUnit *heroUnit;
+
+/// Triggers a push to the url represented by the hero unit
+- (void)tappedUnit:(id)sender;
 
 @end

--- a/Artsy/View_Controllers/Core/ARHeroUnitViewController.m
+++ b/Artsy/View_Controllers/Core/ARHeroUnitViewController.m
@@ -22,7 +22,6 @@ const static CGFloat ARCarouselDelay = 10;
 
 
 @interface ARSiteHeroUnitViewController ()
-- (instancetype)initWithHeroUnit:(SiteHeroUnit *)heroUnit andIndex:(NSInteger)index;
 @property (nonatomic, assign) NSInteger index;
 @property (nonatomic, strong, readwrite) SiteHeroUnit *heroUnit;
 @end
@@ -159,7 +158,7 @@ const static CGFloat ARCarouselDelay = 10;
 - (void)goToHeroUnit:(UIViewController *)vc withDirection:(UIPageViewControllerNavigationDirection)direction
 {
     self.pageViewController.view.userInteractionEnabled = NO;
-    __weak typeof (self) wself = self;
+    __weak typeof(self) wself = self;
     [self.pageViewController setViewControllers:@[ vc ] direction:direction animated:YES completion:^(BOOL finished) {
         __strong typeof (wself) sself = wself;
         [sself.pageControl setCurrentPage:[sself currentViewController].index];
@@ -251,6 +250,7 @@ const static CGFloat ARCarouselDelay = 10;
     [self.view addGestureRecognizer:tapGesture];
 
     ARSiteHeroUnitView *heroUnitView = [[ARSiteHeroUnitView alloc] initWithFrame:self.view.bounds unit:self.heroUnit];
+
     // We can't use autoresizing masks in a view controller contained in a UIPageViewController
     // See: http://stackoverflow.com/questions/17729336/uipageviewcontroller-auto-layout-rotation-issue
     heroUnitView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;

--- a/Artsy/Views/Utilities/ARSiteHeroUnitView.h
+++ b/Artsy/Views/Utilities/ARSiteHeroUnitView.h
@@ -3,9 +3,8 @@
 
 @interface ARSiteHeroUnitView : UIView
 
-- (id)initWithFrame:(CGRect)frame unit:(SiteHeroUnit *)unit;
+- (instancetype)initWithFrame:(CGRect)frame unit:(SiteHeroUnit *)unit;
 
 @property (nonatomic, readonly, assign) enum ARHeroUnitImageColor style;
-@property (nonatomic, copy, readonly) NSString *linkAddress;
 
 @end

--- a/Artsy/Views/Utilities/ARSiteHeroUnitView.m
+++ b/Artsy/Views/Utilities/ARSiteHeroUnitView.m
@@ -12,14 +12,14 @@
 #import <FLKAutoLayout/UIView+FLKAutoLayout.h>
 #import <ObjectiveSugar/ObjectiveSugar.h>
 
-#define AR_HERO_TITLE_FONT 26
-
 static ARParallaxEffect *backgroundParallax;
 static const NSInteger ARHeroUnitParallaxDistance = 30;
 static const CGFloat ARHeroUnitBottomMargin = 34;
 static const CGFloat ARHeroUnitDescriptionButtonMargin = 25;
 static const CGFloat ARHeroUnitButtonCreditMargin = 21;
 static const CGFloat ARHeroUnitTopMargin = 97;
+static const CGFloat ARHeroCompactTitleFontSize = 26;
+
 static CGFloat ARHeroUnitSideMargin;
 static CGFloat ARHeroUnitHeadingTitleMargin;
 static CGFloat ARHeroUnitTitleDescriptionMargin;
@@ -136,7 +136,7 @@ static CGFloat ARHeroUnitDescriptionFont;
 - (UILabel *)createTitleLabelWithText:(NSString *)text
 {
     UILabel *titleLabel = [[UILabel alloc] init];
-    titleLabel.font = [UIFont sansSerifFontWithSize:AR_HERO_TITLE_FONT];
+    titleLabel.font = [UIFont sansSerifFontWithSize:ARHeroCompactTitleFontSize];
 
     NSMutableAttributedString *attributedTitle = nil;
     NSString *title = [text stringByReplacingOccurrencesOfString:@"\n\n" withString:@"\n"];

--- a/Artsy_Tests/Analytics_Tests/ARAppAnalyticsSpec.m
+++ b/Artsy_Tests/Analytics_Tests/ARAppAnalyticsSpec.m
@@ -1,0 +1,51 @@
+#import "ARAppDelegate.h"
+#import "ARAppDelegate+Analytics.h"
+#import "ARStubbedAnalyticsProvider.h"
+#import <ARAnalytics/ARAnalytics.h>
+#import "ARAnalyticsConstants.h"
+
+/// Depending on how this spec turns out, it may be worth migrating it into it's own target
+/// as, in theory, this spec can leak into all the others due to the triggering of analytics.
+
+/// Imports for the VC/Views
+
+#import "ARHeroUnitViewController.h"
+
+/// ZZ to make it go last, thanks to XCTest implmentation details
+SpecBegin(ZZAppAnalytics);
+
+// This should only get run once, as it does all the swizzling
+// calling that multiple times looks to me like it could
+// end up with unexpected behavior
+
+beforeAll(^{
+    ARAppDelegate *delegate = [[ARAppDelegate alloc] init];
+    [delegate setupAnalytics];
+});
+
+__block ARStubbedAnalyticsProvider *analytics;
+
+/// Kill off all existing providers, then replace with our easily introspected provider:
+
+beforeEach(^{
+    analytics = [[ARStubbedAnalyticsProvider alloc] initWithIdentifier:@""];
+    [[ARAnalytics currentProviders].copy each:^(id provider) {
+        [ARAnalytics removeProvider:provider];
+    }];
+
+    [ARAnalytics setupProvider:analytics];
+});
+
+describe(@"ARSiteHeroUnitView", ^{
+    it(@"triggers when tapped", ^{
+
+        ARSiteHeroUnitViewController *controller = [[ARSiteHeroUnitViewController alloc] initWithHeroUnit:[SiteHeroUnit modelWithJSON:@{ @"link":@"/day-2-remember"}] andIndex:0];
+        [controller tappedUnit:nil];
+
+        expect(analytics.lastEventName).to.equal(ARAnalyticsTappedHeroUnit);
+        expect(analytics.lastEventProperties).to.equal(@{ @"destination" : @"/day-2-remember"});
+    });
+
+});
+
+SpecEnd

--- a/Artsy_Tests/Stubs/ARStubbedAnalyticsProvider.h
+++ b/Artsy_Tests/Stubs/ARStubbedAnalyticsProvider.h
@@ -1,0 +1,28 @@
+#import <ARAnalytics/ARAnalyticalProvider.h>
+#import <UIKit/UIKit.h>
+
+
+@interface ARStubbedAnalyticsProvider : ARAnalyticalProvider
+
+@property (readonly, nonatomic, copy) NSString *lastProviderIdentifier;
+
+@property (readonly, nonatomic, copy) NSString *lastEventName;
+@property (readonly, nonatomic, copy) NSDictionary *lastEventProperties;
+
+@property (readonly, nonatomic, copy) NSMutableArray *eventNames;
+
+@property (readonly, nonatomic, copy) NSString *lastUserPropertyValue;
+@property (readonly, nonatomic, copy) NSString *lastUserPropertyKey;
+@property (readonly, nonatomic, assign) NSInteger lastUserPropertyCount;
+
+@property (readonly, nonatomic, copy) NSString *email;
+@property (readonly, nonatomic, copy) NSString *identifier;
+
+@property (readonly, nonatomic, strong) NSError *lastError;
+@property (readonly, nonatomic, copy) NSString *lastErrorMessage;
+
+@property (readonly, nonatomic, strong) UINavigationController *lastMonitoredNavigationController;
+
+@property (readonly, nonatomic, copy) NSString *lastRemoteLog;
+
+@end

--- a/Artsy_Tests/Stubs/ARStubbedAnalyticsProvider.m
+++ b/Artsy_Tests/Stubs/ARStubbedAnalyticsProvider.m
@@ -1,0 +1,73 @@
+#import "ARStubbedAnalyticsProvider.h"
+
+
+@implementation ARStubbedAnalyticsProvider
+
+- (id)initWithIdentifier:(NSString *)identifier
+{
+    self = [super initWithIdentifier:identifier];
+    if (!self) return nil;
+
+    _lastProviderIdentifier = identifier;
+    _eventNames = [NSMutableArray array];
+
+    return self;
+}
+
+- (void)identifyUserWithID:(NSString *)userID andEmailAddress:(NSString *)email
+{
+    _identifier = userID;
+    _email = email;
+}
+
+- (void)setUserProperty:(NSString *)property toValue:(NSString *)value
+{
+    _lastUserPropertyKey = property;
+    _lastUserPropertyValue = value;
+}
+
+- (void)event:(NSString *)event withProperties:(NSDictionary *)properties;
+{
+    _lastEventName = event;
+    _lastEventProperties = properties;
+    [_eventNames addObject:event];
+}
+
+- (void)incrementUserProperty:(NSString *)counterName byInt:(NSNumber *)amount
+{
+    _lastUserPropertyKey = counterName;
+    _lastUserPropertyCount += amount.integerValue;
+}
+
+- (void)error:(NSError *)error withMessage:(NSString *)message
+{
+    _lastError = error;
+    _lastErrorMessage = message;
+}
+
+- (void)monitorNavigationViewController:(UINavigationController *)controller
+{
+    _lastMonitoredNavigationController = controller;
+    [super monitorNavigationViewController:controller];
+}
+
+
+- (void)logTimingEvent:(NSString *)event withInterval:(NSNumber *)interval
+{
+    _lastEventName = event;
+}
+
+- (void)logTimingEvent:(NSString *)event withInterval:(NSNumber *)interval properties:(NSDictionary *)properties
+{
+    [super logTimingEvent:event withInterval:interval properties:properties];
+
+    _lastEventName = event;
+    _lastEventProperties = properties;
+}
+
+- (void)remoteLog:(NSString *)parsedString
+{
+    _lastRemoteLog = parsedString;
+}
+
+@end

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,4 +1,12 @@
 upcoming:
+  version: 2.3.6
+  details: Analytics + Auction Overview (?)
+  dev:
+    - Nothing so far
+  notes:
+    - Fix Analytics for the `ARTopViewController` and the `ARTabContentView` - orta
+
+releases:
   version: 2.3.5
   details: Ideally a small release for iOS8 + Push fixes.
   dev:
@@ -23,7 +31,6 @@ upcoming:
     - Auction's refine view uses metric 'k' suffix for amounts great than a thousand dollars - ash
     - Auction view now downloads sale artworks for the sale - ash
 
-releases:
   - version: 2.3.4
     date: Jan 26, 2016
     notes:

--- a/Dangerfile
+++ b/Dangerfile
@@ -13,3 +13,8 @@ fail("fit left in tests") if `grep -r fit(@ Artsy_Tests/`.length > 1
 
 # Devs shouldn't ship changes to this file
 fail("Developer Specific file shouldn't be changed") if files_modified.include?("Artsy/View_Controllers/App_Navigation/ARTopMenuViewController+DeveloperExtras.m")
+
+# Did you make analytics changes? Well you should also include a change to our analytics spec
+made_analytics_changes = files_modified.include?("/Artsy/App/ARAppDelegate+Analytics.m")
+made_analytics_specs_changes = files_modified.include?("/Artsy_Tests/Analytics_Tests/ARAppAnalyticsSpec.m")
+fail("Analytics changes should have reflected specs changes") if made_analytics_changes and !made_analytics_specs_changes


### PR DESCRIPTION
As this is testing the app delegate's launch code, I'm a bit at odds on how to add a test covering us for this. Going to take a stab at making it possible for us to run analytics tests, but I don't think I can cover _this case_.