### PR TITLE
Tapping an auction lot takes you to that lot's artwork page

### DIFF
--- a/Artsy/Resources/Artsy-Bridging-Header.h
+++ b/Artsy/Resources/Artsy-Bridging-Header.h
@@ -12,6 +12,10 @@
 #import "ARSeparatorViews.h"
 #import "ArtsyAPI+CurrentUserFunctions.h"
 #import "ARSaleArtworkItemWidthDependentModule.h"
+#import "ARArtworkSetViewController.h"
+#import "Fair.h" // Required by the switchboard's loadArtworkWithID(inFair:) function, even if we just pass nil in as a fair.
+
+#import "ARSwitchboard+Eigen.h"
 
 // Perhaps in the future we could use https://github.com/orta/ar_dispatch/ for now though eigen does more than this lib
 #import "ARDispatchManager.h"

--- a/Artsy/View_Controllers/Auction/AuctionViewController.swift
+++ b/Artsy/View_Controllers/Auction/AuctionViewController.swift
@@ -214,7 +214,11 @@ extension RefineSettings: AuctionRefineViewControllerDelegate {
 private typealias EmbeddedModelCallbacks = AuctionViewController
 extension EmbeddedModelCallbacks: ARModelInfiniteScrollViewControllerDelegate {
     func embeddedModelsViewController(controller: AREmbeddedModelsViewController!, didTapItemAtIndex index: UInt) {
-        // TODO
+        let item = saleArtworksViewController.items[Int(index)] as? SaleArtworkViewModel
+        guard let artworkID = item?.artworkID else { return }
+
+        let viewController = ARSwitchBoard.sharedInstance().loadArtworkWithID(artworkID, inFair: nil)
+        navigationController?.pushViewController(viewController, animated: allowAnimations)
     }
 
     func embeddedModelsViewController(controller: AREmbeddedModelsViewController!, shouldPresentViewController viewController: UIViewController!) {

--- a/Artsy/Views/Auction/SaleArtworkViewModel.swift
+++ b/Artsy/Views/Auction/SaleArtworkViewModel.swift
@@ -34,6 +34,10 @@ extension PublicComputedProperties {
         return saleArtwork.numberOfBidsString()
     }
 
+    var artworkID: String {
+        return saleArtwork.artwork.artworkID
+    }
+
     func currentOrStartingBidWithNumberOfBids(includeNumberOfBids: Bool) -> String {
         let bidString = saleArtwork.highestOrStartingBidString()
         if includeNumberOfBids {

--- a/Artsy_Tests/View_Controller_Tests/Auction/SaleArtworkViewModelTests.swift
+++ b/Artsy_Tests/View_Controller_Tests/Auction/SaleArtworkViewModelTests.swift
@@ -67,5 +67,9 @@ class SaleArtworkViewModelTests: QuickSpec {
         it("returns starting bid alone") {
             expect(subject.currentOrStartingBidWithNumberOfBids(true)) == "$1,000 (4 Bids)"
         }
+
+        it("returns artwork ID") {
+            expect(subject.artworkID) == "artwork_id"
+        }
     }
 }

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -24,6 +24,7 @@ upcoming:
     - Auction listings list layout works - ash
     - Auction listings sort works - ash
     - Auction listings use appropriate layout (list vs grid view) - ash
+    - Tapping on an auction lot takes you to that artwork's view - ash
 
 releases:
   - version: 2.3.5


### PR DESCRIPTION
... where you can then bid on the artwork 🎉

So the bridging head changers are a bit odd, eh? What's going on?

Well we have our switchboard, right? And it has methods on it that return various `UIViewController` subclasses. In order to call those methods, Swift needs to have access to the return types of the functions as well the types of any parameters. So even though I'm passing in a `nil` fair, Swift still needs `Fair.h` in the bridging header.