### PR TITLE
Fix for network failures in WorksForYou

### DIFF
--- a/Artsy/Networking/Network_Models/ARWorksForYouNetworkModel.h
+++ b/Artsy/Networking/Network_Models/ARWorksForYouNetworkModel.h
@@ -4,7 +4,11 @@
 
 @protocol ARWorksForYouNetworkModelable <NSObject>
 
+/// Returns YES if all pages have been successfully downloaded
 - (BOOL)allDownloaded;
+
+/// Returns YES if network failure occurs
+- (BOOL)networkingDidFail;
 
 /// Returns an array of ARWorksForYouNotificationItems sorted by most recent publishing date
 - (void)getWorksForYou:(void (^_Nonnull)(NSArray<ARWorksForYouNotificationItem *> *_Nonnull))success failure:(void (^_Nullable)(NSError *_Nullable error))failure;

--- a/Artsy/Networking/Network_Models/ARWorksForYouNetworkModel.m
+++ b/Artsy/Networking/Network_Models/ARWorksForYouNetworkModel.m
@@ -10,6 +10,7 @@
 
 @interface ARWorksForYouNetworkModel ()
 @property (readwrite, nonatomic, assign) BOOL allDownloaded;
+@property (readwrite, nonatomic, assign) BOOL networkingDidFail;
 @property (readwrite, nonatomic, assign) NSInteger currentPage;
 @property (atomic, weak) AFHTTPRequestOperation *currentRequest;
 @property (readwrite, nonatomic, strong) NSMutableArray *downloadedArtworkIDs;
@@ -86,7 +87,10 @@
         NSSortDescriptor *descriptor = [[NSSortDescriptor alloc] initWithKey:@"date" ascending:NO];
         success([notificationItems sortedArrayUsingDescriptors:@[descriptor]]);
 
-    } failure:failure];
+    } failure:^(NSError *error) {
+        self.networkingDidFail = (self.currentPage == 1);
+        if (failure) failure(error);
+    }];
 }
 
 - (void)performWorksForYouRequest:(void (^_Nonnull)(NSArray<Artwork *> *_Nonnull))success failure:(void (^_Nullable)(NSError *_Nullable))failure

--- a/Artsy/View_Controllers/WorksForYou/ARWorksForYouReloadingHostViewController.m
+++ b/Artsy/View_Controllers/WorksForYou/ARWorksForYouReloadingHostViewController.m
@@ -37,7 +37,7 @@
 
 - (void)viewWillAppear:(BOOL)animated;
 {
-    if (self.isContentStale || self.worksForYouViewController.networkingDidFail) {
+    if (self.isContentStale || self.worksForYouViewController.worksForYouNetworkModel.networkingDidFail) {
         [self reloadData];
     }
     [super viewWillAppear:animated];

--- a/Artsy/View_Controllers/WorksForYou/ARWorksForYouReloadingHostViewController.m
+++ b/Artsy/View_Controllers/WorksForYou/ARWorksForYouReloadingHostViewController.m
@@ -37,7 +37,7 @@
 
 - (void)viewWillAppear:(BOOL)animated;
 {
-    if (self.isContentStale) {
+    if (self.isContentStale || self.worksForYouViewController.networkingDidFail) {
         [self reloadData];
     }
     [super viewWillAppear:animated];
@@ -68,7 +68,7 @@
 
 - (BOOL)shouldAutorotate
 {
-  return self.traitDependentAutorotateSupport;
+    return self.traitDependentAutorotateSupport;
 }
 
 @end

--- a/Artsy/View_Controllers/WorksForYou/ARWorksForYouViewController.h
+++ b/Artsy/View_Controllers/WorksForYou/ARWorksForYouViewController.h
@@ -1,6 +1,7 @@
 #import <UIKit/UIKit.h>
+#import "ARWorksForYouNetworkModel.h"
 
 
 @interface ARWorksForYouViewController : UIViewController
-@property (nonatomic, readonly, assign) BOOL networkingDidFail;
+@property (nonatomic, strong, readonly) id<ARWorksForYouNetworkModelable> worksForYouNetworkModel;
 @end

--- a/Artsy/View_Controllers/WorksForYou/ARWorksForYouViewController.h
+++ b/Artsy/View_Controllers/WorksForYou/ARWorksForYouViewController.h
@@ -2,4 +2,5 @@
 
 
 @interface ARWorksForYouViewController : UIViewController
+@property (nonatomic, readonly, assign) BOOL networkingDidFail;
 @end

--- a/Artsy/View_Controllers/WorksForYou/ARWorksForYouViewController.m
+++ b/Artsy/View_Controllers/WorksForYou/ARWorksForYouViewController.m
@@ -1,6 +1,5 @@
 #import "ARWorksForYouViewController.h"
 #import "Artist.h"
-#import "ARWorksForYouNetworkModel.h"
 #import "ARDispatchManager.h"
 #import "ARWorksForYouNotificationItem.h"
 #import "ARSwitchBoard+Eigen.h"
@@ -25,12 +24,9 @@ static int ARLoadingIndicatorView = 1;
 
 
 @interface ARWorksForYouViewController () <UIScrollViewDelegate>
-
+@property (nonatomic, strong, readwrite) id<ARWorksForYouNetworkModelable> worksForYouNetworkModel;
 @property (nonatomic, strong) ORStackScrollView *view;
 @property (nonatomic, strong) ORStackView *emptyStateView;
-@property (nonatomic, strong, readwrite) id<ARWorksForYouNetworkModelable> worksForYouNetworkModel;
-
-@property (nonatomic, assign) BOOL networkingDidFail;
 
 @end
 
@@ -57,7 +53,6 @@ static int ARLoadingIndicatorView = 1;
 {
     [super viewDidLoad];
     self.worksForYouNetworkModel = self.worksForYouNetworkModel ?: [[ARWorksForYouNetworkModel alloc] init];
-    self.networkingDidFail = NO;
 
     ARSerifLabel *titleLabel = [[ARSerifLabel alloc] initWithFrame:CGRectZero];
     titleLabel.text = @"Works by Artists you follow";
@@ -169,11 +164,7 @@ static int ARLoadingIndicatorView = 1;
         } else if (sself.shouldShowEmptyState) {
             [sself showEmptyState];
         }
-    } failure:^(NSError *error) {
-        if (self.worksForYouNetworkModel.currentPage == 1) {
-            self.networkingDidFail = YES;
-        }
-    }];
+    } failure:nil];
 }
 
 - (void)markNotificationsAsRead

--- a/Artsy/View_Controllers/WorksForYou/ARWorksForYouViewController.m
+++ b/Artsy/View_Controllers/WorksForYou/ARWorksForYouViewController.m
@@ -30,6 +30,8 @@ static int ARLoadingIndicatorView = 1;
 @property (nonatomic, strong) ORStackView *emptyStateView;
 @property (nonatomic, strong, readwrite) id<ARWorksForYouNetworkModelable> worksForYouNetworkModel;
 
+@property (nonatomic, assign) BOOL networkingDidFail;
+
 @end
 
 
@@ -55,6 +57,7 @@ static int ARLoadingIndicatorView = 1;
 {
     [super viewDidLoad];
     self.worksForYouNetworkModel = self.worksForYouNetworkModel ?: [[ARWorksForYouNetworkModel alloc] init];
+    self.networkingDidFail = NO;
 
     ARSerifLabel *titleLabel = [[ARSerifLabel alloc] initWithFrame:CGRectZero];
     titleLabel.text = @"Works by Artists you follow";
@@ -166,7 +169,11 @@ static int ARLoadingIndicatorView = 1;
         } else if (sself.shouldShowEmptyState) {
             [sself showEmptyState];
         }
-    } failure:nil];
+    } failure:^(NSError *error) {
+        if (self.worksForYouNetworkModel.currentPage == 1) {
+            self.networkingDidFail = YES;
+        }
+    }];
 }
 
 - (void)markNotificationsAsRead

--- a/Artsy_Tests/Networking_Tests/Networking_Models/ARWorksForYouNetworkModelTests.m
+++ b/Artsy_Tests/Networking_Tests/Networking_Models/ARWorksForYouNetworkModelTests.m
@@ -71,4 +71,26 @@ describe(@"success", ^{
     });
 });
 
+describe(@"handling failures", ^{
+    beforeEach(^{
+        [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+            return [request.URL.path isEqualToString:@"/api/v1/me/notifications"];
+        } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+            return [OHHTTPStubsResponse responseWithError:[NSError errorWithDomain:NSURLErrorDomain code:404 userInfo:nil]];
+        }];
+
+    });
+
+    it(@"sets networkingDidFail to YES if on first page", ^{
+        [networkModel getWorksForYou:^(NSArray<ARWorksForYouNotificationItem *> *items) {} failure:nil];
+        expect(networkModel.networkingDidFail).to.beTruthy();
+    });
+
+    it(@"does not set networkingDidFail if not on first page", ^{
+        networkModel.currentPage = 2;
+        [networkModel getWorksForYou:^(NSArray<ARWorksForYouNotificationItem *> *items) {} failure:nil];
+        expect(networkModel.networkingDidFail).to.beFalsy();
+    });
+});
+
 SpecEnd;

--- a/Artsy_Tests/Stubs/ARStubbedWorksForYouNetworkModel.h
+++ b/Artsy_Tests/Stubs/ARStubbedWorksForYouNetworkModel.h
@@ -5,6 +5,7 @@
 @interface ARStubbedWorksForYouNetworkModel : NSObject <ARWorksForYouNetworkModelable>
 
 @property (nonatomic, assign) BOOL allDownloaded;
+@property (nonatomic, assign) BOOL networkingDidFail;
 @property (nonatomic, copy, readwrite) NSArray<ARWorksForYouNotificationItem *> *notificationItems;
 @property (readwrite, nonatomic, assign) NSInteger currentPage;
 @property (readwrite, nonatomic, strong) NSArray *downloadedArtworkIDs;

--- a/Artsy_Tests/View_Controller_Tests/ARWorksForYouReloadingHostViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/ARWorksForYouReloadingHostViewControllerTests.m
@@ -72,9 +72,9 @@ describe(@"after 1 hour", ^{
 
 describe(@"handling network errors", ^{
     it(@"reloads if networking failed", ^{
-        id viewControllerMock = [OCMockObject partialMockForObject:hostViewController.worksForYouViewController];
-        [[[viewControllerMock stub] andReturnValue:@YES] networkingDidFail];
-        
+        ARStubbedWorksForYouNetworkModel *networkModel = hostViewController.worksForYouViewController.worksForYouNetworkModel;
+        networkModel.networkingDidFail = YES;
+
         id hostViewControllerMock = [OCMockObject partialMockForObject:hostViewController];
         [[hostViewControllerMock expect] reloadData];
         
@@ -85,7 +85,6 @@ describe(@"handling network errors", ^{
     });
     
     it(@"does not reload if networking succeeded", ^{
-        
         id hostViewControllerMock = [OCMockObject partialMockForObject:hostViewController];
         [[hostViewControllerMock reject] reloadData];
         

--- a/Artsy_Tests/View_Controller_Tests/ARWorksForYouReloadingHostViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/ARWorksForYouReloadingHostViewControllerTests.m
@@ -70,4 +70,30 @@ describe(@"after 1 hour", ^{
     });
 });
 
+describe(@"handling network errors", ^{
+    it(@"reloads if networking failed", ^{
+        id viewControllerMock = [OCMockObject partialMockForObject:hostViewController.worksForYouViewController];
+        [[[viewControllerMock stub] andReturnValue:@YES] networkingDidFail];
+        
+        id hostViewControllerMock = [OCMockObject partialMockForObject:hostViewController];
+        [[hostViewControllerMock expect] reloadData];
+        
+        [hostViewController viewWillAppear:NO];
+        
+        [hostViewControllerMock verify];
+        [hostViewControllerMock stopMocking];
+    });
+    
+    it(@"does not reload if networking succeeded", ^{
+        
+        id hostViewControllerMock = [OCMockObject partialMockForObject:hostViewController];
+        [[hostViewControllerMock reject] reloadData];
+        
+        [hostViewController viewWillAppear:NO];
+        
+        [hostViewControllerMock verify];
+        [hostViewControllerMock stopMocking];
+    });
+});
+
 SpecEnd;

--- a/Artsy_Tests/View_Controller_Tests/ARWorksForYouViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/ARWorksForYouViewControllerTests.m
@@ -65,41 +65,6 @@ describe(@"marking notifications as read", ^{
     });
 });
 
-describe(@"handling network failures", ^{
-    it(@"sets networkingDidFail to YES if on first page", ^{
-        subject.worksForYouNetworkModel = stubbedNetworkModel;
-        
-        id networkModelMock = [OCMockObject partialMockForObject:subject.worksForYouNetworkModel];
-        
-        [[[networkModelMock stub] andDo:^(NSInvocation *invocation) {
-            void(^failureBlock)(NSError *);
-            [invocation getArgument:&failureBlock atIndex:3];
-            failureBlock([NSError errorWithDomain:NSURLErrorDomain code:404 userInfo:nil]);
-        }] getWorksForYou:OCMOCK_ANY failure:OCMOCK_ANY];
-        
-        [subject beginAppearanceTransition:YES animated:NO];
-        expect(subject.networkingDidFail).to.beTruthy();
-    });
-    
-    it(@"does not set networkingDidFail if not on first page", ^{
-        subject.worksForYouNetworkModel = stubbedNetworkModel;
-        
-        id networkModelMock = [OCMockObject partialMockForObject:subject.worksForYouNetworkModel];
-        
-        [[[networkModelMock stub] andDo:^(NSInvocation *invocation) {
-            void(^failureBlock)(NSError *);
-            [invocation getArgument:&failureBlock atIndex:3];
-            failureBlock([NSError errorWithDomain:NSURLErrorDomain code:404 userInfo:nil]);
-        }] getWorksForYou:OCMOCK_ANY failure:OCMOCK_ANY];
-        
-        NSInteger page = 2;
-        [[[networkModelMock stub] andReturnValue:@(page)] currentPage];
-        
-        [subject beginAppearanceTransition:YES animated:NO];
-        expect(subject.networkingDidFail).to.beFalsy();
-    });
-});
-
 itHasSnapshotsForDevicesWithName(@"looks right when user has no notifications", ^{
     subject.worksForYouNetworkModel = stubbedNetworkModel;
 

--- a/Artsy_Tests/View_Controller_Tests/ARWorksForYouViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/ARWorksForYouViewControllerTests.m
@@ -66,12 +66,12 @@ describe(@"marking notifications as read", ^{
 });
 
 describe(@"handling network failures", ^{
-    it(@"sets networkingDidFail to YES", ^{
+    it(@"sets networkingDidFail to YES if on first page", ^{
         subject.worksForYouNetworkModel = stubbedNetworkModel;
         
-        id stub = [OCMockObject partialMockForObject:subject.worksForYouNetworkModel];
+        id networkModelMock = [OCMockObject partialMockForObject:subject.worksForYouNetworkModel];
         
-        [[[stub stub] andDo:^(NSInvocation *invocation) {
+        [[[networkModelMock stub] andDo:^(NSInvocation *invocation) {
             void(^failureBlock)(NSError *);
             [invocation getArgument:&failureBlock atIndex:3];
             failureBlock([NSError errorWithDomain:NSURLErrorDomain code:404 userInfo:nil]);
@@ -79,6 +79,24 @@ describe(@"handling network failures", ^{
         
         [subject beginAppearanceTransition:YES animated:NO];
         expect(subject.networkingDidFail).to.beTruthy();
+    });
+    
+    it(@"does not set networkingDidFail if not on first page", ^{
+        subject.worksForYouNetworkModel = stubbedNetworkModel;
+        
+        id networkModelMock = [OCMockObject partialMockForObject:subject.worksForYouNetworkModel];
+        
+        [[[networkModelMock stub] andDo:^(NSInvocation *invocation) {
+            void(^failureBlock)(NSError *);
+            [invocation getArgument:&failureBlock atIndex:3];
+            failureBlock([NSError errorWithDomain:NSURLErrorDomain code:404 userInfo:nil]);
+        }] getWorksForYou:OCMOCK_ANY failure:OCMOCK_ANY];
+        
+        NSInteger page = 2;
+        [[[networkModelMock stub] andReturnValue:@(page)] currentPage];
+        
+        [subject beginAppearanceTransition:YES animated:NO];
+        expect(subject.networkingDidFail).to.beFalsy();
     });
 });
 

--- a/Artsy_Tests/View_Controller_Tests/ARWorksForYouViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/ARWorksForYouViewControllerTests.m
@@ -50,6 +50,7 @@ describe(@"marking notifications as read", ^{
         [subject beginAppearanceTransition:YES animated:NO];
         [subject endAppearanceTransition];
         [networkModelStub verify];
+        [networkModelStub stopMocking];
     });
 
     it(@"tells the top menu vc to update its bell", ^{
@@ -60,6 +61,24 @@ describe(@"marking notifications as read", ^{
         [subject beginAppearanceTransition:YES animated:NO];
         [subject endAppearanceTransition];
         [topMenuStub verify];
+        [topMenuStub stopMocking];
+    });
+});
+
+describe(@"handling network failures", ^{
+    it(@"sets networkingDidFail to YES", ^{
+        subject.worksForYouNetworkModel = stubbedNetworkModel;
+        
+        id stub = [OCMockObject partialMockForObject:subject.worksForYouNetworkModel];
+        
+        [[[stub stub] andDo:^(NSInvocation *invocation) {
+            void(^failureBlock)(NSError *);
+            [invocation getArgument:&failureBlock atIndex:3];
+            failureBlock([NSError errorWithDomain:NSURLErrorDomain code:404 userInfo:nil]);
+        }] getWorksForYou:OCMOCK_ANY failure:OCMOCK_ANY];
+        
+        [subject beginAppearanceTransition:YES animated:NO];
+        expect(subject.networkingDidFail).to.beTruthy();
     });
 });
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,6 +3,7 @@ upcoming:
   details: Analytics improvements
 
   dev:
+    - WorksForYouVC reloads content upon network failure if you leave and then return to its tab - sarah
     - Artwork view hides Contact button for uninquireable works - sarah 
     - Removed the Ask a Specialist button from artwork view - sarah
     - Added a check in danger for ARTopMenuViewController+SwiftDeveloperExtras - sarah

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -312,7 +312,7 @@ SPEC CHECKSUMS:
   AFOAuth1Client: 07ccc935ba06ac8d023c16d39a5bdf04bc6f92e1
   ALPValidator: c74ea0d49bbbff0f8a4228f1eb6589b992255cfe
   Analytics: b342fb4f43fa4f97ca6f4358b44d3295217ba294
-  ARAnalytics: ab25a3d8c6c950f69f25100de470614b6a7d6d9b
+  ARAnalytics: 96e23ba7f54298f4914de9e1ac999db7a15f3fdd
   ARASCIISwizzle: 4800c50a918bdc06f6304020e348ef8c15c554ee
   ARCollectionViewMasonryLayout: 776730bdedd0c7570a5e904c370e4e120f98ea62
   ARGenericTableViewController: 61a0897ba66c35111b5d1cc3b44884282bd3c1a5


### PR DESCRIPTION
If the network connection is lost, WorksForYouVC will reload if the user navigates elsewhere and returns with a solid connection.

Fixes #1425