### PR TITLE
Updates changelog from 3.0.0 release #trivial

### DIFF
--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0</string>
+	<string>3.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,6 +1,15 @@
 upcoming:
-    version: 3.0.0
+    version: 3.0.1
+    details: Patch fix for 3.0.0 release.
+    dev:
+      infrastructure:
+    user_facing:
+
+
+releases:
+  - version: 3.0.0
     details: New personalised collectors edition.
+    date: Oct 21, 2016
     dev:
       infrastructure:
         - Removed background fetch related code - alloy
@@ -12,7 +21,6 @@ upcoming:
       - New Gene View Controller - orta
       - Fixes video embedded in articles not playing inline on iOS 10 - alloy
 
-releases:
   - version: 2.6.4
     details: Auctions Fixes
     date: Oct 6, 2016


### PR DESCRIPTION
Moves the 3.0.0 release from `upcoming` to `releases` and adds a `date` to it. Also creates skeleton for new patch release in `upcoming`. 