### PR TITLE
Adds Swift abstraction for Navigation Buttons

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -284,6 +284,8 @@
 		5E79FCB11C7612D8003D5D65 /* Int+Metrification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E79FCB01C7612D8003D5D65 /* Int+Metrification.swift */; };
 		5E79FCB41C761E1A003D5D65 /* ARSaleArtworkItemMasonryModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E79FCB31C761E1A003D5D65 /* ARSaleArtworkItemMasonryModule.m */; };
 		5E79FCB71C761E49003D5D65 /* ARSaleArtworkMasonryCollectionViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E79FCB61C761E49003D5D65 /* ARSaleArtworkMasonryCollectionViewCell.m */; };
+		5E79FCBA1C768108003D5D65 /* ARNvagiationButton+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E79FCB91C768108003D5D65 /* ARNvagiationButton+Swift.swift */; };
+		5E79FCBC1C76856C003D5D65 /* NavigationButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E79FCBB1C76856C003D5D65 /* NavigationButtonTests.swift */; };
 		5E8A03B51C52B60900EAF18B /* AuctionRefineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E8A03B41C52B60900EAF18B /* AuctionRefineViewController.swift */; };
 		5E9A782019068EDF00734E1B /* ARProfileViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E9A781F19068EDF00734E1B /* ARProfileViewControllerTests.m */; };
 		5E9A78231906BA3D00734E1B /* OCMArg+ClassChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E9A78221906BA3D00734E1B /* OCMArg+ClassChecker.m */; };
@@ -1147,6 +1149,8 @@
 		5E79FCB51C761E49003D5D65 /* ARSaleArtworkMasonryCollectionViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARSaleArtworkMasonryCollectionViewCell.h; sourceTree = "<group>"; };
 		5E79FCB61C761E49003D5D65 /* ARSaleArtworkMasonryCollectionViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARSaleArtworkMasonryCollectionViewCell.m; sourceTree = "<group>"; };
 		5E79FCB81C764780003D5D65 /* ARSaleArtworkItemWidthDependentModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARSaleArtworkItemWidthDependentModule.h; sourceTree = "<group>"; };
+		5E79FCB91C768108003D5D65 /* ARNvagiationButton+Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ARNvagiationButton+Swift.swift"; sourceTree = "<group>"; };
+		5E79FCBB1C76856C003D5D65 /* NavigationButtonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationButtonTests.swift; sourceTree = "<group>"; };
 		5E8A03B41C52B60900EAF18B /* AuctionRefineViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AuctionRefineViewController.swift; path = Auction/AuctionRefineViewController.swift; sourceTree = "<group>"; };
 		5E9A781F19068EDF00734E1B /* ARProfileViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARProfileViewControllerTests.m; sourceTree = "<group>"; };
 		5E9A78211906BA3D00734E1B /* OCMArg+ClassChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "OCMArg+ClassChecker.h"; sourceTree = "<group>"; };
@@ -4357,6 +4361,7 @@
 				342F972963924EC91C9B5CFD /* ARFollowableButton.h */,
 				600EE29C16B3003F002E9F9A /* ARNavigationButton.m */,
 				600EE29D16B3003F002E9F9A /* ARNavigationButton.h */,
+				5E79FCB91C768108003D5D65 /* ARNvagiationButton+Swift.swift */,
 				540262C418A0FAFB00844AE1 /* ARButtonWithImage.h */,
 				540262C518A0FAFB00844AE1 /* ARButtonWithImage.m */,
 			);
@@ -4370,6 +4375,7 @@
 				E612BC3E19D1B9DE00585CD6 /* ARFollowableButtonTests.m */,
 				3CA37E7B1910217500B06E81 /* ARHeartButtonTests.m */,
 				3C28D3DA18BE180B00C846EA /* ARNavigationButtonTests.m */,
+				5E79FCBB1C76856C003D5D65 /* NavigationButtonTests.swift */,
 			);
 			path = Buttons;
 			sourceTree = "<group>";
@@ -4974,6 +4980,7 @@
 				CB8D9D4417CEA7B900F3286B /* AROnboardingMoreInfoViewController.m in Sources */,
 				5EDB120B197E691100E241F0 /* ARParallaxHeaderViewController.m in Sources */,
 				5EA7BC3A1C612454009C52C9 /* AuctionSaleArtworksNetworkModel.swift in Sources */,
+				5E79FCBA1C768108003D5D65 /* ARNvagiationButton+Swift.swift in Sources */,
 				6038B78A1C2856BA00359F3B /* ARSwitchboard+Eigen.m in Sources */,
 				609F984D1AC0F50D0079FE21 /* WatchArtwork+ArtsyModels.m in Sources */,
 				60F63AB71C58E86400DCFF2A /* ARHockeyFeedbackDelegate.swift in Sources */,
@@ -5341,6 +5348,7 @@
 				54289FEE18AA7F4E00681E49 /* UINavigationController_InnermostTopViewControllerSpec.m in Sources */,
 				60F63AB51C58D9B100DCFF2A /* ARSwitchboard+EchoSpec.m in Sources */,
 				342F98EAAAAA4C3264E90CD2 /* ARGeneArtworksNetworkModelTests.m in Sources */,
+				5E79FCBC1C76856C003D5D65 /* NavigationButtonTests.swift in Sources */,
 				E611847218D7B4C4000FE4C9 /* ARSharingControllerTests.m in Sources */,
 				3CA0A17D18EF633900C361E5 /* ARArtistViewControllerTests.m in Sources */,
 				608EE3DB19954CEB001F4FE0 /* UIViewController+Testing.m in Sources */,

--- a/Artsy/View_Controllers/Auction/AuctionInformationViewController.swift
+++ b/Artsy/View_Controllers/Auction/AuctionInformationViewController.swift
@@ -85,13 +85,19 @@ class AuctionInformationViewController : UIViewController {
         auctionBeginsLabel.text = self.auctionInformation.startsAt
         stackView.addSubview(auctionBeginsLabel, withTopMargin: "10", sideMargin: "40")
         
-        let faqButtonDescription = [ARNavigationButtonClassKey: ARNavigationButton.self,
-                                    ARNavigationButtonPropertiesKey: ["title": "AUCTIONS FAQ"],
-                                    ARNavigationButtonHandlerKey: toBlock({ [unowned self] (_) in self.showFAQ(true) })]
-        let contactButtonDescription = [ARNavigationButtonClassKey: ARNavigationButton.self,
-                                        ARNavigationButtonPropertiesKey: ["title": "CONTACT"],
-                                        ARNavigationButtonHandlerKey: toBlock({ [unowned self] (_) in self.showContact(true) })]
-        let buttonsViewController = ARNavigationButtonsViewController(buttonDescriptions: [faqButtonDescription, contactButtonDescription])
+        let faqButtonDescription = NavigationButton(
+            buttonClass: ARNavigationButton.self,
+            properties: ["title": "AUCTIONS FAQ"],
+            handler: { [unowned self] _ in self.showFAQ(true)  }
+        )
+
+        let contactButtonDescription = NavigationButton(
+            buttonClass: ARNavigationButton.self,
+            properties: ["title": "CONTACT"],
+            handler: { [unowned self] _ in self.showContact(true)  }
+        )
+
+        let buttonsViewController = ARNavigationButtonsViewController.viewController(withButtons: [faqButtonDescription, contactButtonDescription])
 
         stackView.addViewController(buttonsViewController, toParent: self, withTopMargin: "20", sideMargin: "40")
     }
@@ -110,10 +116,6 @@ class AuctionInformationViewController : UIViewController {
             controller.setSubject("Questions about “\(self.auctionInformation.title)”")
             self.presentViewController(controller, animated: animated, completion: nil)
         }
-    }
-
-    private func toBlock(closure: @convention (block) UIButton -> Void) -> AnyObject {
-        return unsafeBitCast(closure, AnyObject.self)
     }
 }
 

--- a/Artsy/Views/Styled_Subclasses/Buttons/ARNvagiationButton+Swift.swift
+++ b/Artsy/Views/Styled_Subclasses/Buttons/ARNvagiationButton+Swift.swift
@@ -1,0 +1,27 @@
+import UIKit
+
+struct NavigationButton {
+    typealias HandlerClosure = UIButton -> Void
+
+    let buttonClass: UIButton.Type
+    let properties: [String: String]
+    let handler: HandlerClosure
+
+    var descriptionDictionary: NSDictionary {
+        return [
+            ARNavigationButtonClassKey: buttonClass,
+            ARNavigationButtonPropertiesKey: properties,
+            ARNavigationButtonHandlerKey: toBlock(handler)
+        ]
+    }
+}
+
+extension ARNavigationButtonsViewController {
+    static func viewController(withButtons buttons: [NavigationButton]) -> ARNavigationButtonsViewController {
+        return ARNavigationButtonsViewController(buttonDescriptions: buttons.map { $0.descriptionDictionary })
+    }
+}
+
+private func toBlock(closure: @convention (block) UIButton -> Void) -> AnyObject {
+    return unsafeBitCast(closure, AnyObject.self)
+}

--- a/Artsy_Tests/View_Tests/Buttons/NavigationButtonTests.swift
+++ b/Artsy_Tests/View_Tests/Buttons/NavigationButtonTests.swift
@@ -1,0 +1,32 @@
+import Quick
+import Nimble
+@testable
+import Artsy
+
+class NavigationButtonTests: QuickSpec {
+    override func spec() {
+        it("maps class correctly") {
+            let subject = NavigationButton(buttonClass: UIButton.self, properties: ["key": "value"], handler: { _ in })
+
+            expect(subject.descriptionDictionary[ARNavigationButtonClassKey] as? UIButton.Type).toNot( beNil() )
+        }
+
+        it("maps properties correctly") {
+            let subject = NavigationButton(buttonClass: UIButton.self, properties: ["key": "value"], handler: { _ in })
+
+            expect(subject.descriptionDictionary[ARNavigationButtonPropertiesKey] as? NSDictionary) == ["key": "value"] as NSDictionary
+        }
+
+        typealias CallbackBlock = @convention (block) UIButton -> Void
+
+        it("maps handler correctly") {
+            var called = false
+
+            let subject = NavigationButton(buttonClass: UIButton.self, properties: ["key": "value"], handler: { _ in called = true })
+            let handler = unsafeBitCast(subject.descriptionDictionary[ARNavigationButtonHandlerKey], CallbackBlock.self)
+            handler(UIButton())
+
+            expect(called) == true
+        }
+    }
+}

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -11,6 +11,7 @@ upcoming:
     - Updated Danger to use new org - orta
     - Adds unit tests for auction view controller - ash
     - Dev Extras are only ever called once - ash
+    - New navigation button abstraction for Swift - ash
   notes:
     - Users may now refine sale artworks on native auction view by their low estimates - ash
     - Fix Analytics for the `ARTopViewController` and the `ARTabContentView` - orta


### PR DESCRIPTION
This abstracts the messiness of working with the `ARNavigationButton` stuff with Swift into one place.

Fixes #1169.