### PR TITLE
Fixes auctions with sale artworks that are missing high estimates.

### DIFF
--- a/Artsy/Models/API_Models/LiveAuctionLot.h
+++ b/Artsy/Models/API_Models/LiveAuctionLot.h
@@ -45,8 +45,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readonly) NSString *currency;
 @property (nonatomic, copy, readonly) NSString *currencySymbol;
 
-@property (nonatomic, assign, readonly) UInt64 lowEstimateCents;
-@property (nonatomic, assign, readonly) UInt64 highEstimateCents;
+@property (nonatomic, assign, readonly) NSNumber *_Nullable lowEstimateCents;
+@property (nonatomic, assign, readonly) NSNumber *_Nullable highEstimateCents;
 @property (nonatomic, copy, readonly) NSString *_Nullable estimate;
 @property (nonatomic, assign, readonly) UInt64 askingPriceCents;
 

--- a/Artsy/View_Controllers/Live_Auctions/LiveAuctionBidViewModel.swift
+++ b/Artsy/View_Controllers/Live_Auctions/LiveAuctionBidViewModel.swift
@@ -60,7 +60,7 @@ class LiveAuctionBidViewModel: NSObject {
             let nextBid = salesPerson.bidIncrements.minimumNextBidCentsIncrement(bidIncrements[i])
             bidIncrements += [nextBid]
             i += 1
-        } while bidIncrements[i] < (3 * max(lotVM.askingPrice, lotVM.highEstimateCents))
+        } while bidIncrements[i] < (3 * max(lotVM.askingPrice, lotVM.highEstimateCents ?? 0))
     }
 
     var availableIncrements: Int {

--- a/Artsy/View_Controllers/Live_Auctions/ViewModels/LiveAuctionLotViewModel.swift
+++ b/Artsy/View_Controllers/Live_Auctions/ViewModels/LiveAuctionLotViewModel.swift
@@ -32,7 +32,7 @@ protocol LiveAuctionLotViewModelType: class {
     var lotArtworkDimensions: String? { get }
 
     var estimateString: String? { get }
-    var highEstimateCents: UInt64 { get }
+    var highEstimateCents: UInt64? { get }
     var lotName: String { get }
     var lotID: String { get }
     var lotIndex: String { get }
@@ -241,8 +241,8 @@ class LiveAuctionLotViewModel: NSObject, LiveAuctionLotViewModelType {
         return model.estimate
     }
 
-    var highEstimateCents: UInt64 {
-        return model.highEstimateCents
+    var highEstimateCents: UInt64? {
+        return model.highEstimateCents?.unsignedLongLongValue
     }
 
     var eventIDs: [String] {

--- a/Artsy_Tests/View_Controller_Tests/Live_Auction/LiveAuctionLotViewControllerTests.swift
+++ b/Artsy_Tests/View_Controller_Tests/Live_Auction/LiveAuctionLotViewControllerTests.swift
@@ -144,7 +144,7 @@ class Test_LiveAuctionLotViewModel: LiveAuctionLotViewModelType {
     var numberOfDerivedEvents = 1
     var lotIndex = "2"
     var lotNumber = "2"
-    var highEstimateCents: UInt64 = 2_000_00
+    var highEstimateCents: UInt64? = 2_000_00
     var numberOfBids = 1
     var currencySymbol = "$"
     var imageAspectRatio: CGFloat = 1

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -12,6 +12,7 @@ upcoming:
       - Fixes performance issues on the live auctions lot list - ash
       - Fixes bug in GeneVC where fetching was starting on page 2 - sarah
       - Update home view artworks rails order - maxim
+      - Fix for live sale artworks with missing high estimates - ash
       - Fixes artist link to auction results - alloy
       - Ensures artists in context of a gallery are shown in the new artist view - sarah + alloy
 


### PR DESCRIPTION
Fix for https://github.com/artsy/auctions/issues/178. Mantle was choking on `null` JSON fields and primitive `UInt64` types. This uses `NSNumber` instead to avoid future problems.