### PR TITLE
Upon viewing an artwork, sends recordArtworkView graphql mutation

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -678,6 +678,7 @@
 		6F3D85ED204DD876000BF304 /* Artwork+AttributionClassStrings.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F3D85EC204DD876000BF304 /* Artwork+AttributionClassStrings.m */; };
 		6F3D85F0204DDB37000BF304 /* ArtworkAttributionClassTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F3D85EE204DDB1C000BF304 /* ArtworkAttributionClassTests.m */; };
 		7F45A1682003C7100063D6B5 /* conversations.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 7F45A1672003C7100063D6B5 /* conversations.graphql */; };
+		83071C79208DFE27006020DB /* record_artwork_view_mutation.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 83071C78208DFE27006020DB /* record_artwork_view_mutation.graphql */; };
 		837CEC841C876B7C00A7E0E1 /* ArtsyAPI+Notifications.m in Sources */ = {isa = PBXBuildFile; fileRef = 837CEC831C876B7C00A7E0E1 /* ArtsyAPI+Notifications.m */; };
 		83F9D5801AD6FDE0000BCC77 /* Location.m in Sources */ = {isa = PBXBuildFile; fileRef = 83F9D57F1AD6FDE0000BCC77 /* Location.m */; };
 		83FF73B41CB87A74002B53FA /* RefinableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83FF73B31CB87A74002B53FA /* RefinableType.swift */; };
@@ -1875,6 +1876,7 @@
 		6F3D85EC204DD876000BF304 /* Artwork+AttributionClassStrings.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "Artwork+AttributionClassStrings.m"; sourceTree = "<group>"; };
 		6F3D85EE204DDB1C000BF304 /* ArtworkAttributionClassTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ArtworkAttributionClassTests.m; sourceTree = "<group>"; };
 		7F45A1672003C7100063D6B5 /* conversations.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = conversations.graphql; sourceTree = "<group>"; };
+		83071C78208DFE27006020DB /* record_artwork_view_mutation.graphql */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = record_artwork_view_mutation.graphql; sourceTree = "<group>"; };
 		83282D751EB0D9F1006F30C2 /* ARRootViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARRootViewController.h; sourceTree = "<group>"; };
 		837CEC821C876B7C00A7E0E1 /* ArtsyAPI+Notifications.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ArtsyAPI+Notifications.h"; sourceTree = "<group>"; };
 		837CEC831C876B7C00A7E0E1 /* ArtsyAPI+Notifications.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ArtsyAPI+Notifications.m"; sourceTree = "<group>"; };
@@ -3146,6 +3148,7 @@
 			isa = PBXGroup;
 			children = (
 				5EFB45711F2280CE00328A6B /* favorites.graphql */,
+				83071C78208DFE27006020DB /* record_artwork_view_mutation.graphql */,
 				5EFB45731F22830F00328A6B /* static_sale_data.graphql */,
 				5EFABE221F26934900662FEC /* artworks_in_sale.graphql */,
 				7F45A1672003C7100063D6B5 /* conversations.graphql */,
@@ -4988,6 +4991,7 @@
 				604E08242051E9E000785717 /* ARVIRPhone@3x.png in Resources */,
 				5E6BA6EA1C56B5D700B942C1 /* CircularCancelButton.png in Resources */,
 				49BA7E0E1655ABE600C06572 /* InfoPlist.strings in Resources */,
+				83071C79208DFE27006020DB /* record_artwork_view_mutation.graphql in Resources */,
 				608C6DCE1FAA11630044E235 /* nav_favs@3x.png in Resources */,
 				3C4AE99419094F96009C0E8B /* ViewInRoom_Bench@2x.png in Resources */,
 				608B708117D4A1C80088A56C /* MenuHamburger@2x.png in Resources */,

--- a/Artsy/Networking/API_Modules/ArtsyAPI+Artworks.h
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+Artworks.h
@@ -22,4 +22,6 @@
 
 + (AFHTTPRequestOperation *)createPendingOrderWithArtworkID:(NSString *)artworkID editionSetID:(NSString *)editionSetID success:(void (^)(NSArray *))success failure:(void (^)(NSError *))failure;
 
++ (AFHTTPRequestOperation *)recordViewingOfArtwork:(NSString *)artworkID success:(void (^)(Artwork *artwork))success failure:(void (^)(NSError *error))failure;
+
 @end

--- a/Artsy/Networking/API_Modules/ArtsyAPI+Artworks.m
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+Artworks.m
@@ -75,6 +75,12 @@
     } failure:failure];
 }
 
++ (AFHTTPRequestOperation *)recordViewingOfArtwork:(NSString *)artworkID success:(void (^)(Artwork *artwork))success failure:(void (^)(NSError *error))failure
+{
+  NSURLRequest *request = [ARRouter recordArtworkViewRequest:artworkID];
+  return [self performGraphQLRequest:request success:success failure:failure];
+}
+
 + (AFHTTPRequestOperation *)getArtworksForGene:(Gene *)gene atPage:(NSInteger)page success:(void (^)(NSArray *artworks))success failure:(void (^)(NSError *error))failure
 {
     NSURLRequest *request = [ARRouter newArtworksFromGeneRequest:gene.geneID atPage:page];

--- a/Artsy/Networking/ARRouter+GraphQL.h
+++ b/Artsy/Networking/ARRouter+GraphQL.h
@@ -4,6 +4,7 @@
 
 + (NSString *)graphQueryForFavorites;
 + (NSString *)graphQueryForFavoritesAfter:(NSString *)cursor;
++ (NSString *)graphQueryToRecordViewingOfArtwork:(NSString *)artworkID;
 + (NSString *)graphQueryForArtworksInSale:(NSString *)saleID;
 + (NSString *)graphQLQueryForLiveSaleStaticData:(NSString *)saleID role:(NSString *)causalityRole;
 + (NSString *)graphQueryForConversations;

--- a/Artsy/Networking/ARRouter+GraphQL.m
+++ b/Artsy/Networking/ARRouter+GraphQL.m
@@ -37,6 +37,11 @@
     return [NSString stringWithFormat:[self graphQLFileNamed:@"artworks_in_sale"], saleID];
 }
 
++ (NSString *)graphQueryToRecordViewingOfArtwork:(NSString *)artworkID
+{
+  return [self graphQLFileNamed:@"record_artwork_view_mutation"];
+}
+
 + (NSString *)graphQLQueryForLiveSaleStaticData:(NSString *)saleID role:(NSString *)causalityRole
 {
     return [NSString stringWithFormat:[self graphQLFileNamed:@"static_sale_data"], causalityRole, saleID, saleID];

--- a/Artsy/Networking/ARRouter.h
+++ b/Artsy/Networking/ARRouter.h
@@ -77,6 +77,7 @@
 + (NSURLRequest *)newNewArtworksRequestWithParams:(NSDictionary *)params;
 + (NSURLRequest *)newArtistArtworksRequestWithParams:(NSDictionary *)params andArtistID:(NSString *)artistID;
 + (NSURLRequest *)newArtworksForYouRequestWithID:(NSString *)userID page:(NSInteger)page;
++ (NSURLRequest *)recordArtworkViewRequest:(NSString *)artworkID;
 
 #pragma mark - Artwork Favorites (items in the saved-artwork collection)
 

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -1099,7 +1099,7 @@ static NSString *hostFromString(NSString *string)
 
 + (NSURLRequest *)graphQLRequestForQuery:(NSString *)query
 {
-  return [self graphQLRequestForQuery:query variables:nil];
+    return [self graphQLRequestForQuery:query variables:nil];
 }
 
 + (NSURLRequest *)graphQLRequestForQuery:(NSString *)query variables:(NSDictionary *)variables
@@ -1120,9 +1120,12 @@ static NSString *hostFromString(NSString *string)
   }
   NSError *error;
   
-  NSString *variablesAsString = variables && variables.count > 0 ? [self jsonDictionaryForVariables:variables] : nil;
-  
-  NSMutableURLRequest *request = [jsonSerializer requestWithMethod:@"POST" URLString:url parameters:@{ @"query" : query, @"variables": variablesAsString } error:&error];
+  NSMutableDictionary *params = [[NSMutableDictionary alloc] initWithDictionary:@{ @"query" : query }];
+  if (variables && variables.count > 0) {
+    [params setValue:[self jsonDictionaryForVariables:variables] forKey:@"variables"];
+  }
+
+  NSMutableURLRequest *request = [jsonSerializer requestWithMethod:@"POST" URLString:url parameters:params error:&error];
   
   if (error) {
     NSLog(@"Error serializing request: %@", error);

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -1073,6 +1073,11 @@ static NSString *hostFromString(NSString *string)
     return [self requestWithMethod:@"GET" path:ARSalesForArtworkURL parameters:params];
 }
 
++ (NSURLRequest *)recordArtworkViewRequest:(NSString *)artworkID
+{
+  return [self graphQLRequestForQuery:[self graphQueryToRecordViewingOfArtwork:artworkID] variables:@{@"artwork_id" : artworkID}];
+}
+
 + (NSURLRequest *)artworksForSaleRequest:(NSString *)saleID
 {
     return [self graphQLRequestForQuery:[self graphQueryForArtworksInSale:saleID]];
@@ -1094,28 +1099,42 @@ static NSString *hostFromString(NSString *string)
 
 + (NSURLRequest *)graphQLRequestForQuery:(NSString *)query
 {
-    // Note that we're relying on the host to specify the domain for the request.
-    NSString *url = [self baseMetaphysicsApiURLString];
+  return [self graphQLRequestForQuery:query variables:nil];
+}
 
-    // Makes a copy of the request serializer, one that will encode HTTP body as JSON instead of URL-encoded params.
-    AFJSONRequestSerializer *jsonSerializer = [[AFJSONRequestSerializer alloc] init];
-    for (NSString *key in staticHTTPClient.requestSerializer.HTTPRequestHeaders.allKeys) {
-        id value = staticHTTPClient.requestSerializer.HTTPRequestHeaders[key];
-        [jsonSerializer setValue:value forHTTPHeaderField:key];
-    }
-    if (ARIsRunningInDemoMode) {
-        [jsonSerializer setValue:@"502d15746e721400020006fa" forHTTPHeaderField:@"X-User-ID"];
-    } else {
-        [jsonSerializer setValue:[User currentUser].userID forHTTPHeaderField:@"X-User-ID"];
-    }
-    NSError *error;
-    NSMutableURLRequest *request = [jsonSerializer requestWithMethod:@"POST" URLString:url parameters:@{ @"query" : query } error:&error];
++ (NSURLRequest *)graphQLRequestForQuery:(NSString *)query variables:(NSDictionary *)variables
+{
+  // Note that we're relying on the host to specify the domain for the request.
+  NSString *url = [self baseMetaphysicsApiURLString];
+  
+  // Makes a copy of the request serializer, one that will encode HTTP body as JSON instead of URL-encoded params.
+  AFJSONRequestSerializer *jsonSerializer = [[AFJSONRequestSerializer alloc] init];
+  for (NSString *key in staticHTTPClient.requestSerializer.HTTPRequestHeaders.allKeys) {
+    id value = staticHTTPClient.requestSerializer.HTTPRequestHeaders[key];
+    [jsonSerializer setValue:value forHTTPHeaderField:key];
+  }
+  if (ARIsRunningInDemoMode) {
+    [jsonSerializer setValue:@"502d15746e721400020006fa" forHTTPHeaderField:@"X-User-ID"];
+  } else {
+    [jsonSerializer setValue:[User currentUser].userID forHTTPHeaderField:@"X-User-ID"];
+  }
+  NSError *error;
+  
+  NSString *variablesAsString = variables && variables.count > 0 ? [self jsonDictionaryForVariables:variables] : nil;
+  
+  NSMutableURLRequest *request = [jsonSerializer requestWithMethod:@"POST" URLString:url parameters:@{ @"query" : query, @"variables": variablesAsString } error:&error];
+  
+  if (error) {
+    NSLog(@"Error serializing request: %@", error);
+  }
+  
+  return request;
+}
 
-    if (error) {
-        NSLog(@"Error serializing request: %@", error);
-    }
-
-    return request;
++ (NSString *)jsonDictionaryForVariables:(NSDictionary *)variables
+{
+  NSData *jsonData = [NSJSONSerialization dataWithJSONObject:variables options:0 error:nil];
+  return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
 }
 
 + (NSURLRequest *)liveSaleStaticDataRequest:(NSString *)saleID role:(NSString *)role

--- a/Artsy/Networking/record_artwork_view_mutation.graphql
+++ b/Artsy/Networking/record_artwork_view_mutation.graphql
@@ -1,0 +1,7 @@
+mutation recordArtworkView($artwork_id: String!) {
+  recordArtworkView(
+    input: { artwork_id: $artwork_id }
+  ) {
+    artwork_id
+  }
+}

--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
@@ -16,6 +16,8 @@
 #import "UIViewController+ARUserActivity.h"
 #import "ARScrollNavigationChief.h"
 
+#import "ArtsyAPI+Artworks.h"
+
 #import "UIDevice-Hardware.h"
 
 #import <UIView+BooleanAnimations/UIView+BooleanAnimations.h>
@@ -102,6 +104,8 @@
     } failure:^(NSError *error) {
         completion();
     }];
+  
+    [ArtsyAPI recordViewingOfArtwork:self.artwork.artworkID success:nil failure:nil];
 
     [super viewDidLoad];
 }

--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
@@ -104,8 +104,6 @@
     } failure:^(NSError *error) {
         completion();
     }];
-  
-    [ArtsyAPI recordViewingOfArtwork:self.artwork.artworkID success:nil failure:nil];
 
     [super viewDidLoad];
 }
@@ -113,6 +111,12 @@
 - (UIImageView *)imageView
 {
     return self.view.metadataView.imageView;
+}
+
+-(void)viewWillAppear:(BOOL)animated
+{
+  [super viewWillAppear:animated];
+  [ArtsyAPI recordViewingOfArtwork:self.artwork.artworkID success:nil failure:nil];
 }
 
 - (void)viewDidAppear:(BOOL)animated

--- a/Artsy_Tests/App_Tests/ARAppActivityContinuationDelegateTests.m
+++ b/Artsy_Tests/App_Tests/ARAppActivityContinuationDelegateTests.m
@@ -49,6 +49,8 @@ describe(@"concerning loading a VC from a URL and reporting analytics", ^{
         [[[userManagerMock stub] andReturnValue:@(YES)] hasExistingAccount];
         
         [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/collection/saved-artwork/artworks" withResponse:@{}];
+      
+        [OHHTTPStubs stubJSONResponseForHost:@"metaphysics*.artsy.net" withResponse:@{}];
 
         topMenuMock = [OCMockObject partialMockForObject:[ARTopMenuViewController sharedController]];
         [[topMenuMock expect] pushViewController:[OCMArg checkWithBlock:^(ARArtworkSetViewController *viewController) {

--- a/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
@@ -281,7 +281,7 @@ it(@"calls recordViewingOfArtwork within viewDidLoad", ^{
   
   [[apiMock expect] recordViewingOfArtwork:@"some-artwork" success:nil failure:nil];
   
-  [vc viewDidLoad];
+  [vc viewWillAppear:NO];
   [apiMock verify];
 });
 

--- a/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
@@ -1,6 +1,6 @@
 #import "ARArtworkViewController.h"
 #import "ARArtworkView.h"
-
+#import "ArtsyAPI+Artworks.h"
 
 void stubEmptyBidderPositions(void);
 void stubEmptySaleArtworks(void);
@@ -10,7 +10,6 @@ void stubBidder(BOOL requiresApproval);
 @interface ARArtworkViewController ()
 
 @property (nonatomic, strong) NSTimer *updateInterfaceWhenAuctionChangesTimer;
-
 @end
 
 SpecBegin(ARArtworkViewController);
@@ -26,6 +25,7 @@ beforeEach(^{
     [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/collection/saved-artwork/artworks" withResponse:@[]];
     [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/related/layer/synthetic/main/artworks" withResponse:@[]];
     [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/artwork/some-artwork" withResponse:@{ @"id": @"some-artwork", @"title": @"Some Title" }];
+    [OHHTTPStubs stubJSONResponseForHost:@"metaphysics-staging.artsy.net" withResponse:@{}];
 });
 
 describe(@"no related data", ^{
@@ -274,6 +274,18 @@ it(@"creates an NSUserActivity", ^{
     expect(vc.userActivity).notTo.beNil();
     expect(vc.userActivity.title).to.equal(@"Some Title");
 });
+
+it(@"calls recordViewingOfArtwork within viewDidLoad", ^{
+  ARArtworkViewController *vc = [[ARArtworkViewController alloc] initWithArtworkID:@"some-artwork" fair:nil];
+  id apiMock = [OCMockObject niceMockForClass:ArtsyAPI.class];
+  
+  [[apiMock expect] recordViewingOfArtwork:@"some-artwork" success:nil failure:nil];
+  
+  [vc viewDidLoad];
+  [apiMock verify];
+});
+
+
 
 pending(@"at a fair");
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -9,6 +9,8 @@ upcoming:
     - Buy now layout adjustments, 3 columns on ipad - maxim
     - conditionally adding horizontal line to lotstandings view wrt buy now - maxim
     - Artwork Screen does not get overscrolled after coming back from ARVIR - orta
+  dev:
+    - Records artwork views using metaphysics mutation - Sarah
   
 releases:
   - version: 4.1.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -298,7 +298,7 @@ DEPENDENCIES:
   - "XCTest+OHHTTPStubSuiteCleanUp"
 
 SPEC REPOS:
-  https://github.com/artsy/Specs.git:
+  https://github.com/artsy/Specs:
     - Aerodramus
     - "Artsy+UIColors"
     - "Artsy+UIFonts"


### PR DESCRIPTION
- [x] Sends `recordArtworkView` upon viewing an artwork (this way we can construct a 'Recently Viewed Works' rail)
- [x] Fix tests (mostly related to unstubbed MP request)

Related to: https://artsyproduct.atlassian.net/browse/DISCOVER-23