### PR TITLE
[Live] Ensure we're consistently using bidderID internally

### DIFF
--- a/Artsy/View_Controllers/Live_Auctions/ViewModels/LiveAuctionLotViewModel.swift
+++ b/Artsy/View_Controllers/Live_Auctions/ViewModels/LiveAuctionLotViewModel.swift
@@ -183,7 +183,7 @@ class LiveAuctionLotViewModel: NSObject, LiveAuctionLotViewModelType {
 
     var userIsHighestBidder: Bool {
         guard let
-            bidderID = bidderCredentials.paddleNumber,
+            bidderID = bidderCredentials.bidderID,
             top = topBidEvent else { return false }
         return top.hasBidderID(bidderID)
     }
@@ -194,7 +194,7 @@ class LiveAuctionLotViewModel: NSObject, LiveAuctionLotViewModelType {
 
     var userIsBeingSoldTo: Bool {
         guard let
-            bidderID = bidderCredentials.paddleNumber,
+            bidderID = bidderCredentials.bidderID,
             sellingToBidderID = sellingToBidderID else { return false }
         return bidderID == sellingToBidderID
     }


### PR DESCRIPTION
In https://github.com/artsy/eigen/pull/1661 I made some changes that used the paddle number checks against aa bidderID, which was OK then, but not OK now, because they're two discrete values that are definitely different. Now you correctly get the green button.