### PR TITLE
[Dev] push notification delegate fixes

### DIFF
--- a/Artsy/App/ARAppNotificationsDelegate.m
+++ b/Artsy/App/ARAppNotificationsDelegate.m
@@ -189,7 +189,7 @@
     [notificationInfo setObject:uiApplicationState forKey:@"UIApplicationState"];
 
     NSString *url = userInfo[@"url"];
-    NSString *message = userInfo[@"aps"][@"alert"] ?: url;
+    id message = userInfo[@"aps"][@"alert"] ?: url;
     BOOL isConversation = url && [[[NSURL URLWithString:url] path] hasPrefix:@"/conversation/"];
     
     if (isConversation) {
@@ -213,10 +213,11 @@
             ARConversationComponentViewController * controller = [[[[ARTopMenuViewController sharedController] rootNavigationController] viewControllers] lastObject];
             NSString *conversationID = [notificationInfo[@"conversation_id"] stringValue];
             if ([controller isKindOfClass:ARConversationComponentViewController.class] && [controller.conversationID isEqualToString:conversationID]) {
-                [controller refreshView];
+                [[NSNotificationCenter defaultCenter] postNotificationName:@"notification_received" object:notificationInfo];
             } else {
+                NSString *title = [message isKindOfClass:[NSString class]] ? message : message[@"title"];
                 [ARNotificationView showNoticeInView:[self findVisibleWindow]
-                                               title:message
+                                               title:title
                                             response:^{
                                                 [self tappedNotification:notificationInfo viewController:viewController];
                                             }];

--- a/Artsy/App/ARAppNotificationsDelegate.m
+++ b/Artsy/App/ARAppNotificationsDelegate.m
@@ -210,12 +210,11 @@
             // A notification was received while the app was already active, so we show our own notification view.
             [self receivedNotification:notificationInfo];
             
-            id controller = [[[[ARTopMenuViewController sharedController] rootNavigationController] viewControllers] lastObject];
+            ARConversationComponentViewController * controller = [[[[ARTopMenuViewController sharedController] rootNavigationController] viewControllers] lastObject];
             NSString *conversationID = [notificationInfo[@"conversation_id"] stringValue];
-            if ([controller isKindOfClass:ARConversationComponentViewController.class] && [((ARConversationComponentViewController *) controller).conversationID isEqualToString:conversationID]) {
-                [[NSNotificationCenter defaultCenter] postNotificationName:@"notification_received" object:notificationInfo];
+            if ([controller isKindOfClass:ARConversationComponentViewController.class] && [controller.conversationID isEqualToString:conversationID]) {
+                [controller refreshView];
             } else {
-            
                 [ARNotificationView showNoticeInView:[self findVisibleWindow]
                                                title:message
                                             response:^{

--- a/Artsy/Views/Notifications/ARNotificationView.m
+++ b/Artsy/Views/Notifications/ARNotificationView.m
@@ -69,11 +69,16 @@ static NSMutableArray *notificationQueue = nil; // Global notification queue
     return [self showNoticeInView:view title:title time:6.5 response:response];
 }
 
-+ (ARNotificationView *)showNoticeInView:(UIView *)view title:(NSString *)title time:(CGFloat)time response:(void (^)(void))response
++ (ARNotificationView *)showNoticeInView:(UIView *)view title:(id)title time:(CGFloat)time response:(void (^)(void))response
 
 {
     ARNotificationView *noticeView = [[self alloc] initWithFrame:CGRectMake(0, -panelHeight, view.bounds.size.width, 0) andResponseBlock:response];
-    noticeView.titleLabel.text = title;
+    
+    if ([title isKindOfClass:[NSDictionary class]]) {
+        noticeView.titleLabel.text = ((NSDictionary *)title)[@"title"];
+    } else {
+        noticeView.titleLabel.text = (NSString *)title;
+    }
     noticeView.parentView = view;
     noticeView.hideInterval = time;
 

--- a/Artsy/Views/Notifications/ARNotificationView.m
+++ b/Artsy/Views/Notifications/ARNotificationView.m
@@ -69,16 +69,12 @@ static NSMutableArray *notificationQueue = nil; // Global notification queue
     return [self showNoticeInView:view title:title time:6.5 response:response];
 }
 
-+ (ARNotificationView *)showNoticeInView:(UIView *)view title:(id)title time:(CGFloat)time response:(void (^)(void))response
++ (ARNotificationView *)showNoticeInView:(UIView *)view title:(NSString *)title time:(CGFloat)time response:(void (^)(void))response
 
 {
     ARNotificationView *noticeView = [[self alloc] initWithFrame:CGRectMake(0, -panelHeight, view.bounds.size.width, 0) andResponseBlock:response];
     
-    if ([title isKindOfClass:[NSDictionary class]]) {
-        noticeView.titleLabel.text = ((NSDictionary *)title)[@"title"];
-    } else {
-        noticeView.titleLabel.text = (NSString *)title;
-    }
+    noticeView.titleLabel.text = title;
     noticeView.parentView = view;
     noticeView.hideInterval = time;
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,6 +3,7 @@ upcoming:
     details: Messaging / Consignments / Tabbed Home
     emission_version: 1.4.0
     dev:
+      - Fixes crash when notification payload title is object - luc
       - Sets App & Inbox badge to total unread messages - luc
       - Caches Inbox VC to prevent refetching all data on tab changes - luc
       - When routing from Works For You email, place selected artist from email at top of home feed - sarah


### PR DESCRIPTION
This PR:

- Fixes crash when notification payload title is object
- Adds checks to see if our conversation view controller is presented with the same `conversationID` as the one in the notification payload. if yes, just fetch the latest data.
 - Switches to the messaging tab before presenting conversation VC