### PR TITLE
Updates pre-deploy docs

### DIFF
--- a/docs/deploy_to_app_store.md
+++ b/docs/deploy_to_app_store.md
@@ -13,30 +13,33 @@ It takes about 45 minutes for [Circle CI](https://circleci.com/gh/artsy/eigen) t
 
 ### Test the Beta
 
-Before submitting to the App Store, the binary we submit *must* be tested *on-device*. Install the beta through Testflight and run through the following scenarios:
+Before submitting to the App Store, the binary we submit *must* be tested *on-device*. Install the beta through Testflight and run through the following scenarios **on staging**:
 
-- [ ] Check user registration and onboarding works.
-- [ ] Test the inqury flow. As an Artsy admin, you will be prevented from _actually_ sending an inquiry.
-- [ ] As a freshly created user, perform a smoke test of: 
-  - [ ] Eigen's main tab view controllers (Search, Home, Explore, You, Notifications).
-  - [ ] The artwork, artist, and auctions view controllers.
-  - [ ] Live Auctions interface.
-- [ ] As a user with populated favourites, follows, etc, perform a smoke test of: 
-  - [ ] Eigen's main tab view controllers (Search, Home, Explore, You, Notifications).
-  - [ ] The artwork, artist, and auctions view controllers.
-  - [ ] Live Auctions interface.
 - [ ] Review `CHANGELOG.yml` entries for the release and run through any parts of the app that seem appropriate.
+- [ ] Check user registration and onboarding works.
+- [ ] As a freshly created user, perform a smoke test of: 
+  - [ ] Eigen's main tab view controllers (Home, Search, Inbox, and Favourites).
+  - [ ] The artwork, artist, and auction view controllers.
+  - [ ] Live Auctions interface (Use the `gravity-staging-create-auction-on-demand` Jenkins job to create a sale, it'll take five minute to open before the interface is accessible in Eigen).
+- [ ] As a user with populated favourites, follows, etc, perform a smoke test of: 
+  - [ ] Eigen's main tab view controllers (Home, Search, Inbox, and Favourites).
+  - [ ] The artwork, artist, and auctions view controllers.
+  - [ ] Live Auctions interface (see instructions above).
 - [ ] Open a React Native view, then open a modal view controller (LAI interface, inquiry modal), and navigate back to the RN view. Make sure that [the screen isn't blank](https://github.com/artsy/eigen/issues/2439).
-- [ ] Check that the app opens on the Home feed Works For You tab from a Works For You push notification
+- [ ] Check that the app opens on the Home feed Works For You tab from a Works For You push notification (in gravity staging console, run `NewWorkPushService.notify_user(User.find_by(email: "YOUR_EMAIL@artsymail.com))`).
   - [ ] When app is running in the background
   - [ ] When app is completely inactive
-- [ ] Check that the app opens with the correct conversation from a messaging push notification
+- [ ] Check that the app opens with the correct conversation from a messaging push notification (find the "Invoicing Demo Partner" partner on [Vibrations](https://github.com/artsy/volt) staging, publish one one of their artworks, find it in the app, inquire on it as a non-admin, and reply to the conversation from [Volt](https://github.com/artsy/volt) to trigger a push).
   - [ ] When app is running in the background
   - [ ] When app is completely inactive
+- [ ] After running the conversation push notification test and the conversation tab is populated, smoke test it.
 - [ ] Check that the app opens on the correct artist page from a Safari (or other web browser) link (artsy.net/artist/someone)
   - [ ] When app is running in the background
   - [ ] When app is completely inactive
-- [ ] Check that the app opens on the Home feed Works For You tab from a Works For You email
+- [ ] Check that the app opens on the Home feed Works For You tab from a Works For You email (find one in your inbox) (note this is currently not working, [see this Jira ticket](https://artsyproduct.atlassian.net/browse/BUGS-176)).
+  - [ ] When app is running in the background
+  - [ ] When app is completely inactive
+- [ ] Check that the app opens on the correct Auctions home tab when opened from a sale-opening push notification (in gravity staging console, run `NewSalePushService.notify_user(User.find_by(email: "YOUR_EMAIL@artsymail.com").id, Artist.sample(3).map(:&), 4)`).
   - [ ] When app is running in the background
   - [ ] When app is completely inactive
 


### PR DESCRIPTION
This does a few things:

- Moves testing changes specified in the changelog to the top since it seems like it's the most important and also most likely to spoil a beta.
- Adds detail on how to test certain things, for example where to open a mocktion on staging.
- Removes the inquiry flow test, which is covered by the new conversation push notification test, and replaces it with a smoke test of a populated conversation view.
- Adds steps for our new auctions push notification testing.