### PR TITLE
Fixes problems with unretained observables

### DIFF
--- a/Artsy/View_Controllers/Auction/AuctionBiddersNetworkModel.swift
+++ b/Artsy/View_Controllers/Auction/AuctionBiddersNetworkModel.swift
@@ -16,11 +16,11 @@ class AuctionBiddersNetworkModel: AuctionBiddersNetworkModelType {
 
         // Based on the saleID signal, fetch the sale registration status.
         ArtsyAPI.getCurrentUserBiddersForSale(saleID,
-            success: { [weak self, weak observable] bidders in
+            success: { [weak self] bidders in
                 self?.bidders = bidders
-                observable?.update(.Success(bidders))
-            }, failure: { [weak observable] error in
-                observable?.update(.Error(error as ErrorType))
+                observable.update(.Success(bidders))
+            }, failure: { error in
+                observable.update(.Error(error as ErrorType))
             })
 
         return observable

--- a/Artsy/View_Controllers/Auction/AuctionNetworkModel.swift
+++ b/Artsy/View_Controllers/Auction/AuctionNetworkModel.swift
@@ -38,7 +38,7 @@ extension AuctionNetworkModel: AuctionNetworkModelType {
     func fetch() -> Observable<Result<SaleViewModel>> {
 
         return fetchBidders()
-            .flatMap { [weak self]  (bidders: Result<[Bidder]>) -> Observable<Result<SaleViewModel>> in
+            .flatMap { [weak self] (bidders: Result<[Bidder]>) -> Observable<Result<SaleViewModel>> in
                 guard let `self` = self else { return Observable() }
 
                 switch bidders {
@@ -47,9 +47,9 @@ extension AuctionNetworkModel: AuctionNetworkModelType {
                 case .Error(let error):
                     return Observable(.Error(error))
                 }
-            }.next { [weak self] saleViewModel in
+            }.next { saleViewModel in
                 // Store the SaleViewModel
-                self?.saleViewModel = saleViewModel
+                self.saleViewModel = saleViewModel
             }
     }
 

--- a/Artsy/View_Controllers/Auction/AuctionSaleArtworksNetworkModel.swift
+++ b/Artsy/View_Controllers/Auction/AuctionSaleArtworksNetworkModel.swift
@@ -16,13 +16,13 @@ class AuctionSaleArtworksNetworkModel: AuctionSaleArtworksNetworkModelType {
 
         /// Fetches all the sale artworks associated with the sale.
         /// This serves as a trampoline for the actual recursive call.
-        fetchPage(1, forSaleID: saleID, alreadyFetched: []) { [weak self, weak observable]  result in
+        fetchPage(1, forSaleID: saleID, alreadyFetched: []) { [weak self] result in
             switch result {
             case .Success(let saleArtworks):
                 self?.saleArtworks = saleArtworks
-                observable?.update(.Success(saleArtworks))
+                observable.update(.Success(saleArtworks))
             case .Error(let error):
-                observable?.update(.Error(error))
+                observable.update(.Error(error))
             }
         }
 

--- a/Artsy/View_Controllers/Auction/AuctionSaleNetworkModel.swift
+++ b/Artsy/View_Controllers/Auction/AuctionSaleNetworkModel.swift
@@ -15,12 +15,12 @@ class AuctionSaleNetworkModel: AuctionSaleNetworkModelType {
 
         // Based on the saleID signal, fetch the sale
         ArtsyAPI.getSaleWithID(saleID,
-            success: { [weak self, weak observable] sale in
+            success: { [weak self] sale in
                 self?.sale = sale
-                observable?.update(.Success(sale))
+                observable.update(.Success(sale))
             },
-            failure: { [weak observable] error in
-                observable?.update(.Error(error as ErrorType))
+            failure: { error in
+                observable.update(.Error(error as ErrorType))
             })
 
         return observable

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,6 +5,7 @@ upcoming:
     dev:
       infrastructure:
         - Fixes various memory leaks in live. - ash
+        - Fixes problems that arose from fixing memory leaks. - ash
     user_facing:
       - Fixes various nullability issues. - sarah
       - Fixes iOS 8 by not using new JS API. - sarah & alloy


### PR DESCRIPTION
Fixes #1774, related to #1747. The problem is that calling `subscribe()` or `flatMap()` on an `Observable` doesn't strongly reference that observable. The code we had assumed it was, and didn't take responsibility for referencing the observables strongly, so they were deallocated before the network call completed. Since Interstellar lacks the clarity of a dispose bag or similar structure to explicitly handle "who owns this observable?", sometimes I feel like I'm just guessing 😞 

I take responsibility for this, I tested on device for the live interface but didn't test the existing non-live auction view controller even though I made changes to its network stack, too. 