### PR TITLE
Updates Podfile to use Artsy Specs repo.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -86,9 +86,9 @@ target 'Artsy' do
   pod 'React/Core', :git => 'https://github.com/alloy/react-native.git', :branch => '0.34.1-with-scrollview-fix'
 
   if ENV['ARTSY_STAFF_MEMBER'] != nil || ENV['CI'] != nil
-    pod 'Artsy+UIFonts', :git => "https://github.com/artsy/Artsy-UIFonts.git"
+    pod 'Artsy+UIFonts'
   else
-    pod 'Artsy+UIFonts', :git => "https://github.com/artsy/Artsy-OSSUIFonts.git"
+    pod 'Artsy+OSSUIFonts'
   end
 
   # Facebook

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -52,7 +52,7 @@ PODS:
   - ARTiledImageView (1.2.0):
     - SDWebImage/Core
   - Artsy+UIColors (3.0.1)
-  - Artsy+UIFonts (1.1.0)
+  - Artsy+UIFonts (1.1.1)
   - Artsy+UILabels (2.0.2):
     - Artsy+UIColors (~> 3.0)
     - Artsy+UIFonts
@@ -208,7 +208,7 @@ DEPENDENCIES:
   - ARGenericTableViewController (from `https://github.com/orta/ARGenericTableViewController.git`)
   - ARTiledImageView (from `https://github.com/dblock/ARTiledImageView`)
   - Artsy+UIColors
-  - Artsy+UIFonts (from `https://github.com/artsy/Artsy-UIFonts.git`)
+  - Artsy+UIFonts
   - Artsy+UILabels
   - Artsy-UIButtons (from `https://github.com/artsy/Artsy-UIButtons.git`)
   - CocoaLumberjack (from `https://github.com/CocoaLumberjack/CocoaLumberjack.git`)
@@ -281,8 +281,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/orta/ARGenericTableViewController.git
   ARTiledImageView:
     :git: https://github.com/dblock/ARTiledImageView
-  Artsy+UIFonts:
-    :git: https://github.com/artsy/Artsy-UIFonts.git
   Artsy-UIButtons:
     :git: https://github.com/artsy/Artsy-UIButtons.git
   CocoaLumberjack:
@@ -330,9 +328,6 @@ CHECKOUT OPTIONS:
   ARTiledImageView:
     :commit: 775bc29beb5953e381b2af64edbdfc310b90e074
     :git: https://github.com/dblock/ARTiledImageView
-  Artsy+UIFonts:
-    :commit: 6295cce382764bbca9f2b3e972f71eb2b4d32d57
-    :git: https://github.com/artsy/Artsy-UIFonts.git
   Artsy-UIButtons:
     :commit: c5977f380f512987174805ad1c0ef44618ba2e5a
     :git: https://github.com/artsy/Artsy-UIButtons.git
@@ -375,7 +370,7 @@ SPEC CHECKSUMS:
   ARGenericTableViewController: 61a0897ba66c35111b5d1cc3b44884282bd3c1a5
   ARTiledImageView: 2db7735f5d3fcb4c859c912834a6a1bf20716377
   Artsy+UIColors: 10a2d71e9ffe1015be43d4e084d13ff4337aab97
-  Artsy+UIFonts: 108bfe625c45008ebb15c4c62003882dd345c4b8
+  Artsy+UIFonts: 155b972733a24bb12f152fb6d25e2610c1cb93e0
   Artsy+UILabels: 9b8e8b683488e22633625db9627cd79ab64b610f
   Artsy-UIButtons: 3ef4d1afe54f35d9d8c9512f3c2aedf61923a28f
   Bolts: a0058fa3b331c5a1e4402d534f2dae36dbff31e4
@@ -431,6 +426,6 @@ SPEC CHECKSUMS:
   VCRURLConnection: accd771ebd4be11183a3e4d5a4403f180a9a235e
   XCTest+OHHTTPStubSuiteCleanUp: 4469ec8863c6bc022c5089a9b94233eb3416c5ee
 
-PODFILE CHECKSUM: 4cc57883e01d296ccd45d96921db41ec7465dd14
+PODFILE CHECKSUM: 741320e42a42c46dd03e5cf8693a6a10104a1df8
 
 COCOAPODS: 1.1.1


### PR DESCRIPTION
We were referring to a pod named `Artsy+UIFonts` on a repo which no longer contains an `Artsy+UIFonts.podspec` file, so `pod install` was failing for open source contributors. I spent time over the weekend updating our fonts pods on the [Artsy Specs](https://github.com/artsy/specs) repo, so there shouldn't be any reason to refer to them directly with `git`.

Fixes #2079.