### PR TITLE
Migrates Adjust to use universal links instead of deep links

### DIFF
--- a/Artsy/App/ARAppActivityContinuationDelegate.m
+++ b/Artsy/App/ARAppActivityContinuationDelegate.m
@@ -6,6 +6,7 @@
 #import "ARTopMenuViewController.h"
 #import "ArtsyAPI.h"
 #import "ArtsyAPI+Sailthru.h"
+#import <Adjust/Adjust.h>
 
 #import <CoreSpotlight/CoreSpotlight.h>
 
@@ -34,6 +35,8 @@ static  NSString *SailthruLinkDomain = @"link.artsy.net";
 
     if ([[ARUserManager sharedManager] hasExistingAccount]) {
         DecodeURL(URL, ^(NSURL *decodedURL) {
+//            [Adjust appWillOpenUrl:decodedURL];
+
             [[ARAppDelegate sharedInstance] lookAtURLForAnalytics:decodedURL];
             UIViewController *viewController = [ARSwitchBoard.sharedInstance loadURL:decodedURL];
             if (viewController) {

--- a/Artsy/App_Resources/Artsy.entitlements
+++ b/Artsy/App_Resources/Artsy.entitlements
@@ -19,6 +19,7 @@
 		<string>webcredentials:www.artsy.net</string>
 		<string>webcredentials:staging.artsy.net</string>
 		<string>webcredentials:m.artsy.net</string>
+		<string>applinks:kqwq.adj.st</string>
 	</array>
 	<key>keychain-access-groups</key>
 	<array>

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Adjust (4.13.0):
-    - Adjust/Core (= 4.13.0)
-  - Adjust/Core (4.13.0)
+  - Adjust (4.15.0):
+    - Adjust/Core (= 4.15.0)
+  - Adjust/Core (4.15.0)
   - Aerodramus (0.3.2):
     - ISO8601DateFormatter
   - AFNetworkActivityLogger (2.0.4):
@@ -445,7 +445,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/tipsi/tipsi-stripe.git
 
 SPEC CHECKSUMS:
-  Adjust: 8f204c1005d6635e7c931c6a2cb2f881965bf478
+  Adjust: 30d2cf13dad1a8ba08cf5082d312a26b21da3f29
   Aerodramus: a23208fd4d76a32ee4ca425a8e29319e6c6a9bdc
   AFNetworkActivityLogger: 121486778117d53b3ab1c61d264b88081d0c3eee
   AFNetworking: 05edc0ac4c4c8cf57bcf4b84be5b0744b6d8e71e


### PR DESCRIPTION
This is the new recommendation from Adjust, so it seems like a good time to give it a shot. I've verified that links like https://kqwq.adj.st/?adjust_t=esa8xn would correctly open Eigen and seen in the logs that Adjust has reported the link.