### PR TITLE
[Emission] Add a message to error that RN logs when rejecting a promise #trivial

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -150,7 +150,7 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
             if (newRefineSettings) {
                 resolve(newRefineSettings);
             } else {
-                reject(@"0", @"", nil);
+                reject(@"no_changes", @"No refinement changes were made", nil);
             }
         }];
     };


### PR DESCRIPTION
Ideally RN wouldn’t even generate a callstack in this case, will have to think/talk about that and maybe fix upstream, for now this logged error is less ambiguous.