### PR TITLE
Moves notification delegate creation to after analytics setup

### DIFF
--- a/Artsy/App/ARAppDelegate.m
+++ b/Artsy/App/ARAppDelegate.m
@@ -118,6 +118,8 @@ static ARAppDelegate *_sharedInstance = nil;
     // one of the first things that happen.
     [self setupAnalytics];
 
+    [JSDecoupledAppDelegate sharedAppDelegate].remoteNotificationsDelegate = [[ARAppNotificationsDelegate alloc] init];
+
     self.window = [[ARWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     self.viewController = [ARTopMenuViewController sharedController];
     self.window.rootViewController = self.viewController;

--- a/Artsy/App/ARAppNotificationsDelegate.m
+++ b/Artsy/App/ARAppNotificationsDelegate.m
@@ -19,11 +19,6 @@
 
 @implementation ARAppNotificationsDelegate
 
-+ (void)load
-{
-    [JSDecoupledAppDelegate sharedAppDelegate].remoteNotificationsDelegate = [[self alloc] init];
-}
-
 #pragma mark -
 #pragma mark Local Push Notification Alerts
 

--- a/Artsy_Tests/App_Tests/ARAppNotificationsDelegateTests.m
+++ b/Artsy_Tests/App_Tests/ARAppNotificationsDelegateTests.m
@@ -35,6 +35,7 @@ describe(@"receiveRemoteNotification", ^{
 
     beforeEach(^{
         app = [UIApplication sharedApplication];
+        [JSDecoupledAppDelegate sharedAppDelegate].remoteNotificationsDelegate = [[ARAppNotificationsDelegate alloc] init];
         delegate = (ARAppNotificationsDelegate *)[JSDecoupledAppDelegate sharedAppDelegate].remoteNotificationsDelegate;
 
         mockAnalytics = [OCMockObject mockForClass:[ARAnalytics class]];


### PR DESCRIPTION
The notifications delegate was being created in `load`, one of the first methods to get called when the app is loaded into the runtime. However, because the ARAnalytics DSL swizzles `alloc` to listen for events, events from the notification delegate weren't being fired; the instance had already been created, so `alloc` had already been called. 

This PR fixes that by moving the creation of the notification delegate from `load` into `applicationDidBecomeActive:`. @alloy: Maxim and I wanted to check with you to see if this would have any unintended consequences in the rest of the app.