### PR TITLE
Always create an ARTopViewController with its networking stubs in tests #trivial

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -568,6 +568,7 @@
 		60C1C3181C5FA34400EC98EE /* ARSerifNavigationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 60C1C3171C5FA34400EC98EE /* ARSerifNavigationViewController.m */; };
 		60C26DEA1BBC6D7600229CE8 /* AREmbeddedModelsPreviewDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 60C26DE91BBC6D7600229CE8 /* AREmbeddedModelsPreviewDelegate.m */; };
 		60C26DED1BBC6FEA00229CE8 /* AREmbeddedModelPreviewViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 60C26DEC1BBC6FEA00229CE8 /* AREmbeddedModelPreviewViewController.m */; };
+		60C2CBED1CC0EDDE009B30CA /* ARTopMenuViewController+Testing.m in Sources */ = {isa = PBXBuildFile; fileRef = 60C2CBEC1CC0EDDE009B30CA /* ARTopMenuViewController+Testing.m */; };
 		60C5ADB91C5A28B700E2822E /* ARModelInfiniteScrollViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C5ADB81C5A28B700E2822E /* ARModelInfiniteScrollViewController.swift */; };
 		60CE3CAB1B46F3EE00CA2B75 /* ArtsyOHHTTPAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 60CE3CAA1B46F3EE00CA2B75 /* ArtsyOHHTTPAPI.m */; };
 		60CEA77E19B61F8000CC3A91 /* ARArtistNetworkModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 60CEA77D19B61F8000CC3A91 /* ARArtistNetworkModel.m */; };
@@ -1671,6 +1672,8 @@
 		60C26DE91BBC6D7600229CE8 /* AREmbeddedModelsPreviewDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AREmbeddedModelsPreviewDelegate.m; sourceTree = "<group>"; };
 		60C26DEB1BBC6FEA00229CE8 /* AREmbeddedModelPreviewViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AREmbeddedModelPreviewViewController.h; sourceTree = "<group>"; };
 		60C26DEC1BBC6FEA00229CE8 /* AREmbeddedModelPreviewViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AREmbeddedModelPreviewViewController.m; sourceTree = "<group>"; };
+		60C2CBEB1CC0EDDE009B30CA /* ARTopMenuViewController+Testing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ARTopMenuViewController+Testing.h"; sourceTree = "<group>"; };
+		60C2CBEC1CC0EDDE009B30CA /* ARTopMenuViewController+Testing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ARTopMenuViewController+Testing.m"; sourceTree = "<group>"; };
 		60C5ADB81C5A28B700E2822E /* ARModelInfiniteScrollViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ARModelInfiniteScrollViewController.swift; sourceTree = "<group>"; };
 		60CAA3741782D87B00CA3DA8 /* ARContentViewControllers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARContentViewControllers.h; sourceTree = "<group>"; };
 		60CE3CA91B46F3EE00CA2B75 /* ArtsyOHHTTPAPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArtsyOHHTTPAPI.h; sourceTree = "<group>"; };
@@ -2339,6 +2342,8 @@
 				0CE3C4331B8BB35C0092A24F /* EXPMatcher+UINavigationController.h */,
 				0CE3C4341B8BB35C0092A24F /* EXPMatcher+UINavigationController.m */,
 				5E088DAF1C58141D00C448D7 /* UIViewController+Tests.swift */,
+				60C2CBEB1CC0EDDE009B30CA /* ARTopMenuViewController+Testing.h */,
+				60C2CBEC1CC0EDDE009B30CA /* ARTopMenuViewController+Testing.m */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -5614,6 +5619,7 @@
 				E649708918D7762F009DB0C4 /* ARImageItemProviderTests.m in Sources */,
 				E61E772619A5477300C55E14 /* ARExpectaExtensions.m in Sources */,
 				3CB9A20D18F303B20056C72B /* ARArtworkActionsViewTests.m in Sources */,
+				60C2CBED1CC0EDDE009B30CA /* ARTopMenuViewController+Testing.m in Sources */,
 				3C4877B3192A745400F40062 /* ARFairMapAnnotationCallOutViewTests.m in Sources */,
 				3C3FEA8E1884346D00E1A16F /* ARUserManager+Stubs.m in Sources */,
 				60327DE9198933610075B399 /* ARTabContentViewSpec.m in Sources */,

--- a/Artsy/View_Controllers/Feed_VCs/ARSimpleShowFeedViewController.m
+++ b/Artsy/View_Controllers/Feed_VCs/ARSimpleShowFeedViewController.m
@@ -193,7 +193,7 @@ static NSString *ARShowCellIdentifier = @"ARShowCellIdentifier";
             // So that it won't stop the first one
             [sself.networkStatus.offlineView refreshFailed];
             [sself.networkStatus showOfflineViewIfNeeded];
-            
+
             [sself performSelector:@selector(refreshFeedItems) withObject:nil afterDelay:1];
             [ARAnalytics finishTimingEvent:ARAnalyticsInitialFeedLoadTime];
 

--- a/Artsy_Tests/Extensions/ARTopMenuViewController+Testing.h
+++ b/Artsy_Tests/Extensions/ARTopMenuViewController+Testing.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+
+
+@interface ARTopMenuViewController (Testing)
+
+/// Gives a normal ARTopMenuViewController, but also triggers
+/// stubbed networking API calls for the View Controllers
+- (instancetype)initWithStubbedNetworking;
+
+@end

--- a/Artsy_Tests/Extensions/ARTopMenuViewController+Testing.m
+++ b/Artsy_Tests/Extensions/ARTopMenuViewController+Testing.m
@@ -1,0 +1,17 @@
+
+#import "ARTopMenuViewController+Testing.h"
+
+
+@implementation ARTopMenuViewController (Testing)
+
+- (instancetype)initWithStubbedNetworking
+{
+    [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/xapp_token" withResponse:@{}];
+    [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/site_hero_units" withResponse:@[ @{ @"heading" : @"something" } ]];
+    [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/sets" withResponse:@{}];
+    [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/shows/feed" withResponse:@{}];
+
+    return [super init];
+}
+
+@end

--- a/Artsy_Tests/View_Controller_Tests/App_Menu/ARTopMenuViewControllerSpec.m
+++ b/Artsy_Tests/View_Controller_Tests/App_Menu/ARTopMenuViewControllerSpec.m
@@ -1,4 +1,5 @@
 #import "ARTopMenuViewController.h"
+#import "ARTopMenuViewController+Testing.h"
 #import "ARTestTopMenuNavigationDataSource.h"
 #import "ARTabContentView.h"
 #import "ARTopMenuNavigationDataSource.h"
@@ -37,11 +38,7 @@ __block ARTopMenuViewController *sut;
 __block ARTopMenuNavigationDataSource *dataSource;
 
 dispatch_block_t sharedBefore = ^{
-    [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/xapp_token" withResponse:@{}];
-    [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/site_hero_units" withResponse:@[@{ @"heading": @"something" }]];
-    [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/sets" withResponse:@{}];
-
-    sut = [[ARTopMenuViewController alloc] init];
+    sut = [[ARTopMenuViewController alloc] initWithStubbedNetworking];
     sut.navigationDataSource = dataSource;
     dataSource.browseViewController.networkModel = [[ARStubbedBrowseNetworkModel alloc] init];
     [sut ar_presentWithFrame:[UIScreen mainScreen].bounds];

--- a/Artsy_Tests/View_Controller_Tests/Fair/ARFairGuideViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/ARFairGuideViewControllerTests.m
@@ -19,7 +19,8 @@ beforeEach(^{
     [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/collection/saved-artwork/artworks" withResponse:@[]];
     [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/me/follow/profiles" withResponse:@[]];
     [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/me/follow/artists" withResponse:@[]];
-    
+    [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/fair/fair-id/shows" withResponse:@{}];
+
     Fair *fair = [Fair modelWithJSON:@{ @"id" : @"fair-id", @"name" : @"The Armory Show", @"organizer" : @{ @"profile_id" : @"fair-profile-id" } }];
     fairGuideVC = [[ARFairGuideViewController alloc] initWithFair:fair];
 });

--- a/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/ARCreateAccountViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Login_and_Onboarding/ARCreateAccountViewControllerTests.m
@@ -1,5 +1,6 @@
 #import "ARCreateAccountViewController.h"
 #import "ARTopMenuViewController.h"
+#import "ARTopMenuViewController+Testing.h"
 #import "ARCustomEigenLabels.h"
 #import "UIViewController+SimpleChildren.h"
 #import "ARTextFieldWithPlaceholder.h"
@@ -22,14 +23,10 @@ __block ARTopMenuViewController *topMenuViewController;
 describe(@"warning view", ^{
     
     before(^{
-        // These come from the TopVC
-        [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/collection/saved-artwork/artworks" withResponse:@{}];
-        [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/sets" withResponse:@{}];
-
         vc = [[ARCreateAccountViewController alloc] init];
         [vc ar_presentWithFrame:[[UIScreen mainScreen] bounds]];
 
-        topMenuViewController = [[ARTopMenuViewController alloc] init];
+        topMenuViewController = [[ARTopMenuViewController alloc] initWithStubbedNetworking];
         [topMenuViewController ar_addModernChildViewController:vc];
 
         id ocPartialTop = [OCMockObject partialMockForObject:topMenuViewController];


### PR DESCRIPTION
Make it so that you don't need to know all the requests an `ARTopMenuViewController` makes by default.  Should bring us back down to 0 unstudied networking requests.