### PR TITLE
[Onboarding] Re-enable on launch, which was accidentally disabled.

### DIFF
--- a/Artsy/App/ARAppDelegate.m
+++ b/Artsy/App/ARAppDelegate.m
@@ -148,7 +148,7 @@ static ARAppDelegate *_sharedInstance = nil;
         // of the user to see the activity. This is probably just an edge-case, most people will probably launch the app
         // after installing it.
         if (self.initialLaunchOptions[UIApplicationLaunchOptionsUserActivityDictionaryKey] == nil) {
-            //            [self showTrialOnboarding];
+            [self showTrialOnboarding];
         }
     }
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -30,6 +30,7 @@ upcoming:
     - Add support for routing around a domain instead of just a path - orta
     - Send the eigen trial UUID to internal web-pages via the header - orta
     - Price estimates for saleartworks / live auction lots are now using server data for currency - orta
+    - Re-enable on-boarding on app launch. - alloy
 
 releases:
   - version: 2.3.6


### PR DESCRIPTION
Related to #1242

We were no longer showing the on-boarding screen when launching the app.