### PR TITLE
Analytics fixes for v3

### DIFF
--- a/Artsy/App/ARAnalyticsConstants.m
+++ b/Artsy/App/ARAnalyticsConstants.m
@@ -85,7 +85,7 @@ NSString *const ARAnalyticsArtistUnfollow = @"Follow artist";
 NSString *const ARAnalyticsArtistTappedForSale = @"artist tapped for sale";
 
 NSString *const ARAnalyticsGeneView = @"gene view";
-NSString *const ARAnalyticsGeneFollow = @"gene favorite";
+NSString *const ARAnalyticsGeneFollow = @"Follow category";
 
 NSString *const ARAnalyticsShowMenu = @"user opened menu";
 NSString *const ARAnalyticsMenuTappedHome = @"user menu tapped home";

--- a/Artsy/App/ARAppDelegate+Analytics.m
+++ b/Artsy/App/ARAppDelegate+Analytics.m
@@ -889,7 +889,7 @@
                                 Gene *gene = params.firstObject;
                                 NSString *sourceScreen = @"";
                                 if (controller.searchResultsTable.contentDisplayMode == ARTableViewContentDisplayModePlaceholder) {
-                                    sourceScreen = @"onboarding top artists";
+                                    sourceScreen = @"onboarding top categories";
                                 } else if (controller.searchResultsTable.contentDisplayMode == ARTableViewContentDisplayModeSearchResults) {
                                     sourceScreen = @"onboarding search";
                                 } else if (controller.searchResultsTable.contentDisplayMode == ARTableViewContentDisplayModeRelatedResults) {

--- a/Artsy/App/ARAppDelegate+Analytics.m
+++ b/Artsy/App/ARAppDelegate+Analytics.m
@@ -553,6 +553,7 @@
                                 return @{
                                     @"followed": sender.isHearted? @"yes" : @"no",
                                     @"gene_id" : controller.gene.geneID ?: @"",
+                                    @"source_screen": @"gene page"
                                 };
                             },
                         },
@@ -585,6 +586,13 @@
                             ARAnalyticsEventName: ARAnalyticsOnboardingLogin,
                             ARAnalyticsSelectorName: NSStringFromSelector(@selector(logIn:)),
                         },
+                        @{
+                            ARAnalyticsEventName: ARAnalyticsOnboardingLoginSuccess,
+                            ARAnalyticsSelectorName: ARAnalyticsSelector(loggedInWithSharedCredentials),
+                            ARAnalyticsProperties: ^NSDictionary*(id controller, NSArray *_) {
+                                return @{ @"context type": @"safari keychain" };
+                            }
+                        }
                     ]
                 },
                 @{
@@ -854,8 +862,8 @@
                         @{
                             ARAnalyticsEventName: ARAnalyticsArtistFollow,
                             ARAnalyticsSelectorName: NSStringFromSelector(@selector(artistFollowed:)),
-                            ARAnalyticsProperties: ^NSDictionary*(ARPersonalizeViewController *controller, NSArray *_){
-                                Artist *artist = _.firstObject;
+                            ARAnalyticsProperties: ^NSDictionary*(ARPersonalizeViewController *controller, NSArray *params){
+                                Artist *artist = params.firstObject;
                                 NSString *sourceScreen = @"";
                                 if (controller.searchResultsTable.contentDisplayMode == ARTableViewContentDisplayModePlaceholder) {
                                     sourceScreen = @"onboarding top artists";
@@ -877,8 +885,8 @@
                         @{
                             ARAnalyticsEventName: ARAnalyticsGeneFollow,
                             ARAnalyticsSelectorName: NSStringFromSelector(@selector(categoryFollowed:)),
-                            ARAnalyticsProperties: ^NSDictionary*(ARPersonalizeViewController *controller, NSArray *_){
-//                                Gene *gene = _.firstObject;
+                            ARAnalyticsProperties: ^NSDictionary*(ARPersonalizeViewController *controller, NSArray *params){
+                                Gene *gene = params.firstObject;
                                 NSString *sourceScreen = @"";
                                 if (controller.searchResultsTable.contentDisplayMode == ARTableViewContentDisplayModePlaceholder) {
                                     sourceScreen = @"onboarding top artists";
@@ -888,7 +896,7 @@
                                     sourceScreen = @"onboarding recommended";
                                 }
                                 return @{
-                                         @"gene_id" : @"this needs replacing once categories are fixed", //gene.geneID,
+                                         @"gene_id" : gene.geneID,
                                          @"source_screen" : sourceScreen
                                         };
                             },
@@ -1006,9 +1014,16 @@
                                 return sender.isHearted == YES;
                             },
                             ARAnalyticsProperties: ^NSDictionary*(ARArtistViewController *controller, NSArray *parameters){
+                                NSString *sourcePage = @"";
+                                if (controller.fair) {
+                                    sourcePage = @"artist fair page";
+                                } else {
+                                    sourcePage = @"artist page";
+                                }
                                 return @{
                                          @"artist_slug" : controller.artist.artistID ?: @"",
-                                         @"source_screen" : @"Artist"
+                                         @"artist_id" : controller.artist.artistID ?: @"",
+                                         @"source_screen" : sourcePage
                                 };
                             },
                         },

--- a/Artsy/View_Controllers/Login_and_Onboarding/AROnboardingViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/AROnboardingViewController.m
@@ -416,11 +416,6 @@
 #pragma mark -
 #pragma mark Navigation Delegate
 
-- (void)navigationController:(UINavigationController *)navigationController didShowViewController:(UIViewController *)viewController animated:(BOOL)animated
-{
-    NSString *viewIdentifier = [NSString humanReadableStringFromClass:[viewController class]];
-    if (viewIdentifier) [ARAnalytics pageView:viewIdentifier];
-}
 
 - (id<UIViewControllerAnimatedTransitioning>)navigationController:(UINavigationController *)navigationController
                                   animationControllerForOperation:(UINavigationControllerOperation)operation


### PR DESCRIPTION
Here're the analytics fixes for v3. Some notes:

- Duplicate events with old names were caused by some code left in from the old onboarding that would produce a sort of "catch all". So if we showed the user a view with a class named "ARPersonalizeViewController", we would mangle that into "personalize". @anipetrov Please double check that removing this behaviour didn't accidentally remove any page views we were relying on.
- Firing another page view event when the app goes from foreground -> background -> foreground again is difficult. I've left it out for now, because it really affects how the whole app should work, and the feature would ideally be built into the ARAnalytics library itself. Happy to chat about this, maybe it's something we can squeeze in for v3, but it definitely needs a conversation.

Fixes #1939.