### PR TITLE
Fixes flash of text when pushing auction view controllers.

### DIFF
--- a/Artsy/View_Controllers/Auction/AuctionViewController.swift
+++ b/Artsy/View_Controllers/Auction/AuctionViewController.swift
@@ -161,7 +161,7 @@ extension AuctionViewController {
         self.titleView = titleView
 
         stickyHeader = ScrollingStickyHeaderView().then {
-            $0.toggleAttatched(false, animated:false)
+            $0.toggleAttatched(false, animated: false)
             $0.button.setTitle("Refine", for: .normal)
             $0.titleLabel.text = saleViewModel.displayName
             $0.button.addTarget(self, action: #selector(AuctionViewController.showRefineTapped), for: .touchUpInside)

--- a/Artsy/Views/Pages/ScrollingStickyHeaderView.swift
+++ b/Artsy/Views/Pages/ScrollingStickyHeaderView.swift
@@ -99,7 +99,7 @@ class ScrollingStickyHeaderView: UIView {
 
     func toggleAttatched(_ atTop: Bool, animated: Bool) {
 
-        UIView.animateIf(ARPerformWorkAsynchronously.boolValue, duration: 0.2, {
+        UIView.animateIf(ARPerformWorkAsynchronously.boolValue && animated, duration: 0.2, {
             self.titleLabel.alpha = atTop ? 1 : 0
             self.topSeparator.alpha = atTop ? 1 : 0
             self.bottomSeparator.alpha = atTop ? 1 : 0

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -10,6 +10,7 @@ upcoming:
     user_facing:
       - Jump to current lot CTA only visible once in the LAI interface, instead of once per lot - ash
       - Fixes issue where links in auction descriptions would lead nowhere when tapped - ash
+      - Fixes a strange text-flashing issue on auction views - ash
 
 releases:
   - version: 3.0.2


### PR DESCRIPTION
Pretty simple fix, we were just disregarding the `animated` property.

Fix for https://github.com/artsy/auctions/issues/260.