### PR TITLE
[Bug] Fix white text on white statusbar in home

### DIFF
--- a/Artsy/View_Controllers/Util/ARNavigationController.m
+++ b/Artsy/View_Controllers/Util/ARNavigationController.m
@@ -112,7 +112,6 @@ static void *ARNavigationControllerMenuAwareScrollViewContext = &ARNavigationCon
 
     _statusBarView = [[UIView alloc] init];
     _statusBarView.backgroundColor = UIColor.blackColor;
-    [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleLightContent animated:NO];
 
     [self.view addSubview:_statusBarView];
 


### PR DESCRIPTION
Fix emission/[538](https://github.com/artsy/emission/issues/538)

cc @l2succes, #teameffort

What happens is that if there’s a notification, `ARTopMenuNavigationDatasource` ([here](https://github.com/artsy/eigen/blob/master/Artsy/View_Controllers/App_Navigation/ARTopMenuNavigationDataSource.m#L134L145)) goes through all tabs and `viewDidLoad` on `ARNavigationController` gets executed, _after_ we have done our changing of the status bar (which is [here](https://github.com/artsy/eigen/blob/master/Artsy/View_Controllers/Util/ARNavigationController.m#L325L335)).

Should be easy from here to change it to white background always btw, but didn't mess with that for now :).