### PR TITLE
Fixes assign/strong mixup #trivial

### DIFF
--- a/Artsy/Models/API_Models/LiveAuctionLot.h
+++ b/Artsy/Models/API_Models/LiveAuctionLot.h
@@ -45,8 +45,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readonly) NSString *currency;
 @property (nonatomic, copy, readonly) NSString *currencySymbol;
 
-@property (nonatomic, assign, readonly) NSNumber *_Nullable lowEstimateCents;
-@property (nonatomic, assign, readonly) NSNumber *_Nullable highEstimateCents;
+@property (nonatomic, strong, readonly, nullable) NSNumber *lowEstimateCents;
+@property (nonatomic, strong, readonly, nullable) NSNumber *highEstimateCents;
 @property (nonatomic, copy, readonly) NSString *_Nullable estimate;
 @property (nonatomic, assign, readonly) UInt64 askingPriceCents;
 


### PR DESCRIPTION
When I added `nullable`, I got a compile warning about duplicate nullability specifiers, so it looks like the behaviour is the same. Is this something we want to standardize on? 