### PR TITLE
Updates Emission to 1.3.10

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.2</string>
+	<string>3.2.3</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSExtension</key>

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.2</string>
+	<string>3.2.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -7,6 +7,7 @@ upcoming:
 releases:
   - version: 3.2.2
     details: Scope not known yet
+    date: Jun 26, 2017
     dev:
       - Removes compiler warnings and static analyzer warnings - ash
       - Fix analytics double fire in artwork pages - maxim

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -6,7 +6,7 @@ upcoming:
 
 releases:
   - version: 3.2.2
-    details: Scope not known yet
+    details: Bug fixes for Auctions mostly
     date: Jun 26, 2017
     dev:
       - Removes compiler warnings and static analyzer warnings - ash

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,5 +1,11 @@
 upcoming:
-    version: 3.2.2
+    version: 3.2.3
+    details: Auction price data fix
+    user_facing:
+      - Updates Emission to 1.3.10 which includes a fix for not showing pricing data for closed sales - ash
+
+releases:
+  - version: 3.2.2
     details: Scope not known yet
     dev:
       - Removes compiler warnings and static analyzer warnings - ash
@@ -17,7 +23,6 @@ upcoming:
       - Auctions now filter out lots with unpublished artworks - ash
       - Fixes an issue with the status bar appearence returning from LAI modals - ash
 
-releases:
   - version: 3.2.1
     details: Scope not know yet
     date: May 22, 2017

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -76,7 +76,7 @@ PODS:
     - CocoaLumberjack/Default
   - DHCShakeNotifier (0.2.0)
   - EDColor (1.0.0)
-  - Emission (1.3.9):
+  - Emission (1.3.10):
     - Artsy+UIFonts (>= 3.0.0)
     - Extraction (>= 1.2.1)
     - React/Core (= 0.42.0)
@@ -444,7 +444,7 @@ SPEC CHECKSUMS:
   CocoaLumberjack: 27ae9abcd376c3e4ee726ecd4adfd7b093ddef3f
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
-  Emission: d9abff24f4f02cdb8807c352a484103bd17faa7b
+  Emission: 8652672647bda0ca2f2b6f162aa5a824b221463f
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   Expecta+Snapshots: c343f410c7a6392f3e22e78f94c44b6c0749a516
   Extraction: 612cf0866f74d4c0dd616677ff24146efa200958


### PR DESCRIPTION
Includes only this update from 1.3.9: https://github.com/artsy/emission/pull/675 This fixes a critical bug for auctions, as noted in the changelog.