### PR TITLE
Fixes view-in-room #trivial

### DIFF
--- a/Artsy/Networking/artwork.graphql
+++ b/Artsy/Networking/artwork.graphql
@@ -87,6 +87,9 @@ query OldArtworkQuery($artworkID: String!) {
     signature
     title
     blurb: description(format: PLAIN)
+    width
+    height
+    metric
   }
 }
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -8,6 +8,7 @@ upcoming:
   user_facing:
     - Includes artwork blurbs again - ash&jon
     - BN changes from Emission - orta/chris/matt
+    - Fixes view-in-room not working - ash
 
 releases:
   - version: 4.3.1


### PR DESCRIPTION
Adds width, height, and metric to Artwork GraphQL query. This PR is a WIP because it requires https://github.com/artsy/metaphysics/pull/1350 to be merged and deployed before it can work.

Fixes [DISCO-438](https://artsyproduct.atlassian.net/browse/DISCO-438).