### PR TITLE
[WFU] Do not call forceSetViewController more than once

### DIFF
--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -589,10 +589,9 @@ static const CGFloat ARMenuButtonDimension = 50;
 
     if (!alreadySelectedTab) {
         [self.tabContentView forceSetViewController:presentableController atIndex:index animated:animated];
-    }
-    
-    if (showSelectedArtistFromUniversalLink) {
-        [self.tabContentView forceSetViewController:presentableController atIndex:index animated:NO];
+    } else if (showSelectedArtistFromUniversalLink) {
+        // We are already on Home, and need to force the tab view to show the new Home with its selected artist & without animation
+        [self.tabContentView forceSetViewController:presentableController atIndex:ARTopTabControllerIndexHome animated:NO];
     }
 }
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,6 +3,7 @@ upcoming:
     details: Bug Fixes / iPhone X / ARVIR
     emission_version: 1.4.x
     dev:
+      - Fixes blank view when coming from a deep link to Works For You tab - sarah
       - Updates to Xcode 9.1 - orta
       - Deletes un-used View Controllers - orta
       - Adds a 1024 app icon image - orta


### PR DESCRIPTION
The blank bug was caused by `forceSetViewController` being called twice. This is a small fix to make sure it can't happen, but ideally in the long run we can revisit [this tab view](https://github.com/artsy/eigen/blob/master/Artsy/Views/Utilities/ARTabContentView.m#L147)'s responsibilities, because its relationship with ARTopMenuViewController and ARTopMenuNavigationDataSource is a bit confusing.

#skip_new_tests