### PR TITLE
Don't let ARVIR dim the screen

### DIFF
--- a/Artsy/View_Controllers/ARVIR/VCs/ARAugmentedVIRViewController.m
+++ b/Artsy/View_Controllers/ARVIR/VCs/ARAugmentedVIRViewController.m
@@ -168,6 +168,9 @@ NS_ASSUME_NONNULL_BEGIN
         if (ARPerformWorkAsynchronously) {
             [self animateImageView];
         }
+
+        // Makes it so that the screen doesn't dim
+        [[UIApplication sharedApplication] setIdleTimerDisabled:YES];
     }
 }
 
@@ -325,6 +328,8 @@ NSString *ARFinalARVIRSubtitle =   @"Keep your phone pointed at the work and wal
 
     // I can't think of an edge case for this, but better to be comprehensive
     [self.navigationController popViewControllerAnimated:YES];
+    // Makes it so that the screen can dim again
+    [[UIApplication sharedApplication] setIdleTimerDisabled:NO];
 }
 
 - (NSTimeInterval)timeInAR


### PR DESCRIPTION
Fixes [EV-51](https://artsyproduct.atlassian.net/browse/EV-51)

On loading the screen we disable the idea timer, then when you hit the exit button it is re-enabled.