### PR TITLE
Add checks for iOS 10 support - fixes #1741

### DIFF
--- a/Artsy/View_Controllers/Live_Auctions/LiveAuctionViewController.swift
+++ b/Artsy/View_Controllers/Live_Auctions/LiveAuctionViewController.swift
@@ -184,9 +184,12 @@ class LiveAuctionViewController: UISplitViewController {
         viewControllers.forEach { vc in
             vc.beginAppearanceTransition(false, animated: animated)
         }
-
-        guard let internalPopover = self.valueForKey("_hidden" + "PopoverController") as? UIPopoverController else { return }
-        internalPopover.dismissPopoverAnimated(false)
+        
+        // This crashes on iOS 10
+        if #available(iOS 10, *) {} else {
+            guard let internalPopover = valueForKey("_hidden" + "PopoverController") as? UIPopoverController else { return }
+            internalPopover.dismissPopoverAnimated(false)
+        }
     }
 
     override func viewDidDisappear(animated: Bool) {

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,6 +5,7 @@ upcoming:
   dev:
     infrastructure: 
       - Correctly handle routing to modals via paths - orta
+      - WIP support for iOS10 at runtime - orta
     live_auctions:
       - Uses server-defined increment strategy. - ash
       - Parnter name shows on iPhone. - ash


### PR DESCRIPTION
This isn't comprehensive, but it's a good start. App shouldn't crash the moment you try close a live auction.