### PR TITLE
Expands hit areas for toolbar

### DIFF
--- a/Artsy/Views/Utilities/ARTabContentView.m
+++ b/Artsy/Views/Utilities/ARTabContentView.m
@@ -2,6 +2,7 @@
 
 #import "ARDispatchManager.h"
 #import "ARNavigationController.h"
+#import "UIView+HitTestExpansion.h"
 
 #import <ObjectiveSugar/ObjectiveSugar.h>
 
@@ -63,6 +64,7 @@ static BOOL ARTabViewDirectionRight = YES;
     [self.buttons eachWithIndex:^(UIButton *button, NSUInteger index) {
         button.enabled = [self.dataSource tabContentView:self canPresentViewControllerAtIndex:index];
         [button addTarget:self action:@selector(buttonTapped:) forControlEvents:UIControlEventTouchUpInside];
+        [button ar_extendHitTestSizeByWidth:10 andHeight:20];
     }];
 }
 


### PR DESCRIPTION
Fixes #1916.

Here's what it now looks like, visually:

![simulator screen shot oct 18 2016 12 49 11 pm](https://cloud.githubusercontent.com/assets/498212/19487588/77a9b1a6-9531-11e6-88f6-c8dc71752e2c.png)
