### PR TITLE
Remove the pop on zoom out feature of the ARZoomView

### DIFF
--- a/Artsy/Views/Utilities/Image/ARZoomView.m
+++ b/Artsy/Views/Utilities/Image/ARZoomView.m
@@ -155,12 +155,6 @@ static const CGFloat ARZoomMultiplierForDoubleTap = 1.5;
     //so the background view doesnt show over the edges
     _backgroundView.frame = _zoomableView.frame;
     [self.zoomDelegate zoomViewDidMove:self];
-
-    //close if the zoom goes below minimumZoomScale
-    CGFloat fullScreenScale = [self scaleForFullScreenZoomInSize:self.frame.size];
-    if (self.zoomScale < (fullScreenScale * .95)) {
-        [self.zoomDelegate zoomViewFinished:self];
-    }
 }
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -12,6 +12,7 @@ upcoming:
 
   user_facing:
     - Fixes to the status bar in an inquiry - orta
+    - The zoomed in artwork image won't accidentally close - orta
 
 releases:
   - version: 4.2.2


### PR DESCRIPTION
I think iOS 12's safe area insets screw around with zoom settings in our zoom view. This makes the zooming unpredictable in that it could accidentally pop you out the moment you move anything. I've removed the pop.