### PR TITLE
Updates outbid notification payload parsing

### DIFF
--- a/Artsy/App/ARAppNotificationsDelegate.m
+++ b/Artsy/App/ARAppNotificationsDelegate.m
@@ -215,8 +215,8 @@
             UIViewController *controller = [self getGlobalTopViewController];
 
             NSString *conversationID = [notificationInfo[@"conversation_id"] stringValue];
-            NSString *saleID = notificationInfo[@"sale_id"];
-            NSString *artworkID = notificationInfo[@"artwork_id"];
+            NSString *saleID = notificationInfo[@"sale_slug"];
+            NSString *artworkID = notificationInfo[@"artwork_slug"];
             NSString *action = notificationInfo[@"action"];
 
             // We check whether a notification coming through has this as its action

--- a/Artsy_Tests/App_Tests/ARAppNotificationsDelegateTests.m
+++ b/Artsy_Tests/App_Tests/ARAppNotificationsDelegateTests.m
@@ -169,7 +169,7 @@ describe(@"receiveRemoteNotification", ^{
 
         it(@"suppresses showing the notification view when a notification about outbidding ", ^{
             UIViewController *globalRootController = [UIViewController new];
-            ARBidFlowViewController *bidController = [[ARBidFlowViewController alloc] initWithArtworkID:@"asd1432asda" saleID:@"123ffg3edfsd"];
+            ARBidFlowViewController *bidController = [[ARBidFlowViewController alloc] initWithArtworkID:@"artwork-by-someone-famous" saleID:@"some-sale-id"];
             ARSerifNavigationViewController *navigationController = [[ARSerifNavigationViewController alloc] initWithRootViewController:bidController];
 
             id mockGlbalRootController = [OCMockObject partialMockForObject:globalRootController];
@@ -181,7 +181,7 @@ describe(@"receiveRemoteNotification", ^{
             id mock = [OCMockObject mockForClass:[ARNotificationView class]];
             [[mock reject] showNoticeInView:OCMOCK_ANY title:OCMOCK_ANY response:OCMOCK_ANY];
 
-            [delegate applicationDidReceiveRemoteNotification:@{ @"sale_id" : @"123ffg3edfsd", @"artwork_id": @"asd1432asda", @"action": @"bid outbid" } inApplicationState:appState];
+            [delegate applicationDidReceiveRemoteNotification:@{ @"sale_slug" : @"some-sale-id", @"artwork_slug": @"artwork-by-someone-famous", @"action": @"bid outbid" } inApplicationState:appState];
 
             [mock verify];
             [mock stopMocking];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -18,6 +18,7 @@ upcoming:
     - Users see a spinner while we load necessary data for artwork actions view (eg: bid button) - ash
     - Fixes problem where users didn't see updated bid status after placing a bid - ash
     - Fixed outbid push notification suppresion - ash
+    - Updates outbid notification payload parsing (new keys). - ash
 
 releases:
   - version: 4.2.0


### PR DESCRIPTION
This PR updates the keys that Eigen uses to extract data from the outbid push notifications sent from Pulse. A PR on the pulse side has been submitted: https://github.com/artsy/pulse/pull/218

Together, they fix [PURCHASE-300](
https://artsyproduct.atlassian.net/browse/PURCHASE-300).