### PR TITLE
Consolidates GraphQL response error-handling

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -387,6 +387,7 @@
 		5EBDC94E19792C3A0082C514 /* ARNavigationControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EBDC94D19792C3A0082C514 /* ARNavigationControllerTests.m */; };
 		5EBDC95119794D840082C514 /* ARSearchFieldButtonTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EBDC95019794D840082C514 /* ARSearchFieldButtonTests.m */; };
 		5EBDC95319794DF10082C514 /* ARPendingOperationViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EBDC95219794DF10082C514 /* ARPendingOperationViewControllerTests.m */; };
+		5EC27DCC1F6AFBC000D2A794 /* ArtsyAPI+GraphQLTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EC27DCB1F6AFBC000D2A794 /* ArtsyAPI+GraphQLTests.m */; };
 		5EC883241B1CBA8E000374C9 /* ARArtworkPreviewActionsViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EC883231B1CBA8E000374C9 /* ARArtworkPreviewActionsViewTests.m */; };
 		5EC8C6801CA5C5FC00571B21 /* LiveActionStateReconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC8C67F1CA5C5FC00571B21 /* LiveActionStateReconciler.swift */; };
 		5EC929891C5FEAD10015133E /* UIViewController+Traits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC929881C5FEAD10015133E /* UIViewController+Traits.swift */; };
@@ -1376,6 +1377,7 @@
 		5EBDC94D19792C3A0082C514 /* ARNavigationControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARNavigationControllerTests.m; sourceTree = "<group>"; };
 		5EBDC95019794D840082C514 /* ARSearchFieldButtonTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARSearchFieldButtonTests.m; sourceTree = "<group>"; };
 		5EBDC95219794DF10082C514 /* ARPendingOperationViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARPendingOperationViewControllerTests.m; sourceTree = "<group>"; };
+		5EC27DCB1F6AFBC000D2A794 /* ArtsyAPI+GraphQLTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ArtsyAPI+GraphQLTests.m"; sourceTree = "<group>"; };
 		5EC883231B1CBA8E000374C9 /* ARArtworkPreviewActionsViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARArtworkPreviewActionsViewTests.m; sourceTree = "<group>"; };
 		5EC8C67F1CA5C5FC00571B21 /* LiveActionStateReconciler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LiveActionStateReconciler.swift; path = Live_Auctions/LiveActionStateReconciler.swift; sourceTree = "<group>"; };
 		5EC929881C5FEAD10015133E /* UIViewController+Traits.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Traits.swift"; sourceTree = "<group>"; };
@@ -2577,6 +2579,7 @@
 				3C6BDCBC18E0AEF60028EF5D /* ArtsyAPI+PrivateTests.m */,
 				3CF144AA18E460BE00B1A764 /* ArtsyAPI+SystemTimeTests.m */,
 				3CB37D981922483100089A1D /* ArtsyAPI+ErrorHandlers.m */,
+				5EC27DCB1F6AFBC000D2A794 /* ArtsyAPI+GraphQLTests.m */,
 			);
 			name = "API Modules";
 			path = API_Modules;
@@ -5706,6 +5709,7 @@
 				3C5C7E4018970E8B003823BB /* UIApplicationStateEnumTests.m in Sources */,
 				D35D9D5C1ACB4FF800E67A1D /* ARCustomEigenLabelTests.m in Sources */,
 				5EBDC94E19792C3A0082C514 /* ARNavigationControllerTests.m in Sources */,
+				5EC27DCC1F6AFBC000D2A794 /* ArtsyAPI+GraphQLTests.m in Sources */,
 				60ED311F1C8F73450071DD89 /* LiveAuctionLotViewControllerTests.swift in Sources */,
 				60647C7C1A951F2A00A45247 /* ARFairPopupViewControllerTests.m in Sources */,
 				5E3817011CC1572100477B17 /* LiveAuctionLotListStickyCellCollectionViewLayoutTests.swift in Sources */,

--- a/Artsy/Networking/API_Modules/ArtsyAPI+Artworks.m
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+Artworks.m
@@ -36,17 +36,7 @@
 + (AFHTTPRequestOperation *)getArtworkFromUserFavorites:(NSString *)cursor success:(void (^)(NSString *nextPageCursor, BOOL hasNextPage, NSArray *artworks))success failure:(void (^)(NSError *error))failure
 {
     NSURLRequest *request = [ARRouter newArtworksFromUsersFavoritesRequestWithCursor:cursor];
-    return [self performRequest:request success:^(id json) {
-        // Parse out metadata from GraphQL response.
-        NSArray *errors = json[@"errors"];
-        if (errors) {
-            // GraphQL queries that fail can return 200s but indicate failures with the "errors" key. We need to check them.
-            NSLog(@"Failure fetching GraphQL query: %@", errors);
-            if (failure) {
-                failure([NSError errorWithDomain:@"GraphQL" code:0 userInfo:json]);
-            }
-            return;
-        }
+    return [self performGraphQLRequest:request success:^(id json) {
         id artworksConnection = json[@"data"][@"me"][@"saved_artworks"][@"artworks_connection"];
         NSDictionary *pageInfo = artworksConnection[@"pageInfo"];
         NSArray *artworksJson = [artworksConnection[@"edges"] valueForKey:@"node"];
@@ -67,11 +57,7 @@
         if (success) {
             success(pageInfo[@"endCursor"], [pageInfo[@"hasNextPage"] boolValue], artworks);
         }
-    } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {
-        if (failure) {
-            failure(error);
-        }
-    }];
+    } failure:failure];
 }
 
 + (AFHTTPRequestOperation *)getArtworksForGene:(Gene *)gene atPage:(NSInteger)page success:(void (^)(NSArray *artworks))success failure:(void (^)(NSError *error))failure

--- a/Artsy/Networking/API_Modules/ArtsyAPI+Private.h
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+Private.h
@@ -11,6 +11,9 @@ NetworkFailureBlock passOnNetworkError(void (^)(NSError *error));
 /// A simple method for performing a ARJSONRequest and passing back the returned JSON as a native object
 + (AFHTTPRequestOperation *)performRequest:(NSURLRequest *)request success:(void (^)(id))success failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure;
 
+/// A method for performing an ARJSONRequest that checks for GraphQL errors prior to invoking the success callback.
++ (AFHTTPRequestOperation *)performGraphQLRequest:(NSURLRequest *)request success:(void (^)(id))success failure:(void (^)(NSError *error))failure;
+
 /// A more complete response API for the request, in case you need more than just the response object
 + (AFHTTPRequestOperation *)performRequest:(NSURLRequest *)request fullSuccess:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, id JSON))success failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON))failureCallback;
 

--- a/Artsy/Networking/API_Modules/ArtsyAPI+Sales.m
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+Sales.m
@@ -21,7 +21,7 @@
                                        failure:(void (^)(NSError *))failure
 {
     NSURLRequest *request = [ARRouter artworksForSaleRequest:saleID];
-    return [self performRequest:request success:^(id json) {
+    return [self performGraphQLRequest:request success:^(id json) {
         NSArray *saleArtworksJSON = json[@"data"][@"sale"][@"sale_artworks"];
 
         NSArray *artworks = [saleArtworksJSON map:^id(id json) {
@@ -37,11 +37,7 @@
         if (success) {
             success(artworks);
         }
-    } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {
-        if (failure) {
-            failure(error);
-        }
-    }];
+    } failure:failure];
 }
 
 + (void)getSaleWithID:(NSString *)saleID

--- a/Artsy/Networking/ArtsyAPI.m
+++ b/Artsy/Networking/ArtsyAPI.m
@@ -33,6 +33,30 @@ NetworkFailureBlock passOnNetworkError(void (^failure)(NSError *))
     return operation;
 }
 
++ (AFHTTPRequestOperation *)performGraphQLRequest:(NSURLRequest *)request success:(void (^)(id))success failure:(void (^)(NSError *error))failure
+{
+    return [self performRequest:request success:^(id json) {
+        // Parse out metadata from GraphQL response.
+        NSArray *errors = json[@"errors"];
+        if (errors) {
+            // GraphQL queries that fail will return 200s but indicate failures with the "errors" key. We need to check them.
+            NSLog(@"Failure fetching GraphQL query: %@", errors);
+            if (failure) {
+                failure([NSError errorWithDomain:@"GraphQL" code:0 userInfo:json]);
+            }
+            return;
+        }
+        if (success) {
+            success(json);
+        }
+    } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {
+        if (failure) {
+            NSLog(@"Network failure fetching GraphQL query: %@", error);
+            failure(error);
+        }
+    }];
+}
+
 + (AFHTTPRequestOperation *)performRequest:(NSURLRequest *)request success:(void (^)(id))success failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure
 {
     NSParameterAssert(success);

--- a/Artsy_Tests/Networking_Tests/API_Modules/ArtsyAPI+GraphQLTests.m
+++ b/Artsy_Tests/Networking_Tests/API_Modules/ArtsyAPI+GraphQLTests.m
@@ -1,0 +1,61 @@
+#import "ArtsyAPI.h"
+#import "ArtsyAPI+Private.h"
+
+SpecBegin(ArtsyAPI);
+
+__block NSURL *url;
+__block NSURLRequest *request;
+__block BOOL invoked;
+
+beforeEach(^{
+    url = [NSURL URLWithString:@"http://example.com/"];
+    request = [NSURLRequest requestWithURL:url];
+    invoked = NO;
+});
+
+it(@"invokes success block", ^{
+    [OHHTTPStubs stubJSONResponseAtPath:@"/" withResponse:@{}];
+
+    waitUntil(^(DoneCallback done) {
+        [ArtsyAPI performGraphQLRequest:request success:^(id JSON) {
+            invoked = YES;
+            done();
+        } failure:^(NSError *error) {
+            failure(@"invoked error callback");
+        }];
+    });
+
+    expect(invoked).to.beTruthy();
+});
+
+it(@"invokes failure callback on network error", ^{
+    [OHHTTPStubs stubJSONResponseAtPath:@"/" withResponse:@{} andStatusCode: 503];
+
+    waitUntil(^(DoneCallback done) {
+        [ArtsyAPI performGraphQLRequest:request success:^(id JSON) {
+            failure(@"invoked success callback");
+        } failure:^(NSError *error) {
+            invoked = YES;
+            done();
+        }];
+    });
+
+    expect(invoked).to.beTruthy();
+});
+
+it(@"invokes failure callback when GraphQL response contains errors key", ^{
+    [OHHTTPStubs stubJSONResponseAtPath:@"/" withResponse:@{@"errors": @[]}];
+
+    waitUntil(^(DoneCallback done) {
+        [ArtsyAPI performGraphQLRequest:request success:^(id JSON) {
+            failure(@"invoked success callback");
+        } failure:^(NSError *error) {
+            invoked = YES;
+            done();
+        }];
+    });
+
+    expect(invoked).to.beTruthy();
+});
+
+SpecEnd

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -14,6 +14,7 @@ upcoming:
       - Add switchboard route to open admin menu through Universal Links with https://artsy.net/admin route - alloy
       - Adds an admin flag for haptic feedback during a live Auction - orta
       - Removes bifurcation of bidders/observers for causality websocket connections - ash
+      - Consolidates GraphQL error-handling - ash
 
     user_facing:
       - Adds new routing for inquiries - maxim


### PR DESCRIPTION
This is a longer-term solution for https://github.com/artsy/eigen/pull/2419 which was a hot fix for 3.2.5. The problem is, new users have no favourites and Gravity errors out on Metaphysics. This was causing a crash for new users signing up. Now, the following error gets logged instead.

```
Failure fetching GraphQL query: (
        {
        message = "https://stagingapi.artsy.net/api/v1/collection/saved-artwork/artworks?offset=0&private=true&size=15&total_count=true&user_id=59b7fa3f8b3b813c631e7fd1 - {\"error\":\"Collection Not Found\"}";
    }
)
```