### PR TITLE
Updates deploy documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ This will set you up on our staging server, you will have a running version of t
 
 **Note**: `bundle exec pod install` may fail the first time you run it (due to a [bug](https://github.com/orta/cocoapods-keys/issues/127) in a dependency of ours). Re-running the command should work.
 
+### Deployment
+
+For how we deploy, check out the dedicated documentation:
+
+- [Deploying a beta](docs/deploying_to_beta.md)
+- [Deploying to the App Store](docs/deploy_to_app_store.md)
 
 ### Thanks
 

--- a/docs/deploy_to_app_store.md
+++ b/docs/deploy_to_app_store.md
@@ -1,60 +1,61 @@
 ## Deploy to App Store
 
-### TODOs for anyone before deploying
+### Pre-deploy Checklist
 
-1. Check out eigen Artsy master.
-2. Ensure all required/expected analytics events are in `docs/BETA_CHANGELOG.md`.
-3. Move `docs/BETA_CHANGELOG.md` to `CHANGELOG.md`.
-4. Remove dev only entries from `CHANGELOG.md`.
-5. Run `make appstore`. This runs `pod install` and prompts for a release version number.
-6. Update CHANGELOG with the release number.
-7. Add and commit the changed files, typically with `-m "Preparing for the next release, version X.Y.Z."`.
+1. Check out Eigen Artsy master.
+1. Ensure all required/expected analytics events are in `CHANGELOG.yml`.
+1. Run `make appstore`. This runs `pod install` and prompts for a release version number.
+1. Update `CHANGELOG.yml` with the release number and date.
+1. Add and commit the changed files, typically with `-m "Preparing for the next release, version X.Y.Z."`. PR the change.
+1. Once merged, pull from master and run `make deploy`.
 
-### Provisioning Profiles
+It takes about 45 minutes for [Circle CI](https://circleci.com/gh/artsy/eigen) to build and submit a binary (and for iTunesConnect to process it). You'll be notified via email (and push notification, if you have the [iTunesConnect iOS app](https://itunes.apple.com/us/app/itunes-connect/id376771144?mt=8) installed.
 
-Open the project in Xcode, click on the Artsy project.
+### Test the Beta
 
-1. Change iOS Deployment Target to "iPhone only" in Info, Deployment Target.
-2. Verify that the provisioning profiles under Code Signing are displayed as below in Build Settings.
+Before submitting to the App Store, the binary we submit *must* be tested *on-device*. Install the beta through Testflight and run through the following scenarios:
 
-IMPORTANT: We use the "Artsy Inc Account" not "ARTSY INC" - which is our enterprise account.
+- [ ] Check user registration and onboarding works.
+- [ ] Test the inqury flow. As an Artsy admin, you will be prevented from _actually_ sending an inquiry.
+- [ ] As a freshly created user, perform a smoke test of: 
+  - [ ] Eigen's main tab view controllers (Search, Home, Explore, You, Notifications).
+  - [ ] The artwork, artist, and auctions view controllers.
+  - [ ] Live Auctions interface.
+- [ ] As a user with populated favourites, follows, etc, perform a smoke test of: 
+  - [ ] Eigen's main tab view controllers (Search, Home, Explore, You, Notifications).
+  - [ ] The artwork, artist, and auctions view controllers.
+  - [ ] Live Auctions interface.
+- [ ] Review `CHANGELOG.yml` entries for the release and run through any parts of the app that seem appropriate.
 
-The provisioning profile should be _"Artsy Mobile - App Store DistrProfile"_ and when the Code Signing ( which should be automatic ) is clicked it should show  "_iPhone Distribution : Art.sy Inc"_
+It is *critical* that we catch bugs before we submit to the App Store. If a bug gets out, it can take days or weeks for Apple to review any fix. As the submitter, you are the last line of defence – the whole team is counting on you.
 
-If you don't see the "Artsy Mobile - App Store DistrProfile" in the options above, import the Dev/Apple/Artsy AppStore Identities from the Artsy Engineering Operations 1Password vault.
-
-If you cannot set Code Signing Identity to "Automatic", under which you'll find "iPhone Distribution: Artsy Inc.", open Xcode Preferences and add it@artsymail.com as an apple account. Also, choose the it@artsymail.com apple ID, click "Artsy Inc." and then refresh until you see two iOS Distribution signing identities, one that says "iOS Distribution (2)".
-
-See [certs.md](certs.md) for more info on certificates.
-
-### Prepare in iTunes Connect
+### Prepare in iTunesConnect
 
 1. You need to have copy for the next release, for minor releases this is just a list of notable changes.
-2. Log in to [iTunes Connect](https://itunesconnect.apple.com) as it@artsymail.com ( team _Art.sy Inc_ ).
-3. Manage Your Apps > Which-ever app > Add new version.
-4. Fill in the copy for each localization.
+1. Log in to [iTunesConnect](https://itunesconnect.apple.com) as it@artsymail.com (team _Art.sy Inc_).
+1. Manage Your Apps > Which-ever app > select the version.
+1. Fill in the copy for each localization.
+1. Add "what's new in this version" information.
+1. About halfway down the page, select the binary to submit, and save your changes.
+1. Click 'Submit for Review'. Then answer the subsequent questions as follows:
+  * Have you added or made changes to encryption features since your last submission of this app?: *NO*
+  * Does your app contain, display, or access third-party content?: *YES*
+  * Do you have all necessary rights to that content […]?: *YES*
+  * Does this app use the Advertising Identifier (IDFA)?: *NO*
 
-### Release to AppStore
+### Release to App Store
 
-1. Install HockeyApp from http://hockeyapp.net/apps and run it.
-2. In Xcode, change the target device to _iOS Device_.
-3. In Xcode, hold alt (`⌥`) and go to the menu, hit _Product_ and then _Archive..._.
-4. Check that the Build Configuration is set to _Store_.
-5. Hit _Archive_.
-6. Hit _Distribute_, it will run validations and submit.
+Our App Store releases are done manually, instead of automatically once Apple approves the app. Don't release unless you are available over the next few hours to monitor Sentry for errors.
 
-### Upon Successful Submission
-
-1. Return to iTunes Connect and click ‘Submit for Review’. Then answer the subequent questions as follows:
-  * Have you added or made changes to encryption features since your last submission of this app?: NO
-  * Does your app contain, display, or access third-party content?: YES
-  * Do you have all necessary rights to that content […]?: YES
-  * Does this app use the Advertising Identifier (IDFA)?: NO
-3. HockeyApp will automatically see your new archive. Push Archived build to HockeyApp as a live build.
-4. Make a git tag for the version with `git tag x.y.z`. Push the tags to `artsy/eigen` with `git push --tags`.
+1. Go to [iTunesConnect](https://itunesconnect.apple.com).
+1. Navigate to Eigen.
+1. Select the version.
+1. Hit "Release this Version" button.
+1. Monitor [Sentry](https://sentry.io/artsynet/eigen/) in the #front-end channel on Slack for any errors (all production errors are sent to Slack when they first occur).
 
 ### Prepare for the Next Release
 
 1. Run `make next`. This runs `pod install` and prompts for the next version number.
-2. Add a new section to CHANGELOG called _Next_.
-3. Add and commit the changed files, typically with `-m "Preparing for development, version X.Y.Z."`.
+1. Create a new version of the app in iTunesConnect (if you don't do this, beta deployments will fail).
+1. Move the release from `upcoming` to `releases` in `CHANGELOG.yml` and add a new, empty entry under `upcoming`.
+1. Add and commit the changed files, typically with `-m "Preparing for development, version X.Y.Z."`. PR the changes.

--- a/docs/deploy_to_beta.md
+++ b/docs/deploy_to_beta.md
@@ -1,9 +1,11 @@
 ## Betas
 
-Deployment to testflight is handled by CircleCI when you send a commit to the `beta` branch of eigen, run `make deploy` locally to trigger it. There is a blog post on the process [here](http://artsy.github.io/blog/2015/12/15/Automating-Testflight-Deploys/).
+Deployment to Testflight is handled by Circle CI when you send a commit to the `beta` branch of Eigen, run `make deploy` locally to trigger it. There is a blog post on the process [here](http://artsy.github.io/blog/2015/12/15/Automating-Testflight-Deploys/).
 
-There are two types of betas on testflight: Internal and External.
+Note that only one beta can be deployed at a time; teams should coordinate on how to use that availability.
 
-Internal betas are the ones triggered by shipping code to the `beta` branch ( or by running `make ipa; make distribute` locally.) These need no human intervention in order to ship them to a phone, usually just the processing time which comes to about 10-15 minutes. They go to anyone who is a user inside our iTunes Connect team. That tends to just be the product team.
+There are two types of betas on Testflight: Internal and External.
 
-External betas requires a quick review from Apple. So far these have taken about a day. Nothing too prohibiting, but as of yet, there is no automation with respect to shipping a beta to external developers. You need to go into iTunes Connect, click through to Eigen, then choose an internal beta to be exposed to the outter world.
+Internal betas are the ones triggered by shipping code to the `beta` branch (or by running `make ipa; make distribute` locally.) These need no human intervention in order to ship them to a phone, usually just the processing time which comes to about 10-15 minutes. They go to anyone who is a user inside our iTunes Connect team. That tends to just be the product team.
+
+External betas requires a quick review from Apple. So far these have taken about a day. Nothing too prohibiting, but as of yet, there is no automation with respect to shipping a beta to external developers. You need to go into iTunes Connect, click through to Eigen, then choose an internal beta to be exposed to the outer world.


### PR DESCRIPTION
Our deploy documentation was pretty out of date – it predated Fastlane! So I've updated it, and also added a pre-release checklist as discussed in [Eigen's recent retrospective](https://github.com/artsy/post_mortems/issues/20).

This is just a first draft – if something isn't obvious, make a comment. We should be concise, but comprehensive so that any engineer at Artsy could submit by following these directions.