### PR TITLE
[Analytics] Make ‘sign-up/connect with email/facebook/twitter’ -> ‘created account’ consistent.

### DIFF
--- a/Artsy/Networking/API_Modules/ARUserManager.m
+++ b/Artsy/Networking/API_Modules/ARUserManager.m
@@ -376,15 +376,13 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
                    failure:(void (^)(NSError *error, id JSON))failure
   saveSharedWebCredentials:(BOOL)saveSharedWebCredentials;
 {
+    [ARAnalytics event:ARAnalyticsSignUpEmail];
+
     [ArtsyAPI getXappTokenWithCompletion:^(NSString *xappToken, NSDate *expirationDate) {
-        
-        ARActionLog(@"Got Xapp. Creating a new user account.");
-        
         NSURLRequest *request = [ARRouter newCreateUserRequestWithName:name email:email password:password];
         AFHTTPRequestOperation *op = [AFHTTPRequestOperation JSONRequestOperationWithRequest:request
          success:^(NSURLRequest *request, NSHTTPURLResponse *response, id JSON) {
              NSError *error;
-             [ARAnalytics event:ARAnalyticsSignUpEmail];
 
              User *user = [User modelWithJSON:JSON error:&error];
              if (error) {
@@ -442,13 +440,12 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
              [self storeUserData];
 
              if (success) { success(user); }
-             
-             [ARAnalytics event:ARAnalyticsSignUpEmail];
-             
+
+             [ARAnalytics event:ARAnalyticsAccountCreated];
+
          } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON) {
              failure(error, JSON);
              [ARAnalytics event:ARAnalyticsSignUpError];
-             
          }];
         [op start];
     }];
@@ -477,8 +474,8 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
              
              if(success) success(user);
 
-             [ARAnalytics event:ARAnalyticsSignUpEmail];
-             
+             [ARAnalytics event:ARAnalyticsAccountCreated];
+
          } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON) {
              failure(error, JSON);
              [ARAnalytics event:ARAnalyticsSignUpError];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -12,14 +12,15 @@ upcoming:
     - Wrapped up all but the refine button occasionally tapping through QA items for the Native Auction Views - orta
     - Include tab label in analytics data. - alloy
     - Show images for Live Auctions - orta
-    - Added dude in portrait view in room - dblock
     - Added springs to the Artwork to VIR transitions - orta
+    - Make ‘sign-up/connect with email/facebook/twitter’ -> ‘created account’ analytics consistent. - alloy
 
   notes:
     - Enable new native Works For You view. - sarah + alloy
     - Fixes problem with registration status not updating. - ash
     - The app is woken up when a notification is received and the Works For You view is preloaded. - alloy
     - Add accessibility labels for the Home and Bell tab. - alloy
+    - Added dude in portrait view in room - dblock
 
   notes:
 


### PR DESCRIPTION
Fixes https://github.com/artsy/eigen/issues/1123#issuecomment-198306933.