### PR TITLE
Makes attribution classes case-insensitive

### DIFF
--- a/Artsy/Models/API_Models/Partner_Metadata/Artwork+AttributionClassStrings.m
+++ b/Artsy/Models/API_Models/Partner_Metadata/Artwork+AttributionClassStrings.m
@@ -6,25 +6,25 @@
 
 - (NSString *)shortDescriptionForAttributionClass
 {
-    if ([self.attributionClass isEqualToString:@"unique"]) {
+    if ([self.attributionClass.lowercaseString isEqualToString:@"unique"]) {
         return @"This is a unique work.";
 
-    } else if ([self.attributionClass isEqualToString:@"limited edition"]) {
+    } else if ([self.attributionClass.lowercaseString isEqualToString:@"limited edition"]) {
         return @"This is part of a limited edition set.";
 
-    } else if ([self.attributionClass isEqualToString:@"made-to-order"]) {
+    } else if ([self.attributionClass.lowercaseString isEqualToString:@"made-to-order"]) {
         return @"This is a made-to-order piece.";
 
-    } else if ([self.attributionClass isEqualToString:@"reproduction"]) {
+    } else if ([self.attributionClass.lowercaseString isEqualToString:@"reproduction"]) {
         return @"This work is a reproduction.";
 
-    } else if ([self.attributionClass isEqualToString:@"editioned multiple"]) {
+    } else if ([self.attributionClass.lowercaseString isEqualToString:@"editioned multiple"]) {
         return @"This is an editioned multiple.";
 
-    } else if ([self.attributionClass isEqualToString:@"non-editioned multiple"]) {
+    } else if ([self.attributionClass.lowercaseString isEqualToString:@"non-editioned multiple"]) {
         return @"This is a non-editioned multiple.";
 
-    } else if ([self.attributionClass isEqualToString:@"ephemera"]) {
+    } else if ([self.attributionClass.lowercaseString isEqualToString:@"ephemera"]) {
         return @"This is ephemera, an artifact related to the artist.";
 
     } else {

--- a/Artsy_Tests/Model_Tests/ArtworkAttributionClassTests.m
+++ b/Artsy_Tests/Model_Tests/ArtworkAttributionClassTests.m
@@ -8,6 +8,11 @@ describe(@"shortDescriptionForAttributionClass", ^{
         expect(artwork.shortDescriptionForAttributionClass).to.equal(@"This is ephemera, an artifact related to the artist.");
     });
 
+    it(@"ignores case", ^{
+        Artwork *artwork = [Artwork modelWithJSON:@{ @"id" : @"artwork-id", @"mp_attribution_class" : @{ @"name": @"Ephemera" } }];
+        expect(artwork.shortDescriptionForAttributionClass).to.equal(@"This is ephemera, an artifact related to the artist.");
+    });
+
     it(@"ignores missing attribution class", ^{
         Artwork *artwork = [Artwork modelWithJSON:@{ @"id" : @"artwork-id" }];
         expect(artwork.shortDescriptionForAttributionClass).to.beNil();

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -8,6 +8,7 @@ upcoming:
 
   user_facing:
     - Fixes missing artworks in auction views - ash
+    - Fixes a problem with attribution classes not displaying - ash
 
 releases:
   - version: 4.3.0


### PR DESCRIPTION
This fixes a bug mentioned here:
https://github.com/artsy/eigen/pull/2716#issuecomment-431046347 It prevents the artwork view from displaying the attribution class information for many (all?) artworks, whose `attribution_class` has a capital letter at the beginning. 