### PR TITLE
Fixes bug where LAI registration would invoke BidFlow

### DIFF
--- a/Artsy/App/ARSwitchBoard+Eigen.h
+++ b/Artsy/App/ARSwitchBoard+Eigen.h
@@ -60,7 +60,7 @@
 
 - (UIViewController *)loadBidUIForArtwork:(NSString *)artworkID inSale:(NSString *)saleID;
 
-- (UIViewController *)loadAuctionRegistrationWithID:(NSString *)auctionID;
+- (UIViewController *)loadAuctionRegistrationWithID:(NSString *)auctionID skipBidFlow:(BOOL)skipBidFlow;
 
 /// Load a Partner Page in Martsy
 - (UIViewController *)loadPartnerWithID:(NSString *)partnerID;

--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -163,7 +163,7 @@ NSInteger const ARLiveAuctionsCurrentWebSocketVersionCompatibility = 4;
 
     [self registerEchoRouteForKey:@"ARAuctionRegistrationRoute" handler:JLRouteParams {
         __strong typeof (wself) sself = wself;
-        return [sself loadAuctionRegistrationWithID:parameters[@"id"]];
+        return [sself loadAuctionRegistrationWithID:parameters[@"id"] skipBidFlow:parameters[@"skip_bid_flow"]];
     }];
 
     [self registerEchoRouteForKey:@"ARAuctionRoute" handler:JLRouteParams {

--- a/Artsy/App/ARSwitchboard+Eigen.m
+++ b/Artsy/App/ARSwitchboard+Eigen.m
@@ -102,9 +102,9 @@
     return [self loadURL:[self.liveAuctionsURL URLByAppendingPathComponent:auctionID]];
 }
 
-- (UIViewController *)loadAuctionRegistrationWithID:(NSString *)auctionID;
+- (UIViewController *)loadAuctionRegistrationWithID:(NSString *)auctionID skipBidFlow:(BOOL)skipBidFlow
 {
-    if (self.echo.features[@"ARDisableReactNativeBidFlow"].state == NO) {
+    if (self.echo.features[@"ARDisableReactNativeBidFlow"].state == NO && skipBidFlow == NO) {
         ARBidFlowViewController *viewController = [[ARBidFlowViewController alloc] initWithArtworkID:@"" saleID:auctionID intent:ARBidFlowViewControllerIntentRegister];
         return [[ARSerifNavigationViewController alloc] initWithRootViewController:viewController];
     } else {

--- a/Artsy/View_Controllers/Live_Auctions/LiveAuctionLotSetViewController.swift
+++ b/Artsy/View_Controllers/Live_Auctions/LiveAuctionLotSetViewController.swift
@@ -348,7 +348,7 @@ extension LiveAuctionLotSetViewController: AuctionTitleViewDelegate {
     }
 
     func userDidPressRegister(_ titleView: AuctionTitleView) {
-        let registrationPath = "/auction-registration/\(self.salesPerson.liveSaleID)"
+        let registrationPath = "/auction-registration/\(self.salesPerson.liveSaleID)?skip_bid_flow=true"
         let viewController = ARSwitchBoard.sharedInstance().loadPath(registrationPath)
         self.present(viewController, animated: true) {}
     }

--- a/Artsy/View_Controllers/Live_Auctions/LiveAuctionLotViewController.swift
+++ b/Artsy/View_Controllers/Live_Auctions/LiveAuctionLotViewController.swift
@@ -268,7 +268,7 @@ extension LiveAuctionLotViewController: LiveAuctionBidButtonDelegate {
     }
 
     func bidButtonRequestedRegisterToBid(_ button: LiveAuctionBidButton) {
-        let registrationPath = "/auction-registration/\(self.salesPerson.liveSaleID)"
+        let registrationPath = "/auction-registration/\(self.salesPerson.liveSaleID)?skip_bid_flow=true"
         let viewController = ARSwitchBoard.sharedInstance().loadPath(registrationPath)
         let serifNav = SerifModalWebNavigationController(rootViewController: viewController)
         self.navigationController?.present(serifNav, animated: true) {}

--- a/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
+++ b/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
@@ -25,6 +25,7 @@
 
 #import <Emission/ARArtistComponentViewController.h>
 #import <Emission/ARFavoritesComponentViewController.h>
+#import <Emission/ARBidFlowViewController.h>
 
 #import "Artsy-Swift.h"
 
@@ -421,6 +422,24 @@ describe(@"ARSwitchboard", ^{
             expect(classString).to.contain(@"ARArtistViewController");
         });
 
+        it(@"defaults to the new bid flow", ^{
+            switchboard = [[ARSwitchBoard alloc] init];
+            [switchboard updateRoutes];
+
+            ARSerifNavigationViewController *subjectNav = (id)[switchboard loadPath:@"/auction-registration/the-sale"];
+            ARBidFlowViewController *subject = (id)subjectNav.topViewController;
+
+            expect(subject.saleID).to.equal(@"the-sale");
+        });
+
+        it(@"falls back to force bid registration when skip_bid_flow=true", ^{
+            switchboard = [[ARSwitchBoard alloc] init];
+            [switchboard updateRoutes];
+
+            id subject = [switchboard loadPath:@"/auction-registration/the-sale?skip_bid_flow=true"];
+
+            expect(NSStringFromClass([subject class])).to.equal(@"ARAuctionWebViewController");
+        });
     });
 
     describe(@"loadProfileWithIDileWithID", ^{

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,7 +3,7 @@ upcoming:
   date: TBA
   emission_version: 1.5.15
   dev:
-    -
+    - Fixes a bug where LAI's register button would invoke the BidFlow UI, which caused a crash - ash
 
   user_facing:
     -


### PR DESCRIPTION
Took a look with @erikdstock on this – just an oversight from the BidFlow project. It fixes this crash: https://sentry.io/artsynet/eigen/issues/626942969/?query=is:unresolved# And addresses [PURCHASE-411](https://artsyproduct.atlassian.net/browse/PURCHASE-411#).