### PR TITLE
Suppresses push notifications for things like being outbidded when you're on the ARBidFlow components UIVC

### DIFF
--- a/Artsy/App/ARAppNotificationsDelegate.m
+++ b/Artsy/App/ARAppNotificationsDelegate.m
@@ -16,6 +16,7 @@
 #import "ARDispatchManager.h"
 
 #import <Emission/ARConversationComponentViewController.h>
+#import <Emission/ARBidFlowViewController.h>
 #import <ARAnalytics/ARAnalytics.h>
 
 
@@ -210,10 +211,20 @@
             // A notification was received while the app was already active, so we show our own notification view.
             [self receivedNotification:notificationInfo];
             
-            ARConversationComponentViewController * controller = [[[[ARTopMenuViewController sharedController] rootNavigationController] viewControllers] lastObject];
+            UIViewController *controller = [self getGlobalTopViewController];
+
             NSString *conversationID = [notificationInfo[@"conversation_id"] stringValue];
-            if ([controller isKindOfClass:ARConversationComponentViewController.class] && [controller.conversationID isEqualToString:conversationID]) {
+            NSString *saleID = notificationInfo[@"sale_id"];
+            NSString *artworkID = notificationInfo[@"artwork_id"];
+            NSString *action = notificationInfo[@"action"];
+
+            ARConversationComponentViewController *conversationVC = (id)controller;
+            ARBidFlowViewController *bidFlowVC = (id)controller;
+
+            if ([controller isKindOfClass:ARConversationComponentViewController.class] && [conversationVC.conversationID isEqualToString:conversationID]) {
                 [[NSNotificationCenter defaultCenter] postNotificationName:@"notification_received" object:notificationInfo];
+            } else if ([controller isKindOfClass:ARBidFlowViewController.class] && [action isEqualToString:@"outbid"] && [bidFlowVC.artworkID isEqualToString:artworkID] && [bidFlowVC.saleID isEqualToString:saleID]) {
+                // NO-OP, so that we don't show notifications about bidding activity currently on screen
             } else {
                 NSString *title = [message isKindOfClass:[NSString class]] ? message : message[@"title"];
                 [ARNotificationView showNoticeInView:[self findVisibleWindow]
@@ -228,6 +239,11 @@
             [self tappedNotification:notificationInfo viewController:viewController];
         }
     }
+}
+
+- (UIViewController *)getGlobalTopViewController
+{
+    return [[[[ARTopMenuViewController sharedController] rootNavigationController] viewControllers] lastObject];
 }
 
 - (void)receivedNotification:(NSDictionary *)notificationInfo;

--- a/Artsy/Views/Utilities/Image/ARZoomView.h
+++ b/Artsy/Views/Utilities/Image/ARZoomView.h
@@ -2,7 +2,7 @@
 
 @class ARZoomView, Image;
 
-@protocol ARZoomViewDelegate
+@protocol  ARZoomViewDelegate
 - (void)zoomViewFinished:(ARZoomView *)zoomView;
 - (void)zoomViewDidMove:(ARZoomView *)zoomView;
 @end

--- a/Artsy_Tests/App_Tests/ARAppNotificationsDelegateTests.m
+++ b/Artsy_Tests/App_Tests/ARAppNotificationsDelegateTests.m
@@ -7,7 +7,7 @@
 #import "ARTopMenuViewController.h"
 #import "ARTopMenuNavigationDataSource.h"
 #import "UIApplicationStateEnum.h"
-
+#import <Emission/ARBidFlowViewController.h>
 
 static NSDictionary *
 DictionaryWithAppState(NSDictionary *input, UIApplicationState appState)
@@ -17,6 +17,9 @@ DictionaryWithAppState(NSDictionary *input, UIApplicationState appState)
     return [dictionary copy];
 }
 
+@interface ARAppNotificationsDelegate()
+- (UIViewController *)getGlobalTopViewController;
+@end
 
 SpecBegin(ARAppNotificationsDelegate);
 
@@ -161,6 +164,40 @@ describe(@"receiveRemoteNotification", ^{
 
             [mock verify];
             [mock stopMocking];
+        });
+
+
+
+        it(@"suppresses showing the notification view when a notification about outbidding ", ^{
+            ARBidFlowViewController *bidController = [[ARBidFlowViewController alloc] initWithArtworkID:@"asd1432asda" saleID:@"123ffg3edfsd"];
+
+            id mockedNotificationsDelegate = [OCMockObject partialMockForObject:delegate];
+            [[[mockedNotificationsDelegate stub] andReturn:bidController] getGlobalTopViewController];
+
+            id mock = [OCMockObject mockForClass:[ARNotificationView class]];
+            [[mock reject] showNoticeInView:OCMOCK_ANY title:OCMOCK_ANY response:OCMOCK_ANY];
+
+            [delegate applicationDidReceiveRemoteNotification:@{ @"sale_id" : @"123ffg3edfsd", @"artwork_id": @"asd1432asda", @"action": @"outbid" } inApplicationState:appState];
+
+            [mock verify];
+            [mock stopMocking];
+            [mockedNotificationsDelegate stopMocking];
+        });
+
+        it(@"shows the notification view when a notification about bidding stuff but not the action outbid ", ^{
+            ARBidFlowViewController *bidController = [[ARBidFlowViewController alloc] initWithArtworkID:@"asd1432asda" saleID:@"123ffg3edfsd"];
+
+            id mockedNotificationsDelegate = [OCMockObject partialMockForObject:delegate];
+            [[[mockedNotificationsDelegate stub] andReturn:bidController] getGlobalTopViewController];
+
+            id mock = [OCMockObject mockForClass:[ARNotificationView class]];
+            [[mock expect] showNoticeInView:OCMOCK_ANY title:OCMOCK_ANY response:OCMOCK_ANY];
+
+            [delegate applicationDidReceiveRemoteNotification:@{ @"sale_id" : @"123ffg3edfsd", @"artwork_id": @"asd1432asda", @"action": @"winning" } inApplicationState:appState];
+
+            [mock verify];
+            [mock stopMocking];
+            [mockedNotificationsDelegate stopMocking];
         });
     });
 });

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -7,6 +7,7 @@ upcoming:
 
 
   user_facing:
+    - Outbid push notifications are supressed when you're on the bid wizard  - orta/sweir
     - Admins can get the shake gesture when they log in to the app for the first time - orta
     - iPhone X fix for the zoomed image screen - orta
     - Adds an lab option to have the back button hide after a delay on a zoomed image - orta


### PR DESCRIPTION
Because you're on the screen, and it's going to tell you that stuff anyway