### PR TITLE
[SerifNav] Ensure that the padding for the title is taken into account

### DIFF
--- a/Artsy/View_Controllers/ARSerifNavigationViewController.m
+++ b/Artsy/View_Controllers/ARSerifNavigationViewController.m
@@ -124,7 +124,7 @@
 
         CGRect labelFrame = label.bounds;
         CGFloat idealWidth = CGRectGetWidth(labelFrame) + xOffset;
-        CGFloat max = CGRectGetWidth(navigationController.view.bounds) - (rightButtonsCount * 48) - ((rightButtonsCount - 1) * 10);
+        CGFloat max = CGRectGetWidth(navigationController.view.bounds) - (rightButtonsCount * 48) - ((rightButtonsCount - 1) * 10) - 20;
 
         label.frame = CGRectMake(xOffset, 0, MIN(idealWidth, max), 20);
         UIView *titleMarginWrapper = [[UIView alloc] initWithFrame:(CGRect){CGPointZero, {MIN(idealWidth, max), CGRectGetHeight(labelFrame)}}];


### PR DESCRIPTION
When generating the max size of the bounds for a single VC'd container.

![screen shot 2016-05-09 at 5 20 59 pm](https://cloud.githubusercontent.com/assets/49038/15128548/68c36016-160a-11e6-851d-753814013142.png)


