### PR TITLE
Renames our check for whether a VC is a root view controller to not conflict with a new API used in 11.3

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -235,7 +235,7 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
 
 @implementation ARHomeComponentViewController (ARRootViewController)
 
-- (BOOL)isRootViewController
+- (BOOL)isRootNavViewController
 {
     return YES;
 }
@@ -247,7 +247,7 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
 
 @implementation ARWorksForYouComponentViewController (ARRootViewController)
 
-- (BOOL)isRootViewController
+- (BOOL)isRootNavViewController
 {
     return YES;
 }

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -528,7 +528,7 @@ static const CGFloat ARMenuButtonDimension = 50;
         return;
     }
 
-    if ([viewController respondsToSelector:@selector(isRootViewController)] && [(id<ARRootViewController>)viewController isRootViewController]) {
+    if ([viewController respondsToSelector:@selector(isRootNavViewController)] && [(id<ARRootViewController>)viewController isRootNavViewController]) {
         [self presentRootViewController:viewController animated:animated];
     } else {
         [self.rootNavigationController pushViewController:viewController animated:animated];

--- a/Artsy/View_Controllers/Util/ARBrowseViewController.m
+++ b/Artsy/View_Controllers/Util/ARBrowseViewController.m
@@ -212,7 +212,7 @@
 
 #pragma mark - ARRootViewController
 
-- (BOOL)isRootViewController
+- (BOOL)isRootNavViewController
 {
     return YES;
 }

--- a/Artsy/View_Controllers/Util/ARRootViewController.h
+++ b/Artsy/View_Controllers/Util/ARRootViewController.h
@@ -1,6 +1,6 @@
 @protocol ARRootViewController <NSObject>
 
 @optional
-- (BOOL)isRootViewController;
+- (BOOL)isRootNavViewController;
 
 @end

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,10 +3,10 @@ upcoming:
   emission_version: 1.4.6
   dev:
     - Potential fixes for Adjust session registering with anon users - orta
+  user_facing:
     - Fix for 11.3 users - orta
-
-    - ARVIR:
-      - Adds a new VIR intro screen, which handles disabled states - orta
+  ARVIR:
+    - Adds a new VIR intro screen, which handles disabled states - orta
 
 releases:
   - version: 4.0.2

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,6 +3,7 @@ upcoming:
     emission_version: 1.4.6
     dev:
       - Potential fixes for Adjust session registering with anon users - orta
+      - Fix for 11.3 users - orta
 
       - ARVIR:
         - Adds a new VIR intro screen, which handles disabled states - orta

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,12 +1,12 @@
 upcoming:
-    version: 4.0.3
-    emission_version: 1.4.6
-    dev:
-      - Potential fixes for Adjust session registering with anon users - orta
-      - Fix for 11.3 users - orta
+  version: 4.0.3
+  emission_version: 1.4.6
+  dev:
+    - Potential fixes for Adjust session registering with anon users - orta
+    - Fix for 11.3 users - orta
 
-      - ARVIR:
-        - Adds a new VIR intro screen, which handles disabled states - orta
+    - ARVIR:
+      - Adds a new VIR intro screen, which handles disabled states - orta
 
 releases:
   - version: 4.0.2

--- a/Dangerfile
+++ b/Dangerfile
@@ -49,6 +49,8 @@ begin
   # Common error when making a new version
   fail "Upcoming is an array, it should be an object" if readme_data["upcoming"].is_a? Array
 
+  fail "There must be a `user_facing`` section in upcoming" unless readme_data["upcoming"]["user_facing"]
+
   # Tie all releases to a date
   readme_data["releases"].each do |release|
     fail "Release #{release['version']} does not have a date" unless release["date"]


### PR DESCRIPTION
We had some weird behavior in 11.3 that was making our entire screen push off the edge

![2018-03-05 13_50_30](https://user-images.githubusercontent.com/49038/36993577-37d5d8de-207c-11e8-858b-7b4d336e1dc6.gif)

Turns out that every view controller was now a root view controller. This is because 11.3 adds a new function the Apple's `UIViewController` that we check for with `respondsToSelector:@selector(isRootViewController)`.  Couldn't find docs for it though, so it might not be public. 

[It's not](https://github.com/marksands/iOSHeaders/blob/3a12eb5ea3c05a8cf9436fc1d9b8fa58552c9c8c/private/iTunesStoreUI/UIViewController-SUAdditions.h#L24) -  thanks @marksands

It's likely that the iTunes UI lib is now linked to our app in 11.3 whereas previously it wasn't

This meant that, when you would push a VC, it would fight to place it at the root instead of adding it as a subnav.

```sh
(lldb) po [viewController respondsToSelector:@selector(isRootViewController)]
YES

(lldb) po viewController
<ARArtworkSetViewController: 0x7ff60052b200>

(lldb) po [[[UIViewController alloc] init] respondsToSelector:@selector(isRootViewController)]
YES
```