### PR TITLE
Removes .eigen file docs #trivial

### DIFF
--- a/docs/eigen_tips.md
+++ b/docs/eigen_tips.md
@@ -8,16 +8,6 @@ Quickly load any type of our primitives ( shows / artworks / artists etc ) by pr
 
 Be sure to sign-in with an admin account if you wish to see admin only content, such as ‘unpublished’ artworks.
 
-Use your `.eigen` file
------------------------
-
-Authentication is a lot easier when you don't type so much, create a file in your home directory called `.eigen` and it takes a collection of `key:value` lines to have the username and password set for you in the `ARLoginViewController`.  You can use the `ARDeveloperOptions` class to react to the key value store. For example:
-
-```
-username:ash@artsymail.com
-password:this_is_not_my_actual_password
-```
-
 Use the developer springboard function
 --------------------------------------
 


### PR DESCRIPTION
Specifically, the docs around login using the `.eigen` file, as it's no longer used and not planned for un-obsolescence. 