### PR TITLE
Disables idle timer while the user is looking at a live auction

### DIFF
--- a/Artsy/View_Controllers/Live_Auctions/LiveAuctionViewController.swift
+++ b/Artsy/View_Controllers/Live_Auctions/LiveAuctionViewController.swift
@@ -184,11 +184,19 @@ class LiveAuctionViewController: UISplitViewController {
         internalPopover.dismissPopoverAnimated(false)
     }
 
+    override func viewDidAppear(animated: Bool) {
+        super.viewDidAppear(animated)
+
+        UIApplication.sharedApplication().idleTimerDisabled = true
+    }
+
     override func viewDidDisappear(animated: Bool) {
         super.viewDidDisappear(animated)
         viewControllers.forEach { vc in
             vc.endAppearanceTransition()
         }
+
+        UIApplication.sharedApplication().idleTimerDisabled = false
 
         overlaySubscription?.unsubscribe()
     }


### PR DESCRIPTION
Never an issue because we've been testing on simulator / we've probably increased timeouts on devices we're developing on.