### PR TITLE
Use the ARTopMenuViewController to turn on/off scrolls to top on views

### DIFF
--- a/Artsy/View_Controllers/Util/ARBrowseViewController.m
+++ b/Artsy/View_Controllers/Util/ARBrowseViewController.m
@@ -29,7 +29,7 @@
 /////////////////
 
 
-@interface ARBrowseViewController () <UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout>
+@interface ARBrowseViewController () <UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout, ARMenuAwareViewController>
 @property (nonatomic, strong, readonly) NSArray *menuLinks;
 @end
 
@@ -45,6 +45,11 @@
     [self.collectionView registerClass:[ARBrowseViewCell class] forCellWithReuseIdentifier:[ARBrowseViewCell reuseID]];
 
     [super viewDidLoad];
+}
+
+- (UIScrollView *)menuAwareScrollView
+{
+    return self.collectionView;
 }
 
 - (void)viewDidAppear:(BOOL)animated

--- a/Artsy/Views/Utilities/ARTabContentView.m
+++ b/Artsy/Views/Utilities/ARTabContentView.m
@@ -3,6 +3,7 @@
 #import "ARDispatchManager.h"
 #import "ARNavigationController.h"
 #import "UIView+HitTestExpansion.h"
+#import "ARMenuAwareViewController.h"
 
 #import <ObjectiveSugar/ObjectiveSugar.h>
 
@@ -143,7 +144,7 @@ static BOOL ARTabViewDirectionRight = YES;
     BOOL isARNavigationController = [self.currentNavigationController isKindOfClass:ARNavigationController.class];
 
     // If selecting search button, toggle search VC
-    if ([self.dataSource searchButtonAtIndex:index] && isARNavigationController) {
+    if (isARNavigationController && [self.dataSource searchButtonAtIndex:index]) {
         [(ARNavigationController *)self.currentNavigationController toggleSearch];
         return;
     }
@@ -168,9 +169,14 @@ static BOOL ARTabViewDirectionRight = YES;
     nextViewInitialFrame.origin.x = direction * CGRectGetWidth(self.superview.bounds);
     oldViewEndFrame.origin.x = -direction * CGRectGetWidth(self.superview.bounds);
 
-    __block UIViewController *oldViewController = self.currentNavigationController;
+    __block UINavigationController *oldViewController = self.currentNavigationController;
     _previousViewIndex = self.currentViewIndex;
     _currentViewIndex = index;
+
+    // Ensure there is only one scrollview that has `scrollsToTop`
+    if (isARNavigationController && [oldViewController.topViewController conformsToProtocol:@protocol(ARMenuAwareViewController)]) {
+        [(id)oldViewController.topViewController menuAwareScrollView].scrollsToTop = NO;
+    }
 
     // Get the next View Controller, add to self
     _currentNavigationController = [self navigationControllerForIndex:index];
@@ -205,6 +211,11 @@ static BOOL ARTabViewDirectionRight = YES;
             [self.currentNavigationController beginAppearanceTransition:YES animated:NO];
             [self addSubview:self.currentNavigationController.view];
             [self.currentNavigationController endAppearanceTransition];
+
+            // Ensure there is only one scrollview that has `scrollsToTop`
+            if (isARNavigationController && [self.currentNavigationController.topViewController conformsToProtocol:@protocol(ARMenuAwareViewController)]) {
+                [(id)self.currentNavigationController.topViewController menuAwareScrollView].scrollsToTop = YES;
+            }
 
             animationBlock();
             completionBlock(YES);


### PR DESCRIPTION
This is not comprehensive, but covers a good chunk of our use cases. Essentially we would have multiple scrollviews with `scrollsToTop` enabled, which means it doesn't work at all. This covers _most_ cases, a few view controllers do not conform to the `ARMenuAwareViewController`protocol, and so we cannot turn those off. Which may mean it's going to occasionally show.

The real fix as noted in #1891 is to remove the bandage and use apples tab view controller instead of our custom one.