### PR TITLE
[MSG] Remove back button from inbox VC

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		1C09DFA71E53BAAD003F7BA7 /* onboardingspinner.png in Resources */ = {isa = PBXBuildFile; fileRef = 1C09DFA51E53BAAD003F7BA7 /* onboardingspinner.png */; };
 		1C09DFA81E53BAAD003F7BA7 /* onboardingspinner@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 1C09DFA61E53BAAD003F7BA7 /* onboardingspinner@2x.png */; };
 		1C40C19F1DF8B1B7003F454F /* ArtsyRecordedTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C40C19E1DF8B1B7003F454F /* ArtsyRecordedTests.m */; };
+		1C50D39E1F162B6E00848627 /* ARInboxComponentMenuAwareViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C50D39D1F162B6E00848627 /* ARInboxComponentMenuAwareViewController.m */; };
 		1C5AAEB11CD7D42E00515B73 /* BackArrowBlack@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 1C5AAEB01CD7D42E00515B73 /* BackArrowBlack@2x.png */; };
 		1C5AAEB51CD87D9B00515B73 /* SearchButton.png in Resources */ = {isa = PBXBuildFile; fileRef = 1C5AAEB21CD87D9B00515B73 /* SearchButton.png */; };
 		1C5AAEB61CD87D9B00515B73 /* SearchButton@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 1C5AAEB31CD87D9B00515B73 /* SearchButton@2x.png */; };
@@ -823,6 +824,8 @@
 		1C40C19C1DF8B1B7003F454F /* ArtsyRecordedTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ArtsyRecordedTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1C40C19E1DF8B1B7003F454F /* ArtsyRecordedTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ArtsyRecordedTests.m; sourceTree = "<group>"; };
 		1C40C1A01DF8B1B7003F454F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1C50D39C1F162B6E00848627 /* ARInboxComponentMenuAwareViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARInboxComponentMenuAwareViewController.h; sourceTree = "<group>"; };
+		1C50D39D1F162B6E00848627 /* ARInboxComponentMenuAwareViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARInboxComponentMenuAwareViewController.m; sourceTree = "<group>"; };
 		1C5AAEB01CD7D42E00515B73 /* BackArrowBlack@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "BackArrowBlack@2x.png"; sourceTree = "<group>"; };
 		1C5AAEB21CD87D9B00515B73 /* SearchButton.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = SearchButton.png; sourceTree = "<group>"; };
 		1C5AAEB31CD87D9B00515B73 /* SearchButton@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "SearchButton@2x.png"; sourceTree = "<group>"; };
@@ -3947,6 +3950,8 @@
 				60F9B0901D83314F00DBAC8C /* ARAdminLoadReactComponentViewController.h */,
 				60F9B0911D83314F00DBAC8C /* ARAdminLoadReactComponentViewController.m */,
 				60F9B0921D83314F00DBAC8C /* ARAdminLoadReactComponentViewController.xib */,
+				1C50D39C1F162B6E00848627 /* ARInboxComponentMenuAwareViewController.h */,
+				1C50D39D1F162B6E00848627 /* ARInboxComponentMenuAwareViewController.m */,
 			);
 			path = Admin;
 			sourceTree = "<group>";
@@ -5415,6 +5420,7 @@
 				3C205ACD1908041700B3C2B4 /* ARSearchResultsDataSource.m in Sources */,
 				4938742917BD512700724795 /* ARSignUpSplashViewController.m in Sources */,
 				60327DCD1987AD240075B399 /* ARDispatchManager.m in Sources */,
+				1C50D39E1F162B6E00848627 /* ARInboxComponentMenuAwareViewController.m in Sources */,
 				60B7604617C9FBEA00073A14 /* ARArtworkActionsView.m in Sources */,
 				4938743617BDB2CD00724795 /* ARCrossfadingImageView.m in Sources */,
 				60FC2CBB1C8DF29900ACD78F /* LiveEvent.m in Sources */,

--- a/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
+++ b/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
@@ -24,7 +24,7 @@
 #import <ObjectiveSugar/ObjectiveSugar.h>
 #import <AppHub/AppHub.h>
 #import <Emission/AREmission.h>
-#import <Emission/ARInboxComponentViewController.h>
+#import "ARInboxComponentMenuAwareViewController.h"
 #import "ARAdminLoadReactComponentViewController.h"
 
 #if DEBUG
@@ -171,7 +171,6 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
 }
 
 
-
 - (ARCellData *)generateRestart
 {
     ARCellData *crashCellData = [[ARCellData alloc] initWithIdentifier:AROptionCell];
@@ -223,9 +222,9 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
     [crashCellData setCellConfigurationBlock:^(UITableViewCell *cell) {
         cell.textLabel.text = @"Show Inbox";
     }];
-    
+
     [crashCellData setCellSelectionBlock:^(UITableView *tableView, NSIndexPath *indexPath) {
-        ARInboxComponentViewController *controller = [[ARInboxComponentViewController alloc] initWithInbox];
+        ARInboxComponentMenuAwareViewController *controller = [[ARInboxComponentMenuAwareViewController alloc] initWithInbox];
         [self.navigationController pushViewController:controller animated:YES];
     }];
     return crashCellData;
@@ -275,7 +274,7 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
             cell.textLabel.text = @"Show Red Dot for Martsy Views";
         }
     }];
-    
+
     [martsyCellData setCellSelectionBlock:^(UITableView *tableView, NSIndexPath *indexPath) {
         BOOL current = [AROptions boolForOption:AROptionsShowMartsyOnScreen];
         [AROptions setBool:!current forOption:AROptionsShowMartsyOnScreen];
@@ -520,7 +519,7 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
     ARCellData *stagingMetaphysics = [self cellDataWithName:@"Metaphysics" defaultKey:ARStagingMetaphysicsURLDefault];
     ARCellData *stagingSocket = [self cellDataWithName:@"Live Auctions Socket" defaultKey:ARStagingLiveAuctionSocketURLDefault];
 
-    [labsSectionData addCellDataFromArray:@[stagingAPI, stagingWeb, stagingMetaphysics, stagingSocket]];
+    [labsSectionData addCellDataFromArray:@[ stagingAPI, stagingWeb, stagingMetaphysics, stagingSocket ]];
     return labsSectionData;
 }
 

--- a/Artsy/View_Controllers/Admin/ARInboxComponentMenuAwareViewController.h
+++ b/Artsy/View_Controllers/Admin/ARInboxComponentMenuAwareViewController.h
@@ -1,0 +1,10 @@
+#import <UIKit/UIKit.h>
+#import "ARMenuAwareViewController.h"
+#import <Emission/ARInboxComponentViewController.h>
+
+
+@interface ARInboxComponentMenuAwareViewController : ARInboxComponentViewController <ARMenuAwareViewController>
+
+- (instancetype)initWithInbox;
+
+@end

--- a/Artsy/View_Controllers/Admin/ARInboxComponentMenuAwareViewController.m
+++ b/Artsy/View_Controllers/Admin/ARInboxComponentMenuAwareViewController.m
@@ -1,0 +1,22 @@
+#import "ARInboxComponentMenuAwareViewController.h"
+
+
+@interface ARInboxComponentMenuAwareViewController ()
+
+@property (readwrite, nonatomic, assign) BOOL hidesBackButton;
+
+@end
+
+
+@implementation ARInboxComponentMenuAwareViewController
+
+- (instancetype)initWithInbox;
+{
+    if ((self = [super initWithInbox])) {
+        self.hidesBackButton = YES;
+    }
+    return self;
+}
+
+
+@end

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -6,6 +6,7 @@ upcoming:
     user_facing:
       - Adds new routing for inquiries - maxim
       - Fixes problem with status bar on refine options view - ash
+      - Removes back button from inbox view - maxim
 
 releases:
   - version: 3.2.3


### PR DESCRIPTION
Fix [Emission#666](https://github.com/artsy/emission/issues/666)

I only managed to get it out of the main inbox view, the button still hangs around on a conversation view, issue futher explained in #2389

<img width="829" alt="screen shot 2017-07-12 at 12 04 51" src="https://user-images.githubusercontent.com/373860/28115056-4eab630c-66fb-11e7-8780-a6bfb7c9ffcf.png">
