### PR TITLE
Fixes problem with users registered for too many sales

### DIFF
--- a/Artsy/Networking/API_Modules/ArtsyAPI+Artworks.m
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+Artworks.m
@@ -62,7 +62,7 @@
 + (void)getAuctionArtworkWithSale:(NSString *)saleID artwork:(NSString *)artworkID success:(void (^)(id auctionArtwork))success failure:(void (^)(NSError *error))failure
 {
     NSURLRequest *saleArtworkRequest = [ARRouter saleArtworkRequestForSaleID:saleID artworkID:artworkID];
-    NSURLRequest *biddersRequest = [ARRouter biddersRequest];
+    NSURLRequest *biddersRequest = [ARRouter biddersRequestForSale:saleID];
     NSURLRequest *bidderPositionRequest = [ARRouter bidderPositionsRequestForSaleID:saleID artworkID:artworkID];
 
     [self getRequests:@[ saleArtworkRequest, biddersRequest, bidderPositionRequest ] success:^(NSArray *operations) {

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
     dev:
       infrastructure:
     user_facing:
+      - Fixes problem where users could not bid on sales if they were registered for too many sales - ash
       - Fixes gene routing bug where search routed to old gene VC instead of RN one - sarah
       - Fixes tableview crasher in onboarding - sarah + maxim
       - Fixes email retrieval from Facebook SDK and removes email confirmation screen - maxim


### PR DESCRIPTION
Problem: user sees "Register to Bid" instead of a "Bid" button.

Cause: we were asking for _all_ bidder models for all sales, instead of limiting to our current sale. The models appears to be ordered by oldest first, so after the first page we don't get the model we need to recognize that the user is registered for the sale.

Fix for https://github.com/artsy/auctions/issues/218.