### PR TITLE
[Activity Continuation] Also support link.artsy.net in production builds.

### DIFF
--- a/Artsy/App_Resources/Artsy.Store.entitlements
+++ b/Artsy/App_Resources/Artsy.Store.entitlements
@@ -7,6 +7,7 @@
 		<string>applinks:artsy.net</string>
 		<string>applinks:www.artsy.net</string>
 		<string>applinks:m.artsy.net</string>
+		<string>applinks:link.artsy.net</string>
 		<string>activitycontinuation:artsy.net</string>
 		<string>activitycontinuation:www.artsy.net</string>
 		<string>activitycontinuation:m.artsy.net</string>

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -16,6 +16,7 @@ upcoming:
       - Adds support for lot_label in auctions - ash
       - Fixes a crash in opening sales with no end date - ash
       - Spruced up artworks in auctio view - ash
+      - Add support for Universal Links to Sailthru links - alloy
 
 releases:
   - version: 3.2.0


### PR DESCRIPTION
We have different entitlements files for dev and store, updated the latter now as well.