### PR TITLE
Removes Error 65 workaround #trivial

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,10 +32,6 @@ dependencies:
     - make ci
 
 test:
-  pre:
-    # See https://discuss.circleci.com/t/xcode-exit-code-65/4284/13 
-    - xcrun instruments -w '547B1B63-3F66-4E5B-8001-F78F2F1CDEA7' || true
-    - sleep 15
   override:
     - make test
     - bundle exec danger --danger_id=circle --dangerfile=Dangerfile.circle.rb --verbose


### PR DESCRIPTION
We were trying to pre-launch a simulator for our tests to avoid Error 65, but recent changes to Circle's infrastructure mean this was unnecessary at best, and hurting our changes of getting the error at worst. Additionally, the UUID of the simulator we were trying to launch is out of date.

So I removed the workaround. See conversation on twitter: https://twitter.com/dantoml/status/888385665364365312