### PR TITLE
[Emission] Update to 1.3.3

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -2,6 +2,10 @@ upcoming:
     version: 3.2.1
     details: Scope not know yet
     dev:
+      - Updates TypeScript to 2.3 - orta
+      - Adds back storybooks - orta
+      - Adds initial work on a new personal profile page - orta
+      - Automates TS linting at dev time - orta
       - Updates ARTopMenuVC to allow for unretained instances of root VCs - sarah
       - Adds React Native version of WorksForYou/Notifications tab - sarah
       - Refactors LAI view controller hierarchy - ash
@@ -16,6 +20,8 @@ upcoming:
       - Remove references to martsy, only serve from Force - alloy
       - Makes logic for an auction being closed the same as force - orta
     user_facing:
+      - Ensured rails without artworks cannot be rendered - sarah
+      - Fix for strange scrolling behavior in WFU - sarah
       - Adds support for lot_label in auctions - ash
       - Fixes a crash in opening sales with no end date - ash
       - Spruced up artworks in auctio view - ash
@@ -23,6 +29,8 @@ upcoming:
       - No longer shows bidding status labels for artworks in a closed sale - ash
       - Allows users to place higher bids in advance in LAI - ash
       - Add popular artists fallback url for onboarding - maxim
+      - Fixes display of artworks in non-expanding grids in artwork rails - ash
+      - Adds inline bid info to artist grid elements - ash
 
 releases:
   - version: 3.2.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -76,7 +76,7 @@ PODS:
     - CocoaLumberjack/Default
   - DHCShakeNotifier (0.2.0)
   - EDColor (1.0.0)
-  - Emission (1.3.2):
+  - Emission (1.3.3):
     - Artsy+UIFonts (>= 3.0.0)
     - Extraction (>= 1.2.1)
     - React/Core (= 0.42.0)
@@ -84,6 +84,7 @@ PODS:
     - React/RCTNetwork (= 0.42.0)
     - React/RCTText (= 0.42.0)
     - SDWebImage (>= 3.7.2)
+    - SentryReactNative (= 0.8.3)
     - Yoga (= 0.42.0.React)
   - Expecta (1.0.5)
   - Expecta+Snapshots (3.0.0):
@@ -137,6 +138,69 @@ PODS:
   - JSDecoupledAppDelegate (1.2.0)
   - JWTDecode (2.0.0)
   - Keys (1.0.0)
+  - KSCrash (1.15.8):
+    - KSCrash/Installations (= 1.15.8)
+  - KSCrash/Installations (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting
+  - KSCrash/Recording (1.15.8):
+    - KSCrash/Recording/Tools (= 1.15.8)
+  - KSCrash/Recording/Tools (1.15.8)
+  - KSCrash/Reporting (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting/Filters (= 1.15.8)
+    - KSCrash/Reporting/MessageUI (= 1.15.8)
+    - KSCrash/Reporting/Sinks (= 1.15.8)
+    - KSCrash/Reporting/Tools (= 1.15.8)
+  - KSCrash/Reporting/Filters (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting/Filters/Alert (= 1.15.8)
+    - KSCrash/Reporting/Filters/AppleFmt (= 1.15.8)
+    - KSCrash/Reporting/Filters/Base (= 1.15.8)
+    - KSCrash/Reporting/Filters/Basic (= 1.15.8)
+    - KSCrash/Reporting/Filters/GZip (= 1.15.8)
+    - KSCrash/Reporting/Filters/JSON (= 1.15.8)
+    - KSCrash/Reporting/Filters/Sets (= 1.15.8)
+    - KSCrash/Reporting/Filters/Stringify (= 1.15.8)
+    - KSCrash/Reporting/Filters/Tools (= 1.15.8)
+  - KSCrash/Reporting/Filters/Alert (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting/Filters/Base
+  - KSCrash/Reporting/Filters/AppleFmt (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting/Filters/Base
+  - KSCrash/Reporting/Filters/Base (1.15.8):
+    - KSCrash/Recording
+  - KSCrash/Reporting/Filters/Basic (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting/Filters/Base
+  - KSCrash/Reporting/Filters/GZip (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting/Filters/Base
+  - KSCrash/Reporting/Filters/JSON (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting/Filters/Base
+  - KSCrash/Reporting/Filters/Sets (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting/Filters/AppleFmt
+    - KSCrash/Reporting/Filters/Base
+    - KSCrash/Reporting/Filters/Basic
+    - KSCrash/Reporting/Filters/GZip
+    - KSCrash/Reporting/Filters/JSON
+    - KSCrash/Reporting/Filters/Stringify
+  - KSCrash/Reporting/Filters/Stringify (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting/Filters/Base
+  - KSCrash/Reporting/Filters/Tools (1.15.8):
+    - KSCrash/Recording
+  - KSCrash/Reporting/MessageUI (1.15.8):
+    - KSCrash/Recording
+  - KSCrash/Reporting/Sinks (1.15.8):
+    - KSCrash/Recording
+    - KSCrash/Reporting/Filters
+    - KSCrash/Reporting/Tools
+  - KSCrash/Reporting/Tools (1.15.8):
+    - KSCrash/Recording
   - KSDeferred (0.2.0)
   - Mantle (1.5.6):
     - Mantle/extobjc (= 1.5.6)
@@ -162,6 +226,8 @@ PODS:
   - ORStackView (2.0.3):
     - FLKAutoLayout
   - Quick (0.10.0)
+  - React (0.42.0):
+    - React/Core (= 0.42.0)
   - React/Core (0.42.0):
     - React/cxxreact
     - Yoga (= 0.42.0.React)
@@ -186,6 +252,12 @@ PODS:
   - SDWebImage (3.7.3):
     - SDWebImage/Core (= 3.7.3)
   - SDWebImage/Core (3.7.3)
+  - Sentry (2.1.9):
+    - KSCrash (~> 1.15.5)
+  - SentryReactNative (0.8.3):
+    - React
+    - RSSwizzle (~> 0.1.0)
+    - Sentry (~> 2.1.9)
   - Specta (1.0.5)
   - SSFadingScrollView (1.1.0)
   - Starscream (2.0.4)
@@ -367,7 +439,7 @@ SPEC CHECKSUMS:
   CocoaLumberjack: 27ae9abcd376c3e4ee726ecd4adfd7b093ddef3f
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
-  Emission: 8f3738a955654eac6f4a038190d2f8993ee08436
+  Emission: 4946f2ddb0a7e3c9bb322274038336b08c9c4fe3
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   Expecta+Snapshots: c343f410c7a6392f3e22e78f94c44b6c0749a516
   Extraction: 612cf0866f74d4c0dd616677ff24146efa200958
@@ -386,6 +458,7 @@ SPEC CHECKSUMS:
   JSDecoupledAppDelegate: 5905e144cbe6e0c889248eebbee6784510f315e1
   JWTDecode: 178e47e5d28d3abcff778bacced8342858cd6cb5
   Keys: 9c35bf00f612ee1d48556f4a4b9b4551e224e90f
+  KSCrash: 4acb0f9cdb0b1ce7155c608dc175d91d750a8c3a
   KSDeferred: e72d005162986b2978e1e2eee17fbce1c6876cfe
   Mantle: a197db93e0f1e36194b1fdbc078219a8492eaef2
   MARKRangeSlider: dbf0878b03e921b52e4ef1e7766c1a8affb0c577
@@ -405,6 +478,8 @@ SPEC CHECKSUMS:
   ReactiveCocoa: e2db045570aa97c695e7aa97c2bcab222ae51f4a
   RSSwizzle: d561958f595028bfcef98c7d55c318b3878a61c6
   SDWebImage: 1d2b1a1efda1ade1b00b6f8498865f8ddedc8a84
+  Sentry: 0025c374b2f9fb0da8185a45199de985408a40b2
+  SentryReactNative: 0642e75b4a35a81627fa8e98a8fffe5523ac8a08
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
   SSFadingScrollView: a2f142312afad23585e354a41a6ed337045e1aa3
   Starscream: df5974ee928b157c8eda8af8de7c620276b7dfcc


### PR DESCRIPTION
      - Ensured rails without artworks cannot be rendered - sarah
      - Fix for strange scrolling behavior in WFU - sarah
      - Adds support for lot_label in auctions - ash
      - Fixes a crash in opening sales with no end date - ash
      - Spruced up artworks in auctio view - ash
      - Add support for Universal Links to Sailthru links - alloy
      - No longer shows bidding status labels for artworks in a closed sale - ash
      - Allows users to place higher bids in advance in LAI - ash
      - Add popular artists fallback url for onboarding - maxim
      - Fixes display of artworks in non-expanding grids in artwork rails - ash
      - Adds inline bid info to artist grid elements - ash