### PR TITLE
[Facebook] Fix crash when account does not have associated email

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -13,6 +13,7 @@ upcoming:
       - Fixes issue where links in auction descriptions would lead nowhere when tapped - ash
       - Countdowns to live auctions show the time until live bidding opens, instead of when the sale ends - ash
       - Fixes a strange text-flashing issue on auction views - ash
+      - Fixes a bug when facebook users login without an associated email - maxim
 
 releases:
   - version: 3.0.3


### PR DESCRIPTION
Fix #2095. 

Currently, the fix is that we do not accept Facebook accounts that don't have primary emails - we give the user a warning with what the issue is. 

This seemed simpler for now than having a separate screen that allows users to enter an email (like we used to), because in that case, I would say that users can create an email account instead. 

@orta  - sorry, more indentation grief! 

