### PR TITLE
Prep for 3.2.4 release

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.3</string>
+	<string>3.2.4</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSExtension</key>

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.3</string>
+	<string>3.2.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,21 +1,7 @@
 upcoming:
-    version: 3.2.3
-    version: 3.3.0
+    version: 3.2.4
     details: Messaging
-    dev:
-      - Reload active bids on pull-to-refresh - alloy
-      - Make active bids link to their artworks - alloy
-      - Make zero inbox state hide on load if bids or conversations exist - alloy
-      - Fix crash on Gene view, when integrated into Eigen, due to missing RCTAnimation dependency - alloy
-      - Fix issue with missing icons - alloy
-
     user_facing:
-      - Adds new routing for inquiries - maxim
-      - Removes "Contact for Price" on related works in auction list - ash
-      - Fixes problem with status bar on refine options view - ash
-      - Fixes login for users with short passwords - ash
-      - Fixes inconsistencies in bid counts of online sales - ash
-      - Fixes a minor problem displaying lots in past auctions - ash
       - Fixes inconsistencies in post-sale artwork supplementary info - ash
 
 releases:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -76,7 +76,7 @@ PODS:
     - CocoaLumberjack/Default
   - DHCShakeNotifier (0.2.0)
   - EDColor (1.0.0)
-  - Emission (1.3.10):
+  - Emission (1.3.11):
     - Artsy+UIFonts (>= 3.0.0)
     - Extraction (>= 1.2.1)
     - React/Core (= 0.42.0)
@@ -431,9 +431,9 @@ SPEC CHECKSUMS:
   AFOAuth1Client: 07ccc935ba06ac8d023c16d39a5bdf04bc6f92e1
   ALPValidator: c74ea0d49bbbff0f8a4228f1eb6589b992255cfe
   Analytics: b342fb4f43fa4f97ca6f4358b44d3295217ba294
-  AppHub: 03788112dd48c42b60d51321c0ffff4ef15a4432
-  ARAnalytics: c00626b8fc45cb7cff0253efc19f20652603b417
-  ARCollectionViewMasonryLayout: 97cb468434b546b79a98c7c0908447ff803eb85e
+  AppHub: '03788112dd48c42b60d51321c0ffff4ef15a4432'
+  ARAnalytics: 96e23ba7f54298f4914de9e1ac999db7a15f3fdd
+  ARCollectionViewMasonryLayout: 776730bdedd0c7570a5e904c370e4e120f98ea62
   ARGenericTableViewController: 61a0897ba66c35111b5d1cc3b44884282bd3c1a5
   ARTiledImageView: 2db7735f5d3fcb4c859c912834a6a1bf20716377
   Artsy+UIColors: 31c03c4146f5e6618a9b950f37dfe02dd9ac09a6
@@ -444,13 +444,13 @@ SPEC CHECKSUMS:
   CocoaLumberjack: 27ae9abcd376c3e4ee726ecd4adfd7b093ddef3f
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
-  Emission: 8652672647bda0ca2f2b6f162aa5a824b221463f
+  Emission: 614a29d8f268d854b98151c6a8ce525e74f643d2
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   Expecta+Snapshots: c343f410c7a6392f3e22e78f94c44b6c0749a516
   Extraction: 612cf0866f74d4c0dd616677ff24146efa200958
   FBSDKCoreKit: d2aaed5e9ab7d8d6301c533376a1fbff1cf3deb5
   FBSDKLoginKit: 699ff169080e3072de4b9b0faca90bf23dc36deb
-  FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
+  FBSnapshotTestCase: '094f9f314decbabe373b87cc339bea235a63e07a'
   FLKAutoLayout: 106b14dbae09d32c6730190f4e78a959759ba4a4
   Forgeries: 64ced144ea8341d89a7eec9d1d7986f0f1366250
   FXBlurView: 5121730176fd52bcf7bffd0bd8c1485e8aabc3cb


### PR DESCRIPTION
- Fixes bad changelog merge from #2402.
- Updates bundle versions.
- Updates Emission to 1.3.11.
- Changes Podfile.lock one final time