### PR TITLE
Fixes the iPhone X support for a zoomed iamge

### DIFF
--- a/Artsy/App/AROptions.h
+++ b/Artsy/App/AROptions.h
@@ -13,6 +13,7 @@ extern NSString *const AROptionsStagingReactEnv;
 extern NSString *const AROptionsDevReactEnv;
 extern NSString *const AROptionsDebugARVIR;
 extern NSString *const AROptionsUseNewBidFlow;
+extern NSString *const AROptionsHideBackButtonOnScroll;
 
 @interface AROptions : NSObject
 

--- a/Artsy/App/AROptions.m
+++ b/Artsy/App/AROptions.m
@@ -11,6 +11,7 @@ NSString *const AROptionsStagingReactEnv = @"Use Staging React ENV";
 NSString *const AROptionsDevReactEnv = @"Use Dev React ENV";
 NSString *const AROptionsDebugARVIR = @"Debug AR View in Room";
 NSString *const AROptionsUseNewBidFlow = @"Use new Bid Flow";
+NSString *const AROptionsHideBackButtonOnScroll = @"Hide the Back Button in Zoom image";
 
 @implementation AROptions
 
@@ -23,7 +24,8 @@ NSString *const AROptionsUseNewBidFlow = @"Use new Bid Flow";
         AROptionsDisableNativeLiveAuctions,
         
         AROptionsDebugARVIR,
-        AROptionsUseNewBidFlow
+        AROptionsUseNewBidFlow,
+        AROptionsHideBackButtonOnScroll
     ];
 }
 

--- a/Artsy/View_Controllers/Artwork/ARZoomArtworkImageViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARZoomArtworkImageViewController.m
@@ -1,6 +1,7 @@
 #import "ARZoomArtworkImageViewController.h"
-
+#import "ARTopMenuViewController.h"
 #import "UIDevice-Hardware.h"
+#import "AROptions.h"
 
 #import <ReactiveObjC/ReactiveObjC.h>
 
@@ -8,6 +9,7 @@
 @interface ARZoomArtworkImageViewController () <ARZoomViewDelegate>
 
 @property (nonatomic, assign) BOOL popped;
+@property (readwrite, nonatomic, assign) BOOL hidesBackButton;
 
 @end
 
@@ -28,11 +30,6 @@
 
 #pragma mark - ARMenuAwareViewController
 
-- (BOOL)hidesBackButton
-{
-    return NO;
-}
-
 - (BOOL)hidesToolbarMenu
 {
     return YES;
@@ -50,12 +47,12 @@
     return YES;
 }
 
-- (void)loadView
+- (void)viewDidLoad
 {
-    UIView *clearView = [[UIView alloc] init];
-    clearView.backgroundColor = [UIColor whiteColor];
-    clearView.opaque = NO;
-    self.view = clearView;
+    [super viewDidLoad];
+
+    self.view.backgroundColor = [UIColor whiteColor];
+    self.view.opaque = NO;
 }
 
 - (void)setZoomView:(ARZoomView *)zoomView
@@ -90,6 +87,7 @@
         [zoomView performBlockWhileIgnoringContentOffsetChanges:^{
             [zoomView setZoomScale:zoomScale animated:YES];
         }];
+
         [zoomView setContentOffset:targetContentOffset animated:YES];
     }];
 }
@@ -108,6 +106,25 @@
     [self.zoomView finish];
     self.popped = YES;
     [self.navigationController popViewControllerAnimated:YES];
+}
+
+- (void)zoomViewDidMove:(ARZoomView *)zoomView
+{
+    if ([AROptions boolForOption:AROptionsHideBackButtonOnScroll]) {
+        [self showBackButton];
+        [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(hideBackButton) object:nil];
+        [self performSelector:@selector(hideBackButton) withObject:nil afterDelay:3];
+    }
+}
+
+- (void)hideBackButton
+{
+   self.hidesBackButton = YES;
+}
+
+- (void)showBackButton
+{
+    self.hidesBackButton = NO;
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Artsy/Views/Utilities/Image/ARZoomView.h
+++ b/Artsy/Views/Utilities/Image/ARZoomView.h
@@ -4,6 +4,7 @@
 
 @protocol ARZoomViewDelegate
 - (void)zoomViewFinished:(ARZoomView *)zoomView;
+- (void)zoomViewDidMove:(ARZoomView *)zoomView;
 @end
 
 

--- a/Artsy/Views/Utilities/Image/ARZoomView.m
+++ b/Artsy/Views/Utilities/Image/ARZoomView.m
@@ -154,12 +154,18 @@ static const CGFloat ARZoomMultiplierForDoubleTap = 1.5;
 {
     //so the background view doesnt show over the edges
     _backgroundView.frame = _zoomableView.frame;
+    [self.zoomDelegate zoomViewDidMove:self];
 
     //close if the zoom goes below minimumZoomScale
     CGFloat fullScreenScale = [self scaleForFullScreenZoomInSize:self.frame.size];
     if (self.zoomScale < (fullScreenScale * .95)) {
         [self.zoomDelegate zoomViewFinished:self];
     }
+}
+
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView
+{
+    [self.zoomDelegate zoomViewDidMove:self];
 }
 
 - (CGFloat)scaleForFullScreenZoomInSize:(CGSize)size

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,8 +5,11 @@ upcoming:
   dev:
     - Clear Relay response cache on logout/switch env - alloy
 
+
   user_facing:
     - Admins can get the shake gesture when they log in to the app for the first time - orta
+    - iPhone X fix for the zoomed image screen - orta
+    - Adds an lab option to have the back button hide after a delay on a zoomed image - orta
 
 releases:
   - version: 4.2.0


### PR DESCRIPTION
Previously the image would be cropped and you can't zoom in on an iPhone X after tapping for the full zoomed image, now you can zoom in to a full screen. 

As a bonus, I added a lab option for something @bhoggard wanted a few years ago (hah) which was letting the back button fade after some inactivity (3 seconds) - congrats on moving to android Barry :P