### PR TITLE
[!] [Onboarding] Fix code using old delegate method, resulting in crash

### DIFF
--- a/Artsy/View_Controllers/Login_and_Onboarding/AROnboardingViewController.h
+++ b/Artsy/View_Controllers/Login_and_Onboarding/AROnboardingViewController.h
@@ -17,7 +17,6 @@
 @end
 
 @protocol ARLoginSignupDelegate <NSObject>
-- (void)didSignUpAndLogin;
 - (void)dismissOnboardingWithVoidAnimation:(BOOL)animated;
 @end
 

--- a/Artsy/View_Controllers/Login_and_Onboarding/ARPersonalizeWebViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/ARPersonalizeWebViewController.m
@@ -57,16 +57,6 @@
     }
 }
 
-- (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error
-{
-    [self exitOnboarding];
-}
-
-- (void)exitOnboarding
-{
-    [self.personalizeDelegate didSignUpAndLogin];
-}
-
 - (void)showLoading
 {
     [self.spinner fadeInAnimated:YES];

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/3_-_Sign_Up_+_Log_In/ARCreateAccountViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/3_-_Sign_Up_+_Log_In/ARCreateAccountViewController.m
@@ -217,7 +217,7 @@
     [[ARUserManager sharedManager] createUserWithName:self.textFieldsView.nameField.text email:username password:password success:^(User *user) {
         __strong typeof (wself) sself = wself;
         [sself loginWithUserCredentialsWithSuccess:^{
-            [sself.delegate didSignUpAndLogin];
+            [sself.delegate dismissOnboardingWithVoidAnimation:YES];
         }];
     } failure:^(NSError *error, id JSON) {
         __strong typeof (wself) sself = wself;


### PR DESCRIPTION
Sorry everyone... this needs to go in for 3.0.2! 

In the clean up around Facebook's signup process, I removed methods we weren't using anymore / didn't do anything, but the email signup method still called it. 

Not sure if I should changelog this, as it hasn't officially gone out yet? 