### PR TITLE
Applies refine settings to filter artworks

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -297,6 +297,7 @@
 		5ED9EC021C458E9500C979A6 /* SwiftExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ED9EC011C458E9500C979A6 /* SwiftExtensions.swift */; };
 		5EDB120B197E691100E241F0 /* ARParallaxHeaderViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EDB120A197E691100E241F0 /* ARParallaxHeaderViewController.m */; };
 		5EE5DE14190167A400040B84 /* ARProfileViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EE5DE13190167A400040B84 /* ARProfileViewController.m */; };
+		5EF64A381C6D68530045B088 /* SaleViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF64A371C6D68530045B088 /* SaleViewModelTests.swift */; };
 		5EF9E1141C56CEDB00CD80DB /* AuctionRefineSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF9E1131C56CEDB00CD80DB /* AuctionRefineSettings.swift */; };
 		5EF9E1171C56D0B900CD80DB /* AuctionRefineCheck.png in Resources */ = {isa = PBXBuildFile; fileRef = 5EF9E1151C56D0B900CD80DB /* AuctionRefineCheck.png */; };
 		5EF9E1181C56D0B900CD80DB /* AuctionRefineCheck@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 5EF9E1161C56D0B900CD80DB /* AuctionRefineCheck@2x.png */; };
@@ -1151,6 +1152,7 @@
 		5EE5DE12190167A400040B84 /* ARProfileViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARProfileViewController.h; sourceTree = "<group>"; };
 		5EE5DE13190167A400040B84 /* ARProfileViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARProfileViewController.m; sourceTree = "<group>"; };
 		5EE5DE1519019EFD00040B84 /* ARFairAwareObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARFairAwareObject.h; sourceTree = "<group>"; };
+		5EF64A371C6D68530045B088 /* SaleViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SaleViewModelTests.swift; path = Auction/SaleViewModelTests.swift; sourceTree = "<group>"; };
 		5EF9E1131C56CEDB00CD80DB /* AuctionRefineSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AuctionRefineSettings.swift; path = Auction/AuctionRefineSettings.swift; sourceTree = "<group>"; };
 		5EF9E1151C56D0B900CD80DB /* AuctionRefineCheck.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = AuctionRefineCheck.png; sourceTree = "<group>"; };
 		5EF9E1161C56D0B900CD80DB /* AuctionRefineCheck@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AuctionRefineCheck@2x.png"; sourceTree = "<group>"; };
@@ -2796,6 +2798,7 @@
 			isa = PBXGroup;
 			children = (
 				5E20BB771C655DF500C6D781 /* AuctionRefineViewControllerTests.swift */,
+				5EF64A371C6D68530045B088 /* SaleViewModelTests.swift */,
 				5E20BB6C1C654EEA00C6D781 /* Networking */,
 			);
 			name = Auctions;
@@ -5160,6 +5163,7 @@
 				D322204B1B4F0352008C2FBF /* ARCollapsableTextViewTests.m in Sources */,
 				E655E4B8194B4BEF00F2B7DA /* ARArtworkFavoritesNetworkModelTests.m in Sources */,
 				510261711BBE96BE002AB8BB /* ARAuctionWebViewControllerTests.m in Sources */,
+				5EF64A381C6D68530045B088 /* SaleViewModelTests.swift in Sources */,
 				E67DF2131A40A73C00C8495E /* ARSearchViewControllerSpec.m in Sources */,
 				3C6BDCBD18E0AEF60028EF5D /* ArtsyAPI+PrivateTests.m in Sources */,
 				3CB37D991922483100089A1D /* ArtsyAPI+ErrorHandlers.m in Sources */,

--- a/Artsy/View_Controllers/Auction/AuctionViewController.swift
+++ b/Artsy/View_Controllers/Auction/AuctionViewController.swift
@@ -72,7 +72,7 @@ class AuctionViewController: UIViewController {
 
 extension AuctionViewController {
     func setupForSale(saleViewModel: SaleViewModel) {
-        // TODO: Sale is currently private on the SVM
+        // TODO: Sale is currently private on the SaleViewModel, also Sale will need to be extended to conform to ARSpotlightMetadataProvider
         // artworksViewController.spotlightEntity = saleViewModel.sale
 
         self.saleViewModel = saleViewModel
@@ -95,7 +95,7 @@ extension AuctionViewController {
         artworksViewController.stickyHeaderView = stickyHeader
         artworksViewController.invalidateHeaderHeight()
 
-        self.artworksViewController.modelViewController.appendItems(saleViewModel.artworks)
+        displayItems(saleViewModel.artworks)
         self.artworksViewController.modelViewController.showTrailingLoadingIndicator = false
 
         self.ar_removeIndeterminateLoadingIndicatorAnimated(true) // TODO: Animated?
@@ -118,6 +118,12 @@ extension AuctionViewController {
         }
         presentViewController(refineViewController, animated: true, completion: nil)
     }
+
+    // TODO: This needs to be a SaleArtwork. Don't know how yet.
+    func displayItems(items: [Artwork]) {
+        artworksViewController.modelViewController.resetItems()
+        artworksViewController.modelViewController.appendItems(items)
+    }
 }
 
 private typealias TitleCallbacks = AuctionViewController
@@ -139,6 +145,9 @@ extension RefineSettings: AuctionRefineViewControllerDelegate {
 
     func userDidApply(settings: AuctionRefineSettings, controller: AuctionRefineViewController) {
         refineSettings = settings
+
+        let items = saleViewModel.refinedArtworks(settings)
+        displayItems(items)
         dismissViewControllerAnimated(true, completion: nil)
     }
 }

--- a/Artsy/View_Controllers/Embedded/Generics/AREmbeddedModelsViewController.h
+++ b/Artsy/View_Controllers/Embedded/Generics/AREmbeddedModelsViewController.h
@@ -35,6 +35,9 @@
 /// The items shown by the embedded models VC
 @property (nonatomic, copy, readonly) NSArray *items;
 
+/// Removes items and collectionview items
+- (void)resetItems;
+
 /// Appends items and inserts the collectionview items
 - (void)appendItems:(NSArray *)items;
 

--- a/Artsy/View_Controllers/Embedded/Generics/AREmbeddedModelsViewController.m
+++ b/Artsy/View_Controllers/Embedded/Generics/AREmbeddedModelsViewController.m
@@ -155,6 +155,18 @@
     return [self.activeModule items];
 }
 
+- (void)resetItems
+{
+    if (!self && !self.collectionView) {
+        return;
+    }
+
+    self.activeModule.items = @[];
+    [self.collectionView reloadData];
+
+    [self postItemChangeCleanup];
+}
+
 - (void)appendItems:(NSArray *)items
 {
     if ((!self && !self.collectionView) || items.count == 0) {
@@ -188,6 +200,12 @@
     //        [CATransaction commit];
     //    }
 
+    [self postItemChangeCleanup];
+}
+
+// Actions that need to be performed after updating our active module's items.
+- (void)postItemChangeCleanup
+{
     [self updateViewConstraints];
     [self.view.superview setNeedsUpdateConstraints];
 }

--- a/Artsy_Tests/View_Controller_Tests/Auction/SaleViewModelTests.swift
+++ b/Artsy_Tests/View_Controller_Tests/Auction/SaleViewModelTests.swift
@@ -1,0 +1,70 @@
+import Quick
+import Nimble
+@testable
+import Artsy
+
+class SaleViewModelTests: QuickSpec {
+    override func spec() {
+        let sale = try! Sale(dictionary: ["name": "The 🎉 Sale"], error: Void())
+        let saleArtworks = [
+            testSaleArtworkEstimateAt(500),
+            testSaleArtworkEstimateAt(1500)
+        ]
+
+        describe("pruning items when refining") {
+            var subject: SaleViewModel!
+
+            beforeEach {
+                subject = SaleViewModel(sale: sale, saleArtworks: saleArtworks)
+            }
+
+            it("includes high and low inclusive") {
+                let refinedArtworks = subject.refinedArtworks(AuctionRefineSettings(ordering: .LotNumber, range: (min: 500, max: 1500)))
+
+                expect(refinedArtworks.count) == 2
+            }
+
+            it("excludes low low estimates") {
+                let refinedArtworks = subject.refinedArtworks(AuctionRefineSettings(ordering: .LotNumber, range: (min: 1000, max: 1500)))
+
+                expect(refinedArtworks.count) == 1
+            }
+
+            it("excludes high low estimates") {
+                let refinedArtworks = subject.refinedArtworks(AuctionRefineSettings(ordering: .LotNumber, range: (min: 500, max: 1000)))
+
+                expect(refinedArtworks.count) == 1
+            }
+        }
+
+        it("calculates a lowEstimate range") {
+            let subject = SaleViewModel(sale: sale, saleArtworks: saleArtworks)
+
+            let range = subject.lowEstimateRange
+
+            expect(range.min) == 500
+            expect(range.max) == 1500
+        }
+
+        it("calculates a lowEstimate range when a lowEstimate is nil") {
+            let nilInfestedSaleArtworks = saleArtworks + [testSaleArtworkEstimateAt(nil)]
+            let subject = SaleViewModel(sale: sale, saleArtworks: nilInfestedSaleArtworks)
+
+            expect(subject.lowEstimateRange).notTo( raiseException() )
+        }
+
+        it("calculates a lowEstimate range when all lowEstimates are nil") {
+            let subject = SaleViewModel(sale: sale, saleArtworks: [testSaleArtworkEstimateAt(nil)])
+
+            expect(subject.lowEstimateRange).notTo( raiseException() )
+        }
+    }
+}
+
+func testSaleArtworkEstimateAt(lowEstimate: Int?) -> SaleArtwork {
+    return try! SaleArtwork(dictionary: [
+        "saleArtworkID" : "sale-artwrrrrrk",
+        "lowEstimateCents" : lowEstimate ?? NSNull(),
+        "artwork" : [:]
+        ], error: Void())
+}

--- a/Artsy_Tests/View_Controller_Tests/Embedded/AREmbeddedModelsViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Embedded/AREmbeddedModelsViewControllerTests.m
@@ -202,4 +202,13 @@ describe(@"masonry layout", ^{
     });
 });
 
+it(@"resets items", ^{
+    AREmbeddedModelsViewController *subject = AREmbeddedModelsViewControllerWithLayout(ARArtworkMasonryLayout2Column);
+    [subject appendItems:@[ArtworkWithImageAspectRatio(1)]];
+
+    [subject resetItems];
+
+    expect(subject.items.count).to.equal(0);
+});
+
 SpecEnd;

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -8,6 +8,7 @@ upcoming:
     - Removes rotation support on refine auction listings view for iPhone - ash
     - Updated Danger to use new org - orta
   notes:
+    - Users may now refine sale artworks on native auction view by their low estimates - ash
     - Fix Analytics for the `ARTopViewController` and the `ARTabContentView` - orta
     - Added slug analytics to a few view controllers - orta
     - Fix for search button in Fairs - orta

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -316,7 +316,7 @@ SPEC CHECKSUMS:
   AFOAuth1Client: 07ccc935ba06ac8d023c16d39a5bdf04bc6f92e1
   ALPValidator: c74ea0d49bbbff0f8a4228f1eb6589b992255cfe
   Analytics: 7a5f10f6a2dd313d650f5db2642d9f967da3c693
-  ARAnalytics: 96e23ba7f54298f4914de9e1ac999db7a15f3fdd
+  ARAnalytics: ab25a3d8c6c950f69f25100de470614b6a7d6d9b
   ARASCIISwizzle: 4800c50a918bdc06f6304020e348ef8c15c554ee
   ARCollectionViewMasonryLayout: 776730bdedd0c7570a5e904c370e4e120f98ea62
   ARGenericTableViewController: 61a0897ba66c35111b5d1cc3b44884282bd3c1a5


### PR DESCRIPTION
Related to #972.

@orta I had some questions about how to use the embedded model view controller. Specifically, what are you thoughts on an approach to display not _just_ artworks? We'll need two different cells, one for each masonry/list layout. Could we chat tomorrow sometime?

In the mean time, filtering by price works :tada: and I shored up the tests around the sale view model.