### PR TITLE
Removes old subscriptions to improve lot list scrolling performance

### DIFF
--- a/Artsy/View_Controllers/Live_Auctions/LiveAuctionLotListViewController.swift
+++ b/Artsy/View_Controllers/Live_Auctions/LiveAuctionLotListViewController.swift
@@ -44,6 +44,8 @@ class LiveAuctionLotListViewController: UICollectionViewController {
                 return sSelf.stickyCollectionViewLayout.setActiveIndex(nil)
             }
 
+            sSelf.unsubscribeCurrentLotState()
+
             // A lot can be the _current_ lot without being _opened_ yet. We check the current lot state to make sure that the activeIndex of the layout corresponds to the lotState that the cells are using to render themselves.
             sSelf.currentLotStateSubscription = lot.lotStateSignal.subscribe { lotState in
                 let activeIndex: Int? = (lotState == .LiveLot ? sSelf.salesPerson.indexForViewModel(lot) : nil)
@@ -58,7 +60,6 @@ class LiveAuctionLotListViewController: UICollectionViewController {
     }
 
     deinit {
-        currentLotStateSubscription?.unsubscribe()
         unsubscribeCurrentLotState()
     }
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -9,6 +9,7 @@ upcoming:
       - Fixes tableview crasher in onboarding - sarah + maxim
       - Fixes email retrieval from Facebook SDK and removes email confirmation screen - maxim
       - Fixes crasher in onboarding tableview when no selection was made - alloy
+      - Fixes performance issues on the live auctions lot list - ash
 
 
 releases:


### PR DESCRIPTION
Fix for https://github.com/artsy/auctions/issues/181.

Explanation: a lot's state is a mapping of its bidding status, which gets [updated](https://github.com/artsy/eigen/blob/master/Artsy/View_Controllers/Live_Auctions/LiveActionStateReconciler.swift#L139) every time there's a new derived lot data (which happens on every related lot broadcast, which happens very very often). We weren't unsubscribing from old subscriptions, leading to hundreds of callbacks _per lot_ in a list of hundreds of lots. 

This issue is difficult to debug because it only occurs on sales with many lots, so I'll have to monitor an auction later to QA.