### PR TITLE
[WIP] Adds metaphysics static data fetcher

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -300,6 +300,8 @@
 		5E79FCB71C761E49003D5D65 /* ARSaleArtworkMasonryCollectionViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E79FCB61C761E49003D5D65 /* ARSaleArtworkMasonryCollectionViewCell.m */; };
 		5E79FCBA1C768108003D5D65 /* ARNvagiationButton+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E79FCB91C768108003D5D65 /* ARNvagiationButton+Swift.swift */; };
 		5E79FCBC1C76856C003D5D65 /* NavigationButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E79FCBB1C76856C003D5D65 /* NavigationButtonTests.swift */; };
+		5E88414E1CB3445A00A33BCE /* LiveAuctionStaticDataFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E88414D1CB3445A00A33BCE /* LiveAuctionStaticDataFetcher.swift */; };
+		5E8841501CB3462100A33BCE /* LiveAuctionStaticDataFetcherSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E88414F1CB3462100A33BCE /* LiveAuctionStaticDataFetcherSpec.swift */; };
 		5E8A03B51C52B60900EAF18B /* AuctionRefineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E8A03B41C52B60900EAF18B /* AuctionRefineViewController.swift */; };
 		5E9A782019068EDF00734E1B /* ARProfileViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E9A781F19068EDF00734E1B /* ARProfileViewControllerTests.m */; };
 		5E9A78231906BA3D00734E1B /* OCMArg+ClassChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E9A78221906BA3D00734E1B /* OCMArg+ClassChecker.m */; };
@@ -1214,6 +1216,8 @@
 		5E79FCB81C764780003D5D65 /* ARSaleArtworkItemWidthDependentModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARSaleArtworkItemWidthDependentModule.h; sourceTree = "<group>"; };
 		5E79FCB91C768108003D5D65 /* ARNvagiationButton+Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ARNvagiationButton+Swift.swift"; sourceTree = "<group>"; };
 		5E79FCBB1C76856C003D5D65 /* NavigationButtonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationButtonTests.swift; sourceTree = "<group>"; };
+		5E88414D1CB3445A00A33BCE /* LiveAuctionStaticDataFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LiveAuctionStaticDataFetcher.swift; path = Live_Auctions/LiveAuctionStaticDataFetcher.swift; sourceTree = "<group>"; };
+		5E88414F1CB3462100A33BCE /* LiveAuctionStaticDataFetcherSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LiveAuctionStaticDataFetcherSpec.swift; path = Live_Auctions/LiveAuctionStaticDataFetcherSpec.swift; sourceTree = "<group>"; };
 		5E8A03B41C52B60900EAF18B /* AuctionRefineViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AuctionRefineViewController.swift; path = Auction/AuctionRefineViewController.swift; sourceTree = "<group>"; };
 		5E9A781F19068EDF00734E1B /* ARProfileViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARProfileViewControllerTests.m; sourceTree = "<group>"; };
 		5E9A78211906BA3D00734E1B /* OCMArg+ClassChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "OCMArg+ClassChecker.h"; sourceTree = "<group>"; };
@@ -2905,6 +2909,7 @@
 				5E6A16921C98A914004DB29B /* LiveAuctionStateManagerSpec.swift */,
 				5E174F5B1CADB35800657743 /* LiveAuctionStateReconcilerSpec.swift */,
 				5EF3C93C1C99DB9F002FF956 /* LiveAuctionStateFetcherSpec.swift */,
+				5E88414F1CB3462100A33BCE /* LiveAuctionStaticDataFetcherSpec.swift */,
 			);
 			name = "Live Auctions";
 			sourceTree = "<group>";
@@ -3266,6 +3271,7 @@
 				5E0DD14A1C9764420037F9E4 /* LiveAuctionStateManager.swift */,
 				5EC8C67F1CA5C5FC00571B21 /* LiveActionStateReconciler.swift */,
 				5E6A16941C99B657004DB29B /* LiveAuctionStateFetcher.swift */,
+				5E88414D1CB3445A00A33BCE /* LiveAuctionStaticDataFetcher.swift */,
 			);
 			name = "Live Auctions";
 			sourceTree = "<group>";
@@ -5083,6 +5089,7 @@
 				CBE939F817FA336C00AD7DDD /* ARArtworkBlurbView.m in Sources */,
 				5E47F35D1C444E3300EC0751 /* UIViewController+ORStackView.swift in Sources */,
 				6088B75917D20A0A00E4BB67 /* ARSlideshowView.m in Sources */,
+				5E88414E1CB3445A00A33BCE /* LiveAuctionStaticDataFetcher.swift in Sources */,
 				49405AB317BEBAFF004F86D8 /* AROnboardingNavBarView.m in Sources */,
 				49F45188176A71B50041A4B4 /* ARArtworkSetViewController.m in Sources */,
 				49473F3317C18772004BF082 /* ARSlideshowViewController.m in Sources */,
@@ -5638,6 +5645,7 @@
 				342F9FBB86D02FABC8AA9339 /* ARNavigationButtonsViewControllerTests.m in Sources */,
 				E6AD6D4218E610DA005C8A3A /* ArtsyAPI+ArtworksTests.m in Sources */,
 				3CF144B818E9E00400B1A764 /* ARSignUpSplashViewControllerTests.m in Sources */,
+				5E8841501CB3462100A33BCE /* LiveAuctionStaticDataFetcherSpec.swift in Sources */,
 				3C33299218AD9399006D28C0 /* ARFairSearchViewControllerTests.m in Sources */,
 				3CCCC8941899676E008015DD /* ARFairPostsViewControllerTests.m in Sources */,
 				3C1266F118BE6CC700B5AE72 /* ARFairGuideViewControllerTests.m in Sources */,

--- a/Artsy/Constants/ARDefaults.h
+++ b/Artsy/Constants/ARDefaults.h
@@ -4,6 +4,7 @@ extern NSString *const ARUseStagingDefault;
 extern NSString *const ARStagingAPIURLDefault;
 extern NSString *const ARStagingPhoneWebURLDefault;
 extern NSString *const ARStagingPadWebURLDefault;
+extern NSString *const ARStagingMetaphysicsURLDefault;
 extern NSString *const ARStagingLiveAuctionSocketURLDefault;
 
 extern NSString *const AROAuthTokenDefault;

--- a/Artsy/Constants/ARDefaults.m
+++ b/Artsy/Constants/ARDefaults.m
@@ -9,6 +9,7 @@ NSString *const ARUseStagingDefault = @"ARUseStagingDefault";
 NSString *const ARStagingAPIURLDefault = @"ARStagingAPIURLDefault";
 NSString *const ARStagingPhoneWebURLDefault = @"ARStagingPhoneWebURLDefault";
 NSString *const ARStagingPadWebURLDefault = @"ARStagingPadWebURLDefault";
+NSString *const ARStagingMetaphysicsURLDefault = @"ARStagingMetaphysicsURLDefault";
 NSString *const ARStagingLiveAuctionSocketURLDefault = @"ARStagingLiveAuctionSocketURLDefault";
 
 NSString *const AROAuthTokenDefault = @"AROAuthToken";
@@ -48,6 +49,7 @@ NSString *const ARShowAuctionResultsButtonDefault = @"auction-results";
         ARStagingAPIURLDefault : @"https://stagingapi.artsy.net",
         ARStagingPhoneWebURLDefault : @"http://m-staging.artsy.net",
         ARStagingPadWebURLDefault : @"https://staging.artsy.net",
+        ARStagingMetaphysicsURLDefault : @"http://metaphysics-staging.artsy.net",
         ARStagingLiveAuctionSocketURLDefault : @"https://prediction-staging.artsy.net"
     }];
 }

--- a/Artsy/Networking/API_Modules/ArtsyAPI+Private.h
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+Private.h
@@ -2,6 +2,9 @@
 
 @class AFHTTPRequestOperation;
 
+typedef void (^NetworkFailureBlock)(NSURLRequest *, NSHTTPURLResponse *, NSError *);
+NetworkFailureBlock passOnNetworkError(void (^)(NSError *error));
+
 
 @interface ArtsyAPI (Private)
 

--- a/Artsy/Networking/API_Modules/ArtsyAPI+Sales.h
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+Sales.h
@@ -29,4 +29,9 @@
                            success:(void (^)(id state))success
                            failure:(void (^)(NSError *error))failure;
 
++ (void)getLiveSaleStaticDataWithSaleID:(NSString *)saleID
+                                   host:(NSString *)host
+                                success:(void (^)(id state))success
+                                failure:(void (^)(NSError *error))failure;
+
 @end

--- a/Artsy/Networking/API_Modules/ArtsyAPI+Sales.h
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+Sales.h
@@ -30,7 +30,6 @@
                            failure:(void (^)(NSError *error))failure;
 
 + (void)getLiveSaleStaticDataWithSaleID:(NSString *)saleID
-                                   host:(NSString *)host
                                 success:(void (^)(id state))success
                                 failure:(void (^)(NSError *error))failure;
 

--- a/Artsy/Networking/API_Modules/ArtsyAPI+Sales.m
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+Sales.m
@@ -47,9 +47,7 @@
     NSURLRequest *request = [ARRouter liveSaleStateRequest:saleID host:host];
     [self performRequest:request
                  success:success
-                 failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {
-        failure(error);
-    }];
+                 failure:passOnNetworkError(failure)];
 }
 
 + (void)getLiveSaleStaticDataWithSaleID:(NSString *)saleID
@@ -59,9 +57,7 @@
     NSURLRequest *request = [ARRouter liveSaleStaticDataRequest:saleID];
     [self performRequest:request
                  success:success
-                 failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {
-        failure(error);
-    }];
+                 failure:passOnNetworkError(failure)];
 }
 
 @end

--- a/Artsy/Networking/API_Modules/ArtsyAPI+Sales.m
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+Sales.m
@@ -53,11 +53,10 @@
 }
 
 + (void)getLiveSaleStaticDataWithSaleID:(NSString *)saleID
-                                   host:(NSString *)host
                                 success:(void (^)(id state))success
                                 failure:(void (^)(NSError *error))failure
 {
-    NSURLRequest *request = [ARRouter liveSaleStaticDataRequest:saleID host:host];
+    NSURLRequest *request = [ARRouter liveSaleStaticDataRequest:saleID];
     [self performRequest:request
                  success:success
                  failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {

--- a/Artsy/Networking/API_Modules/ArtsyAPI+Sales.m
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+Sales.m
@@ -52,4 +52,17 @@
     }];
 }
 
++ (void)getLiveSaleStaticDataWithSaleID:(NSString *)saleID
+                                   host:(NSString *)host
+                                success:(void (^)(id state))success
+                                failure:(void (^)(NSError *error))failure
+{
+    NSURLRequest *request = [ARRouter liveSaleStaticDataRequest:saleID host:host];
+    [self performRequest:request
+                 success:success
+                 failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {
+        failure(error);
+    }];
+}
+
 @end

--- a/Artsy/Networking/ARNetworkConstants.h
+++ b/Artsy/Networking/ARNetworkConstants.h
@@ -37,6 +37,7 @@ extern NSString *const ARBidderPositionsForSaleAndArtworkURL;
 extern NSString *const ARSaleArtworkForSaleAndArtworkURLFormat;
 extern NSString *const ARSaleURLFormat;
 extern NSString *const ARLiveSaleStateFormat;
+extern NSString *const ARLiveSaleStaticDataFormat;
 extern NSString *const ARSaleArtworksURLFormat;
 extern NSString *const ARArtworkFairsURLFormat;
 

--- a/Artsy/Networking/ARNetworkConstants.h
+++ b/Artsy/Networking/ARNetworkConstants.h
@@ -1,6 +1,7 @@
 extern NSString *const ARBaseDesktopWebURL;
 extern NSString *const ARBaseMobileWebURL;
 extern NSString *const ARBaseApiURL;
+extern NSString *const ARBaseMetaphysicsApiURL;
 extern NSString *const ARStagingBaseWebURL;
 extern NSString *const ARStagingBaseMobileWebURL;
 
@@ -37,7 +38,6 @@ extern NSString *const ARBidderPositionsForSaleAndArtworkURL;
 extern NSString *const ARSaleArtworkForSaleAndArtworkURLFormat;
 extern NSString *const ARSaleURLFormat;
 extern NSString *const ARLiveSaleStateFormat;
-extern NSString *const ARLiveSaleStaticDataFormat;
 extern NSString *const ARSaleArtworksURLFormat;
 extern NSString *const ARArtworkFairsURLFormat;
 

--- a/Artsy/Networking/ARNetworkConstants.m
+++ b/Artsy/Networking/ARNetworkConstants.m
@@ -39,6 +39,7 @@ NSString *const ARBidderPositionsForSaleAndArtworkURL = @"/api/v1/me/bidder_posi
 NSString *const ARSaleArtworkForSaleAndArtworkURLFormat = @"/api/v1/sale/%@/sale_artwork/%@";
 NSString *const ARSaleURLFormat = @"/api/v1/sale/%@";
 NSString *const ARLiveSaleStateFormat = @"%@/state/%@";
+NSString *const ARLiveSaleStaticDataFormat = @"%@";
 NSString *const ARSaleArtworksURLFormat = @"/api/v1/sale/%@/sale_artworks";
 NSString *const ARArtworkFairsURLFormat = @"/api/v1/related/fairs";
 

--- a/Artsy/Networking/ARNetworkConstants.m
+++ b/Artsy/Networking/ARNetworkConstants.m
@@ -3,6 +3,7 @@
 NSString *const ARBaseDesktopWebURL = @"https://www.artsy.net";
 NSString *const ARBaseMobileWebURL = @"https://m.artsy.net";
 NSString *const ARBaseApiURL = @"https://api.artsy.net";
+NSString *const ARBaseMetaphysicsApiURL = @"https://metaphysics-production.artsy.net/";
 
 NSString *const ARPersonalizePath = @"personalize";
 
@@ -39,7 +40,6 @@ NSString *const ARBidderPositionsForSaleAndArtworkURL = @"/api/v1/me/bidder_posi
 NSString *const ARSaleArtworkForSaleAndArtworkURLFormat = @"/api/v1/sale/%@/sale_artwork/%@";
 NSString *const ARSaleURLFormat = @"/api/v1/sale/%@";
 NSString *const ARLiveSaleStateFormat = @"%@/state/%@";
-NSString *const ARLiveSaleStaticDataFormat = @"%@";
 NSString *const ARSaleArtworksURLFormat = @"/api/v1/sale/%@/sale_artworks";
 NSString *const ARArtworkFairsURLFormat = @"/api/v1/related/fairs";
 

--- a/Artsy/Networking/ARRouter.h
+++ b/Artsy/Networking/ARRouter.h
@@ -156,6 +156,7 @@
 + (NSURLRequest *)artworksForSaleRequest:(NSString *)saleID;
 + (NSURLRequest *)artworksForSaleRequest:(NSString *)saleID page:(NSInteger)page pageSize:(NSInteger)pageSize;
 + (NSURLRequest *)liveSaleStateRequest:(NSString *)saleID host:(NSString *)host;
++ (NSURLRequest *)liveSaleStaticDataRequest:(NSString *)saleID host:(NSString *)host;
 + (NSURLRequest *)biddersRequest;
 + (NSURLRequest *)biddersRequestForSale:(NSString *)saleID;
 + (NSURLRequest *)createBidderPositionsForSaleID:(NSString *)saleID artworkID:(NSString *)artworkID maxBidAmountCents:(NSInteger)maxBidAmountCents;

--- a/Artsy/Networking/ARRouter.h
+++ b/Artsy/Networking/ARRouter.h
@@ -156,7 +156,7 @@
 + (NSURLRequest *)artworksForSaleRequest:(NSString *)saleID;
 + (NSURLRequest *)artworksForSaleRequest:(NSString *)saleID page:(NSInteger)page pageSize:(NSInteger)pageSize;
 + (NSURLRequest *)liveSaleStateRequest:(NSString *)saleID host:(NSString *)host;
-+ (NSURLRequest *)liveSaleStaticDataRequest:(NSString *)saleID host:(NSString *)host;
++ (NSURLRequest *)liveSaleStaticDataRequest:(NSString *)saleID;
 + (NSURLRequest *)biddersRequest;
 + (NSURLRequest *)biddersRequestForSale:(NSString *)saleID;
 + (NSURLRequest *)createBidderPositionsForSaleID:(NSString *)saleID artworkID:(NSString *)artworkID maxBidAmountCents:(NSInteger)maxBidAmountCents;

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -69,6 +69,16 @@ static NSString *hostFromString(NSString *string)
     }
 }
 
++ (NSString *)baseMetaphysicsApiURLString
+{
+    if ([AROptions boolForOption:ARUseStagingDefault]) {
+        NSString *stagingBaseAPI = [[NSUserDefaults standardUserDefaults] stringForKey:ARStagingMetaphysicsURLDefault];
+        return stagingBaseAPI;
+    } else {
+        return ARBaseMetaphysicsApiURL;
+    }
+}
+
 + (NSURL *)baseWebURL
 {
     return [UIDevice isPad] ? [self baseDesktopWebURL] : [self baseMobileWebURL];
@@ -968,10 +978,10 @@ static NSString *hostFromString(NSString *string)
     return [self requestWithMethod:@"GET" URLString:url parameters:nil];
 }
 
-+ (NSURLRequest *)liveSaleStaticDataRequest:(NSString *)saleID host:(NSString *)host
++ (NSURLRequest *)liveSaleStaticDataRequest:(NSString *)saleID
 {
     // Note that we're relying on the host to specify the domain for the request.
-    NSString *url = [NSString stringWithFormat:ARLiveSaleStaticDataFormat, host];
+    NSString *url = [self baseMetaphysicsApiURLString];
     NSString *query = [NSString stringWithFormat:@"{\
     sale(id: \"%@\") {\
         sale_artworks {\

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -982,31 +982,32 @@ static NSString *hostFromString(NSString *string)
 {
     // Note that we're relying on the host to specify the domain for the request.
     NSString *url = [self baseMetaphysicsApiURLString];
-    NSString *query = [NSString stringWithFormat:@"{\
-    sale(id: \"%@\") {\
-        sale_artworks {\
-            id\
-            position\
-            currency\
-            symbol\
-            reserve_status\
-            low_estimate_cents\
-            high_estimate_cents\
-            amount_cents\
-            artwork {\
-                title\
-                artist {\
-                    name\
-                }\
-                image {\
-                    width\
-                    height\
-                    url(version: \"large\")\
-                }\
-            }\
-        }\
-    }\
-}", saleID];
+    // Ending spaces are to avoid stripping newlines characters later on.
+    NSString *query = [[NSString stringWithFormat:@"{\
+    sale(id: \"%@\") { \
+        sale_artworks { \
+            id \
+            position \
+            currency \
+            symbol \
+            reserve_status \
+            low_estimate_cents \
+            high_estimate_cents \
+            amount_cents \
+            artwork { \
+                title \
+                artist { \
+                    name \
+                } \
+                image { \
+                    width \
+                    height \
+                    url(version: \"large\") \
+                } \
+            } \
+        } \
+    } \
+}", saleID] stringByReplacingOccurrencesOfString:@"    " withString:@""];
 
     NSMutableURLRequest *request = [self requestWithMethod:@"GET" URLString:url parameters:@{@"query": query}];
 

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -983,33 +983,35 @@ static NSString *hostFromString(NSString *string)
     // Note that we're relying on the host to specify the domain for the request.
     NSString *url = [self baseMetaphysicsApiURLString];
     // Ending spaces are to avoid stripping newlines characters later on.
-    NSString *query = [[NSString stringWithFormat:@"{\
-    sale(id: \"%@\") { \
-        sale_artworks { \
-            id \
-            position \
-            currency \
-            symbol \
-            reserve_status \
-            low_estimate_cents \
-            high_estimate_cents \
-            amount_cents \
-            artwork { \
-                title \
-                artist { \
-                    name \
-                } \
-                image { \
-                    width \
-                    height \
-                    url(version: \"large\") \
-                } \
-            } \
+    NSString *query = [NSString stringWithFormat:@"\
+{\
+  sale(id: \"%@\") { \
+    sale_artworks { \
+      id \
+      position \
+      currency \
+      symbol \
+      reserve_status \
+      low_estimate_cents \
+      high_estimate_cents \
+      amount_cents \
+      artwork { \
+        title \
+        artist { \
+          name \
         } \
+        image { \
+          width \
+          height \
+          url(version: \"large\") \
+        } \
+      } \
     } \
-}", saleID] stringByReplacingOccurrencesOfString:@"    " withString:@""];
+  } \
+}",
+                                                 saleID];
 
-    NSMutableURLRequest *request = [self requestWithMethod:@"GET" URLString:url parameters:@{@"query": query}];
+    NSMutableURLRequest *request = [self requestWithMethod:@"GET" URLString:url parameters:@{ @"query" : query }];
 
     return request;
 }

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -964,8 +964,43 @@ static NSString *hostFromString(NSString *string)
 + (NSURLRequest *)liveSaleStateRequest:(NSString *)saleID host:(NSString *)host
 {
     // Note that we're relying on the host to specify the domain for the request.
-    NSString *url = [NSString stringWithFormat:ARLiveSaleStateFormat, host, saleID];
+    NSString *url = [NSString stringWithFormat:ARLiveSaleStateFormat, host];
     return [self requestWithMethod:@"GET" URLString:url parameters:nil];
+}
+
++ (NSURLRequest *)liveSaleStaticDataRequest:(NSString *)saleID host:(NSString *)host
+{
+    // Note that we're relying on the host to specify the domain for the request.
+    NSString *url = [NSString stringWithFormat:ARLiveSaleStaticDataFormat, host];
+    NSString *query = [NSString stringWithFormat:@"{\
+    sale(id: \"%@\") {\
+        sale_artworks {\
+            id\
+            position\
+            currency\
+            symbol\
+            reserve_status\
+            low_estimate_cents\
+            high_estimate_cents\
+            amount_cents\
+            artwork {\
+                title\
+                artist {\
+                    name\
+                }\
+                image {\
+                    width\
+                    height\
+                    url(version: \"large\")\
+                }\
+            }\
+        }\
+    }\
+}", saleID];
+
+    NSMutableURLRequest *request = [self requestWithMethod:@"GET" URLString:url parameters:@{@"query": query}];
+
+    return request;
 }
 
 + (NSURLRequest *)biddersRequest

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -974,7 +974,7 @@ static NSString *hostFromString(NSString *string)
 + (NSURLRequest *)liveSaleStateRequest:(NSString *)saleID host:(NSString *)host
 {
     // Note that we're relying on the host to specify the domain for the request.
-    NSString *url = [NSString stringWithFormat:ARLiveSaleStateFormat, host];
+    NSString *url = [NSString stringWithFormat:ARLiveSaleStateFormat, host, saleID];
     return [self requestWithMethod:@"GET" URLString:url parameters:nil];
 }
 

--- a/Artsy/Networking/ArtsyAPI.m
+++ b/Artsy/Networking/ArtsyAPI.m
@@ -16,6 +16,14 @@
 #import <ObjectiveSugar/ObjectiveSugar.h>
 
 
+NetworkFailureBlock passOnNetworkError(void (^failure)(NSError *))
+{
+    return ^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {
+        failure(error);
+    };
+}
+
+
 @implementation ArtsyAPI
 
 + (AFHTTPRequestOperation *)performRequest:(NSURLRequest *)request success:(void (^)(id))success failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure

--- a/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
+++ b/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
@@ -233,9 +233,10 @@ NSString *const ARLabOptionCell = @"LabOptionCell";
     ARCellData *stagingAPI = [self cellDataWithName:@"API" defaultKey:ARStagingAPIURLDefault];
     ARCellData *stagingPhoneWeb = [self cellDataWithName:@"Phone Web" defaultKey:ARStagingPhoneWebURLDefault];
     ARCellData *stagingPadWeb = [self cellDataWithName:@"Pad Web" defaultKey:ARStagingPadWebURLDefault];
+    ARCellData *stagingMetaphysics = [self cellDataWithName:@"Metaphysics" defaultKey:ARStagingMetaphysicsURLDefault];
     ARCellData *stagingSocket = [self cellDataWithName:@"Live Auctions Socket" defaultKey:ARStagingLiveAuctionSocketURLDefault];
 
-    [labsSectionData addCellDataFromArray:@[ stagingAPI, stagingPhoneWeb, stagingPadWeb, stagingSocket ]];
+    [labsSectionData addCellDataFromArray:@[ stagingAPI, stagingPhoneWeb, stagingPadWeb, stagingMetaphysics, stagingSocket ]];
     return labsSectionData;
 }
 

--- a/Artsy/View_Controllers/Live_Auctions/LiveAuctionSalesPerson.swift
+++ b/Artsy/View_Controllers/Live_Auctions/LiveAuctionSalesPerson.swift
@@ -37,7 +37,7 @@ class LiveAuctionsSalesPerson:  NSObject, LiveAuctionsSalesPersonType {
     init(saleID: String,
          accessToken: String,
          defaults: NSUserDefaults = NSUserDefaults.standardUserDefaults(),
-         stateManagerCreator: StateManagerCreator = LiveAuctionsSalesPerson.stubbedStateManagerCreator()) {
+         stateManagerCreator: StateManagerCreator = LiveAuctionsSalesPerson.defaultStateManagerCreator()) {
 
         self.saleID = saleID
         let host = defaults.stringForKey(ARStagingLiveAuctionSocketURLDefault) ?? "http://localhost:5000"

--- a/Artsy/View_Controllers/Live_Auctions/LiveAuctionStateManager.swift
+++ b/Artsy/View_Controllers/Live_Auctions/LiveAuctionStateManager.swift
@@ -17,12 +17,14 @@ Based on socket events:
 class LiveAuctionStateManager: NSObject {
     typealias SocketCommunicatorCreator = (host: String, saleID: String, accessToken: String) -> LiveAuctionSocketCommunicatorType
     typealias StateFetcherCreator = (host: String, saleID: String) -> LiveAuctionStateFetcherType
+    typealias StaticDataFetcherCreator = (saleID: String) -> LiveAuctionStaticDataFetcherType
     typealias StateReconcilerCreator = () -> LiveAuctionStateReconcilerType
 
     let saleID: String
 
     private let socketCommunicator: LiveAuctionSocketCommunicatorType
     private let stateFetcher: LiveAuctionStateFetcherType
+    private let staticDataFetcher: LiveAuctionStaticDataFetcherType
     private let stateReconciler: LiveAuctionStateReconcilerType
 
     init(host: String,
@@ -30,14 +32,20 @@ class LiveAuctionStateManager: NSObject {
         accessToken: String,
         socketCommunicatorCreator: SocketCommunicatorCreator = LiveAuctionStateManager.defaultSocketCommunicatorCreator(),
         stateFetcherCreator: StateFetcherCreator = LiveAuctionStateManager.defaultStateFetcherCreator(),
+        staticDataFetcherCreator: StaticDataFetcherCreator = LiveAuctionStateManager.defaultStaticDataFetcherCreator(),
         stateReconcilerCreator: StateReconcilerCreator = LiveAuctionStateManager.defaultStateReconcilerCreator()) {
 
         self.saleID = saleID
         self.socketCommunicator = socketCommunicatorCreator(host: host, saleID: saleID, accessToken: accessToken)
         self.stateFetcher = stateFetcherCreator(host: host, saleID: saleID)
+        self.staticDataFetcher = staticDataFetcherCreator(saleID: saleID)
         self.stateReconciler = stateReconcilerCreator()
 
         super.init()
+
+        staticDataFetcher.fetchStaticData().next { [weak self] staticData in
+            print("Static Data: \(staticData)")
+        }
 
         stateFetcher.fetchSale().next { [weak self] state in
             self?.stateReconciler.updateState(state)
@@ -94,6 +102,12 @@ extension DefaultCreators {
     class func defaultStateFetcherCreator() -> StateFetcherCreator {
         return { host, saleID in
             return LiveAuctionStateFetcher(host: host, saleID: saleID)
+        }
+    }
+
+    class func defaultStaticDataFetcherCreator() -> StaticDataFetcherCreator {
+        return { saleID in
+            return LiveAuctionStaticDataFetcher(saleID: saleID)
         }
     }
 

--- a/Artsy/View_Controllers/Live_Auctions/LiveAuctionStaticDataFetcher.swift
+++ b/Artsy/View_Controllers/Live_Auctions/LiveAuctionStaticDataFetcher.swift
@@ -16,7 +16,6 @@ class LiveAuctionStaticDataFetcher: LiveAuctionStaticDataFetcherType {
         let signal = Signal<AnyObject>()
 
         ArtsyAPI.getLiveSaleStaticDataWithSaleID(saleID,
-            host: "http://metaphysics-staging.artsy.net",
             success: { state in
                 signal.update(state)
             }, failure: { error in

--- a/Artsy/View_Controllers/Live_Auctions/LiveAuctionStaticDataFetcher.swift
+++ b/Artsy/View_Controllers/Live_Auctions/LiveAuctionStaticDataFetcher.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Interstellar
+
+protocol LiveAuctionStaticDataFetcherType {
+    func fetchStaticData() -> Signal<AnyObject>
+}
+
+class LiveAuctionStaticDataFetcher: LiveAuctionStaticDataFetcherType {
+    let saleID: String
+
+    init(saleID: String) {
+        self.saleID = saleID
+    }
+
+    func fetchStaticData() -> Signal<AnyObject> {
+        let signal = Signal<AnyObject>()
+
+        ArtsyAPI.getLiveSaleStaticDataWithSaleID(saleID,
+            host: "http://metaphysics-staging.artsy.net",
+            success: { state in
+                signal.update(state)
+            }, failure: { error in
+                signal.update(error as ErrorType)
+            })
+
+        return signal
+    }
+    
+}

--- a/Artsy/View_Controllers/Live_Auctions/LiveAuctionViewController.swift
+++ b/Artsy/View_Controllers/Live_Auctions/LiveAuctionViewController.swift
@@ -15,7 +15,7 @@ class LiveAuctionViewController: UIViewController {
     lazy var salesPerson: LiveAuctionsSalesPersonType = {
         // TODO: Very brittle! Assumes user is logged in. Prediction doesn't have guest support yet.
         let accessToken = UICKeyChainStore.stringForKey(AROAuthTokenDefault) ?? ""
-        return LiveAuctionsSalesPerson(saleID: self.saleID, accessToken: accessToken)
+        return LiveAuctionsSalesPerson(saleID: self.saleID, accessToken: accessToken) // TODO: stub
     }()
 
     var pageController: UIPageViewController!

--- a/Artsy/View_Controllers/Live_Auctions/LiveAuctionViewController.swift
+++ b/Artsy/View_Controllers/Live_Auctions/LiveAuctionViewController.swift
@@ -15,7 +15,7 @@ class LiveAuctionViewController: UIViewController {
     lazy var salesPerson: LiveAuctionsSalesPersonType = {
         // TODO: Very brittle! Assumes user is logged in. Prediction doesn't have guest support yet.
         let accessToken = UICKeyChainStore.stringForKey(AROAuthTokenDefault) ?? ""
-        return LiveAuctionsSalesPerson(saleID: self.saleID, accessToken: accessToken) // TODO: stub
+        return LiveAuctionsSalesPerson(saleID: self.saleID, accessToken: accessToken, stateManagerCreator: LiveAuctionsSalesPerson.stubbedStateManagerCreator())
     }()
 
     var pageController: UIPageViewController!

--- a/Artsy_Tests/Networking_Tests/Live_Auctions/LiveAuctionStateFetcherSpec.swift
+++ b/Artsy_Tests/Networking_Tests/Live_Auctions/LiveAuctionStateFetcherSpec.swift
@@ -14,7 +14,7 @@ class LiveAuctionStateFetcherSpec: QuickSpec {
         var subject: LiveAuctionStateFetcher!
 
         beforeEach {
-            OHHTTPStubs.stubJSONResponseAtPath("\(host)/state/\(saleID)", withResponse: saleJSON)
+            OHHTTPStubs.stubJSONResponseAtPath("http://sillyhost/state/sale_id", withResponse: saleJSON)
 
             subject = LiveAuctionStateFetcher(host: host, saleID: saleID)
         }
@@ -37,7 +37,7 @@ class LiveAuctionStateFetcherSpec: QuickSpec {
             }
 
             let dictionary = receivedState as? NSDictionary
-            expect((dictionary ?? [:])["id"] as? String) == saleID
+            expect(dictionary) == saleJSON
         }
     }
 }

--- a/Artsy_Tests/Networking_Tests/Live_Auctions/LiveAuctionStateFetcherSpec.swift
+++ b/Artsy_Tests/Networking_Tests/Live_Auctions/LiveAuctionStateFetcherSpec.swift
@@ -14,7 +14,7 @@ class LiveAuctionStateFetcherSpec: QuickSpec {
         var subject: LiveAuctionStateFetcher!
 
         beforeEach {
-            OHHTTPStubs.stubJSONResponseAtPath("http://sillyhost/state/sale_id", withResponse: saleJSON)
+            OHHTTPStubs.stubJSONResponseAtPath("\(host)/state/\(saleID)", withResponse: saleJSON)
 
             subject = LiveAuctionStateFetcher(host: host, saleID: saleID)
         }
@@ -37,7 +37,7 @@ class LiveAuctionStateFetcherSpec: QuickSpec {
             }
 
             let dictionary = receivedState as? NSDictionary
-            expect(dictionary) == saleJSON
+            expect((dictionary ?? [:])["id"] as? String) == saleID
         }
     }
 }

--- a/Artsy_Tests/Networking_Tests/Live_Auctions/LiveAuctionStaticDataFetcherSpec.swift
+++ b/Artsy_Tests/Networking_Tests/Live_Auctions/LiveAuctionStaticDataFetcherSpec.swift
@@ -1,0 +1,38 @@
+import Quick
+import Nimble
+import OHHTTPStubs
+@testable
+import Artsy
+
+class LiveAuctionStaticDataFetcherSpec: QuickSpec {
+    override func spec() {
+
+        let saleID = "sale_id"
+        let stateJSON: NSDictionary = ["id": saleID]
+
+        var subject: LiveAuctionStaticDataFetcher!
+
+        beforeEach {
+            OHHTTPStubs.stubJSONResponseAtPath("http://metaphysics-staging.artsy.net", withResponse: stateJSON)
+
+            subject = LiveAuctionStaticDataFetcher(saleID: saleID)
+        }
+        
+        it("configures its sale ID correctly") {
+            expect(subject.saleID) == saleID
+        }
+
+        it("fetches the static data") {
+            var receivedState: AnyObject?
+
+            subject
+                .fetchStaticData()
+                .next { state in
+                    receivedState = state
+            }
+
+            let dictionary = receivedState as? NSDictionary
+            expect(dictionary) == stateJSON
+        }
+    }
+}

--- a/Artsy_Tests/Networking_Tests/Live_Auctions/LiveAuctionStaticDataFetcherSpec.swift
+++ b/Artsy_Tests/Networking_Tests/Live_Auctions/LiveAuctionStaticDataFetcherSpec.swift
@@ -13,7 +13,7 @@ class LiveAuctionStaticDataFetcherSpec: QuickSpec {
         var subject: LiveAuctionStaticDataFetcher!
 
         beforeEach {
-            OHHTTPStubs.stubJSONResponseAtPath("http://metaphysics-staging.artsy.net", withResponse: stateJSON)
+            OHHTTPStubs.stubJSONResponseAtPath("https://metaphysics-production.artsy.net/", withResponse: stateJSON)
 
             subject = LiveAuctionStaticDataFetcher(saleID: saleID)
         }

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -6,6 +6,7 @@ upcoming:
     - Updates for Xcode 7.3. - ash
     - New state reconciliation for live auctions. -ash
     - Scaffolding for sending live auction events. - ash
+    - Basic metaphysics access for live sale static data. - ash
 
   notes:
     - Fixes long auction names falling off right edge. - ash


### PR DESCRIPTION
Adds a basic, hackey metaphysics call as per https://github.com/artsy/prediction/issues/119 Next steps will be to set up static data from the response, then make the existing sale state fetching code collate its results into something the UI can consume.

*Note*: this PR is against `socket-events` because I wanted some changes from that branch, but I wanted to keep this work separate. Feedback on this welcome here, or wherever.