### PR TITLE
Updates Homebrew before installing dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ certs:
 
 distribute:  change_version_to_date set_git_properties setup_fastlane_env
 	brew update
-	brew install getsentry/tools/sentry-cli || true
+	brew install getsentry/tools/sentry-cli
 	bundle exec fastlane update_plugins
 	bundle exec fastlane ship_beta
 

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ certs:
 	bundle exec match appstore
 
 distribute:  change_version_to_date set_git_properties setup_fastlane_env
+	brew update
 	brew install getsentry/tools/sentry-cli || true
 	bundle exec fastlane update_plugins
 	bundle exec fastlane ship_beta


### PR DESCRIPTION
Eigen deploys were broken, see this link for more info: https://discuss.circleci.com/t/homebrew-must-be-run-under-ruby-2-3-runtimeerror/17232/8

I've tested and it works: https://circleci.com/gh/artsy/eigen/4512