### PR TITLE
Fixes problem with fancy lot layout #trivial

### DIFF
--- a/Artsy/View_Controllers/Live_Auctions/Views/LiveAuctionFancyLotCollectionViewLayout.swift
+++ b/Artsy/View_Controllers/Live_Auctions/Views/LiveAuctionFancyLotCollectionViewLayout.swift
@@ -303,7 +303,11 @@ private extension PrivateFunctions {
     func applyRepulsionToCenters(centers: CenterXPositions, atPosition position: CellPosition) -> CenterXPositions {
         // TODO: There's a problem with next/previous cells dis/appearing without animation if they're in/visible at the beginning or end of animation.
         // This hack keeps them "close enough" to visible most of the time to work, but a better solution would be to implement initialLayoutAttributesForAppearingItemAtIndexPath and finalLayoutAttributesForDisappearingItemAtIndexPath
-        let diff = min(repulsionConstant/4, visiblePrevNextSliceSize)
+
+        // scaleDownConstant takes the repulsion constant given to us and scales it down. We anticipate large
+        // repulsionConstant vaues, so we scale them down so the prev/next cells don't go too far too fast.
+        let scaleDownConstant: CGFloat = 4
+        let diff = min(repulsionConstant/scaleDownConstant, visiblePrevNextSliceSize)
         switch position {
         case .Current:
             return centers

--- a/Artsy/View_Controllers/Live_Auctions/Views/LiveAuctionFancyLotCollectionViewLayout.swift
+++ b/Artsy/View_Controllers/Live_Auctions/Views/LiveAuctionFancyLotCollectionViewLayout.swift
@@ -303,7 +303,7 @@ private extension PrivateFunctions {
     func applyRepulsionToCenters(centers: CenterXPositions, atPosition position: CellPosition) -> CenterXPositions {
         // TODO: There's a problem with next/previous cells dis/appearing without animation if they're in/visible at the beginning or end of animation.
         // This hack keeps them "close enough" to visible most of the time to work, but a better solution would be to implement initialLayoutAttributesForAppearingItemAtIndexPath and finalLayoutAttributesForDisappearingItemAtIndexPath
-        let diff = min(repulsionConstant/8, visiblePrevNextSliceSize)
+        let diff = min(repulsionConstant/4, visiblePrevNextSliceSize)
         switch position {
         case .Current:
             return centers


### PR DESCRIPTION
The repulsion constant is driven by the bid history delta. When we made the history larger when closed, we changed the maximum delta, and thus the maximum `repulsionConstant`. I decreased the scale down factor to accommodate the new history size and added clarifying documentation to match. 