### PR TITLE
increase modal close hit area

### DIFF
--- a/Artsy/View_Controllers/ARSerifNavigationViewController.m
+++ b/Artsy/View_Controllers/ARSerifNavigationViewController.m
@@ -52,6 +52,7 @@
     ARSerifToolbarButtonItem *exit = [[ARSerifToolbarButtonItem alloc] initWithImage:image];
 
     [exit.button addTarget:self action:@selector(closeModal) forControlEvents:UIControlEventTouchUpInside];
+    [exit.button ar_extendHitTestSizeByWidth:10 andHeight:10];
     self.exitButton = exit;
 
     UIButton *back = [[UIButton alloc] initWithFrame:CGRectMake(0, 0, 30, 40)];


### PR DESCRIPTION
This PR makes the hit area for the modal exit button 10 bigger.
![image](https://user-images.githubusercontent.com/9088720/42238560-47ef80c4-7ecf-11e8-931d-43393730c9f4.png)
