### PR TITLE
Adds a custom prefix to keychain keys when in staging

### DIFF
--- a/Artsy/Networking/API_Modules/ARKeychainable.m
+++ b/Artsy/Networking/API_Modules/ARKeychainable.m
@@ -1,5 +1,6 @@
 #import <UICKeyChainStore/UICKeyChainStore.h>
-
+#import "ARDefaults.h"
+#import "AROptions.h"
 #import "ARKeychainable.h"
 
 
@@ -9,6 +10,18 @@
 {
     NSDictionary *info = [[NSBundle mainBundle] infoDictionary];
     return [NSString stringWithFormat:@"%@%@.keychain-group", info[@"AppIdentifierPrefix"], info[@"CFBundleIdentifier"]];
+}
+
+- (NSString *)keyForEnvironment:(NSString *)key
+{
+    BOOL useStaging = [AROptions boolForOption:ARUseStagingDefault];
+    // For prod, keep backawards compatabilty by re-using existing key
+    if (!useStaging) {
+        return key;
+    }
+    // For staging use a postfixed key so they cannot share with
+    // production data at all.
+    return [key stringByAppendingString:@"-staging"];
 }
 
 - (void)removeKeychainStringForKey:(NSString *)key

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -6,6 +6,7 @@ upcoming:
     - Updates Emission to 1.5.3 - ash
     - Removes Hockey feedback prompt when taking screenshot, screen recording - ash
     - Removes deprecated ReactiveCocoa and uses ReactiveObjC library instead - ash
+    - Separates access to keychain items between staging/prod - orta
   user_facing:
     - Adds a round corner to all native buttons - orta
     - ARVIR2 animates - orta


### PR DESCRIPTION
When someone jumps between prod and beta builds, they can end up with an access token for the wrong environment. This makes that infeasible.