### PR TITLE
[Adjust] Send `anonymous_id` to partner integrations (Segment). #trivial

### DIFF
--- a/Artsy/App/ARAppDelegate.m
+++ b/Artsy/App/ARAppDelegate.m
@@ -420,9 +420,9 @@ static ARAppDelegate *_sharedInstance = nil;
     NSInteger numberOfRuns = [[NSUserDefaults standardUserDefaults] integerForKey:ARAnalyticsAppUsageCountProperty] + 1;
     if (numberOfRuns == 1) {
         [ARAnalytics event:ARAnalyticsFreshInstall];
-        ADJEvent *event = [ADJEvent eventWithEventToken:ARAdjustFirstUserInstall];
-        [event addCallbackParameter:@"anonymous_id" value:ARUserManager.sharedManager.localTemporaryUserUUID];
-        [Adjust trackEvent:event];
+        [Adjust addSessionPartnerParameter:@"anonymous_id"
+                                     value:ARUserManager.sharedManager.localTemporaryUserUUID];
+        [Adjust trackEvent:[ADJEvent eventWithEventToken:ARAdjustFirstUserInstall]];
     }
 
     [[NSUserDefaults standardUserDefaults] setInteger:numberOfRuns forKey:ARAnalyticsAppUsageCountProperty];


### PR DESCRIPTION
For https://github.com/artsy/collector-experience/issues/124

From the email thread by an Adjust employee:

> In case a customer wants to use the Segment module within Adjust, they must implement a Session Partner Parameter whose key is `anonymous_id`. 

So if I understood it correctly, this is the only required change on our side.