### PR TITLE
Updates to the latest emission

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.2.2</string>
+	<string>4.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>2018.04.18.12</string>
 	<key>NSExtension</key>

--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -19,8 +19,8 @@
 #import "ARRootViewController.h"
 #import "ARAppStatus.h"
 #import "ARRouter.h"
+#import "ArtsyEcho.h"
 
-#import <Aerodramus/Aerodramus.h>
 #import <Keys/ArtsyKeys.h>
 #import <Emission/AREmission.h>
 #import <Emission/ARTemporaryAPIModule.h>
@@ -105,7 +105,15 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
         stripePublishableKey = keys.stripeProductionPublishableKey;
     }
 
-    NSDictionary *labOptions = [AROptions labOptionsMap];
+    // Pass lab options into Emission
+    NSMutableDictionary *options = [NSMutableDictionary dictionary];
+    [options addEntriesFromDictionary:[AROptions labOptionsMap]];
+    
+    // Also pass echo features
+    ArtsyEcho *aero = [[ArtsyEcho alloc] init];
+    [aero setup];
+    [options addEntriesFromDictionary:[aero featuresMap]];
+
     AREmissionConfiguration *config = [[AREmissionConfiguration alloc] initWithUserID:userID
                                                                       authenticationToken:authenticationToken
                                                                                 sentryDSN:sentryDSN
@@ -115,7 +123,7 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
                                                                            metaphysicsURL:metaphysics
                                                                             predictionURL:liveAuctionsURL
                                                                                 userAgent:ARRouter.userAgent
-                                                                                  options:labOptions];
+                                                                                  options:options];
 
     AREmission *emission = [[AREmission alloc] initWithConfiguration:config packagerURL:packagerURL];
     [AREmission setSharedInstance:emission];

--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -105,6 +105,7 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
         stripePublishableKey = keys.stripeProductionPublishableKey;
     }
 
+    NSDictionary *labOptions = [AROptions labOptionsMap];
     AREmissionConfiguration *config = [[AREmissionConfiguration alloc] initWithUserID:userID
                                                                       authenticationToken:authenticationToken
                                                                                 sentryDSN:sentryDSN
@@ -113,7 +114,8 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
                                                                                gravityURL:gravity
                                                                            metaphysicsURL:metaphysics
                                                                             predictionURL:liveAuctionsURL
-                                                                                userAgent:ARRouter.userAgent];
+                                                                                userAgent:ARRouter.userAgent
+                                                                                  options:labOptions];
 
     AREmission *emission = [[AREmission alloc] initWithConfiguration:config packagerURL:packagerURL];
     [AREmission setSharedInstance:emission];

--- a/Artsy/App/AROptions.h
+++ b/Artsy/App/AROptions.h
@@ -4,7 +4,6 @@
 // All the options as consts
 extern NSString *const AROptionsLoadingScreenAlpha;
 extern NSString *const AROptionsUseVCR;
-extern NSString *const AROptionsSettingsMenu;
 extern NSString *const AROptionsTappingPartnerSendsToPartner;
 extern NSString *const AROptionsShowAnalyticsOnScreen;
 extern NSString *const AROptionsShowMartsyOnScreen;

--- a/Artsy/App/AROptions.h
+++ b/Artsy/App/AROptions.h
@@ -19,7 +19,12 @@ extern NSString *const AROptionsHideBackButtonOnScroll;
 
 /// Returns all the current options
 + (NSArray *)labsOptions;
+// Special cases
 + (NSArray *)labsOptionsThatRequireRestart;
+// For UIs
++ (NSString *)descriptionForOption:(NSString *)option;
+/// A dictionary of lab options to true/false as NSNumbers for Emission basically
++ (NSDictionary *)labOptionsMap;
 
 /// Get and set individual options
 + (BOOL)boolForOption:(NSString *)option;

--- a/Artsy/App/AROptions.m
+++ b/Artsy/App/AROptions.m
@@ -1,38 +1,80 @@
 #import "AROptions.h"
 
+static NSDictionary *options = nil;
+
+
+// UI Tweaks
 NSString *const AROptionsLoadingScreenAlpha = @"Loading screens are transparent";
-NSString *const AROptionsUseVCR = @"Use offline recording";
-NSString *const AROptionsSettingsMenu = @"Enable user settings";
-NSString *const AROptionsTappingPartnerSendsToPartner = @"Partner name in feed goes to partner";
 NSString *const AROptionsShowAnalyticsOnScreen = @"AROptionsShowAnalyticsOnScreen";
 NSString *const AROptionsShowMartsyOnScreen = @"AROptionsShowMartsyOnScreen";
+
+// UX changes
 NSString *const AROptionsDisableNativeLiveAuctions = @"Disable Native Live Auctions";
+NSString *const AROptionsDebugARVIR = @"Debug AR View in Room";
+NSString *const AROptionsHideBackButtonOnScroll = @"Hide the Back Button in Zoom image";
+
+// RN
 NSString *const AROptionsStagingReactEnv = @"Use Staging React ENV";
 NSString *const AROptionsDevReactEnv = @"Use Dev React ENV";
-NSString *const AROptionsDebugARVIR = @"Debug AR View in Room";
-NSString *const AROptionsForceBuyNow = @"Enable Buy Now Flow";
-NSString *const AROptionsHideBackButtonOnScroll = @"Hide the Back Button in Zoom image";
+
+// Dev
+NSString *const AROptionsUseVCR = @"Use offline recording";
+NSString *const AROptionsSettingsMenu = @"Enable user settings";
+
+// Replicating the options in Emission
+// See: https://github.com/artsy/emission/blob/master/Example/Emission/ARLabOptions.m
+NSString *const AROptionsForceBuyNow = @"enableBuyNowMakeOffer";
+
+// The case change
 
 @implementation AROptions
 
++ (void)initialize
+{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        options = @{
+         AROptionsSettingsMenu: @"Enable user settings",
+         AROptionsShowAnalyticsOnScreen: @"Show on-screen analytics",
+         AROptionsShowMartsyOnScreen: @"Show when on a Martsy page",
+         AROptionsDisableNativeLiveAuctions: @"Disable Native Live Auctions",
+         AROptionsDebugARVIR: @"Debug AR View in Room",
+         AROptionsForceBuyNow: @"Enable Buy Now Flow",
+         AROptionsHideBackButtonOnScroll: @"Hide the Back Button in Zoom image",
+         AROptionsStagingReactEnv: @"Use Staging React ENV",
+         AROptionsDevReactEnv: @"Use Dev React ENV",
+         AROptionsLoadingScreenAlpha: @"Loading screens are transparent",
+         AROptionsUseVCR: @"Use offline recording",
+        };
+    });
+}
+
 + (NSArray *)labsOptions
 {
-    return @[
-        AROptionsUseVCR,
-        AROptionsSettingsMenu,
-        AROptionsTappingPartnerSendsToPartner,
-        AROptionsDisableNativeLiveAuctions,
-        
-        AROptionsDebugARVIR,
-        AROptionsForceBuyNow,
-        AROptionsHideBackButtonOnScroll
-    ];
+    return options.allKeys;
+}
+
++ (NSString *)descriptionForOption:(NSString *)option
+{
+    return options[option];
+}
+
++ (NSDictionary *)labOptionsMap
+{
+    NSArray *options = [self labsOptions];
+    NSMutableDictionary *mutableOptions = [NSMutableDictionary dictionary];
+    
+    for (NSString *option in options) {
+        [mutableOptions setObject:@([self boolForOption:option]) forKey:option];
+    }
+    return [mutableOptions copy];
 }
 
 + (NSArray *)labsOptionsThatRequireRestart
 {
     return @[
         AROptionsDisableNativeLiveAuctions,
+        AROptionsForceBuyNow
     ];
 }
 

--- a/Artsy/App/AROptions.m
+++ b/Artsy/App/AROptions.m
@@ -2,6 +2,7 @@
 
 static NSDictionary *options = nil;
 
+// Up here is the NSUserDefault set, and sent into Emission
 
 // UI Tweaks
 NSString *const AROptionsLoadingScreenAlpha = @"Loading screens are transparent";
@@ -19,32 +20,29 @@ NSString *const AROptionsDevReactEnv = @"Use Dev React ENV";
 
 // Dev
 NSString *const AROptionsUseVCR = @"Use offline recording";
-NSString *const AROptionsSettingsMenu = @"Enable user settings";
 
-// Replicating the options in Emission
+// These variables may need to replicate the options in Emission
 // See: https://github.com/artsy/emission/blob/master/Example/Emission/ARLabOptions.m
-NSString *const AROptionsForceBuyNow = @"enableBuyNowMakeOffer";
-
-// The case change
+NSString *const AROptionsForceBuyNow = @"Enable Buy Now Flow via Force";
+NSString *const AROptionsBuyNow = @"enableBuyNowMakeOffer";
 
 @implementation AROptions
+
+// Down here is the user-facing description
 
 + (void)initialize
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         options = @{
-         AROptionsSettingsMenu: @"Enable user settings",
-         AROptionsShowAnalyticsOnScreen: @"Show on-screen analytics",
-         AROptionsShowMartsyOnScreen: @"Show when on a Martsy page",
          AROptionsDisableNativeLiveAuctions: @"Disable Native Live Auctions",
          AROptionsDebugARVIR: @"Debug AR View in Room",
-         AROptionsForceBuyNow: @"Enable Buy Now Flow",
+         
+         AROptionsBuyNow: @"Enable Eigen/Emission Buy Now integration",
+         AROptionsForceBuyNow: @"Enable Buy Now purchase flow via Force",
          AROptionsHideBackButtonOnScroll: @"Hide the Back Button in Zoom image",
-         AROptionsStagingReactEnv: @"Use Staging React ENV",
-         AROptionsDevReactEnv: @"Use Dev React ENV",
+         
          AROptionsLoadingScreenAlpha: @"Loading screens are transparent",
-         AROptionsUseVCR: @"Use offline recording",
         };
     });
 }

--- a/Artsy/App/ArtsyEcho.h
+++ b/Artsy/App/ArtsyEcho.h
@@ -3,5 +3,6 @@
 @interface ArtsyEcho: Aerodramus
 
 - (instancetype)init;
+- (NSDictionary *)featuresMap;
 
 @end

--- a/Artsy/App/ArtsyEcho.m
+++ b/Artsy/App/ArtsyEcho.m
@@ -6,7 +6,8 @@
 
 @implementation ArtsyEcho
 
-- (instancetype)init {
+- (instancetype)init
+{
     ArtsyKeys *keys = [ArtsyKeys new];
     NSURL *url = [[NSURL alloc] initWithString:@"https://echo-api-production.herokuapp.com/"];
     self = [self initWithServerURL:url accountID:1 APIKey:[keys artsyEchoProductionToken] localFilename:@"Echo"];
@@ -24,6 +25,15 @@
             [super checkForUpdates:updateCheckCompleted];
         }
     }
+}
+
+- (NSDictionary *)featuresMap
+{
+    NSMutableDictionary *mutableOptions = [NSMutableDictionary dictionary];
+    for (NSString *key in self.features) {
+        [mutableOptions setObject:@(self.features[key].state) forKey:key];
+    }
+    return [mutableOptions copy];
 }
 
 @end

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.2.2</string>
+	<string>4.3.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
+++ b/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
@@ -55,7 +55,6 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
     ]];
     [tableViewData addSectionData:userSectionData];
 
-
     ARSectionData *launcherSections = [[ARSectionData alloc] initWithCellDataArray:@[
         [self generateOnboarding],
         [self generateShowAllLiveAuctions],
@@ -63,7 +62,8 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
         [self showSentryBreadcrumbs],
         [self generateQuicksilver],
         [self generateEchoContents],
-   ]];
+    ]];
+
     launcherSections.headerTitle = @"Launcher";
     [tableViewData addSectionData:launcherSections];
 
@@ -387,38 +387,38 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
     return cellData;
 }
 
-
 - (ARSectionData *)createLabsSection
 {
     ARSectionData *labsSectionData = [[ARSectionData alloc] init];
     labsSectionData.headerTitle = @"Labs";
-
+    
     NSArray *options = [AROptions labsOptions];
     for (NSInteger index = 0; index < options.count; index++) {
-        NSString *title = options[index];
+        NSString *key = options[index];
+        NSString *title = [AROptions descriptionForOption:key];
         BOOL requiresRestart = [[AROptions labsOptionsThatRequireRestart] indexOfObject:title] != NSNotFound;
-
+        
         ARCellData *cellData = [[ARCellData alloc] initWithIdentifier:ARLabOptionCell];
         [cellData setCellConfigurationBlock:^(UITableViewCell *cell) {
             cell.textLabel.text = requiresRestart ? [title stringByAppendingString:@" (restarts)"] : title;
-            cell.accessoryView = [[ARAnimatedTickView alloc] initWithSelection:[AROptions boolForOption:title]];
+            cell.accessoryView = [[ARAnimatedTickView alloc] initWithSelection:[AROptions boolForOption:key]];
         }];
-
+        
         [cellData setCellSelectionBlock:^(UITableView *tableView, NSIndexPath *indexPath) {
-            BOOL currentSelection = [AROptions boolForOption:title];
-            [AROptions setBool:!currentSelection forOption:title];
-
+            BOOL currentSelection = [AROptions boolForOption:key];
+            [AROptions setBool:!currentSelection forOption:key];
+            
             if (requiresRestart) {
                 // Show checkmark.
-                ar_dispatch_after(1, ^{
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
                     exit(0);
                 });
             }
-
+            
             UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
             [(ARAnimatedTickView *)cell.accessoryView setSelected:!currentSelection animated:YES];
         }];
-
+        
         [labsSectionData addCellData:cellData];
     }
     return labsSectionData;

--- a/Artsy/Views/Table_View_Cells/Feed_Items/Modern/ARModernPartnerShowTableViewCell.m
+++ b/Artsy/Views/Table_View_Cells/Feed_Items/Modern/ARModernPartnerShowTableViewCell.m
@@ -205,13 +205,7 @@ static CGFloat ARPartnerShowCellSideMargin;
 
 - (void)openPartner:(UITapGestureRecognizer *)gesture
 {
-    if ([AROptions boolForOption:AROptionsTappingPartnerSendsToPartner]) {
-        UIViewController *viewController = [ARSwitchBoard.sharedInstance loadPartnerWithID:self.show.partner.partnerID];
-        [self.delegate modernPartnerShowTableViewCell:self shouldShowViewController:(id)viewController];
-
-    } else {
-        [self openShow:gesture];
-    }
+    [self openShow:gesture];
 }
 
 #pragma mark - AREmbeddedModelsViewControllerDelegate

--- a/Artsy_Tests/Supporting_Files/ARTestHelper.m
+++ b/Artsy_Tests/Supporting_Files/ARTestHelper.m
@@ -68,7 +68,8 @@
                                                                            gravityURL:gravity
                                                                        metaphysicsURL:metaphysics
                                                                         predictionURL:@""
-                                                                            userAgent:@"Eigen Tests"];
+                                                                            userAgent:@"Eigen Tests"
+                                                                              options:@{}];
 
     AREmission *emission = [[AREmission alloc] initWithConfiguration:config packagerURL:nil];
     [AREmission setSharedInstance:emission];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,19 +1,28 @@
 upcoming:
-  version: 4.2.2
+  version: 4.3.0
   date: TBA
-  emission_version: 1.5.15
+  emission_version: 1.6.x
   dev:
-    - Fixes a bug where LAI's register button would invoke the BidFlow UI, which caused a crash - ash
-    - Updated echo configuration, checks for AREnableBuyNowFlow feature - ash
-    - Remove the native Artist ViewController - orta
-    - Updates the mutation name to use the ecommerce prefix - orta
-    - Updates mutation result reference to use new prefix - ash
-    - Fixes a problem with order creation input - ash
+    - Updates Emission - ash
 
   user_facing:
-    - Updates error messaging for Buy Now mutation failures. - ash
+    - None yet
 
 releases:
+  - version: 4.2.2
+    date: Sep 17, 2018
+    emission_version: 1.5.15
+    dev:
+      - Fixes a bug where LAI's register button would invoke the BidFlow UI, which caused a crash - ash
+      - Updated echo configuration, checks for AREnableBuyNowFlow feature - ash
+      - Remove the native Artist ViewController - orta
+      - Updates the mutation name to use the ecommerce prefix - orta
+      - Updates mutation result reference to use new prefix - ash
+      - Fixes a problem with order creation input - ash
+
+    user_facing:
+      - Updates error messaging for Buy Now mutation failur
+
   - version: 4.2.1
     date: July 23, 2018
     emission_version: 1.5.15

--- a/Podfile
+++ b/Podfile
@@ -84,7 +84,7 @@ target 'Artsy' do
   pod 'Artsy+UILabels'
   pod 'Extraction'
 
-  pod 'Emission', '~> 1.5.0'
+  pod 'Emission', '~> 1.6.0'
   pod 'yoga', :podspec => "https://raw.githubusercontent.com/artsy/emission/v1.5.2/externals/yoga/yoga.podspec.json"
   pod 'React/Core'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -72,7 +72,7 @@ PODS:
   - DHCShakeNotifier (0.2.0)
   - DoubleConversion (1.1.5)
   - EDColor (1.0.0)
-  - Emission (1.5.15):
+  - Emission (1.6.0):
     - "Artsy+UIColors"
     - "Artsy+UIFonts (>= 3.0.0)"
     - DoubleConversion (= 1.1.5)
@@ -261,7 +261,7 @@ DEPENDENCIES:
   - CocoaLumberjack (from `https://github.com/CocoaLumberjack/CocoaLumberjack.git`)
   - DHCShakeNotifier
   - EDColor
-  - Emission (~> 1.5.0)
+  - Emission (~> 1.6.0)
   - Expecta
   - "Expecta+Snapshots"
   - Extraction
@@ -465,7 +465,7 @@ SPEC CHECKSUMS:
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
-  Emission: e629bdc59d0324c482fc5337cc106c93b5cf4720
+  Emission: 18b92a14e6674f90c0fa1bdb0423a0c871940a0f
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   "Expecta+Snapshots": c343f410c7a6392f3e22e78f94c44b6c0749a516
   Extraction: 642a73b8ccc7806e9a7daf95ebb4c14c374829f1
@@ -519,6 +519,6 @@ SPEC CHECKSUMS:
   "XCTest+OHHTTPStubSuiteCleanUp": 4469ec8863c6bc022c5089a9b94233eb3416c5ee
   yoga: de8782b10b9fdede33554bcad8a2a6653e0ebb30
 
-PODFILE CHECKSUM: 39d5804f58ce2880baa73b760bafd252b01b0248
+PODFILE CHECKSUM: b6f9632ca77cba76b8afa177254e7cdc1fbe00eb
 
 COCOAPODS: 1.6.0.beta.1


### PR DESCRIPTION
Updates us the latest build of Emission.

The latest build of Emission includes a change to the `AREmission` host API  https://github.com/artsy/emission/pull/1184 to include an options dictionary. This PR takes all the options that we use (from Echo and from the Admin) and passes them into Emission so that people can make feature flags etc in React Native code.