### PR TITLE
Turns on "hide the backbutton after a delay" as default

### DIFF
--- a/Artsy/App/AROptions.h
+++ b/Artsy/App/AROptions.h
@@ -13,7 +13,6 @@ extern NSString *const AROptionsDevReactEnv;
 extern NSString *const AROptionsDebugARVIR;
 extern NSString *const AROptionsForceBuyNow;
 extern NSString *const AROptionsBuyNow;
-extern NSString *const AROptionsHideBackButtonOnScroll;
 
 @interface AROptions : NSObject
 

--- a/Artsy/App/AROptions.m
+++ b/Artsy/App/AROptions.m
@@ -12,7 +12,6 @@ NSString *const AROptionsShowMartsyOnScreen = @"AROptionsShowMartsyOnScreen";
 // UX changes
 NSString *const AROptionsDisableNativeLiveAuctions = @"Disable Native Live Auctions";
 NSString *const AROptionsDebugARVIR = @"Debug AR View in Room";
-NSString *const AROptionsHideBackButtonOnScroll = @"Hide the Back Button in Zoom image";
 
 // RN
 NSString *const AROptionsStagingReactEnv = @"Use Staging React ENV";
@@ -40,7 +39,6 @@ NSString *const AROptionsBuyNow = @"enableBuyNowMakeOffer";
          
          AROptionsBuyNow: @"Enable Eigen/Emission Buy Now integration",
          AROptionsForceBuyNow: @"Enable Buy Now purchase flow via Force",
-         AROptionsHideBackButtonOnScroll: @"Hide the Back Button in Zoom image",
          
          AROptionsLoadingScreenAlpha: @"Loading screens are transparent",
         };

--- a/Artsy/View_Controllers/Artwork/ARZoomArtworkImageViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARZoomArtworkImageViewController.m
@@ -110,11 +110,9 @@
 
 - (void)zoomViewDidMove:(ARZoomView *)zoomView
 {
-    if ([AROptions boolForOption:AROptionsHideBackButtonOnScroll]) {
-        [self showBackButton];
-        [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(hideBackButton) object:nil];
-        [self performSelector:@selector(hideBackButton) withObject:nil afterDelay:3];
-    }
+    [self showBackButton];
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(hideBackButton) object:nil];
+    [self performSelector:@selector(hideBackButton) withObject:nil afterDelay:2.5];
 }
 
 - (void)hideBackButton

--- a/Artsy/Views/Utilities/Image/ARZoomView.m
+++ b/Artsy/Views/Utilities/Image/ARZoomView.m
@@ -155,12 +155,6 @@ static const CGFloat ARZoomMultiplierForDoubleTap = 1.5;
     //so the background view doesnt show over the edges
     _backgroundView.frame = _zoomableView.frame;
     [self.zoomDelegate zoomViewDidMove:self];
-
-    //close if the zoom goes below minimumZoomScale
-    CGFloat fullScreenScale = [self scaleForFullScreenZoomInSize:self.frame.size];
-    if (self.zoomScale < (fullScreenScale * .95)) {
-        [self.zoomDelegate zoomViewFinished:self];
-    }
 }
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -12,6 +12,7 @@ upcoming:
 
   user_facing:
     - Fixes to the status bar in an inquiry - orta
+    - The zoomed in artwork image won't accidentally close - orta
 
 releases:
   - version: 4.2.2

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -14,6 +14,8 @@ upcoming:
     - Fixes to the status bar in an inquiry - orta
     - The zoomed in artwork image won't accidentally close - orta
     - Auction lots show multiple artistsin live - orta
+    - If you wait on an Artwork zoom view, the back button is hidden - orta
+    - When zooming into an artwork you can wait 2 seconds and the back button will disappear - orta
 
 releases:
   - version: 4.2.2


### PR DESCRIPTION
Also includes #2703 

I've had this as a lab option for a while, had a chat with Stephen a few weeks back and he reminded me today that we agreed to make this default.

![zoom 2018-10-10 14_47_06](https://user-images.githubusercontent.com/49038/46758652-5f8eee80-cc9b-11e8-9d53-bd98b3f32ffc.gif)
