### PR TITLE
[Live] Localization Improvements

### DIFF
--- a/Artsy/Categories/Apple/Int+Metrification.swift
+++ b/Artsy/Categories/Apple/Int+Metrification.swift
@@ -1,24 +1,31 @@
 import Foundation
 
 private struct Formatter {
-    private static var _formatter: NSNumberFormatter?
-    private static var formatter: NSNumberFormatter {
-        guard let formatter = _formatter else {
-            let newFormatter = NSNumberFormatter()
-            newFormatter.locale = NSLocale.currentLocale()
-            newFormatter.currencyCode = "USD"
-            newFormatter.numberStyle = .CurrencyStyle
-            newFormatter.maximumFractionDigits = 0
-            newFormatter.alwaysShowsDecimalSeparator = false
-            return newFormatter
-        }
+    private static var formatters = [String: NSNumberFormatter]()
 
-        return formatter
+    private static func createFormatter(currencySymbol: String) -> NSNumberFormatter {
+        let newFormatter = NSNumberFormatter()
+        newFormatter.locale = NSLocale.currentLocale()
+        // TODO: We should ideally be DIing this too.
+        // newFormatter.currencyCode = "USD"
+        newFormatter.currencySymbol = currencySymbol
+        newFormatter.numberStyle = .CurrencyStyle
+        newFormatter.maximumFractionDigits = 0
+        newFormatter.alwaysShowsDecimalSeparator = false
+        return newFormatter
     }
 
     static func formatCents(number: NSNumber, currencySymbol: String) -> String! {
-        self.formatter.currencySymbol = currencySymbol
-        return self.formatter.stringFromNumber(NSDecimalNumber(mantissa: number.unsignedLongLongValue, exponent: -2, isNegative: false))
+        let formatter: NSNumberFormatter
+        switch formatters[currencySymbol] {
+        case .None:
+            formatter = createFormatter(currencySymbol)
+            formatters[currencySymbol] = formatter
+        case .Some(let existingFormatter):
+            formatter = existingFormatter
+        }
+
+        return formatter.stringFromNumber(NSDecimalNumber(mantissa: number.unsignedLongLongValue, exponent: -2, isNegative: false))
     }
 }
 

--- a/Artsy/Models/API_Models/Live/LiveEvent.m
+++ b/Artsy/Models/API_Models/Live/LiveEvent.m
@@ -3,6 +3,7 @@
 #import "ARLogger.h"
 #import "ARMacros.h"
 #import "LiveBidder.h"
+#import "ARDeveloperOptions.h"
 
 
 @implementation LiveEvent
@@ -35,6 +36,10 @@
     } else {
         ARErrorLog(@"Error! Ignoring unknown event type '%@'\nEvent: %@", type, dictionaryValue);
         return nil;
+    }
+
+    if ([ARDeveloperOptions options][@"log_live_events"]) {
+        NSLog(@"Live Event: %@", dictionaryValue);
     }
 
     return [[klass alloc] initWithDictionary:dictionaryValue error:error];

--- a/Artsy/Views/Auction/SaleViewModel.swift
+++ b/Artsy/Views/Auction/SaleViewModel.swift
@@ -106,7 +106,6 @@ extension SaleViewModel {
     }
 
     func formattedStringForPriceRange(range: PriceRange) -> String {
-        let currencySymbol = saleArtworks.first?.currencySymbol ?? "" // .first returns an Optional, defaulting to ""
         let min = range.min.roundCentsToNearestThousandAndFormat(currencySymbol)
         let max = range.max.roundCentsToNearestThousandAndFormat(currencySymbol)
         return "・\(min)–\(max)"


### PR DESCRIPTION
Auctions that were held in non-USD currencies were still showing the currency in USD, which ain't optimal. 

I've also added a developer option, giving someone the ability to log live events, mine currently looks like:

```
username:orta@artsymail.com
password:???
suppress_network_logs:yes
log_live_events:yes
```