### PR TITLE
Re-enables the safari web keychain, and only shows it on the 3rd launch

### DIFF
--- a/Artsy/App/ARAppDelegate.m
+++ b/Artsy/App/ARAppDelegate.m
@@ -346,7 +346,7 @@ static ARAppDelegate *_sharedInstance = nil;
   sourceApplication:(NSString *)sourceApplication
          annotation:(id)annotation
 {
-    return [self application:application openURL:url options:@{
+    return [self application:application openURL:url options: @{
         UIApplicationOpenURLOptionsSourceApplicationKey: sourceApplication ?: @"",
         UIApplicationOpenURLOptionsAnnotationKey: annotation  ?: @""
     }];
@@ -469,6 +469,10 @@ static ARAppDelegate *_sharedInstance = nil;
     if (numberOfRuns == 1) {
         [ARAnalytics event:ARAnalyticsFreshInstall];
         [Adjust trackEvent:[ADJEvent eventWithEventToken:ARAdjustFirstUserInstall]];
+    }
+
+    if (numberOfRuns == 3) {
+        [[ARUserManager sharedManager] tryStoreSavedCredentialsToWebKeychain];
     }
 
     [[NSUserDefaults standardUserDefaults] setInteger:numberOfRuns forKey:ARAnalyticsAppUsageCountProperty];

--- a/Artsy/Networking/API_Modules/ARUserManager.h
+++ b/Artsy/Networking/API_Modules/ARUserManager.h
@@ -33,6 +33,7 @@ extern NSString *const ARUserSessionStartedNotification;
 - (void)tryReLoginWithKeychainCredentials:(void (^)(User *currentUser))success authenticationFailure:(void (^)(NSError *error))authError;
 
 - (void)disableSharedWebCredentials;
+- (void)tryStoreSavedCredentialsToWebKeychain;
 - (void)tryLoginWithSharedWebCredentials:(void (^)(NSError *error))completion;
 
 - (void)loginWithUsername:(NSString *)username

--- a/Artsy/Networking/API_Modules/ARUserManager.m
+++ b/Artsy/Networking/API_Modules/ARUserManager.m
@@ -548,6 +548,19 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
     ARUserManagerDisableSharedWebCredentials = YES;
 }
 
+- (void)tryStoreSavedCredentialsToWebKeychain
+{
+    NSString *email = [self.keychain keychainStringForKey:ARUsernameKeychainKey];
+    NSString *password = [self.keychain keychainStringForKey:ARPasswordKeychainKey];
+
+    if (!email || !password) {
+        NSLog(@"Skipping saving credentials to safari keychain because username or password is missing");
+        return;
+    }
+
+    [self saveSharedWebCredentialsWithEmail:email password:password];
+}
+
 - (void)saveSharedWebCredentialsWithEmail:(NSString *)email
                                  password:(NSString *)password;
 {

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -19,6 +19,8 @@ upcoming:
     - Fixes to loading Facebook links coming from the FB app - orta
     - If you wait on an Artwork zoom view, the back button is hidden - orta
     - When zooming into an artwork you can wait 2 seconds and the back button will disappear - orta
+    - Adds a 5s timeout to the shared web credentials - orta
+    - Re-enables saving email/pass to safari's keychain on the 3rd app launch - orta
 
 releases:
   - version: 4.2.2


### PR DESCRIPTION
Now that we store the email/password we can try save the creds at a later stage than just onboarding. This adds it on the third run.