### PR TITLE
Update MP's staging URL to https

### DIFF
--- a/Artsy/Constants/ARDefaults.m
+++ b/Artsy/Constants/ARDefaults.m
@@ -49,7 +49,7 @@ NSString *const ARAugmentedRealityHasSuccessfullyRan = @"ARAugmentedRealityHasSu
         ARUseStagingDefault : @(useStagingDefault),
         ARStagingAPIURLDefault : @"https://stagingapi.artsy.net",
         ARStagingWebURLDefault : @"https://staging.artsy.net",
-        ARStagingMetaphysicsURLDefault : @"http://metaphysics-staging.artsy.net",
+        ARStagingMetaphysicsURLDefault : @"https://metaphysics-staging.artsy.net",
         ARStagingLiveAuctionSocketURLDefault : @"wss://causality-staging.artsy.net"
     }];
 }


### PR DESCRIPTION
# Problem
We are now forcing SSL on staging to match production. 

# Solution
Update default staging url to `https`.