### PR TITLE
Fixes crash attaching photos to a consignment submission.

### DIFF
--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -97,6 +97,8 @@
 	<string>Used for beta testers to collect usage information.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Camera access is needed for this experience.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Camera access is needed to submit consignments.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Photos will be used to gauge the quality of the work you are submitting.</string>
 	<key>UIAppFonts</key>

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -9,6 +9,7 @@ upcoming:
     - Buy now layout adjustments, 3 columns on ipad - maxim
     - conditionally adding horizontal line to lotstandings view wrt buy now - maxim
     - Artwork Screen does not get overscrolled after coming back from ARVIR - orta
+    - Fixes crash when submitting consignments from iOS 11 - ash
   
 releases:
   - version: 4.1.0


### PR DESCRIPTION
A friend reported that the app crashed while attaching a photo to their consignment submission. I found [the corresponding crash report](https://sentry.io/artsynet/eigen/issues/452245164/events/18647931286/) and took a very quick look, and it appears that as of iOS 11, the `NSPhotoLibraryAddUsageDescription` key is required to be included in an app's `Info.plist`, or else the following SIGABRT is raised:

```
abort | NSPhotoLibraryAddUsageDescription | This app has crashed because it attempted to access privacy-sensitive data without a usage description.  The app's Info.plist must contain an NSPhotoLibraryAddUsageDescription key with a string value explaining to the user how the app uses this data.
```

This PR adds the key, which should fix the crashes.