### PR TITLE
Use danger to show error messages for snapshots #trivial

### DIFF
--- a/Artsy_Tests/View_Controller_Tests/Fair/Views/ARSearchFieldButtonTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/Views/ARSearchFieldButtonTests.m
@@ -3,7 +3,7 @@
 SpecBegin(ARSearchFieldButton);
 
 it(@"has a valid snapshot", ^{
-    ARSearchFieldButton *button = [[ARSearchFieldButton alloc] initWithFrame:CGRectMake(0, 0, 280, 44)];
+    ARSearchFieldButton *button = [[ARSearchFieldButton alloc] initWithFrame:CGRectMake(0, 0, 180, 20)];
     expect(button).to.haveValidSnapshot();
 });
 

--- a/Artsy_Tests/View_Controller_Tests/Fair/Views/ARSearchFieldButtonTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/Views/ARSearchFieldButtonTests.m
@@ -3,7 +3,7 @@
 SpecBegin(ARSearchFieldButton);
 
 it(@"has a valid snapshot", ^{
-    ARSearchFieldButton *button = [[ARSearchFieldButton alloc] initWithFrame:CGRectMake(0, 0, 180, 20)];
+    ARSearchFieldButton *button = [[ARSearchFieldButton alloc] initWithFrame:CGRectMake(0, 0, 280, 44)];
     expect(button).to.haveValidSnapshot();
 });
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -35,8 +35,5 @@ end
 # So if there's snapshot fails, we should also fail danger, but we can make the thing clickable in a comment instead of hidden in the log
 # Note: this may break in a future build of Danger, I am debating sandboxing the runner from ENV vars.
 build_log = File.read( File.join(ENV["CIRCLE_ARTIFACTS"], "xcode_test_raw.log") )
-eigen_prefix = "https://eigen-ci.s3.amazonaws.com/"
-if build_log.include? "Failures: #{eigen_prefix}"
-  url = eigen_prefix + build_log.split("Failures: #{eigen_prefix}").last.split(" ")
-  fail("There were snapshot errors, see #{url}")
-end
+snapshots_url = build_log.match(%r{https://eigen-ci.s3.amazonaws.com/\d+/index.html})
+fail("There were snapshot errors, see #{snapshots_url}") if snapshots_url

--- a/Dangerfile
+++ b/Dangerfile
@@ -36,4 +36,4 @@ end
 # Note: this may break in a future build of Danger, I am debating sandboxing the runner from ENV vars.
 build_log = File.read( File.join(ENV["CIRCLE_ARTIFACTS"], "xcode_test_raw.log") )
 snapshots_url = build_log.match(%r{https://eigen-ci.s3.amazonaws.com/\d+/index.html})
-fail("There were snapshot errors, see #{snapshots_url}") if snapshots_url
+fail("There were [snapshot errors](#{snapshots_url})") if snapshots_url

--- a/Dangerfile
+++ b/Dangerfile
@@ -31,3 +31,12 @@ begin
 rescue e
   fail("CHANGELOG isn't legit YAML")
 end
+
+# So if there's snapshot fails, we should also fail danger, but we can make the thing clickable in a comment instead of hidden in the log
+# Note: this may break in a future build of Danger, I am debating sandboxing the runner from ENV vars.
+build_log = File.read( File.join(ENV["CIRCLE_ARTIFACTS"], "xcode_test_raw.log") )
+eigen_prefix = "https://eigen-ci.s3.amazonaws.com/"
+if build_log.include? "Failures: #{eigen_prefix}"
+  url = eigen_prefix + build_log.split("Failures: #{eigen_prefix}").last.split(" ")
+  fail("There were snapshot errors, see #{url}")
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/danger/danger.git
-  revision: 3f5d9c21f92f6d9e5c64939d5ece12db30899575
+  revision: a3eae2338f9e3e167274d82e5664aa3e3e8ee2b3
   specs:
     danger (0.2.1)
       claide

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ build:
 	set -o pipefail && xcodebuild -workspace $(WORKSPACE) -scheme $(SCHEME) -configuration '$(CONFIGURATION)' -sdk iphonesimulator build -destination $(DEVICE_HOST) | tee $(CIRCLE_ARTIFACTS)/xcode_build_raw.log | bundle exec xcpretty -c
 
 test:
-	set -o pipefail && xcodebuild -workspace $(WORKSPACE) -scheme $(SCHEME) -configuration Debug build test -sdk iphonesimulator -destination $(DEVICE_HOST) | bundle exec second_curtain | tee $(CIRCLE_ARTIFACTS)/xcode_test_raw.log  | bundle exec xcpretty -c --test --report junit --output $(CIRCLE_TEST_REPORTS)/xcode/results.xml
+	set -o pipefail && xcodebuild -workspace $(WORKSPACE) -scheme $(SCHEME) -configuration Debug build test -sdk iphonesimulator -destination $(DEVICE_HOST) | bundle exec second_curtain 2>&1 | tee $(CIRCLE_ARTIFACTS)/xcode_test_raw.log  | bundle exec xcpretty -c --test --report junit --output $(CIRCLE_TEST_REPORTS)/xcode/results.xml
 
 ### CI
 


### PR DESCRIPTION
Contains a broken snapshot.

Danger should spot this and provide a message for us.