### PR TITLE
[Auctions] Add support for showing auctions home tab on /auctions push notification

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.1.2</string>
+	<string>4.1.3</string>
 	<key>CFBundleVersion</key>
 	<string>2018.04.18.12</string>
 	<key>NSExtension</key>

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.1.2</string>
+	<string>4.1.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -297,7 +297,7 @@ static const CGFloat ARMenuButtonDimension = 50;
     }
     
     [switchboard registerPathCallbackAtPath:@"/works-for-you" callback:^id _Nullable(NSDictionary * _Nullable parameters) {
-        return [self rootNavigationControllerAtIndex:ARTopTabControllerIndexHome parameters:parameters].rootViewController;
+        return [self rootNavigationControllerHomeWithTab:ARHomeTabArtists].rootViewController;
     }];
     
     [switchboard registerPathCallbackAtPath:@"/auctions" callback:^id _Nullable(NSDictionary * _Nullable parameters) {
@@ -611,8 +611,6 @@ static const CGFloat ARMenuButtonDimension = 50;
     } else if (showWorksForYouWithSelectedArtistFromUniversalLink) {
         // We are already on Home, and need to force the tab view to show the new Home with its selected artist & without animation
         [self.tabContentView forceSetViewController:presentableController atIndex:ARTopTabControllerIndexHome animated:NO];
-    } else {
-        [self.tabContentView forceSetViewController:presentableController atIndex:index animated:NO];
     }
 }
 

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -299,6 +299,10 @@ static const CGFloat ARMenuButtonDimension = 50;
     [switchboard registerPathCallbackAtPath:@"/works-for-you" callback:^id _Nullable(NSDictionary * _Nullable parameters) {
         return [self rootNavigationControllerAtIndex:ARTopTabControllerIndexHome parameters:parameters].rootViewController;
     }];
+    
+    [switchboard registerPathCallbackAtPath:@"/auctions" callback:^id _Nullable(NSDictionary * _Nullable parameters) {
+        return [self rootNavigationControllerHomeWithTab:ARHomeTabAuctions].rootViewController;
+    }];
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
@@ -347,6 +351,12 @@ static const CGFloat ARMenuButtonDimension = 50;
     return (ARNavigationController *)[self.navigationDataSource navigationControllerAtIndex:index parameters:params];
 }
 
+- (ARNavigationController *)rootNavigationControllerHomeWithTab:(ARHomeTabType)tab
+{
+    ARNavigationController *homeRootNavigationViewController = [self rootNavigationControllerAtIndex:ARTopTabControllerIndexHome];
+    [(ARHomeComponentViewController *)homeRootNavigationViewController.rootViewController changeHomeTabTo:tab];
+    return homeRootNavigationViewController;
+}
 
 - (NSInteger)indexOfRootViewController:(UIViewController *)viewController;
 {
@@ -565,6 +575,9 @@ static const CGFloat ARMenuButtonDimension = 50;
             if (showWorksForYouWithSelectedArtistFromUniversalLink) {
                 NSString *selectedArtistID = [(ARHomeComponentViewController *)viewController selectedArtist];
                 presentableController = [self.navigationDataSource navigationControllerAtIndex:ARTopTabControllerIndexHome parameters:@{@"artist_id": selectedArtistID}];
+            } else if ([viewController isKindOfClass:ARHomeComponentViewController.class]) {
+                // just show the home controller as passed in / intended, as it may have tab selections
+                presentableController = (ARNavigationController *)viewController.navigationController;
             } else {
                 presentableController = [self rootNavigationControllerAtIndex:index];
             }
@@ -573,6 +586,8 @@ static const CGFloat ARMenuButtonDimension = 50;
             presentableController = [self rootNavigationControllerAtIndex:index];
             break;
         case ARTopTabControllerIndexFavorites:
+            presentableController = [self rootNavigationControllerAtIndex:index];
+            break;
         case ARTopTabControllerIndexProfile:
             presentableController = [[ARNavigationController alloc] initWithRootViewController:viewController];
 
@@ -596,6 +611,8 @@ static const CGFloat ARMenuButtonDimension = 50;
     } else if (showWorksForYouWithSelectedArtistFromUniversalLink) {
         // We are already on Home, and need to force the tab view to show the new Home with its selected artist & without animation
         [self.tabContentView forceSetViewController:presentableController atIndex:ARTopTabControllerIndexHome animated:NO];
+    } else {
+        [self.tabContentView forceSetViewController:presentableController atIndex:index animated:NO];
     }
 }
 
@@ -649,20 +666,6 @@ static const CGFloat ARMenuButtonDimension = 50;
 
 - (BOOL)tabContentView:(ARTabContentView *)tabContentView shouldChangeToIndex:(NSInteger)index
 {
-    // TODO MAXIM : Change this for demo mode
-    //    BOOL favoritesInDemoMode = (index == ARTopTabControllerIndexFavorites && ARIsRunningInDemoMode);
-    //    BOOL loggedOutBellOrFavorites = (index == ARTopTabControllerIndexFavorites || index == ARTopTabControllerIndexNotifications) && [User isLocalTemporaryUser];
-    //    if (!favoritesInDemoMode && loggedOutBellOrFavorites) {
-    //        ARTrialContext context = (index == ARTopTabControllerIndexFavorites) ? ARTrialContextShowingFavorites : ARTrialContextNotifications;
-    //        [ARTrialController presentTrialWithContext:context success:^(BOOL newUser) {
-    //            if (newUser) {
-    //                [self.tabContentView setCurrentViewIndex:ARTopTabControllerIndexFeed animated:NO];
-    //            } else {
-    //                [self.tabContentView setCurrentViewIndex:index animated:NO];
-    //            }
-    //        }];
-    //        return NO;
-    //    }
 
     if (index == self.selectedTabIndex) {
         ARNavigationController *controller = (id)[tabContentView currentNavigationController];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,13 +1,18 @@
 upcoming:
-  version: 4.1.2
+  version: 4.1.3
   date: TBA
-  emission_version: 1.4.8
+  emission_version: 1.4.9
   user_facing:
-    - Adds GDPR compliance screen to sign up flow - luc
     - Add push notification support for /auctions - maxim
     - Adds a new ARVIR behind a feature flag - orta
 
 releases:
+  - version: 4.1.2
+    date: May 22, 2018
+    emission_version: 1.4.8
+    user_facing:
+      - Adds GDPR compliance screen to sign up flow - luc
+
   - version: 4.1.1
     date: May 7, 2018
     emission_version: 1.4.8

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
   emission_version: 1.4.8
   user_facing:
     - Adds GDPR compliance screen to sign up flow - luc
+    - Add push notification support for /auctions - maxim
 
 releases:
   - version: 4.1.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -73,7 +73,7 @@ PODS:
     - CocoaLumberjack/Default
   - DHCShakeNotifier (0.2.0)
   - EDColor (1.0.0)
-  - Emission (1.4.8):
+  - Emission (1.4.9):
     - "Artsy+UIColors"
     - "Artsy+UIFonts (>= 3.0.0)"
     - Extraction (>= 1.2.1)
@@ -445,7 +445,7 @@ SPEC CHECKSUMS:
   CocoaLumberjack: 27ae9abcd376c3e4ee726ecd4adfd7b093ddef3f
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
-  Emission: ece22c8238543667b49ab7d255618ca848072d6d
+  Emission: e111efb4d128656160df73fc75c3b34c2d4f58d0
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   "Expecta+Snapshots": c343f410c7a6392f3e22e78f94c44b6c0749a516
   Extraction: 612cf0866f74d4c0dd616677ff24146efa200958


### PR DESCRIPTION
So, this will be corresponding with [Emission 1052](https://github.com/artsy/emission/pull/1052).

The switchboard registration and `rootNavigationControllerHomeWithTab` are legit, I think.

The code written in `presentRootViewController` is just... I don't know, I did what _I_ thought made sense, but I'm not 100% convinced. 

Basically, there are a few things that are odd:
1) There is no final `else`. There are cases in which nothing is presented, because nothing is being force set, as some of the variables/flags don't apply. Why is this a present VC method then? -> So I added a final clause
2) Favourites was missing, and would end up as a Home VC
3) (from my understanding) it essentially overwrites the passed through View Controller in the case of home, because it gets the rootNavigationVC from its `rootNavigationControllerAtIndex` method. That's fine if switching tabs to an existing RootNav, but not sufficient for needing to show a new home tab, as the information you needed to switch in the first place is now lost. If the index is 0 (meaning, home), it will default to Artists (the first tab within home). So I hope my change makes sense here.

I also deleted some code from an old TODO 😄 

Oh, and please test with a new Emission 1.4.x before merging 💕 
