### PR TITLE
[Adjust] Configure to include partner params with install event.

### DIFF
--- a/Artsy/App/ARAppDelegate.m
+++ b/Artsy/App/ARAppDelegate.m
@@ -420,8 +420,6 @@ static ARAppDelegate *_sharedInstance = nil;
     NSInteger numberOfRuns = [[NSUserDefaults standardUserDefaults] integerForKey:ARAnalyticsAppUsageCountProperty] + 1;
     if (numberOfRuns == 1) {
         [ARAnalytics event:ARAnalyticsFreshInstall];
-        [Adjust addSessionPartnerParameter:@"anonymous_id"
-                                     value:ARUserManager.sharedManager.localTemporaryUserUUID];
         [Adjust trackEvent:[ADJEvent eventWithEventToken:ARAdjustFirstUserInstall]];
     }
 

--- a/Artsy/Networking/API_Modules/ARUserManager.m
+++ b/Artsy/Networking/API_Modules/ARUserManager.m
@@ -59,12 +59,12 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
 + (void)identifyAnalyticsUser
 {
     User *user = [User currentUser];
+    NSString *anonymousID = self.sharedManager.localTemporaryUserUUID;
 
     [ARAnalytics setUserProperty:@"is_temporary_user" toValue:@(user == nil)];
+    [ARAnalytics identifyUserWithID:user.userID anonymousID:anonymousID andEmailAddress:user.email];
 
-    [ARAnalytics identifyUserWithID:user.userID
-                        anonymousID:self.sharedManager.localTemporaryUserUUID
-                    andEmailAddress:user.email];
+    [Adjust addSessionPartnerParameter:@"anonymous_id" value:anonymousID];
 }
 
 - (instancetype)init

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -11,6 +11,7 @@ upcoming:
       - Adds scroll to top on onboarding search - maxim
       - Parallelizes auctions network calls - ash
       - Fix issue with push notification when not coming from account creation - maxim
+      - Fix anonymous user ID not being included in Adjust install events - alloy
     user_facing:
       - Adds support for lot_label in auctions - ash
       - Fixes a crash in opening sales with no end date - ash


### PR DESCRIPTION
We were providing the anonymous ID after initializing the SDK.

For https://github.com/artsy/collector-experience/issues/124
Also see https://github.com/adjust/ios_sdk/pull/285

/cc @wrgoldstein 