### PR TITLE
Fix for searchVC routing to old geneVC #tiny

### DIFF
--- a/Artsy/View_Controllers/App_Navigation/ARAppSearchViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARAppSearchViewController.m
@@ -114,7 +114,7 @@ static const NSInteger ARAppSearchParallaxDistance = 20;
         NSString *path = NSStringWithFormat(@"/artist/%@", result.modelID);
         controller = [[ARSwitchBoard sharedInstance] loadPath:path];
     } else if (result.model == [Gene class]) {
-        controller = [[ARGeneViewController alloc] initWithGeneID:result.modelID];
+        controller = [[ARSwitchBoard sharedInstance] loadGeneWithID:result.modelID];
     } else if (result.model == [Profile class]) {
         controller = [ARSwitchBoard.sharedInstance loadProfileWithID:result.modelID];
     } else if (result.model == [SiteFeature class]) {


### PR DESCRIPTION
Is this part still necessary?

https://github.com/artsy/eigen/blob/master/Artsy/App/ARSwitchboard+Eigen.m#L140

Is there ever going to be a case where we want to be using the old version of this VC?

Fixes #1995 