### PR TITLE
Removes Contact for Price from auction works.

### DIFF
--- a/Artsy/Views/Artwork/ARArtworkRelatedArtworksView.m
+++ b/Artsy/Views/Artwork/ARArtworkRelatedArtworksView.m
@@ -171,6 +171,10 @@
     __weak typeof(self) wself = self;
     [self addRelatedArtworkRequest:[auction getArtworks:^(NSArray *artworks) {
         __strong typeof (wself) sself = wself;
+        // We need to explicitly set this here, for the ArtworkThumbnailMetadataView to display everything correctly.
+        [artworks each:^(id object) {
+            [object setAuction:auction];
+        }];
         [sself addSectionWithTag:ARRelatedArtworksSameAuction artworks:artworks heading:@"Other works in auction"];
     }]];
 }

--- a/Artsy/Views/Collection_View_Cells/ARArtworkWithMetadataThumbnailCell.m
+++ b/Artsy/Views/Collection_View_Cells/ARArtworkWithMetadataThumbnailCell.m
@@ -36,7 +36,7 @@ static const CGFloat ARArtworkCellMetadataMargin = 8;
 
 + (BOOL)showPriceLabelWithArtwork:(Artwork *)artwork
 {
-    return artwork.saleMessage.length;
+    return artwork.saleMessage.length && !artwork.auction;
 }
 
 - (void)prepareForReuse

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,6 +5,7 @@ upcoming:
       - Emission updated to 1.4.0 - alloy
     user_facing:
       - Adds new routing for inquiries - maxim
+      - Removes "Contact for Price" on related works in auction list - ash
       - Fixes problem with status bar on refine options view - ash
 
 releases:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -431,7 +431,7 @@ SPEC CHECKSUMS:
   AFOAuth1Client: 07ccc935ba06ac8d023c16d39a5bdf04bc6f92e1
   ALPValidator: c74ea0d49bbbff0f8a4228f1eb6589b992255cfe
   Analytics: b342fb4f43fa4f97ca6f4358b44d3295217ba294
-  AppHub: '03788112dd48c42b60d51321c0ffff4ef15a4432'
+  AppHub: 03788112dd48c42b60d51321c0ffff4ef15a4432
   ARAnalytics: 96e23ba7f54298f4914de9e1ac999db7a15f3fdd
   ARCollectionViewMasonryLayout: 776730bdedd0c7570a5e904c370e4e120f98ea62
   ARGenericTableViewController: 61a0897ba66c35111b5d1cc3b44884282bd3c1a5
@@ -450,7 +450,7 @@ SPEC CHECKSUMS:
   Extraction: 612cf0866f74d4c0dd616677ff24146efa200958
   FBSDKCoreKit: d2aaed5e9ab7d8d6301c533376a1fbff1cf3deb5
   FBSDKLoginKit: 699ff169080e3072de4b9b0faca90bf23dc36deb
-  FBSnapshotTestCase: '094f9f314decbabe373b87cc339bea235a63e07a'
+  FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   FLKAutoLayout: 106b14dbae09d32c6730190f4e78a959759ba4a4
   Forgeries: 64ced144ea8341d89a7eec9d1d7986f0f1366250
   FXBlurView: 5121730176fd52bcf7bffd0bd8c1485e8aabc3cb


### PR DESCRIPTION
This is a fix for https://github.com/artsy/auctions/issues/515 . This isn't the fix I wanted to submit, though; ideally we could reuse the `ARSaleArtworkItemMasonryModule` from the auction view controller. However, this module is tightly coupled to that particular view controller, and the `ARArtworkRelatedArtworksView` is tightly coupled to using only `ARArtworkMasonryModule`, which is a shame. 

The "related artworks" view is, like, begging to be replaced by existing React Native infrastructure, which would be a fun little project. So, I'm submitting this PR with the expectation of replacing the whole component soon. The upside is this fix is easy and fast, but the downside is that we _should_ display lot number, number of bids, etc, but won't be until we replace this component.