### PR TITLE
Adds supports for point estimates

### DIFF
--- a/Artsy/Models/API_Models/Auctions/SaleArtwork.h
+++ b/Artsy/Models/API_Models/Auctions/SaleArtwork.h
@@ -41,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) NSNumber *_Nullable openingBidCents;
 @property (nonatomic, strong) NSNumber *minimumNextBidCents;
+@property (nonatomic, strong) NSNumber *_Nullable estimateCents;
 @property (nonatomic, strong) NSNumber *_Nullable lowEstimateCents;
 @property (nonatomic, strong) NSNumber *_Nullable highEstimateCents;
 @property (nonatomic, strong) NSNumber *_Nullable bidCount;
@@ -54,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 // This is shared behavior between SaleArtwork and LiveLot
 
 + (NSValueTransformer *)reserveStatusJSONTransformer;
-+ (NSString *)estimateStringForLowEstimate:(NSNumber *_Nullable)lowEstimateCents highEstimateCents:(NSNumber *_Nullable)highEstimateCents currencySymbol:(NSString *)symbol currency:(NSString *)currency;
++ (NSString *)estimateStringForEstimate:(NSNumber *_Nullable)estimateCents lowEstimate:(NSNumber *_Nullable)lowEstimateCents highEstimateCents:(NSNumber *_Nullable)highEstimateCents currencySymbol:(NSString *)symbol currency:(NSString *)currency;
 + (NSString *)dollarsFromCents:(NSNumber *)cents currencySymbol:(NSString *)symbol;
 
 

--- a/Artsy/Models/API_Models/Auctions/SaleArtwork.m
+++ b/Artsy/Models/API_Models/Auctions/SaleArtwork.m
@@ -37,6 +37,7 @@ static NSNumberFormatter *currencyFormatter;
         ar_keypath(SaleArtwork.new, minimumNextBidCents) : @"minimum_next_bid_cents",
         ar_keypath(SaleArtwork.new, saleHighestBid) : @"highest_bid",
         ar_keypath(SaleArtwork.new, artworkNumPositions) : @"bidder_positions_count",
+        ar_keypath(SaleArtwork.new, estimateCents) : @"estimate_cents",
         ar_keypath(SaleArtwork.new, lowEstimateCents) : @"low_estimate_cents",
         ar_keypath(SaleArtwork.new, highEstimateCents) : @"high_estimate_cents",
         ar_keypath(SaleArtwork.new, reserveStatus) : @"reserve_status",
@@ -154,14 +155,16 @@ static NSNumberFormatter *currencyFormatter;
 
 - (BOOL)hasEstimate
 {
-    return self.lowEstimateCents || self.highEstimateCents;
+    return self.estimateCents || self.lowEstimateCents || self.highEstimateCents;
 }
 
-+ (NSString *)estimateStringForLowEstimate:(NSNumber *_Nullable)lowEstimateCents highEstimateCents:(NSNumber *_Nullable)highEstimateCents currencySymbol:(NSString *)symbol currency:(NSString *)currency
++ (NSString *)estimateStringForEstimate:(NSNumber *_Nullable)estimateCents lowEstimate:(NSNumber *_Nullable)lowEstimateCents highEstimateCents:(NSNumber *_Nullable)highEstimateCents currencySymbol:(NSString *)symbol currency:(NSString *)currency
 {
     NSString *estimateValue;
     if (lowEstimateCents && highEstimateCents) {
         estimateValue = [NSString stringWithFormat:@"%@ – %@", [self dollarsFromCents:lowEstimateCents currencySymbol:symbol], [self dollarsFromCents:highEstimateCents currencySymbol:symbol]];
+    } else if (estimateCents) {
+        estimateValue = [self dollarsFromCents:estimateCents currencySymbol:symbol];
     } else if (lowEstimateCents) {
         estimateValue = [self dollarsFromCents:lowEstimateCents currencySymbol:symbol];
     } else if (highEstimateCents) {
@@ -175,7 +178,7 @@ static NSNumberFormatter *currencyFormatter;
 
 - (NSString *)estimateString
 {
-    return [self.class estimateStringForLowEstimate:self.lowEstimateCents highEstimateCents:self.highEstimateCents currencySymbol:self.currencySymbol currency:self.currency];
+    return [self.class estimateStringForEstimate:self.estimateCents lowEstimate:self.lowEstimateCents highEstimateCents:self.highEstimateCents currencySymbol:self.currencySymbol currency:self.currency];
 }
 
 - (NSString *)numberOfBidsString

--- a/Artsy/Models/API_Models/LiveAuctionLot.h
+++ b/Artsy/Models/API_Models/LiveAuctionLot.h
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readonly) NSString *currency;
 @property (nonatomic, copy, readonly) NSString *currencySymbol;
 
-@property (nonatomic, strong, readonly, nullable) NSNumber *lowEstimateCents;
+@property (nonatomic, strong, readonly, nullable) NSNumber *estimateCents;
 @property (nonatomic, strong, readonly, nullable) NSNumber *highEstimateCents;
 @property (nonatomic, copy, readonly) NSString *_Nullable estimate;
 @property (nonatomic, assign, readonly) UInt64 askingPriceCents;

--- a/Artsy/Models/API_Models/LiveAuctionLot.m
+++ b/Artsy/Models/API_Models/LiveAuctionLot.m
@@ -36,7 +36,7 @@
         ar_keypath(LiveAuctionLot.new, artistName) : @"artwork.artist.name",
         ar_keypath(LiveAuctionLot.new, artistBlurb) : @"artwork.artist.blurb",
         ar_keypath(LiveAuctionLot.new, highEstimateCents) : @"high_estimate_cents",
-        ar_keypath(LiveAuctionLot.new, lowEstimateCents) : @"low_estimate_cents",
+        ar_keypath(LiveAuctionLot.new, estimateCents) : @"estimate_cents",
         ar_keypath(LiveAuctionLot.new, lotLabel) : @"lot_label",
         ar_keypath(LiveAuctionLot.new, imageDictionary) : @"artwork.image",
         ar_keypath(LiveAuctionLot.new, currencySymbol) : @"symbol",

--- a/Artsy/View_Controllers/Live_Auctions/LiveAuctionBidViewModel.swift
+++ b/Artsy/View_Controllers/Live_Auctions/LiveAuctionBidViewModel.swift
@@ -79,7 +79,7 @@ class LiveAuctionBidViewModel: NSObject {
 
         bidIncrements = [currentBid]
 
-        let threshold = 5 * max(lotVM.askingPrice, (lotVM.highEstimateCents ?? 0))
+        let threshold = 5 * max(lotVM.askingPrice, (lotVM.highEstimateOrEstimateCents ?? 0))
         var i = 0
         repeat {
             let nextBid = salesPerson.bidIncrements.minimumNextBidCentsIncrement(bidIncrements[i])

--- a/Artsy/View_Controllers/Live_Auctions/ViewModels/LiveAuctionLotViewModel.swift
+++ b/Artsy/View_Controllers/Live_Auctions/ViewModels/LiveAuctionLotViewModel.swift
@@ -32,7 +32,7 @@ protocol LiveAuctionLotViewModelType: class {
     var lotArtworkDimensions: String? { get }
 
     var estimateString: String? { get }
-    var highEstimateCents: UInt64? { get }
+    var highEstimateOrEstimateCents: UInt64? { get }
     var lotName: String { get }
     var lotID: String { get }
     var lotLabel: String? { get }
@@ -243,8 +243,8 @@ class LiveAuctionLotViewModel: NSObject, LiveAuctionLotViewModelType {
         return model.estimate
     }
 
-    var highEstimateCents: UInt64? {
-        return model.highEstimateCents?.uint64Value
+    var highEstimateOrEstimateCents: UInt64? {
+        return model.highEstimateCents?.uint64Value ?? model.estimateCents?.uint64Value
     }
 
     var eventIDs: [String] {

--- a/Artsy_Tests/Model_Tests/SaleArtworkTests.m
+++ b/Artsy_Tests/Model_Tests/SaleArtworkTests.m
@@ -15,12 +15,12 @@ describe(@"artwork for sale", ^{
         expect([_saleArtwork auctionState]).to.equal(ARAuctionStateDefault);
     });
 
-    it(@"says it has no estimate when there is no min/max estimate", ^{
+    it(@"says it has no estimate when there is no min/max/point estimate", ^{
         _saleArtwork = [[SaleArtwork alloc] init];
         expect(_saleArtwork.hasEstimate).to.beFalsy();
     });
     
-    it(@"says it has an estimate when there is no min/max estimate", ^{
+    it(@"says it has an estimate when there is a min/max/point estimate", ^{
         _saleArtwork = [SaleArtwork modelWithJSON:@{@"high_estimate_cents" : @20000}];
         expect(_saleArtwork.hasEstimate).to.beTruthy();
 
@@ -29,6 +29,9 @@ describe(@"artwork for sale", ^{
 
         _saleArtwork = [SaleArtwork modelWithJSON:@{@"high_estimate_cents" : @20000, @"low_estimate_cents" : @10000}];
         expect(_saleArtwork.hasEstimate).to.beTruthy();
+
+        _saleArtwork = [SaleArtwork modelWithJSON:@{@"estimate_cents": @20000}];
+        expect(_saleArtwork.hasEstimate).to.beTruthy();
     });
     
     describe(@"estimate string", ^{
@@ -36,6 +39,19 @@ describe(@"artwork for sale", ^{
         it(@"returns a string showing both low and high ", ^{
             _saleArtwork = [SaleArtwork modelWithJSON:@{ @"high_estimate_cents" : @20000, @"low_estimate_cents" : @10000, @"currency" : @"USD", @"symbol" : @"$"}];
             expect(_saleArtwork.estimateString).to.equal(@"Estimate: $100 – $200 USD");
+        });
+
+        it(@"returns a string showing point estimate", ^{
+            _saleArtwork = [SaleArtwork modelWithJSON:@{ @"estimate_cents" : @20000, @"currency" : @"USD", @"symbol" : @"$"}];
+            expect(_saleArtwork.estimateString).to.equal(@"Estimate: $200 USD");
+        });
+
+        it(@"prefers point estimates to only a low or high estimate", ^{
+            _saleArtwork = [SaleArtwork modelWithJSON:@{ @"estimate_cents" : @20000, @"low_estimate_cents" : @10000, @"currency" : @"USD", @"symbol" : @"$"}];
+            expect(_saleArtwork.estimateString).to.equal(@"Estimate: $200 USD");
+
+            _saleArtwork = [SaleArtwork modelWithJSON:@{ @"estimate_cents" : @20000, @"high_estimate_cents" : @30000, @"currency" : @"USD", @"symbol" : @"$"}];
+            expect(_saleArtwork.estimateString).to.equal(@"Estimate: $200 USD");
         });
         
         it(@"returns a string showing low if available ", ^{

--- a/Artsy_Tests/Networking_Tests/LiveAuctionLotViewModelSpecs.swift
+++ b/Artsy_Tests/Networking_Tests/LiveAuctionLotViewModelSpecs.swift
@@ -49,5 +49,31 @@ class LiveAuctionLotViewModelSpec: QuickSpec {
 
             expect(subject.numberOfDerivedEvents) == 1
         }
+
+        context("estimates") {
+            let creds = BiddingCredentials(bidders: [], paddleNumber: "")
+
+            it("calculates highEstimateOrEstimateCents with only a highEstimate") {
+                let lot = LiveAuctionLot(json: ["high_estimate_cents": 20000])
+                subject = LiveAuctionLotViewModel(lot: lot!, bidderCredentials: creds)
+
+                expect(subject.highEstimateOrEstimateCents) == 20000
+            }
+
+            it("calculates highEstimateOrEstimateCents with only an estimate") {
+                let lot = LiveAuctionLot(json: ["estimate_cents": 30000])
+                subject = LiveAuctionLotViewModel(lot: lot!, bidderCredentials: creds)
+
+                expect(subject.highEstimateOrEstimateCents) == 30000
+
+            }
+
+            it("prefers a highEstimate when calculating highEstimateOrEstimateCents") {
+                let lot = LiveAuctionLot(json: ["estimate_cents": 40000, "high_estimate_cents": 50000])
+                subject = LiveAuctionLotViewModel(lot: lot!, bidderCredentials: creds)
+
+                expect(subject.highEstimateOrEstimateCents) == 50000
+            }
+        }
     }
 }

--- a/Artsy_Tests/View_Controller_Tests/Live_Auction/LiveAuctionLotViewControllerTests.swift
+++ b/Artsy_Tests/View_Controller_Tests/Live_Auction/LiveAuctionLotViewControllerTests.swift
@@ -151,7 +151,7 @@ class Test_LiveAuctionLotViewModel: LiveAuctionLotViewModelType {
     var reserveStatusString = "is testing reserve"
     var numberOfDerivedEvents = 1
     var lotLabel: String? = "2"
-    var highEstimateCents: UInt64? = 2_000_00
+    var highEstimateOrEstimateCents: UInt64? = 2_000_00
     var numberOfBids = 1
     var currencySymbol = "$"
     var imageAspectRatio: CGFloat = 1

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -32,6 +32,7 @@ upcoming:
       - Fixes login for users with short passwords - ash
       - Fixes inconsistencies in bid counts of online sales - ash
       - Fixes a minor problem displaying lots in past auctions - ash
+      - Adds support for point estimates - ash
       - Do not intercept tel links with our custom dialog modal - isac
       - Presents live bidding interface when sale has opened and UI reappearing from an artwork VC - ash
       - Fix for launch screen image being truncated - orta


### PR DESCRIPTION
Okay so this PR adds support for point estimates (in lieu of estimate _ranges_). There are two important components:

- a generic lot model that adds support for the estimate field for display in the UI, and
- a live-specific lot model that needs the estimate field for capping the max bid to be placed by the user (display for estimates in live sales is already computed for us by metaphysics)

The second point is kind of interesting since we want to move away from Eigen calculating appropriate bid values altogether and only rely on Causality/Metaphysics. But in the mean time, I've replaced the unused `lowEstimateCents` with just `estimateCents`. 

~This PR is a WIP because it has no tests yet. In fact, I believe it will fail to compile on CI.~

Here's what it looks like:

![simulator screen shot dec 14 2017 at 3 43 34 pm](https://user-images.githubusercontent.com/498212/34013453-99154c82-e0e5-11e7-8e5d-90e739c64d08.png)
![simulator screen shot dec 14 2017 at 3 42 27 pm](https://user-images.githubusercontent.com/498212/34013454-99236592-e0e5-11e7-8794-a5aa2d43ca42.png)

Tracked in https://github.com/artsy/auctions/issues/177.