### PR TITLE
Updates bid count UI after model has been updated

### DIFF
--- a/Artsy/View_Controllers/Live_Auctions/ViewModels/LiveAuctionLotViewModel.swift
+++ b/Artsy/View_Controllers/Live_Auctions/ViewModels/LiveAuctionLotViewModel.swift
@@ -55,6 +55,7 @@ protocol LiveAuctionLotViewModelType: class {
     var reserveStatusSignal: Observable<ARReserveStatus> { get }
     var lotStateSignal: Observable<LotState> { get }
     var askingPriceSignal: Observable<UInt64> { get }
+    var numberOfBidsSignal: Observable<Int> { get }
     var currentBidSignal: Observable<CurrentBid> { get }
     var newEventsSignal: Observable<[LiveAuctionEventViewModel]> { get }
 }
@@ -106,6 +107,7 @@ class LiveAuctionLotViewModel: NSObject, LiveAuctionLotViewModelType {
     let reserveStatusSignal = Observable<ARReserveStatus>()
     let lotStateSignal: Observable<LotState>
     let askingPriceSignal = Observable<UInt64>()
+    let numberOfBidsSignal = Observable<Int>()
 
     let newEventsSignal = Observable<[LiveAuctionEventViewModel]>()
 
@@ -304,6 +306,7 @@ class LiveAuctionLotViewModel: NSObject, LiveAuctionLotViewModelType {
 
     func updateOnlineBidCount(_ onlineBidCount: Int) {
         model.onlineBidCount = onlineBidCount
+        numberOfBidsSignal.update(onlineBidCount)
     }
 
     func updateSellingToBidder(_ sellingToBidderID: String?) {

--- a/Artsy/View_Controllers/Live_Auctions/Views/LiveAuctionToolbarView.swift
+++ b/Artsy/View_Controllers/Live_Auctions/Views/LiveAuctionToolbarView.swift
@@ -75,8 +75,7 @@ class LiveAuctionToolbarView: UIView {
                 guard self.numberOfBidsObserver == nil else { return }
 
                 self.numberOfBidsObserver = self.lotViewModel
-                    .newEventsSignal
-                    .map { [weak self] _ in self?.lotViewModel.numberOfBids ?? 0 }
+                    .numberOfBidsSignal
                     .subscribe { [weak self] numberOfBids in
                         label.attributedText = self?.attributify(String(numberOfBids)) ?? NSAttributedString()
                 }

--- a/Artsy_Tests/View_Controller_Tests/Live_Auction/LiveAuctionLotViewControllerTests.swift
+++ b/Artsy_Tests/View_Controller_Tests/Live_Auction/LiveAuctionLotViewControllerTests.swift
@@ -111,7 +111,7 @@ class LiveAuctionLotViewControllerTests: QuickSpec {
                 subject.loadViewProgrammatically()
 
                 lotViewModel.numberOfBids = 2
-                lotViewModel.newEventsSignal.update([])
+                lotViewModel.numberOfBidsSignal.update(2)
 
                 expect(subject) == snapshot()
             }
@@ -180,6 +180,7 @@ class Test_LiveAuctionLotViewModel: LiveAuctionLotViewModelType {
 
     let askingPrice: UInt64 = 5_000_00
     let askingPriceSignal = Observable<UInt64>(5_000_00)
+    let numberOfBidsSignal = Observable<Int>()
     let reserveStatusSignal = Observable<ARReserveStatus>(.noReserve)
     let newEventsSignal = Observable<[LiveAuctionEventViewModel]>()
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -25,6 +25,7 @@ upcoming:
       - Fixes inconsistencies in post-sale artwork supplementary info - ash
       - Do not intercept tel links with our custom dialog modal - isac
       - Presents live bidding interface when sale has opened and UI reappearing from an artwork VC - ash
+      - Updates bid count UI after model has been updated - ash
 
 releases:
   - version: 3.2.3


### PR DESCRIPTION
Fixes https://github.com/artsy/auctions/issues/606 . What was happening was we were using the new events signal to update the # of bids UI, but the number of bids on the model wasn't being updated until _after_ the events were added (so we would typically number of bids from 1 event ago). This PR adds an observable for the number of bids specifically.