### PR TITLE
Fixes a problem with number of bids not updating 📱

### DIFF
--- a/Artsy/View_Controllers/Live_Auctions/Views/LiveAuctionToolbarView.swift
+++ b/Artsy/View_Controllers/Live_Auctions/Views/LiveAuctionToolbarView.swift
@@ -43,6 +43,7 @@ class LiveAuctionToolbarView: UIView {
         if newSuperview == nil {
             lotStateObserver?.unsubscribe()
             numberOfBidsObserver?.unsubscribe()
+            numberOfBidsObserver = nil
         }
     }
 
@@ -72,7 +73,9 @@ class LiveAuctionToolbarView: UIView {
 
             numberOfBidsClosure = { [weak self] label in
                 guard let `self` = self else { return }
-                guard self.numberOfBidsObserver == nil else { return }
+                if let existingObserver = self.numberOfBidsObserver {
+                    existingObserver.unsubscribe()
+                }
 
                 self.numberOfBidsObserver = self.lotViewModel
                     .newEventsSignal

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,6 +3,7 @@ upcoming:
     details: Bug fixes
     user_facing:
       - Custom sale-on-hold banner - ash
+      - Fixes a problem where the number of bids weren't being updated in LAI
     dev:
       - Adds client metadata info to causality events - ash
 


### PR DESCRIPTION
While testing the beta to submit 3.2.6 to the App Store, I opened the Phillips sale we had on and noticed that the label for the number of bids in the LAI interface never updated, even as new bids came in.

The bug was that if we had a previous subscription to the new events signal, we would never replace it until we were removed from our superview. That's fine as long as we are removed from the superview before being set up again. But if you had your view set up twice, for whatever reason, the subscription would still be the first one pointing to the first label (which is now an orphaned view). The solution is to unsubscribe existing subscriptions and always create a new subscription.

I couldn't reproduce the build in the simulator, only on device. I suspect that something about the view setup process on devices differs from the simulator.

Probably related to https://github.com/artsy/auctions/issues/606