### PR TITLE
No longer show sale messaging banner for artwork pages for lots in closed sales.

### DIFF
--- a/Artsy/Views/Artwork/ARAuctionBannerView.m
+++ b/Artsy/Views/Artwork/ARAuctionBannerView.m
@@ -39,6 +39,10 @@
     }
     _auctionState = auctionState;
 
+    if (auctionState & ARAuctionStateEnded) {
+        return;
+    }
+
     if (auctionState & ARAuctionStateUserIsHighBidder) {
         self.backgroundColor = [UIColor artsyPurpleRegular];
         self.label.text = @"You are currently the high\nbidder for this lot.";

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -32,6 +32,7 @@ upcoming:
       - Add popular artists fallback url for onboarding - maxim
       - Fixes display of artworks in non-expanding grids in artwork rails - ash
       - Adds inline bid info to artist grid elements - ash
+      - No longer show sale messaging banner for artwork pages for lots in closed sales - ash
 
 releases:
   - version: 3.2.0


### PR DESCRIPTION
This removes the purple banner at the top of the artwork pages for artworks in sales that have closed. 

![simulator screen shot may 16 2017 11 53 39 am](https://cloud.githubusercontent.com/assets/498212/26115570/5a7a893c-3a2e-11e7-9706-8d52c977170f.png)

This is a fix for https://github.com/artsy/auctions/issues/459 .