### PR TITLE
[Debug] Add flag to indicate martsy views

### DIFF
--- a/Artsy/App/AROptions.h
+++ b/Artsy/App/AROptions.h
@@ -7,6 +7,7 @@ extern NSString *const AROptionsUseVCR;
 extern NSString *const AROptionsSettingsMenu;
 extern NSString *const AROptionsTappingPartnerSendsToPartner;
 extern NSString *const AROptionsShowAnalyticsOnScreen;
+extern NSString *const AROptionsShowMartsyOnScreen;
 extern NSString *const AROptionsDisableNativeLiveAuctions;
 extern NSString *const AROptionsStagingReactEnv;
 extern NSString *const AROptionsDevReactEnv;

--- a/Artsy/App/AROptions.m
+++ b/Artsy/App/AROptions.m
@@ -5,6 +5,7 @@ NSString *const AROptionsUseVCR = @"Use offline recording";
 NSString *const AROptionsSettingsMenu = @"Enable user settings";
 NSString *const AROptionsTappingPartnerSendsToPartner = @"Partner name in feed goes to partner";
 NSString *const AROptionsShowAnalyticsOnScreen = @"AROptionsShowAnalyticsOnScreen";
+NSString *const AROptionsShowMartsyOnScreen = @"AROptionsShowMartsyOnScreen";
 NSString *const AROptionsDisableNativeLiveAuctions = @"Disable native live auctions";
 NSString *const AROptionsStagingReactEnv = @"Use Staging React ENV";
 NSString *const AROptionsDevReactEnv = @"Use Dev React ENV";

--- a/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
+++ b/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
@@ -62,6 +62,7 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
         [self generateQuicksilver],
         [self generateShowAllLiveAuctions],
         [self generateOnScreenAnalytics],
+        [self generateOnScreenMartsy],
         [self generateEchoContents],
     ]];
 
@@ -241,6 +242,25 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
         exit(YES);
     }];
     return crashCellData;
+}
+
+- (ARCellData *)generateOnScreenMartsy
+{
+    ARCellData *martsyCellData = [[ARCellData alloc] initWithIdentifier:AROptionCell];
+    [martsyCellData setCellConfigurationBlock:^(UITableViewCell *cell) {
+        if ([AROptions boolForOption:AROptionsShowMartsyOnScreen]) {
+            cell.textLabel.text = @"Hide Red Dot for Martsy Views";
+        } else {
+            cell.textLabel.text = @"Show Red Dot for Martsy Views";
+        }
+    }];
+    
+    [martsyCellData setCellSelectionBlock:^(UITableView *tableView, NSIndexPath *indexPath) {
+        BOOL current = [AROptions boolForOption:AROptionsShowMartsyOnScreen];
+        [AROptions setBool:!current forOption:AROptionsShowMartsyOnScreen];
+        exit(YES);
+    }];
+    return martsyCellData;
 }
 
 - (ARCellData *)generateEchoContents

--- a/Artsy/View_Controllers/Web_Browsing/ARInternalMobileWebViewController.m
+++ b/Artsy/View_Controllers/Web_Browsing/ARInternalMobileWebViewController.m
@@ -8,6 +8,7 @@
 #import "ARSwitchBoard+Eigen.h"
 #import "ARTopMenuViewController.h"
 #import "UIViewController+TopMenuViewController.h"
+#import "AROptions.h"
 
 static void *ARProgressContext = &ARProgressContext;
 
@@ -74,9 +75,21 @@ static void *ARProgressContext = &ARProgressContext;
 {
     [super viewDidLoad];
     [self showLoading];
-
+    
     // KVO on progress for when we can show the page
     [self.webView addObserver:self forKeyPath:@"estimatedProgress" options:NSKeyValueObservingOptionNew & NSKeyValueObservingOptionOld context:ARProgressContext];
+    
+    if ([AROptions boolForOption:AROptionsShowMartsyOnScreen]) {
+        [self displayDebugMartsyIndicator];
+    }
+}
+
+- (void)displayDebugMartsyIndicator {
+    UIView *view = [[UIView alloc] initWithFrame:CGRectMake(self.view.frame.size.width - 25, 30, 10, 10)]; // nice and oldschool
+    view.layer.cornerRadius = 5;
+    view.layer.masksToBounds = YES;
+    view.backgroundColor = [UIColor redColor];
+    [self.view insertSubview:view aboveSubview:self.webView];
 }
 
 - (void)viewWillAppear:(BOOL)animated


### PR DESCRIPTION
A bit gutted I didn't manage to get this in for the beta!

Was chatting with @orta about internal martsy views the other day (wrt analytics), so I added a debug option to indicate them with a little red dot :).

![simulator screen shot 3 may 2017 16 15 30](https://cloud.githubusercontent.com/assets/373860/25664930/66d38ab0-301c-11e7-8183-96d5c15aeaf8.png)

![simulator screen shot 3 may 2017 16 18 37](https://cloud.githubusercontent.com/assets/373860/25664933/69e0ef86-301c-11e7-9c9c-8682206764aa.png)

