### PR TITLE
[ARUserManager] Re-enable save creds in iCloud Keychain.

### DIFF
--- a/Artsy/Networking/API_Modules/ARUserManager.m
+++ b/Artsy/Networking/API_Modules/ARUserManager.m
@@ -157,7 +157,7 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
                          gotUser:gotUser
            authenticationFailure:authenticationFailure
                   networkFailure:networkFailure
-        saveSharedWebCredentials:NO]; // This has been changed to NO because in the current onboarding flow we do not request this
+        saveSharedWebCredentials:YES];
 }
 
 - (void)loginWithUsername:(NSString *)username

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -16,6 +16,7 @@ upcoming:
       - Adds support for lot_label in auctions - ash
       - Fixes a crash in opening sales with no end date - ash
       - Spruced up artworks in auctio view - ash
+      - Re-enable saving of credentials in iCloud Keychain - alloy
 
 releases:
   - version: 3.2.0


### PR DESCRIPTION
@mennenia I don’t understand the comment, re-enabling it doesn’t show me an alert or something. Was that the reason you had disabled it?