### PR TITLE
Analytics Screen IDs

### DIFF
--- a/Artsy/App/ARAppDelegate+Analytics.m
+++ b/Artsy/App/ARAppDelegate+Analytics.m
@@ -55,7 +55,7 @@
 #import "ARSearchViewController.h"
 #import "ARNavigationController.h"
 #import "ARArtworkInfoViewController.h"
-#import <Emission/ARWorksForYouModule.h>
+#import <Emission/ARWorksForYouComponentViewController.h>
 #import <Emission/ARArtistComponentViewController.h>
 #import <Emission/ARHomeComponentViewController.h>
 #import <Emission/ARGeneComponentViewController.h>
@@ -1173,7 +1173,7 @@
                             ]
                 },
                 @{
-                    ARAnalyticsClass: ARWorksForYouModule.class,
+                    ARAnalyticsClass: ARWorksForYouComponentViewController.class,
                     ARAnalyticsDetails: @[
                             @{
                                 ARAnalyticsPageName: @"Works by artists you follow",

--- a/Artsy/App/ARAppDelegate+Analytics.m
+++ b/Artsy/App/ARAppDelegate+Analytics.m
@@ -1141,7 +1141,6 @@
                     ARAnalyticsDetails: @[
                         @{
                             ARAnalyticsPageName: @"Search",
-                            ARAnalyticsSelectorName: @"viewDidAppear:",
                         }
                     ]
                 },
@@ -1150,7 +1149,6 @@
                     ARAnalyticsDetails: @[
                             @{
                                 ARAnalyticsPageName: @"Home",
-                                ARAnalyticsSelectorName: @"viewDidAppear:",
                                 }
                             ]
                 },
@@ -1159,7 +1157,6 @@
                     ARAnalyticsDetails: @[
                             @{
                                 ARAnalyticsPageName: @"Explore",
-                                ARAnalyticsSelectorName: @"viewDidAppear:",
                                 }
                             ]
                 },
@@ -1168,7 +1165,6 @@
                     ARAnalyticsDetails: @[
                             @{
                                 ARAnalyticsPageName: @"You",
-                                ARAnalyticsSelectorName: @"viewDidAppear:",
                                 }
                             ]
                 },
@@ -1177,7 +1173,6 @@
                     ARAnalyticsDetails: @[
                             @{
                                 ARAnalyticsPageName: @"Works by artists you follow",
-                                ARAnalyticsSelectorName: @"viewDidAppear:",
                                 }
                             ]
                 },
@@ -1211,12 +1206,11 @@
                             ARAnalyticsPageName: @"Artwork More Info",
                             ARAnalyticsSelectorName: @"viewDidAppear:",
                             ARAnalyticsProperties: ^NSDictionary *(ARArtworkInfoViewController *controller, NSArray *_) {
-                                NSDictionary *basics =  @{
+                                return @{
                                     @"owner_type": @"artwork",
                                     @"owner_id": controller.artwork.artworkUUID ?: @"",
                                     @"owner_slug": controller.artwork.artworkID ?: @""
                                 };
-                                return basics;
                             }
                         }
                     ]
@@ -1228,12 +1222,11 @@
                             ARAnalyticsPageName: @"Contact gallery",
                             ARAnalyticsSelectorName: @"viewDidAppear:",
                             ARAnalyticsProperties: ^NSDictionary *(ARInquireForArtworkViewController *controller, NSArray *_) {
-                                NSDictionary *basics =  @{
+                                return @{
                                     @"owner_type": @"artwork",
                                     @"owner_id": controller.artwork.artworkUUID ?: @"",
                                     @"owner_slug": controller.artwork.artworkID ?: @""
                                 };
-                                return basics;
                             }
                         }
                     ]
@@ -1244,11 +1237,10 @@
                         @{
                             ARAnalyticsPageName: @"Artist",
                             ARAnalyticsProperties: ^NSDictionary *(ARArtistComponentViewController *controller, NSArray *_) {
-                                NSString *artistID = controller.artistID ?: @"";
                                 return @{
                                          @"owner_type": @"artist",
                                          @"owner_id": @"",
-                                         @"owner_slug": artistID
+                                         @"owner_slug": controller.artistID ?: @""
                                          };
                             }
                         }
@@ -1284,7 +1276,8 @@
                             ARAnalyticsProperties: ^NSDictionary *(ARGeneComponentViewController *controller, NSArray *_) {
                                 return @{ @"owner-type": @"gene",
                                           @"owner-id": @"",
-                                          @"owner-slug": controller.geneID ?: @"" };
+                                          @"owner-slug": controller.geneID ?: @""
+                                          };
                             }
                         }
                     ]

--- a/Artsy/App/ARAppDelegate+Analytics.m
+++ b/Artsy/App/ARAppDelegate+Analytics.m
@@ -54,7 +54,11 @@
 #import "ARBrowseViewController.h"
 #import "ARSearchViewController.h"
 #import "ARNavigationController.h"
+#import "ARArtworkInfoViewController.h"
+#import <Emission/ARWorksForYouModule.h>
 #import <Emission/ARArtistComponentViewController.h>
+#import <Emission/ARHomeComponentViewController.h>
+#import <Emission/ARGeneComponentViewController.h>
 
 // Views
 #import "ARHeartButton.h"
@@ -440,54 +444,6 @@
                         },
                     ]
                 },
-//                    @{
-//                    ARAnalyticsClass: ARLoginViewController.class,
-//                    ARAnalyticsDetails: @[
-//                        @{
-//                            ARAnalyticsEventName: ARAnalyticsSignInEmail,
-//                            ARAnalyticsSelectorName: NSStringFromSelector(@selector(loggedInWithType:user:)),
-//                            ARAnalyticsShouldFire: ^BOOL(ARLoginViewController *controller, NSArray *parameters){
-//                                NSNumber *typeNumber = parameters.firstObject;
-//                                ARLoginViewControllerLoginType type = typeNumber.integerValue;
-//                                return type == ARLoginViewControllerLoginTypeEmail;
-//                            },
-//                        },
-//                        @{
-//                            ARAnalyticsEventName: ARAnalyticsSignInTwitter,
-//                            ARAnalyticsSelectorName: NSStringFromSelector(@selector(loggedInWithType:user:)),
-//                            ARAnalyticsShouldFire: ^BOOL(ARLoginViewController *controller, NSArray *parameters){
-//                                NSNumber *typeNumber = parameters.firstObject;
-//                                ARLoginViewControllerLoginType type = typeNumber.integerValue;
-//                                return type == ARLoginViewControllerLoginTypeTwitter;
-//                            },
-//                        },
-//                        @{
-//                            ARAnalyticsEventName: ARAnalyticsSignInFacebook,
-//                            ARAnalyticsSelectorName: NSStringFromSelector(@selector(loggedInWithType:user:)),
-//                            ARAnalyticsShouldFire: ^BOOL(ARLoginViewController *controller, NSArray *parameters){
-//                                NSNumber *typeNumber = parameters.firstObject;
-//                                ARLoginViewControllerLoginType type = typeNumber.integerValue;
-//                                return type == ARLoginViewControllerLoginTypeFacebook;
-//                            },
-//                        },
-//                        @{
-//                            ARAnalyticsEventName: ARAnalyticsSignInError,
-//                            ARAnalyticsSelectorName: NSStringFromSelector(@selector(failedToLoginToTwitter)),
-//                        },
-//                        @{
-//                            ARAnalyticsEventName: ARAnalyticsSignInError,
-//                            ARAnalyticsSelectorName: NSStringFromSelector(@selector(authenticationFailure)),
-//                        },
-//                        @{
-//                            ARAnalyticsEventName: ARAnalyticsSignInError,
-//                            ARAnalyticsSelectorName: NSStringFromSelector(@selector(networkFailure:)),
-//                        },
-//                        @{
-//                            ARAnalyticsEventName: ARAnalyticsSignInError,
-//                            ARAnalyticsSelectorName: NSStringFromSelector(@selector(failedToLoginToFacebook)),
-//                        }
-//                    ]
-//                },
                 @{
                     ARAnalyticsClass: ARFairMapAnnotationCallOutView.class,
                     ARAnalyticsDetails: @[
@@ -1096,8 +1052,9 @@
                         }
                     ]
                 },
-            ],
+            ], // ========== SCREENS ==========
             ARAnalyticsTrackedScreens: @[
+                // ========== ONBOARDING ==========
                 @{
                     ARAnalyticsClass: ARSignUpSplashViewController.class,
                     ARAnalyticsDetails: @[ @{ ARAnalyticsPageName: @"Onboarding start" } ]
@@ -1178,76 +1135,53 @@
                             }
                         }
                     ]
-                },
+                }, // ========== PRIMARY NAVIGATION ==========
                 @{
-                    ARAnalyticsClass: ARNavigationController.class,
+                    ARAnalyticsClass: ARAppSearchViewController.class,
                     ARAnalyticsDetails: @[
                         @{
                             ARAnalyticsPageName: @"Search",
-                            ARAnalyticsSelectorName: @"search:",
+                            ARAnalyticsSelectorName: @"viewDidAppear:",
                         }
                     ]
                 },
                 @{
-                    ARAnalyticsClass: ARTabContentView.class,
+                    ARAnalyticsClass: ARHomeComponentViewController.class,
                     ARAnalyticsDetails: @[
-                        @{
-                            ARAnalyticsPageName: @"Home",
-                            ARAnalyticsSelectorName: @"forceSetCurrentViewIndex:animated:",
-                            ARAnalyticsShouldFire: ^BOOL(ARTabContentView *view, NSArray *parameters) {
-                                return [parameters.firstObject integerValue] == ARTopTabControllerIndexFeed;
-                            }
-                        },@{
-                            ARAnalyticsPageName: @"Explore",
-                            ARAnalyticsSelectorName: @"forceSetCurrentViewIndex:animated:",
-                            ARAnalyticsShouldFire: ^BOOL(ARTabContentView *view, NSArray *parameters) {
-                                return [parameters.firstObject integerValue] == ARTopTabControllerIndexBrowse;
-                            }
-                        },@{
-                            ARAnalyticsPageName: @"You",
-                            ARAnalyticsSelectorName: @"forceSetCurrentViewIndex:animated:",
-                            ARAnalyticsShouldFire: ^BOOL(ARTabContentView *view, NSArray *parameters) {
-                                return [parameters.firstObject integerValue] == ARTopTabControllerIndexFavorites;
-                            },
-                            ARAnalyticsProperties: ^NSDictionary *(ARTabContentView *view, NSArray *parameters) {
-                                // Always starts on artworks tab
-                                return @{ @"tab": @"Artworks" };
-                            }
-                        },@{
-                            ARAnalyticsPageName: @"Notifications",
-                            ARAnalyticsSelectorName: @"forceSetCurrentViewIndex:animated:",
-                            ARAnalyticsShouldFire: ^BOOL(ARTabContentView *view, NSArray *parameters) {
-                                return [parameters.firstObject integerValue] == ARTopTabControllerIndexNotifications;
-                            },
-                        },@{
-                            ARAnalyticsPageName: @"Notifications Tab Tapped",
-                            ARAnalyticsSelectorName: ARAnalyticsSelector(buttonTapped:),
-                            ARAnalyticsShouldFire: ^BOOL(ARTabContentView *view, NSArray *parameters) {
-                                return [parameters.firstObject tag] == ARNavButtonNotificationsTag;
-                            }
-                        }
-                    ]
+                            @{
+                                ARAnalyticsPageName: @"Home",
+                                ARAnalyticsSelectorName: @"viewDidAppear:",
+                                }
+                            ]
+                },
+                @{
+                    ARAnalyticsClass: ARBrowseViewController.class,
+                    ARAnalyticsDetails: @[
+                            @{
+                                ARAnalyticsPageName: @"Explore",
+                                ARAnalyticsSelectorName: @"viewDidAppear:",
+                                }
+                            ]
                 },
                 @{
                     ARAnalyticsClass: ARFavoritesViewController.class,
-                    ARAnalyticsDetails: @[@{
-                          ARAnalyticsPageName: @"You",
-                        ARAnalyticsSelectorName: ARAnalyticsSelector(switchView:didPressButtonAtIndex:animated:),
-                        ARAnalyticsProperties: ^NSDictionary *(ARFavoritesViewController *controller, NSArray *parameters) {
-                            NSInteger buttonIndex = [parameters[1] integerValue];
-
-                            NSString *tab = @"";
-                            if (buttonIndex == ARSwitchViewFavoriteArtworksIndex) {
-                                tab = @"Artworks";
-                            } else if (buttonIndex == ARSwitchViewFavoriteArtistsIndex) {
-                                tab = @"Artists";
-                            } else if (buttonIndex == ARSwitchViewFavoriteCategoriesIndex) {
-                                tab = @"Categories";
-                            }
-                            return @{ @"tab": tab};
-                        }
-                    }]
+                    ARAnalyticsDetails: @[
+                            @{
+                                ARAnalyticsPageName: @"You",
+                                ARAnalyticsSelectorName: @"viewDidAppear:",
+                                }
+                            ]
                 },
+                @{
+                    ARAnalyticsClass: ARWorksForYouModule.class,
+                    ARAnalyticsDetails: @[
+                            @{
+                                ARAnalyticsPageName: @"Works by artists you follow",
+                                ARAnalyticsSelectorName: @"viewDidAppear:",
+                                }
+                            ]
+                },
+                // ========== CORE CONTENT SCREENS ==========
                 @{
                     ARAnalyticsClass: ARArtworkView.class,
                     ARAnalyticsDetails: @[
@@ -1256,10 +1190,9 @@
                             ARAnalyticsSelectorName: @"artworkUpdated",
                             ARAnalyticsProperties: ^NSDictionary *(ARArtworkView *view, NSArray *_) {
                                 NSDictionary *basics =  @{
-                                    @"slug": view.artwork.artworkID ?: @"",
-                                    @"artist_slug": view.artwork.artist.artistID ?: @"",
-                                    @"partner": view.artwork.partner.partnerID ?: @"",
-                                    @"price": view.artwork.price ?: @""
+                                    @"owner_type": @"artwork",
+                                    @"owner_id": view.artwork.artworkUUID ?: @"",
+                                    @"owner_slug": view.artwork.artworkID ?: @""
                                 };
 
                                 if (view.artwork.fair.fairID) {
@@ -1272,45 +1205,51 @@
                     ]
                 },
                 @{
-                    ARAnalyticsClass: ARFairArtistViewController.class,
+                    ARAnalyticsClass: ARArtworkInfoViewController.class,
                     ARAnalyticsDetails: @[
                         @{
-                            ARAnalyticsPageName: @"Fair artist",
-                            ARAnalyticsSelectorName: @"artistDidLoad",
-                            ARAnalyticsProperties: ^NSDictionary *(ARFairArtistViewController *controller, NSArray *_) {
-                                // Fair artists only show all
-                                NSString *fairID = controller.fair.fairID ?: @"";
-                                NSString *artistID = controller.artist.artistID ?: @"";
-                                return @{ @"fair_slug": fairID, @"artist_slug": artistID};
+                            ARAnalyticsPageName: @"Artwork More Info",
+                            ARAnalyticsSelectorName: @"viewDidAppear:",
+                            ARAnalyticsProperties: ^NSDictionary *(ARArtworkInfoViewController *controller, NSArray *_) {
+                                NSDictionary *basics =  @{
+                                    @"owner_type": @"artwork",
+                                    @"owner_id": controller.artwork.artworkUUID ?: @"",
+                                    @"owner_slug": controller.artwork.artworkID ?: @""
+                                };
+                                return basics;
                             }
                         }
                     ]
                 },
                 @{
-                    ARAnalyticsClass: ARArtistViewController.class,
+                    ARAnalyticsClass: ARInquireForArtworkViewController.class,
+                    ARAnalyticsDetails: @[
+                        @{
+                            ARAnalyticsPageName: @"Contact gallery",
+                            ARAnalyticsSelectorName: @"viewDidAppear:",
+                            ARAnalyticsProperties: ^NSDictionary *(ARInquireForArtworkViewController *controller, NSArray *_) {
+                                NSDictionary *basics =  @{
+                                    @"owner_type": @"artwork",
+                                    @"owner_id": controller.artwork.artworkUUID ?: @"",
+                                    @"owner_slug": controller.artwork.artworkID ?: @""
+                                };
+                                return basics;
+                            }
+                        }
+                    ]
+                },
+                @{
+                    ARAnalyticsClass: ARArtistComponentViewController.class,
                     ARAnalyticsDetails: @[
                         @{
                             ARAnalyticsPageName: @"Artist",
-                            ARAnalyticsProperties: ^NSDictionary *(ARFairArtistViewController *controller, NSArray *_) {
-                                // Displays all by default
-                                NSString *artistID = controller.artist.artistID ?: @"";
-                                return @{ @"tab": @"All", @"artist_slug": artistID };
-                            }
-                        },
-                        @{
-                            ARAnalyticsPageName: @"Artist",
-                            ARAnalyticsSelectorName: ARAnalyticsSelector(switchView:didPressButtonAtIndex:animated:),
-                            ARAnalyticsProperties: ^NSDictionary *(ARFairArtistViewController *controller, NSArray *parameters) {
-                                NSInteger index = [parameters[1] integerValue];
-                                NSString *artistID = controller.artist.artistID ?: @"";
-
-                                NSString *tab = @"";
-                                if (index == ARSwitchViewArtistButtonIndex) {
-                                    tab = @"All";
-                                } else if (index == ARSwitchViewForSaleButtonIndex) {
-                                    tab = @"For Sale";
-                                }
-                                return @{ @"tab": tab, @"artist_slug":artistID };
+                            ARAnalyticsProperties: ^NSDictionary *(ARArtistComponentViewController *controller, NSArray *_) {
+                                NSString *artistID = controller.artistID ?: @"";
+                                return @{
+                                         @"owner_type": @"artist",
+                                         @"owner_id": @"",
+                                         @"owner_slug": artistID
+                                         };
                             }
                         }
                     ]
@@ -1322,8 +1261,10 @@
                             ARAnalyticsPageName: @"Show",
                             ARAnalyticsSelectorName: @"showDidLoad",
                             ARAnalyticsProperties:^NSDictionary *(ARShowViewController *controller, NSArray *_) {
-                                NSDictionary *basics =  @{ @"slug": controller.show.showID,
-                                    @"partner_slug": controller.show.partner.partnerID ?: @""
+                                NSDictionary *basics =  @{
+                                                          @"owner_type": @"partner_show",
+                                                          @"owner_id": controller.show.showUUID,
+                                                          @"owner_slug": controller.show.showID
                                 };
 
                                 if (controller.show.fair.fairID) {
@@ -1336,14 +1277,45 @@
                     ]
                 },
                 @{
+                    ARAnalyticsClass: ARGeneComponentViewController.class,
+                    ARAnalyticsDetails: @[
+                        @{
+                            ARAnalyticsPageName: @"Category",
+                            ARAnalyticsProperties: ^NSDictionary *(ARGeneComponentViewController *controller, NSArray *_) {
+                                return @{ @"owner-type": @"gene",
+                                          @"owner-id": @"",
+                                          @"owner-slug": controller.geneID ?: @"" };
+                            }
+                        }
+                    ]
+                },
+                // ========== FAIRS ==========
+                @{
+                    ARAnalyticsClass: ARFairArtistViewController.class,
+                    ARAnalyticsDetails: @[
+                        @{
+                            ARAnalyticsPageName: @"Fair artist",
+                            ARAnalyticsSelectorName: @"artistDidLoad",
+                            ARAnalyticsProperties: ^NSDictionary *(ARFairArtistViewController *controller, NSArray *_) {
+                                return @{ @"owner_type": @"fair",
+                                          @"owner_id" : controller.fair.fairUUID,
+                                          @"owner_slug": controller.fair.fairID ?: @"",
+                                    };
+                            }
+                        }
+                    ]
+                },
+                @{
                     ARAnalyticsClass: ARFairViewController.class,
                     ARAnalyticsDetails: @[
                         @{
                             ARAnalyticsPageName: @"Fair",
                             ARAnalyticsSelectorName: @"fairDidLoad",
                             ARAnalyticsProperties: ^NSDictionary *(ARFairViewController *controller, NSArray *_) {
-                                return @{ @"slug": controller.fair.fairID ?: @"",
-                                    @"screen_type": @"Overview" };
+                                return @{ @"owner_type": @"fair",
+                                          @"owner_id" : controller.fair.fairUUID,
+                                          @"owner_slug": controller.fair.fairID ?: @"",
+                                    };
                             }
                         }
                     ]
@@ -1352,22 +1324,12 @@
                     ARAnalyticsClass: ARFairSearchViewController.class,
                     ARAnalyticsDetails: @[
                         @{
-                            ARAnalyticsPageName: @"Fair",
+                            ARAnalyticsPageName: @"Fair Search",
                             ARAnalyticsProperties: ^NSDictionary *(ARFairSearchViewController *controller, NSArray *_) {
-                                return @{ @"slug": controller.fair.fairID ?: @"",
-                                    @"screen_type": @"Search" };
-                            }
-                        }
-                    ]
-                },
-                @{
-                    ARAnalyticsClass: ARFairMapViewController.class,
-                    ARAnalyticsDetails: @[
-                        @{
-                            ARAnalyticsPageName: @"Fair",
-                            ARAnalyticsProperties: ^NSDictionary *(ARFairMapViewController *controller, NSArray *_) {
-                                return @{ @"slug": controller.fair.fairID ?: @"",
-                                    @"screen_type": @"Map" };
+                                return @{ @"owner_type": @"fair",
+                                          @"owner_id" : controller.fair.fairUUID,
+                                          @"owner_slug": controller.fair.fairID ?: @"",
+                                    };
                             }
                         }
                     ]
@@ -1376,36 +1338,18 @@
                     ARAnalyticsClass: ARFairGuideViewController.class,
                     ARAnalyticsDetails: @[
                         @{
-                            ARAnalyticsPageName: @"Fair",
-                            ARAnalyticsSelectorName: @"setFairLoaded",
-                            ARAnalyticsShouldFire: ^BOOL(ARFairGuideViewController *controller, BOOL newValue) {
-                                return newValue == YES;
-                            },
+                            ARAnalyticsPageName: @"Fair Personalized Guide",
+                            ARAnalyticsSelectorName: @"viewDidAppear:",
                             ARAnalyticsProperties: ^NSDictionary *(ARFairGuideViewController *controller, NSArray *_) {
-                                return @{ @"slug": controller.fair.fairID ?: @"",
-                                    @"screen_type": @"Personalized Guide" };
-                            }
-                        },
-                        @{
-                            ARAnalyticsPageName: @"Fair personalized guide",
-                            ARAnalyticsSelectorName: ARAnalyticsSelector(setSelectedTabIndex:),
-                            ARAnalyticsProperties: ^NSDictionary *(ARFairGuideViewController *controller, NSArray *parameters) {
-                                NSInteger index = [parameters.firstObject integerValue];
-                                NSString *tab = @"";
-
-                                if (index == ARFairGuideSelectedTabWork) {
-                                    tab = @"Work";
-                                } else if (index == ARFairGuideSelectedTabArtists) {
-                                    tab = @"Artists";
-                                } else if (index == ARFairGuideSelectedTabExhibitors) {
-                                    tab = @"Exhibitors";
-                                }
-
-                                return @{ @"tab": tab, @"slug": controller.fair.fairID ?: @"" };
+                                    return @{ @"owner_type": @"fair",
+                                          @"owner_id" : controller.fair.fairUUID,
+                                          @"owner_slug": controller.fair.fairID ?: @"",
+                                    };
                             }
                         }
                     ]
                 },
+                // ========== OTHER ==========
                 @{
                     ARAnalyticsClass: ARArtistBiographyViewController.class,
                     ARAnalyticsDetails: @[
@@ -1413,28 +1357,6 @@
                             ARAnalyticsPageName: @"Artist Biography",
                             ARAnalyticsProperties: ^NSDictionary *(ARArtistBiographyViewController *controller, NSArray *_) {
                                 return @{ @"artist_slug": controller.artist.artistID ?: @"" };
-                            }
-                        }
-                    ]
-                },
-                @{
-                    ARAnalyticsClass: ARGeneViewController.class,
-                    ARAnalyticsDetails: @[
-                        @{
-                            ARAnalyticsPageName: @"Category",
-                            ARAnalyticsProperties: ^NSDictionary *(ARGeneViewController *controller, NSArray *_) {
-                                return @{ @"slug": controller.gene.geneID ?: @"" };
-                            }
-                        }
-                    ]
-                },
-                @{
-                    ARAnalyticsClass: ARInternalMobileWebViewController.class,
-                    ARAnalyticsDetails: @[
-                        @{
-                            ARAnalyticsPageName: @"internal_mobile_web", // convert to Mobile Web? This is backwards compat as-is
-                            ARAnalyticsProperties: ^NSDictionary *(ARInternalMobileWebViewController *controller, NSArray *_) {
-                                return @{ @"slug": controller.initialURL.path ?: @"" };
                             }
                         }
                     ]

--- a/Artsy/Models/API_Models/Fair/Fair.h
+++ b/Artsy/Models/API_Models/Fair/Fair.h
@@ -31,6 +31,7 @@
 @property (nonatomic, copy, readonly) NSString *name;
 @property (nonatomic, copy, readonly) NSString *defaultProfileID;
 @property (nonatomic, copy, readonly) NSString *fairID;
+@property (nonatomic, copy, readonly) NSString *fairUUID;
 @property (nonatomic, copy, readwrite) NSArray *maps;
 @property (nonatomic, strong, readonly) NSSet *shows;
 @property (nonatomic, copy, readonly) NSString *city;

--- a/Artsy/Models/API_Models/Fair/Fair.m
+++ b/Artsy/Models/API_Models/Fair/Fair.m
@@ -38,6 +38,7 @@
     return @{
         ar_keypath(Fair.new, name) : @"name",
         ar_keypath(Fair.new, fairID) : @"id",
+        ar_keypath(Fair.new, fairUUID) : @"_id",
         ar_keypath(Fair.new, defaultProfileID) : @"default_profile_id",
         ar_keypath(Fair.new, organizer) : @"organizer",
         ar_keypath(Fair.new, startDate) : @"start_at",

--- a/Artsy/Models/API_Models/Partner_Metadata/Artwork.h
+++ b/Artsy/Models/API_Models/Partner_Metadata/Artwork.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface Artwork : MTLModel <ARPostAttachment, MTLJSONSerializing, ARHasImageBaseURL, ARShareableObject, ARSpotlightMetadataProvider>
 
 @property (nonatomic, copy) NSString *artworkID;
+@property (nonatomic, copy) NSString *artworkUUID;
 @property (nonatomic, strong) NSNumber *depth;
 @property (nonatomic, strong) NSNumber *diameter;
 @property (nonatomic, strong) NSNumber *height;

--- a/Artsy/Models/API_Models/Partner_Metadata/Artwork.m
+++ b/Artsy/Models/API_Models/Partner_Metadata/Artwork.m
@@ -54,6 +54,7 @@
 {
     return @{
         ar_keypath(Artwork.new, artworkID) : @"id",
+        ar_keypath(Artwork.new, artworkUUID) : @"_id",
         ar_keypath(Artwork.new, auctionResultCount) : @"comparables_count",
         ar_keypath(Artwork.new, canShareImage) : @"can_share_image",
         ar_keypath(Artwork.new, collectingInstitution) : @"collecting_institution",

--- a/Artsy/Models/API_Models/Partner_Metadata/PartnerShow.h
+++ b/Artsy/Models/API_Models/Partner_Metadata/PartnerShow.h
@@ -14,6 +14,7 @@
 @property (nonatomic, strong, readonly) Location *location;
 
 @property (nonatomic, copy, readonly) NSString *showID;
+@property (nonatomic, copy, readonly) NSString *showUUID;
 
 @property (nonatomic, copy, readonly) NSString *name;
 @property (nonatomic, copy, readonly) NSString *officialDescription;

--- a/Artsy/Models/API_Models/Partner_Metadata/PartnerShow.m
+++ b/Artsy/Models/API_Models/Partner_Metadata/PartnerShow.m
@@ -40,6 +40,7 @@ static ARStandardDateFormatter *staticDateFormatter;
 {
     return @{
         ar_keypath(PartnerShow.new, showID) : @"id",
+        ar_keypath(PartnerShow.new, showUUID) : @"_id",
         ar_keypath(PartnerShow.new, partner) : @"partner",
         ar_keypath(PartnerShow.new, artworks) : @"artworks",
         ar_keypath(PartnerShow.new, artists) : @"artists",

--- a/Artsy/View_Controllers/Artwork/ARArtworkInfoViewController.h
+++ b/Artsy/View_Controllers/Artwork/ARArtworkInfoViewController.h
@@ -4,6 +4,8 @@
 
 @interface ARArtworkInfoViewController : UIViewController
 
+@property (nonatomic, strong) Artwork *artwork;
+
 - (instancetype)initWithArtwork:(Artwork *)artwork;
 
 @end

--- a/Artsy/View_Controllers/Artwork/ARArtworkInfoViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkInfoViewController.m
@@ -11,7 +11,6 @@
 
 
 @interface ARArtworkInfoViewController () <ARTextViewDelegate>
-@property (nonatomic, strong) Artwork *artwork;
 @property (nonatomic, strong) ORStackScrollView *view;
 @end
 

--- a/Artsy_Tests/View_Controller_Tests/Fair/ARFairSearchViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/ARFairSearchViewControllerTests.m
@@ -104,6 +104,7 @@ describe(@"init", ^{
           @{
               @"model" : @"artist",
               @"id" : @"leila-pazooki",
+              @"_id" : @"5074b70927ef8d0002000141",
               @"display": @"Leila Pazooki",
               @"label": @"Artist",
               @"published": @YES,

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -15,6 +15,7 @@ upcoming:
       - Fix anonymous user ID not being included in Adjust install events - alloy
       - Remove references to martsy, only serve from Force - alloy
       - Makes logic for an auction being closed the same as force - orta
+      - Update screen analytics - maxim
     user_facing:
       - Adds support for lot_label in auctions - ash
       - Fixes a crash in opening sales with no end date - ash


### PR DESCRIPTION
Fix #2261 , as per [schema doc](https://docs.google.com/spreadsheets/d/1P6qUe7yFPzly5JYicAa6eQ3BAy9s7Bx1_6k-Q5hB-Pw/edit#gid=0) from @anipetrov 

Ani - I've annotated in the sheet what's gone in. I'm missing gravity IDs for Artists and Genes (I need to see how to expose them from Emission). Refine view is another one. I've also noted all the martsy views, and hence those are not implemented here.

@ashfurrow thought it'd be nice to request your feedback :) let me know if you have Qs about the scope of the work!

@alloy I'm not sure if you think this should go into this release or hold off. I also need to work out a way to expose a `viewDidAppear` for refine from Emission (and preferably gravity ids also). I assume I can send something in `componentDidMount`?