### PR TITLE
Improve analytics when an inquiry fails

### DIFF
--- a/Artsy/App/ARAppDelegate+Analytics.m
+++ b/Artsy/App/ARAppDelegate+Analytics.m
@@ -449,6 +449,8 @@
                                 return @{
                                     @"errors" : ([error localizedDescription] ?: [error description]) ?: @"",
                                     @"response" : responseString ?: @"",
+                                    @"artwork_id" : controller.artwork.artworkID ?: @"",
+                                    @"inquirable" : controller.artwork.inquireable ?: @1
                                 };
                             }
                         },


### PR DESCRIPTION
It's looking like some of the shared logic seems to be failing on the artwork view's inquiry button occasionally, adding some more breadcrumbs till  I can devote [considerable time](https://artsy.slack.com/archives/gmv-ios/p1463403163000804) to it.