### PR TITLE
[Onboarding] Tidy up conditionals in App Delegate

### DIFF
--- a/Artsy/App/ARAppDelegate.h
+++ b/Artsy/App/ARAppDelegate.h
@@ -23,8 +23,7 @@
 - (void)showOnboarding;
 - (void)showOnboardingWithState:(enum ARInitialOnboardingState)state;
 
-// A sign-in is considered cancelled when the user taps the close button on a ARSignUpActiveUserViewController,
-- (void)finishOnboardingAnimated:(BOOL)animated didCancel:(BOOL)cancelledSignIn;
+- (void)finishOnboardingAnimated:(BOOL)animated;
 
 @end
 

--- a/Artsy/Networking/API_Modules/ARUserManager.m
+++ b/Artsy/Networking/API_Modules/ARUserManager.m
@@ -107,7 +107,7 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
 
 - (BOOL)hasExistingAccount
 {
-    return (self.currentUser && [self hasValidAuthenticationToken]) || [self hasValidXAppToken];
+    return (self.currentUser && [self hasValidAuthenticationToken]);
 }
 
 - (BOOL)hasValidAuthenticationToken

--- a/Artsy/View_Controllers/Login_and_Onboarding/AROnboardingViewController.h
+++ b/Artsy/View_Controllers/Login_and_Onboarding/AROnboardingViewController.h
@@ -52,8 +52,6 @@ typedef NS_ENUM(NSInteger, AROnboardingStage) {
 - (void)showTermsAndConditions;
 - (void)showPrivacyPolicy;
 
-// Technically one can't cancel the onboarding currently
-- (void)dismissOnboardingWithVoidAnimation:(BOOL)createdAccount didCancel:(BOOL)cancelledSignIn;
 - (void)dismissOnboardingWithVoidAnimation:(BOOL)createdAccount;
 
 @end

--- a/Artsy/View_Controllers/Login_and_Onboarding/AROnboardingViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/AROnboardingViewController.m
@@ -333,21 +333,16 @@
     }
 }
 
-- (void)dismissOnboardingWithVoidAnimation:(BOOL)createdAccount;
-{
-    [self dismissOnboardingWithVoidAnimation:createdAccount didCancel:NO];
-}
-
-- (void)dismissOnboardingWithVoidAnimation:(BOOL)createdAccount didCancel:(BOOL)cancelledSignIn;
+- (void)dismissOnboardingWithVoidAnimation:(BOOL)createdAccount
 {
     // send them off into the app
 
     if (createdAccount) {
         [self applyPersonalizationToUser];
-        [[ARAppDelegate sharedInstance] finishOnboardingAnimated:createdAccount didCancel:cancelledSignIn];
+        [[ARAppDelegate sharedInstance] finishOnboardingAnimated:createdAccount];
     } else {
         self.modalTransitionStyle = UIModalTransitionStyleCrossDissolve;
-        [[ARAppDelegate sharedInstance] finishOnboardingAnimated:createdAccount didCancel:cancelledSignIn];
+        [[ARAppDelegate sharedInstance] finishOnboardingAnimated:createdAccount];
     }
 }
 


### PR DESCRIPTION
- No more dodging the onboarding #1837 (done by not allowing an xapp token to qualified as 'having an account')
- Removed the request for push notifications upon launch, because that'll be part of onboarding or artist follows. 