### PR TITLE
EV-55 - Fixes the Artwork not being able to scroll correctly when moving into VIR

### DIFF
--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -445,7 +445,9 @@ static const CGFloat ARMenuButtonDimension = 50;
 {
     CGFloat bottomMargin = [self bottomMargin];
     CGFloat newConstant = hideToolbar ? CGRectGetHeight(self.tabContainer.frame) : bottomMargin;
-    if (newConstant == self.tabBottomConstraint.constant) { return; }
+    CGFloat oldConstant = self.tabBottomConstraint.constant;
+    BOOL shouldChange = newConstant != oldConstant;
+    if (!shouldChange) { return; }
 
     [UIView animateIf:animated duration:ARAnimationQuickDuration:^{
         self.tabBottomConstraint.constant = newConstant;

--- a/Artsy/View_Controllers/Util/ARNavigationController.m
+++ b/Artsy/View_Controllers/Util/ARNavigationController.m
@@ -1,6 +1,7 @@
 #import <MultiDelegate/AIMultiDelegate.h>
 #import <objc/runtime.h>
 #import <objc/message.h>
+#import "ARDispatchManager.h"
 
 #import "UIView+HitTestExpansion.h"
 #import "UIViewController+InnermostTopViewController.h"
@@ -192,8 +193,10 @@ static void *ARNavigationControllerMenuAwareScrollViewContext = &ARNavigationCon
         [self showStatusBarBackground:[self shouldShowStatusBarBackgroundForViewController:viewController] animated:animated white:useWhite];
         [self setNeedsStatusBarAppearanceUpdate];
 
-        BOOL hideToolbar = [self shouldHideToolbarMenuForViewController:viewController];
-        [[ARTopMenuViewController sharedController] hideToolbar:hideToolbar animated:animated];
+        ar_dispatch_after(0.05, ^{
+            BOOL hideToolbar = [self shouldHideToolbarMenuForViewController:viewController];
+            [[ARTopMenuViewController sharedController] hideToolbar:hideToolbar animated:animated];
+        });
     }
 }
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -7,6 +7,7 @@ upcoming:
     - ARVIR fixes & improvements - orta
     - Buy now layout adjustments, 3 columns on ipad - maxim
     - conditionally adding horizontal line to lotstandings view wrt buy now - maxim
+    - Artwork Screen does not get overscrolled after coming back from ARVIR - orta
   
 releases:
   - version: 4.1.0


### PR DESCRIPTION
Re: https://artsyproduct.atlassian.net/browse/EV-55

I decoupled the setting of the new toolbar state from when the artwork is still the top view controller for the navigation stack. This means that the changes in the layout don't affect the ArtworkVC and it becomes immune to the bug.