### PR TITLE
Live auctions web views are presented in a modal view controller

### DIFF
--- a/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
+++ b/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
@@ -5,6 +5,7 @@
 #import "ArtsyAPI.h"
 #import "ArtsyAPI+Profiles.h"
 #import "ARTopMenuViewController.h"
+#import "ARSerifNavigationViewController.h"
 #import "ARFavoritesViewController.h"
 #import "ARProfileViewController.h"
 #import "ARArtistViewController.h"
@@ -154,7 +155,9 @@ describe(@"ARSwitchboard", ^{
         it(@"loads internal webviews for trusted but unpredictable hosts", ^{
             NSURL *internalButUnpredictableURL = [[NSURL alloc] initWithString:@"https://live-staging.artsy.net/54c7e8fa7261692b5acd0600"];
             id viewController = [switchboard loadURL:internalButUnpredictableURL];
-            expect(viewController).to.beKindOf(ARInternalMobileWebViewController.class);
+
+            expect(viewController).to.beKindOf(ARSerifNavigationViewController.class);
+            expect([viewController topViewController]).to.beKindOf(ARInternalMobileWebViewController.class);
         });
 
         it(@"loads web view for external urls", ^{

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -41,6 +41,7 @@ upcoming:
     - Offline support for Live. - orta
     - Support for trial users, and non-registered users on live auctions - orta
     - Lot list displays proper price. - ash
+    - Mobile live auctions web views are presented in a modal view controller instead of pushed. - ash
 
   notes:
     - Fixes long auction names falling off right edge. - ash


### PR DESCRIPTION
The results are that pretty:

![screen shot 2016-05-19 at 11 13 33 am](https://cloud.githubusercontent.com/assets/498212/15398710/c693a002-1db2-11e6-84ea-203a6c5d7b1b.png)

But keep in mind this is an emergency stop-gap and a clutch for users who haven't upgraded to the native live version by the time we hold our first auction. @katarinabatina we can chat about how to make it less gauche.

Fixes #1515.