### PR TITLE
[home] force set homeVC with selected artist if using universal link

### DIFF
--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -509,9 +509,16 @@ static const CGFloat ARMenuButtonDimension = 50;
     // If there is an existing instance at that index, use it. Otherwise use the instance passed in as viewController.
     // If for some reason something went wrong, default to Home
     BOOL alreadySelectedTab = self.selectedTabIndex == index;
-
+    BOOL showSelectedArtistFromUniversalLink = [viewController isKindOfClass:ARHomeComponentViewController.class] && [(ARHomeComponentViewController *)viewController selectedArtist];
     switch (index) {
         case ARTopTabControllerIndexHome:
+            if (showSelectedArtistFromUniversalLink) {
+                NSString *selectedArtistID = [(ARHomeComponentViewController *)viewController selectedArtist];
+                presentableController = [self.navigationDataSource navigationControllerAtIndex:ARTopTabControllerIndexHome parameters:@{@"artist_id": selectedArtistID}];
+            } else {
+                presentableController = [self rootNavigationControllerAtIndex:index];
+            }
+            break;
         case ARTopTabControllerIndexMessaging:
             presentableController = [self rootNavigationControllerAtIndex:index];
             break;
@@ -534,6 +541,10 @@ static const CGFloat ARMenuButtonDimension = 50;
 
     if (!alreadySelectedTab) {
         [self.tabContentView forceSetViewController:presentableController atIndex:index animated:animated];
+    }
+    
+    if (showSelectedArtistFromUniversalLink) {
+        [self.tabContentView forceSetViewController:presentableController atIndex:index animated:NO];
     }
 }
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -6,6 +6,7 @@ upcoming:
       - Fixes crash when notification payload title is object - luc
       - Tidy analytics, deprecating unused views and old tabs - maxim
       - Sets App & Inbox badge to total unread messages - luc
+      - When coming from a universal link with a selected artist, double-checks that Home loads special Works For You notification - sarah
       - Caches Inbox VC to prevent refetching all data on tab changes - luc
       - When routing from Works For You email, place selected artist from email at top of home feed - sarah
       - Reload active bids on pull-to-refresh - alloy


### PR DESCRIPTION
Not the _most_ elegant way to do this, but it ensures that the selected artist param from a deep link definitely doesn't get lost in the shuffle.

I think I want to spend some more time thinking about how to do this more elegantly (maybe with some work in Emission?) but given time constraints, this at least fixes the bug I found and works in all cases on my physical iPad.
  