### PR TITLE
Fixes "Artist at Artsy" and "Show link" buttons

### DIFF
--- a/Artsy/View_Controllers/Fair/ARFairArtistViewController.m
+++ b/Artsy/View_Controllers/Fair/ARFairArtistViewController.m
@@ -131,13 +131,22 @@ AR_VC_OVERRIDE_SUPER_DESIGNATED_INITIALIZERS;
 - (void)addArtistOnArtsyButton
 {
     NSString *title = NSStringWithFormat(@"%@ on Artsy", self.artist.name);
-    ARNavigationButton *button = [[ARNavigationButton alloc] initWithTitle:title];
-    button.tag = ARFairArtistOnArtsy;
-    button.onTap = ^(UIButton *tappedButton) {
-        UIViewController *viewController = [ARSwitchBoard.sharedInstance loadArtistWithID:self.artist.artistID inFair:nil];
-        [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
-    };
-    [self.view.stackView addSubview:button withTopMargin:@"20" sideMargin:@"40"];
+
+    NSArray *artistOnArtsyButtonDescription = @[@{ ARNavigationButtonClassKey : ARNavigationButton.class,
+                                                   ARNavigationButtonPropertiesKey : @{
+                                                           ar_keypath(ARNavigationButton.new, title) : title
+                                                           },
+                                                   ARNavigationButtonHandlerKey : ^(UIButton *sender) {
+                                                       UIViewController *viewController = [ARSwitchBoard.sharedInstance loadArtistWithID:self.artist.artistID inFair:nil];
+                                                       [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
+                                                   }
+                                                   }];
+
+    ARNavigationButtonsViewController* arstistOnArstyNavigationButtonVC = [[ARNavigationButtonsViewController alloc] init];
+    [arstistOnArstyNavigationButtonVC addButtonDescriptions:artistOnArtsyButtonDescription unique:YES];
+    arstistOnArstyNavigationButtonVC.view.tag = ARFairArtistOnArtsy;
+
+    [self.view.stackView addViewController:arstistOnArstyNavigationButtonVC toParent:self withTopMargin:@"20" sideMargin:@"40"];
 }
 
 - (void)addArtworksForShowToStack:(PartnerShow *)show tag:(NSInteger)tag
@@ -156,13 +165,22 @@ AR_VC_OVERRIDE_SUPER_DESIGNATED_INITIALIZERS;
 
 - (void)addNavigationButtonForShowToStack:(PartnerShow *)show tag:(NSInteger)tag
 {
-    ARNavigationButton *button = [[ARSerifNavigationButton alloc] initWithTitle:show.partner.name andSubtitle:show.locationInFair withBorder:0];
-    button.tag = tag;
-    button.onTap = ^(UIButton *tappedButton) {
-        UIViewController *viewController = [ARSwitchBoard.sharedInstance loadShow:show fair:self.fair];
-        [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
-    };
-    [self.view.stackView addSubview:button withTopMargin:@"0" sideMargin:@"40"];
+    NSArray *showButtonDescription = @[@{ ARNavigationButtonClassKey : ARNavigationButton.class,
+                                          ARNavigationButtonPropertiesKey : @{
+                                                  ar_keypath(ARNavigationButton.new, title) : show.partner.name,
+                                                  ar_keypath(ARNavigationButton.new, subtitle) : show.locationInFair
+                                                  },
+                                          ARNavigationButtonHandlerKey : ^(UIButton *sender) {
+                                              UIViewController *viewController = [ARSwitchBoard.sharedInstance loadShow:show fair:self.fair];
+                                              [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
+                                          }
+                                          }];
+
+    ARNavigationButtonsViewController* showNavigationButtonVC = [[ARNavigationButtonsViewController alloc] init];
+    [showNavigationButtonVC addButtonDescriptions:showButtonDescription unique:YES];
+    showNavigationButtonVC.view.tag = tag;
+
+    [self.view.stackView addViewController:showNavigationButtonVC toParent:self withTopMargin:@"0" sideMargin:@"40"];
 }
 
 - (void)addSubtitle


### PR DESCRIPTION
Fixes #2195 

As discussed in the issue, both buttons were wrapped in an `ARNavigationButtonsViewController`. Not sure if the buttons could have been added in a cleaner way 🤔 (feedback is welcome).

End result:
<img src="https://cloud.githubusercontent.com/assets/1916041/23571435/11dc7700-0048-11e7-9e6f-f02978c7cb3d.png" width="300">

Also, @orta noticed that the snapshot test for this screen [is commented out](https://github.com/artsy/eigen/issues/2195#issuecomment-282342629). I was not able to run the tests locally, so I wasn't confident bringing the test back myself.