### PR TITLE
Adds -u to `make pr` command #trivial

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ synxify:
 	bundle exec synx --spaces-to-underscores -e "/Documentation" Artsy.xcodeproj
 
 pr:
-	if [ "$(LOCAL_BRANCH)" == "master" ]; then echo "In master, not PRing"; else git push origin "$(LOCAL_BRANCH):$(BRANCH)"; open "https://github.com/artsy/eigen/pull/new/artsy:master...$(BRANCH)"; fi
+	if [ "$(LOCAL_BRANCH)" == "master" ]; then echo "In master, not PRing"; else git push -u origin "$(LOCAL_BRANCH):$(BRANCH)"; open "https://github.com/artsy/eigen/pull/new/artsy:master...$(BRANCH)"; fi
 
 push:
 	if [ "$(LOCAL_BRANCH)" == "master" ]; then echo "In master, not pushing"; else git push origin $(LOCAL_BRANCH):$(BRANCH); fi


### PR DESCRIPTION
So I've had the following scenario happen a few times:

- Do work and `make pr` at work.
- Pull that branch at home, commit+push more work.
- Next day, try to pull that work.

Git doesn't know where to pull from because we didn't set our local branch to track the remote one when we initially pushed in `make pr`. I can't think of any downsides or inadvertent side-effects.