### PR TITLE
Fixes crash in auction view controller caused by missing nullability specifier

### DIFF
--- a/Artsy/Models/API_Models/Partner_Metadata/Artwork.h
+++ b/Artsy/Models/API_Models/Partner_Metadata/Artwork.h
@@ -58,7 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) enum ARArtworkAvailability availability;
 
 @property (nonatomic, copy) NSString *date;
-@property (nonatomic, copy) NSString *title;
+@property (nonatomic, copy) NSString *_Nullable title;
 @property (nonatomic, copy) NSString *displayTitle;
 @property (nonatomic, copy) NSString *exhibitionHistory;
 @property (nonatomic, copy) NSString *additionalInfo;

--- a/Artsy/Models/API_Models/Partner_Metadata/Artwork.h
+++ b/Artsy/Models/API_Models/Partner_Metadata/Artwork.h
@@ -26,6 +26,8 @@ typedef NS_ENUM(NSInteger, ARDimensionMetric) {
     ARDimensionMetricNoMetric
 };
 
+NS_ASSUME_NONNULL_BEGIN
+
 
 @interface Artwork : MTLModel <ARPostAttachment, MTLJSONSerializing, ARHasImageBaseURL, ARShareableObject, ARSpotlightMetadataProvider>
 
@@ -40,7 +42,7 @@ typedef NS_ENUM(NSInteger, ARDimensionMetric) {
 @property (nonatomic, copy) NSString *dimensionsInches;
 
 // The artist that created the artwork. This may be `nil`.
-@property (nonatomic, strong) Artist *artist;
+@property (nonatomic, strong) Artist *_Nullable artist;
 @property (nonatomic, copy) NSString *imageFormatAddress;
 
 @property (nonatomic, strong) Partner *partner;
@@ -106,20 +108,20 @@ typedef NS_ENUM(NSInteger, ARDimensionMetric) {
 - (void)updatePartnerShow;
 
 /// Adds a callback when the artwork has been update, does not trigger said update.
-- (KSPromise *)onArtworkUpdate:(void (^)(void))success
-                       failure:(void (^)(NSError *error))failure;
-- (KSPromise *)onSaleArtworkUpdate:(void (^)(SaleArtwork *saleArtwork))success
-                           failure:(void (^)(NSError *error))failure;
-- (KSPromise *)onSaleArtworkUpdate:(void (^)(SaleArtwork *saleArtwork))success
-                           failure:(void (^)(NSError *error))failure
+- (KSPromise *)onArtworkUpdate:(nullable void (^)(void))success
+                       failure:(nullable void (^)(NSError *error))failure;
+- (KSPromise *)onSaleArtworkUpdate:(nullable void (^)(SaleArtwork *saleArtwork))success
+                           failure:(nullable void (^)(NSError *error))failure;
+- (KSPromise *)onSaleArtworkUpdate:(nullable void (^)(SaleArtwork *saleArtwork))success
+                           failure:(nullable void (^)(NSError *error))failure
                        allowCached:(BOOL)allowCached;
-- (KSPromise *)onFairUpdate:(void (^)(Fair *fair))success
-                    failure:(void (^)(NSError *error))failure;
-- (KSPromise *)onPartnerShowUpdate:(void (^)(PartnerShow *show))success
-                           failure:(void (^)(NSError *error))failure;
+- (KSPromise *)onFairUpdate:(nullable void (^)(Fair *fair))success
+                    failure:(nullable void (^)(NSError *error))failure;
+- (KSPromise *)onPartnerShowUpdate:(nullable void (^)(PartnerShow *show))success
+                           failure:(nullable void (^)(NSError *error))failure;
 
-- (void)setFollowState:(BOOL)state success:(void (^)(id))success failure:(void (^)(NSError *))failure;
-- (void)getFavoriteStatus:(void (^)(ARHeartStatus status))success failure:(void (^)(NSError *error))failure;
+- (void)setFollowState:(BOOL)state success:(nullable void (^)(id))success failure:(nullable void (^)(NSError *))failure;
+- (void)getFavoriteStatus:(nullable void (^)(ARHeartStatus status))success failure:(nullable void (^)(NSError *error))failure;
 
 - (BOOL)canViewInRoom;
 - (BOOL)hasWidth;
@@ -140,3 +142,5 @@ typedef NS_ENUM(NSInteger, ARDimensionMetric) {
 - (instancetype)initWithArtworkID:(NSString *)artworkID;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Artsy/Models/API_Models/Partner_Metadata/Artwork.m
+++ b/Artsy/Models/API_Models/Partner_Metadata/Artwork.m
@@ -310,7 +310,7 @@
     return [self.provenance length] || [self.exhibitionHistory length] || [self.signature length] || [self.additionalInfo length] || [self.literature length];
 }
 
-- (KSPromise *)onArtworkUpdate:(void (^)(void))success failure:(void (^)(NSError *error))failure
+- (KSPromise *)onArtworkUpdate:(nullable void (^)(void))success failure:(nullable void (^)(NSError *error))failure
 {
     __weak typeof(self) wself = self;
 
@@ -381,14 +381,14 @@
     }];
 }
 
-- (KSPromise *)onSaleArtworkUpdate:(void (^)(SaleArtwork *saleArtwork))success
-                           failure:(void (^)(NSError *error))failure
+- (KSPromise *)onSaleArtworkUpdate:(nullable void (^)(SaleArtwork *saleArtwork))success
+                           failure:(nullable void (^)(NSError *error))failure
 {
     return [self onSaleArtworkUpdate:success failure:failure allowCached:YES];
 }
 
-- (KSPromise *)onSaleArtworkUpdate:(void (^)(SaleArtwork *saleArtwork))success
-                           failure:(void (^)(NSError *error))failure
+- (KSPromise *)onSaleArtworkUpdate:(nullable void (^)(SaleArtwork *saleArtwork))success
+                           failure:(nullable void (^)(NSError *error))failure
                        allowCached:(BOOL)allowCached;
 {
     KSDeferred *deferred = [self deferredSaleArtworkUpdate];
@@ -438,7 +438,7 @@
     }];
 }
 
-- (KSPromise *)onFairUpdate:(void (^)(Fair *))success failure:(void (^)(NSError *))failure
+- (KSPromise *)onFairUpdate:(nullable void (^)(Fair *))success failure:(nullable void (^)(NSError *))failure
 {
     KSDeferred *deferred = [self deferredFairUpdate];
     return [deferred.promise then:^(id value) {
@@ -463,7 +463,7 @@
     return _partnerShowDeferred;
 }
 
-- (KSPromise *)onPartnerShowUpdate:(void (^)(PartnerShow *show))success failure:(void (^)(NSError *error))failure;
+- (KSPromise *)onPartnerShowUpdate:(nullable void (^)(PartnerShow *show))success failure:(nullable void (^)(NSError *error))failure;
 {
     KSDeferred *deferred = self.deferredPartnerShowUpdate;
     return [deferred.promise then:^(PartnerShow *show) {
@@ -490,7 +490,7 @@
     }];
 }
 
-- (void)setFollowState:(BOOL)state success:(void (^)(id))success failure:(void (^)(NSError *))failure
+- (void)setFollowState:(BOOL)state success:(nullable void (^)(id))success failure:(nullable void (^)(NSError *))failure
 {
     __weak typeof(self) wself = self;
     [ArtsyAPI setFavoriteStatus:state forArtwork:self success:^(id response) {
@@ -517,7 +517,7 @@
 }
 
 
-- (void)getFavoriteStatus:(void (^)(ARHeartStatus status))success failure:(void (^)(NSError *error))failure
+- (void)getFavoriteStatus:(nullable void (^)(ARHeartStatus status))success failure:(nullable void (^)(NSError *error))failure
 {
     if ([User isTrialUser]) {
         _heartStatus = ARHeartStatusNo;

--- a/Artsy/Views/Auction/SaleArtworkViewModel.swift
+++ b/Artsy/Views/Auction/SaleArtworkViewModel.swift
@@ -19,7 +19,7 @@ extension PublicComputedProperties {
     }
 
     var artistName: String {
-        return saleArtwork.artwork.artist.name
+        return saleArtwork.artwork.artist?.name ?? ""
     }
 
     var artworkName: String {

--- a/Artsy/Views/Auction/SaleArtworkViewModel.swift
+++ b/Artsy/Views/Auction/SaleArtworkViewModel.swift
@@ -23,7 +23,7 @@ extension PublicComputedProperties {
     }
 
     var artworkName: String {
-        return saleArtwork.artwork.title
+        return saleArtwork.artwork.title ?? ""
     }
 
     var lotNumber: String {

--- a/Artsy/Views/Auction/SaleViewModel.swift
+++ b/Artsy/Views/Auction/SaleViewModel.swift
@@ -121,7 +121,7 @@ extension SaleArtwork: AuctionOrderable {
     }
 
     var artistSortableID: String {
-        return artwork.artist.sortableID
+        return artwork.artist?.sortableID ?? ""
     }
 
     var currentBid: Int {

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -23,6 +23,7 @@ upcoming:
     - Fixes live auction lots being in the wrong order. - ash
     - Adds support for loading Artsy subdomains internally. - ash
     - Live auction lot list. - ash
+    - Fixes crash due to missing nullability specifiers on Artwork. - ash
 
 
 releases:


### PR DESCRIPTION
I've added a macro so all properties, method parameters, etc on `Artwork` are assumed to be non-null, then added nullability specifiers for things that _can_ be null (the `artist` property and methods that accept ObjC blocks). 

As a result, if an artwork _doesn't_ have an artist, its cell looks a little weird:

![simulator screen shot apr 15 2016 3 33 55 pm](https://cloud.githubusercontent.com/assets/498212/14572965/f34a3d66-031f-11e6-9898-49c56b2cab1e.png)

This happens rarely enough that this seems, to me, an acceptable solution. However, I'm open to suggestions :bow:

Fixes #1413.