### PR TITLE
More accurate "auction begins" data in auction info VC.

### DIFF
--- a/Artsy/View_Controllers/Auction/AuctionInformationViewController.swift
+++ b/Artsy/View_Controllers/Auction/AuctionInformationViewController.swift
@@ -89,7 +89,6 @@ class AuctionInformationViewController: UIViewController {
 
         let auctionBeginsHeaderLabel = UILabel()
         auctionBeginsHeaderLabel.font = UIFont.sansSerifFontWithSize(12)
-        auctionBeginsHeaderLabel.text = "AUCTION BEGINS"
         stackView.addSubview(auctionBeginsHeaderLabel, withTopMargin: "0", sideMargin: "40")
 
         let auctionBeginsLabel = UILabel()
@@ -97,8 +96,15 @@ class AuctionInformationViewController: UIViewController {
         let formatter = NSDateFormatter()
         formatter.dateStyle = .MediumStyle
         formatter.timeStyle = .LongStyle
-        auctionBeginsLabel.text = formatter.stringFromDate(saleViewModel.startDate)
         stackView.addSubview(auctionBeginsLabel, withTopMargin: "10", sideMargin: "40")
+
+        if let liveAuctionStartDate = saleViewModel.liveAuctionStartDate {
+            auctionBeginsHeaderLabel.text = "LIVE BIDDING BEGINS"
+            auctionBeginsLabel.text = formatter.stringFromDate(liveAuctionStartDate)
+        } else {
+            auctionBeginsHeaderLabel.text = "AUCTION BEGINS"
+            auctionBeginsLabel.text = formatter.stringFromDate(saleViewModel.startDate)
+        }
 
         let faqButtonDescription = NavigationButton(
             buttonClass: ARNavigationButton.self,

--- a/Artsy/Views/Auction/SaleViewModel.swift
+++ b/Artsy/Views/Auction/SaleViewModel.swift
@@ -55,8 +55,12 @@ extension SaleViewModel {
         }
     }
 
+    var liveAuctionStartDate: NSDate? {
+        return sale.liveAuctionStartDate
+    }
+
     var isRunningALiveAuction: Bool {
-        return sale.liveAuctionStartDate != nil
+        return liveAuctionStartDate != nil
     }
 
     var shouldShowLiveInterface: Bool {

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -14,6 +14,7 @@ upcoming:
       - Update home view artworks rails order - maxim
       - Fixes artist link to auction results - alloy
       - Ensures artists in context of a gallery are shown in the new artist view - sarah + alloy
+      - More accurate "auction begins" data in auction info VC - ash
 
 releases:
   - version: 3.0.1


### PR DESCRIPTION
Fix for https://github.com/artsy/auctions/issues/175. Basically we want to show the live start time instead of the auction open time (if it's a live auction).