### PR TITLE
Add support for showing the bell tapped analytics events

### DIFF
--- a/Artsy/App/ARAnalyticsConstants.h
+++ b/Artsy/App/ARAnalyticsConstants.h
@@ -159,3 +159,7 @@ extern NSString *const ARAdjustCreatedAnAccount;
 extern NSString *const ARAdjustSentArtworkInquiry;
 extern NSString *const ARAdjustFirstUserInstall;
 extern NSString *const ARAdjustTappedBidButton;
+
+// Linking between analytics / app code
+
+extern NSInteger const ARNavButtonNotificationsTag;

--- a/Artsy/App/ARAnalyticsConstants.m
+++ b/Artsy/App/ARAnalyticsConstants.m
@@ -122,4 +122,4 @@ NSString *const ARAdjustSentArtworkInquiry = @"duxtlx";
 NSString *const ARAdjustFirstUserInstall = @"kju96h";
 NSString *const ARAdjustTappedBidButton = @"w5e24e";
 
-
+NSInteger const ARNavButtonNotificationsTag = (NSInteger)&ARNavButtonNotificationsTag;

--- a/Artsy/App/ARAppDelegate+Analytics.m
+++ b/Artsy/App/ARAppDelegate+Analytics.m
@@ -1225,6 +1225,12 @@
                             ARAnalyticsShouldFire: ^BOOL(ARTabContentView *view, NSArray *parameters) {
                                 return [parameters.firstObject integerValue] == ARTopTabControllerIndexNotifications;
                             },
+                        },@{
+                            ARAnalyticsPageName: @"Bell Tapped",
+                            ARAnalyticsSelectorName: ARAnalyticsSelector(buttonTapped:),
+                            ARAnalyticsShouldFire: ^BOOL(ARTabContentView *view, NSArray *parameters) {
+                                return [parameters.firstObject tag] == ARNavButtonNotificationsTag;
+                            }
                         }
                     ]
                 },

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -8,6 +8,7 @@
 #import "ARUserManager.h"
 #import "ArtsyAPI+Private.h"
 #import "ARAppConstants.h"
+#import "ARAnalyticsConstants.h"
 #import "ARFonts.h"
 #import "User.h"
 #import "ARTrialController.h"
@@ -70,6 +71,7 @@ static const CGFloat ARMenuButtonDimension = 46;
     ARNavigationTabButton *magazineButton = [[ARNavigationTabButton alloc] init];
     ARNavigationTabButton *favoritesButton = [[ARNavigationTabButton alloc] init];
     ARNavigationTabButton *notificationsButton = [[ARNavigationTabButton alloc] init];
+    notificationsButton.tag = ARNavButtonNotificationsTag;
 
     [homeButton setImage:[UIImage imageNamed:@"HomeButton"] forState:UIControlStateNormal];
     [homeButton setImage:[UIImage imageNamed:@"HomeButton"] forState:UIControlStateSelected];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -2,7 +2,7 @@ upcoming:
   version: 2.3.6
   details: Analytics + Auction Overview (?)
   dev:
-    - Nothing so far
+    - Adds an analytics event for Bell Tapped which is only for the tap - orta
   notes:
     - Fix Analytics for the `ARTopViewController` and the `ARTabContentView` - orta
 


### PR DESCRIPTION
Allow us to differentiate between push / taps WRT the bell.