### PR TITLE
Version bump to 3.2.7

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.6</string>
+	<string>3.2.7</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSExtension</key>

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.6</string>
+	<string>3.2.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,12 +1,21 @@
 upcoming:
-    version: 3.2.6
+    version: 3.2.7
     details: Bug fixes
+    user_facing:
+      -
+    dev:
+      -
+
+releases:
+  - version: 3.2.6
+    details: Bug fixes
+    date: October 18, 2017
     user_facing:
       - Custom sale-on-hold banner - ash
     dev:
       - Adds client metadata info to causality events - ash
+      - Removes nulls from JSON in GraphQL responses.
 
-releases:
   - version: 3.2.5
     details: Bug fixes
     date: Oct 10, 2017


### PR DESCRIPTION
This updates the changelog for a new (hypothetical, not planning on it) 3.2.7 patch release. It also adds a note about JSON null-handing in GraphQL requests that had been omitted. 