### PR TITLE
Use Top Menu for view controllers

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -348,6 +348,8 @@
 		60026AF21BDE3EFB0040257C /* ARWebViewCacheHost.m in Sources */ = {isa = PBXBuildFile; fileRef = 60026AF11BDE3EFB0040257C /* ARWebViewCacheHost.m */; };
 		60026AF51BDE912C0040257C /* ARAuctionResultsNetworkModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 60026AF41BDE912C0040257C /* ARAuctionResultsNetworkModel.m */; };
 		60026AF91BDF76040040257C /* ARAuctionArtworkResultsViewControllerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 60026AF71BDE97320040257C /* ARAuctionArtworkResultsViewControllerSpec.m */; };
+		6002C2601CC5125200E249B2 /* UIViewController+TopMenuViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6002C25F1CC5125200E249B2 /* UIViewController+TopMenuViewController.m */; };
+		6002C2651CC5153300E249B2 /* UIViewControllerTopMenuViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6002C2631CC512E200E249B2 /* UIViewControllerTopMenuViewControllerTests.m */; };
 		600415C917C4ECE2003C7974 /* ArtsyAPI+RelatedModels.m in Sources */ = {isa = PBXBuildFile; fileRef = 600415C817C4ECE2003C7974 /* ArtsyAPI+RelatedModels.m */; };
 		600A734317DE3F3F00E21233 /* ArtsyAPI+DeviceTokens.m in Sources */ = {isa = PBXBuildFile; fileRef = 600A734217DE3F3F00E21233 /* ArtsyAPI+DeviceTokens.m */; };
 		600B8B451C4FCEEC00776F84 /* CHANGELOG.yml in Resources */ = {isa = PBXBuildFile; fileRef = 600B8B441C4FCEEC00776F84 /* CHANGELOG.yml */; };
@@ -1304,6 +1306,9 @@
 		60026AF31BDE912C0040257C /* ARAuctionResultsNetworkModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARAuctionResultsNetworkModel.h; sourceTree = "<group>"; };
 		60026AF41BDE912C0040257C /* ARAuctionResultsNetworkModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARAuctionResultsNetworkModel.m; sourceTree = "<group>"; };
 		60026AF71BDE97320040257C /* ARAuctionArtworkResultsViewControllerSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ARAuctionArtworkResultsViewControllerSpec.m; path = Auction_Results/ARAuctionArtworkResultsViewControllerSpec.m; sourceTree = "<group>"; };
+		6002C25E1CC5125200E249B2 /* UIViewController+TopMenuViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+TopMenuViewController.h"; sourceTree = "<group>"; };
+		6002C25F1CC5125200E249B2 /* UIViewController+TopMenuViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+TopMenuViewController.m"; sourceTree = "<group>"; };
+		6002C2631CC512E200E249B2 /* UIViewControllerTopMenuViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIViewControllerTopMenuViewControllerTests.m; sourceTree = "<group>"; };
 		600415C717C4ECE2003C7974 /* ArtsyAPI+RelatedModels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ArtsyAPI+RelatedModels.h"; sourceTree = "<group>"; };
 		600415C817C4ECE2003C7974 /* ArtsyAPI+RelatedModels.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ArtsyAPI+RelatedModels.m"; sourceTree = "<group>"; };
 		600A734117DE3F3F00E21233 /* ArtsyAPI+DeviceTokens.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ArtsyAPI+DeviceTokens.h"; sourceTree = "<group>"; };
@@ -2230,6 +2235,8 @@
 				5E4962431CA1C7E800E77DD5 /* NSAttributedString+Additions.swift */,
 				608AFFF41CB68A2800534754 /* UIView+Spinner.h */,
 				608AFFF51CB68A2800534754 /* UIView+Spinner.m */,
+				6002C25E1CC5125200E249B2 /* UIViewController+TopMenuViewController.h */,
+				6002C25F1CC5125200E249B2 /* UIViewController+TopMenuViewController.m */,
 			);
 			path = Apple;
 			sourceTree = "<group>";
@@ -2404,8 +2411,8 @@
 		3C5C7E3D18970E73003823BB /* Util Tests */ = {
 			isa = PBXGroup;
 			children = (
+				6002C2611CC512B700E249B2 /* Categories */,
 				E676B2F318D2307D0057B4E1 /* Sharing Tests */,
-				54289FED18AA7F4E00681E49 /* UINavigationController_InnermostTopViewControllerSpec.m */,
 				3C5C7E3E18970E78003823BB /* Enumerations */,
 				604151E41A7998E300D5F9CA /* NSDate+RangeTests.m */,
 				D3F69A491AC1F7CB007C65C9 /* ARDefaultsTests.m */,
@@ -3128,6 +3135,15 @@
 				60026AF71BDE97320040257C /* ARAuctionArtworkResultsViewControllerSpec.m */,
 			);
 			name = "Auction Results";
+			sourceTree = "<group>";
+		};
+		6002C2611CC512B700E249B2 /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				54289FED18AA7F4E00681E49 /* UINavigationController_InnermostTopViewControllerSpec.m */,
+				6002C2631CC512E200E249B2 /* UIViewControllerTopMenuViewControllerTests.m */,
+			);
+			name = Categories;
 			sourceTree = "<group>";
 		};
 		60059B1B17CE6D3400BE132D /* 1 - Slideshow */ = {
@@ -5334,6 +5350,7 @@
 				609E394E1C9FEC840035C6FC /* LiveAuctionLotImagesPreviewView.swift in Sources */,
 				60DE2DE11677B30700621540 /* ARLoginViewController.m in Sources */,
 				600A734317DE3F3F00E21233 /* ArtsyAPI+DeviceTokens.m in Sources */,
+				6002C2601CC5125200E249B2 /* UIViewController+TopMenuViewController.m in Sources */,
 				B31DB35B17FA234C009B122B /* ARArtworkMetadataView.m in Sources */,
 				5435192E18A8E9420060F31E /* UIView+OldSchoolSnapshots.m in Sources */,
 				51D141B91AF25DB4000091CF /* ARAutoLayoutDebugging.m in Sources */,
@@ -5644,6 +5661,7 @@
 				60E738741C64ACA000AC381B /* ARAppAnalyticsSpec.m in Sources */,
 				60F8FFC1197E773E00DC3869 /* ARArtworkSetViewControllerSpec.m in Sources */,
 				5EBDC95119794D840082C514 /* ARSearchFieldButtonTests.m in Sources */,
+				6002C2651CC5153300E249B2 /* UIViewControllerTopMenuViewControllerTests.m in Sources */,
 				60AF60CB1CB395600041B430 /* LiveAuctionBidButtonTests.swift in Sources */,
 				5E0AEB7A19B9EF57009F34DE /* ARShowNetworkModelTests.m in Sources */,
 				D3ACE5391AEEF47C0053E0CE /* ARExternalWebBrowserViewControllerTests.m in Sources */,

--- a/Artsy/Categories/Apple/UIViewController+TopMenuViewController.h
+++ b/Artsy/Categories/Apple/UIViewController+TopMenuViewController.h
@@ -1,0 +1,10 @@
+#import <UIKit/UIKit.h>
+
+@class ARTopMenuViewController;
+
+
+@interface UIViewController (TopMenuViewController)
+
+- (ARTopMenuViewController *_Nullable)ar_TopMenuViewController;
+
+@end

--- a/Artsy/Categories/Apple/UIViewController+TopMenuViewController.m
+++ b/Artsy/Categories/Apple/UIViewController+TopMenuViewController.m
@@ -1,0 +1,20 @@
+#import "UIViewController+TopMenuViewController.h"
+#import "ARTopMenuViewController.h"
+
+
+@implementation UIViewController (TopMenuViewController)
+
+- (ARTopMenuViewController *_Nullable)ar_TopMenuViewController
+{
+    if ([self.parentViewController isKindOfClass:ARTopMenuViewController.class]) {
+        return (id)self.parentViewController;
+    }
+
+    if ([self.navigationController.parentViewController isKindOfClass:ARTopMenuViewController.class]) {
+        return (id)self.navigationController.parentViewController;
+    }
+
+    return [self.parentViewController ar_TopMenuViewController];
+}
+
+@end

--- a/Artsy/Networking/Network_Models/ARFairFavoritesNetworkModel.m
+++ b/Artsy/Networking/Network_Models/ARFairFavoritesNetworkModel.m
@@ -202,7 +202,7 @@ const NSInteger ARFairFavoritesNetworkModelMaxRandomExhibitors = 10;
         __strong typeof (wself) sself = wself;
         ARPartnerShowFeedItem *showFeedItem = parsed.firstObject;
         if (feed && showFeedItem) { // check feed to retain it
-            UIViewController *viewController = [[ARSwitchBoard sharedInstance] loadShow:showFeedItem.show fair:fair];
+            UIViewController *viewController = [ARSwitchBoard.sharedInstance loadShow:showFeedItem.show fair:fair];
             [sself.delegate fairFavoritesNetworkModel:self shouldPresentViewController:viewController];
         }
     } failure:nil];
@@ -210,19 +210,19 @@ const NSInteger ARFairFavoritesNetworkModelMaxRandomExhibitors = 10;
 
 - (void)handleShowButtonPress:(PartnerShow *)show fair:(Fair *)fair
 {
-    UIViewController *viewController = [[ARSwitchBoard sharedInstance] loadShow:show fair:fair];
+    UIViewController *viewController = [ARSwitchBoard.sharedInstance loadShow:show fair:fair];
     [self.delegate fairFavoritesNetworkModel:self shouldPresentViewController:viewController];
 }
 
 - (void)handleArtworkButtonPress:(Artwork *)artwork fair:(Fair *)fair
 {
-    ARArtworkSetViewController *viewController = [[ARSwitchBoard sharedInstance] loadArtwork:artwork inFair:fair];
+    ARArtworkSetViewController *viewController = [ARSwitchBoard.sharedInstance loadArtwork:artwork inFair:fair];
     [self.delegate fairFavoritesNetworkModel:self shouldPresentViewController:viewController];
 }
 
 - (void)handleArtistButtonPress:(Artist *)artist fair:(Fair *)fair
 {
-    id viewController = [[ARSwitchBoard sharedInstance] loadArtistWithID:artist.artistID inFair:fair];
+    id viewController = [ARSwitchBoard.sharedInstance loadArtistWithID:artist.artistID inFair:fair];
     [self.delegate fairFavoritesNetworkModel:viewController shouldPresentViewController:viewController];
 }
 

--- a/Artsy/View_Controllers/App_Navigation/ARAppSearchViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARAppSearchViewController.m
@@ -14,6 +14,8 @@
 #import "UIView+HitTestExpansion.h"
 #import "ARSwitchBoard+Eigen.h"
 #import "ARMenuAwareViewController.h"
+#import "ARTopMenuViewController.h"
+#import "UIViewController+TopMenuViewController.h"
 
 #import <FXBlurView/FXBlurView.h>
 #import <FLKAutoLayout/UIView+FLKAutoLayout.h>
@@ -114,7 +116,7 @@ static const NSInteger ARAppSearchParallaxDistance = 20;
         controller = [ARSwitchBoard.sharedInstance loadPath:path];
     }
 
-    [self.navigationController pushViewController:controller animated:YES];
+    [self.ar_TopMenuViewController pushViewController:controller animated:YES];
 }
 
 - (void)closeSearch:(id)sender

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -153,7 +153,7 @@ static const CGFloat ARMenuButtonDimension = 46;
     // be assured that any VCs guide can be trusted.
     (void)self.keyboardLayoutGuide;
 
-    [self registerWithSwitchBoard:[ARSwitchBoard sharedInstance]];
+    [self registerWithSwitchBoard:ARSwitchBoard.sharedInstance];
 }
 
 - (void)registerWithSwitchBoard:(ARSwitchBoard *)switchboard
@@ -352,6 +352,11 @@ static const CGFloat ARMenuButtonDimension = 46;
 - (void)pushViewController:(UIViewController *)viewController animated:(BOOL)animated
 {
     NSAssert(viewController != nil, @"Attempt to push a nil view controller.");
+    if ([viewController isKindOfClass:UINavigationController.class]) {
+        [self presentViewController:viewController animated:animated completion:nil];
+        return;
+    }
+
     NSInteger index = [self indexOfRootViewController:viewController];
     if (index != NSNotFound) {
         [self presentRootViewControllerAtIndex:index animated:(animated && index != self.selectedTabIndex)];

--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController+ButtonActions.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController+ButtonActions.m
@@ -92,7 +92,7 @@
 {
     [ArtsyAPI getShowsForArtworkID:self.artwork.artworkID inFairID:self.fair.fairID success:^(NSArray *shows) {
         if (shows.count > 0) {
-            ARFairMapViewController *viewController = [[ARSwitchBoard sharedInstance] loadMapInFair:self.fair title:self.artwork.partner.name selectedPartnerShows:shows];
+            ARFairMapViewController *viewController = [ARSwitchBoard.sharedInstance loadMapInFair:self.fair title:self.artwork.partner.name selectedPartnerShows:shows];
             [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
         }
     } failure:^(NSError *error){
@@ -192,7 +192,7 @@
         NSString *orderID = [JSON valueForKey:@"id"];
         NSString *resumeToken = [JSON valueForKey:@"token"];
         ARErrorLog(@"Created order %@", orderID);
-        UIViewController *controller = [[ARSwitchBoard sharedInstance] loadOrderUIForID:orderID resumeToken:resumeToken];
+        UIViewController *controller = [ARSwitchBoard.sharedInstance loadOrderUIForID:orderID resumeToken:resumeToken];
         [self.navigationController pushViewController:controller animated:YES];
 
     }

--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
@@ -1,6 +1,8 @@
 #import "ARArtworkViewController.h"
 
 #import "Artwork.h"
+#import "ARTopMenuViewController.h"
+#import "UIViewController+TopMenuViewController.h"
 #import "UIViewController+FullScreenLoading.h"
 #import "ARArtworkRelatedArtworksView.h"
 #import "ARArtworkBlurbView.h"
@@ -225,14 +227,14 @@
 
 - (void)artworkBlurView:(ARArtworkBlurbView *)blurbView shouldPresentViewController:(UIViewController *)viewController
 {
-    [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
+    [self.ar_TopMenuViewController pushViewController:viewController animated:ARPerformWorkAsynchronously];
 }
 
 #pragma mark - ARArtworkDetailViewDelegate
 
 - (void)artworkDetailView:(ARArtworkDetailView *)detailView shouldPresentViewController:(UIViewController *)viewController
 {
-    [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
+    [self.ar_TopMenuViewController pushViewController:viewController animated:ARPerformWorkAsynchronously];
 }
 
 - (void)didUpdateArtworkDetailView:(id)detailView
@@ -252,14 +254,14 @@
 
 - (void)postViewController:(ARPostsViewController *)postViewController shouldShowViewController:(UIViewController *)viewController
 {
-    [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
+    [self.ar_TopMenuViewController pushViewController:viewController animated:ARPerformWorkAsynchronously];
 }
 
 #pragma mark - ARArtworkRelatedArtworksViewParentViewController
 
 - (void)relatedArtworksView:(ARArtworkRelatedArtworksView *)view shouldShowViewController:(UIViewController *)viewController
 {
-    [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
+    [self.ar_TopMenuViewController pushViewController:viewController animated:ARPerformWorkAsynchronously];
 }
 
 - (void)relatedArtworksView:(ARArtworkRelatedArtworksView *)view didAddSection:(UIView *)section;

--- a/Artsy/View_Controllers/Auction_Results/ARAuctionWebViewController.m
+++ b/Artsy/View_Controllers/Auction_Results/ARAuctionWebViewController.m
@@ -105,7 +105,7 @@
         return;
     }
 
-    artworkViewController = [[ARSwitchBoard sharedInstance] loadArtworkWithID:self.artworkID inFair:nil];
+    artworkViewController = [ARSwitchBoard.sharedInstance loadArtworkWithID:self.artworkID inFair:nil];
     NSMutableArray *mutatedStack = [stack mutableCopy];
     [mutatedStack insertObject:artworkViewController atIndex:stack.count-1];
     self.navigationController.viewControllers = mutatedStack;

--- a/Artsy/View_Controllers/Core/ARArtistViewController.m
+++ b/Artsy/View_Controllers/Core/ARArtistViewController.m
@@ -35,6 +35,9 @@
 #import <FLKAutoLayout/UIView+FLKAutoLayout.h>
 #import <ObjectiveSugar/ObjectiveSugar.h>
 
+#import "ARTopMenuViewController.h"
+#import "UIViewController+TopMenuViewController.h"
+
 static const NSInteger ARMinimumArtworksFor2Column = 5;
 
 typedef NS_ENUM(NSInteger, ARArtistViewIndex) {
@@ -626,6 +629,7 @@ typedef NS_ENUM(NSInteger, ARArtistArtworksDisplayMode) {
 - (void)embeddedModelsViewController:(AREmbeddedModelsViewController *)controller didTapItemAtIndex:(NSUInteger)index
 {
     ARArtworkSetViewController *viewController = [ARSwitchBoard.sharedInstance loadArtworkSet:self.artworkVC.items inFair:nil atIndex:index];
+
     [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
 }
 

--- a/Artsy/View_Controllers/Core/ARFeedLinkUnitViewController.m
+++ b/Artsy/View_Controllers/Core/ARFeedLinkUnitViewController.m
@@ -1,4 +1,9 @@
+// MARK: Formatter Exempt
+
 #import "ARFeedLinkUnitViewController.h"
+
+#import "ARTopMenuViewController.h"
+#import "UIViewController+TopMenuViewController.h"
 
 #import "ArtsyAPI+OrderedSets.h"
 #import "ARNavigationButton.h"
@@ -77,11 +82,11 @@
             ARNavigationButtonHandlerKey: ^(UIButton *sender) {
                 __strong typeof (wself) sself = wself;
                 UIViewController *viewController = [ARSwitchBoard.sharedInstance loadPath:featuredLink.href];
-                [sself.navigationController pushViewController:viewController animated:YES];
+                [sself.ar_TopMenuViewController pushViewController:viewController animated:ARPerformWorkAsynchronously];
+            }
+        }];
     }
-}];
-}
-return phoneNavigation;
+    return phoneNavigation;
 }
 
 - (FeaturedLink *)defaultFeedLink

--- a/Artsy/View_Controllers/Core/ARHeroUnitViewController.m
+++ b/Artsy/View_Controllers/Core/ARHeroUnitViewController.m
@@ -261,8 +261,6 @@ const static CGFloat ARCarouselDelay = 10;
 {
     UIViewController *viewController = [ARSwitchBoard.sharedInstance loadPath:self.heroUnit.link];
     if (viewController) {
-        // Normally we use self.navigationController here, but
-        // in this case we need to have checks for the class to ensure we don't crash - see #1061
         [ARTopMenuViewController.sharedController pushViewController:viewController animated:YES];
     }
 }

--- a/Artsy/View_Controllers/Embedded/Generics/AREmbeddedModelsPreviewDelegate.m
+++ b/Artsy/View_Controllers/Embedded/Generics/AREmbeddedModelsPreviewDelegate.m
@@ -62,7 +62,7 @@
 {
     id object = viewControllerToCommit.object;
     id viewController = nil;
-    ARSwitchBoard *switchBoard = [ARSwitchBoard sharedInstance];
+    ARSwitchBoard *switchBoard = ARSwitchBoard.sharedInstance;
 
     if ([object isKindOfClass:Artwork.class]) {
         NSArray *items = self.modelVC.items;

--- a/Artsy/View_Controllers/Fair/ARFairArtistViewController.m
+++ b/Artsy/View_Controllers/Fair/ARFairArtistViewController.m
@@ -134,7 +134,7 @@ AR_VC_OVERRIDE_SUPER_DESIGNATED_INITIALIZERS;
     ARNavigationButton *button = [[ARNavigationButton alloc] initWithTitle:title];
     button.tag = ARFairArtistOnArtsy;
     button.onTap = ^(UIButton *tappedButton) {
-        UIViewController *viewController = [[ARSwitchBoard sharedInstance] loadArtistWithID:self.artist.artistID inFair:nil];
+        UIViewController *viewController = [ARSwitchBoard.sharedInstance loadArtistWithID:self.artist.artistID inFair:nil];
         [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
     };
     [self.view.stackView addSubview:button withTopMargin:@"20" sideMargin:@"40"];
@@ -159,7 +159,7 @@ AR_VC_OVERRIDE_SUPER_DESIGNATED_INITIALIZERS;
     ARNavigationButton *button = [[ARSerifNavigationButton alloc] initWithTitle:show.partner.name andSubtitle:show.locationInFair withBorder:0];
     button.tag = tag;
     button.onTap = ^(UIButton *tappedButton) {
-        UIViewController *viewController = [[ARSwitchBoard sharedInstance] loadShow:show fair:self.fair];
+        UIViewController *viewController = [ARSwitchBoard.sharedInstance loadShow:show fair:self.fair];
         [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
     };
     [self.view.stackView addSubview:button withTopMargin:@"0" sideMargin:@"40"];
@@ -209,7 +209,7 @@ AR_VC_OVERRIDE_SUPER_DESIGNATED_INITIALIZERS;
     __weak typeof(self) wself = self;
     [self.fair getFairMaps:^(NSArray *maps) {
         __strong typeof (wself) sself = wself;
-        ARFairMapViewController *viewController = [[ARSwitchBoard sharedInstance] loadMapInFair:sself.fair title:sself.header selectedPartnerShows:sself.partnerShows];
+        ARFairMapViewController *viewController = [ARSwitchBoard.sharedInstance loadMapInFair:sself.fair title:sself.header selectedPartnerShows:sself.partnerShows];
         [sself.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
     }];
 }

--- a/Artsy/View_Controllers/Fair/ARFairPopupViewController.m
+++ b/Artsy/View_Controllers/Fair/ARFairPopupViewController.m
@@ -3,6 +3,8 @@
 #import "ARAppConstants.h"
 #import "Fair.h"
 #import "ARSwitchBoard+Eigen.h"
+#import "ARTopMenuViewController.h"
+#import "UIViewController+TopMenuViewController.h"
 
 #import "UIImageView+AsyncImageLoading.h"
 
@@ -102,7 +104,7 @@ AR_VC_OVERRIDE_SUPER_DESIGNATED_INITIALIZERS;
     [self dismissPopover];
 
     UIViewController *controller = [ARSwitchBoard.sharedInstance loadPath:self.slug];
-    [self.presentingViewController.navigationController pushViewController:controller animated:YES];
+    [self.presentingViewController.ar_TopMenuViewController pushViewController:controller animated:ARPerformWorkAsynchronously];
 }
 
 - (void)presentOnViewController:(UIViewController *)parent animated:(BOOL)animated

--- a/Artsy/View_Controllers/Fair/ARFairPostsViewController.m
+++ b/Artsy/View_Controllers/Fair/ARFairPostsViewController.m
@@ -1,11 +1,15 @@
 #import "ARFairPostsViewController.h"
 
+#import "ARAppConstants.h"
 #import "Fair.h"
 #import "ARFeedTimeline.h"
 #import "ARPostFeedItem.h"
 #import "ARPostFeedItemLinkView.h"
 #import "ORStackView+ArtsyViews.h"
 #import "ARSwitchBoard+Eigen.h"
+#import "ARTopMenuViewController.h"
+#import "UIViewController+TopMenuViewController.h"
+
 
 @implementation ARFairPostsViewController
 
@@ -50,7 +54,7 @@
         [self.selectionDelegate didSelectPost:sender.targetPath];
     } else {
         UIViewController *viewController = [ARSwitchBoard.sharedInstance loadPath:sender.targetPath];
-        [self.navigationController pushViewController:viewController animated:YES];
+        [self.ar_TopMenuViewController pushViewController:viewController animated:ARPerformWorkAsynchronously];
     }
 }
 

--- a/Artsy/View_Controllers/Fair/ARFairViewController.m
+++ b/Artsy/View_Controllers/Fair/ARFairViewController.m
@@ -1,3 +1,5 @@
+// MARK: Formatter Exempt
+
 #import "ARFairViewController.h"
 
 #import "Artist.h"
@@ -27,6 +29,8 @@
 #import "OrderedSet.h"
 #import "ARSwitchBoard+Eigen.h"
 #import "ARScrollNavigationChief.h"
+#import "ARTopMenuViewController.h"
+#import "UIViewController+TopMenuViewController.h"
 
 #import "UIDevice-Hardware.h"
 
@@ -270,11 +274,10 @@ NSString *const ARFairHighlightFavoritePartnersKey = @"ARFairHighlightFavoritePa
         },
         ARNavigationButtonHandlerKey : ^(ARButtonWithImage *button){
             __strong typeof(wself) sself = wself;
-    ARFairMapViewController *viewController = [[ARSwitchBoard sharedInstance] loadMapInFair:self.fair];
-    [sself.navigationController pushViewController:viewController animated:YES];
-}
-}
-;
+            ARFairMapViewController *viewController = [ARSwitchBoard.sharedInstance loadMapInFair:self.fair];
+            [sself.navigationController pushViewController:viewController animated:YES];
+       }
+    };
 }
 
 - (NSDictionary *)buttonDescriptionForFeaturedLink:(FeaturedLink *)featuredLink buttonClass:(Class)buttonClass
@@ -290,13 +293,12 @@ NSString *const ARFairHighlightFavoritePartnersKey = @"ARFairHighlightFavoritePa
         },
         ARNavigationButtonHandlerKey : ^(UIButton *button){
             __strong typeof(wself) sself = wself;
-    if ([button isKindOfClass:[ARButtonWithImage class]]) {
-        ARButtonWithImage *buttonWithImage = (ARButtonWithImage *)button;
-        [sself buttonPressed:buttonWithImage];
-    }
-}
-}
-;
+            if ([button isKindOfClass:[ARButtonWithImage class]]) {
+                ARButtonWithImage *buttonWithImage = (ARButtonWithImage *)button;
+                [sself buttonPressed:buttonWithImage];
+            }
+        }
+    };
 }
 
 - (void)buttonPressed:(ARButtonWithImage *)buttonWithImage
@@ -351,34 +353,32 @@ NSString *const ARFairHighlightFavoritePartnersKey = @"ARFairHighlightFavoritePa
 
 - (void)selectedResult:(SearchResult *)result ofType:(NSString *)type fromQuery:(NSString *)query
 {
-    ARSwitchBoard *switchBoard = [ARSwitchBoard sharedInstance];
+    ARSwitchBoard *switchBoard = ARSwitchBoard.sharedInstance;
+    UIViewController *controller = nil;
+
     if (result.model == [Artwork class]) {
-        UIViewController *controller = [switchBoard loadArtworkWithID:result.modelID inFair:self.fair];
-        [self.navigationController pushViewController:controller animated:YES];
+        controller = [switchBoard loadArtworkWithID:result.modelID inFair:self.fair];
 
     } else if (result.model == [Artist class]) {
         Artist *artist = [[Artist alloc] initWithArtistID:result.modelID];
-        UIViewController *controller = [switchBoard loadArtistWithID:artist.artistID inFair:self.fair];
-        [self.navigationController pushViewController:controller animated:YES];
+        controller = [switchBoard loadArtistWithID:artist.artistID inFair:self.fair];
 
     } else if (result.model == [Gene class]) {
-        UIViewController *controller = [switchBoard loadGeneWithID:result.modelID];
-        [self.navigationController pushViewController:controller animated:YES];
+        controller = [switchBoard loadGeneWithID:result.modelID];
 
     } else if (result.model == [Profile class]) {
-        UIViewController *controller = [ARSwitchBoard.sharedInstance routeProfileWithID:result.modelID];
-        [self.navigationController pushViewController:controller animated:YES];
+        controller = [switchBoard routeProfileWithID:result.modelID];
 
     } else if (result.model == [SiteFeature class]) {
         NSString *path = NSStringWithFormat(@"/feature/%@", result.modelID);
-        UIViewController *controller = [[ARSwitchBoard sharedInstance] loadPath:path];
-        [self.navigationController pushViewController:controller animated:YES];
+        controller = [switchBoard loadPath:path];
 
     } else if (result.model == [PartnerShow class]) {
         PartnerShow *partnerShow = [[PartnerShow alloc] initWithShowID:result.modelID];
-        UIViewController *controller = [switchBoard loadShowWithID:partnerShow.showID fair:self.fair];
-        [self.navigationController pushViewController:controller animated:YES];
+        controller = [switchBoard loadShowWithID:partnerShow.showID fair:self.fair];
     }
+
+    [self.ar_TopMenuViewController pushViewController:controller animated:ARPerformWorkAsynchronously];
 }
 
 - (void)cancelledSearch:(ARFairSearchViewController *)controller

--- a/Artsy/View_Controllers/Fair/ARShowViewController.m
+++ b/Artsy/View_Controllers/Fair/ARShowViewController.m
@@ -190,7 +190,7 @@ self.actionButtonsView.actionButtonDescriptions = descriptions;
     __weak typeof(self) wself = self;
     [self.showNetworkModel getFairMaps:^(NSArray *maps) {
         __strong typeof (wself) sself = wself;
-        ARFairMapViewController *viewController = [[ARSwitchBoard sharedInstance] loadMapInFair:sself.fair title:sself.show.title selectedPartnerShows:@[sself.show]];
+        ARFairMapViewController *viewController = [ARSwitchBoard.sharedInstance loadMapInFair:sself.fair title:sself.show.title selectedPartnerShows:@[sself.show]];
         [sself.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
     }];
 }

--- a/Artsy/View_Controllers/Fair/Guides/ARFairMapViewController.m
+++ b/Artsy/View_Controllers/Fair/Guides/ARFairMapViewController.m
@@ -24,6 +24,7 @@
 #import "ARCustomEigenLabels.h"
 #import "ARSwitchBoard+Eigen.h"
 #import "ARTopMenuViewController.h"
+#import "UIViewController+TopMenuViewController.h"
 #import "ARMacros.h"
 
 #import <FLKAutoLayout/UIViewController+FLKAutoLayout.h>
@@ -285,26 +286,33 @@
 
 - (void)selectedResult:(SearchResult *)result ofType:(NSString *)type fromQuery:(NSString *)query
 {
-    ARSwitchBoard *switchboard = [ARSwitchBoard sharedInstance];
-    if (result.model == [Artwork class]) {
-        UIViewController *controller = [switchboard loadArtworkWithID:result.modelID inFair:self.fair];
-        [self.navigationController pushViewController:controller animated:YES];
-    } else if (result.model == [Artist class]) {
+    ARSwitchBoard *switchboard = ARSwitchBoard.sharedInstance;
+    UIViewController *controller = nil;
+
+    // Top two don't need new view controllers
+    if (result.model == [Artist class]) {
         Artist *artist = [[Artist alloc] initWithArtistID:result.modelID];
         [self selectedArtist:artist];
-    } else if (result.model == [Gene class]) {
-        UIViewController *controller = [switchboard loadGeneWithID:result.modelID];
-        [self.navigationController pushViewController:controller animated:YES];
-    } else if (result.model == [Profile class]) {
-        UIViewController *controller = [switchboard routeProfileWithID:result.modelID];
-        [self.navigationController pushViewController:controller animated:YES];
-    } else if (result.model == [SiteFeature class]) {
-        NSString *path = NSStringWithFormat(@"/feature/%@", result.modelID);
-        UIViewController *controller = [switchboard loadPath:path];
-        [self.navigationController pushViewController:controller animated:YES];
+
     } else if (result.model == [PartnerShow class]) {
         PartnerShow *partnerShow = [[PartnerShow alloc] initWithShowID:result.modelID];
         [self selectedPartnerShow:partnerShow];
+
+    } else if (result.model == [Artwork class]) {
+        controller = [switchboard loadArtworkWithID:result.modelID inFair:self.fair];
+
+    } else if (result.model == [Gene class]) {
+        controller = [switchboard loadGeneWithID:result.modelID];
+
+    } else if (result.model == [Profile class]) {
+        controller = [switchboard routeProfileWithID:result.modelID];
+    } else if (result.model == [SiteFeature class]) {
+        NSString *path = NSStringWithFormat(@"/feature/%@", result.modelID);
+        controller = [switchboard loadPath:path];
+    }
+    
+    if (controller) {
+        [self.ar_TopMenuViewController pushViewController:controller animated:ARPerformWorkAsynchronously];
     }
 }
 
@@ -326,7 +334,7 @@
         }];
     } failure:^(NSError *error) {
         [[completionCommand execute:nil] subscribeCompleted:^{
-            UIViewController *controller = [[ARSwitchBoard sharedInstance] loadShowWithID:partnerShow.showID fair:self.fair];
+            UIViewController *controller = [ARSwitchBoard.sharedInstance loadShowWithID:partnerShow.showID fair:self.fair];
             [self.navigationController pushViewController:controller animated:YES];
         }];
     }];
@@ -344,8 +352,8 @@
         }];
     } failure:^(NSError *error) {
         [[completionCommand execute:nil] subscribeCompleted:^{
-            UIViewController *controller = [[ARSwitchBoard sharedInstance] loadArtistWithID:artist.artistID inFair:self.fair];
-            [self.navigationController pushViewController:controller animated:YES];
+            UIViewController *controller = [ARSwitchBoard.sharedInstance loadArtistWithID:artist.artistID inFair:self.fair];
+            [self.ar_TopMenuViewController pushViewController:controller animated:ARPerformWorkAsynchronously];
         }];
     }];
 }

--- a/Artsy/View_Controllers/Favorites/ARFavoritesViewController.m
+++ b/Artsy/View_Controllers/Favorites/ARFavoritesViewController.m
@@ -20,6 +20,8 @@
 #import "ARSwitchBoard+Eigen.h"
 #import "ARScrollNavigationChief.h"
 #import "ARDispatchManager.h"
+#import "ARTopMenuViewController.h"
+#import "UIViewController+TopMenuViewController.h"
 
 #import "UIDevice-Hardware.h"
 
@@ -339,18 +341,21 @@
 
 - (void)embeddedModelsViewController:(AREmbeddedModelsViewController *)controller didTapItemAtIndex:(NSUInteger)index
 {
+    UIViewController *newViewController = nil;
+
     if (self.displayMode == ARFavoritesDisplayModeArtworks) {
-        ARArtworkSetViewController *viewController = [ARSwitchBoard.sharedInstance loadArtworkSet:self.embeddedItemsVC.items inFair:nil atIndex:index];
-        [self.navigationController pushViewController:viewController animated:YES];
+        newViewController = [ARSwitchBoard.sharedInstance loadArtworkSet:self.embeddedItemsVC.items inFair:nil atIndex:index];
+
     } else if (self.displayMode == ARFavoritesDisplayModeArtists) {
         Artist *artist = self.embeddedItemsVC.items[index];
-        UIViewController *viewController = [ARSwitchBoard.sharedInstance loadArtistWithID:artist.artistID];
-        [self.navigationController pushViewController:viewController animated:YES];
+        newViewController = [ARSwitchBoard.sharedInstance loadArtistWithID:artist.artistID];
+
     } else if (self.displayMode == ARFavoritesDisplayModeGenes) {
         Gene *gene = self.embeddedItemsVC.items[index];
-        UIViewController *viewController = [ARSwitchBoard.sharedInstance loadGene:gene];
-        [self.navigationController pushViewController:viewController animated:YES];
+        newViewController = [ARSwitchBoard.sharedInstance loadGene:gene];
     }
+
+    [self.ar_TopMenuViewController pushViewController:newViewController animated:ARPerformWorkAsynchronously];
 }
 
 - (void)embeddedModelsViewControllerDidScrollPastEdge:(AREmbeddedModelsViewController *)embeddedModelsViewController

--- a/Artsy/View_Controllers/Post/ARPostsViewController.m
+++ b/Artsy/View_Controllers/Post/ARPostsViewController.m
@@ -39,7 +39,7 @@
 
 - (void)tappedPostFeedItemLinkView:(ARPostFeedItemLinkView *)sender
 {
-    UIViewController *viewController = [[ARSwitchBoard sharedInstance] loadPath:[sender targetPath]];
+    UIViewController *viewController = [ARSwitchBoard.sharedInstance loadPath:[sender targetPath]];
     if (viewController) {
         [self.delegate postViewController:self shouldShowViewController:viewController];
     }

--- a/Artsy/View_Controllers/Util/ARBrowseCategoriesViewController.m
+++ b/Artsy/View_Controllers/Util/ARBrowseCategoriesViewController.m
@@ -10,6 +10,8 @@
 #import "ARSwitchBoard+Eigen.h"
 #import "ARScrollNavigationChief.h"
 #import "ARLogger.h"
+#import "ARTopMenuViewController.h"
+#import "UIViewController+TopMenuViewController.h"
 
 #import "UIDevice-Hardware.h"
 
@@ -97,7 +99,7 @@
 {
     UIViewController *viewController = [ARSwitchBoard.sharedInstance loadPath:featuredLink.href];
     if (viewController) {
-        [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
+        [self.ar_TopMenuViewController pushViewController:viewController animated:ARPerformWorkAsynchronously];
     }
 }
 

--- a/Artsy/View_Controllers/Util/ARBrowseViewController.m
+++ b/Artsy/View_Controllers/Util/ARBrowseViewController.m
@@ -1,7 +1,10 @@
 #import "ARBrowseViewController.h"
 #import "UIViewController+FullScreenLoading.h"
 #import "ARBrowseFeaturedLinksCollectionViewCell.h"
+#import "ARAppConstants.h"
 #import "ARSwitchBoard+Eigen.h"
+#import "ARTopMenuViewController.h"
+#import "UIViewController+TopMenuViewController.h"
 
 #import "UIDevice-Hardware.h"
 
@@ -165,7 +168,7 @@
     FeaturedLink *link = [self.menuLinks objectAtIndex:indexPath.row];
     UIViewController *viewController = [ARSwitchBoard.sharedInstance loadPath:link.href];
     if (viewController) {
-        [self.navigationController pushViewController:viewController animated:YES];
+        [self.ar_TopMenuViewController pushViewController:viewController animated:ARPerformWorkAsynchronously];
     }
 }
 

--- a/Artsy/View_Controllers/Web_Browsing/ARExternalWebBrowserViewController.m
+++ b/Artsy/View_Controllers/Web_Browsing/ARExternalWebBrowserViewController.m
@@ -156,7 +156,7 @@
 {
     if (navigationAction.navigationType == WKNavigationTypeLinkActivated) {
         NSURL *URL = navigationAction.request.URL;
-        ARSwitchBoard *switchboard = [ARSwitchBoard sharedInstance];
+        ARSwitchBoard *switchboard = ARSwitchBoard.sharedInstance;
         if ([switchboard canRouteURL:URL]) {
             UIViewController *controller = [switchboard loadURL:URL];
             if (controller) {

--- a/Artsy/View_Controllers/Web_Browsing/ARInternalMobileWebViewController.m
+++ b/Artsy/View_Controllers/Web_Browsing/ARInternalMobileWebViewController.m
@@ -1,3 +1,4 @@
+#import "ARAppConstants.h"
 #import "ARLogger.h"
 #import "ARInternalMobileWebViewController.h"
 #import "UIViewController+FullScreenLoading.h"
@@ -5,6 +6,8 @@
 #import "ARInternalShareValidator.h"
 #import "ARAppDelegate.h"
 #import "ARSwitchBoard+Eigen.h"
+#import "ARTopMenuViewController.h"
+#import "UIViewController+TopMenuViewController.h"
 
 static void *ARProgressContext = &ARProgressContext;
 
@@ -175,8 +178,8 @@ static void *ARProgressContext = &ARProgressContext;
 
         } else {
             UIViewController *viewController = [ARSwitchBoard.sharedInstance loadURL:URL fair:self.fair];
-            if (viewController && ![self.navigationController.viewControllers containsObject:viewController]) {
-                [self.navigationController pushViewController:viewController animated:YES];
+            if (viewController) {
+                [self.ar_TopMenuViewController pushViewController:viewController animated:ARPerformWorkAsynchronously];
             }
 
             ARActionLog(@"Martsy URL: Denied - %@ - %@", URL, @(navigationAction.navigationType));

--- a/Artsy/Views/Artist/ARRelatedArtistsViewController.m
+++ b/Artsy/Views/Artist/ARRelatedArtistsViewController.m
@@ -121,7 +121,7 @@
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath
 {
     Artist *artist = self.relatedArtists[indexPath.row];
-    UIViewController *viewController = [[ARSwitchBoard sharedInstance] loadArtistWithID:artist.artistID inFair:self.fair];
+    UIViewController *viewController = [ARSwitchBoard.sharedInstance loadArtistWithID:artist.artistID inFair:self.fair];
     [self.navigationController pushViewController:viewController animated:YES];
 }
 

--- a/Artsy/Views/Collection_Views/ARGeneViewController.m
+++ b/Artsy/Views/Collection_Views/ARGeneViewController.m
@@ -19,6 +19,9 @@
 #import "ARTrialController.h"
 #import "ARScrollNavigationChief.h"
 
+#import "ARTopMenuViewController.h"
+#import "UIViewController+TopMenuViewController.h"
+
 #import "UILabel+Typography.h"
 #import "UIDevice-Hardware.h"
 
@@ -289,7 +292,7 @@
 - (void)embeddedModelsViewController:(AREmbeddedModelsViewController *)controller didTapItemAtIndex:(NSUInteger)index
 {
     ARArtworkSetViewController *viewController = [ARSwitchBoard.sharedInstance loadArtworkSet:self.artworksViewController.items inFair:nil atIndex:index];
-    [self.navigationController pushViewController:viewController animated:YES];
+    [self.ar_TopMenuViewController pushViewController:viewController animated:ARPerformWorkAsynchronously];
 }
 
 - (void)embeddedModelsViewControllerDidScrollPastEdge:(AREmbeddedModelsViewController *)controller

--- a/Artsy/Views/Fair/ARFairMapAnnotationCallOutView.m
+++ b/Artsy/Views/Fair/ARFairMapAnnotationCallOutView.m
@@ -163,12 +163,16 @@
 - (void)tapped:(id)sender
 {
     id representedObject = self.annotation.representedObject;
+    UIViewController *controller = nil;
     if ([representedObject isKindOfClass:PartnerShow.class]) {
         PartnerShow *partnerShow = (PartnerShow *)representedObject;
-        ARShowViewController *viewController = [[ARSwitchBoard sharedInstance] loadShow:partnerShow fair:self.fair];
-        [[ARTopMenuViewController sharedController] pushViewController:viewController];
+        controller = [ARSwitchBoard.sharedInstance loadShow:partnerShow fair:self.fair];
     } else if (self.annotation.href) {
-        [[ARSwitchBoard sharedInstance] loadPath:self.annotation.href];
+        controller = [ARSwitchBoard.sharedInstance loadPath:self.annotation.href];
+    }
+
+    if (controller) {
+        [[ARTopMenuViewController sharedController] pushViewController:controller];
     }
 }
 

--- a/Artsy/Views/Table_View_Cells/Feed_Items/Modern/ARModernPartnerShowTableViewCell.m
+++ b/Artsy/Views/Table_View_Cells/Feed_Items/Modern/ARModernPartnerShowTableViewCell.m
@@ -197,14 +197,14 @@ static CGFloat ARPartnerShowCellSideMargin;
 
 - (void)openShow:(UITapGestureRecognizer *)gesture
 {
-    ARShowViewController *viewController = [[ARSwitchBoard sharedInstance] loadShow:self.show];
+    ARShowViewController *viewController = [ARSwitchBoard.sharedInstance loadShow:self.show];
     [self.delegate modernPartnerShowTableViewCell:self shouldShowViewController:(id)viewController];
 }
 
 - (void)openPartner:(UITapGestureRecognizer *)gesture
 {
     if ([AROptions boolForOption:AROptionsTappingPartnerSendsToPartner]) {
-        UIViewController *viewController = [[ARSwitchBoard sharedInstance] loadPartnerWithID:self.show.partner.partnerID];
+        UIViewController *viewController = [ARSwitchBoard.sharedInstance loadPartnerWithID:self.show.partner.partnerID];
         [self.delegate modernPartnerShowTableViewCell:self shouldShowViewController:(id)viewController];
 
     } else {

--- a/Artsy_Tests/Util_Tests/UIViewControllerTopMenuViewControllerTests.m
+++ b/Artsy_Tests/Util_Tests/UIViewControllerTopMenuViewControllerTests.m
@@ -1,0 +1,37 @@
+#import "UIViewController+TopMenuViewController.h"
+#import "ARTopMenuViewController+Testing.h"
+
+SpecBegin(UIViewController_TopMenuViewController);
+
+it(@"returns the nil for view controllers that are not in a heirarchy with a ARTopMenuVC", ^{
+    expect([[[UIViewController alloc] init] ar_TopMenuViewController]).to.beNil();
+});
+
+it(@"returns a TopMenuVC for view controllers that are directly in a heirarchy with a ARTopMenuVC", ^{
+    UIViewController *viewController = [[UIViewController alloc] init];
+
+    ARTopMenuViewController *topVC = [[ARTopMenuViewController alloc] initWithStubbedNetworking];
+    [topVC ar_presentWithFrame:CGRectMake(0, 0, 320, 200)];
+    [topVC pushViewController:viewController animated:NO];
+
+    expect(viewController.ar_TopMenuViewController).to.equal(topVC);
+});
+
+
+it(@"returns a TopMenuVC for view controllers that are deeper in a heirarchy with a ARTopMenuVC", ^{
+
+    UIViewController *viewController = [[UIViewController alloc] init];
+    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:viewController];
+
+    UIViewController *viewControllerTwo = [[UIViewController alloc] init];
+    [viewControllerTwo ar_addModernChildViewController:navController];
+
+    ARTopMenuViewController *topVC = [[ARTopMenuViewController alloc] initWithStubbedNetworking];
+    [topVC ar_presentWithFrame:CGRectMake(0, 0, 320, 200)];
+
+    [topVC pushViewController:viewControllerTwo animated:NO];
+
+    expect(viewController.ar_TopMenuViewController).to.equal(topVC);
+});
+
+SpecEnd;

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,6 +1,6 @@
 upcoming:
   version: 2.4.2
-  details: Analytics improvements
+  details: Onboarding / New Gene VC / Live
 
   dev:
     - Artwork view hides Contact button for uninquireable works - sarah 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -8,8 +8,8 @@ upcoming:
     - Added a check in danger for ARTopMenuViewController+SwiftDeveloperExtras - sarah
     - Generalized the RefineViewController - sarah
     - Updates for Xcode 7.3. - ash
-    - CocoaPods now is v1.0b. - orta
-
+    - CocoaPods now is v1.0b.8 - orta
+    - All UIViewController routing goes through ARTopMenuVC instead of self.navigationController - orta
     - New state reconciliation for live auctions. -ash
     - Scaffolding for sending live auction events. - ash
     - Started the Live Auction Bidding Interface - orta
@@ -24,7 +24,6 @@ upcoming:
     - Adds support for loading Artsy subdomains internally. - ash
     - Live auction lot list. - ash
     - Fixes crash due to missing nullability specifiers on Artwork. - ash
-
 
 releases:
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'cocoapods', '1.0.0.beta.7'
+gem 'cocoapods', '1.0.0.beta.8'
 gem 'cocoapods-keys'
 
 # 1.6.7 contains the OS X build fix.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,24 +15,24 @@ GEM
       json (~> 1.4)
       nokogiri (>= 1.4.4)
     claide (1.0.0.beta.3)
-    cocoapods (1.0.0.beta.7)
+    cocoapods (1.0.0.beta.8)
       activesupport (>= 4.0.2)
       claide (>= 1.0.0.beta.3, < 2.0)
-      cocoapods-core (= 1.0.0.beta.7)
+      cocoapods-core (= 1.0.0.beta.8)
       cocoapods-deintegrate (>= 1.0.0.beta.1, < 2.0)
       cocoapods-downloader (= 1.0.0.beta.3)
       cocoapods-plugins (>= 1.0.0.beta.1, < 2.0)
       cocoapods-search (= 1.0.0.beta.2)
       cocoapods-stats (= 1.0.0.beta.4)
-      cocoapods-trunk (= 1.0.0.beta.3)
-      cocoapods-try (>= 1.0.0.beta.3, < 2.0)
+      cocoapods-trunk (= 1.0.0.beta.4)
+      cocoapods-try (= 1.0.0.beta.4)
       colored (~> 1.2)
       escape (~> 0.0.4)
       fourflusher (~> 0.3.0)
       molinillo (~> 0.4.4)
       nap (~> 1.0)
       xcodeproj (= 1.0.0.beta.4)
-    cocoapods-core (1.0.0.beta.7)
+    cocoapods-core (1.0.0.beta.8)
       activesupport (>= 4.0.2)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
@@ -45,10 +45,10 @@ GEM
       nap
     cocoapods-search (1.0.0.beta.2)
     cocoapods-stats (1.0.0.beta.4)
-    cocoapods-trunk (1.0.0.beta.3)
+    cocoapods-trunk (1.0.0.beta.4)
       nap (>= 0.8, < 2.0)
       netrc (= 0.7.8)
-    cocoapods-try (1.0.0.beta.3)
+    cocoapods-try (1.0.0.beta.4)
     colored (1.2)
     danger (0.6.5)
       claide
@@ -106,7 +106,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (= 1.0.0.beta.7)
+  cocoapods (= 1.0.0.beta.8)
   cocoapods-keys
   danger
   lowdown

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -51,7 +51,7 @@ PODS:
   - ARTiledImageView (1.2.0):
     - SDWebImage/Core
   - Artsy+UIColors (3.0.1)
-  - Artsy+UIFonts (2.0.0)
+  - Artsy+UIFonts (1.1.0)
   - Artsy+UILabels (2.0.2):
     - Artsy+UIColors (~> 3.0)
     - Artsy+UIFonts
@@ -164,7 +164,7 @@ DEPENDENCIES:
   - ARGenericTableViewController (from `https://github.com/orta/ARGenericTableViewController.git`)
   - ARTiledImageView (from `https://github.com/dblock/ARTiledImageView`)
   - Artsy+UIColors
-  - Artsy+UIFonts (from `https://github.com/artsy/Artsy-OSSUIFonts.git`)
+  - Artsy+UIFonts (from `https://github.com/artsy/Artsy-UIFonts.git`)
   - Artsy+UILabels
   - Artsy-UIButtons
   - CocoaLumberjack (from `https://github.com/CocoaLumberjack/CocoaLumberjack.git`)
@@ -230,7 +230,7 @@ EXTERNAL SOURCES:
   ARTiledImageView:
     :git: https://github.com/dblock/ARTiledImageView
   Artsy+UIFonts:
-    :git: https://github.com/artsy/Artsy-OSSUIFonts.git
+    :git: https://github.com/artsy/Artsy-UIFonts.git
   CocoaLumberjack:
     :git: https://github.com/CocoaLumberjack/CocoaLumberjack.git
   FBSnapshotTestCase:
@@ -274,8 +274,8 @@ CHECKOUT OPTIONS:
     :commit: 775bc29beb5953e381b2af64edbdfc310b90e074
     :git: https://github.com/dblock/ARTiledImageView
   Artsy+UIFonts:
-    :commit: e8bd95cae1b68dc9afdd748bbef0da7c2ac269cf
-    :git: https://github.com/artsy/Artsy-OSSUIFonts.git
+    :commit: 6295cce382764bbca9f2b3e972f71eb2b4d32d57
+    :git: https://github.com/artsy/Artsy-UIFonts.git
   CocoaLumberjack:
     :commit: a09dd37888d9f51159c4926d4280794f915d726c
     :git: https://github.com/CocoaLumberjack/CocoaLumberjack.git
@@ -312,13 +312,13 @@ SPEC CHECKSUMS:
   AFOAuth1Client: 07ccc935ba06ac8d023c16d39a5bdf04bc6f92e1
   ALPValidator: c74ea0d49bbbff0f8a4228f1eb6589b992255cfe
   Analytics: b342fb4f43fa4f97ca6f4358b44d3295217ba294
-  ARAnalytics: ab25a3d8c6c950f69f25100de470614b6a7d6d9b
+  ARAnalytics: 96e23ba7f54298f4914de9e1ac999db7a15f3fdd
   ARASCIISwizzle: 4800c50a918bdc06f6304020e348ef8c15c554ee
   ARCollectionViewMasonryLayout: 776730bdedd0c7570a5e904c370e4e120f98ea62
   ARGenericTableViewController: 61a0897ba66c35111b5d1cc3b44884282bd3c1a5
   ARTiledImageView: 2db7735f5d3fcb4c859c912834a6a1bf20716377
   Artsy+UIColors: 10a2d71e9ffe1015be43d4e084d13ff4337aab97
-  Artsy+UIFonts: b1c53a1f9998bfce96ef1b544191f846e7ed1b0e
+  Artsy+UIFonts: 108bfe625c45008ebb15c4c62003882dd345c4b8
   Artsy+UILabels: 9b8e8b683488e22633625db9627cd79ab64b610f
   Artsy-UIButtons: 26e6d1e0d2174773e9cf7693985d27faddd61743
   Bolts: a0058fa3b331c5a1e4402d534f2dae36dbff31e4


### PR DESCRIPTION
This does not actually add the routing for Live Auctions, but provides the foundations. If `ARSwitchBoard` now returns a `UINavigationController` then the topVC will present it modally instead of pushing it on a anv. `UINavigationController` doesn't support pushing a `UINavigationController` anyway.

I didn't add this _everywhere_ because there are a lot of places where we're guaranteed to return a `UIViewController` because we use an ARSwitchBoard+Artsy method that returns a known class.

I did consolidate the way we access `ARSwitchBoard sharedSwitchboard` specifically so it's easy to look over all of them with a single find.