### PR TITLE
Handle links that come through the FB app in an unusual format

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -15,6 +15,7 @@ upcoming:
     - Shows the edition info on an artwork screen - orta
     - The zoomed in artwork image won't accidentally close - orta
     - Auction lots show multiple artistsin live - orta
+    - Fixes to loading Facebook links coming from the FB app - orta
 
 releases:
   - version: 4.2.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -118,9 +118,9 @@ PODS:
   - "Extraction/UILabel+Typography (1.2.4)"
   - "Extraction/UIView+ARSpinner (1.2.4)":
     - Extraction/ARAnimationContinuation
-  - FBSDKCoreKit (4.33.0):
+  - FBSDKCoreKit (4.37.0):
     - Bolts (~> 1.7)
-  - FBSDKLoginKit (4.33.0):
+  - FBSDKLoginKit (4.37.0):
     - FBSDKCoreKit
   - FBSnapshotTestCase (2.1.4):
     - FBSnapshotTestCase/SwiftSupport (= 2.1.4)
@@ -469,8 +469,8 @@ SPEC CHECKSUMS:
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   "Expecta+Snapshots": c343f410c7a6392f3e22e78f94c44b6c0749a516
   Extraction: 642a73b8ccc7806e9a7daf95ebb4c14c374829f1
-  FBSDKCoreKit: 572b047a7e029bc44542bcf8a59414e7ff2b543e
-  FBSDKLoginKit: 88cb456349cfb3b554427ce4f8b43729d85dfb40
+  FBSDKCoreKit: fe5f3474499a81963e11e3f3a5c753d0a95ca2b4
+  FBSDKLoginKit: 2f7249686d1e30ce8a5ef5400eedf50b3e3df332
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   FLKAutoLayout: 106b14dbae09d32c6730190f4e78a959759ba4a4
   Folly: 211775e49d8da0ca658aebc8eab89d642935755c


### PR DESCRIPTION
OK, so I went through getting started docs and I'm alright with saying this is just how they send URLs to us occasionally. I verified that it doesn't break FB auth in the app.