### PR TITLE
[dev] Removes redundant call to ARAppNotificationsDelegate

### DIFF
--- a/Artsy/App/ARAppDelegate.m
+++ b/Artsy/App/ARAppDelegate.m
@@ -202,13 +202,6 @@ static ARAppDelegate *_sharedInstance = nil;
     }
     [self.window makeKeyAndVisible];
 
-    NSDictionary *remoteNotification = self.initialLaunchOptions[UIApplicationLaunchOptionsRemoteNotificationKey];
-    if (remoteNotification) {
-        // The app was not running, so considering it to be in the UIApplicationStateInactive state.
-        [self.remoteNotificationsDelegate applicationDidReceiveRemoteNotification:remoteNotification
-                                                               inApplicationState:UIApplicationStateInactive];
-    }
-
     [ARWebViewCacheHost startup];
     [self registerNewSessionOpened];
 }

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,6 +3,7 @@ upcoming:
     details: Bug Fixes / iPhone X / ARVIR
     emission_version: 1.4.5
     dev:
+      - Removes redundant call to notifications delegate in ARAppDelegate - sarah
       - Fixes universal links in iOS 11 - sarah
       - Fixes blank view when coming from a deep link to Works For You tab - sarah
       - Updates to Xcode 9.1 - orta


### PR DESCRIPTION
This makes sure the ARAppNotificationsDelegate is called only once when a push notification is received.