### PR TITLE
[Onboarding] Fix spacing for landscape ipad keyboard

### DIFF
--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/3_-_Sign_Up_+_Log_In/ARLoginViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/3_-_Sign_Up_+_Log_In/ARLoginViewController.m
@@ -36,6 +36,8 @@
 @property (nonatomic, strong) ARLoginFieldsView *textFieldsView;
 @property (nonatomic, strong) ARLoginButtonsView *buttonsView;
 @property (nonatomic, strong) ARSerifLineHeightLabel *titleLabel;
+@property (nonatomic, strong) NSLayoutConstraint *titleToTextFieldsSpacer;
+
 
 @property (nonatomic, strong) UIButton *back;
 @property (nonatomic, strong) UIButton *testBotButton;
@@ -92,7 +94,8 @@
 
     [self.textFieldsView constrainWidthToView:self.view predicate:self.useLargeLayout ? @"*.6" : @"*.9"];
     [self.textFieldsView alignCenterXWithView:self.view predicate:@"0"];
-    [self.textFieldsView constrainTopSpaceToView:self.titleLabel predicate:self.useLargeLayout ? @"120" : @"60"];
+    self.titleToTextFieldsSpacer = [self.textFieldsView constrainTopSpaceToView:self.titleLabel predicate:self.useLargeLayout ? @"120" : @"60"];
+
     [self.textFieldsView constrainHeight:@">=108"];
     [self.textFieldsView setupForLogin];
 
@@ -243,12 +246,14 @@
     [self.view endEditing:YES];
 }
 
+
 - (void)keyboardWillShow:(NSNotification *)notification
 {
-    CGSize keyboardSize = [[[notification userInfo] objectForKey:UIKeyboardFrameBeginUserInfoKey] CGRectValue].size;
     CGFloat duration = [[[notification userInfo] objectForKey:UIKeyboardAnimationDurationUserInfoKey] doubleValue];
-
-    self.keyboardConstraint.constant = -keyboardSize.height - ([UIDevice isPad] ? 20 : 10);
+    
+    if (UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation])) {
+        self.titleToTextFieldsSpacer = [self.textFieldsView constrainTopSpaceToView:self.titleLabel predicate:self.useLargeLayout ? @"20" : @"60"];
+    }
     [UIView animateIf:YES duration:duration:^{
         [self.view layoutIfNeeded];
     }];
@@ -257,12 +262,13 @@
 - (void)keyboardWillHide:(NSNotification *)notification
 {
     CGFloat duration = [[[notification userInfo] objectForKey:UIKeyboardAnimationDurationUserInfoKey] doubleValue];
-
-    self.keyboardConstraint.constant = 0;
+    
+    self.titleToTextFieldsSpacer = [self.textFieldsView constrainTopSpaceToView:self.titleLabel predicate:self.useLargeLayout ? @"120" : @"60"];
     [UIView animateIf:YES duration:duration:^{
         [self.view layoutIfNeeded];
     }];
 }
+
 
 #pragma mark -
 #pragma mark Networking


### PR DESCRIPTION
Fix issue that @katarinabatina mentioned earlier today with keyboard coverup in iPad landscape.

![simulator screen shot 19 oct 2016 17 06 24](https://cloud.githubusercontent.com/assets/373860/19527024/7bbc6c6e-961e-11e6-9ab7-b875a05a9dfb.png)
