### PR TITLE
Remove the github auth from CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,6 @@ machine:
     AWS_ACCESS_KEY_ID: from_admin
     AWS_SECRET_ACCESS_KEY: from_admin
     DANGER_GITHUB_API_TOKEN: from_admin
-    GITHUB_API_KEY : from_admin
     MATCH_PASSWORD : from_admin
     HOCKEY_API_TOKEN : from_admin
     FASTLANE_USERNAME : from_admin
@@ -25,10 +24,6 @@ machine:
     SegmentDevWriteKey: from_admin
     AdjustProductionAppToken: from_admin
     ArtsyEchoProductionToken:  from_admin
-
-  post:
-    - echo "machine github.com login $GITHUB_API_KEY" > ~/.netrc
-    - chmod 600 ~/.netrc
 
 dependencies:
   override:


### PR DESCRIPTION
Mysteriously about 2 weeks ago our Circle builds stopped working. I don't really know the cause, but the symptom was that Circle could not access our [private pod](http://artsy.github.io/blog/2014/06/20/artsys-first-closed-source-pod/).

We were using the `.netrc` to auth our HTTP requests for the git repo, which worked. Now we're using a CircleCI feature called user keys, which is the encouraged way in the docs

![screen shot 2016-08-09 at 9 37 49 am](https://cloud.githubusercontent.com/assets/49038/17518214/f9d4eaa0-5e14-11e6-99f4-b332273e020a.png)