### PR TITLE
WIP: Fixes status bar problem on Refine view controller

### DIFF
--- a/Artsy/View_Controllers/ARSerifNavigationViewController.m
+++ b/Artsy/View_Controllers/ARSerifNavigationViewController.m
@@ -89,11 +89,7 @@
 
 - (void)closeModal
 {
-    // For reasons yet unknown, when re-appearing from some (eg live auctions) view controllers, we need to call this manually.
-    id presentingViewController = self.presentingViewController;
-    [presentingViewController dismissViewControllerAnimated:YES completion:^{
-        [presentingViewController setNeedsStatusBarAppearanceUpdate];
-    }];
+    [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -279,11 +279,6 @@ static const CGFloat ARMenuButtonDimension = 50;
     }];
 }
 
-- (UIViewController *)visibleViewController;
-{
-    return self.presentedViewController ?: self.rootNavigationController.visibleViewController;
-}
-
 - (ARNavigationController *)rootNavigationController;
 {
     return (ARNavigationController *)[self.tabContentView currentNavigationController];
@@ -407,12 +402,12 @@ static const CGFloat ARMenuButtonDimension = 50;
 
 - (UIViewController *)childViewControllerForStatusBarHidden
 {
-    return self.visibleViewController;
+    return self.rootNavigationController;
 }
 
 - (UIViewController *)childViewControllerForStatusBarStyle
 {
-    return self.visibleViewController;
+    return self.rootNavigationController;
 }
 
 #pragma mark - Pushing VCs

--- a/Artsy/View_Controllers/Auction/AuctionViewController.swift
+++ b/Artsy/View_Controllers/Auction/AuctionViewController.swift
@@ -82,12 +82,6 @@ class AuctionViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(AuctionViewController.registrationUpdated(_:)), name: NSNotification.Name.ARAuctionArtworkRegistrationUpdated, object: nil)
     }
     
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        // For reasons yet unknown, when re-appearing from auctions info or review view controllers, we need to call this manually. 
-        setNeedsStatusBarAppearanceUpdate()
-    }
-
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         userActivity?.invalidate()
@@ -284,7 +278,7 @@ extension AuctionViewController {
         properties["context"] = "auction"
         properties["slub"] = "/auction/\(saleViewModel.saleID)/refine"
         refineViewController.viewDidAppearAnalyticsOption = RefinementAnalyticsOption(name: "Sale Information", properties: properties)
-        refineViewController.statusBarStyle = (self.traitCollection.horizontalSizeClass == .compact) ? .`default` : .lightContent
+        refineViewController.statusBarHidden = (self.traitCollection.horizontalSizeClass == .compact)
         present(refineViewController, animated: animated, completion: nil)
     }
 

--- a/Artsy/View_Controllers/Auction/RefinementOptionsViewController.swift
+++ b/Artsy/View_Controllers/Auction/RefinementOptionsViewController.swift
@@ -39,7 +39,7 @@ class RefinementOptionsViewController<R: RefinableType>: UIViewController {
         }
     }
 
-    var statusBarStyle = UIStatusBarStyle.default
+    var statusBarHidden = false
 
     init(defaultSettings: R, initialSettings: R, currencySymbol: String, userDidCancelClosure: ((RefinementOptionsViewController) -> Void)?, userDidApplyClosure: ((R) -> Void)?) {
         self.defaultSettings = defaultSettings
@@ -105,8 +105,8 @@ class RefinementOptionsViewController<R: RefinableType>: UIViewController {
         viewDidAppearAnalyticsOption?.sendAsPageView()
     }
 
-    override var preferredStatusBarStyle: UIStatusBarStyle {
-        return statusBarStyle
+    override var prefersStatusBarHidden: Bool {
+        return true
     }
 
     override var supportedInterfaceOrientations : UIInterfaceOrientationMask {

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,6 +5,7 @@ upcoming:
       - Emission updated to 1.4.0 - alloy
     user_facing:
       - Adds new routing for inquiries - maxim
+      - Fixes problem with status bar on refine options view - ash
 
 releases:
   - version: 3.2.2


### PR DESCRIPTION
This problem was introduced [here](https://github.com/artsy/eigen/pull/2368/files#diff-49c86a13feb606822a3e4f37eae08989L42) in #2368. I accidentally switched from status bar _hidden_ to status bar _style_. But, since this VC isn't shown full screen on an iPad, we can simply always say it prefers the status bar hidden.

Investigating the iPad status bar issues led me further down a rabbit hole until I figured out what was causing our problems with status bars having to be manually changed back in `viewDidAppear`. The problem was our top menu VC was overriding `childViewControllerForStatusBarHidden` and `childViewControllerForStatusBarStyle`, returning the _presented_ view controller in all cases. iOS is smart enough to decide (based on presentation contexts and trait collections) which VC to use. So I removed that code and deferred only to our root nav controllers, which use the default iOS behaviour. Everything seems to work, and there's less code :tada: 

Fixes https://github.com/artsy/eigen/issues/2384

This is a WIP because I need to test the live VC's but our staging environment is currently under the weather. Will un-WIP once I've done that.