### PR TITLE
Fix the ARSearchFieldButton tap delegate

### DIFF
--- a/Artsy/View_Controllers/Fair/Views/ARSearchFieldButton.m
+++ b/Artsy/View_Controllers/Fair/Views/ARSearchFieldButton.m
@@ -7,6 +7,7 @@
 #import <ReactiveCocoa/ReactiveCocoa.h>
 #import <FLKAutoLayout/UIView+FLKAutoLayout.h>
 
+
 @interface ARSearchFieldButton ()
 
 @property (nonatomic, strong) UIImageView *imageView;
@@ -47,11 +48,20 @@
     [self.label alignTrailingEdgeWithView:self predicate:@"0"];
     [self.label alignTop:@"2" bottom:@"0" toView:self];
 
-    UITapGestureRecognizer *recognizer = [[UITapGestureRecognizer alloc] init];
-    [recognizer addTarget:self.delegate action:@selector(searchFieldButtonWasPressed:)];
-    [self addGestureRecognizer:recognizer];
-
     return self;
+}
+
+- (void)setDelegate:(id<ARSearchFieldButtonDelegate>)delegate
+{
+    _delegate = delegate;
+
+    for (UIGestureRecognizer *gesture in self.gestureRecognizers.copy) {
+        [self removeGestureRecognizer:gesture];
+    }
+
+    UITapGestureRecognizer *recognizer = [[UITapGestureRecognizer alloc] init];
+    [recognizer addTarget:delegate action:@selector(searchFieldButtonWasPressed:)];
+    [self addGestureRecognizer:recognizer];
 }
 
 - (CGSize)intrinsicContentSize

--- a/Artsy_Tests/View_Controller_Tests/Fair/Views/ARSearchFieldButtonTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/Views/ARSearchFieldButtonTests.m
@@ -7,4 +7,14 @@ it(@"has a valid snapshot", ^{
     expect(button).to.haveValidSnapshot();
 });
 
+it(@"adds a gesture recogniser when a delegate is set", ^{
+    ARSearchFieldButton *button = [[ARSearchFieldButton alloc] initWithFrame:CGRectMake(0, 0, 280, 44)];
+    // starts out nil
+    expect(button.gestureRecognizers).to.beFalsy();
+
+    id <ARSearchFieldButtonDelegate> object = (id)[[NSObject alloc] init];
+    [button setDelegate:object];
+    expect(button.gestureRecognizers).to.haveCountOf(1);
+});
+
 SpecEnd;

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -9,6 +9,7 @@ upcoming:
     - Updated Danger to use new org - orta
   notes:
     - Fix Analytics for the `ARTopViewController` and the `ARTabContentView` - orta
+    - Fix for search button in Fairs - orta
 
 releases:
   - version: 2.3.5


### PR DESCRIPTION
ARSearchFieldButton accidentally used `self.delegate` before it existed, now it creates the gesture on `setDelegate` - :phone: 