### PR TITLE
[dev] Fix for blank screen from push notifications on iOS 11 #trivial

### DIFF
--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -557,10 +557,10 @@ static const CGFloat ARMenuButtonDimension = 50;
     // If there is an existing instance at that index, use it. Otherwise use the instance passed in as viewController.
     // If for some reason something went wrong, default to Home
     BOOL alreadySelectedTab = self.selectedTabIndex == index;
-    BOOL showSelectedArtistFromUniversalLink = [viewController isKindOfClass:ARHomeComponentViewController.class] && [(ARHomeComponentViewController *)viewController selectedArtist];
+    BOOL showWorksForYouWithSelectedArtistFromUniversalLink = [viewController isKindOfClass:ARHomeComponentViewController.class] && [(ARHomeComponentViewController *)viewController selectedArtist];
     switch (index) {
         case ARTopTabControllerIndexHome:
-            if (showSelectedArtistFromUniversalLink) {
+            if (showWorksForYouWithSelectedArtistFromUniversalLink) {
                 NSString *selectedArtistID = [(ARHomeComponentViewController *)viewController selectedArtist];
                 presentableController = [self.navigationDataSource navigationControllerAtIndex:ARTopTabControllerIndexHome parameters:@{@"artist_id": selectedArtistID}];
             } else {
@@ -591,7 +591,7 @@ static const CGFloat ARMenuButtonDimension = 50;
     BOOL appIsLaunching = self.selectedTabIndex < 0;
     if (!alreadySelectedTab && !appIsLaunching) {
         [self.tabContentView forceSetViewController:presentableController atIndex:index animated:animated];
-    } else if (showSelectedArtistFromUniversalLink) {
+    } else if (showWorksForYouWithSelectedArtistFromUniversalLink) {
         // We are already on Home, and need to force the tab view to show the new Home with its selected artist & without animation
         [self.tabContentView forceSetViewController:presentableController atIndex:ARTopTabControllerIndexHome animated:NO];
     }

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -586,8 +586,10 @@ static const CGFloat ARMenuButtonDimension = 50;
     if (presentableController.viewControllers.count > 1) {
         [presentableController popToRootViewControllerAnimated:(animated && alreadySelectedTab)];
     }
-
-    if (!alreadySelectedTab) {
+    
+    /// If app is launching and hasn't yet set a tab, it's not ready to forceSet a view controller
+    BOOL appIsLaunching = self.selectedTabIndex < 0;
+    if (!alreadySelectedTab && !appIsLaunching) {
         [self.tabContentView forceSetViewController:presentableController atIndex:index animated:animated];
     } else if (showSelectedArtistFromUniversalLink) {
         // We are already on Home, and need to force the tab view to show the new Home with its selected artist & without animation


### PR DESCRIPTION
This should make sure `forceSetViewController` isn't being called so many times. I would really like some time to look at how our `ARTopMenuViewController` does routing, because this particular method is called so many times when it seems like it should only happen once, and it's not entirely clear why. For this sprint though, this fixes the blank screen issue and should go into the next release.

Fixes https://artsyproduct.atlassian.net/browse/IN-93

Related: https://artsyproduct.atlassian.net/browse/IN-40