### PR TITLE
Logged-in user email is displayed in admin menu #trivial

### DIFF
--- a/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
+++ b/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
@@ -43,9 +43,10 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
     NSString *build = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"];
     NSString *version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
     NSString *gitCommitRevision = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"GITCommitRev"];
+    NSString *userEmail = [[[ARUserManager sharedManager] currentUser] email];
 
     ARSectionData *userSectionData = [[ARSectionData alloc] init];
-    userSectionData.headerTitle = [NSString stringWithFormat:@"%@ v%@, build %@ (%@)", name, version, build, gitCommitRevision];
+    userSectionData.headerTitle = [NSString stringWithFormat:@"%@ v%@, build %@ (%@), %@", name, version, build, gitCommitRevision, userEmail];
 
     [userSectionData addCellDataFromArray:@[
         [self generateStagingSwitch],

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
   emission_version: 1.5.10
   dev:
     - Clear Relay response cache on logout/switch env - alloy
+    - Logged-in user email is displayed in admin menu - ash
 
 
   user_facing:


### PR DESCRIPTION
When testing things across multiple accounts, it's often helpful to know which account I'm logged in with from within the app. This PR adds the email to the build info at the top:

![screen shot 2018-07-19 at 9 30 46 am](https://user-images.githubusercontent.com/498212/42945494-8f865976-8b36-11e8-8ab4-777b707a4b0d.png)
