### PR TITLE
Fixes bid status not updating

### DIFF
--- a/Artsy/Views/Artwork/ARArtworkActionsView.h
+++ b/Artsy/Views/Artwork/ARArtworkActionsView.h
@@ -2,7 +2,7 @@
 
 #import <ORStackView/ORStackView.h>
 
-@class Artwork, ARArtworkActionsView;
+@class Artwork, SaleArtwork, ARArtworkActionsView;
 
 @protocol ARArtworkActionsViewDelegate <NSObject>
 - (void)didUpdateArtworkActionsView:(ARArtworkActionsView *)actionsView;
@@ -21,10 +21,13 @@
 
 
 @interface ARArtworkActionsView : ORStackView
+
 - (instancetype)initWithArtwork:(Artwork *)artwork;
-- (void)updateUI;
+
+- (void)updateUIForSaleArtwork:(SaleArtwork *)saleArtwork;
 - (void)showSpinner;
 
 @property (nonatomic, assign) BOOL enabled;
 @property (nonatomic, weak) id<ARArtworkActionsViewDelegate, ARArtworkActionsViewButtonDelegate> delegate;
+
 @end

--- a/Artsy/Views/Artwork/ARArtworkActionsView.m
+++ b/Artsy/Views/Artwork/ARArtworkActionsView.m
@@ -84,10 +84,15 @@
     [self addSubview:self.spinner withTopMargin:@"0" sideMargin:@"0"];
 }
 
+- (void)updateUIForSaleArtwork:(SaleArtwork *)saleArtwork
+{
+    self.saleArtwork = saleArtwork;
+    [self updateUI];
+}
+
 // The central state for a lot of this logic is in:
 // https://docs.google.com/document/d/1kQSHhCiFWxfVkSeql3GQA7UbBbhpNe-UyQ-c6q95Uq0/
 //
-
 - (void)updateUI
 {
     for (UIView *subview in self.subviews) {

--- a/Artsy/Views/Artwork/ARArtworkMetadataView.h
+++ b/Artsy/Views/Artwork/ARArtworkMetadataView.h
@@ -22,7 +22,7 @@
 
 - (void)setDelegate:(id<ARArtworkDetailViewDelegate, ARArtworkDetailViewButtonDelegate, ARArtworkActionsViewDelegate, ARArtworkActionsViewButtonDelegate, ARArtworkPreviewImageViewDelegate, ARArtworkPreviewActionsViewDelegate>)delegate;
 
-- (void)updateUI;
+- (void)updateUIForSaleArtwork:(SaleArtwork *)saleArtwork;
 - (void)showActionsViewSpinner;
 
 @property (nonatomic, strong, readonly) UIView *left;

--- a/Artsy/Views/Artwork/ARArtworkMetadataView.m
+++ b/Artsy/Views/Artwork/ARArtworkMetadataView.m
@@ -171,9 +171,9 @@
     [self.actionsView showSpinner];
 }
 
--(void)updateUI
+- (void)updateUIForSaleArtwork:(SaleArtwork *)saleArtwork
 {
-    [self.actionsView updateUI];
+    [self.actionsView updateUIForSaleArtwork:saleArtwork];
 }
 
 - (void)setDelegate:(id<ARArtworkDetailViewDelegate, ARArtworkDetailViewButtonDelegate, ARArtworkActionsViewDelegate, ARArtworkActionsViewButtonDelegate, ARArtworkPreviewImageViewDelegate, ARArtworkPreviewActionsViewDelegate>)delegate

--- a/Artsy/Views/Artwork/ARArtworkView.m
+++ b/Artsy/Views/Artwork/ARArtworkView.m
@@ -171,7 +171,7 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
                     [sself.banner updateHeightConstraint];
                     [sself.stackView layoutIfNeeded];
                 }];
-                [sself.metadataView updateUI];
+                [sself.metadataView updateUIForSaleArtwork:saleArtwork];
             }
         }
       failure:nil

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -14,6 +14,7 @@ upcoming:
     - Removes duplicate navigation bar on BidFlow - ash
     - Users now prompted to bid on artworks in a sale, instead of just registering to bid - ash
     - Users now have access to Echo-gated BidFlow - ash
+    - Fixes problem where users didn't see updated bid status after placing a bid - ash
 
 releases:
   - version: 4.2.0


### PR DESCRIPTION
This is for [Purchase-290](
https://artsyproduct.atlassian.net/browse/PURCHASE-290) but it needs more testing before merging. 

Here's the cause of the bug:

- `ARArtworkView` fetches API results when new bids are placed.
- We were relying on `ARArtworkView` to notify subviews when there is new bid status (from API fetch).
- We expected the model in the nested `ARArtworkActionsView` to be updated in-place based on the fetch **but** they weren't.

The solution is to pass down the new sale artwork model as a parameter to the `updateUI` function.