### PR TITLE
Add support for breaking out of the sandbox when needed

### DIFF
--- a/Artsy/App/ARSwitchBoard.h
+++ b/Artsy/App/ARSwitchBoard.h
@@ -44,10 +44,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (UIViewController *)loadPath:(NSString *)path fair:(Fair *_Nullable)fair;
 
 /// Send an URL through the router
-- (UIViewController *)loadURL:(NSURL *)url;
+- (UIViewController *_Nullable)loadURL:(NSURL *)url;
 
 /// Send an URL through the router with an optional fair object
-- (UIViewController *)loadURL:(NSURL *)url fair:(Fair *_Nullable)fair;
+- (UIViewController *_Nullable)loadURL:(NSURL *)url fair:(Fair *_Nullable)fair;
 
 /// Can the Switchboard handle a URL?
 - (BOOL)canRouteURL:(NSURL *)url;

--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -40,11 +40,13 @@
 #import <ObjectiveSugar/ObjectiveSugar.h>
 
 
+NSString *const AREscapeSandboxQueryString = @"eigen_escape_sandbox";
+
+
 @interface ARSwitchBoard ()
 
 @property (nonatomic, strong) JLRoutes *routes;
 @property (nonatomic, strong) Aerodramus *echo;
-@property (nonatomic, strong) UIApplication *sharedApplication;
 
 @end
 
@@ -268,9 +270,9 @@
         return [self routeInternalURL:fixedURL fair:fair];
 
     } else if ([ARRouter isWebURL:url]) {
-        /// Is is a webpage we could open in webkit?
-        if (ARIsRunningInDemoMode || [url.query containsString:@"eigen_escape_sandbox"]) {
-            [self.sharedApplication openURL:url];
+        /// Is is a webpage we could open in webkit?, or need to break out to safari (see PR #1195)
+        if (ARIsRunningInDemoMode || [url.query containsString:AREscapeSandboxQueryString]) {
+            [[UIApplication sharedApplication] openURL:url];
             return nil;
         } else {
             return [[ARExternalWebBrowserViewController alloc] initWithURL:url];
@@ -336,13 +338,6 @@
         return [NSURL URLWithString:newURLString];
     }
     return url;
-}
-
-#pragma mark DI -
-
-- (UIApplication *)sharedApplication
-{
-    return _sharedApplication ?: [UIApplication sharedApplication];
 }
 
 @end

--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -44,6 +44,7 @@
 
 @property (nonatomic, strong) JLRoutes *routes;
 @property (nonatomic, strong) Aerodramus *echo;
+@property (nonatomic, strong) UIApplication *sharedApplication;
 
 @end
 
@@ -268,12 +269,14 @@
 
     } else if ([ARRouter isWebURL:url]) {
         /// Is is a webpage we could open in webkit?
-        if (ARIsRunningInDemoMode) {
-            [[UIApplication sharedApplication] openURL:url];
+        if (ARIsRunningInDemoMode || [url.query containsString:@"eigen_escape_sandbox"]) {
+            [self.sharedApplication openURL:url];
+            return nil;
         } else {
             return [[ARExternalWebBrowserViewController alloc] initWithURL:url];
         }
     }
+
     /// It's probably an app link, offer to jump out
     [self openURLInExternalService:url];
     return nil;
@@ -333,6 +336,13 @@
         return [NSURL URLWithString:newURLString];
     }
     return url;
+}
+
+#pragma mark DI -
+
+- (UIApplication *)sharedApplication
+{
+    return _sharedApplication ?: [UIApplication sharedApplication];
 }
 
 @end

--- a/Artsy/View_Controllers/Web_Browsing/ARExternalWebBrowserViewController.m
+++ b/Artsy/View_Controllers/Web_Browsing/ARExternalWebBrowserViewController.m
@@ -158,7 +158,10 @@
         NSURL *URL = navigationAction.request.URL;
         ARSwitchBoard *switchboard = [ARSwitchBoard sharedInstance];
         if ([switchboard canRouteURL:URL]) {
-            [switchboard presentViewController:[switchboard loadURL:URL]];
+            UIViewController *controller = [switchboard loadURL:URL];
+            if (controller) {
+                [switchboard presentViewController:controller];
+            }
             return WKNavigationActionPolicyCancel;
         }
     }

--- a/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
+++ b/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
@@ -26,6 +26,7 @@
 - (id)routeInternalURL:(NSURL *)url fair:(Fair *)fair;
 - (void)openURLInExternalService:(NSURL *)url;
 - (void)updateRoutes;
+@property (nonatomic, strong) UIApplication *sharedApplication;
 @end
 
 
@@ -118,7 +119,16 @@ describe(@"ARSwitchboard", ^{
                 [switchboard loadURL:internalURL];
                 [switchboardMock verify];
             });
+        });
 
+        it(@"handles breaking out of the eigen routing sandbox when needed", ^{
+            id sharedAppMock = [OCMockObject partialMockForObject:[UIApplication sharedApplication]];
+            [[sharedAppMock expect] openURL:OCMOCK_ANY];
+
+            NSURL *internalURL = [[NSURL alloc] initWithString:@"http://mysitethatmustbeopenedinsafari.com?eigen_escape_sandbox=true"];
+            [switchboard loadURL:internalURL];
+            
+            [sharedAppMock verify];
         });
 
         describe(@"with applewebdata urls", ^{

--- a/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
+++ b/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
@@ -26,7 +26,6 @@
 - (id)routeInternalURL:(NSURL *)url fair:(Fair *)fair;
 - (void)openURLInExternalService:(NSURL *)url;
 - (void)updateRoutes;
-@property (nonatomic, strong) UIApplication *sharedApplication;
 @end
 
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -8,6 +8,7 @@ upcoming:
     - Additional work on the auction title view - ash
     - Removes rotation support on refine auction listings view for iPhone - ash
   notes:
+    - Support breaking out of the router sandboxing when there's a link with ?eigen_escape_sandbox' - orta
     - Users may now refine sale artworks on native auction view by their low estimates - ash
     - Show auction information, such as a description, FAQ, and contact - alloy
     - Auction listings list layout works - ash


### PR DESCRIPTION
We have a link that needs to escape the eigen sandboxing around routing, in this case - the link is a link that safari can handle and create an event in someone's calendar. In the future, well, it could be anything. 

So we want to provide a way to optionally skip this routing for _non_ artsy URLs. So, prerequisites are: not in this list `artsyHosts = [NSSet setWithObjects:@"art.sy", @"artsyapi.com", @"artsy.net", @"m.artsy.net", @"staging.artsy.net", @"m-staging.artsy.net", nil];`, and has a query string which includes the string `eigen_escape_sandbox`. 

/cc @broskoski