### PR TITLE
[Artist] Use new view for artists in gallery context.

### DIFF
--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -147,16 +147,12 @@ NSInteger const ARLiveAuctionsCurrentWebSocketVersionCompatibility = 3;
     }];
 
     // For artists in a gallery context, like https://artsy.net/spruth-magers/artist/astrid-klein . Until we have a native
-    // version of the gallery profile/context, we will use the normal native artist view instead of showing a web view on iPad.
-
-    if ([UIDevice isPad]) {
-        [self registerEchoRouteForKey:@"ARProfileArtistRoute" handler:JLRouteParams {
-            __strong typeof (wself) sself = wself;
-
-            Fair *fair = [parameters[@"fair"] isKindOfClass:Fair.class] ? parameters[@"fair"] : nil;
-            return [sself loadArtistWithID:parameters[@"id"] inFair:fair];
-        }];
-    }
+    // version of the gallery profile/context, we will use the normal native artist view instead of showing a web view.
+    [self registerEchoRouteForKey:@"ARProfileArtistRoute" handler:JLRouteParams {
+        __strong typeof (wself) sself = wself;
+        Fair *fair = [parameters[@"fair"] isKindOfClass:Fair.class] ? parameters[@"fair"] : nil;
+        return [sself loadArtistWithID:parameters[@"id"] inFair:fair];
+    }];
 
     [self registerEchoRouteForKey:@"ARArtworkRoute" handler:JLRouteParams {
         __strong typeof (wself) sself = wself;

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -10,10 +10,10 @@ upcoming:
       - Fixes email retrieval from Facebook SDK and removes email confirmation screen - maxim
       - Fixes crasher in onboarding tableview when no selection was made - alloy
       - Fixes performance issues on the live auctions lot list - ash
-
       - Fixes bug in GeneVC where fetching was starting on page 2 - sarah
       - Update home view artworks rails order - maxim
-      - Fix artist link to auction results - alloy
+      - Fixes artist link to auction results - alloy
+      - Ensures artists in context of a gallery are shown in the new artist view - sarah + alloy
 
 releases:
   - version: 3.0.1


### PR DESCRIPTION
Fixes #2023.

It seems like this was only enabled for iPad, I’m not entirely sure I understand why.