### PR TITLE
Exposes admin menu to non-admin users via URL

### DIFF
--- a/Artsy/App/ARSwitchboard+Eigen.m
+++ b/Artsy/App/ARSwitchboard+Eigen.m
@@ -39,9 +39,6 @@
 
 - (UIViewController *)loadAdminMenu;
 {
-    if (!ARAppStatus.isBetaDevOrAdmin) {
-        return nil;
-    }
     return [[ARAdminSettingsViewController alloc] initWithStyle:UITableViewStyleGrouped];
 }
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -7,6 +7,7 @@ upcoming:
     - Adds a new ARVIR behind a feature flag - orta
   admin:
     - Adds an admin button to trigger getting notifications - orta
+    - Adds ability to see admin screen when logged in as non-admins via URL - ash
 
 releases:
   - version: 4.1.2


### PR DESCRIPTION
This was actually already done! Eigen handles the `/admin` route already so this PR just removes the check when instantiating that view controller. I looked around and I don't see anywhere else that calls that function, so we're good.

**One note**: In Safari I had to use triple-slash to get the route recognized by JRRoutes (I think because the URL is missing a host name). So the URL to visit in Safari is `artsy:///admin`.