### PR TITLE
[Onboarding] Update create account screen with more contrasting changes

### DIFF
--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/3_-_Sign_Up_+_Log_In/ARCreateAccountViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/3_-_Sign_Up_+_Log_In/ARCreateAccountViewController.m
@@ -70,6 +70,12 @@
                                                object:nil];
 }
 
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+    [self.textFieldsView.nameField becomeFirstResponder];
+}
+
 - (void)viewDidLoad
 {
     UITapGestureRecognizer *keyboardCancelTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(hideKeyboard)];
@@ -94,7 +100,7 @@
     self.view.backgroundColor = [UIColor whiteColor];
 
     self.titleLabel = [[ARSerifLineHeightLabel alloc] initWithLineSpacing:1.4];
-    self.titleLabel.text = @"Sign up to see our recommendations for you";
+    self.titleLabel.text = @"Set up your Artsy account";
     self.titleLabel.font = [UIFont serifFontWithSize:self.useLargeLayout ? 40.0 : 30.0];
     self.titleLabel.textAlignment = self.useLargeLayout ? NSTextAlignmentCenter : NSTextAlignmentLeft;
 
@@ -103,14 +109,14 @@
     [self.titleLabel constrainWidthToView:self.view predicate:@"*.9"];
     [self.titleLabel alignCenterXWithView:self.view predicate:@"0"];
     [self.titleLabel alignTopEdgeWithView:self.view predicate:@"20"];
-    [self.titleLabel constrainHeight:@"80"];
+    [self.titleLabel constrainHeight:@"60"];
 
     self.textFieldsView = [[ARLoginFieldsView alloc] init];
     [self.view addSubview:self.textFieldsView];
 
     [self.textFieldsView constrainWidthToView:self.view predicate:self.useLargeLayout ? @"*.6" : @"*.9"];
     [self.textFieldsView alignCenterXWithView:self.view predicate:@"0"];
-    self.titleToTextFieldsSpacer = [self.textFieldsView constrainTopSpaceToView:self.titleLabel predicate:self.useLargeLayout ? @"120" : @"80"];
+    self.titleToTextFieldsSpacer = [self.textFieldsView constrainTopSpaceToView:self.titleLabel predicate:self.useLargeLayout ? @"120" : @"20"];
     [self.textFieldsView constrainHeight:@">=162"];
     [self.textFieldsView setupForSignUp];
 
@@ -125,11 +131,14 @@
     self.textFieldsView.nameField.delegate = self;
     self.textFieldsView.emailField.delegate = self;
     self.textFieldsView.passwordField.delegate = self;
+    
+    [self.buttonsView.emailActionButton setTitle:@"Complete" forState:UIControlStateNormal];
 
     [self.buttonsView.emailActionButton addTarget:self action:@selector(submit:) forControlEvents:UIControlEventTouchUpInside];
     [self.buttonsView.facebookActionButton addTarget:self action:@selector(fb:) forControlEvents:UIControlEventTouchUpInside];
 
     [self.buttonsView.emailActionButton setEnabled:[self canSubmit] animated:YES];
+    
 }
 
 - (void)keyboardWillShow:(NSNotification *)notification
@@ -358,6 +367,20 @@
 - (void)textChanged:(NSNotification *)n
 {
     [self.buttonsView.emailActionButton setEnabled:[self canSubmit] animated:YES];
+}
+
+- (void)textFieldDidBeginEditing:(UITextField *)textField
+{
+    textField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:textField.placeholder attributes:@{NSForegroundColorAttributeName : [UIColor artsyGrayMedium]}];
+    
+    ((ARTextFieldWithPlaceholder *)textField).baseline.backgroundColor = [UIColor blackColor].CGColor;
+}
+
+- (void)textFieldDidEndEditing:(UITextField *)textField
+{
+    textField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:textField.placeholder attributes:@{NSForegroundColorAttributeName : [UIColor artsyGraySemibold]}];
+    
+    ((ARTextFieldWithPlaceholder *)textField).baseline.backgroundColor = [UIColor artsyGrayRegular].CGColor;
 }
 
 #pragma mark - delegate

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/3_-_Sign_Up_+_Log_In/ARLoginButtonsView.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/3_-_Sign_Up_+_Log_In/ARLoginButtonsView.m
@@ -64,7 +64,7 @@
     [self.separatorLine constrainHeight:@"1"];
     [self.separatorLine constrainWidthToView:self predicate:@"0"];
     [self.separatorLine alignCenterXWithView:self predicate:@"0"];
-    [self.separatorLine constrainTopSpaceToView:self.emailActionButton predicate:@"50"];
+    [self.separatorLine constrainTopSpaceToView:self.emailActionButton predicate:@"30"];
 
     self.separatorLabel.text = @"OR";
     self.separatorLabel.backgroundColor = [UIColor whiteColor];
@@ -83,7 +83,7 @@
     [self.facebookActionButton constrainWidthToView:self predicate:@"0"];
     [self.facebookActionButton constrainHeight:@"40"];
     [self.facebookActionButton alignCenterXWithView:self predicate:@"0"];
-    [self.facebookActionButton constrainTopSpaceToView:self.separatorLine predicate:@"50"];
+    [self.facebookActionButton constrainTopSpaceToView:self.separatorLine predicate:@"30"];
 }
 
 - (void)addTwitterButton

--- a/Artsy/View_Controllers/Util/ARTextFieldWithPlaceholder.h
+++ b/Artsy/View_Controllers/Util/ARTextFieldWithPlaceholder.h
@@ -3,4 +3,6 @@
 
 @interface ARTextFieldWithPlaceholder : UITextField
 
+@property (nonatomic, strong) CALayer *baseline;
+
 @end

--- a/Artsy/View_Controllers/Util/ARTextFieldWithPlaceholder.m
+++ b/Artsy/View_Controllers/Util/ARTextFieldWithPlaceholder.m
@@ -7,7 +7,6 @@
 
 @interface ARTextFieldWithPlaceholder ()
 @property (nonatomic, assign) BOOL swizzledClear;
-@property (nonatomic, strong) CALayer *baseline;
 @end
 
 


### PR DESCRIPTION
Fix #2012.

Cut a lot of padding to make it fit by default on the screen with keyboard up.

Hoping to squeeze this one into 3.0.2! (cc @alloy)

![ezgif-4124747406](https://cloud.githubusercontent.com/assets/373860/20312027/db77e774-ab49-11e6-8174-b31fc1c38485.gif)

