### PR TITLE
Fixes crash due to IUO

### DIFF
--- a/Artsy/Views/Auction/SaleViewModel.swift
+++ b/Artsy/Views/Auction/SaleViewModel.swift
@@ -102,7 +102,7 @@ extension SaleViewModel {
         return sale.startDate
     }
 
-    var closingDate: Date {
+    var closingDate: Date? {
         return sale.endDate
     }
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -10,6 +10,7 @@ upcoming:
       - Parallelizes auctions network calls - ash
     user_facing:
       - Adds support for lot_label in auctions - ash
+      - Fixes a crash in opening sales with no end date - ash
 
 releases:
   - version: 3.2.0


### PR DESCRIPTION
Sales with no closing date could cause issues due to Swift implicitly unwrapping a nil optional.

Related to https://github.com/artsy/emission/issues/486