### PR TITLE
Support routing a domain to a view controller - fixes #1198

### DIFF
--- a/Artsy/App/ARSwitchBoard.h
+++ b/Artsy/App/ARSwitchBoard.h
@@ -37,6 +37,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Allows other objects to hook into the switchboard
 - (void)registerPathCallbackAtPath:(NSString *)path callback:(id _Nullable (^)(NSDictionary *_Nullable parameters))callback;
 
+/// Allows other objects to hook into the switchboard at the URL level
+- (void)registerPathCallbackForDomain:(NSString *)domain callback:(id _Nullable (^)(NSURL *url))callback;
+
 /// Load a path relative to the baseURL through the router
 - (UIViewController *)loadPath:(NSString *)path;
 

--- a/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
+++ b/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
@@ -162,7 +162,6 @@ describe(@"ARSwitchboard", ^{
                 [switchboard loadURL:externalURL];
                 [switchboardMock verify];
             });
-
         });
     });
 
@@ -179,6 +178,30 @@ describe(@"ARSwitchboard", ^{
             expect([switchboard loadPath:@"thingy"]).to.equal(newVC);
         });
     });
+
+    describe(@"adding a new domain", ^{
+        it(@"supports adding via the register method", ^{
+            UIViewController *newVC = [[UIViewController alloc] init];
+            [switchboard registerPathCallbackForDomain:@"orta.artsy.net" callback:^id _Nullable(NSURL * _Nonnull url) {
+                return newVC;
+            }];
+
+            expect([switchboard loadURL:[NSURL URLWithString:@"https://orta.artsy.net/me/thing"]]).to.equal(newVC);
+        });
+
+        it(@"sends the URL in to the callback for the URL routing", ^{
+            UIViewController *newVC = [[UIViewController alloc] init];
+            __block NSString *path = nil;
+            [switchboard registerPathCallbackForDomain:@"orta.artsy.net" callback:^id _Nullable(NSURL * _Nonnull url) {
+                path = url.path;
+                return newVC;
+            }];
+
+            [switchboard loadURL:[NSURL URLWithString:@"https://orta.artsy.net/me/thing"]];
+            expect(path).to.equal(@"/me/thing");
+        });
+    });
+
 
     describe(@"routeInternalURL", ^{
         it(@"routes profiles", ^{

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -17,7 +17,8 @@ upcoming:
     - Auction listings sort works - ash
     - Auction listings use appropriate layout (list vs grid view) - ash
     - Tapping on an auction lot takes you to that artwork's view - ash
-    - Auction information views use real data - orta 
+    - Auction information views use real data - orta
+    - Add support for routing around a domain instead of just a path - orta
 
 releases:
   - version: 2.3.6

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -255,7 +255,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Aerodramus:
-    :commit: d2a338d071e00fe9f16fdd89c59540cf295bc491
+    :commit: f3ad5f2c4d4f060722510bab83e07026c202ac7a
     :git: https://github.com/artsy/Aerodramus.git
   AFOAuth1Client:
     :git: https://github.com/lxcid/AFOAuth1Client.git


### PR DESCRIPTION
For Live Auctions we need to be able to deal with routes like `https://live.artsy.net/auction` - both from external links on the website and from inside the app. So as JLRoutes has no concept around host based routing, I've added a _very simple_ domain router. So far this is the simplest thing we'll need. 

I still have to go and add the route to echo, so I've not added tests around the actual existing routing that should happen from the app. As that can do something different in my next PR.

 fixes #1198