### PR TITLE
Fixes crash with new users without any favourites

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.4</string>
+	<string>3.2.5</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSExtension</key>

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.4</string>
+	<string>3.2.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Artsy/Networking/API_Modules/ArtsyAPI+Artworks.m
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+Artworks.m
@@ -38,6 +38,15 @@
     NSURLRequest *request = [ARRouter newArtworksFromUsersFavoritesRequestWithCursor:cursor];
     return [self performRequest:request success:^(id json) {
         // Parse out metadata from GraphQL response.
+        NSArray *errors = json[@"errors"];
+        if (errors) {
+            // GraphQL queries that fail can return 200s but indicate failures with the "errors" key. We need to check them.
+            NSLog(@"Failure fetching GraphQL query: %@", errors);
+            if (failure) {
+                failure([NSError errorWithDomain:@"GraphQL" code:0 userInfo:json]);
+            }
+            return;
+        }
         id artworksConnection = json[@"data"][@"me"][@"saved_artworks"][@"artworks_connection"];
         NSDictionary *pageInfo = artworksConnection[@"pageInfo"];
         NSArray *artworksJson = [artworksConnection[@"edges"] valueForKey:@"node"];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,17 +1,22 @@
 upcoming:
-    version: 3.2.4
+    version: 3.2.5
     details: Messaging
+    user_facing:
+      - Fixes a crash related to users with no favourited artworks - ash
+
+releases:
+  - version: 3.2.4
+    date: Sep 8, 2017
+    details: Bug fixes
     user_facing:
       - Fixes inconsistencies in post-sale artwork supplementary info - ash
 
-releases:
   - version: 3.2.3
     date: Jul 11, 2017
     details: Auction price data fix
     user_facing:
       - Updates Emission to 1.3.10 which includes a fix for not showing pricing data for closed sales - ash
 
-releases:
   - version: 3.2.2
     details: Bug fixes for Auctions mostly
     date: Jun 26, 2017

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -431,7 +431,7 @@ SPEC CHECKSUMS:
   AFOAuth1Client: 07ccc935ba06ac8d023c16d39a5bdf04bc6f92e1
   ALPValidator: c74ea0d49bbbff0f8a4228f1eb6589b992255cfe
   Analytics: b342fb4f43fa4f97ca6f4358b44d3295217ba294
-  AppHub: '03788112dd48c42b60d51321c0ffff4ef15a4432'
+  AppHub: 03788112dd48c42b60d51321c0ffff4ef15a4432
   ARAnalytics: 96e23ba7f54298f4914de9e1ac999db7a15f3fdd
   ARCollectionViewMasonryLayout: 776730bdedd0c7570a5e904c370e4e120f98ea62
   ARGenericTableViewController: 61a0897ba66c35111b5d1cc3b44884282bd3c1a5
@@ -450,7 +450,7 @@ SPEC CHECKSUMS:
   Extraction: 612cf0866f74d4c0dd616677ff24146efa200958
   FBSDKCoreKit: d2aaed5e9ab7d8d6301c533376a1fbff1cf3deb5
   FBSDKLoginKit: 699ff169080e3072de4b9b0faca90bf23dc36deb
-  FBSnapshotTestCase: '094f9f314decbabe373b87cc339bea235a63e07a'
+  FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   FLKAutoLayout: 106b14dbae09d32c6730190f4e78a959759ba4a4
   Forgeries: 64ced144ea8341d89a7eec9d1d7986f0f1366250
   FXBlurView: 5121730176fd52bcf7bffd0bd8c1485e8aabc3cb


### PR DESCRIPTION
This fixes [a crash](https://sentry.io/artsynet/eigen/issues/347208068) caused by a misunderstanding in how GraphQL errors are reported (they return a 200 status code, Eigen was relying on a non-200 to indicate failure). This needs to be applied to everywhere in Eigen we're calling metaphysics, and I will follow up with a PR to master that refactors that. In the mean time, this patch should be deployed as soon as possible.