### PR TITLE
Move React Artists to be the default, and add the ability to stop loading React views

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -10,6 +10,7 @@
 #import "ARTopMenuViewController.h"
 #import "ARAppConstants.h"
 
+#import <Aerodramus/Aerodramus.h>
 #import <Emission/AREmission.h>
 #import <Emission/ARTemporaryAPIModule.h>
 #import <Emission/ARSwitchBoardModule.h>
@@ -52,6 +53,7 @@ ArtistSetFollowStatus(NSString *artistID, BOOL following, RCTResponseSenderBlock
 
 - (void)setupEmission;
 {
+
     AREmission *emission = [AREmission sharedInstance];
     emission.APIModule.artistFollowStatusProvider = ^(NSString *artistID, RCTResponseSenderBlock block) {
         // Leave the view state ‘unselected’ if there’s no signed-in user.

--- a/Artsy/App/ARAppDelegate.m
+++ b/Artsy/App/ARAppDelegate.m
@@ -135,9 +135,7 @@ static ARAppDelegate *_sharedInstance = nil;
     [[ARLogger sharedLogger] startLogging];
     [FBSDKSettings setAppID:[ArtsyKeys new].artsyFacebookAppID];
 
-    if ([AROptions boolForOption:AROptionsEnableReactArtist]) {
-        [self setupEmission];
-    }
+    [self setupEmission];
 
     // This has to be checked *before* creating the first Xapp token.
     BOOL showOnboarding = ![[ARUserManager sharedManager] hasExistingAccount];

--- a/Artsy/App/AROptions.h
+++ b/Artsy/App/AROptions.h
@@ -8,7 +8,6 @@ extern NSString *const AROptionsSettingsMenu;
 extern NSString *const AROptionsTappingPartnerSendsToPartner;
 extern NSString *const AROptionsShowAnalyticsOnScreen;
 extern NSString *const AROptionsEnableNativeLiveAuctions;
-extern NSString *const AROptionsEnableReactArtist;
 
 
 @interface AROptions : NSObject

--- a/Artsy/App/AROptions.m
+++ b/Artsy/App/AROptions.m
@@ -6,7 +6,6 @@ NSString *const AROptionsSettingsMenu = @"Enable user settings";
 NSString *const AROptionsTappingPartnerSendsToPartner = @"Partner name in feed goes to partner";
 NSString *const AROptionsShowAnalyticsOnScreen = @"AROptionsShowAnalyticsOnScreen";
 NSString *const AROptionsEnableNativeLiveAuctions = @"Enable native live auctions";
-NSString *const AROptionsEnableReactArtist = @"Enable React Artist view";
 
 
 @implementation AROptions
@@ -18,7 +17,6 @@ NSString *const AROptionsEnableReactArtist = @"Enable React Artist view";
         AROptionsSettingsMenu,
         AROptionsTappingPartnerSendsToPartner,
         AROptionsEnableNativeLiveAuctions,
-        AROptionsEnableReactArtist,
     ];
 }
 
@@ -26,7 +24,6 @@ NSString *const AROptionsEnableReactArtist = @"Enable React Artist view";
 {
     return @[
          AROptionsEnableNativeLiveAuctions,
-         AROptionsEnableReactArtist,
     ];
 }
 

--- a/Artsy/App/ARSwitchboard+Eigen.m
+++ b/Artsy/App/ARSwitchboard+Eigen.m
@@ -140,12 +140,16 @@
 
 - (UIViewController<ARFairAwareObject> *)loadArtistWithID:(NSString *)artistID inFair:(Fair *)fair
 {
+    BOOL blacklistUsingReactArtists = self.echo.features[@"DisableReactArtists"] != nil;
+
     if (fair) {
         return [[ARFairArtistViewController alloc] initWithArtistID:artistID fair:fair];
-    } else if ([AROptions boolForOption:AROptionsEnableReactArtist]) {
-        return (UIViewController<ARFairAwareObject> *)[[ARArtistComponentViewController alloc] initWithArtistID:artistID];
-    } else {
+
+    } else if (blacklistUsingReactArtists) {
         return [[ARArtistViewController alloc] initWithArtistID:artistID];
+
+    } else {
+        return (UIViewController<ARFairAwareObject> *)[[ARArtistComponentViewController alloc] initWithArtistID:artistID];
     }
 }
 

--- a/Artsy/View_Controllers/App_Navigation/ARAppSearchViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARAppSearchViewController.m
@@ -108,11 +108,8 @@ static const NSInteger ARAppSearchParallaxDistance = 20;
     if (result.model == [Artwork class]) {
         controller = [[ARArtworkSetViewController alloc] initWithArtworkID:result.modelID];
     } else if (result.model == [Artist class]) {
-        if ([AROptions boolForOption:AROptionsEnableReactArtist]) {
-            controller = (UIViewController *)[[ARArtistComponentViewController alloc] initWithArtistID:result.modelID];
-        } else {
-            controller = [[ARArtistViewController alloc] initWithArtistID:result.modelID];
-        }
+        NSString *path = NSStringWithFormat(@"/artist/%@", result.modelID);
+        controller = [[ARSwitchBoard sharedInstance] loadPath:path];
     } else if (result.model == [Gene class]) {
         controller = [[ARGeneViewController alloc] initWithGeneID:result.modelID];
     } else if (result.model == [Profile class]) {

--- a/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
+++ b/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
@@ -226,7 +226,7 @@ describe(@"ARSwitchboard", ^{
 
         it(@"routes artists", ^{
             id subject = [switchboard routeInternalURL:[[NSURL alloc] initWithString:@"http://artsy.net/artist/artistname"] fair:nil];
-            expect(subject).to.beKindOf(ARArtistViewController.class);
+            expect(subject).to.beKindOf(ARArtistComponentViewController.class);
         });
 
         it(@"routes artists in a gallery context on iPad", ^{
@@ -236,7 +236,7 @@ describe(@"ARSwitchboard", ^{
                 [switchboard updateRoutes];
 
                 id viewController = [switchboard routeInternalURL:[[NSURL alloc] initWithString:@"http://artsy.net/some-gallery/artist/artistname"] fair:nil];
-                expect(viewController).to.beKindOf(ARArtistViewController.class);
+                expect(viewController).to.beKindOf(ARArtistComponentViewController.class);
             }];
         });
 
@@ -372,6 +372,19 @@ describe(@"ARSwitchboard", ^{
             NSString *classString = NSStringFromClass([subject class]);
             expect(classString).toNot.contain(@"AuctionViewController");
         });
+
+        it(@"can not route to react artists when echo has a feature called 'DisableReactArtists'", ^{
+            switchboard = [[ARSwitchBoard alloc] init];
+            [switchboard updateRoutes];
+            ArtsyEcho *echo = [[ArtsyEcho alloc] init];
+            echo.features = @{ @"DisableReactArtists" : [[Feature alloc] initWithName:@"" state:@1] };
+            switchboard.echo = echo;
+
+            id subject = [switchboard loadPath:@"/artist/myauctionthing"];
+            NSString *classString = NSStringFromClass([subject class]);
+            expect(classString).to.contain(@"ARArtistViewController");
+        });
+
     });
 
     describe(@"routeProfileWithID", ^{


### PR DESCRIPTION
Removes the AROption
Uses Echo to look for a flag that will disable React views. 


_minor note_ only one bad thing happens with this ( and I don't think it matters) we used to pass in a "full" artist object when searching, now it's only the ID, but given hat I think the react one ignores the model object completely - it's not really a problem.