### PR TITLE
[Buy] Fix iPad layout to be 3 columns

### DIFF
--- a/Artsy/View_Controllers/AuctionBuyNowView.swift
+++ b/Artsy/View_Controllers/AuctionBuyNowView.swift
@@ -12,7 +12,7 @@ class AuctionBuyNowView: ORStackView {
         let titleView = AuctionBuyNowTitleView(isCompact: isCompact)
         addSubview(titleView, withTopMargin: "0", sideMargin:"0")
 
-        let layout = UIDevice.isPad() ? ARArtworkMasonryLayout.layout3Column : ARArtworkMasonryLayout.layout2Column
+        let layout = isCompact ? ARArtworkMasonryLayout.layout2Column : ARArtworkMasonryLayout.layout3Column
 
         let module = ARArtworkMasonryModule(layout: layout, andStyle: .artworkMetadata)
         let buyNowWorksVC = AREmbeddedModelsViewController()

--- a/Artsy/View_Controllers/AuctionBuyNowView.swift
+++ b/Artsy/View_Controllers/AuctionBuyNowView.swift
@@ -12,8 +12,7 @@ class AuctionBuyNowView: ORStackView {
         let titleView = AuctionBuyNowTitleView(isCompact: isCompact)
         addSubview(titleView, withTopMargin: "0", sideMargin:"0")
 
-        let screenSize = ARTopMenuViewController.shared().view.bounds.size
-        let layout = UIDevice.isPad() && (screenSize.width > screenSize.height) ? ARArtworkMasonryLayout.layout3Column : ARArtworkMasonryLayout.layout2Column
+        let layout = UIDevice.isPad() ? ARArtworkMasonryLayout.layout3Column : ARArtworkMasonryLayout.layout2Column
 
         let module = ARArtworkMasonryModule(layout: layout, andStyle: .artworkMetadata)
         let buyNowWorksVC = AREmbeddedModelsViewController()

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,6 +5,7 @@ upcoming:
   user_facing:
     - WIP Buy now works show in an Auction screen - Chris
     - ARVIR fixes & improvements - orta
+    - Buy now layout adjustments, 3 columns on ipad - maxim
   
 releases:
   - version: 4.1.0


### PR DESCRIPTION
As per https://artsyproduct.atlassian.net/browse/PURCHASE-14

New layout (basically always 3 columns for iPad):

![simulator screen shot - ipad air 2 - 2018-04-13 at 14 35 02](https://user-images.githubusercontent.com/373860/38738167-52a816c4-3f29-11e8-8674-b70e84ab91ed.png)
![simulator screen shot - ipad air 2 - 2018-04-13 at 14 34 55](https://user-images.githubusercontent.com/373860/38738168-52c1a382-3f29-11e8-987a-32360808eed1.png)
