### PR TITLE
Eliminate semantic issue

### DIFF
--- a/Artsy/App/ARAppActivityContinuationDelegate.m
+++ b/Artsy/App/ARAppActivityContinuationDelegate.m
@@ -8,27 +8,22 @@
 
 #import <CoreSpotlight/CoreSpotlight.h>
 
-// Only available on iOS 9.
-static BOOL IsSpotlightActionTypeAvailable = NO;
-
-
 @implementation ARAppActivityContinuationDelegate
 
 + (void)load
 {
-    IsSpotlightActionTypeAvailable = &CSSearchableItemActionType != NULL;
     [JSDecoupledAppDelegate sharedAppDelegate].activityContinuationDelegate = [[self alloc] init];
 }
 
 - (BOOL)application:(UIApplication *)application willContinueUserActivityWithType:(NSString *)userActivityType;
 {
-    return [userActivityType isEqualToString:NSUserActivityTypeBrowsingWeb] || (IsSpotlightActionTypeAvailable && [userActivityType isEqualToString:CSSearchableItemActionType]) || [userActivityType hasPrefix:@"net.artsy.artsy."];
+    return [userActivityType isEqualToString:NSUserActivityTypeBrowsingWeb] || ([userActivityType isEqualToString:CSSearchableItemActionType]) || [userActivityType hasPrefix:@"net.artsy.artsy."];
 }
 
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray *restorableObjects))restorationHandler;
 {
     NSURL *URL = nil;
-    if (IsSpotlightActionTypeAvailable && [userActivity.activityType isEqualToString:CSSearchableItemActionType]) {
+    if ([userActivity.activityType isEqualToString:CSSearchableItemActionType]) {
         URL = [NSURL URLWithString:userActivity.userInfo[CSSearchableItemActivityIdentifier]];
     } else {
         URL = userActivity.webpageURL;

--- a/Artsy/App/ARAppStatus.h
+++ b/Artsy/App/ARAppStatus.h
@@ -16,7 +16,4 @@
 
 /// Is the app running tests?
 + (BOOL)isRunningTests;
-
-/// Is the app running in iOS 9
-+ (BOOL)isOSNineOrGreater;
 @end

--- a/Artsy/App/ARAppStatus.m
+++ b/Artsy/App/ARAppStatus.m
@@ -50,9 +50,4 @@
     });
     return isRunningTests;
 }
-
-+ (BOOL)isOSNineOrGreater
-{
-    return (&UIApplicationOpenURLOptionsAnnotationKey != NULL);
-}
 @end

--- a/Artsy/Networking/API_Modules/ARUserManager.h
+++ b/Artsy/Networking/API_Modules/ARUserManager.h
@@ -53,13 +53,6 @@ extern NSString *const ARUserSessionStartedNotification;
          authenticationFailure:(void (^)(NSError *error))authenticationFailure
                 networkFailure:(void (^)(NSError *error))networkFailure;
 
-- (void)loginWithTwitterToken:(NSString *)token
-                       secret:(NSString *)secret
-       successWithCredentials:(void (^)(NSString *accessToken, NSDate *expirationDate))credentials
-                      gotUser:(void (^)(User *currentUser))gotUser
-        authenticationFailure:(void (^)(NSError *error))authenticationFailure
-               networkFailure:(void (^)(NSError *error))networkFailure;
-
 - (void)createUserWithName:(NSString *)name
                      email:(NSString *)email
                   password:(NSString *)password
@@ -79,12 +72,6 @@ extern NSString *const ARUserSessionStartedNotification;
                                success:(void (^)(User *user))success
                                failure:(void (^)(NSError *error, id JSON))failure;
 
-- (void)createUserViaTwitterWithToken:(NSString *)token
-                               secret:(NSString *)secret
-                                email:(NSString *)email
-                                 name:(NSString *)name
-                              success:(void (^)(User *user))success
-                              failure:(void (^)(NSError *error, id JSON))failure;
 
 - (void)sendPasswordResetForEmail:(NSString *)email
                           success:(void (^)(void))success

--- a/Artsy/View_Controllers/Login_and_Onboarding/AROnboardingViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/AROnboardingViewController.m
@@ -45,7 +45,7 @@
 @property (nonatomic, strong, readwrite) UIView *progressBackgroundBar;
 @property (nonatomic, strong, readwrite) NSString *email;
 @property (nonatomic, strong, readwrite) NSString *password;
-@property (nonnull, strong, readwrite) UITextField *tempTextField;
+@property (nonatomic, nonnull, strong, readwrite) UITextField *tempTextField;
 
 @end
 

--- a/Artsy/View_Controllers/Util/ARSecureTextFieldWithPlaceholder.h
+++ b/Artsy/View_Controllers/Util/ARSecureTextFieldWithPlaceholder.h
@@ -2,7 +2,4 @@
 
 
 @interface ARSecureTextFieldWithPlaceholder : ARTextFieldWithPlaceholder
-
-- (void)toggleShowContents;
-
 @end

--- a/Artsy/View_Controllers/Util/ARTextFieldWithPlaceholder.m
+++ b/Artsy/View_Controllers/Util/ARTextFieldWithPlaceholder.m
@@ -23,6 +23,7 @@
 
 - (void)awakeFromNib
 {
+    [super awakeFromNib];
     [self setup];
 }
 


### PR DESCRIPTION
It seems that there are several semantic issue warnings.
In this PR, I eliminated those issues as much as possible.

I just left following warning which was introduced by https://github.com/artsy/eigen/pull/1049 since I'm not sure which is better just removing or updating to something `checkForiOS9Deprecation`.

```
eigen/Artsy/App/ARAppDelegate.m:440:10: Comparison of address of 'UIApplicationOpenURLOptionsAnnotationKey' not equal to a null pointer is always true
```