### PR TITLE
Fix for double sliding animation in artworkVC

### DIFF
--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
@@ -17,6 +17,7 @@
 
 #import <UIView_BooleanAnimations/UIView+BooleanAnimations.h>
 
+
 @interface ARArtworkViewController () <UIScrollViewDelegate, ARArtworkRelatedArtworksViewParentViewController, ARArtworkBlurbViewDelegate, ARPostsViewControllerDelegate>
 
 @property (nonatomic, strong) ARArtworkView *view;
@@ -83,7 +84,7 @@
         [self ar_removeIndeterminateLoadingIndicatorAnimated:ARPerformWorkAsynchronously];
     }
 
-    __weak typeof (self) wself = self;
+    __weak typeof(self) wself = self;
 
     void (^completion)(void) = ^{
         __strong typeof (wself) sself = wself;
@@ -147,7 +148,7 @@
 
 - (void)getRelatedPosts
 {
-    __weak typeof (self) wself = self;
+    __weak typeof(self) wself = self;
     [self.artwork getRelatedPosts:^(NSArray *posts) {
         __strong typeof (wself) sself = wself;
         [sself updateWithRelatedPosts:posts];
@@ -266,18 +267,8 @@
 
 - (void)relatedArtworksView:(ARArtworkRelatedArtworksView *)view didAddSection:(UIView *)section;
 {
-    section.alpha = 0;
-    [UIView animateTwoStepIf:ARPerformWorkAsynchronously
-        duration:ARAnimationDuration *
-        2:^{
-            [self.view.stackView setNeedsLayout];
-            [self.view.stackView layoutIfNeeded];
-        }
-        midway:^{
-            section.alpha = 1;
-            [self.view flashScrollIndicators];
-        }
-        completion:nil];
+    [self.view.stackView setNeedsLayout];
+    [self.view.stackView layoutIfNeeded];
 }
 
 @end

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -10,6 +10,7 @@ upcoming:
         - Moves live sales away from using end_at gravity field - ash
         - Adds integration tests - maxim
     user_facing:
+      - Fixes bug in push animation of ArtworkVC - sarah
       - Jump to current lot CTA only visible once in the LAI interface, instead of once per lot - ash
       - Fixes issue where links in auction descriptions would lead nowhere when tapped - ash
       - Countdowns to live auctions show the time until live bidding opens, instead of when the sale ends - ash


### PR DESCRIPTION
I haven't done any work on the ArtworkVC animations so I'm not sure what the ideal is supposed to be - is it supposed to slide up from the bottom? In any case, the current app store version has the VC slide in from right with a gray artwork placeholder before loading the image. For some reason in the iOS10/Xcode8-compiled version, the transition was adding an extra slide. 

Was the slide supposed to be there all along and got lost in the shuffle? If so, is it worth it to try and make it work again, or leave this as-is? 

With redundant animation:

![broken](https://cloud.githubusercontent.com/assets/2712962/22148869/ead62ff0-df10-11e6-98c2-2ace9cd56c67.gif)


With this PR, and also what the App Store version currently does:

![fixed](https://cloud.githubusercontent.com/assets/2712962/22148842/c6d49466-df10-11e6-918f-3cbebef3a743.gif)


Fixes #2117 