### PR TITLE
Live Cleanup

### DIFF
--- a/Artsy/View_Controllers/Auction/AuctionViewController.swift
+++ b/Artsy/View_Controllers/Auction/AuctionViewController.swift
@@ -58,25 +58,26 @@ class AuctionViewController: UIViewController {
 
         self.ar_presentIndeterminateLoadingIndicator(animated: animated)
 
-        self.networkModel.fetch().next { [weak self] saleViewModel in
+        self.networkModel
+            .fetch()
+            .next { [weak self] saleViewModel in
 
-            if saleViewModel.shouldShowLiveInterface {
-                self?.setupLiveInterfaceAndPop()
-            } else if saleViewModel.isUpcomingAndHasNoLots {
-                self?.setupForUpcomingSale(saleViewModel)
-            } else {
-                self?.setupForSale(saleViewModel)
-            }
+                if saleViewModel.shouldShowLiveInterface {
+                    self?.setupLiveInterfaceAndPop()
+                } else if saleViewModel.isUpcomingAndHasNoLots {
+                    self?.setupForUpcomingSale(saleViewModel)
+                } else {
+                    self?.setupForSale(saleViewModel)
+                }
 
-            if let timeToLiveStart = saleViewModel.timeToLiveStart {
-                self?.setupForUpcomingLiveInterface(timeToLiveStart)
+                if let timeToLiveStart = saleViewModel.timeToLiveStart {
+                    self?.setupForUpcomingLiveInterface(timeToLiveStart)
+                }
 
-            }
-
-            saleViewModel.registerSaleAsActiveActivity(self)
+                saleViewModel.registerSaleAsActiveActivity(self)
             }.error { error in
                 // TODO: Error-handling somehow
-        }
+            }
 
         NotificationCenter.default.addObserver(self, selector: #selector(AuctionViewController.registrationUpdated(_:)), name: NSNotification.Name.ARAuctionArtworkRegistrationUpdated, object: nil)
     }
@@ -227,6 +228,7 @@ extension AuctionViewController {
     }
 
     func setupForUpcomingLiveInterface(_ timeToLiveStart: TimeInterval) {
+        guard timeToLiveStart > 0 else { return }
         self.showLiveInterfaceWhenAuctionOpensTimer = Timer.scheduledTimer(timeInterval: timeToLiveStart, target: self, selector: #selector(AuctionViewController.setupLiveInterfaceAndPop), userInfo: nil, repeats: false)
     }
 

--- a/Artsy/View_Controllers/Live_Auctions/LiveAuctionSalesPerson.swift
+++ b/Artsy/View_Controllers/Live_Auctions/LiveAuctionSalesPerson.swift
@@ -140,22 +140,22 @@ extension LiveAuctionsSalesPerson {
 
     // Returns nil if there is no current lot.
     func lotViewModelRelativeToShowingIndex(_ offset: Int) -> LiveAuctionLotViewModelType {
-        precondition(abs(offset) < lotCount)
-
         let currentlyShowingIndex = currentFocusedLotIndex.peek() ?? 0 // The coalesce is only to satisfy the compiler, should never happen since the currentFocusedLotIndex is created with an initial value.
 
         // Apply the offset
         let newIndex = currentlyShowingIndex + offset
+        var loopingIndex = newIndex
 
         // Guarantee the offset is within the bounds of our array.
-        let loopingIndex: Int
-        if newIndex >= lotCount {
-            loopingIndex = newIndex - lotCount
-        } else if newIndex < 0 {
-            loopingIndex = newIndex + lotCount
-        } else {
-            loopingIndex = newIndex
-        }
+        repeat {
+            if loopingIndex >= lotCount {
+                loopingIndex -= lotCount
+            } else if loopingIndex < 0 {
+                loopingIndex += lotCount
+            } else {
+                loopingIndex = newIndex
+            }
+        } while !lots.indices.contains(loopingIndex)
 
         return lotViewModelForIndex(loopingIndex)
     }

--- a/Artsy/Views/Auction/SaleViewModel.swift
+++ b/Artsy/Views/Auction/SaleViewModel.swift
@@ -88,10 +88,11 @@ extension SaleViewModel {
     }
 
     var timeToLiveStart: TimeInterval? {
-        guard let liveStartDate = sale.liveAuctionStartDate, shouldShowLiveInterface else { return nil }
+        guard let liveStartDate = sale.liveAuctionStartDate else { return nil }
 
         let now = ARSystemTime.date()
-        return liveStartDate.timeIntervalSince(now!)
+        let timeInterval = liveStartDate.timeIntervalSince(now!)
+        return (timeInterval > 0 ? timeInterval : nil)
     }
 
     var saleID: NSString {

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -8,6 +8,7 @@ upcoming:
       - Adds timer for artwork view that refreshes UI when the associated live sale opens - ash
       - Fix crash where facebook email can be nil - maxim
       - Fixes a problem with auction information views now showing auction end time - ash
+      - Fixes a problem with auction views not refreshing when live sales opened - ash
 
 releases:
   - version: 3.2.1


### PR DESCRIPTION
This primarily includes a fix for https://github.com/artsy/auctions/issues/477 .

- Fixes sales with only one, two, or three lots.
- Fixes a problem preventing auction VCs from reloading their content when a sale goes live (`shouldShowLiveInterface`).
- Cleans up some indentation.