### PR TITLE
[Tabs] Don’t send a message to the search VC it doesn’t accept.

### DIFF
--- a/Artsy/Views/Utilities/ARTabContentView.m
+++ b/Artsy/Views/Utilities/ARTabContentView.m
@@ -174,8 +174,11 @@ static BOOL ARTabViewDirectionRight = YES;
     _currentViewIndex = index;
 
     // Ensure there is only one scrollview that has `scrollsToTop`
-    if (isARNavigationController && [oldViewController.topViewController conformsToProtocol:@protocol(ARMenuAwareViewController)] && [oldViewController.topViewController respondsToSelector:@selector(menuAwareScrollView)]) {
-        [(id)oldViewController.topViewController menuAwareScrollView].scrollsToTop = NO;
+    if (isARNavigationController) {
+      UIViewController<ARMenuAwareViewController> *oldTopViewController = (id)oldViewController.topViewController;
+      if ([oldTopViewController respondsToSelector:@selector(menuAwareScrollView)]) {
+          oldTopViewController.menuAwareScrollView.scrollsToTop = NO;
+      }
     }
 
     // Get the next View Controller, add to self

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,6 +5,7 @@ upcoming:
       infrastructure:
     user_facing:
       - Fixes an intermittent crash on the live interface - ash
+      - Attempts to fix a crash that would occur by sending a message to a search VC that it doesn’t implement - alloy
 
 
 releases:


### PR DESCRIPTION
Fixes #1976. (Or, rather, attempts to.)

Disclaimer: I wasn’t able to find a reproduction for this crash yet. What I think is happening is that concurrent code influences the result of sending the `topViewController` message to the `oldViewController`, so that by the time line 178 was reached the actual object returned might not respond to `menuAwareScrollView`.