### PR TITLE
Removes unnecessary field

### DIFF
--- a/Artsy/Models/API_Models/Auctions/Bidder.h
+++ b/Artsy/Models/API_Models/Auctions/Bidder.h
@@ -7,5 +7,4 @@
 @property (nonatomic, strong) NSString *saleID;
 
 @property (nonatomic, assign) BOOL qualifiedForBidding;
-@property (nonatomic, assign) BOOL saleRequiresBidderApproval;
 @end

--- a/Artsy/Models/API_Models/Auctions/Bidder.m
+++ b/Artsy/Models/API_Models/Auctions/Bidder.m
@@ -8,7 +8,6 @@
     return @{
         @"bidderID" : @"id",
         @"saleID" : @"sale.id",
-        @"saleRequiresBidderApproval" : @"sale.require_bidder_approval",
         @"qualifiedForBidding" : @"qualified_for_bidding"
     };
 }

--- a/Artsy/Models/API_Models/Auctions/SaleArtwork.m
+++ b/Artsy/Models/API_Models/Auctions/SaleArtwork.m
@@ -68,7 +68,7 @@ static NSNumberFormatter *currencyFormatter;
     }
 
     if (self.bidder) {
-        if (self.bidder.saleRequiresBidderApproval && !self.bidder.qualifiedForBidding) {
+        if (!self.bidder.qualifiedForBidding) {
             state |= ARAuctionStateUserPendingRegistration;
         } else {
             state |= ARAuctionStateUserIsRegistered;

--- a/Artsy/View_Controllers/Live_Auctions/LiveAuctionStaticDataFetcher+Stubs.swift
+++ b/Artsy/View_Controllers/Live_Auctions/LiveAuctionStaticDataFetcher+Stubs.swift
@@ -11,7 +11,7 @@ class Stubbed_StaticDataFetcher: LiveAuctionStaticDataFetcherType {
     var paddleNumber: String = "123456"
 
     init() {
-        if let bidder = try? Bidder(dictionary: ["qualifiedForBidding": true, "saleRequiresBidderApproval": true, "bidderID": "123456"], error: Void()) {
+        if let bidder = try? Bidder(dictionary: ["qualifiedForBidding": true, "bidderID": "123456"], error: Void()) {
             bidders = [bidder]
         }
     }

--- a/Artsy/Views/Auction/SaleAuctionStatus.swift
+++ b/Artsy/Views/Auction/SaleAuctionStatus.swift
@@ -32,7 +32,7 @@ extension SaleAuctionStatusType {
         }
 
         if let bidder = bidders.bestBidder {
-            if bidder.saleRequiresBidderApproval && !bidder.qualifiedForBidding {
+            if !bidder.qualifiedForBidding {
                 state.insert(.userPendingRegistration)
             } else {
                 state.insert(.userIsRegistered)

--- a/Artsy_Tests/Model_Tests/SaleArtworkTests.m
+++ b/Artsy_Tests/Model_Tests/SaleArtworkTests.m
@@ -59,6 +59,7 @@ describe(@"artwork for sale", ^{
         beforeEach(^{
             _saleArtwork.auction = nil;
             _saleArtwork.bidder = [[Bidder alloc] init];
+            _saleArtwork.bidder.qualifiedForBidding = YES;
         });
 
         it(@"sets user is registered state", ^{

--- a/Artsy_Tests/View_Controller_Tests/Auction/AuctionViewControllerTests.swift
+++ b/Artsy_Tests/View_Controller_Tests/Auction/AuctionViewControllerTests.swift
@@ -10,8 +10,8 @@ import Mantle
 import Artsy
 
 
-let pendingBidder = try! Bidder(dictionary: ["qualifiedForBidding": false, "saleRequiresBidderApproval": true, "bidderID": "123456"], error: Void())
-let qualifiedBidder = try! Bidder(dictionary: ["qualifiedForBidding": true, "saleRequiresBidderApproval": true, "bidderID": "123456"], error: Void())
+let pendingBidder = try! Bidder(dictionary: ["qualifiedForBidding": false, "bidderID": "123456"], error: Void())
+let qualifiedBidder = try! Bidder(dictionary: ["qualifiedForBidding": true, "bidderID": "123456"], error: Void())
 
 
 var dateMock: AnyObject?

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,6 +5,7 @@ upcoming:
       - Refactors LAI view controller hierarchy - ash
       - Improves Swift compile times - ash
       - Fixes echo update issues - ash
+      - Removes saleRequiresBidderApproval field from Bidder model - ash
     user_facing:
       - Adds support for lot_label in auctions - ash
 


### PR DESCRIPTION
Force [already includes this check](https://github.com/artsy/force/blob/master/desktop/apps/auction/templates/registration_component.jade#L3) for calculating the `qualified_for_bidding` field. I still need to run through the app and remove uses of this field. /cc @sweir27 