### PR TITLE
Cleanup surrounding non-native live support

### DIFF
--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -367,10 +367,13 @@ NSString *const AREscapeSandboxQueryString = @"eigen_escape_sandbox";
 
 - (UIViewController *)routeInternalURL:(NSURL *)url fair:(Fair *)fair
 {
-    // Use the internal JLRouter for the actual routing
-    id routedViewController = [self.routes routeURL:url withParameters:(fair ? @{ @"fair" : fair } : nil)];
-    if (routedViewController) {
-        return routedViewController;
+    BOOL isTrustedHostForPredictableRouting = ([[ARRouter artsyHosts] containsObject:url.host] || url.host == nil);
+    if (isTrustedHostForPredictableRouting) {
+        // Use the internal JLRouter for the actual routing
+        id routedViewController = [self.routes routeURL:url withParameters:(fair ? @{ @"fair" : fair } : nil)];
+        if (routedViewController) {
+            return routedViewController;
+        }
     }
 
     // We couldn't find one? Well, then we should present it as a martsy view

--- a/Artsy/View_Controllers/Debug/Quicksilver/ARQuicksilverViewController.m
+++ b/Artsy/View_Controllers/Debug/Quicksilver/ARQuicksilverViewController.m
@@ -222,7 +222,13 @@
 {
     [self.presentedViewController dismissViewControllerAnimated:NO completion:nil];
 
-    SearchResult *result = self.contentArray[indexPath.row];
+    SearchResult *result;
+    if (!self.contentArray || self.contentArray.count == 0) {
+        result = (id)self.searchController.searchBar.text;
+    } else {
+        result = self.contentArray[indexPath.row];
+    }
+
     [self addObjectToRecents:result];
 
     UIViewController *controller = nil;

--- a/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
+++ b/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
@@ -151,6 +151,12 @@ describe(@"ARSwitchboard", ^{
             });
         });
 
+        it(@"loads internal webviews for trusted but unpredictable hosts", ^{
+            NSURL *internalButUnpredictableURL = [[NSURL alloc] initWithString:@"https://live-staging.artsy.net/54c7e8fa7261692b5acd0600"];
+            id viewController = [switchboard loadURL:internalButUnpredictableURL];
+            expect(viewController).to.beKindOf(ARInternalMobileWebViewController.class);
+        });
+
         it(@"loads web view for external urls", ^{
             it(@"loads browser", ^{
                 NSURL *externalURL = [[NSURL alloc] initWithString:@"http://google.com"];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -7,6 +7,8 @@ upcoming:
     - WorksForYouVC reloads content upon network failure if you leave and then return to its tab - sarah
     - Removed updateConstraintsIfNeeded from ARNavigationButton to solve autolayout bugs in home screen tableview - sarah
     - Artwork view hides Contact button for uninquireable works - sarah
+    - QuickSilver now supports direct URLs. - ash
+    - Adds support for unknown Artsy URLs using internal web browsers. - ash
     - Removed the Ask a Specialist button from artwork view - sarah
     - Added a check in danger for ARTopMenuViewController+SwiftDeveloperExtras - sarah
     - Generalized the RefineViewController - sarah


### PR DESCRIPTION
In favour of #1489.

## Problem

I'd like to route https://live-staging.artsy.net/54c7e8fa7261692b5acd0600 to use an internal web browser. However, it gets routed as a profile. 

## Change

I've changed the switchboard to only route URLs with known Artsy hosts (so an unexpected Artsy subdomain will get routed to an internal web view instead of as a profile, which would remove the custom subdomain and replace it with either staging or production (m)artsy).

Paired with @orta. 