### PR TITLE
Presents Live interface when reappearing when sale has opened.

### DIFF
--- a/Artsy/View_Controllers/Auction/AuctionViewController.swift
+++ b/Artsy/View_Controllers/Auction/AuctionViewController.swift
@@ -49,8 +49,12 @@ class AuctionViewController: UIViewController {
         super.viewWillAppear(animated)
 
         if appeared {
-            // Re-appearing, so re-fetch lot standings and update.
-            fetchLotStandingsAndUpdate()
+            // Re-appearing, so: check if Live has launched, and if not, re-fetch lot standings and update.
+            if saleViewModel.shouldShowLiveInterface {
+                setupLiveInterfaceAndPop()
+            } else {
+                fetchLotStandingsAndUpdate()
+            }
         }
 
         guard appeared == false else { return }

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -24,6 +24,7 @@ upcoming:
       - Fixes a minor problem displaying lots in past auctions - ash
       - Fixes inconsistencies in post-sale artwork supplementary info - ash
       - Do not intercept tel links with our custom dialog modal - isac
+      - Presents live bidding interface when sale has opened and UI reappearing from an artwork VC - ash
 
 releases:
   - version: 3.2.3


### PR DESCRIPTION
This fixes the following bug:

- Open auctions view before live bidding opens.
- Tap an artwork, wait until live bidding opens.
- Tap "back" button.

App would show auctions view with timer at zero instead of the live interface.