### PR TITLE
Fixes problem with attribution classes from Gravity

### DIFF
--- a/Artsy/Models/API_Models/Partner_Metadata/Artwork.m
+++ b/Artsy/Models/API_Models/Partner_Metadata/Artwork.m
@@ -41,6 +41,9 @@
 @property (nonatomic, strong) NSNumber *gravIsInquireable;
 @property (nonatomic, strong) NSNumber *mpIsInquirable;
 
+@property (nonatomic, strong) NSString *gravAttributionClass;
+@property (nonatomic, strong) NSString *mpAttributionClass;
+
 @end
 
 @implementation Artwork {
@@ -81,7 +84,8 @@
         ar_keypath(Artwork.new, additionalInfo) : @"additional_information",
         ar_keypath(Artwork.new, dimensionsCM) : @"dimensions.cm",
         ar_keypath(Artwork.new, dimensionsInches) : @"dimensions.in",
-        ar_keypath(Artwork.new, attributionClass) : @"attribution_class.name",
+        ar_keypath(Artwork.new, mpAttributionClass) : @"mp_attribution_class.name",
+        ar_keypath(Artwork.new, gravAttributionClass) : @"attribution_class",
         
         ar_keypath(Artwork.new, editionSets) : @"edition_sets",
         ar_keypath(Artwork.new, editionOf) : @"edition_of",
@@ -273,6 +277,11 @@
 - (NSNumber *)isAcquireable
 {
     return self.gravIsAcquirable.boolValue ? self.gravIsAcquirable : self.mpIsAcquirable;
+}
+
+- (NSString *)attributionClass
+{
+    return self.gravAttributionClass ?: self.mpAttributionClass;
 }
 
 - (BOOL)hasWidth

--- a/Artsy/Networking/artwork.graphql
+++ b/Artsy/Networking/artwork.graphql
@@ -46,7 +46,7 @@ query OldArtworkQuery($artworkID: String!) {
       in
     }
 
-    attribution_class {
+    mp_attribution_class {
       name
     }
     

--- a/Artsy/Networking/artwork.graphql
+++ b/Artsy/Networking/artwork.graphql
@@ -2,7 +2,7 @@ query OldArtworkQuery($artworkID: String!) {
   artwork(id: $artworkID) {
     id
     _id
- 
+
     artist {
       id
       _id
@@ -46,10 +46,10 @@ query OldArtworkQuery($artworkID: String!) {
       in
     }
 
-    mp_attribution_class {
+    mp_attribution_class: attribution_class {
       name
     }
-    
+
     edition_sets {
       id
       sale_message

--- a/Artsy_Tests/Model_Tests/ArtworkAttributionClassTests.m
+++ b/Artsy_Tests/Model_Tests/ArtworkAttributionClassTests.m
@@ -4,7 +4,7 @@ SpecBegin(ArtworkAttributionClass);
 
 describe(@"shortDescriptionForAttributionClass", ^{
     it(@"returns the correct short description for a given attribution class", ^{
-        Artwork *artwork = [Artwork modelWithJSON:@{ @"id" : @"artwork-id", @"attribution_class" : @{ @"name": @"ephemera" } }];
+        Artwork *artwork = [Artwork modelWithJSON:@{ @"id" : @"artwork-id", @"mp_attribution_class" : @{ @"name": @"ephemera" } }];
         expect(artwork.shortDescriptionForAttributionClass).to.equal(@"This is ephemera, an artifact related to the artist.");
     });
 
@@ -14,7 +14,7 @@ describe(@"shortDescriptionForAttributionClass", ^{
     });
 
     it(@"ignores nil attribution class", ^{
-        Artwork *artwork = [Artwork modelWithJSON:@{ @"id" : @"artwork-id", @"attribution_class" : [NSNull null] }];
+        Artwork *artwork = [Artwork modelWithJSON:@{ @"id" : @"artwork-id", @"mp_attribution_class" : [NSNull null] }];
         expect(artwork.shortDescriptionForAttributionClass).to.beNil();
     });
 });

--- a/Artsy_Tests/Model_Tests/ArtworkTests.m
+++ b/Artsy_Tests/Model_Tests/ArtworkTests.m
@@ -113,13 +113,17 @@ describe(@"defaultImage", ^{
                 @"is_sold": @(YES),
                 @"is_acquireable": @(YES),
                 @"is_inquireable": @(YES),
-                @"is_price_hidden": @(YES)
+                @"is_price_hidden": @(YES),
+                @"mp_attribution_class": @{
+                    @"name": @"classy class"
+                }
             }];
 
             expect(artwork.sold).to.beTruthy();
             expect(artwork.isAcquireable).to.beTruthy();
             expect(artwork.isInquireable).to.beTruthy();
             expect(artwork.isPriceHidden).to.beTruthy();
+            expect(artwork.attributionClass).to.equal(@"classy class");
         });
         
         it(@"deals with gravity style results for the is_* things", ^{
@@ -128,13 +132,15 @@ describe(@"defaultImage", ^{
                 @"sold": @(YES),
                 @"acquireable": @(YES),
                 @"inquireable": @(YES),
-                @"price_hidden": @(YES)
+                @"price_hidden": @(YES),
+                @"attribution_class": @"classy class"
             }];
             
             expect(artwork.sold).to.beTruthy();
             expect(artwork.isAcquireable).to.beTruthy();
             expect(artwork.isInquireable).to.beTruthy();
             expect(artwork.isPriceHidden).to.beTruthy();
+            expect(artwork.attributionClass).to.equal(@"classy class");
         });
         
     });

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -7,7 +7,7 @@ upcoming:
     - Improvements to BNMO analytics - orta
 
   user_facing:
-    - Nothing yet
+    - Fixes missing artworks in auction views - ash
 
 releases:
   - version: 4.3.0


### PR DESCRIPTION
This PR is to remedy [an ongoing incident](https://trello.com/c/UTDSwXwm/181-ios-app-not-showing-lots-in-auction-views).

[Recent changes](https://github.com/artsy/eigen/pull/2688) to the artwork modelling were deployed today, causing a long series of events that led users to see the auction view with few or zero lots. Only artworks with no attribution class were visible.

tl;dr

- We changed the JSON Mantle mapping for `attributionClass` to be `attributionClass.name`, since it's nested in Metaphysics.
- However, Gravity models don't return that nesting. When Mantle calls `valueForKeyPath` with `attribution_class.name` on Gravity models, it has an `NSString` for the `attribution_class` key path, but string is not key value coding compliant for the `name` key, so [this](https://github.com/Mantle/Mantle/blob/e41221ee948e00707bd5651465e1c0d1c3cb2b1a/Mantle/MTLJSONAdapter.m#L166-L180) try/catch re-throws and is later [silently ignored](https://github.com/Mantle/Mantle/blob/e41221ee948e00707bd5651465e1c0d1c3cb2b1a/Mantle/MTLJSONAdapter.m#L211).

The solution was to extend the existing pattern for handling collisions. I had to prefix `attribution_class` with `mp_` since the type are different. 