### PR TITLE
Fixes auction countdown timer issue on iPad

### DIFF
--- a/Artsy/Views/Artwork/ARArtworkActionsView.m
+++ b/Artsy/Views/Artwork/ARArtworkActionsView.m
@@ -386,7 +386,7 @@ return [navigationButtons copy];
 {
     ARCountdownView *countdownView = [[ARCountdownView alloc] init];
     countdownView.delegate = self;
-    [self addSubview:countdownView withTopMargin:@"8" sideMargin:@"120"];
+    [self addSubview:countdownView withTopMargin:@"8" sideMargin:@"30"];
     self.countdownView = countdownView;
     [self updateCountdownView];
 }

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
     dev:
       infrastructure:
     user_facing:
+      - Fixes auction countdown timer on iPad - ash
       - Fixes problem where users could not bid on sales if they were registered for too many sales - ash
       - Fixes gene routing bug where search routed to old gene VC instead of RN one - sarah
       - Fixes tableview crasher in onboarding - sarah + maxim


### PR DESCRIPTION
Fix for https://github.com/artsy/auctions/issues/185 . There just wasn't enough space on either side of the countdown timer, autolayout was clipping individual labels.