### PR TITLE
[Pods] Update Emission to 1.2.2

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -76,7 +76,7 @@ PODS:
     - CocoaLumberjack/Default
   - DHCShakeNotifier (0.2.0)
   - EDColor (1.0.0)
-  - Emission (1.2.1):
+  - Emission (1.2.2):
     - Artsy+UIFonts (>= 3.0.0)
     - Extraction (>= 1.2.1)
     - React/Core (= 0.34.1)
@@ -366,7 +366,7 @@ SPEC CHECKSUMS:
   CocoaLumberjack: 27ae9abcd376c3e4ee726ecd4adfd7b093ddef3f
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
-  Emission: 957ec3bbbfbdc625ef8e8825ada96e169d8866df
+  Emission: 71b9ee3a67b2b216015ac7203eb96fec08456505
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   Expecta+Snapshots: c343f410c7a6392f3e22e78f94c44b6c0749a516
   Extraction: 612cf0866f74d4c0dd616677ff24146efa200958


### PR DESCRIPTION
Just includes the fix to move the active bids module to the top of the home feed.