### PR TITLE
Support code injection !m!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ fastlane/Preview.html
 
 Artsy/View_Controllers/App_Navigation/ARTopMenuViewController+DeveloperExtras.m
 Artsy/Eigen.playground/
+
+iOSInjectionProject/

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController+DeveloperExtras.h
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController+DeveloperExtras.h
@@ -4,5 +4,6 @@
 @interface ARTopMenuViewController (DeveloperExtras)
 
 - (void)runDeveloperExtras;
+- (void)appHasBeenInjected:(NSNotification *)notification;
 
 @end

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController+DeveloperExtras.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController+DeveloperExtras.m
@@ -1,14 +1,41 @@
 #import "ARTopMenuViewController+DeveloperExtras.h"
+#import "Artsy-Swift.h"
 
-// You can tell git to ignore changes to this file by running
-//
-//   git update-index --assume-unchanged Artsy/View_Controllers/App_Navigation/ARTopMenuViewController+DeveloperExtras.m
+// This file is for running developer specific code, either when
+// the app is loaded, or when you have injected fresh code in via
+// InjectionForXcode (which you can install via Alcatraz.)
+
+// See: https://github.com/artsy/eigen/pull/1236
+
+// It is put in gitignore as the current state of what you see now,
+// any changes you make will be erased when you switch branches.
 
 
 @implementation ARTopMenuViewController (DeveloperExtras)
 
-// Use this function to run code once the app is loaded, useful for pushing a
-// specific VC etc.
+// Called when the app has been re-injected with some code,
+// the default here will pop the top view controller and
+// re-run the developerExtras
+
+- (void)appHasBeenInjected:(NSNotification *)notification
+{
+    [self.rootNavigationController popViewControllerAnimated:NO];
+    [self runDeveloperExtras];
+}
+
+// Use this to create a new ViewController and push it on to the stack
+//
+// @example
+//
+//  id viewController = [[LiveAuctionViewController alloc] init];
+//  [self pushViewController:viewController animated:YES];
+//
+// @example
+//
+//  NSString *path = @"/artwork/helidon-xhixha-energia-delle-forme";
+//  id viewController = [[ARSwitchBoard sharedInstance] loadPath:path];
+//  [self pushViewController:viewController animated:YES];
+//
 
 - (void)runDeveloperExtras
 {

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -318,6 +318,8 @@ static const CGFloat ARMenuButtonDimension = 46;
     if ([ARAppStatus isRunningTests] == NO) {
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{
+            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appHasBeenInjected:) name:@"INJECTION_BUNDLE_NOTIFICATION" object:nil];
+
             [self runDeveloperExtras];
         });
     }

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -9,14 +9,15 @@ upcoming:
     - Added a switch between native and martsy works for you view - maxim
     - Made the searchbar larger in fair views on iPhone - maxim
     - Additional work on the auction title view - ash
-    - Quicksilver is now accessible to non-Eigen devs - orta 
+    - Quicksilver is now accessible to non-Eigen devs - orta
     - Removes rotation support on refine auction listings view for iPhone - ash
     - Developers can choose to have a custom url for their staging environment - orta
     - Initial work on the Live Auctions view controller - orta
     - AuctionVC supports before state - orta
     - Initial working structure for Live Auctions with stubbed data - orta
     - Shows a lot of the main views on Live Auctions - orta
-    
+    - AMAZING - Added support for dynamic code-injection - orta
+
   notes:
     - Support breaking out of the router sandboxing when there's a link with ?eigen_escape_sandbox' - orta
     - Users may now refine sale artworks on native auction view by their low estimates - ash


### PR DESCRIPTION
OK - THIS IS AMAZING. 

My compile & run cycle just went from (and I counted) 11 seconds to ~1 second. 

#### Before we start, check out this GIF

![2016-03-05 11_45_44](https://cloud.githubusercontent.com/assets/49038/13548868/131cbb1e-e2c8-11e5-9f61-4acdfd10b6aa.gif)

#### What is happening?

**Injection**: Dynamically re-compiles files you've saved, and ships those changes to your currently running app.

**How does this work?** In simple, it is an Xcode plugin that can compile your code into a bundle, this bundle is then added to your app. It will include newer versions of the classes you've injected via this bundle, then it is up to you to do something with this.

**What does this PR do?** So, the default behaviour of Injection is to allows re-compiled classes to know that they have been re-compiled. Given the `viewDidLoad` heavy view controllers we create I felt it would be better for our flow to work a little different from that.

Instead of letting the view controllers themselves act upon the injection, our top view controller is expanded to deal with the changes and adds some smart defaults. I've been recommending everyone use our developer extras to do their app cycle work: e,g,

``` objc
- (void)runDeveloperExtras
{
    LiveAuctionViewController *liveVC = [[LiveAuctionViewController alloc] init];
    [self pushViewController:liveVC animated:YES];
}
```

I've expanded that to include a pop when injected, and to re-run the code inside developer extras. This means that the code inside `runDeveloperExtras` will be run on every injection. So you can keep working in the same file, constantly injecting new versions in again & again.