### PR TITLE
Add support for custom web / api staging urls for eigen

### DIFF
--- a/Artsy/Constants/ARDefaults.h
+++ b/Artsy/Constants/ARDefaults.h
@@ -1,6 +1,9 @@
 extern NSString *const ARUserIdentifierDefault;
 extern NSString *const ARUseStagingDefault;
+
 extern NSString *const ARStagingAPIURLDefault;
+extern NSString *const ARStagingPhoneWebURLDefault;
+extern NSString *const ARStagingPadWebURLDefault;
 
 extern NSString *const AROAuthTokenDefault;
 extern NSString *const AROAuthTokenExpiryDateDefault;

--- a/Artsy/Constants/ARDefaults.h
+++ b/Artsy/Constants/ARDefaults.h
@@ -1,5 +1,6 @@
 extern NSString *const ARUserIdentifierDefault;
 extern NSString *const ARUseStagingDefault;
+extern NSString *const ARStagingAPIURLDefault;
 
 extern NSString *const AROAuthTokenDefault;
 extern NSString *const AROAuthTokenExpiryDateDefault;

--- a/Artsy/Constants/ARDefaults.m
+++ b/Artsy/Constants/ARDefaults.m
@@ -5,6 +5,7 @@ const static NSInteger AROnboardingPromptDefault = 25;
 
 NSString *const ARUserIdentifierDefault = @"ARUserIdentifier";
 NSString *const ARUseStagingDefault = @"ARUseStagingDefault";
+NSString *const ARStagingAPIURLDefault = @"ARStagingAPIURLDefault";
 
 NSString *const AROAuthTokenDefault = @"AROAuthToken";
 NSString *const AROAuthTokenExpiryDateDefault = @"AROAuthTokenExpiryDate";
@@ -38,7 +39,8 @@ NSString *const ARShowAuctionResultsButtonDefault = @"auction-results";
         AROnboardingSkipPersonalizeDefault : @(NO),
         AROnboardingSkipCollectorLevelDefault : @(NO),
         AROnboardingSkipPriceRangeDefault : @(NO),
-        AROnboardingPromptThresholdDefault : @(NO)
+        AROnboardingPromptThresholdDefault : @(NO),
+        ARStagingAPIURLDefault : @"https://stagingapi.artsy.net"
     }];
 }
 

--- a/Artsy/Constants/ARDefaults.m
+++ b/Artsy/Constants/ARDefaults.m
@@ -5,7 +5,10 @@ const static NSInteger AROnboardingPromptDefault = 25;
 
 NSString *const ARUserIdentifierDefault = @"ARUserIdentifier";
 NSString *const ARUseStagingDefault = @"ARUseStagingDefault";
+
 NSString *const ARStagingAPIURLDefault = @"ARStagingAPIURLDefault";
+NSString *const ARStagingPhoneWebURLDefault = @"ARStagingPhoneWebURLDefault";
+NSString *const ARStagingPadWebURLDefault = @"ARStagingPadWebURLDefault";
 
 NSString *const AROAuthTokenDefault = @"AROAuthToken";
 NSString *const AROAuthTokenExpiryDateDefault = @"AROAuthTokenExpiryDate";
@@ -34,13 +37,16 @@ NSString *const ARShowAuctionResultsButtonDefault = @"auction-results";
 #endif
 
     [[NSUserDefaults standardUserDefaults] registerDefaults:@{
-        ARUseStagingDefault : @(useStagingDefault),
         AROnboardingPromptThresholdDefault : @(AROnboardingPromptDefault),
         AROnboardingSkipPersonalizeDefault : @(NO),
         AROnboardingSkipCollectorLevelDefault : @(NO),
         AROnboardingSkipPriceRangeDefault : @(NO),
         AROnboardingPromptThresholdDefault : @(NO),
-        ARStagingAPIURLDefault : @"https://stagingapi.artsy.net"
+
+        ARUseStagingDefault : @(useStagingDefault),
+        ARStagingAPIURLDefault : @"https://stagingapi.artsy.net",
+        ARStagingPhoneWebURLDefault : @"http://m-staging.artsy.net",
+        ARStagingPadWebURLDefault : @"https://staging.artsy.net"
     }];
 }
 

--- a/Artsy/Networking/ARNetworkConstants.h
+++ b/Artsy/Networking/ARNetworkConstants.h
@@ -3,7 +3,6 @@ extern NSString *const ARBaseMobileWebURL;
 extern NSString *const ARBaseApiURL;
 extern NSString *const ARStagingBaseWebURL;
 extern NSString *const ARStagingBaseMobileWebURL;
-extern NSString *const ARStagingBaseApiURL;
 
 extern NSString *const ARPersonalizePath;
 

--- a/Artsy/Networking/ARNetworkConstants.m
+++ b/Artsy/Networking/ARNetworkConstants.m
@@ -1,13 +1,11 @@
 #import <Foundation/Foundation.h>
 
-
 NSString *const ARBaseDesktopWebURL = @"https://www.artsy.net";
 NSString *const ARBaseMobileWebURL = @"https://m.artsy.net";
 NSString *const ARBaseApiURL = @"https://api.artsy.net";
 
 NSString *const ARStagingBaseWebURL = @"https://staging.artsy.net";
 NSString *const ARStagingBaseMobileWebURL = @"http://m-staging.artsy.net";
-NSString *const ARStagingBaseApiURL = @"https://stagingapi.artsy.net";
 
 NSString *const ARPersonalizePath = @"personalize";
 

--- a/Artsy/Networking/ARNetworkConstants.m
+++ b/Artsy/Networking/ARNetworkConstants.m
@@ -4,9 +4,6 @@ NSString *const ARBaseDesktopWebURL = @"https://www.artsy.net";
 NSString *const ARBaseMobileWebURL = @"https://m.artsy.net";
 NSString *const ARBaseApiURL = @"https://api.artsy.net";
 
-NSString *const ARStagingBaseWebURL = @"https://staging.artsy.net";
-NSString *const ARStagingBaseMobileWebURL = @"http://m-staging.artsy.net";
-
 NSString *const ARPersonalizePath = @"personalize";
 
 NSString *const ARTwitterCallbackPath = @"artsy://twitter-callback";

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -28,12 +28,26 @@
 static AFHTTPSessionManager *staticHTTPClient = nil;
 static NSSet *artsyHosts = nil;
 
+static NSString *hostFromString(NSString *string)
+{
+    return [[NSURL URLWithString:string] host];
+}
+
 
 @implementation ARRouter
 
 + (void)setup
 {
-    artsyHosts = [NSSet setWithObjects:@"art.sy", @"artsyapi.com", @"artsy.net", @"m.artsy.net", @"staging.artsy.net", @"m-staging.artsy.net", nil];
+    NSString *productionHost = hostFromString(ARBaseDesktopWebURL);
+    NSString *productionMobile = hostFromString(ARBaseMobileWebURL);
+    NSString *productionAPI = hostFromString(ARBaseMobileWebURL);
+
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSString *stagingHost = hostFromString([defaults stringForKey:ARStagingPadWebURLDefault]);
+    NSString *stagingMobile = hostFromString([defaults stringForKey:ARStagingPhoneWebURLDefault]);
+    NSString *stagingAPI = hostFromString([defaults stringForKey:ARStagingAPIURLDefault]);
+
+    artsyHosts = [NSSet setWithArray:@[ productionAPI, productionHost, productionMobile, stagingAPI, stagingHost, stagingMobile ]];
 
     [ARRouter setupWithBaseApiURL:[ARRouter baseApiURL]];
 
@@ -62,12 +76,16 @@ static NSSet *artsyHosts = nil;
 
 + (NSURL *)baseDesktopWebURL
 {
-    return [NSURL URLWithString:[AROptions boolForOption:ARUseStagingDefault] ? ARStagingBaseWebURL : ARBaseDesktopWebURL];
+    NSString *stagingBaseWebURL = [[NSUserDefaults standardUserDefaults] stringForKey:ARStagingPadWebURLDefault];
+    NSString *url = [AROptions boolForOption:ARUseStagingDefault] ? stagingBaseWebURL : ARBaseDesktopWebURL;
+    return [NSURL URLWithString:url];
 }
 
 + (NSURL *)baseMobileWebURL
 {
-    return [NSURL URLWithString:[AROptions boolForOption:ARUseStagingDefault] ? ARStagingBaseMobileWebURL : ARBaseMobileWebURL];
+    NSString *stagingBaseWebURL = [[NSUserDefaults standardUserDefaults] stringForKey:ARStagingPhoneWebURLDefault];
+    NSString *url = [AROptions boolForOption:ARUseStagingDefault] ? stagingBaseWebURL : ARBaseMobileWebURL;
+    return [NSURL URLWithString:url];
 }
 
 + (void)setupWithBaseApiURL:(NSURL *)baseApiURL

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -48,7 +48,8 @@ static NSSet *artsyHosts = nil;
 + (NSURL *)baseApiURL
 {
     if ([AROptions boolForOption:ARUseStagingDefault]) {
-        return [NSURL URLWithString:ARStagingBaseApiURL];
+        NSString *stagingBaseAPI = [[NSUserDefaults standardUserDefaults] stringForKey:ARStagingAPIURLDefault];
+        return [NSURL URLWithString:stagingBaseAPI];
     } else {
         return [NSURL URLWithString:ARBaseApiURL];
     }

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -47,7 +47,7 @@ static NSString *hostFromString(NSString *string)
     NSString *stagingMobile = hostFromString([defaults stringForKey:ARStagingPhoneWebURLDefault]);
     NSString *stagingAPI = hostFromString([defaults stringForKey:ARStagingAPIURLDefault]);
 
-    artsyHosts = [NSSet setWithArray:@[ productionAPI, productionHost, productionMobile, stagingAPI, stagingHost, stagingMobile ]];
+    artsyHosts = [NSSet setWithArray:@[ @"artsy.net", productionAPI, productionHost, productionMobile, stagingAPI, stagingHost, stagingMobile ]];
 
     [ARRouter setupWithBaseApiURL:[ARRouter baseApiURL]];
 

--- a/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
+++ b/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
@@ -61,6 +61,9 @@ NSString *const ARLabOptionCell = @"LabOptionCell";
     ARSectionData *vcrSection = [self createVCRSection];
     [tableViewData addSectionData:vcrSection];
 
+    ARSectionData *developerSection = [self createDeveloperSection];
+    [tableViewData addSectionData:developerSection];
+
     self.tableViewData = tableViewData;
     self.tableView.contentInset = UIEdgeInsetsMake(88, 0, 0, 0);
 }
@@ -183,6 +186,45 @@ NSString *const ARLabOptionCell = @"LabOptionCell";
     }
     return labsSectionData;
 }
+
+- (ARSectionData *)createDeveloperSection
+{
+    ARSectionData *labsSectionData = [[ARSectionData alloc] init];
+    labsSectionData.headerTitle = @"Developer";
+
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSString *stagingAddress = [defaults stringForKey:ARStagingAPIURLDefault];
+
+    ARCellData *stagingURL = [[ARCellData alloc] initWithIdentifier:ARLabOptionCell];
+    [stagingURL setCellConfigurationBlock:^(UITableViewCell *cell) {
+        cell.textLabel.text = [NSString stringWithFormat:@"Staging URL: %@", stagingAddress];
+    }];
+
+    [stagingURL setCellSelectionBlock:^(UITableView *tableView, NSIndexPath *indexPath) {
+        UIAlertController *controller = [UIAlertController alertControllerWithTitle:@"Change URL" message:@"" preferredStyle:UIAlertControllerStyleAlert];
+        [controller addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
+            textField.text = stagingAddress;
+        }];
+
+        [controller addAction:[UIAlertAction actionWithTitle:@"Save + Log out" style:UIAlertActionStyleDestructive handler:^(UIAlertAction * _Nonnull action) {
+            UITextField *newStagingTextField = [controller textFields].firstObject;
+            [defaults setObject:newStagingTextField.text forKey:ARStagingAPIURLDefault];
+            [defaults synchronize];
+            exit(0);
+        }]];
+
+        [controller addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
+            [controller.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+        }]];
+        
+        [self presentViewController:controller animated:YES completion:nil];
+    }];
+
+    [labsSectionData addCellData:stagingURL];
+
+    return labsSectionData;
+}
+
 
 - (ARSectionData *)createVCRSection
 {

--- a/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
+++ b/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
@@ -192,36 +192,11 @@ NSString *const ARLabOptionCell = @"LabOptionCell";
     ARSectionData *labsSectionData = [[ARSectionData alloc] init];
     labsSectionData.headerTitle = @"Developer";
 
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    NSString *stagingAddress = [defaults stringForKey:ARStagingAPIURLDefault];
+    ARCellData *stagingAPI = [self cellDataWithName:@"API" defaultKey:ARStagingAPIURLDefault];
+    ARCellData *stagingPhoneWeb = [self cellDataWithName:@"Phone Web" defaultKey:ARStagingPhoneWebURLDefault];
+    ARCellData *stagingPadWeb = [self cellDataWithName:@"Pad Web" defaultKey:ARStagingPadWebURLDefault];
 
-    ARCellData *stagingURL = [[ARCellData alloc] initWithIdentifier:ARLabOptionCell];
-    [stagingURL setCellConfigurationBlock:^(UITableViewCell *cell) {
-        cell.textLabel.text = [NSString stringWithFormat:@"Staging URL: %@", stagingAddress];
-    }];
-
-    [stagingURL setCellSelectionBlock:^(UITableView *tableView, NSIndexPath *indexPath) {
-        UIAlertController *controller = [UIAlertController alertControllerWithTitle:@"Change URL" message:@"" preferredStyle:UIAlertControllerStyleAlert];
-        [controller addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
-            textField.text = stagingAddress;
-        }];
-
-        [controller addAction:[UIAlertAction actionWithTitle:@"Save + Log out" style:UIAlertActionStyleDestructive handler:^(UIAlertAction * _Nonnull action) {
-            UITextField *newStagingTextField = [controller textFields].firstObject;
-            [defaults setObject:newStagingTextField.text forKey:ARStagingAPIURLDefault];
-            [defaults synchronize];
-            exit(0);
-        }]];
-
-        [controller addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
-            [controller.presentingViewController dismissViewControllerAnimated:YES completion:nil];
-        }]];
-        
-        [self presentViewController:controller animated:YES completion:nil];
-    }];
-
-    [labsSectionData addCellData:stagingURL];
-
+    [labsSectionData addCellDataFromArray:@[ stagingAPI, stagingPhoneWeb, stagingPadWeb ]];
     return labsSectionData;
 }
 
@@ -303,6 +278,40 @@ NSString *const ARLabOptionCell = @"LabOptionCell";
 - (BOOL)shouldAutorotate
 {
     return NO;
+}
+
+- (ARCellData *)cellDataWithName:(NSString *)name defaultKey:(NSString *)key
+{
+    ARCellData *cell = [[ARCellData alloc] initWithIdentifier:ARLabOptionCell];
+
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSString *value = [defaults stringForKey:key];
+
+    [cell setCellConfigurationBlock:^(UITableViewCell *cell) {
+        cell.textLabel.text = [NSString stringWithFormat:@"%@: %@", name, value];
+    }];
+
+    [cell setCellSelectionBlock:^(UITableView *tableView, NSIndexPath *indexPath) {
+        UIAlertController *controller = [UIAlertController alertControllerWithTitle:name message:@"" preferredStyle:UIAlertControllerStyleAlert];
+
+        [controller addAction:[UIAlertAction actionWithTitle:@"Save + Restart" style:UIAlertActionStyleDestructive handler:^(UIAlertAction * _Nonnull action) {
+            UITextField *theTextField = [controller textFields].firstObject;
+            [defaults setObject:theTextField.text forKey:key];
+            [defaults synchronize];
+            exit(0);
+        }]];
+
+        [controller addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
+            [controller.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+        }]];
+
+        [controller addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
+            textField.text = value;
+        }];
+
+        [self presentViewController:controller animated:YES completion:nil];
+    }];
+    return cell;
 }
 
 @end

--- a/Artsy_Tests/Networking_Tests/API_Modules/ARUserManagerTests.m
+++ b/Artsy_Tests/Networking_Tests/API_Modules/ARUserManagerTests.m
@@ -10,7 +10,11 @@
 + (void)clearUserData:(ARUserManager *)manager useStaging:(id)useStaging;
 @end
 
-SpecBegin(ARUserManager);
+// This makes a lot of global changes to the  NSUserDefaults shared
+// user defaults, and so is ran at the end.
+// FIXME: Migrate to using DI for defaults.
+
+SpecBegin(ZARUserManager);
 
 beforeEach(^{
     [ARUserManager clearUserData];
@@ -161,7 +165,7 @@ describe(@"clearUserData", ^{
         });
 
         it(@"explicitly sets staging default to yes", ^{
-            expect([[NSUserDefaults standardUserDefaults] valueForKey:ARUseStagingDefault]).to.beNil();
+            expect([[NSUserDefaults standardUserDefaults] objectForKey:ARUseStagingDefault]).to.beTruthy();
             expect([[NSUserDefaults standardUserDefaults] valueForKey:@"TestKey"]).to.equal(@"test value");
             [ARUserManager clearUserData:[ARUserManager sharedManager] useStaging:@(YES)];
             expect([[NSUserDefaults standardUserDefaults] valueForKey:ARUseStagingDefault]).to.beTruthy();
@@ -169,7 +173,7 @@ describe(@"clearUserData", ^{
         });
         
         it(@"explicitly sets staging default to no", ^{
-            expect([[NSUserDefaults standardUserDefaults] valueForKey:ARUseStagingDefault]).to.beNil();
+            expect([[NSUserDefaults standardUserDefaults] valueForKey:ARUseStagingDefault]).to.beTruthy();
             expect([[NSUserDefaults standardUserDefaults] valueForKey:@"TestKey"]).to.equal(@"test value");
             [ARUserManager clearUserData:[ARUserManager sharedManager] useStaging:@(NO)];
             expect([[NSUserDefaults standardUserDefaults] valueForKey:ARUseStagingDefault]).to.beFalsy();

--- a/Artsy_Tests/Supporting_Files/ARTestHelper.m
+++ b/Artsy_Tests/Supporting_Files/ARTestHelper.m
@@ -24,6 +24,8 @@
              NSStringFromCGSize(nativeResolution));
 
     ARPerformWorkAsynchronously = NO;
+
+    [ARDefaults setup];
     [ARRouter setup];
 
     // Disable this so that no actual changes are made to the index as side-effects of favoriting entities.

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -7,6 +7,7 @@ upcoming:
     - Made the searchbar larger in fair views on iPhone - maxim
     - Additional work on the auction title view - ash
     - Removes rotation support on refine auction listings view for iPhone - ash
+    - Developers can choose to have a custom url for their staging environment - orta
   notes:
     - Users may now refine sale artworks on native auction view by their low estimates - ash
     - Show auction information, such as a description, FAQ, and contact - alloy


### PR DESCRIPTION
Makes it easier for non-cocoa devs to move to test Eigen support without deploying to staging or production:

![screen shot 2016-02-23 at 11 25 03 am](https://cloud.githubusercontent.com/assets/49038/13258174/1af601b6-da20-11e5-8ac6-53fe6e0fc6af.png)

![screen shot 2016-02-23 at 11 24 34 am](https://cloud.githubusercontent.com/assets/49038/13258177/1cd5f1da-da20-11e5-9ab9-4ad0541cf1d1.png)

![screen shot 2016-02-23 at 11 25 06 am](https://cloud.githubusercontent.com/assets/49038/13258183/20f52880-da20-11e5-8b77-57e3c565d7e7.png)
