### PR TITLE
Requires AROption set for native live auctions

### DIFF
--- a/Artsy/App/AROptions.h
+++ b/Artsy/App/AROptions.h
@@ -7,6 +7,7 @@ extern NSString *const AROptionsUseVCR;
 extern NSString *const AROptionsSettingsMenu;
 extern NSString *const AROptionsTappingPartnerSendsToPartner;
 extern NSString *const AROptionsShowAnalyticsOnScreen;
+extern NSString *const AROptionsEnableNativeLiveAuctions;
 
 
 @interface AROptions : NSObject

--- a/Artsy/App/AROptions.m
+++ b/Artsy/App/AROptions.m
@@ -5,6 +5,7 @@ NSString *const AROptionsUseVCR = @"Use offline recording";
 NSString *const AROptionsSettingsMenu = @"Enable user settings";
 NSString *const AROptionsTappingPartnerSendsToPartner = @"Partner name in feed goes to partner";
 NSString *const AROptionsShowAnalyticsOnScreen = @"AROptionsShowAnalyticsOnScreen";
+NSString *const AROptionsEnableNativeLiveAuctions = @"Enable native live auctions";
 
 
 @implementation AROptions
@@ -14,7 +15,8 @@ NSString *const AROptionsShowAnalyticsOnScreen = @"AROptionsShowAnalyticsOnScree
     return @[
         AROptionsUseVCR,
         AROptionsSettingsMenu,
-        AROptionsTappingPartnerSendsToPartner
+        AROptionsTappingPartnerSendsToPartner,
+        AROptionsEnableNativeLiveAuctions
     ];
 }
 

--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -203,13 +203,15 @@ NSString *const AREscapeSandboxQueryString = @"eigen_escape_sandbox";
         return [[ARBrowseCategoriesViewController alloc] init];
     }];
 
-    Route *route = self.echo.routes[@"ARLiveAuctionsURLDomain"];
-    if (route) {
-        [self registerPathCallbackForDomain:route.path callback:^id _Nullable(NSURL *_Nonnull url) {
-            NSString *path = url.path;
-            NSString *slug = [[path split:@"/"] lastObject];
-            return [[LiveAuctionViewController alloc] initWithSaleSlugOrID:slug];
-        }];
+    if ([AROptions boolForOption:AROptionsEnableNativeLiveAuctions]) {
+        Route *route = self.echo.routes[@"ARLiveAuctionsURLDomain"];
+        if (route) {
+            [self registerPathCallbackForDomain:route.path callback:^id _Nullable(NSURL *_Nonnull url) {
+                NSString *path = url.path;
+                NSString *slug = [[path split:@"/"] lastObject];
+                return [[LiveAuctionViewController alloc] initWithSaleSlugOrID:slug];
+            }];
+        }
     }
 
     // This route will match any single path component and thus should be added last.

--- a/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
+++ b/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
@@ -331,6 +331,7 @@ describe(@"ARSwitchboard", ^{
         });
 
         it(@"routes live auctions", ^{
+            [AROptions setBool:YES forOption:AROptionsEnableNativeLiveAuctions];
             switchboard = [[ARSwitchBoard alloc] init];
             [switchboard updateRoutes];
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -25,6 +25,7 @@ upcoming:
     - Updates to Interstellar v2. - ash
     - Moves to Interstellar v2 unsubscription mechanism where needed. - ash
     - New socket communication work for updated Causality. - ash
+    - Put native live auctions behind AROptions. - ash
 
   notes:
     - Fixes long auction names falling off right edge. - ash


### PR DESCRIPTION
A few notes:

- Since Prediction staging is currently on a _non_ `.artsy.net` domain, it gets treated as an external link. When it gets moved to a proper domain, I'll check that move does indeed work.
- Because of the way routes are loaded on startup, after changing the Adoption, you need to restart the app. Wasn't sure how best to document this, open to suggestions.

Fixes #1466.