### PR TITLE
[Buy] Show separator line only when there's lotstandings and no buy now segment

### DIFF
--- a/Artsy/View_Controllers/Auction/AuctionViewController.swift
+++ b/Artsy/View_Controllers/Auction/AuctionViewController.swift
@@ -136,6 +136,13 @@ extension AuctionViewController {
     var isCompactSize: Bool {
         return traitCollection.horizontalSizeClass == .compact
     }
+    
+    var buyNowSegmentWillBeShown: Bool {
+        guard let promotedSaleArtworks = self.saleViewModel.promotedSaleArtworks , promotedSaleArtworks.count > 0 else {
+            return false
+        }
+        return true
+    }
 
     // Fetches new lot standings, updates the model, removes the old standings view, and adds a fresh one.
     func fetchLotStandingsAndUpdate() {
@@ -185,7 +192,8 @@ extension AuctionViewController {
                 guard let artworkViewController = ARArtworkSetViewController(artwork: lotStanding.saleArtwork.artwork) else { return }
                 
                 self?.navigationController?.pushViewController(artworkViewController, animated: true)
-            }
+            },
+            isFinalHeaderElement: !self.buyNowSegmentWillBeShown
         )
         lotStandingsView.tag = ViewTags.lotStandings.rawValue
         headerStack?.addSubview(lotStandingsView, withTopMargin: "0", sideMargin: "0")

--- a/Artsy/View_Controllers/Live_Auctions/Views/LotStandingsView.swift
+++ b/Artsy/View_Controllers/Live_Auctions/Views/LotStandingsView.swift
@@ -7,11 +7,13 @@ class LotStandingsView: UIView {
     let saleViewModel: SaleViewModel
     let isCompact: Bool
     let lotStandingTappedClosure: LotStandingTappedClosure
+    let isFinalHeaderElement: Bool
 
-    init(saleViewModel: SaleViewModel, isCompact: Bool, lotStandingTappedClosure: @escaping LotStandingTappedClosure) {
+    init(saleViewModel: SaleViewModel, isCompact: Bool, lotStandingTappedClosure: @escaping LotStandingTappedClosure, isFinalHeaderElement: Bool) {
         self.saleViewModel = saleViewModel
         self.isCompact = isCompact
         self.lotStandingTappedClosure = lotStandingTappedClosure
+        self.isFinalHeaderElement = isFinalHeaderElement
 
         super.init(frame: CGRect.zero)
 
@@ -38,13 +40,15 @@ extension PrivateFunctions {
         listView.constrainTopSpace(toView: titleView, predicate: "0")
         listView.alignLeading("0", trailing: "0", toView: self)
         listView.alignBottomEdge(withView: self, predicate: isCompact ? "-10" : "-30")
-
-        let bottomBorder = UIView().then {
-            $0.backgroundColor = UIColor.artsyGrayRegular()
-            $0.constrainHeight("1")
+        
+        if (self.isFinalHeaderElement) {
+            let bottomBorder = UIView().then {
+                $0.backgroundColor = UIColor.artsyGrayRegular()
+                $0.constrainHeight("1")
+            }
+            addSubview(bottomBorder)
+            bottomBorder.alignBottomEdge(withView: self, predicate: "0")
+            bottomBorder.alignLeading("0", trailing: "0", toView: self)
         }
-        addSubview(bottomBorder)
-        bottomBorder.alignBottomEdge(withView: self, predicate: "0")
-        bottomBorder.alignLeading("0", trailing: "0", toView: self)
     }
 }

--- a/Artsy_Tests/View_Controller_Tests/Auction/Views/LotStandingsViewTests.swift
+++ b/Artsy_Tests/View_Controller_Tests/Auction/Views/LotStandingsViewTests.swift
@@ -33,7 +33,7 @@ class LotStandingsViewTests: QuickSpec {
             }
 
             it("looks good") {
-                let subject = LotStandingsView(saleViewModel: saleViewModel, isCompact: isCompact, lotStandingTappedClosure: { _ in })
+                let subject = LotStandingsView(saleViewModel: saleViewModel, isCompact: isCompact, lotStandingTappedClosure: { _ in }, isFinalHeaderElement: true)
 
                 subject.stubHorizontalSizeClass(horizontalSizeClass)
                 if isCompact {

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -6,6 +6,7 @@ upcoming:
     - WIP Buy now works show in an Auction screen - Chris
     - ARVIR fixes & improvements - orta
     - Buy now layout adjustments, 3 columns on ipad - maxim
+    - conditionally adding horizontal line to lotstandings view wrt buy now - maxim
   
 releases:
   - version: 4.1.0


### PR DESCRIPTION
[PURCHASE-29](https://artsyproduct.atlassian.net/browse/PURCHASE-29)

For tomorrow's release. 

New shiny:

### Neither lotStandings nor Buy Now:
![simulator screen shot - ipad air 2 - 2018-04-17 at 16 38 40](https://user-images.githubusercontent.com/373860/38880701-46a4bb88-425e-11e8-8ace-ad18d66c1b26.png)

### Lot Standings _and_ Buy Now (case referenced in the ticket):
![simulator screen shot - ipad air 2 - 2018-04-17 at 16 38 33](https://user-images.githubusercontent.com/373860/38880702-46bc8bfa-425e-11e8-9eab-dfc963920963.png)

### Only Lot Standings, _no_ Buy Now:
![simulator screen shot - ipad air 2 - 2018-04-17 at 16 38 30](https://user-images.githubusercontent.com/373860/38880703-46d6d5be-425e-11e8-8163-a5b103ef8ce1.png)

