### PR TITLE
[Top Menu] cache messages VC after initial load

### DIFF
--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuNavigationDataSource.h
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuNavigationDataSource.h
@@ -21,9 +21,9 @@ typedef NS_ENUM(NSInteger, ARTopTabControllerIndex) {
 
 @interface ARTopMenuNavigationDataSource : NSObject <ARTabViewDataSource>
 
-- (ARNavigationController *)getMessagingNavigationController;
-- (ARNavigationController *)getProfileNavigationController;
-- (ARNavigationController *)getFavoritesNavigationController;
+@property (readonly, nonatomic, strong) ARNavigationController *messagingNavigationController;
+@property (readonly, nonatomic, strong) ARNavigationController *profileNavigationController;
+@property (readonly, nonatomic, strong) ARNavigationController *favoritesNavigationController;
 
 - (ARNavigationController *)navigationControllerAtIndex:(NSInteger)index;
 - (ARNavigationController *)navigationControllerAtIndex:(NSInteger)index parameters:(NSDictionary *)params;

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuNavigationDataSource.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuNavigationDataSource.m
@@ -26,9 +26,9 @@
 @property (nonatomic, assign, readonly) NSUInteger *badgeCounts;
 
 @property (readonly, nonatomic, strong) ARNavigationController *feedNavigationController;
-@property (readonly, nonatomic, strong) ARNavigationController *messagingNavigationController;
-@property (readonly, nonatomic, strong) ARNavigationController *savedNavigationController;
-@property (readonly, nonatomic, strong) ARNavigationController *profileNavigationController;
+@property (nonatomic, strong) ARNavigationController *favoritesNavigationController;
+@property (nonatomic, strong) ARNavigationController *messagingNavigationController;
+@property (nonatomic, strong) ARNavigationController *profileNavigationController;
 
 @end
 
@@ -55,11 +55,10 @@
     return self;
 }
 
-- (ARNavigationController *)getMessagingNavigationController
+- (ARNavigationController *)messagingNavigationController
 {
-    // This is an assumption baked into the component itself ( see the header for ARInboxComponentViewController)
-    if (self.messagingNavigationController) {
-        return self.messagingNavigationController;
+    if (_messagingNavigationController) {
+        return _messagingNavigationController;
     }
 
     ARComponentViewController *messagingVC = [[ARInboxComponentViewController alloc] initWithInbox];
@@ -74,10 +73,10 @@
     return _feedNavigationController;
 }
 
-- (ARNavigationController *)getProfileNavigationController
+- (ARNavigationController *)profileNavigationController
 {
-    if (self.profileNavigationController) {
-        return self.profileNavigationController;
+    if (_profileNavigationController) {
+        return _profileNavigationController;
     }
 
     ARComponentViewController *profileVC = [[ARMyProfileViewController alloc] init];
@@ -85,15 +84,11 @@
     return _profileNavigationController;
 }
 
-- (ARNavigationController *)getFavoritesNavigationController
+- (ARNavigationController *)favoritesNavigationController
 {
-    // Make a new one each time the favorites tab is selected, so that it presents up-to-date data.
-    //
-    // According to Laura, the existing instance was kept alive in the past and updated whenever new favourite data
-    // became available, but it was removed because of some crashes. This likely had to do with
-    // https://github.com/artsy/eigen/issues/287#issuecomment-88036710
-    ARFavoritesComponentViewController *favoritesViewController = [[ARFavoritesComponentViewController alloc] init];
-    return [[ARNavigationController alloc] initWithRootViewController:favoritesViewController];
+    ARFavoritesComponentViewController *favoritesVC = [[ARFavoritesComponentViewController alloc] init];
+    _favoritesNavigationController = [[ARNavigationController alloc] initWithRootViewController:favoritesVC];
+    return _favoritesNavigationController;
 }
 
 - (ARNavigationController *)worksForYouNavigationControllerWithSelectedArtist:(NSString *)artistID
@@ -118,13 +113,13 @@
             }
 
         case ARTopTabControllerIndexMessaging:
-            return [self getMessagingNavigationController];
+            return [self messagingNavigationController];
 
         case ARTopTabControllerIndexFavorites:
-            return self.getFavoritesNavigationController;
+            return [self favoritesNavigationController];
 
         case ARTopTabControllerIndexProfile:
-        return [self getProfileNavigationController];
+            return [self profileNavigationController];
 
     }
 

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuNavigationDataSource.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuNavigationDataSource.m
@@ -57,9 +57,10 @@
 
 - (ARNavigationController *)getMessagingNavigationController
 {
-    // Make a new one each time the favorites tab is selected, so that it presents up-to-date data.
-    //
     // This is an assumption baked into the component itself ( see the header for ARInboxComponentViewController)
+    if (self.messagingNavigationController) {
+        return self.messagingNavigationController;
+    }
 
     ARComponentViewController *messagingVC = [[ARInboxComponentViewController alloc] initWithInbox];
     _messagingNavigationController = [[ARNavigationController alloc] initWithRootViewController:messagingVC];

--- a/Artsy_Tests/View_Controller_Tests/App_Menu/ARTopMenuNavigationDataSourceSpec.m
+++ b/Artsy_Tests/View_Controller_Tests/App_Menu/ARTopMenuNavigationDataSourceSpec.m
@@ -33,22 +33,22 @@ it(@"uses the same home feed vc", ^{
 });
 
 it(@"uses a single profile vc", ^{
-    ARNavigationController *navigationController = [navDataSource getProfileNavigationController];
+    ARNavigationController *navigationController = [navDataSource profileNavigationController];
     UIViewController *rootVC = [[navigationController viewControllers] objectAtIndex:0];
     expect(rootVC).to.beKindOf(ARComponentViewController.class);
 
-    ARNavigationController *newNavigationController = [navDataSource getProfileNavigationController];
+    ARNavigationController *newNavigationController = [navDataSource profileNavigationController];
     UIViewController *newRootVC = [[newNavigationController viewControllers] objectAtIndex:0];
     expect(newNavigationController).to.equal(navigationController);
     expect(newRootVC).to.equal(rootVC);
 });
 
 it(@"generates favorites vc each time", ^{
-    ARNavigationController *navigationController = [navDataSource getFavoritesNavigationController];
+    ARNavigationController *navigationController = [navDataSource favoritesNavigationController];
     UIViewController *rootVC = [[navigationController viewControllers] objectAtIndex:0];
     expect(rootVC).to.beKindOf([ARFavoritesComponentViewController class]);
 
-    ARNavigationController *newNavigationController = [navDataSource getFavoritesNavigationController];
+    ARNavigationController *newNavigationController = [navDataSource favoritesNavigationController];
     UIViewController *newRootVC = [[newNavigationController viewControllers] objectAtIndex:0];
     expect(newNavigationController).notTo.equal(navigationController);
     expect(newRootVC).notTo.equal(rootVC);

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,6 +3,7 @@ upcoming:
     details: Messaging / Consignments / Tabbed Home
     emission_version: 1.4.0
     dev:
+      - Caches Inbox VC to prevent refetching all data on tab changes - luc
       - When routing from Works For You email, place selected artist from email at top of home feed - sarah
       - Reload active bids on pull-to-refresh - alloy
       - Make active bids link to their artworks - alloy


### PR DESCRIPTION
Fixes: https://github.com/artsy/collector-experience/issues/794

Currently, every time the user taps on the messages tab, we create a new instance of `ARInboxComponentViewController` and present it. That causes the view loading indicator to show more than we'd like even though data has been loaded already.

In order for the view to be refreshed properly, we'll have to refresh data in emission when the tab is active using one of the react lifecycle (i.e. `componentWillMount`).

Before
<img src="https://user-images.githubusercontent.com/296775/33557515-0afee5fa-d93a-11e7-9bc3-b36901a5e6c9.gif" width="300" />

After
<img src="https://user-images.githubusercontent.com/296775/33557533-13a84a02-d93a-11e7-92c5-298f27d2330a.gif" width="300" />
