### PR TITLE
Updates Emission to 1.5.5

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -5266,6 +5266,7 @@
 				"${PODS_ROOT}/NAMapKit/NAMapKit/pin_red_floating.png",
 				"${PODS_ROOT}/NAMapKit/NAMapKit/pin_red_floating@2x.png",
 				"${PODS_CONFIGURATION_BUILD_DIR}/NPKeyboardLayoutGuide/NPKeyboardLayoutGuide.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Stripe/Stripe.bundle",
 				"${PODS_ROOT}/iRate/iRate/iRate.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
@@ -5308,6 +5309,7 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/pin_red_floating.png",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/pin_red_floating@2x.png",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/NPKeyboardLayoutGuide.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Stripe.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/iRate.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -95,10 +95,17 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
     NSString *gravity = [[ARRouter baseApiURL] absoluteString];
     NSString *metaphysics = [ARRouter baseMetaphysicsApiURLString];
 
+    NSString *stripePublishableKey;
+    if ([AROptions boolForOption:ARUseStagingDefault]) {
+        stripePublishableKey = keys.stripeStagingPublishableKey;
+    } else {
+        stripePublishableKey = keys.stripeProductionPublishableKey;
+    }
 
     AREmissionConfiguration *config = [[AREmissionConfiguration alloc] initWithUserID:userID
                                                                       authenticationToken:authenticationToken
                                                                                 sentryDSN:sentryDSN
+                                                                     stripePublishableKey:stripePublishableKey
                                                                          googleMapsAPIKey:[keys googleMapsAPIKey]
                                                                                gravityURL:gravity
                                                                            metaphysicsURL:metaphysics

--- a/Artsy_Tests/Supporting_Files/ARTestHelper.m
+++ b/Artsy_Tests/Supporting_Files/ARTestHelper.m
@@ -63,6 +63,7 @@
     AREmissionConfiguration *config = [[AREmissionConfiguration alloc] initWithUserID:@""
                                                                   authenticationToken:@""
                                                                             sentryDSN:@""
+                                                                 stripePublishableKey:@""
                                                                      googleMapsAPIKey:@""
                                                                            gravityURL:gravity
                                                                        metaphysicsURL:metaphysics

--- a/Podfile
+++ b/Podfile
@@ -59,6 +59,8 @@ target 'Artsy' do
   pod 'MARKRangeSlider'
   pod 'EDColor'
   pod 'SSFadingScrollView', :git => 'https://github.com/alloy/SSFadingScrollView.git', :branch => 'add-axial-support'
+  # For Stripe integration with Emission
+  pod 'tipsi-stripe', :git => "https://github.com/erikdstock/tipsi-stripe.git", :branch => 'fix-podspec-requires-packagejson'
 
   # Core owned by Artsy
   pod 'ARTiledImageView', :git => 'https://github.com/dblock/ARTiledImageView'

--- a/Podfile
+++ b/Podfile
@@ -28,6 +28,8 @@ plugin 'cocoapods-keys', {
     "ArtsyEchoProductionToken",  # Runtime behavior changes
     "SentryProductionDSN",       # Crash Logging
     "SentryStagingDSN",          #
+    "StripeProductionPublishableKey", # Necessary for Stripe integration
+    "StripeStagingPublishableKey",
     "GoogleMapsAPIKey",          # Consignment Location Lookup
   ]
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -72,7 +72,7 @@ PODS:
   - DHCShakeNotifier (0.2.0)
   - DoubleConversion (1.1.5)
   - EDColor (1.0.0)
-  - Emission (1.5.4):
+  - Emission (1.5.5):
     - "Artsy+UIColors"
     - "Artsy+UIFonts (>= 3.0.0)"
     - DoubleConversion (= 1.1.5)
@@ -466,7 +466,7 @@ SPEC CHECKSUMS:
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
-  Emission: da8cd72a61a391b39cf58ada7409f8f311d67543
+  Emission: 2f11e0b836a2f589b175ec9d5d68b741f772d120
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   "Expecta+Snapshots": c343f410c7a6392f3e22e78f94c44b6c0749a516
   Extraction: 612cf0866f74d4c0dd616677ff24146efa200958

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -72,7 +72,7 @@ PODS:
   - DHCShakeNotifier (0.2.0)
   - DoubleConversion (1.1.5)
   - EDColor (1.0.0)
-  - Emission (1.5.3):
+  - Emission (1.5.4):
     - "Artsy+UIColors"
     - "Artsy+UIFonts (>= 3.0.0)"
     - DoubleConversion (= 1.1.5)
@@ -454,7 +454,7 @@ SPEC CHECKSUMS:
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
-  Emission: 5a7051081e063c05653252ad121772e5478292bc
+  Emission: da8cd72a61a391b39cf58ada7409f8f311d67543
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   "Expecta+Snapshots": c343f410c7a6392f3e22e78f94c44b6c0749a516
   Extraction: 612cf0866f74d4c0dd616677ff24146efa200958
@@ -506,6 +506,6 @@ SPEC CHECKSUMS:
   "XCTest+OHHTTPStubSuiteCleanUp": 4469ec8863c6bc022c5089a9b94233eb3416c5ee
   yoga: de8782b10b9fdede33554bcad8a2a6653e0ebb30
 
-PODFILE CHECKSUM: 0aeacffa5d8fc1469a480ad19c89a822129467e2
+PODFILE CHECKSUM: 46d2a70ef1ae99a0fd03591f071272b7311ae00c
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -229,8 +229,12 @@ PODS:
   - Specta (1.0.5)
   - SSFadingScrollView (1.1.0)
   - Starscream (3.0.4)
+  - Stripe (11.2.0)
   - SwiftyJSON (4.0.0)
   - Then (2.3.0)
+  - tipsi-stripe (5.2.1):
+    - React
+    - Stripe (~> 11.2.0)
   - UICKeyChainStore (1.0.5)
   - "UIView+BooleanAnimations (1.0.2)"
   - VCRURLConnection (0.2.0)
@@ -298,6 +302,7 @@ DEPENDENCIES:
   - Starscream
   - SwiftyJSON
   - Then
+  - tipsi-stripe (from `https://github.com/erikdstock/tipsi-stripe.git`, branch `fix-podspec-requires-packagejson`)
   - UICKeyChainStore
   - "UIView+BooleanAnimations"
   - VCRURLConnection
@@ -359,6 +364,7 @@ SPEC REPOS:
     - Sentry
     - Specta
     - Starscream
+    - Stripe
     - SwiftyJSON
     - Then
     - UICKeyChainStore
@@ -395,6 +401,9 @@ EXTERNAL SOURCES:
   SSFadingScrollView:
     :branch: add-axial-support
     :git: https://github.com/alloy/SSFadingScrollView.git
+  tipsi-stripe:
+    :branch: fix-podspec-requires-packagejson
+    :git: https://github.com/erikdstock/tipsi-stripe.git
   yoga:
     :podspec: https://raw.githubusercontent.com/artsy/emission/v1.5.2/externals/yoga/yoga.podspec.json
 
@@ -432,6 +441,9 @@ CHECKOUT OPTIONS:
   SSFadingScrollView:
     :commit: 3920e3582e46c9fe23b0d1200e28614ebd66d801
     :git: https://github.com/alloy/SSFadingScrollView.git
+  tipsi-stripe:
+    :commit: efcbc49dc7cf472099d8aa8c3fb2b64441fc5ea1
+    :git: https://github.com/erikdstock/tipsi-stripe.git
 
 SPEC CHECKSUMS:
   Adjust: 8f204c1005d6635e7c931c6a2cb2f881965bf478
@@ -498,14 +510,16 @@ SPEC CHECKSUMS:
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
   SSFadingScrollView: a2f142312afad23585e354a41a6ed337045e1aa3
   Starscream: f5da93fe6984c77b694366bf7299b7dc63a76f26
+  Stripe: 898f83a95d72180c6eb4acd65b2ae6158fc6a8bd
   SwiftyJSON: 070dabdcb1beb81b247c65ffa3a79dbbfb3b48aa
   Then: ee21c97b85ff6062b9b0080c9abb1eea46743345
+  tipsi-stripe: 7cb9ec05e2b76170f9eec68227fca11aec49863f
   UICKeyChainStore: e81dc3b58d56ffaed61ab6669eb97071e53fc377
   "UIView+BooleanAnimations": a760be9a066036e55f298b7b7350a6cb14cfcd97
   VCRURLConnection: accd771ebd4be11183a3e4d5a4403f180a9a235e
   "XCTest+OHHTTPStubSuiteCleanUp": 4469ec8863c6bc022c5089a9b94233eb3416c5ee
   yoga: de8782b10b9fdede33554bcad8a2a6653e0ebb30
 
-PODFILE CHECKSUM: 46d2a70ef1ae99a0fd03591f071272b7311ae00c
+PODFILE CHECKSUM: 58a81928796b6281bf56e44820e13e475318f06c
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
⚠️ Do not merge! ⚠️ 

We're trying to get an Eigen release out the door, would rather not complicate things with an Emission update. Also I can't find where to add the `pod keys set` command for our deploys.