### PR TITLE
Remove the check for colored

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -38,6 +38,9 @@ dependencies:
 
 test:
   pre:
+    # See https://discuss.circleci.com/t/xcode-exit-code-65/4284/13 
+    - xcrun instruments -w '547B1B63-3F66-4E5B-8001-F78F2F1CDEA7' || true
+    - sleep 15
     - make ci
   override:
     - make test

--- a/dependencyci.yml
+++ b/dependencyci.yml
@@ -1,0 +1,5 @@
+platforms:
+  rubygems:
+    colored:
+      tests:
+        unmaintained: skip 


### PR DESCRIPTION
Hrm, bit of a weird one this - basically every iOS app using dep CI will need to set this.