### PR TITLE
Updates deploy docs

### DIFF
--- a/docs/deploy_to_app_store.md
+++ b/docs/deploy_to_app_store.md
@@ -13,7 +13,9 @@ It takes about 45 minutes for [Circle CI](https://circleci.com/gh/artsy/eigen) t
 
 ### Test the Beta
 
-Before submitting to the App Store, the binary we submit *must* be tested *on-device*. Install the beta through Testflight and run through the following scenarios **on staging**:
+Before submitting to the App Store, the binary we submit *must* be tested *on-device*. Install the beta through Testflight and run through the following two groups of scenarios.
+
+### Staging Tests
 
 - [ ] Review `CHANGELOG.yml` entries for the release and run through any parts of the app that seem appropriate.
 - [ ] Check user registration and onboarding works.
@@ -21,28 +23,41 @@ Before submitting to the App Store, the binary we submit *must* be tested *on-de
   - [ ] Eigen's main tab view controllers (Home, Search, Inbox, and Favourites).
   - [ ] The artwork, artist, and auction view controllers.
   - [ ] Live Auctions interface (Use the `gravity-staging-create-auction-on-demand` Jenkins job to create a sale, it'll take five minute to open before the interface is accessible in Eigen).
-- [ ] As a user with populated favourites, follows, etc, perform a smoke test of: 
-  - [ ] Eigen's main tab view controllers (Home, Search, Inbox, and Favourites).
-  - [ ] The artwork, artist, and auctions view controllers.
-  - [ ] Live Auctions interface (see instructions above).
+- [ ] Open an artwork view.
+  - [ ] for an artwork with an attribute class (aka classification: unique, limited edition, etc). Does it display the classification?
+  - [ ] for an artwork with a description (`blurb` in Gravity). Does it display?
 - [ ] Open a React Native view, then open a modal view controller (LAI interface, inquiry modal), and navigate back to the RN view. Make sure that [the screen isn't blank](https://github.com/artsy/eigen/issues/2439).
-- [ ] Check that the app opens on the Home feed Works For You tab from a Works For You push notification (in gravity staging console, run `NewWorkPushService.notify_user(User.find_by(email: "YOUR_EMAIL@artsymail.com))`).
-  - [ ] When app is running in the background
-  - [ ] When app is completely inactive
 - [ ] Check that the app opens with the correct conversation from a messaging push notification (find the "Invoicing Demo Partner" partner on [Vibrations](https://github.com/artsy/vibrations) staging, publish one one of their artworks, find it in the app, inquire on it as a non-admin, and reply to the conversation from [Volt](https://github.com/artsy/volt) to trigger a push).
   - [ ] When app is running in the background
-  - [ ] When app is completely inactive (note this isn't working, see [this Jira ticket](https://artsyproduct.atlassian.net/browse/EV-164))
 - [ ] After running the conversation push notification test and the conversation tab is populated, smoke test it.
-- [ ] Check that the app opens on the correct artist page from a Safari (or other web browser) link (artsy.net/artist/someone)
-  - [ ] When app is running in the background
-  - [ ] When app is completely inactive
-- [ ] Check that the app opens on the Home feed Works For You tab from a Works For You email (find one in your inbox) (note this is currently not working, [see this Jira ticket](https://artsyproduct.atlassian.net/browse/BUGS-176)).
-  - [ ] When app is running in the background
-  - [ ] When app is completely inactive
 - [ ] Check that the app opens on the correct Auctions home tab when opened from a sale-opening push notification (in gravity staging console, run `NewSalePushService.notify_user(User.find_by(email: "YOUR_EMAIL@artsymail.com").id, Artist.sample(3).map(&:id), 4)`).
   - [ ] When app is running in the background
   - [ ] When app is completely inactive
 
+### Production Tests
+
+- [ ] Open several auctions (Home tab -> Auctions at the top -> pick an auction)
+  - [ ] Do the number of lots in Eigen match the number on the web?
+- [ ] If possible, open the Live Auctions interface while a live auction is ongoing. Does the interface update in response to websocket events?
+- [ ] As a user with populated favourites, follows, etc, perform a smoke test of: 
+  - [ ] Eigen's main tab view controllers (Home, Search, Inbox, and Favourites).
+  - [ ] The artwork, artist, and auctions view controllers.
+- [ ] Check that the app opens on the correct artist page from a Safari (or other web browser) link (artsy.net/artist/someone)
+  - [ ] When app is running in the background
+  - [ ] When app is completely inactive
+
+### Pending Tests
+
+These are tests that currently don't work. Each item here should have a corresponding Jira ticket.
+
+- [ ] Check that the app opens with the correct conversation from a messaging push notification.
+  - [ ] When app is completely inactive ([Jira](https://artsyproduct.atlassian.net/browse/EV-164))
+- [ ] Check that the app opens on the Home feed Works For You tab from a Works For You email (find one in your inbox) ([Jira](https://artsyproduct.atlassian.net/browse/BUGS-176)).
+  - [ ] When app is running in the background
+  - [ ] When app is completely inactive
+- [ ] Check that the app opens on the Home feed Works For You tab from a Works For You push notification (in gravity staging console, run `NewWorkPushService.notify_user(User.find_by(email: "YOUR_EMAIL@artsymail.com"))`) ([Jira](https://artsyproduct.atlassian.net/browse/BUGS-523)).
+  - [ ] When app is running in the background
+  - [ ] When app is completely inactive
 
 It is *critical* that we catch bugs before we submit to the App Store. If a bug gets out, it can take days or weeks for Apple to review any fix. As the submitter, you are the last line of defence – the whole team is counting on you.
 

--- a/docs/deploy_to_app_store.md
+++ b/docs/deploy_to_app_store.md
@@ -74,7 +74,8 @@ It is *critical* that we catch bugs before we submit to the App Store. If a bug 
   * Have you added or made changes to encryption features since your last submission of this app?: *NO*
   * Does your app contain, display, or access third-party content?: *YES*
   * Do you have all necessary rights to that content […]?: *YES*
-  * Does this app use the Advertising Identifier (IDFA)?: *NO*
+  * Does this app use the Advertising Identifier (IDFA)?: *YES*
+    - When asked for the use case of the IDFA, select the second option: "Attribute this app installation to a previously served advertisement"
 
 ## Release to App Store
 

--- a/docs/deploy_to_app_store.md
+++ b/docs/deploy_to_app_store.md
@@ -26,6 +26,7 @@ Before submitting to the App Store, the binary we submit *must* be tested *on-de
 - [ ] Open an artwork view.
   - [ ] for an artwork with an attribute class (aka classification: unique, limited edition, etc). Does it display the classification?
   - [ ] for an artwork with a description (`blurb` in Gravity). Does it display?
+  - [ ] for an artwork with view-in-room enabled. Does view-in-room work? Does AR view-in-room work?
 - [ ] Open a React Native view, then open a modal view controller (LAI interface, inquiry modal), and navigate back to the RN view. Make sure that [the screen isn't blank](https://github.com/artsy/eigen/issues/2439).
 - [ ] Check that the app opens with the correct conversation from a messaging push notification (find the "Invoicing Demo Partner" partner on [Vibrations](https://github.com/artsy/vibrations) staging, publish one one of their artworks, find it in the app, inquire on it as a non-admin, and reply to the conversation from [Volt](https://github.com/artsy/volt) to trigger a push).
   - [ ] When app is running in the background

--- a/docs/deploy_to_app_store.md
+++ b/docs/deploy_to_app_store.md
@@ -1,6 +1,6 @@
-## Deploy to App Store
+# Deploy to App Store
 
-### Pre-deploy Checklist
+## Pre-deploy Checklist
 
 1. Check out Eigen Artsy master.
 1. Ensure all required/expected analytics events are in `CHANGELOG.yml`.
@@ -11,7 +11,7 @@
 
 It takes about 45 minutes for [Circle CI](https://circleci.com/gh/artsy/eigen) to build and submit a binary (and for iTunesConnect to process it). You'll be notified via email (and push notification, if you have the [iTunesConnect iOS app](https://itunes.apple.com/us/app/itunes-connect/id376771144?mt=8) installed.
 
-### Test the Beta
+## Test the Beta
 
 Before submitting to the App Store, the binary we submit *must* be tested *on-device*. Install the beta through Testflight and run through the following two groups of scenarios.
 
@@ -61,7 +61,7 @@ These are tests that currently don't work. Each item here should have a correspo
 
 It is *critical* that we catch bugs before we submit to the App Store. If a bug gets out, it can take days or weeks for Apple to review any fix. As the submitter, you are the last line of defence – the whole team is counting on you.
 
-### Prepare in iTunesConnect
+## Prepare in iTunesConnect
 
 1. You need to have copy for the next release, for minor releases this is just a list of notable changes.
 1. Log in to [iTunesConnect](https://itunesconnect.apple.com) as it@artsymail.com (team _Art.sy Inc_).
@@ -75,7 +75,7 @@ It is *critical* that we catch bugs before we submit to the App Store. If a bug 
   * Do you have all necessary rights to that content […]?: *YES*
   * Does this app use the Advertising Identifier (IDFA)?: *NO*
 
-### Release to App Store
+## Release to App Store
 
 Our App Store releases are done manually, instead of automatically once Apple approves the app. Don't release unless you are available over the next few hours to monitor Sentry for errors.
 
@@ -85,7 +85,7 @@ Our App Store releases are done manually, instead of automatically once Apple ap
 1. Hit "Release this Version" button.
 1. Monitor [Sentry](https://sentry.io/artsynet/eigen/) in the #front-end channel on Slack for any errors (all production errors are sent to Slack when they first occur).
 
-### Prepare for the Next Release
+## Prepare for the Next Release
 
 1. Run `make next`. This runs `pod install` and prompts for the next version number.
 1. Create a new version of the app in iTunesConnect (if you don't do this, beta deployments will fail).


### PR DESCRIPTION
This updates the deploy docs in a few important ways:

- Splits our pre-deploy QA into one of three groups:
  - Tests that need to be run on staging.
  - Tests that need to be run on production.
  - Tests that currently don't work (with Jira links).
- I added a test that would have caught [Eigen's incident last week](https://trello.com/c/UTDSwXwm/181-ios-app-not-showing-lots-in-auction-views)
- I added notes for a recent problem with view-in-room as well.
- Adds note about our use of IDFA.

I also updated the Markdown headers so the page has an `H1`.