### PR TITLE
[Onboarding] Add fallback url with popular artists

### DIFF
--- a/Artsy/Networking/API_Modules/ArtsyAPI+RelatedModels.h
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+RelatedModels.h
@@ -10,6 +10,7 @@
 + (AFHTTPRequestOperation *)getRelatedGenesForGene:(Gene *)gene excluding:(NSArray *)genesToExclude success:(void (^)(NSArray *genes))success failure:(void (^)(NSError *error))failure;
 + (AFHTTPRequestOperation *)getRelatedGeneForGene:(Gene *)gene excluding:(NSArray *)genesToExclude success:(void (^)(NSArray *relatedGene))success failure:(void (^)(NSError *error))failure;
 + (AFHTTPRequestOperation *)getPopularArtistsWithSuccess:(void (^)(NSArray *artists))success failure:(void (^)(NSError *error))failure;
++ (AFHTTPRequestOperation *)getPopularArtistsFallbackWithSuccess:(void (^)(NSArray *artists))success failure:(void (^)(NSError *error))failure;
 + (AFHTTPRequestOperation *)getPopularGenesWithSuccess:(void (^)(NSArray *genes))success failure:(void (^)(NSError *error))failure;
 + (AFHTTPRequestOperation *)getRelatedArtworksForArtwork:(Artwork *)artwork success:(void (^)(NSArray *artworks))success failure:(void (^)(NSError *error))failure;
 + (AFHTTPRequestOperation *)getRelatedArtworksForArtwork:(Artwork *)artwork inFair:(Fair *)fair success:(void (^)(NSArray *artworks))success failure:(void (^)(NSError *error))failure;

--- a/Artsy/Networking/API_Modules/ArtsyAPI+RelatedModels.m
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+RelatedModels.m
@@ -52,6 +52,13 @@
     return [self getRequest:request parseIntoAnArrayOfClass:[Artist class] withKey:nil success:success failure:failure];
 }
 
++ (AFHTTPRequestOperation *)getPopularArtistsFallbackWithSuccess:(void (^)(NSArray *artists))success
+                                                 failure:(void (^)(NSError *error))failure
+{
+    NSURLRequest *request = [ARRouter newArtistsPopularRequestFallback];
+    return [self getRequest:request parseIntoAnArrayOfClass:[Artist class] withKey:nil success:success failure:failure];
+}
+
 + (AFHTTPRequestOperation *)getPopularGenesWithSuccess:(void (^)(NSArray *genes))success
                                                failure:(void (^)(NSError *error))failure
 {

--- a/Artsy/Networking/ARRouter.h
+++ b/Artsy/Networking/ARRouter.h
@@ -100,6 +100,7 @@
 + (NSURLRequest *)newGeneRelatedToGeneRequest:(Gene *)gene excluding:(NSArray *)genesToExclude;
 + (NSURLRequest *)newGenesRelatedToGeneRequest:(Gene *)gene excluding:(NSArray *)genesToExclude;
 + (NSURLRequest *)newArtistsPopularRequest;
++ (NSURLRequest *)newArtistsPopularRequestFallback;
 + (NSURLRequest *)newGenesPopularRequest;
 + (NSURLRequest *)newShowsRequestForArtist:(NSString *)artistID;
 + (NSURLRequest *)newShowsRequestForArtistID:(NSString *)artistID inFairID:(NSString *)fairID;

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -702,6 +702,16 @@ static NSString *hostFromString(NSString *string)
     return [self requestWithMethod:@"GET" path:ARPopularArtistsURL parameters:nil];
 }
 
++ (NSURLRequest *)newArtistsPopularRequestFallback
+{
+    // we guard against delta not being able to provide us the current popular artists
+    // by having a backup list on S3
+    
+    NSString *stringURL = @"https://s3.amazonaws.com/eigen-production/json/eigen_popularartists.json";
+    
+    return [[NSURLRequest alloc] initWithURL:[NSURL URLWithString:stringURL]];
+}
+
 + (NSURLRequest *)newGenesPopularRequest
 
 {

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/ARPersonalizeViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/ARPersonalizeViewController.m
@@ -646,22 +646,21 @@
     [self.searchResultsTable showLoadingSpinner];
 
     self.searchResultsTable.contentDisplayMode = ARTableViewContentDisplayModePlaceholder;
+    
+    void (^updateArtistsTable)(NSArray*) = ^(NSArray *artists) {
+        [self.searchResultsTable removeLoadingSpinner];
+        [self.searchResultsTable updateTableContentsFor:artists
+                                        replaceContents:ARSearchResultsReplaceAll
+                                               animated:animated];
+    };
 
     self.searchRequestOperation = [ArtsyAPI getPopularArtistsWithSuccess:^(NSArray *artists) {
         if (artists.count == 0) {
-            self.searchRequestOperation = [ArtsyAPI getPopularArtistsFallbackWithSuccess:^(NSArray *artists) {
-                [self.searchResultsTable removeLoadingSpinner];
-                [self.searchResultsTable updateTableContentsFor:artists
-                                                replaceContents:ARSearchResultsReplaceAll
-                                                       animated:animated];
-            } failure:^(NSError *error) {
+            self.searchRequestOperation = [ArtsyAPI getPopularArtistsFallbackWithSuccess:updateArtistsTable failure:^(NSError *error) {
                 [self reportError:error];
             }];
         } else {
-            [self.searchResultsTable removeLoadingSpinner];
-            [self.searchResultsTable updateTableContentsFor:artists
-                                            replaceContents:ARSearchResultsReplaceAll
-                                                   animated:animated];
+            updateArtistsTable(artists);
         }
 
     } failure:^(NSError *error) {

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/ARPersonalizeViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/ARPersonalizeViewController.m
@@ -648,10 +648,22 @@
     self.searchResultsTable.contentDisplayMode = ARTableViewContentDisplayModePlaceholder;
 
     self.searchRequestOperation = [ArtsyAPI getPopularArtistsWithSuccess:^(NSArray *artists) {
-        [self.searchResultsTable removeLoadingSpinner];
-        [self.searchResultsTable updateTableContentsFor:artists
-                                        replaceContents:ARSearchResultsReplaceAll
-                                               animated:animated];
+        if (artists.count == 0) {
+            self.searchRequestOperation = [ArtsyAPI getPopularArtistsFallbackWithSuccess:^(NSArray *artists) {
+                [self.searchResultsTable removeLoadingSpinner];
+                [self.searchResultsTable updateTableContentsFor:artists
+                                                replaceContents:ARSearchResultsReplaceAll
+                                                       animated:animated];
+            } failure:^(NSError *error) {
+                [self reportError:error];
+            }];
+        } else {
+            [self.searchResultsTable removeLoadingSpinner];
+            [self.searchResultsTable updateTableContentsFor:artists
+                                            replaceContents:ARSearchResultsReplaceAll
+                                                   animated:animated];
+        }
+
     } failure:^(NSError *error) {
         [self reportError:error];
     }];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -22,6 +22,7 @@ upcoming:
       - Add support for Universal Links to Sailthru links - alloy
       - No longer shows bidding status labels for artworks in a closed sale - ash
       - Allows users to place higher bids in advance in LAI - ash
+      - Add popular artists fallback url for onboarding - maxim
 
 releases:
   - version: 3.2.0


### PR DESCRIPTION
Fix #2324 

@alloy was hoping to get this in for release!

Very unglamorous code, I had originally wanted the `Artsy API popularArtists` to deal with it when it doesn't get any artists back, but I wasn't sure how to do it within that method and still return a request, so I just do it twice in the onboarding code :/. 

I've probably overlooked a better way of doing it, happy to amend!


