### PR TITLE
Adds Danger rule for sticker extension version

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.1</string>
+	<string>3.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSExtension</key>

--- a/Dangerfile
+++ b/Dangerfile
@@ -55,6 +55,9 @@ begin
   current_version = `/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" Artsy/App_Resources/Artsy-Info.plist`.strip
   fail("You need to set the App's plist version to #{upcoming_version}") if current_version != upcoming_version
 
+  current_sticker_version = `/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" Artsy\ Stickers/Info.plist`.strip
+  fail("You need to set the Sticker extensions's plist version to #{upcoming_version}") if current_sticker_version != upcoming_version
+
 rescue StandardError
   # YAML could not be parsed, fail the build.
   fail("CHANGELOG isn't valid YAML")


### PR DESCRIPTION
This is a work-in-progress because I want to verify it works. Once I've done that, I'll modify our `make` task to update it, and update the Info.plist file.

Fixes https://github.com/artsy/eigen/issues/2219