### PR TITLE
[Coordinate Merge] Switch to latest error type

### DIFF
--- a/Artsy/Networking/create_order.graphql
+++ b/Artsy/Networking/create_order.graphql
@@ -12,7 +12,9 @@ mutation createOrder(
       }
       ... on OrderWithMutationFailure {
         error {
-          description
+          type
+          code
+          data
         }
       }
     }


### PR DESCRIPTION
# Change
Update `createOrder` mutation to match latest error type introduced in https://github.com/artsy/metaphysics/pull/1276