### PR TITLE
Update the version, and add back the universal links changes

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.2</string>
+	<string>4.0.3</string>
 	<key>CFBundleVersion</key>
 	<string>2017.07.07.13</string>
 	<key>NSExtension</key>

--- a/Artsy/App/ARAppDelegate.m
+++ b/Artsy/App/ARAppDelegate.m
@@ -115,6 +115,11 @@ static ARAppDelegate *_sharedInstance = nil;
 
 - (void)applicationDidBecomeActive:(UIApplication *)application
 {
+    [self setupForAppLaunch];
+}
+
+- (void)setupForAppLaunch
+{
     // In case everything's already set up
     if (self.window) {
         return;
@@ -146,11 +151,11 @@ static ARAppDelegate *_sharedInstance = nil;
     NSInteger numberOfRuns = [[NSUserDefaults standardUserDefaults] integerForKey:ARAnalyticsAppUsageCountProperty];
 
     BOOL shouldShowOnboarding;
-    
+
     BOOL firstTimeUser = (numberOfRuns == 1);
     BOOL hasAccount = [[ARUserManager sharedManager] hasExistingAccount];
     AROnboardingUserProgressStage onboardingState = [[NSUserDefaults standardUserDefaults] integerForKey:AROnboardingUserProgressionStage];
-    
+
     if (firstTimeUser && !hasAccount && (onboardingState == AROnboardingStageDefault)) {
         // you are a fresh install - you will be onboarding and we set the enum to check when you come back
         [[NSUserDefaults standardUserDefaults] setInteger:AROnboardingStageOnboarding forKey:AROnboardingUserProgressionStage];
@@ -165,7 +170,7 @@ static ARAppDelegate *_sharedInstance = nil;
         // fallback, if the user has no account, they have to log in / onboard to prevent crash
         shouldShowOnboarding = YES;
     }
-    
+
     if (ARIsRunningInDemoMode) {
         [self.viewController presentViewController:[[ARDemoSplashViewController alloc] init] animated:NO completion:nil];
         [self performSelector:@selector(finishDemoSplash) withObject:nil afterDelay:1];
@@ -207,6 +212,15 @@ static ARAppDelegate *_sharedInstance = nil;
     [ARWebViewCacheHost startup];
     [self registerNewSessionOpened];
 }
+
+/// This is called when the app is almost done launching
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+    /// Make sure we set up here so there is an ARTopMenuViewController for routing when launching from a universal link
+    [self setupForAppLaunch];
+    return YES;
+}
+
 
 - (void)startupApp
 {
@@ -332,8 +346,8 @@ static ARAppDelegate *_sharedInstance = nil;
          annotation:(id)annotation
 {
     return [self application:application openURL:url options:@{
-       UIApplicationOpenURLOptionsSourceApplicationKey: sourceApplication ?: @"",
-       UIApplicationOpenURLOptionsAnnotationKey: annotation  ?: @""
+        UIApplicationOpenURLOptionsSourceApplicationKey: sourceApplication ?: @"",
+        UIApplicationOpenURLOptionsAnnotationKey: annotation  ?: @""
     }];
 }
 

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.2</string>
+	<string>4.0.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,16 +1,20 @@
 upcoming:
-    version: 4.0.2
+    version: 4.0.3
     emission_version: 1.4.6
     dev:
-      - Fixes universal links in iOS 11 - sarah
-
       - ARVIR:
         - Adds a new VIR intro screen, which handles disabled states - orta
+
+releases:
+  - version: 4.0.2
+    emission_version: 1.4.6
+    date: Feb 23, 2018
+    dev:
+      - Fixes universal links in iOS 11 - sarah
 
     user_facing:
       - Show Online Exclusive label for shows without location - ashkan
 
-releases:
   - version: 4.0.1
     details: Bug Fixes / iPhone X
     emission_version: 1.4.5


### PR DESCRIPTION
I [compared 4.0.2 to master](https://github.com/artsy/eigen/compare/4.0.2-0...master) and spotted that a bad rebase had removed some of the code for universal links. This brings that back, and prepares us for making a 4.0.3 build.