### PR TITLE
Fix a typo in the #ifdef for release builds #trivial

### DIFF
--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.0</string>
+	<string>2.4.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Artsy/Networking/Network_Models/ARWorksForYouNetworkModel.m
+++ b/Artsy/Networking/Network_Models/ARWorksForYouNetworkModel.m
@@ -31,7 +31,7 @@
     _currentPage = 1;
     _downloadedArtworkIDs = [[NSMutableArray alloc] init];
 
-#ifndef NSBLOCK_ASSERTIONS
+#ifndef NS_BLOCK_ASSERTIONS
     _downloadInformation = [[NSMutableDictionary alloc] init];
 #endif
 


### PR DESCRIPTION
Fixes a typo that failed a build of the beta: https://circleci.com/gh/artsy/eigen/1834 

As we run tests in debug, this slipped past us.