### PR TITLE
Fixes overflow issue for 32-bit compilation

### DIFF
--- a/Artsy/View_Controllers/Live_Auctions/LiveAuctionBidViewController.swift
+++ b/Artsy/View_Controllers/Live_Auctions/LiveAuctionBidViewController.swift
@@ -62,7 +62,7 @@ class LiveAuctionBidViewModel: NSObject {
         case 10_000_00...19_999_99: return 100_000
         case 20_000_00...49_999_99: return 200_000
         case 50_000_00...99_999_99: return 500_000
-        case 100_000_00...100_000_000_000_00: return 10_000_00
+        case 100_000_00...Int.max: return 10_000_00
         default: return bid
         }
     }


### PR DESCRIPTION
I tried switching to Int64 throughout the codebase but it quickly became a rabbit hole. A hundred billion dollars (the previous high value of the range) is a... pretty unlikely bid amount, so I used `Int.max` instead (which will work on either architecture). This introduces a problem if a bid exceeds $21 474 836.47 on an older device, but I don't think that's likely in the short term. @alloy it may be worth considering opening an issue to make sure this gets addressed eventually.

Fixes #1405.