### PR TITLE
[API] Update eigen popular categories url

### DIFF
--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -712,7 +712,7 @@ static NSString *hostFromString(NSString *string)
 
 {
     // we get hard coded categories from this json file that force uses also
-    NSString *stringURL = @"https://s3.amazonaws.com/force-production/json/eigen_popular_categories.json";
+    NSString *stringURL = @"https://s3.amazonaws.com/eigen-production/json/eigen_categories.json";
 
     return [[NSURLRequest alloc] initWithURL:[NSURL URLWithString:stringURL]];
 }


### PR DESCRIPTION
Fix #1868 and #1826 

Have uploaded the new json file and images on our S3 instance (login details are the default artsy it ones in 1pass). 

Links:
- https://s3.amazonaws.com/eigen-production/json/eigen_categories.json
- example image: https://s3.amazonaws.com/eigen-production/images/minimalism.jpg

In Onboarding (these are a few - I did check all of them):

<img width="1043" alt="screen shot 2016-09-30 at 16 23 18" src="https://cloud.githubusercontent.com/assets/373860/18996978/6ebb4484-872a-11e6-88b5-1c097f40d49e.png">

cc @katarinabatina 