### PR TITLE
[On-boarding] Collect screen data to improve future on-boarding.

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -218,6 +218,7 @@
 		5102616F1BBE8324002AB8BB /* ARAuctionWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5102616E1BBE8324002AB8BB /* ARAuctionWebViewController.m */; };
 		510261711BBE96BE002AB8BB /* ARAuctionWebViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 510261701BBE96BE002AB8BB /* ARAuctionWebViewControllerTests.m */; };
 		5108A7BC1BA1AB2C0011CD72 /* ARAppActivityContinuationDelegateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5108A7BB1BA1AB2C0011CD72 /* ARAppActivityContinuationDelegateTests.m */; };
+		511287FD1C90970100936CBC /* ARAnalyticsPapertrail.m in Sources */ = {isa = PBXBuildFile; fileRef = 511287FC1C90970100936CBC /* ARAnalyticsPapertrail.m */; };
 		5122D69A1A89E5F800DA2704 /* ARFairMapAnnotationViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5122D6991A89E5F800DA2704 /* ARFairMapAnnotationViewTests.m */; };
 		512AB35B1BD7C7A100F92B9A /* CoreSpotlight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 512AB35A1BD7C7A100F92B9A /* CoreSpotlight.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		512AB35C1BD7C82F00F92B9A /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06E44EB8170235D8001B2EBF /* MessageUI.framework */; };
@@ -1080,6 +1081,8 @@
 		5102616E1BBE8324002AB8BB /* ARAuctionWebViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARAuctionWebViewController.m; sourceTree = "<group>"; };
 		510261701BBE96BE002AB8BB /* ARAuctionWebViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARAuctionWebViewControllerTests.m; sourceTree = "<group>"; };
 		5108A7BB1BA1AB2C0011CD72 /* ARAppActivityContinuationDelegateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARAppActivityContinuationDelegateTests.m; sourceTree = "<group>"; };
+		511287FB1C90970100936CBC /* ARAnalyticsPapertrail.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARAnalyticsPapertrail.h; sourceTree = "<group>"; };
+		511287FC1C90970100936CBC /* ARAnalyticsPapertrail.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARAnalyticsPapertrail.m; sourceTree = "<group>"; };
 		5122D6991A89E5F800DA2704 /* ARFairMapAnnotationViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARFairMapAnnotationViewTests.m; sourceTree = "<group>"; };
 		512AB35A1BD7C7A100F92B9A /* CoreSpotlight.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreSpotlight.framework; path = System/Library/Frameworks/CoreSpotlight.framework; sourceTree = SDKROOT; };
 		513483541AADD0A10062E624 /* PSPDFKitImproveRecursiveDescription.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PSPDFKitImproveRecursiveDescription.m; sourceTree = "<group>"; };
@@ -3973,6 +3976,8 @@
 		60A0E9FB1C51070F002754A8 /* Analytics */ = {
 			isa = PBXGroup;
 			children = (
+				511287FB1C90970100936CBC /* ARAnalyticsPapertrail.h */,
+				511287FC1C90970100936CBC /* ARAnalyticsPapertrail.m */,
 				60F63AB61C58E86400DCFF2A /* ARHockeyFeedbackDelegate.swift */,
 				4191F43D1C8745D90054F823 /* ARAnalyticsVisualizer.h */,
 				4191F43E1C8745D90054F823 /* ARAnalyticsVisualizer.m */,
@@ -5288,6 +5293,7 @@
 				CB73B48B17D2581400891305 /* SiteFeature.m in Sources */,
 				6099F90A17904F9B0004EF04 /* ARModelCollectionViewModule.m in Sources */,
 				602C09BA1B5E5CE6003681D3 /* AFHTTPRequestOperation+JSON.m in Sources */,
+				511287FD1C90970100936CBC /* ARAnalyticsPapertrail.m in Sources */,
 				609F98611AC106030079FE21 /* WatchBiddingDetails.m in Sources */,
 				609B3C091761F80C00953CB2 /* ARSiteHeroUnitView.m in Sources */,
 				605B11B217CFD78400334196 /* AROnboardingWebViewController.m in Sources */,

--- a/Artsy/App/ARAnalyticsPapertrail.h
+++ b/Artsy/App/ARAnalyticsPapertrail.h
@@ -1,0 +1,7 @@
+@import Foundation;
+@import ARAnalytics;
+
+
+@interface ARAnalyticsPapertrail : ARAnalyticalProvider
+- (instancetype)initWithDestinationURL:(NSURL *)URL NS_DESIGNATED_INITIALIZER;
+@end

--- a/Artsy/App/ARAnalyticsPapertrail.m
+++ b/Artsy/App/ARAnalyticsPapertrail.m
@@ -1,0 +1,49 @@
+#import "ARAnalyticsPapertrail.h"
+
+
+@interface ARAnalyticsPapertrail ()
+@property (nonatomic, strong) NSOutputStream *stream;
+@property (nonatomic, strong) dispatch_queue_t queue;
+@end
+
+
+@implementation ARAnalyticsPapertrail
+
+- (void)dealloc;
+{
+    [_stream close];
+}
+
+- (instancetype)initWithDestinationURL:(NSURL *)URL;
+{
+    if ((self = [super init])) {
+        _queue = dispatch_queue_create("net.artsy.analytics-papertrail", DISPATCH_QUEUE_SERIAL);
+        _stream = [[NSOutputStream alloc] initWithURL:URL append:YES];
+        [_stream open];
+    }
+    return self;
+}
+
+- (void)didShowNewPageView:(NSString *)pageTitle withProperties:(NSDictionary *)properties;
+{
+    dispatch_async(self.queue, ^{
+        NSMutableDictionary *slugs = [NSMutableDictionary new];
+        for (NSString *key in properties.allKeys) {
+            if ([key hasSuffix:@"slug"]) {
+                slugs[key] = properties[key];
+            }
+        }
+        if (slugs.count > 0) {
+            NSError *error = nil;
+            [NSJSONSerialization writeJSONObject:@{ @"screen": pageTitle, @"slugs": slugs }
+                                        toStream:self.stream
+                                         options:0
+                                           error:&error];
+            NSAssert(error == nil, @"Unable to save analytics papertrail: %@", error);
+            NSInteger written = [self.stream write:"\n" maxLength:1];
+            NSAssert(written == 1, @"Unable to append newline.");
+        }
+    });
+}
+
+@end

--- a/Artsy/App/ARAppDelegate+Analytics.m
+++ b/Artsy/App/ARAppDelegate+Analytics.m
@@ -25,6 +25,7 @@
 #import "Profile.h"
 #import "ARFairMapAnnotation.h"
 #import "ARAnalyticsVisualizer.h"
+#import "ARAnalyticsPapertrail.h"
 
 // View Controllers
 #import "ARFairGuideViewController.h"
@@ -102,10 +103,19 @@
     if (ARAppStatus.isRunningTests == NO) {
         // Skipping ARAnalytics because Adjust has its own expectations
         // around event names being < 6 chars
-
         ADJConfig *adjustConfig = [ADJConfig configWithAppToken:keys.adjustProductionAppToken environment:environment];
         [Adjust appDidLaunch:adjustConfig];
     }
+
+    if ([AROptions boolForOption:AROptionsShowAnalyticsOnScreen]) {
+        ARAnalyticsVisualizer *visualizer = [ARAnalyticsVisualizer new];
+        [ARAnalytics setupProvider:visualizer];
+    }
+
+    NSString *documentsDir = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES)[0];
+    NSURL *papertrailURL = [NSURL fileURLWithPath:[documentsDir stringByAppendingPathComponent:@"papertrail.json"]];
+    ARAnalyticsPapertrail *papertrail = [[ARAnalyticsPapertrail alloc] initWithDestinationURL:papertrailURL];
+    [ARAnalytics setupProvider:papertrail];
 
 #if DEBUG
     BITHockeyManager *hockey = [BITHockeyManager sharedHockeyManager];
@@ -122,12 +132,6 @@
         return !heartedShouldFireBlock(controller, parameters);
     };
 
-    if ([AROptions boolForOption:AROptionsShowAnalyticsOnScreen]) {
-        ARAnalyticsVisualizer *visualizer = [ARAnalyticsVisualizer new];
-        [ARAnalytics setupProvider: visualizer];
-    }
-
-    
     [ARAnalytics setupWithAnalytics:
     @{
         ARHockeyAppBetaID: @"306e66bde3cb91a2043f2606cf335700",

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -17,6 +17,7 @@ upcoming:
     - Added an option for Admins to visualize analytics - ani/alloy/orta
     - Initial working structure for Live Auctions with stubbed data - orta
     - Shows a lot of the main views on Live Auctions - orta
+    - Keep a papertrail of screen views that have slugs, which we can use to improve on-boarding in an upcoming version when we require sign-up. - alloy
 
   notes:
     - Support breaking out of the router sandboxing when there's a link with ?eigen_escape_sandbox' - orta


### PR DESCRIPTION
Nothing fancy, just stores entities that have slugs. How/if we’re going to use this data in the future is not yet defined.

![NSA](http://media4.giphy.com/media/3oEdv8AomOYAdBQkM0/giphy.gif)