### PR TITLE
[STI-35] Add support for online exclusive shows

### DIFF
--- a/Artsy/View_Controllers/Fair/ARShowViewController.m
+++ b/Artsy/View_Controllers/Fair/ARShowViewController.m
@@ -333,6 +333,10 @@ self.actionButtonsView.actionButtonDescriptions = descriptions;
             ARSerifLabel *addressLabel = [self metadataLabel:self.show.location.addressAndCity];
             addressLabel.tag = ARFairShowViewLocationAddress;
             [self.view.stackView addSubview:addressLabel withTopMargin:@"8" sideMargin:[self sideMarginPredicate]];
+        } else if (self.show.location == nil || self.show.fairLocation == nil) {
+            ARSerifLabel *addressLabel = [self metadataLabel:@"Online Exclusive"];
+            addressLabel.tag = ARFairShowViewLocationAddress;
+            [self.view.stackView addSubview:addressLabel withTopMargin:@"8" sideMargin:[self sideMarginPredicate]];
         }
 
         if (self.show.officialDescription) {

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -14,6 +14,7 @@ upcoming:
       - Augmented Reality View in Room lab feature, defaults to off - orta/lazerwalker
       - Removes the status bar in the old VIR - orta
       - speeds up martsy pages - orta
+      - Show Online Exclusive label for shows without location - ashkan
 
 releases:
   - version: 4.0.0


### PR DESCRIPTION
# Problem
We want to be able to show _Online Exclusive_ label for shows without `location` or `fair_location`.
https://artsyproduct.atlassian.net/browse/STI-35

# Solution
Updated `ARShowViewController` to check if `location` and `show.fairLocation` are not available, show `Online Exclusive` label.

# Question
Noticed that in `PartnerShow` model we also have https://github.com/artsy/eigen/blob/master/Artsy/Models/API_Models/Partner_Metadata/PartnerShow.m#L209 and https://github.com/artsy/eigen/blob/master/Artsy/Models/API_Models/Partner_Metadata/PartnerShow.m#L175 I updated those but they are not used in this view controller so didn't commit those changes, let me know if those need to be updated too.

# Selfie

![simulator screen shot - iphone 8 - 2018-02-19 at 15 24 04](https://user-images.githubusercontent.com/1230819/36396330-847e668e-158b-11e8-97f7-e935f079aba8.png)
