### PR TITLE
[Live] Derive Top Bidder status by using `sellingToBidder`

### DIFF
--- a/Artsy/View_Controllers/Live_Auctions/LiveActionStateReconciler.swift
+++ b/Artsy/View_Controllers/Live_Auctions/LiveActionStateReconciler.swift
@@ -122,6 +122,10 @@ private extension PrivateFunctions {
         if let biddingStatus = derivedState["biddingStatus"] as? String {
             lot.updateBiddingStatus(biddingStatus)
         }
+
+        if let biddingStatus = derivedState["sellingToBidder"] as? [String: AnyObject] {
+            lot.updateSellingToBidder(biddingStatus)
+        }
     }
 
     func updateLotWithEvents(lot: LiveAuctionLotViewModel, lotEvents: [[String: AnyObject]], fullEventOrder: [String]? = nil) {

--- a/Artsy/View_Controllers/Live_Auctions/ViewModels/LiveAuctionLotViewModel.swift
+++ b/Artsy/View_Controllers/Live_Auctions/ViewModels/LiveAuctionLotViewModel.swift
@@ -37,6 +37,7 @@ protocol LiveAuctionLotViewModelType: class {
     var dateLotOpened: NSDate? { get }
 
     var userIsHighestBidder: Bool { get }
+    var userIsBeingSoldTo: Bool { get }
 
     var reserveStatusSignal: Observable<ARReserveStatus> { get }
     var lotStateSignal: Observable<LotState> { get }
@@ -69,6 +70,8 @@ class LiveAuctionLotViewModel: NSObject, LiveAuctionLotViewModelType {
     let askingPriceSignal = Observable<UInt64>()
 
     let newEventsSignal = Observable<[LiveAuctionEventViewModel]>()
+
+    var sellingToBidderID: String? = nil
 
     init(lot: LiveAuctionLot, bidderID: String?) {
         self.model = lot
@@ -157,9 +160,17 @@ class LiveAuctionLotViewModel: NSObject, LiveAuctionLotViewModelType {
     }
 
     var userIsHighestBidder: Bool {
-        guard let bidderID = bidderID else { return false }
-        guard let top = topBidEvent else { return false }
+        guard let
+            bidderID = bidderID,
+            top = topBidEvent else { return false }
         return top.hasBidderID(bidderID)
+    }
+
+    var userIsBeingSoldTo: Bool {
+        guard let
+            bidderID = bidderID,
+            sellingToBidderID = sellingToBidderID else { return false }
+        return bidderID == sellingToBidderID
     }
 
     func findBidWithValue(amountCents: UInt64) -> LiveAuctionEventViewModel? {
@@ -243,6 +254,10 @@ class LiveAuctionLotViewModel: NSObject, LiveAuctionLotViewModelType {
         if updated {
             biddingStatusSignal.update(model.biddingStatus)
         }
+    }
+
+    func updateSellingToBidder(sellingToBidder: [String: AnyObject]) {
+        sellingToBidderID = sellingToBidder["bidderId"] as? String
     }
 
     func addEvents(newEvents: [LiveEvent]) {

--- a/Artsy/View_Controllers/Live_Auctions/Views/LiveAuctionBiddingViewModel.swift
+++ b/Artsy/View_Controllers/Live_Auctions/Views/LiveAuctionBiddingViewModel.swift
@@ -71,8 +71,6 @@ class LiveAuctionBiddingViewModel: LiveAuctionBiddingViewModelType {
                 }
 
             case .LiveLot:
-                // TODO: This is sufficient for now, but will need to handle state _while_ bidding once that's in. That can go in another observable.
-
                 let biddingState: LiveAuctionBiddingProgressState
 
                 switch  bidderStatus {
@@ -81,9 +79,10 @@ class LiveAuctionBiddingViewModel: LiveAuctionBiddingViewModelType {
 
                 case .Registered:
                     let isHighestBiddder = state.currentLot?.userIsHighestBidder ?? false
+                    let isSellingToMe = state.currentLot?.userIsBeingSoldTo ?? false
 
-                    if isHighestBiddder {
-                        biddingState = .BidAcknowledged
+                    if isHighestBiddder && isSellingToMe {
+                        biddingState = .BidBecameMaxBidder
                     } else {
                         biddingState = .Biddable(askingPrice: state.askingPrice, currencySymbol: currencySymbol)
                     }

--- a/Artsy_Tests/View_Controller_Tests/Live_Auction/LiveAuctionLotViewControllerTests.swift
+++ b/Artsy_Tests/View_Controller_Tests/Live_Auction/LiveAuctionLotViewControllerTests.swift
@@ -129,7 +129,7 @@ class Test_LiveAuctionLotViewModel: LiveAuctionLotViewModelType {
     var liveAuctionLotID = "lotID"
     var dateLotOpened: NSDate?
     var userIsHighestBidder: Bool = false
-
+    var userIsBeingSoldTo: Bool = false
     // Whether or not (all) events returned from this test VM should be cancelled.
     var cancelEvents = false
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -13,6 +13,7 @@ upcoming:
       - Fixes duplicated events in event history, supports changes in # of user-visible events. - ash
       - Adds overlay for oeprator disconnects - ash
       - Registration is cancellable. - ash
+      - Differentiate between a max bid, and a winning bid. - orta
   user_facing:
       - Allows max bids on live auctions - orta
 


### PR DESCRIPTION
Previously we would say you were the top bidder if you had the top bid, now we check if you're being sold to. The difference is subtle, but important when reserves haven't been set yet. 