### PR TITLE
Consolidates the options for buy now into one flag from echo

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -105,14 +105,21 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
         stripePublishableKey = keys.stripeProductionPublishableKey;
     }
 
-    // Pass lab options into Emission
+    // Set up all the difference places we get settings to merge into one place
     NSMutableDictionary *options = [NSMutableDictionary dictionary];
-    [options addEntriesFromDictionary:[AROptions labOptionsMap]];
-    
-    // Also pass echo features
+
+    // Grab echo features and make that the base of all options
     ArtsyEcho *aero = [[ArtsyEcho alloc] init];
     [aero setup];
-    [options addEntriesFromDictionary:[aero featuresMap]];
+    NSDictionary *features = [aero featuresMap];
+    [options addEntriesFromDictionary:features];
+
+    // Handle the fact that it's "AREnableBuyNowFlow" in iOS world - and echo, then "enableBuyNowMakeOffer" in Emission world
+    options[AROptionsBuyNow] = features[@"AREnableBuyNowFlow"];
+
+    // Lab options come last (as they are admin/dev controlled, giving them a chance to override)
+    [options addEntriesFromDictionary:[AROptions labOptionsMap]];
+
 
     AREmissionConfiguration *config = [[AREmissionConfiguration alloc] initWithUserID:userID
                                                                       authenticationToken:authenticationToken

--- a/Artsy/App/AROptions.h
+++ b/Artsy/App/AROptions.h
@@ -12,6 +12,7 @@ extern NSString *const AROptionsStagingReactEnv;
 extern NSString *const AROptionsDevReactEnv;
 extern NSString *const AROptionsDebugARVIR;
 extern NSString *const AROptionsForceBuyNow;
+extern NSString *const AROptionsBuyNow;
 extern NSString *const AROptionsHideBackButtonOnScroll;
 
 @interface AROptions : NSObject

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
   emission_version: 1.6.x
   dev:
     - Updates Emission - ash
+    - The Echo config for buy now also triggers buy now code in Emission - orta
     - Uses metaphysics for the ArtworkVC's Artwork update API - orta
 
   user_facing:


### PR DESCRIPTION
This means when we turn on Buy Now via Echo the changes in Emission should also receive those settings, we chatted about we chatted about this [in slack](https://artsy.slack.com/archives/C02BAQ5K7/p1538602434000100)