### PR TITLE
[Analytics] Fix double fire in artwork pages

### DIFF
--- a/Artsy/App/ARAppDelegate+Analytics.m
+++ b/Artsy/App/ARAppDelegate+Analytics.m
@@ -1183,12 +1183,12 @@
                 },
                 // ========== CORE CONTENT SCREENS ==========
                 @{
-                    ARAnalyticsClass: ARArtworkView.class,
+                    ARAnalyticsClass: ARArtworkViewController.class,
                     ARAnalyticsDetails: @[
                         @{
                             ARAnalyticsPageName: @"Artwork",
-                            ARAnalyticsSelectorName: @"artworkUpdated",
-                            ARAnalyticsProperties: ^NSDictionary *(ARArtworkView *view, NSArray *_) {
+                            ARAnalyticsProperties: ^NSDictionary *(ARArtworkViewController *vc, NSArray *_) {
+                                ARArtworkView *view = (ARArtworkView *)vc.view;
                                 NSDictionary *basics =  @{
                                     @"owner_type": @"artwork",
                                     @"owner_id": view.artwork.artworkUUID ?: @"",

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -2,6 +2,7 @@ upcoming:
     version: 3.2.2
     details: Scope not known yet
     dev:
+      - Fix analytics double fire in artwork pages - maxim
     user_facing:
       - Adds timer for artwork view that refreshes UI when the associated live sale opens - ash
 


### PR DESCRIPTION
Fix #2265 

I understood from @katarinabatina that the only remaining issue in there was the artwork double fire, so this should complete that ticket! :)

The issue was RAC related - multiple fires of the artwork being updated, so I've just changed to the ArtworkVC's viewDidAppear event, with grabbing details from its artwork view still.

