### PR TITLE
[AC-61] Add attribution class aka "classification" to artwork view

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -660,6 +660,8 @@
 		66A43C681CE470C400FFD6ED /* Hash@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 66A43C651CE470C400FFD6ED /* Hash@2x.png */; };
 		66A43C691CE470C400FFD6ED /* Hash@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 66A43C661CE470C400FFD6ED /* Hash@3x.png */; };
 		66A43C6B1CE48FA800FFD6ED /* SearchButtonWhite@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 66A43C6A1CE48FA800FFD6ED /* SearchButtonWhite@2x.png */; };
+		6F3D85ED204DD876000BF304 /* Artwork+AttributionClassStrings.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F3D85EC204DD876000BF304 /* Artwork+AttributionClassStrings.m */; };
+		6F3D85F0204DDB37000BF304 /* ArtworkAttributionClassTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F3D85EE204DDB1C000BF304 /* ArtworkAttributionClassTests.m */; };
 		7091E01A0E49F283EF9BF395 /* Pods_Artsy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BEA0E7F562681F61B29D4C4 /* Pods_Artsy.framework */; };
 		7F45A1682003C7100063D6B5 /* conversations.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 7F45A1672003C7100063D6B5 /* conversations.graphql */; };
 		837CEC841C876B7C00A7E0E1 /* ArtsyAPI+Notifications.m in Sources */ = {isa = PBXBuildFile; fileRef = 837CEC831C876B7C00A7E0E1 /* ArtsyAPI+Notifications.m */; };
@@ -1834,6 +1836,9 @@
 		66A43C651CE470C400FFD6ED /* Hash@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Hash@2x.png"; sourceTree = "<group>"; };
 		66A43C661CE470C400FFD6ED /* Hash@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Hash@3x.png"; sourceTree = "<group>"; };
 		66A43C6A1CE48FA800FFD6ED /* SearchButtonWhite@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "SearchButtonWhite@2x.png"; sourceTree = "<group>"; };
+		6F3D85EB204DD876000BF304 /* Artwork+AttributionClassStrings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Artwork+AttributionClassStrings.h"; sourceTree = "<group>"; };
+		6F3D85EC204DD876000BF304 /* Artwork+AttributionClassStrings.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "Artwork+AttributionClassStrings.m"; sourceTree = "<group>"; };
+		6F3D85EE204DDB1C000BF304 /* ArtworkAttributionClassTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ArtworkAttributionClassTests.m; sourceTree = "<group>"; };
 		7F45A1672003C7100063D6B5 /* conversations.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = conversations.graphql; sourceTree = "<group>"; };
 		83282D751EB0D9F1006F30C2 /* ARRootViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARRootViewController.h; sourceTree = "<group>"; };
 		837CEC821C876B7C00A7E0E1 /* ArtsyAPI+Notifications.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ArtsyAPI+Notifications.h"; sourceTree = "<group>"; };
@@ -3631,6 +3636,8 @@
 				499A5893166683AB004B0E2F /* Artist.m */,
 				60B6F13C16638815007C9587 /* Artwork.h */,
 				60B6F13D16638815007C9587 /* Artwork.m */,
+				6F3D85EB204DD876000BF304 /* Artwork+AttributionClassStrings.h */,
+				6F3D85EC204DD876000BF304 /* Artwork+AttributionClassStrings.m */,
 				342F9A17225A44AC4BE26303 /* PartnerShowFairLocation.m */,
 				342F9C73F3EBBD7348B5CB83 /* PartnerShowFairLocation.h */,
 				342F93E38025E2D2DA90C6DA /* MapFeature.m */,
@@ -4500,6 +4507,7 @@
 				600E73531DAD42EC0007BF39 /* RefineGeneStubs */,
 				3C22227018C647CC00B7CE3A /* Data */,
 				3C7A7FA618C6EDAB00E8D336 /* ArtworkTests.m */,
+				6F3D85EE204DDB1C000BF304 /* ArtworkAttributionClassTests.m */,
 				600E73511DAD42D40007BF39 /* GeneRefineSettingTests.swift */,
 				3CCCC89C18997948008015DD /* FairTests.m */,
 				3CA55D8818BFF8F800B44CD3 /* MapFeatureTests.m */,
@@ -5456,6 +5464,7 @@
 				5E0AEB7819B9EA43009F34DE /* ARShowNetworkModel.m in Sources */,
 				E616B2481911664900D1CBC6 /* ARArtworkView.m in Sources */,
 				60647C791A95095800A45247 /* ARFairPopupViewController.m in Sources */,
+				6F3D85ED204DD876000BF304 /* Artwork+AttributionClassStrings.m in Sources */,
 				E676A62B18F3421600B9AF2C /* ARSeparatorViews.m in Sources */,
 				607E2E7E17C8CA4D00396120 /* ARZoomArtworkImageViewController.m in Sources */,
 				5E20BB671C62C00D00C6D781 /* AuctionCircularButtons.swift in Sources */,
@@ -5877,6 +5886,7 @@
 				5E7598061D9D92F60084AAEC /* LiveAuctionLotBidHistoryGestureControllerTests.swift in Sources */,
 				E6F111A018A2A7CB00D33C3E /* ARBrowseFeaturedLinksCollectionViewControllerTests.m in Sources */,
 				3C7A7FA718C6EDAB00E8D336 /* ArtworkTests.m in Sources */,
+				6F3D85F0204DDB37000BF304 /* ArtworkAttributionClassTests.m in Sources */,
 				5EE9A3E11D1211230014A3C9 /* BiddingIncrementSpecs.swift in Sources */,
 				E67E1DB219475642004252E0 /* ARAnimatedTickViewTest.m in Sources */,
 				604151E51A7998E300D5F9CA /* NSDate+RangeTests.m in Sources */,

--- a/Artsy/Models/API_Models/Partner_Metadata/Artwork+AttributionClassStrings.h
+++ b/Artsy/Models/API_Models/Partner_Metadata/Artwork+AttributionClassStrings.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+
+@class Artwork;
+
+
+@interface Artwork (AttributionClassStrings)
+
+- (NSString *)shortDescriptionForAttributionClass;
+
+@end

--- a/Artsy/Models/API_Models/Partner_Metadata/Artwork+AttributionClassStrings.m
+++ b/Artsy/Models/API_Models/Partner_Metadata/Artwork+AttributionClassStrings.m
@@ -1,0 +1,35 @@
+#import "Artwork.h"
+#import "Artwork+AttributionClassStrings.h"
+
+
+@implementation Artwork (AttributionClassStrings)
+
+- (NSString *)shortDescriptionForAttributionClass
+{
+    if ([self.attributionClass isEqualToString:@"unique"]) {
+        return @"This is a unique work.";
+
+    } else if ([self.attributionClass isEqualToString:@"limited edition"]) {
+        return @"This is part of a limited edition set.";
+
+    } else if ([self.attributionClass isEqualToString:@"made-to-order"]) {
+        return @"This is a made-to-order piece.";
+
+    } else if ([self.attributionClass isEqualToString:@"reproduction"]) {
+        return @"This work is a reproduction.";
+
+    } else if ([self.attributionClass isEqualToString:@"editioned multiple"]) {
+        return @"This is an editioned multiple.";
+
+    } else if ([self.attributionClass isEqualToString:@"non-editioned multiple"]) {
+        return @"This is a non-editioned multiple.";
+
+    } else if ([self.attributionClass isEqualToString:@"ephemera"]) {
+        return @"This is a peripheral artifact related to the artist.";
+
+    } else {
+        return nil;
+    }
+}
+
+@end

--- a/Artsy/Models/API_Models/Partner_Metadata/Artwork.h
+++ b/Artsy/Models/API_Models/Partner_Metadata/Artwork.h
@@ -42,6 +42,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) NSString *dimensionsCM;
 @property (nonatomic, copy) NSString *dimensionsInches;
 
+@property (nonatomic, copy) NSString *attributionClass;
+
 // The artist that created the artwork. This may be `nil`.
 @property (nonatomic, strong) Artist *_Nullable artist;
 @property (nonatomic, copy) NSString *imageFormatAddress;

--- a/Artsy/Models/API_Models/Partner_Metadata/Artwork.m
+++ b/Artsy/Models/API_Models/Partner_Metadata/Artwork.m
@@ -62,6 +62,7 @@
         ar_keypath(Artwork.new, additionalInfo) : @"additional_information",
         ar_keypath(Artwork.new, dimensionsCM) : @"dimensions.cm",
         ar_keypath(Artwork.new, dimensionsInches) : @"dimensions.in",
+        ar_keypath(Artwork.new, attributionClass) : @"attribution_class",
         ar_keypath(Artwork.new, displayTitle) : @"display",
         ar_keypath(Artwork.new, editionSets) : @"edition_sets",
         ar_keypath(Artwork.new, exhibitionHistory) : @"exhibition_history",

--- a/Artsy/Views/Artwork/ARArtworkDetailView.m
+++ b/Artsy/Views/Artwork/ARArtworkDetailView.m
@@ -3,6 +3,7 @@
 #import "ARCustomEigenLabels.h"
 #import "Artist.h"
 #import "Artwork.h"
+#import "Artwork+AttributionClassStrings.h"
 #import "ARFonts.h"
 #import "ARTextView.h"
 #import "Fair.h"
@@ -18,6 +19,7 @@ typedef NS_ENUM(NSInteger, ARDetailSubViewOrder) {
     ARDetailArtworkMedium,
     ARDetailDimensionInches,
     ARDetailDimensionCM,
+    ARDetailAttributionClass,
     ARDetailCollectionInstitution,
     ARDetailImageRights,
     ARDetailPartner,
@@ -51,7 +53,7 @@ typedef NS_ENUM(NSInteger, ARDetailSubViewOrder) {
 - (void)setDelegate:(id<ARArtworkDetailViewDelegate, ARArtworkDetailViewButtonDelegate>)delegate
 {
     _delegate = delegate;
-   __weak typeof (self) wself = self;
+    __weak typeof(self) wself = self;
     [self.artwork onArtworkUpdate:^{
         __strong typeof (wself) sself = wself;
         [sself updateWithArtwork:self.artwork];
@@ -103,6 +105,17 @@ typedef NS_ENUM(NSInteger, ARDetailSubViewOrder) {
 
         case ARDetailDimensionCM: {
             view = [[ARSerifLabel alloc] init];
+            break;
+        }
+
+        case ARDetailAttributionClass: {
+            view = [[UIView alloc] init];
+            UILabel *label = [[ARSerifLabel alloc] init];
+            [view addSubview:label];
+            [view constrainHeightToView:label predicate:@"0"];
+            [label constrainBottomSpaceToView:view predicate:@"0"];
+            [label constrainWidthToView:view predicate:@"0"];
+            [label alignCenterXWithView:view predicate:@"0"];
             break;
         }
 
@@ -198,6 +211,15 @@ typedef NS_ENUM(NSInteger, ARDetailSubViewOrder) {
         dimensionCMLabel.text = artwork.dimensionsCM;
 
         [self addSubview:dimensionCMLabel withTopMargin:@"4" sideMargin:@"0"];
+    }
+
+    if (artwork.attributionClass.length) {
+        UIView *view = [self viewFor:ARDetailAttributionClass];
+
+        ARSerifLabel *attributionClassLabel = [view subviews][0];
+        attributionClassLabel.text = artwork.shortDescriptionForAttributionClass;
+
+        [self addSubview:view withTopMargin:@"40" sideMargin:@"0"];
     }
 
     if (artwork.imageRights.length) {

--- a/Artsy_Tests/Model_Tests/ArtworkAttributionClassTests.m
+++ b/Artsy_Tests/Model_Tests/ArtworkAttributionClassTests.m
@@ -1,0 +1,23 @@
+#import "Artwork+AttributionClassStrings.h"
+
+SpecBegin(ArtworkAttributionClass);
+
+describe(@"shortDescriptionForAttributionClass", ^{
+    it(@"returns the correct short description for a given attribution class", ^{
+        Artwork *artwork = [Artwork modelWithJSON:@{ @"id" : @"artwork-id", @"attribution_class" : @"ephemera" }];
+        expect(artwork.shortDescriptionForAttributionClass).to.equal(@"This is a peripheral artifact related to the artist.");
+    });
+
+    it(@"ignores missing attribution class", ^{
+        Artwork *artwork = [Artwork modelWithJSON:@{ @"id" : @"artwork-id" }];
+        expect(artwork.shortDescriptionForAttributionClass).to.beNil();
+    });
+
+    it(@"ignores nil attribution class", ^{
+        Artwork *artwork = [Artwork modelWithJSON:@{ @"id" : @"artwork-id", @"attribution_class" : [NSNull null] }];
+        expect(artwork.shortDescriptionForAttributionClass).to.beNil();
+    });
+});
+
+
+SpecEnd;

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,6 +5,7 @@ upcoming:
     - Potential fixes for Adjust session registering with anon users - orta
   user_facing:
     - Fix for 11.3 users - orta
+    - Add attribution class aka "classification" to artwork view - anandaroop/oxaudo
   ARVIR:
     - Adds a new VIR intro screen, which handles disabled states - orta
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/AC-61

This displays the new `attribution_class` field on Artwork, aka our concept of "classification" (unique vs. multiples vs. ephemera, etc)

If the field is present, a corresponding human-friendly short description is shown, else it is ignored.

In the example below the copy "This is a unique work" appears because this artwork's `attribution_class` == "unique"

<img width="559" alt="unique" src="https://user-images.githubusercontent.com/140521/37045384-d256956c-2133-11e8-8fce-54008e81bdcc.png">
