### PR TITLE
[Onboarding] Fix crash that occurs when de-selecting in a tableview.

### DIFF
--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/AROnboardingPersonalizationGeneImageStateReconciler.h
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/AROnboardingPersonalizationGeneImageStateReconciler.h
@@ -2,7 +2,7 @@
 
 @class Gene;
 
-
+NS_ASSUME_NONNULL_BEGIN
 @interface AROnboardingPersonalizationGeneImageStateReconciler : NSObject
 
 - (NSURL *)imageURLForGene:(Gene *)gene atIndexPath:(NSIndexPath *)indexPath;
@@ -11,3 +11,4 @@
 - (void)reset;
 
 @end
+NS_ASSUME_NONNULL_END

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/AROnboardingPersonalizeTableViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/AROnboardingPersonalizeTableViewController.m
@@ -195,8 +195,8 @@
             cell.alpha = 0.7;
         } completion:^(BOOL finished) {
             cell.alpha = 1.0;
+            self.selectedRowToReplace = nil;
         }];
-        self.selectedRowToReplace = nil;
     }
 }
 

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/AROnboardingPersonalizeTableViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/AROnboardingPersonalizeTableViewController.m
@@ -66,7 +66,9 @@
             if (searchResults.count) {
                 [self.searchResults replaceObjectAtIndex:self.tableView.indexPathForSelectedRow.row withObject:searchResults[0]];
                 self.selectedRowToReplace = self.tableView.indexPathForSelectedRow;
-                [self.geneImageReconciler addReplacedGene:self.selectedRowToReplace];
+                if (self.selectedRowToReplace) {
+                    [self.geneImageReconciler addReplacedGene:self.selectedRowToReplace];
+                }
             } else if (self.searchResults.count) {
                 [self.searchResults removeObjectAtIndex:self.tableView.indexPathForSelectedRow.row];
             }

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -7,6 +7,7 @@ upcoming:
       - Fixes gene routing bug where search routed to old gene VC instead of RN one - sarah
       - Fixes tableview crasher in onboarding - sarah + maxim
       - Fixes email retrieval from Facebook SDK and removes email confirmation screen - maxim
+      - Fixes crasher in onboarding tableview when no selection was made - alloy
 
 
 releases:


### PR DESCRIPTION
Fixes #1994.

Alas, even with nullability info Xcode did not flag that line as being a risk, not sure what’s up with that, so doing this based purely on the crash log.