### PR TITLE
[Auctions] Improve SaleArtworks state for auction closed

### DIFF
--- a/Artsy/Models/API_Models/Auctions/SaleArtwork.m
+++ b/Artsy/Models/API_Models/Auctions/SaleArtwork.m
@@ -50,7 +50,7 @@ static NSNumberFormatter *currencyFormatter;
     NSDate *now = [ARSystemTime date];
 
     BOOL hasStarted = [self.auction.startDate compare:now] == NSOrderedAscending;
-    BOOL hasFinished = [self.auction.endDate compare:now] == NSOrderedAscending;
+    BOOL hasFinished = self.auction.saleState == SaleStateClosed;
     BOOL notYetStarted = [self.auction.startDate compare:now] == NSOrderedDescending;
     // registrationEndsAtDate is often nil.
     BOOL regstrationClosed = self.auction.registrationEndsAtDate && [self.auction.registrationEndsAtDate compare:now] == NSOrderedAscending;

--- a/Artsy_Tests/Model_Tests/SaleArtworkTests.m
+++ b/Artsy_Tests/Model_Tests/SaleArtworkTests.m
@@ -87,15 +87,30 @@ describe(@"artwork for sale", ^{
         });
     });
 
-    describe(@"with an auction that has ended", ^{
+    describe(@"with an auction that has closed", ^{
         beforeEach(^{
-            _saleArtwork.auction = [Sale saleWithStart:[NSDate distantPast] end:[NSDate distantPast]];
+            _saleArtwork.auction = [Sale modelWithJSON:@{ @"auction_state" : @"closed"}];
         });
 
         it(@"sets auction ended state", ^{
             expect([_saleArtwork auctionState]).to.equal(ARAuctionStateEnded);
         });
     });
+
+    describe(@"with an auction that has closed with no set end date", ^{
+        beforeEach(^{
+            _saleArtwork.auction = [Sale modelWithJSON:@{
+               @"auction_state" : @"closed",
+               @"startDate" : [NSDate distantPast],
+               @"endDate" : [NSNull null]
+           }];
+        });
+
+        it(@"sets auction ended state", ^{
+            expect([_saleArtwork auctionState]).to.equal(ARAuctionStateEnded);
+        });
+    });
+
 
     describe(@"with a bid", ^{
         beforeEach(^{

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -12,6 +12,7 @@ upcoming:
       - Parallelizes auctions network calls - ash
       - Fix issue with push notification when not coming from account creation - maxim
       - Fix anonymous user ID not being included in Adjust install events - alloy
+      - Makes logic for an auction being closed the same as force - orta
     user_facing:
       - Adds support for lot_label in auctions - ash
       - Fixes a crash in opening sales with no end date - ash


### PR DESCRIPTION
The definition is now based on gravity's sale data - fixes https://github.com/artsy/eigen/issues/2311

As all of the production examples from yesterday I could use are now "fixed" from a data perspective, I couldn't test this against a direct reproduction.  