### PR TITLE
Fixes problem with redirects on profile VCs

### DIFF
--- a/Artsy/Constants/ARDefaults.m
+++ b/Artsy/Constants/ARDefaults.m
@@ -46,7 +46,7 @@ NSString *const AROnboardingPromptThresholdDefault = @"eigen-onboard-prompt-thre
 
         ARUseStagingDefault : @(useStagingDefault),
         ARStagingAPIURLDefault : @"https://stagingapi.artsy.net",
-        ARStagingPhoneWebURLDefault : @"http://m-staging.artsy.net",
+        ARStagingPhoneWebURLDefault : @"https://m-staging.artsy.net",
         ARStagingPadWebURLDefault : @"https://staging.artsy.net",
         ARStagingMetaphysicsURLDefault : @"http://metaphysics-staging.artsy.net",
         ARStagingLiveAuctionSocketURLDefault : @"wss://causality-staging.artsy.net"

--- a/Artsy/Networking/API_Modules/ArtsyAPI+HEAD.h
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+HEAD.h
@@ -5,7 +5,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ArtsyAPI (HEAD)
 
-+ (void)getHTTPResponseHeadersForRequest:(NSURLRequest *)request completion:(void (^)(NSInteger responseCode, NSDictionary *headers, NSError *_Nullable error))completion;
++ (void)getHTTPRedirectForRequest:(NSURLRequest *)request completion:(void (^)(NSString *_Nullable redirectLocation, NSError *_Nullable error))completion;
 
 @end
 

--- a/Artsy/Networking/API_Modules/ArtsyAPI+HEAD.m
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+HEAD.m
@@ -7,8 +7,8 @@
 + (void)getHTTPRedirectForRequest:(NSURLRequest *)request completion:(void (^)(NSString *_Nullable redirectLocation, NSError *_Nullable error))completion
 {
     [self performRequest:request fullSuccess:^(NSURLRequest *request, NSHTTPURLResponse *response, id JSON) {
-        BOOL redirects = request.URL != response.URL;
-        if (redirects) {
+        BOOL redirected = ([request.URL isEqual:response.URL] == NO);
+        if (redirected) {
             completion(response.URL.absoluteString, nil);
         } else {
             completion(nil, nil);

--- a/Artsy/Networking/API_Modules/ArtsyAPI+HEAD.m
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+HEAD.m
@@ -4,12 +4,17 @@
 
 @implementation ArtsyAPI (HEAD)
 
-+ (void)getHTTPResponseHeadersForRequest:(NSURLRequest *)request completion:(void (^)(NSInteger responseCode, NSDictionary *headers, NSError *_Nullable error))completion
++ (void)getHTTPRedirectForRequest:(NSURLRequest *)request completion:(void (^)(NSString *_Nullable redirectLocation, NSError *_Nullable error))completion
 {
     [self performRequest:request fullSuccess:^(NSURLRequest *request, NSHTTPURLResponse *response, id JSON) {
-        completion(response.statusCode, response.allHeaderFields, nil);
+        BOOL redirects = request.URL != response.URL;
+        if (redirects) {
+            completion(response.URL.absoluteString, nil);
+        } else {
+            completion(nil, nil);
+        }
     } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON) {
-        completion(response.statusCode, response.allHeaderFields, error);
+        completion(nil, error);
     }];
 }
 @end

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -1187,7 +1187,8 @@ static NSString *hostFromString(NSString *string)
 
 + (NSURLRequest *)newHEADRequestForPath:(NSString *)path
 {
-    return [self requestWithMethod:@"HEAD" path:path parameters:nil];
+    NSString *fullPath = [[NSURL URLWithString:path relativeToURL:[ARRouter baseWebURL]] absoluteString];
+    return [self requestWithMethod:@"HEAD" URLString:fullPath parameters:nil];
 }
 
 @end

--- a/Artsy/View_Controllers/ARMutableLinkViewController.m
+++ b/Artsy/View_Controllers/ARMutableLinkViewController.m
@@ -53,7 +53,9 @@
             return;
         }
 
+        [internalViewController beginAppearanceTransition:true animated:false];
         [self ar_addAlignedModernChildViewController:internalViewController];
+        [internalViewController endAppearanceTransition];
     }];
 }
 

--- a/Artsy/View_Controllers/ARMutableLinkViewController.m
+++ b/Artsy/View_Controllers/ARMutableLinkViewController.m
@@ -35,13 +35,13 @@
     [self ar_presentIndeterminateLoadingIndicatorAnimated:ARPerformWorkAsynchronously];
 
     NSURLRequest *headRequest = [ARRouter newHEADRequestForPath:self.originalPath];
-    [ArtsyAPI getHTTPResponseHeadersForRequest:headRequest completion:^(NSInteger responseCode, NSDictionary *_Nonnull headers, NSError *_Nullable error) {
+    [ArtsyAPI getHTTPRedirectForRequest:headRequest completion:^(NSString *_Nullable redirectLocation, NSError *_Nullable error) {
         [self ar_removeIndeterminateLoadingIndicatorAnimated:ARPerformWorkAsynchronously];
 
         UIViewController *internalViewController;
 
-        if (responseCode == 302 && headers[@"Location"]) {
-            internalViewController = [ARSwitchBoard.sharedInstance loadPath:headers[@"Location"]];
+        if (redirectLocation) {
+            internalViewController = [ARSwitchBoard.sharedInstance loadPath:redirectLocation];
         } else {
             internalViewController = [ARSwitchBoard.sharedInstance loadProfileWithID:self.originalPath];
         }

--- a/Artsy/View_Controllers/ARMutableLinkViewController.m
+++ b/Artsy/View_Controllers/ARMutableLinkViewController.m
@@ -53,6 +53,8 @@
             return;
         }
 
+        // We need to call begin/endAppearanceTransition manually, because at this point, our view controller
+        // has already appeared (so newly added children won't receive viewWill/DidAppear callbacks automatically).
         [internalViewController beginAppearanceTransition:true animated:false];
         [self ar_addAlignedModernChildViewController:internalViewController];
         [internalViewController endAppearanceTransition];

--- a/Artsy_Tests/View_Controller_Tests/Web_Browsing/ARInternalMobileWebViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Web_Browsing/ARInternalMobileWebViewControllerTests.m
@@ -104,17 +104,17 @@ describe(@"initWithURL", ^{
 
         it(@"rewrites the scheme", ^{
             ARInternalMobileWebViewController *controller = [[ARInternalMobileWebViewController alloc] initWithURL:[NSURL URLWithString:@"https://m-staging.artsy.net/foo/bar"]];
-            expect([controller currentURL].absoluteString).to.equal(@"http://m-staging.artsy.net/foo/bar");
+            expect([controller currentURL].absoluteString).to.equal(@"https://m-staging.artsy.net/foo/bar");
         });
 
         it(@"with an artsy.net url", ^{
             ARInternalMobileWebViewController *controller = [[ARInternalMobileWebViewController alloc] initWithURL:[NSURL URLWithString:@"http://staging.artsy.net/foo/bar"]];
-            expect([controller currentURL].absoluteString).to.equal(@"http://m-staging.artsy.net/foo/bar");
+            expect([controller currentURL].absoluteString).to.equal(@"https://m-staging.artsy.net/foo/bar");
         });
 
         it(@"with a relative url", ^{
             ARInternalMobileWebViewController *controller = [[ARInternalMobileWebViewController alloc] initWithURL:[NSURL URLWithString:@"/foo/bar"]];
-            expect([controller currentURL].absoluteString).to.equal(@"http://m-staging.artsy.net/foo/bar");
+            expect([controller currentURL].absoluteString).to.equal(@"https://m-staging.artsy.net/foo/bar");
         });
 
         it(@"with an external artsy.net url", ^{

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -24,24 +24,6 @@ releases:
     user_facing:
       - Fade truncated parts of current refine settings on auction view. - alloy
 
-
-  - version: 2.6.1
-    details: Live Auctions Polish
-
-    dev:
-      infrastructure: 
-        - Correctly handle routing to modals via paths - orta
-        - WIP support for iOS10 at runtime - orta
-      live_auctions:
-        - Uses server-defined increment strategy. - ash
-        - Parnter name shows on iPhone. - ash
-        - New loading indicator. - ash
-        - Improved bid button interaction. - ash
-        - Use a spinner UI for the Max Bid - orta/ash
-        - Better bid history cell separators. - ash
-    user_facing:
-      - Fade truncated parts of current refine settings on auction view. - alloy
-
   - version: 2.6.0
     details: Live Auctions / Artist Profile polish
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,9 +1,10 @@
 upcoming:
-  - version: 2.6.2
+    version: 2.6.2
     details: Bug fix around re-directs
 
     dev:
-      - Bug fix around redirection view controllers - sarah
+    user_facing:
+      - Fixes bug where a black screen would appear instead of the intended view. - ash
 
 releases:
   - version: 2.6.1
@@ -23,6 +24,23 @@ releases:
     user_facing:
       - Fade truncated parts of current refine settings on auction view. - alloy
 
+
+  - version: 2.6.1
+    details: Live Auctions Polish
+
+    dev:
+      infrastructure: 
+        - Correctly handle routing to modals via paths - orta
+        - WIP support for iOS10 at runtime - orta
+      live_auctions:
+        - Uses server-defined increment strategy. - ash
+        - Parnter name shows on iPhone. - ash
+        - New loading indicator. - ash
+        - Improved bid button interaction. - ash
+        - Use a spinner UI for the Max Bid - orta/ash
+        - Better bid history cell separators. - ash
+    user_facing:
+      - Fade truncated parts of current refine settings on auction view. - alloy
 
   - version: 2.6.0
     details: Live Auctions / Artist Profile polish


### PR DESCRIPTION
A black screen would appear on VCs routed through vanity URLs because `viewWIllAppear:` wasn't getting called, which needs to be to [load the profile](https://github.com/artsy/eigen/blob/195633eb3eba35fdaeee709d25931fda7a565428/Artsy/View_Controllers/Fair/ARProfileViewController.m#L56). The result was a blank, black view. 

The fix was to add begin/end appearance transition methods to the appearing view controller. I've tested this with the `/paf-auction` vanity URL on staging and it worked, but the `/ash-test-url` to redirect to a testing live auction, didn't. Looking into it, @joeyAghion was right about us testing for URLs against the staging domain instead of the web domain, so I fixed that. But then we were getting false negatives because AFNetworking was handling redirects with the proper domain differently, so I changed our redirect-detecting code to look for a difference in request/response URLS instead of a 302 status code (AFNetworking is transparently handling the redirects for us).