### PR TITLE
Fixes outbid notification suppression.

### DIFF
--- a/Artsy/App/ARAppNotificationsDelegate.m
+++ b/Artsy/App/ARAppNotificationsDelegate.m
@@ -10,6 +10,7 @@
 #import "ARNotificationView.h"
 #import "ARSwitchBoard.h"
 #import "ARTopMenuViewController.h"
+#import "ARSerifNavigationViewController.h"
 #import "ARLogger.h"
 #import "ARDefaults.h"
 #import "AROptions.h"
@@ -222,11 +223,15 @@
             NSString *outbidNotificationLabel = @"bid outbid";
 
             ARConversationComponentViewController *conversationVC = (id)controller;
-            ARBidFlowViewController *bidFlowVC = (id)controller;
+            ARBidFlowViewController *bidFlowVC;
+            ARSerifNavigationViewController *serifNavigationController = (id)[controller presentedViewController];
+            if ([serifNavigationController isKindOfClass:[ARSerifNavigationViewController class]]) {
+                bidFlowVC = [[serifNavigationController viewControllers] firstObject];
+            }
 
             if ([controller isKindOfClass:ARConversationComponentViewController.class] && [conversationVC.conversationID isEqualToString:conversationID]) {
                 [[NSNotificationCenter defaultCenter] postNotificationName:@"notification_received" object:notificationInfo];
-            } else if ([controller isKindOfClass:ARBidFlowViewController.class] && [action isEqualToString:outbidNotificationLabel] && [bidFlowVC.artworkID isEqualToString:artworkID] && [bidFlowVC.saleID isEqualToString:saleID]) {
+            } else if ([bidFlowVC isKindOfClass:ARBidFlowViewController.class] && [action isEqualToString:outbidNotificationLabel] && [bidFlowVC.artworkID isEqualToString:artworkID] && [bidFlowVC.saleID isEqualToString:saleID]) {
                 // NO-OP, so that we don't show notifications about bidding activity currently on screen
             } else {
                 NSString *title = [message isKindOfClass:[NSString class]] ? message : message[@"title"];

--- a/Artsy_Tests/App_Tests/ARAppNotificationsDelegateTests.m
+++ b/Artsy_Tests/App_Tests/ARAppNotificationsDelegateTests.m
@@ -5,6 +5,7 @@
 #import "ARAnalyticsConstants.h"
 #import "ARNotificationView.h"
 #import "ARTopMenuViewController.h"
+#import "ARSerifNavigationViewController.h"
 #import "ARTopMenuNavigationDataSource.h"
 #import "UIApplicationStateEnum.h"
 #import <Emission/ARBidFlowViewController.h>
@@ -167,10 +168,15 @@ describe(@"receiveRemoteNotification", ^{
         });
 
         it(@"suppresses showing the notification view when a notification about outbidding ", ^{
+            UIViewController *globalRootController = [UIViewController new];
             ARBidFlowViewController *bidController = [[ARBidFlowViewController alloc] initWithArtworkID:@"asd1432asda" saleID:@"123ffg3edfsd"];
+            ARSerifNavigationViewController *navigationController = [[ARSerifNavigationViewController alloc] initWithRootViewController:bidController];
+
+            id mockGlbalRootController = [OCMockObject partialMockForObject:globalRootController];
+            [[[mockGlbalRootController stub] andReturn:navigationController] presentedViewController];
 
             id mockedNotificationsDelegate = [OCMockObject partialMockForObject:delegate];
-            [[[mockedNotificationsDelegate stub] andReturn:bidController] getGlobalTopViewController];
+            [[[mockedNotificationsDelegate stub] andReturn:mockGlbalRootController] getGlobalTopViewController];
 
             id mock = [OCMockObject mockForClass:[ARNotificationView class]];
             [[mock reject] showNoticeInView:OCMOCK_ANY title:OCMOCK_ANY response:OCMOCK_ANY];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -17,6 +17,7 @@ upcoming:
     - Users now have access to Echo-gated BidFlow - ash
     - Users see a spinner while we load necessary data for artwork actions view (eg: bid button) - ash
     - Fixes problem where users didn't see updated bid status after placing a bid - ash
+    - Fixed outbid push notification suppresion - ash
 
 releases:
   - version: 4.2.0


### PR DESCRIPTION
I've got a more detailed description of the bug [here](
https://github.com/artsy/eigen/pull/2666/files#r204059063) but the gist is, since BidFlow is presented modally, we can't rely on a simple class check of the global top view controller. 

Testing push notifications is really tricky since our staging environment uses Apple's production servers and they'll only push to properly deployed builds of the app, so I've updated the tests and read the code until I'm confident it'll probably work. More eyes on this would be helpful to double-check. I'll definitely test on the next beta. 