### PR TITLE
[ARVIR] After placing an artwork, don't update the positions of walls

### DIFF
--- a/Artsy/View_Controllers/ARVIR/AR/ARAugmentedVIRInteractionController.m
+++ b/Artsy/View_Controllers/ARVIR/AR/ARAugmentedVIRInteractionController.m
@@ -133,8 +133,9 @@ NSInteger wallHeightMeters = 5;
 - (void)renderer:(id<SCNSceneRenderer>)renderer didUpdateNode:(SCNNode *)node forAnchor:(ARAnchor *)anchor API_AVAILABLE(ios(11.0))
 {
     // Used to update and re-align vertical planes as ARKit sends new updates for the positioning
-    if(!anchor) { return; }
-    if(![anchor isKindOfClass:ARPlaneAnchor.class]) { return; }
+    if (!anchor) { return; }
+    if (![anchor isKindOfClass:ARPlaneAnchor.class]) { return; }
+    if (!self.artwork) { return; }
 
     // Animate instead of jumping positions
     SCNTransaction.animationDuration = 0.1;

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,6 +5,7 @@ upcoming:
   user_facing:
     - WIP Buy now works show in an Auction screen - Chris
     - ARVIR fixes & improvements - orta
+    - Wall positions are not updated after placing a work - orta
     - Buy now layout adjustments, 3 columns on ipad - maxim
     - conditionally adding horizontal line to lotstandings view wrt buy now - maxim
   


### PR DESCRIPTION
With this merged ARVIR does not update the wall positioning after an Artwork has been placed, [see slack](https://artsy.slack.com/archives/C9ZHUJXEZ/p1524062272000754) for full context. 