### PR TITLE
Moves to use the new iOS 10 open url syntax

### DIFF
--- a/Artsy/App/ARAppDelegate.m
+++ b/Artsy/App/ARAppDelegate.m
@@ -317,12 +317,25 @@ static ARAppDelegate *_sharedInstance = nil;
     }
 }
 
+// For pre-iOS 10
 - (BOOL)application:(UIApplication *)application
             openURL:(NSURL *)url
   sourceApplication:(NSString *)sourceApplication
          annotation:(id)annotation
 {
-    _referralURLRepresentation = sourceApplication;
+    return [self application:application openURL:url options:@{
+       UIApplicationOpenURLOptionsSourceApplicationKey: sourceApplication ?: @"",
+       UIApplicationOpenURLOptionsAnnotationKey: annotation  ?: @""
+    }];
+}
+
+// For iOS 10
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
+{
+    NSString *sourceApplication = options[UIApplicationOpenURLOptionsSourceApplicationKey];
+    id annotation = options[UIApplicationOpenURLOptionsAnnotationKey];
+
+    _referralURLRepresentation = options[UIApplicationOpenURLOptionsSourceApplicationKey];
     _landingURLRepresentation = [url absoluteString];
 
     [self lookAtURLForAnalytics:url];
@@ -345,7 +358,7 @@ static ARAppDelegate *_sharedInstance = nil;
     if ([[url scheme] isEqualToString:fbScheme]) {
         // Call FBAppCall's handleOpenURL:sourceApplication to handle Facebook app responses
         FBSDKApplicationDelegate *fbAppDelegate = [FBSDKApplicationDelegate sharedInstance];
-        return [fbAppDelegate application:application openURL:url sourceApplication:sourceApplication annotation:annotation];
+        return [fbAppDelegate application:app openURL:url sourceApplication:sourceApplication annotation:annotation];
     }
 
     if ([url isFileURL]) {

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -18,6 +18,7 @@ upcoming:
       - Removes bifurcation of bidders/observers for causality websocket connections - ash
       - New Admin UI - orta
       - Fix small bug with analytics popovers not turning off - maxim
+      - Fix for opening URLs in iOS 11 - orta
 
     user_facing:
       - Adds a new navigation UI - orta


### PR DESCRIPTION
Apple announced an API switcheroo with iOS 10, then forced it on iOS 11 - should fix #2460 