### PR TITLE
Add the plist option for 'does not contain crypto' #trivial

### DIFF
--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -86,6 +86,8 @@
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>


### PR DESCRIPTION
There's a way to skip that question in iTunes connect, by doing this. So less is less.