### PR TITLE
Use a stricter version of CP-check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,8 @@ source 'https://rubygems.org'
 gem 'cocoapods', git: 'https://github.com/CocoaPods/CocoaPods.git'
 gem 'cocoapods-core', git: 'https://github.com/CocoaPods/Core.git'
 
-gem 'cocoapods-check' # So we know if we need to run `pod install`
+# So we know if we need to run `pod install`
+gem 'cocoapods-check',  git: 'https://github.com/orta/cocoapods-check.git', branch: 'different_manifests'
 gem 'cocoapods-keys' # So we don't leak ENV vars
 gem 'psych' # So our Podfile.lock is consistent
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/CocoaPods/CocoaPods.git
-  revision: 3edf0f3fdc4e34327e5a9507b4d933fd325339b8
+  revision: 18fd90e1395974dfa10225194e75280aa0ea9839
   specs:
     cocoapods (1.4.0)
       activesupport (>= 4.0.2, < 5)
@@ -24,12 +24,20 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: 1a92ff1b5aa2bd21b9694d0941406aff328fdd2a
+  revision: 07273d3a68c845d76b7a292d1364c4ac3c0b2d69
   specs:
     cocoapods-core (1.4.0)
       activesupport (>= 4.0.2, < 6)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
+
+GIT
+  remote: https://github.com/orta/cocoapods-check.git
+  revision: 9746c399a70f3b3aaf0be47ad8f31f759a4a2e2f
+  branch: different_manifests
+  specs:
+    cocoapods-check (1.0.1)
+      cocoapods (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -76,8 +84,6 @@ GEM
       cork
       nap
       open4 (~> 1.3)
-    cocoapods-check (1.0.0)
-      cocoapods (~> 1.0)
     cocoapods-deintegrate (1.0.2)
     cocoapods-downloader (1.1.3)
     cocoapods-keys (1.6.1)
@@ -276,7 +282,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods!
-  cocoapods-check
+  cocoapods-check!
   cocoapods-core!
   cocoapods-keys
   danger


### PR DESCRIPTION
Right now master is failing because the lockfile & manifest aren't the same, I want to be avoiding downloading the specs repo so we use CocoaPods-Check to decide if we do that. 

It only works with the installed Pods, but doesn't validate the manifest in the way CP will do at compile time. I sent over a PR adding that, https://github.com/square/cocoapods-check/pull/9 and migrated us.