### PR TITLE
Removed the Dev reference to injection

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -16,7 +16,6 @@ upcoming:
     - AuctionVC supports before state - orta
     - Initial working structure for Live Auctions with stubbed data - orta
     - Shows a lot of the main views on Live Auctions - orta
-    - AMAZING - Added support for dynamic code-injection - orta
 
   notes:
     - Support breaking out of the router sandboxing when there's a link with ?eigen_escape_sandbox' - orta


### PR DESCRIPTION
I had a think about this, our changelogs are sent to apple during beta review, I don't think it's a good idea to include this line.