### PR TITLE
Update banner after bid

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -41,6 +41,7 @@
 #import "ARAdminNetworkModel.h"
 #import "Artsy-Swift.h"
 
+
 static void
 FollowRequestSuccess(RCTResponseSenderBlock block, BOOL following)
 {
@@ -94,6 +95,11 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
 
     NSString *gravity = [[ARRouter baseApiURL] absoluteString];
     NSString *metaphysics = [ARRouter baseMetaphysicsApiURLString];
+    
+    BOOL useStaging = [AROptions boolForOption:ARUseStagingDefault];
+    NSString *echoDomainKey = useStaging ? @"ARLiveAuctionsStagingURLDomain" : @"ARLiveAuctionsURLDomain";
+    NSString *domain = [[[ARSwitchBoard sharedInstance] echo] routes][echoDomainKey].path;
+    NSString *liveAuctionsURL = [[NSURL URLWithString:[@"https://" stringByAppendingString:domain]] absoluteString];
 
     NSString *stripePublishableKey;
     if ([AROptions boolForOption:ARUseStagingDefault]) {
@@ -109,6 +115,7 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
                                                                          googleMapsAPIKey:[keys googleMapsAPIKey]
                                                                                gravityURL:gravity
                                                                            metaphysicsURL:metaphysics
+                                                                            predictionURL:liveAuctionsURL
                                                                                 userAgent:ARRouter.userAgent];
 
     AREmission *emission = [[AREmission alloc] initWithConfiguration:config packagerURL:packagerURL];

--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -96,10 +96,7 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
     NSString *gravity = [[ARRouter baseApiURL] absoluteString];
     NSString *metaphysics = [ARRouter baseMetaphysicsApiURLString];
     
-    BOOL useStaging = [AROptions boolForOption:ARUseStagingDefault];
-    NSString *echoDomainKey = useStaging ? @"ARLiveAuctionsStagingURLDomain" : @"ARLiveAuctionsURLDomain";
-    NSString *domain = [[[ARSwitchBoard sharedInstance] echo] routes][echoDomainKey].path;
-    NSString *liveAuctionsURL = [[NSURL URLWithString:[@"https://" stringByAppendingString:domain]] absoluteString];
+    NSString *liveAuctionsURL = [[[ARSwitchBoard sharedInstance] liveAuctionsURL] absoluteString];
 
     NSString *stripePublishableKey;
     if ([AROptions boolForOption:ARUseStagingDefault]) {

--- a/Artsy/App/ARSwitchBoard+Eigen.h
+++ b/Artsy/App/ARSwitchBoard+Eigen.h
@@ -22,6 +22,8 @@
 
 @interface ARSwitchBoard (Eigen)
 
+@property (nonatomic, strong, readonly) NSURL *liveAuctionsURL;
+
 #pragma mark - Dev
 
 - (UIViewController *)loadAdminMenu;

--- a/Artsy/App/ARSwitchboard+Eigen.m
+++ b/Artsy/App/ARSwitchboard+Eigen.m
@@ -36,6 +36,15 @@
 
 @implementation ARSwitchBoard (Eigen)
 
+
+-(NSURL *)liveAuctionsURL
+{
+    BOOL useStaging = [AROptions boolForOption:ARUseStagingDefault];
+    NSString *echoDomainKey = useStaging ? @"ARLiveAuctionsStagingURLDomain" : @"ARLiveAuctionsURLDomain";
+    NSString *domain = self.echo.routes[echoDomainKey].path;
+    return [NSURL URLWithString:[@"https://" stringByAppendingString:domain]];
+}
+
 #pragma mark - Dev
 
 - (UIViewController *)loadAdminMenu;
@@ -90,15 +99,7 @@
 
 - (UIViewController *)loadLiveAuction:(NSString *)auctionID
 {
-    /// In order for others to use Live Auctions inside the app, there
-    /// has to be some palce where the knowledge of what the official routes are
-    /// rather than let VCs know about it, this lets it stay inside the switchboard.
-
-    BOOL useStaging = [AROptions boolForOption:ARUseStagingDefault];
-    NSString *echoDomainKey = useStaging ? @"ARLiveAuctionsStagingURLDomain" : @"ARLiveAuctionsURLDomain";
-    NSString *domain = self.echo.routes[echoDomainKey].path;
-    NSURL *liveAuctionsURL = [NSURL URLWithString:[@"https://" stringByAppendingString:domain]];
-    return [self loadURL:[liveAuctionsURL URLByAppendingPathComponent:auctionID]];
+    return [self loadURL:[self.liveAuctionsURL URLByAppendingPathComponent:auctionID]];
 }
 
 - (UIViewController *)loadAuctionRegistrationWithID:(NSString *)auctionID;

--- a/Artsy/Views/Artwork/ARArtworkActionsView.h
+++ b/Artsy/Views/Artwork/ARArtworkActionsView.h
@@ -22,6 +22,7 @@
 
 @interface ARArtworkActionsView : ORStackView
 - (instancetype)initWithArtwork:(Artwork *)artwork;
+- (void)updateUI;
 @property (nonatomic, assign) BOOL enabled;
 @property (nonatomic, weak) id<ARArtworkActionsViewDelegate, ARArtworkActionsViewButtonDelegate> delegate;
 @end

--- a/Artsy/Views/Artwork/ARArtworkActionsView.h
+++ b/Artsy/Views/Artwork/ARArtworkActionsView.h
@@ -23,6 +23,8 @@
 @interface ARArtworkActionsView : ORStackView
 - (instancetype)initWithArtwork:(Artwork *)artwork;
 - (void)updateUI;
+- (void)showSpinner;
+
 @property (nonatomic, assign) BOOL enabled;
 @property (nonatomic, weak) id<ARArtworkActionsViewDelegate, ARArtworkActionsViewButtonDelegate> delegate;
 @end

--- a/Artsy/Views/Artwork/ARArtworkActionsView.m
+++ b/Artsy/Views/Artwork/ARArtworkActionsView.m
@@ -90,11 +90,8 @@
         for (UIView *subview in self.subviews) {
             [self removeSubview:subview];
         }
-        ARSpinner *spinner = [[ARSpinner alloc] initWithFrame:CGRectMake(0, 0, 44, 44)];
-        self.spinner = spinner;
-        [self.spinner constrainHeight:@"100"];
-        [self.spinner fadeInAnimated:ARPerformWorkAsynchronously];
-        [self addSubview:self.spinner withTopMargin:@"0" sideMargin:@"0"];
+
+        [self showSpinner];
 
         // Then fetch the up-to-date data.
         __weak typeof(self) wself = self;
@@ -105,6 +102,15 @@
             sself.spinner = nil;
         } failure:nil allowCached:NO];
     }
+}
+
+- (void)showSpinner
+{
+    ARSpinner *spinner = [[ARSpinner alloc] initWithFrame:CGRectMake(0, 0, 44, 44)];
+    self.spinner = spinner;
+    [self.spinner constrainHeight:@"100"];
+    [self.spinner fadeInAnimated:ARPerformWorkAsynchronously];
+    [self addSubview:self.spinner withTopMargin:@"0" sideMargin:@"0"];
 }
 
 // The central state for a lot of this logic is in:

--- a/Artsy/Views/Artwork/ARArtworkActionsView.m
+++ b/Artsy/Views/Artwork/ARArtworkActionsView.m
@@ -39,11 +39,6 @@
 
 @implementation ARArtworkActionsView
 
-- (void)dealloc;
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (instancetype)initWithArtwork:(Artwork *)artwork
 {
     self = [super init];
@@ -75,37 +70,13 @@
         return returnable;
     } error:nil];
 
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(artworkBidUpdated:)
-                                                 name:ARAuctionArtworkBidUpdatedNotification
-                                               object:nil];
-}
-
-- (void)artworkBidUpdated:(NSNotification *)notification;
-{
-    if ([notification.userInfo[ARAuctionArtworkIDKey] isEqualToString:self.artwork.artworkID]) {
-        // First clear the old status so the user is not confronted with out-of-date data, which could be worrisome to
-        // the user if they have just made a bid.
-        self.saleArtwork = nil;
-        for (UIView *subview in self.subviews) {
-            [self removeSubview:subview];
-        }
-
-        [self showSpinner];
-
-        // Then fetch the up-to-date data.
-        __weak typeof(self) wself = self;
-        [self.artwork onSaleArtworkUpdate:^(SaleArtwork *saleArtwork) {
-            __strong typeof (wself) sself = wself;
-            sself.saleArtwork = saleArtwork;
-            [sself updateUI];
-            sself.spinner = nil;
-        } failure:nil allowCached:NO];
-    }
 }
 
 - (void)showSpinner
 {
+    for (UIView *subview in self.subviews) {
+        [self removeSubview:subview];
+    }
     ARSpinner *spinner = [[ARSpinner alloc] initWithFrame:CGRectMake(0, 0, 44, 44)];
     self.spinner = spinner;
     [self.spinner constrainHeight:@"100"];

--- a/Artsy/Views/Artwork/ARArtworkMetadataView.h
+++ b/Artsy/Views/Artwork/ARArtworkMetadataView.h
@@ -26,6 +26,7 @@
 
 @property (nonatomic, strong, readonly) UIView *left;
 @property (nonatomic, strong, readonly) UIView *right;
+@property (nonatomic, strong) ARArtworkActionsView *actionsView;
 
 /// TODO: Make this a view controller so that we can negate doing this.
 /// Let subviews know that we're in a fair context

--- a/Artsy/Views/Artwork/ARArtworkMetadataView.h
+++ b/Artsy/Views/Artwork/ARArtworkMetadataView.h
@@ -22,6 +22,8 @@
 
 - (void)setDelegate:(id<ARArtworkDetailViewDelegate, ARArtworkDetailViewButtonDelegate, ARArtworkActionsViewDelegate, ARArtworkActionsViewButtonDelegate, ARArtworkPreviewImageViewDelegate, ARArtworkPreviewActionsViewDelegate>)delegate;
 
+- (void)updateUI;
+
 @property (nonatomic, strong, readonly) UIView *left;
 @property (nonatomic, strong, readonly) UIView *right;
 

--- a/Artsy/Views/Artwork/ARArtworkMetadataView.h
+++ b/Artsy/Views/Artwork/ARArtworkMetadataView.h
@@ -23,10 +23,10 @@
 - (void)setDelegate:(id<ARArtworkDetailViewDelegate, ARArtworkDetailViewButtonDelegate, ARArtworkActionsViewDelegate, ARArtworkActionsViewButtonDelegate, ARArtworkPreviewImageViewDelegate, ARArtworkPreviewActionsViewDelegate>)delegate;
 
 - (void)updateUI;
+- (void)showActionsViewSpinner;
 
 @property (nonatomic, strong, readonly) UIView *left;
 @property (nonatomic, strong, readonly) UIView *right;
-@property (nonatomic, strong) ARArtworkActionsView *actionsView;
 
 /// TODO: Make this a view controller so that we can negate doing this.
 /// Let subviews know that we're in a fair context

--- a/Artsy/Views/Artwork/ARArtworkMetadataView.m
+++ b/Artsy/Views/Artwork/ARArtworkMetadataView.m
@@ -10,7 +10,7 @@
 @interface ARArtworkMetadataView ()
 @property (nonatomic, strong) ARArtworkPreviewActionsView *artworkPreviewActions;
 @property (nonatomic, strong) ARArtworkPreviewImageView *artworkPreview;
-@property (nonatomic, strong) ARArtworkActionsView *actionsView;
+//@property (nonatomic, strong) ARArtworkActionsView *actionsView;
 @property (nonatomic, strong) ARArtworkDetailView *artworkDetailView;
 @property (nonatomic, strong, readonly) NSArray *verticalConstraints;
 @property (nonatomic, strong, readonly) NSArray *horizontalConstraints;

--- a/Artsy/Views/Artwork/ARArtworkMetadataView.m
+++ b/Artsy/Views/Artwork/ARArtworkMetadataView.m
@@ -166,6 +166,11 @@
     }
 }
 
+-(void)updateUI
+{
+    [self.actionsView updateUI];
+}
+
 - (void)setDelegate:(id<ARArtworkDetailViewDelegate, ARArtworkDetailViewButtonDelegate, ARArtworkActionsViewDelegate, ARArtworkActionsViewButtonDelegate, ARArtworkPreviewImageViewDelegate, ARArtworkPreviewActionsViewDelegate>)delegate
 {
     self.artworkPreview.delegate = delegate;

--- a/Artsy/Views/Artwork/ARArtworkMetadataView.m
+++ b/Artsy/Views/Artwork/ARArtworkMetadataView.m
@@ -10,7 +10,7 @@
 @interface ARArtworkMetadataView ()
 @property (nonatomic, strong) ARArtworkPreviewActionsView *artworkPreviewActions;
 @property (nonatomic, strong) ARArtworkPreviewImageView *artworkPreview;
-//@property (nonatomic, strong) ARArtworkActionsView *actionsView;
+@property (nonatomic, strong) ARArtworkActionsView *actionsView;
 @property (nonatomic, strong) ARArtworkDetailView *artworkDetailView;
 @property (nonatomic, strong, readonly) NSArray *verticalConstraints;
 @property (nonatomic, strong, readonly) NSArray *horizontalConstraints;
@@ -164,6 +164,11 @@
             [NSLayoutConstraint activateConstraints:self.verticalConstraints];
         }
     }
+}
+
+-(void)showActionsViewSpinner
+{
+    [self.actionsView showSpinner];
 }
 
 -(void)updateUI

--- a/Artsy/Views/Artwork/ARArtworkView.m
+++ b/Artsy/Views/Artwork/ARArtworkView.m
@@ -161,7 +161,7 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
 {
     if ([notification.userInfo[ARAuctionArtworkIDKey] isEqualToString:self.artwork.artworkID]) {
         __weak typeof (self) wself = self;
-        [self.metadataView.actionsView showSpinner];
+        [self.metadataView showActionsViewSpinner];
         [self.artwork onSaleArtworkUpdate:^(SaleArtwork * _Nonnull saleArtwork) {
             __strong typeof (wself) sself = wself;
             if (saleArtwork.auctionState & ARAuctionStateUserIsBidder) {

--- a/Artsy/Views/Artwork/ARArtworkView.m
+++ b/Artsy/Views/Artwork/ARArtworkView.m
@@ -162,10 +162,11 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
 // 3. In callback from 2., update our self.banner.auctionState and also call self.matadataview.actionVIew.updateSaleArtwork(saleASrtwork)
 - (void)artworkBidUpdated:(NSNotification *)notification;
 {
+    
     if ([notification.userInfo[ARAuctionArtworkIDKey] isEqualToString:self.artwork.artworkID]) {
         __weak typeof (self) wself = self;
         // Pt 1: Goes here
-        // self.metadataview.actionView.showSpinner() change notificationcenter bits into a fn
+        [self.metadataView.actionsView showSpinner];
         [self.artwork onSaleArtworkUpdate:^(SaleArtwork * _Nonnull saleArtwork) { // this is the pt 2
             __strong typeof (wself) sself = wself;
             if (!sself) { return; }
@@ -182,9 +183,6 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
       failure:nil
         allowCached:NO];
         [self.artwork updateSaleArtwork];
-        //
-        
-
     }
 }
 

--- a/Artsy/Views/Artwork/ARArtworkView.m
+++ b/Artsy/Views/Artwork/ARArtworkView.m
@@ -157,27 +157,21 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
                                                object:nil];
 }
 
-// 1. Call self.metadataview.ctionView.showSpinner()
-// 2. Make a call to onSaleArtworkUpdate with allowCachedno
-// 3. In callback from 2., update our self.banner.auctionState and also call self.matadataview.actionVIew.updateSaleArtwork(saleASrtwork)
 - (void)artworkBidUpdated:(NSNotification *)notification;
 {
-    
     if ([notification.userInfo[ARAuctionArtworkIDKey] isEqualToString:self.artwork.artworkID]) {
         __weak typeof (self) wself = self;
-        // Pt 1: Goes here
         [self.metadataView.actionsView showSpinner];
-        [self.artwork onSaleArtworkUpdate:^(SaleArtwork * _Nonnull saleArtwork) { // this is the pt 2
+        [self.artwork onSaleArtworkUpdate:^(SaleArtwork * _Nonnull saleArtwork) {
             __strong typeof (wself) sself = wself;
-            if (!sself) { return; }
             if (saleArtwork.auctionState & ARAuctionStateUserIsBidder) {
                 [ARAnalytics setUserProperty:@"has_placed_bid" toValue:@"true"];
-                sself.banner.auctionState = saleArtwork.auctionState; // this is also part of pt 3
+                sself.banner.auctionState = saleArtwork.auctionState;
                 [UIView animateIf:ARPerformWorkAsynchronously duration:ARAnimationDuration :^{
                     [sself.banner updateHeightConstraint];
                     [sself.stackView layoutIfNeeded];
                 }];
-                [sself.metadataView updateUI];  // test whether this uses the new data- maybe it doesn't yet (this is pt 3)
+                [sself.metadataView updateUI];
             }
         }
       failure:nil

--- a/Artsy/Views/Artwork/ARArtworkView.m
+++ b/Artsy/Views/Artwork/ARArtworkView.m
@@ -87,6 +87,8 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
 
         [self setUpCallbacks];
         [self createHeightConstraints];
+    } else {
+        [[NSNotificationCenter defaultCenter] removeObserver:self name:ARAuctionArtworkBidUpdatedNotification object:nil];
     }
 }
 
@@ -112,7 +114,7 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
 
 - (void)setUpCallbacks
 {
-    __weak typeof (self) wself = self;
+    __weak typeof(self) wself = self;
 
     void (^completion)(void) = ^{
         __strong typeof (wself) sself = wself;
@@ -133,6 +135,7 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
         __strong typeof (wself) sself = wself;
         if (!sself || !fair) return;
 
+        
         [sself.metadataView updateWithFair:fair];
         [sself.stackView layoutIfNeeded];
     } failure:nil];
@@ -148,6 +151,22 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
             }];
         }
     } failure:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(artworkBidUpdated:)
+                                                 name:ARAuctionArtworkBidUpdatedNotification
+                                               object:nil];
+}
+
+- (void)artworkBidUpdated:(NSNotification *)notification;
+{
+    if ([notification.userInfo[ARAuctionArtworkIDKey] isEqualToString:self.artwork.artworkID]) {
+        // keep this?
+        [self.artwork updateSaleArtwork];
+
+        // 1. Call self.metadataview.ctionView.showSpinner()
+        // 2. Make a call to onSaleArtworkUpdate with allowCachedno
+        // 3. In callback from 2., update our self.banner.auctionState and also call self.matadataview.actionVIew.updateSaleArtwork(saleASrtwork)
+    }
 }
 
 - (void)createHeightConstraints

--- a/Artsy_Tests/Supporting_Files/ARTestHelper.m
+++ b/Artsy_Tests/Supporting_Files/ARTestHelper.m
@@ -67,6 +67,7 @@
                                                                      googleMapsAPIKey:@""
                                                                            gravityURL:gravity
                                                                        metaphysicsURL:metaphysics
+                                                                        predictionURL:@""
                                                                             userAgent:@"Eigen Tests"];
 
     AREmission *emission = [[AREmission alloc] initWithConfiguration:config packagerURL:nil];

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -72,7 +72,7 @@ PODS:
   - DHCShakeNotifier (0.2.0)
   - DoubleConversion (1.1.5)
   - EDColor (1.0.0)
-  - Emission (1.5.11):
+  - Emission (1.5.12):
     - "Artsy+UIColors"
     - "Artsy+UIFonts (>= 3.0.0)"
     - DoubleConversion (= 1.1.5)
@@ -465,7 +465,7 @@ SPEC CHECKSUMS:
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
-  Emission: af1bf0ab8c90ed8cdcd6e63f4293f8b3b4732cc7
+  Emission: 1f23bf88e8ebf6afb037beadf6ebda0c54b07443
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   "Expecta+Snapshots": c343f410c7a6392f3e22e78f94c44b6c0749a516
   Extraction: 642a73b8ccc7806e9a7daf95ebb4c14c374829f1


### PR DESCRIPTION
Tracked in https://artsyproduct.atlassian.net/browse/PURCHASE-248

@ashfurrow helped me with the first two commits of this. It seems to be working now (see below- the banner should update after bidding and going from outbid to winning) but there is an error I've seen before [see below].
![bannerupdate](https://user-images.githubusercontent.com/9088720/42817644-fab73756-89ce-11e8-82dd-79f572c808e9.gif) 

[resolved]
```
2018-07-17 14:36:32.614393+0200 Artsy[83465:8377853] This application is modifying the autolayout engine from a background thread after the engine was accessed from the main thread. This can lead to engine corruption and weird crashes.
 Stack:(
	0   Foundation                          0x000000010e626df7 _AssertAutolayoutOnAllowedThreadsOnly + 77
	1   Foundation                          0x000000010e432540 -[NSISEngine withBehaviors:performModifications:] + 28
	2   Foundation                          0x000000010e42dd67 +[NSLayoutConstraint _addOrRemoveConstraints:activate:] + 403
	3   UIKit                               0x00000001111b174b _UIViewRemoveConstraintsMadeDanglyByChangingSuperview + 1189
	4   UIKit                               0x00000001106f505a __45-[UIView(Hierarchy) _postMovedFromSuperview:]_block_invoke + 61
	5   UIKit                               0x00000001106f4f8a -[UIView(Hierarchy) _postMovedFromSuperview:] + 808
	6   UIKit                               0x00000001106f2e3e __UIViewWasRemovedFromSuperview + 169
	7   UIKit                               0x00000001106f2930 -[UIView(Hierarchy) removeFromSuperview] + 479
	8   Artsy                               0x000000010c4c5b14 -[ORStackView removeSubview:] + 212
	9   Artsy                               0x000000010bfdb547 -[ARArtworkActionsView artworkBidUpdated:] + 647
	10  CoreFoundation  
```

