### PR TITLE
Fix Emission VCs not being considered Root 

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -32,6 +32,8 @@
 #import <Emission/ARArtistComponentViewController.h>
 #import <Emission/ARHomeComponentViewController.h>
 #import <Emission/ARWorksForYouComponentViewController.h>
+#import <Emission/ARInboxComponentViewController.h>
+#import <Emission/ARFavoritesComponentViewController.h>
 
 #import <React/RCTUtils.h>
 #import <objc/runtime.h>
@@ -234,6 +236,30 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
 @end
 
 @implementation ARHomeComponentViewController (ARRootViewController)
+
+- (BOOL)isRootNavViewController
+{
+    return YES;
+}
+
+@end
+
+@interface ARInboxComponentViewController (ARRootViewController) <ARRootViewController>
+@end
+
+@implementation ARInboxComponentViewController (ARRootViewController)
+
+- (BOOL)isRootNavViewController
+{
+    return YES;
+}
+
+@end
+
+@interface ARFavoritesComponentViewController (ARRootViewController) <ARRootViewController>
+@end
+
+@implementation ARFavoritesComponentViewController (ARRootViewController)
 
 - (BOOL)isRootNavViewController
 {

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -531,17 +531,10 @@ static const CGFloat ARMenuButtonDimension = 50;
     }
 
     if ([viewController respondsToSelector:@selector(isRootNavViewController)] && [(id<ARRootViewController>)viewController isRootNavViewController]) {
-        [self presentRootViewController:viewController animated:animated];
-    } else if ([self isEmissionRootViewController:viewController]){
-        // Override animation, because tab switching should never be animated
         [self presentRootViewController:viewController animated:NO];
     } else {
         [self.rootNavigationController pushViewController:viewController animated:animated];
     }
-}
-
-- (BOOL)isEmissionRootViewController:(UIViewController *)viewController {
-    return [viewController isKindOfClass:ARInboxComponentViewController.class] || [viewController isKindOfClass:ARHomeComponentViewController.class] || [viewController isKindOfClass:ARFavoritesComponentViewController.class];
 }
 
 - (void)presentRootViewControllerAtIndex:(NSInteger)index animated:(BOOL)animated;

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -532,9 +532,16 @@ static const CGFloat ARMenuButtonDimension = 50;
 
     if ([viewController respondsToSelector:@selector(isRootNavViewController)] && [(id<ARRootViewController>)viewController isRootNavViewController]) {
         [self presentRootViewController:viewController animated:animated];
+    } else if ([self isEmissionRootViewController:viewController]){
+        // Override animation, because tab switching should never be animated
+        [self presentRootViewController:viewController animated:NO];
     } else {
         [self.rootNavigationController pushViewController:viewController animated:animated];
     }
+}
+
+- (BOOL)isEmissionRootViewController:(UIViewController *)viewController {
+    return [viewController isKindOfClass:ARInboxComponentViewController.class] || [viewController isKindOfClass:ARHomeComponentViewController.class] || [viewController isKindOfClass:ARFavoritesComponentViewController.class];
 }
 
 - (void)presentRootViewControllerAtIndex:(NSInteger)index animated:(BOOL)animated;

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -10,6 +10,7 @@ upcoming:
     - conditionally adding horizontal line to lotstandings view wrt buy now - maxim
     - Artwork Screen does not get overscrolled after coming back from ARVIR - orta
     - Fixes crash when submitting consignments from iOS 11 - ash
+    - Adds a method to determine root emission VCs for tabbing - maxim
   dev:
     - Records artwork views using metaphysics mutation - Sarah
   


### PR DESCRIPTION
Fix [PURCHASE-103](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=41&projectKey=PURCHASE&modal=detail&selectedIssue=PURCHASE-103)

This is far from an elegant solution. Another option is amending the Emission View Controllers to have the `isRootNavViewController` property (which is currently considered `false`, which caused the bug).  That would mean an Emission release though, and I opted in favour for this, for the time being. 

