### PR TITLE
Make sure modals cannot change back button visibility of presenters #trivial

### DIFF
--- a/Artsy/View_Controllers/Util/ARNavigationController.m
+++ b/Artsy/View_Controllers/Util/ARNavigationController.m
@@ -455,7 +455,8 @@ ShouldHideItem(UIViewController *viewController, SEL itemSelector, ...)
     } else if (context == ARNavigationControllerScrollingChiefContext) {
         // All hail the chief
         ARScrollNavigationChief *chief = object;
-
+        
+        NSAssert(self.visibleViewController == self.topViewController, @"Called by a VC that is not part of this navigation controller's stack.");
         [self showBackButton:[self shouldShowBackButtonForViewController:self.topViewController] && chief.allowsMenuButtons animated:YES];
     } else if (context == ARNavigationControllerMenuAwareScrollViewContext) {
         UIViewController<ARMenuAwareViewController> *vc = object;

--- a/Artsy/View_Controllers/Web_Browsing/ARExternalWebBrowserViewController.m
+++ b/Artsy/View_Controllers/Web_Browsing/ARExternalWebBrowserViewController.m
@@ -138,7 +138,7 @@
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
-    if (self.navigationController && [self.navigationController isKindOfClass:ARNavigationController.class]) {
+    if ([self.navigationController isKindOfClass:ARNavigationController.class]) {
         [[ARScrollNavigationChief chief] scrollViewDidScroll:scrollView];
     }
 }

--- a/Artsy/View_Controllers/Web_Browsing/ARExternalWebBrowserViewController.m
+++ b/Artsy/View_Controllers/Web_Browsing/ARExternalWebBrowserViewController.m
@@ -138,7 +138,9 @@
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
-    [[ARScrollNavigationChief chief] scrollViewDidScroll:scrollView];
+    if (self.navigationController && [self.navigationController isKindOfClass:ARNavigationController.class]) {
+        [[ARScrollNavigationChief chief] scrollViewDidScroll:scrollView];
+    }
 }
 
 #pragma mark UIGestureRecognizerDelegate

--- a/Artsy/View_Controllers/Web_Browsing/ARExternalWebBrowserViewController.m
+++ b/Artsy/View_Controllers/Web_Browsing/ARExternalWebBrowserViewController.m
@@ -69,7 +69,6 @@
     [webView loadRequest:initialRequest];
 
     UIScrollView *scrollView = webView.scrollView;
-    scrollView.delegate = self;
     scrollView.decelerationRate = UIScrollViewDecelerationRateNormal;
 
     // Work around bug in WKScrollView by setting private ivar directly: http://trac.webkit.org/changeset/188541
@@ -91,6 +90,13 @@
 
     _webView = webView;
 }
+
+- (void)willMoveToParentViewController:(UIViewController *)parent;
+{
+    [super willMoveToParentViewController:parent];
+    self.scrollView.delegate = [parent isKindOfClass:ARNavigationController.class] ? self : nil;
+}
+
 
 - (UIStatusBarStyle)preferredStatusBarStyle
 {

--- a/Artsy_Tests/View_Controller_Tests/Web_Browsing/ARExternalWebBrowserViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Web_Browsing/ARExternalWebBrowserViewControllerTests.m
@@ -29,16 +29,6 @@ it(@"forwards its web view's scroll view", ^{
     expect(vc.scrollView).to.equal(vc.webView.scrollView);
 });
 
-it(@"forwards `scrollViewDidScroll` to scroll chief", ^{
-    [vc ar_presentWithFrame:[UIScreen mainScreen].bounds];
-
-    id chiefMock = [OCMockObject partialMockForObject:[ARScrollNavigationChief chief]];
-    [[chiefMock expect] scrollViewDidScroll:vc.scrollView];
-    [vc scrollViewDidScroll:vc.scrollView];
-    [chiefMock verify];
-});
-
-
 it(@"uses the shared ARWebViewCacheHost WKWebView instances", ^{
     [vc ar_presentWithFrame:[UIScreen mainScreen].bounds];
 

--- a/Artsy_Tests/View_Controller_Tests/Web_Browsing/ARExternalWebBrowserViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Web_Browsing/ARExternalWebBrowserViewControllerTests.m
@@ -19,9 +19,15 @@ afterEach(^{
     vc = nil;
 });
 
-it(@"sets the scroll view's `delegate`", ^{
+it(@"sets the scroll view's `delegate` if it belongs to ARNavigationController", ^{
     [vc ar_presentWithFrame:[UIScreen mainScreen].bounds];
+    ARNavigationController *nav =[[ARNavigationController alloc] initWithRootViewController:vc];
     expect(vc.scrollView.delegate).to.equal(vc);
+});
+
+it(@"does not set the scroll view's `delegate` if it does not belong to ARNavigationController", ^{
+    [vc ar_presentWithFrame:[UIScreen mainScreen].bounds];
+    expect(vc.scrollView.delegate).to.equal(nil);
 });
 
 it(@"forwards its web view's scroll view", ^{


### PR DESCRIPTION
Without making any sweeping structural changes, this fix makes sure the payment request modal (or any visible view controller that uses the scroll chief) doesn't change the back button visibility of its presenter.

Fixes https://github.com/artsy/collector-experience/issues/791

#skip_new_tests