### PR TITLE
Add a check for `fit` in swift tests #trivial

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -13,7 +13,8 @@ warn("Needs testing on a Phone if change is non-trivial") if lines_of_code > 50 
 
 # Don't let testing shortcuts get into master
 fail("fdescribe left in tests") if `grep -r fdescribe Artsy_Tests/`.length > 1
-fail("fit left in tests") if `grep -r "fit(@" Artsy_Tests/`.length > 1
+fail("fit left in tests") if `grep -rI "fit(@" Artsy_Tests/`.length > 1
+fail("fit left in tests") if `grep -rI "fit(" Artsy_Tests/`.length > 1
 
 # Devs shouldn't ship changes to this file
 fail("Developer Specific file shouldn't be changed") if modified_files.include?("Artsy/View_Controllers/App_Navigation/ARTopMenuViewController+DeveloperExtras.m")


### PR DESCRIPTION
See - https://github.com/artsy/eigen/pull/1370

Danger wasn't looking for a swift syntax WRT `fit` tests