### PR TITLE
Shows spinner during API request load.

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -14,6 +14,7 @@ upcoming:
     - Removes duplicate navigation bar on BidFlow - ash
     - Users now prompted to bid on artworks in a sale, instead of just registering to bid - ash
     - Users now have access to Echo-gated BidFlow - ash
+    - Users see a spinner while we load necessary data for artwork actions view (eg: bid button) - ash
 
 releases:
   - version: 4.2.0


### PR DESCRIPTION
This PR shows a spinner while the necessary API requests to display the artwork actions view (bid button, contact gallery button, countdown timer, etc) are fetched. 

The bug was incorrectly identified as a regression. We saw the beta behave as described in the ticket, and saw the App Store version working fine a few minutes later. During that time, I believe a staging blip corrected itself. I could no longer produce the lag on the beta _but_ sometimes API requests take time, so we should still show the spinner while they're in flight.

Fixes [Purchase-292](https://artsyproduct.atlassian.net/browse/PURCHASE-292).