### PR TITLE
Fixes Danger sticker version check

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -55,7 +55,7 @@ begin
   current_version = `/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" Artsy/App_Resources/Artsy-Info.plist`.strip
   fail("You need to set the App's plist version to #{upcoming_version}") if current_version != upcoming_version
 
-  current_sticker_version = `/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" Artsy\ Stickers/Info.plist`.strip
+  current_sticker_version = `/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "Artsy Stickers/Info.plist"`.strip
   fail("You need to set the Sticker extensions's plist version to #{upcoming_version}") if current_sticker_version != upcoming_version
 
 rescue StandardError


### PR DESCRIPTION
Popped the check into irb it was returning `Error Reading File: Artsy` and failing on all PRs. Spaces-in-file-paths strikes again!