### PR TITLE
Add a header for the eigen trial user account to web requests

### DIFF
--- a/Artsy/Networking/ARNetworkConstants.h
+++ b/Artsy/Networking/ARNetworkConstants.h
@@ -10,6 +10,8 @@ extern NSString *const ARTwitterCallbackPath;
 
 extern NSString *const ARAuthHeader;
 extern NSString *const ARXappHeader;
+extern NSString *const AREigenTrialUserIDHeader;
+
 extern NSString *const ARTotalHeader;
 
 extern NSString *const AROAuthURL;

--- a/Artsy/Networking/ARNetworkConstants.m
+++ b/Artsy/Networking/ARNetworkConstants.m
@@ -10,6 +10,8 @@ NSString *const ARTwitterCallbackPath = @"artsy://twitter-callback";
 
 NSString *const ARAuthHeader = @"X-Access-Token";
 NSString *const ARXappHeader = @"X-Xapp-Token";
+NSString *const AREigenTrialUserIDHeader = @"X-Eigen-Trial-ID";
+
 NSString *const ARTotalHeader = @"X-Total-Count";
 
 NSString *const AROAuthURL = @"/oauth2/access_token";

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -108,7 +108,9 @@ static NSString *hostFromString(NSString *string)
     // but make sure that this is not a slip-up due to background fetch downloading
 
     UIApplicationState state = [[UIApplication sharedApplication] applicationState];
-    if (![[ARUserManager sharedManager] hasExistingAccount] && state != UIApplicationStateBackground) {
+    ARUserManager *user = [ARUserManager sharedManager];
+
+    if (![user hasExistingAccount] && state != UIApplicationStateBackground) {
         [UICKeyChainStore removeItemForKey:AROAuthTokenDefault];
         [UICKeyChainStore removeItemForKey:ARXAppTokenKeychainKey];
     }
@@ -122,6 +124,10 @@ static NSString *hostFromString(NSString *string)
         ARActionLog(@"Found trial XApp token in keychain");
         NSString *xapp = [UICKeyChainStore stringForKey:ARXAppTokenKeychainKey];
         [ARRouter setXappToken:xapp];
+    }
+
+    if ([User isTrialUser]) {
+        [self setHTTPHeader:AREigenTrialUserIDHeader value:user.trialUserUUID];
     }
 }
 
@@ -183,6 +189,7 @@ static NSString *hostFromString(NSString *string)
     if (![ARRouter isInternalURL:url]) {
         [request setValue:nil forHTTPHeaderField:ARAuthHeader];
         [request setValue:nil forHTTPHeaderField:ARXappHeader];
+        [request setValue:nil forHTTPHeaderField:AREigenTrialUserIDHeader];
     }
 
     return request;

--- a/Artsy/View_Controllers/Embedded/Sale_Artworks/ARSaleArtworkItemMasonryModule.m
+++ b/Artsy/View_Controllers/Embedded/Sale_Artworks/ARSaleArtworkItemMasonryModule.m
@@ -4,7 +4,7 @@
 
 @import ARCollectionViewMasonryLayout;
 
-CGFloat marginForTraitCollection(UITraitCollection *traitCollection)
+static CGFloat marginForTraitCollection(UITraitCollection *traitCollection)
 {
     return (traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact ? 20 : 40);
 }

--- a/Artsy_Tests/Networking_Tests/ARRouterTests.m
+++ b/Artsy_Tests/Networking_Tests/ARRouterTests.m
@@ -1,6 +1,7 @@
 #import "ARRouter.h"
 #import "AROptions.h"
 #import "ARNetworkConstants.h"
+#import "ARUserManager+Stubs.h"
 
 SpecBegin(ARRouter);
 
@@ -144,6 +145,33 @@ describe(@"User-Agent", ^{
         request = [ARRouter newShowsRequestForArtist:@"orta"];
         expect(request.allHTTPHeaderFields[@"User-Agent"]).to.equal(userAgent);
     });
+});
+
+describe(@"sending eigen uuids to martsy/force", ^{
+    it(@"trial users send the eigen uuid", ^{
+        [ARUserManager logoutAndSetUseStaging:NO];
+        [ARRouter setup];
+
+        NSURLRequest *request = [ARRouter requestForURL:[NSURL URLWithString:@"http://m.artsy.net"]];
+        expect([request valueForHTTPHeaderField:AREigenTrialUserIDHeader]).to.beTruthy();
+    });
+
+    it(@"logged in users don't send the uuid", ^{
+        [ARUserManager stubAndLoginWithUsername];
+        [ARRouter setup];
+
+        NSURLRequest *request = [ARRouter requestForURL:[NSURL URLWithString:@"http://m.artsy.net"]];
+        expect([request valueForHTTPHeaderField:AREigenTrialUserIDHeader]).to.beFalsy();
+    });
+
+    it(@"other websites dont get the uuid", ^{
+        [ARUserManager logoutAndSetUseStaging:YES];
+        [ARRouter setup];
+
+        NSURLRequest *request = [ARRouter requestForURL:[NSURL URLWithString:@"http://orta.io"]];
+        expect([request valueForHTTPHeaderField:AREigenTrialUserIDHeader]).to.beFalsy();
+    });
+
 });
 
 describe(@"baseWebURL", ^{

--- a/Artsy_Tests/Networking_Tests/ARRouterTests.m
+++ b/Artsy_Tests/Networking_Tests/ARRouterTests.m
@@ -148,8 +148,14 @@ describe(@"User-Agent", ^{
 });
 
 describe(@"sending eigen uuids to martsy/force", ^{
+    __block id userMock;
+    after(^{
+        [userMock stopMocking];
+    });
+
     it(@"trial users send the eigen uuid", ^{
-        [ARUserManager logoutAndSetUseStaging:NO];
+        id userMock = [OCMockObject niceMockForClass:[User class]];
+        [[[userMock stub] andReturnValue:@(YES)] isTrialUser];
         [ARRouter setup];
 
         NSURLRequest *request = [ARRouter requestForURL:[NSURL URLWithString:@"http://m.artsy.net"]];
@@ -157,7 +163,8 @@ describe(@"sending eigen uuids to martsy/force", ^{
     });
 
     it(@"logged in users don't send the uuid", ^{
-        [ARUserManager stubAndLoginWithUsername];
+        id userMock = [OCMockObject niceMockForClass:[User class]];
+        [[[userMock stub] andReturnValue:@(NO)] isTrialUser];
         [ARRouter setup];
 
         NSURLRequest *request = [ARRouter requestForURL:[NSURL URLWithString:@"http://m.artsy.net"]];
@@ -165,13 +172,14 @@ describe(@"sending eigen uuids to martsy/force", ^{
     });
 
     it(@"other websites dont get the uuid", ^{
-        [ARUserManager logoutAndSetUseStaging:YES];
+        id userMock = [OCMockObject niceMockForClass:[User class]];
+        [[[userMock stub] andReturnValue:@(YES)] isTrialUser];
+
         [ARRouter setup];
 
         NSURLRequest *request = [ARRouter requestForURL:[NSURL URLWithString:@"http://orta.io"]];
         expect([request valueForHTTPHeaderField:AREigenTrialUserIDHeader]).to.beFalsy();
     });
-
 });
 
 describe(@"baseWebURL", ^{

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -17,7 +17,8 @@ upcoming:
     - Auction listings sort works - ash
     - Auction listings use appropriate layout (list vs grid view) - ash
     - Tapping on an auction lot takes you to that artwork's view - ash
-    - Auction information views use real data - orta 
+    - Auction information views use real data - orta
+    - Send the eigen trial UUID to internal web-pages via the header - orta
 
 releases:
   - version: 2.3.6


### PR DESCRIPTION
Passes the UUID for a trial account as a header so that analytics events can be hooked up between eigen and martsy/force. The ID is a header named `"X-Eigen-Trial-ID"` 