### PR TITLE
[ARVIR] Use a higher point in the screen for projecting the artwork vs the wall

### DIFF
--- a/Artsy/View_Controllers/ARVIR/AR/ARVIRHorizontalPlaneInteractionController.m
+++ b/Artsy/View_Controllers/ARVIR/AR/ARVIRHorizontalPlaneInteractionController.m
@@ -40,6 +40,8 @@ API_AVAILABLE(ios(11.0))
 @property (nonatomic, strong) SCNNode *ghostArtwork;
 
 @property (nonatomic, assign) CGPoint pointOnScreenForArtworkProjection;
+@property (nonatomic, assign) CGPoint pointOnScreenForWallProjection;
+
 @end
 
 NSInteger attempt = 0;
@@ -59,7 +61,9 @@ NSInteger attempt = 0;
     _delegate = delegate;
 
     CGRect bounds = [UIScreen mainScreen].bounds;
-    _pointOnScreenForArtworkProjection = CGPointMake(bounds.size.width/2, bounds.size.height/2);
+    _pointOnScreenForWallProjection = CGPointMake(bounds.size.width/2, bounds.size.height/2);
+    // Use a subset of the screen for centering, the 180 comes from the height of the UI in the ARAugmentedVIRVC
+    _pointOnScreenForArtworkProjection = CGPointMake(bounds.size.width/2, bounds.size.height/2  - 180);
     return self;
 }
 
@@ -120,7 +124,7 @@ NSInteger attempt = 0;
             SCNHitTestOptionSearchMode: @(SCNHitTestSearchModeAll)
         };
 
-        NSArray <SCNHitTestResult *> *results = [self.sceneView hitTest:self.pointOnScreenForArtworkProjection options: options];
+        NSArray <SCNHitTestResult *> *results = [self.sceneView hitTest:self.pointOnScreenForWallProjection options:options];
         for (SCNHitTestResult *result in results) {
 
             // When you want to place the invisible wall, based on the current ghostWall
@@ -271,7 +275,7 @@ NSInteger attempt = 0;
         SCNHitTestBackFaceCullingKey: @NO
     };
 
-    NSArray <SCNHitTestResult *> *results = [self.sceneView hitTest:self.pointOnScreenForArtworkProjection options: options];
+    NSArray <SCNHitTestResult *> *results = [self.sceneView hitTest:self.pointOnScreenForWallProjection options: options];
     for (SCNHitTestResult *result in results) {
 
         if ([self.invisibleFloors containsObject:result.node]) {


### PR DESCRIPTION
Re-aligns the artwork to use a different screen point of reference in comparison to the floor. This fixes a weird UX issue. EV-209