### PR TITLE
Fix tiny white box on bidding form

### DIFF
--- a/Artsy/View_Controllers/ARSerifNavigationViewController.m
+++ b/Artsy/View_Controllers/ARSerifNavigationViewController.m
@@ -109,29 +109,30 @@
         [navBar hideNavigationBarShadow:false];
 
     } else {
-        // On the root view, we want a left aligned title.
-        UILabel *label = [ARSerifLabel new];
-        label.font = [UIFont serifFontWithSize:20];
-        label.text = nav.title;
-        label.numberOfLines = 1;
-        // Only make it as wide as necessary, otherwise it might cover the right bar button item.
-        [label sizeToFit];
+        if (nav.title && nav.title.length > 0) {
+            // On the root view, we want a left aligned title.
+            UILabel *label = [ARSerifLabel new];
+            label.font = [UIFont serifFontWithSize:20];
+            label.text = nav.title;
+            label.numberOfLines = 1;
+            // Only make it as wide as necessary, otherwise it might cover the right bar button item.
+            [label sizeToFit];
 
-        // At the time of writing, 4 is the additional x offset that a UILabel in a left bar button needs
-        // to align to the content of e.g. AuctionInformationViewController.
-        NSInteger rightButtonsCount = nav.rightBarButtonItems.count;
-        static CGFloat xOffset = 4;
+            // At the time of writing, 4 is the additional x offset that a UILabel in a left bar button needs
+            // to align to the content of e.g. AuctionInformationViewController.
+            NSInteger rightButtonsCount = nav.rightBarButtonItems.count;
+            static CGFloat xOffset = 4;
 
-        CGRect labelFrame = label.bounds;
-        CGFloat idealWidth = CGRectGetWidth(labelFrame) + xOffset;
-        CGFloat max = CGRectGetWidth(navigationController.view.bounds) - (rightButtonsCount * 48) - ((rightButtonsCount - 1) * 10) - 20;
+            CGRect labelFrame = label.bounds;
+            CGFloat idealWidth = CGRectGetWidth(labelFrame) + xOffset;
+            CGFloat max = CGRectGetWidth(navigationController.view.bounds) - (rightButtonsCount * 48) - ((rightButtonsCount - 1) * 10) - 20;
 
-        label.frame = CGRectMake(xOffset, 0, MIN(idealWidth, max), 20);
-        UIView *titleMarginWrapper = [[UIView alloc] initWithFrame:(CGRect){CGPointZero, {MIN(idealWidth, max), CGRectGetHeight(labelFrame)}}];
-        [titleMarginWrapper addSubview:label];
+            label.frame = CGRectMake(xOffset, 0, MIN(idealWidth, max), 20);
+            UIView *titleMarginWrapper = [[UIView alloc] initWithFrame:(CGRect){CGPointZero, {MIN(idealWidth, max), CGRectGetHeight(labelFrame)}}];
+            [titleMarginWrapper addSubview:label];
 
-        nav.leftBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:titleMarginWrapper];
-
+            nav.leftBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:titleMarginWrapper];
+        }
         // Just a dummy view to ensure that the navigation bar doesn’t create a new title view.
         nav.titleView = [UIView new];
 


### PR DESCRIPTION
Tracked in [purchase-220](https://artsyproduct.atlassian.net/browse/PURCHASE-220)
cc @sweir27 @yuki24 @zephraph 

This PR is an attempt to address the issue mentioned above- a tiny white box in the upper left corner of the screen which becomes visible when you scroll the Billing Address form (here covering the 'F' in 'Full Name':
![image](https://user-images.githubusercontent.com/9088720/42532823-071665c2-8456-11e8-811a-9b7ae15afbfb.png)

This seems to address the issue but I'm not sure if it is the best way or what other implications might come along- I just shoehorned in a single check for presence of `nav.title` and `nav.length`.


View debugger shows it is an ARSerifLabel:
![image](https://user-images.githubusercontent.com/9088720/42532870-2629e63c-8456-11e8-8dd3-ee91d8814753.png)



Updated debugger view hierarchy:
![image](https://user-images.githubusercontent.com/9088720/42532716-c4f8bd34-8455-11e8-830d-6b630a747e33.png)
