### PR TITLE
Removes remaining deprecated UIKit API uses

### DIFF
--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController+ButtonActions.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController+ButtonActions.m
@@ -1,11 +1,6 @@
 #import <ARAnalytics/ARAnalytics.h>
 #import <Adjust/Adjust.h>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#import <UIAlertView_Blocks/UIAlertView+Blocks.h>
-#pragma clang diagnostic pop
-
 #import "ARAuctionWebViewController.h"
 #import "Artist.h"
 #import "Artwork.h"
@@ -101,10 +96,13 @@
 - (void)tappedContactGallery
 {
     if (ARIsRunningInDemoMode) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        [UIAlertView showWithTitle:nil message:@"Feature not enabled for this demo" cancelButtonTitle:@"OK" otherButtonTitles:nil tapBlock:nil];
-#pragma clang diagnostic pop
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:nil message:@"Feature not enabled for this demo" preferredStyle:UIAlertControllerStyleAlert];
+        UIAlertAction *okay = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+            [self dismissViewControllerAnimated:YES completion:nil];
+        }];
+        [alert addAction:okay];
+        [self presentViewController:alert animated:YES completion:nil];
+        
         return;
     }
 

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/2_-_Calls_to_Action/ARSignUpSplashViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/2_-_Calls_to_Action/ARSignUpSplashViewController.m
@@ -212,10 +212,7 @@
     [label alignBottomEdgeWithView:self.view predicate:self.useLargeLayout ? @"-55" : @"-10"];
 
     [self hideControls];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [self finaliseValuesForiPadWithInterfaceOrientation:self.interfaceOrientation];
-#pragma clang diagnostic pop
+    [self finaliseValuesForiPadWithInterfaceOrientation:UIApplication.sharedApplication.statusBarOrientation];
 }
 
 - (void)hideControls

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/ARPersonalizeViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/ARPersonalizeViewController.m
@@ -219,11 +219,8 @@
         default:
             break;
     }
-    
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [self finaliseValuesForiPadWithInterfaceOrientation:self.interfaceOrientation];
-#pragma clang diagnostic pop
+
+    [self finaliseValuesForiPadWithInterfaceOrientation:UIApplication.sharedApplication.statusBarOrientation];
 }
 
 // Yes, this is deprecated, but it's the most straightforward way to change 2 values for iPad landscape

--- a/Artsy/View_Controllers/Util/Sharing/ARSharingController.m
+++ b/Artsy/View_Controllers/Util/Sharing/ARSharingController.m
@@ -70,44 +70,20 @@
         UIActivityTypePostToTencentWeibo
         ];
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-
-    // Declare it here so it can be accessed from the UIActivityViewController's completionHandler.
-    __block UIPopoverController *popover = nil;
-
     if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
         [[ARTopMenuViewController sharedController] presentViewController:activityVC animated:YES completion:nil];
     } else {
-        popover = [[UIPopoverController alloc] initWithContentViewController:activityVC];
-        [popover presentPopoverFromRect:frame
-                                 inView:view
-               permittedArrowDirections:UIPopoverArrowDirectionAny
-                               animated:YES];
+        activityVC.modalPresentationStyle = UIModalPresentationPopover;
+        [[ARTopMenuViewController sharedController] presentViewController:activityVC animated:YES completion:nil];
+        UIPopoverPresentationController *popoverController = activityVC.popoverPresentationController;
+        popoverController.permittedArrowDirections = UIPopoverArrowDirectionAny;
+        popoverController.sourceView = view;
+        popoverController.sourceRect = frame;
     }
-#pragma clang diagnostic pop
 
     activityVC.completionWithItemsHandler = ^(NSString *activityType, BOOL completed, NSArray *returnedItems, NSError *activityError) {
-        [popover dismissPopoverAnimated:YES];
-        // Set to `nil` to signal loop below that we're done.
-        popover = nil;
         [self handleActivityCompletion:activityType completed:completed];
     };
-
-    // This is so we don't need to retain the popover and have the caller retain us and then again having to
-    // tell the caller we're done (from e.g. a delegate).
-    //
-    // TODO It appears that on iOS 8 the popver is retained by the system? In which case this can be removed.
-    if (popover) {
-        // Extra hack to ensure the button doesn't remain highlighted during this loop.
-        if ([view isKindOfClass:UIButton.class]) {
-            [(UIButton *)view setHighlighted:NO];
-        }
-
-        while (popover != nil) {
-            [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];
-        }
-    }
 }
 
 - (void)handleActivityCompletion:(NSString *)activityType completed:(BOOL)completed

--- a/Artsy/View_Controllers/Util/Sharing/ARSharingController.m
+++ b/Artsy/View_Controllers/Util/Sharing/ARSharingController.m
@@ -10,12 +10,6 @@
 #import "ARTopMenuViewController.h"
 
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#import <UIAlertView_Blocks/UIAlertView+Blocks.h>
-#pragma clang diagnostic pop
-
-
 @interface ARSharingController ()
 @property (nonatomic, strong) id<ARShareableObject> object;
 @property (nonatomic, strong) NSURL *thumbnailImageURL;
@@ -53,11 +47,14 @@
 - (void)presentActivityViewControllerFromView:(UIView *)view frame:(CGRect)frame
 {
     if (ARIsRunningInDemoMode) {
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:nil message:@"Feature not enabled for this demo" preferredStyle:UIAlertControllerStyleAlert];
+        UIAlertAction *okay = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+            [alert.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+        }];
+        [alert addAction:okay];
+        // Kind of a hack to present from [ARTopMenuViewController sharedController] but it works.
+        [[ARTopMenuViewController sharedController] presentViewController:alert animated:YES completion:nil];
         
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        [UIAlertView showWithTitle:nil message:@"Feature not enabled for this demo" cancelButtonTitle:@"OK" otherButtonTitles:nil tapBlock:nil];
-#pragma clang diagnostic pop
         return;
     }
 

--- a/Artsy/View_Controllers/Web_Browsing/ARInternalMobileWebViewController.m
+++ b/Artsy/View_Controllers/Web_Browsing/ARInternalMobileWebViewController.m
@@ -12,7 +12,7 @@
 
 static void *ARProgressContext = &ARProgressContext;
 
-@interface ARInternalMobileWebViewController () <UIAlertViewDelegate, WKNavigationDelegate>
+@interface ARInternalMobileWebViewController () <WKNavigationDelegate>
 @property (nonatomic, assign) BOOL loaded;
 @property (nonatomic, strong) ARInternalShareValidator *shareValidator;
 @end

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,6 +5,7 @@ upcoming:
       - Removes compiler warnings and static analyzer warnings - ash
       - Fix analytics double fire in artwork pages - maxim
       - Moves to iOS7+ status bar APIs - ash
+      - Removes use of deprecated UIAlertView API - ash
     user_facing:
       - Adds timer for artwork view that refreshes UI when the associated live sale opens - ash
       - Fix crash where facebook email can be nil - maxim

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -6,6 +6,7 @@ upcoming:
       - Fix analytics double fire in artwork pages - maxim
       - Moves to iOS7+ status bar APIs - ash
       - Removes use of deprecated UIAlertView API - ash
+      - Removes use of deprecated UIPopoverController API - ash
     user_facing:
       - Adds timer for artwork view that refreshes UI when the associated live sale opens - ash
       - Fix crash where facebook email can be nil - maxim

--- a/Podfile
+++ b/Podfile
@@ -69,10 +69,6 @@ target 'Artsy' do
   # Custom CollectionView Layouts
   pod 'ARCollectionViewMasonryLayout', :git => 'https://github.com/ashfurrow/ARCollectionViewMasonryLayout', :branch => "modern"
 
-  # Deprecated:
-  # UIAlertView is deprecated for iOS8 APIs
-  pod 'UIAlertView+Blocks'
-
   # Language Enhancements
   pod 'KSDeferred'
   pod 'MultiDelegate'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -263,7 +263,6 @@ PODS:
   - Starscream (2.0.4)
   - SwiftyJSON (3.1.4)
   - Then (2.1.0)
-  - UIAlertView+Blocks (0.8)
   - UICKeyChainStore (1.0.5)
   - UIView+BooleanAnimations (1.0.2)
   - VCRURLConnection (0.2.0)
@@ -336,7 +335,6 @@ DEPENDENCIES:
   - Starscream
   - SwiftyJSON
   - Then
-  - UIAlertView+Blocks
   - UICKeyChainStore
   - UIView+BooleanAnimations
   - VCRURLConnection
@@ -492,13 +490,12 @@ SPEC CHECKSUMS:
   Starscream: df5974ee928b157c8eda8af8de7c620276b7dfcc
   SwiftyJSON: c2842d878f95482ffceec5709abc3d05680c0220
   Then: 8496793c8fcac95482b943909b440724c7d8d82c
-  UIAlertView+Blocks: 6b408d63507287b22c6e631a2b25ca26f96fb609
   UICKeyChainStore: e81dc3b58d56ffaed61ab6669eb97071e53fc377
   UIView+BooleanAnimations: a760be9a066036e55f298b7b7350a6cb14cfcd97
   VCRURLConnection: accd771ebd4be11183a3e4d5a4403f180a9a235e
   XCTest+OHHTTPStubSuiteCleanUp: 4469ec8863c6bc022c5089a9b94233eb3416c5ee
   Yoga: 77f4e44e919b274504599a3536cdc90140fb58d8
 
-PODFILE CHECKSUM: a8aa200764a9cd051349edebee6c2f9130ad0658
+PODFILE CHECKSUM: 3d6786857a9d4e425e9e5b578658a8f99a389f5f
 
 COCOAPODS: 1.2.1


### PR DESCRIPTION
~I was trawling for deprecated things to remove from Eigen and this seemed like an easy one. Next up is our use of popovers, but it won't be as easy or straightforward.~

Edit: I did popover controllers too 🙈 

- Removes UIAlertView and associated dependency
- Removes use of deprecated UIPopoverController API