### PR TITLE
Fix Black Status Bar Issue

### DIFF
--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController+ButtonActions.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController+ButtonActions.m
@@ -108,8 +108,8 @@
     }
 
     ARInquiryComponentViewController *inquireVC = [[ARInquiryComponentViewController alloc] initWithArtworkID:self.artwork.artworkID];
-    //[[ARTopMenuViewController sharedController] presentViewController:inquireVC animated:YES completion:nil];
-    [[ARTopMenuViewController sharedController] pushViewController:inquireVC];
+    ARNavigationController* nvc = [[ARNavigationController alloc] initWithRootViewController:inquireVC];
+    [[ARTopMenuViewController sharedController] presentViewController:nvc animated:YES completion:nil];
 }
 
 - (void)tappedAuctionInfo

--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController+ButtonActions.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController+ButtonActions.m
@@ -108,7 +108,8 @@
     }
 
     ARInquiryComponentViewController *inquireVC = [[ARInquiryComponentViewController alloc] initWithArtworkID:self.artwork.artworkID];
-    [[ARTopMenuViewController sharedController] presentViewController:inquireVC animated:YES completion:nil];
+    //[[ARTopMenuViewController sharedController] presentViewController:inquireVC animated:YES completion:nil];
+    [[ARTopMenuViewController sharedController] pushViewController:inquireVC];
 }
 
 - (void)tappedAuctionInfo

--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController+ButtonActions.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController+ButtonActions.m
@@ -108,8 +108,8 @@
     }
 
     ARInquiryComponentViewController *inquireVC = [[ARInquiryComponentViewController alloc] initWithArtworkID:self.artwork.artworkID];
-    ARNavigationController* nvc = [[ARNavigationController alloc] initWithRootViewController:inquireVC];
-    [[ARTopMenuViewController sharedController] presentViewController:nvc animated:YES completion:nil];
+    ARNavigationController* wrapperNav = [[ARNavigationController alloc] initWithRootViewController:inquireVC];
+    [[ARTopMenuViewController sharedController] presentViewController:wrapperNav animated:YES completion:nil];
 }
 
 - (void)tappedAuctionInfo

--- a/Artsy/Views/Artwork/ARArtworkView.m
+++ b/Artsy/Views/Artwork/ARArtworkView.m
@@ -50,7 +50,7 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
         self.scrollIndicatorInsets = UIEdgeInsetsMake(20, 0, 0, 0);
     }
 
-    self.backgroundColor = [UIColor whiteColor];
+    self.backgroundColor = [UIColor blackColor];
     self.stackView.backgroundColor = [UIColor whiteColor];
     self.stackView.bottomMarginHeight = 20;
 

--- a/Artsy/Views/Artwork/ARArtworkView.m
+++ b/Artsy/Views/Artwork/ARArtworkView.m
@@ -50,7 +50,7 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
         self.scrollIndicatorInsets = UIEdgeInsetsMake(20, 0, 0, 0);
     }
 
-    self.backgroundColor = [UIColor blackColor];
+    self.backgroundColor = [UIColor whiteColor];
     self.stackView.backgroundColor = [UIColor whiteColor];
     self.stackView.bottomMarginHeight = 20;
 


### PR DESCRIPTION
# Problem
On Contact Gallery page, status bar is black.
fixes https://github.com/artsy/collector-experience/issues/912

# Solution
Originally tried to fix this by changing `presentViewController:` to a `pushViewController` which fixes the issue, but with this change cancel button doesn't work anymore and if we go with this approach we need to update cancel button in Emission to properly dismiss the view assuming it was pushed.

Better solution, thanks to @orta, was to embed `ARInquiryComponentViewController` in a `ARNAvigationController` and present that instead.

# Selfie :)
<img width="297" alt="screen shot 2018-01-19 at 3 59 53 pm" src="https://user-images.githubusercontent.com/1230819/35171452-d52fdcec-fd31-11e7-8bfc-7d9187deb753.png">
