### PR TITLE
[Admin] You can access the admin tools after finishing onboarding

### DIFF
--- a/Artsy/App/ARAppDelegate.m
+++ b/Artsy/App/ARAppDelegate.m
@@ -294,6 +294,7 @@ static ARAppDelegate *_sharedInstance = nil;
         if ([User currentUser]) {
             [self.remoteNotificationsDelegate fetchNotificationCounts];
             [ARSpotlight indexAllUsersFavorites];
+            [self setupAdminTools];
         }
     });
 }

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -6,7 +6,7 @@ upcoming:
     - Clear Relay response cache on logout/switch env - alloy
 
   user_facing:
-    - Nothing yet
+    - Admins can get the shake gesture when they log in to the app for the first time - orta
 
 releases:
   - version: 4.2.0


### PR DESCRIPTION
This allows you to sign up and then be able to get to the admin panel without restarting the app.