### PR TITLE
Also apply the font changes to ARThemes

### DIFF
--- a/Artsy/Theming/ARTheme.m
+++ b/Artsy/Theming/ARTheme.m
@@ -84,7 +84,7 @@ static ARTheme *defaultTheme;
     self.name = name;
     self.themeDictionary = [content mutableCopy];
     self.fontShortcuts = @{
-        @"Avant" : @"AvantGardeGothicITCW01Dm",
+        @"Avant" : @"ITCAvantGardeDemi_Track03",
         @"Garamond" : @"AGaramondPro-Regular",
         @"GaramondBold" : @"AGaramondPro-Bold"
     };


### PR DESCRIPTION
Looks like there was a place the font changes were missed by us in #2449 , interestingly the places this code touches ( ArtworkVCs related pages, Fair Guide, and native old ArtistVC) seemed to not have snapshot tests covering them. Weird.