### PR TITLE
[Search] Auto-selects the search query when you go back to a search view

### DIFF
--- a/Artsy/View_Controllers/Search/ARSearchViewController.m
+++ b/Artsy/View_Controllers/Search/ARSearchViewController.m
@@ -140,6 +140,10 @@
     [super viewDidAppear:animated];
 
     [self.textField becomeFirstResponder];
+
+    if (self.textField.text.length > 0) {
+        [self.textField selectAll:nil];
+    }
 }
 
 - (BOOL)textFieldShouldReturn:(UITextField *)textField

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -23,8 +23,7 @@ upcoming:
     - Add accessibility labels for the Home and Bell tab. - alloy
     - Auctions are now native views by default - orta
     - Added dude in portrait view in room - dblock
-
-  notes:
+    - Search will auto-select the old query, meaning when you go back and type again it will start a new search  - orta
 
 releases:
   - version: 2.4.0


### PR DESCRIPTION
This makes it so when you're trying to use the search more than once per session, you can easily do another query as the text is highlighted for you. 

As this is probably more the use case than the opposite, of wanting to expand on the current query,  I've added it.