### PR TITLE
Updates changelog for 4.3.1 release.

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.3.1</string>
+	<string>4.3.2</string>
 	<key>CFBundleVersion</key>
 	<string>2018.10.17.10</string>
 	<key>NSExtension</key>

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.3.1</string>
+	<string>4.3.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,16 +1,25 @@
 upcoming:
-  version: 4.3.1
+  version: 4.3.2
   date: TBD
   emission_version: 1.6.x
   dev:
-    - Crash fixes for fairs - ashfurrow
-    - Improvements to BNMO analytics - orta
+    - 
 
   user_facing:
-    - Fixes missing artworks in auction views - ash
-    - Fixes a problem with attribution classes not displaying - ash
+    - 
 
 releases:
+  - version: 4.3.1
+    date: Oct 19, 2018
+    emission_version: 1.6.x
+    dev:
+      - Crash fixes for fairs - ashfurrow
+      - Improvements to BNMO analytics - orta
+
+    user_facing:
+      - Fixes missing artworks in auction views - ash
+      - Fixes a problem with attribution classes not displaying - ash
+
   - version: 4.3.0
     date: Oct 14, 2018
     emission_version: 1.6.x


### PR DESCRIPTION
4.3.1 was just released; this PR gets the changelog ready for 4.3.2, which I've created in iTunesConnect (required for the next beta). 