### PR TITLE
Fixes grey bar left along iPhone X after dismissing modals

### DIFF
--- a/Artsy/View_Controllers/ARSerifNavigationViewController.m
+++ b/Artsy/View_Controllers/ARSerifNavigationViewController.m
@@ -14,6 +14,11 @@
 static CGFloat exitButtonDimension = 40;
 
 @interface ARSerifNavigationBar : UINavigationBar
+
+/// There's a UIKit bug we need to workaround; see implementation for more details.
+/// Only set this to `true` if we're presented the auction view controller (in split view).
+@property (nonatomic, assign) BOOL needsLiveAuctionsBackgroundColorFix;
+
 /// Show/hides the underline from a navigation bar
 - (void)hideNavigationBarShadow:(BOOL)hide;
 @end
@@ -141,6 +146,7 @@ static CGFloat exitButtonDimension = 40;
     }
 
     ARSerifNavigationBar *navBar = (id)self.navigationBar;
+    navBar.needsLiveAuctionsBackgroundColorFix = [NSStringFromClass(viewController.class) containsString:@"LiveAuction"];
 
     if (navigationController.viewControllers.count > 1) {
         nav.leftBarButtonItem = self.backButton;
@@ -242,14 +248,16 @@ static CGFloat exitButtonDimension = 40;
 
     [self nudgeViews:self.topItem.rightBarButtonItems horizontally:10];
 
-    // This is a total hack.
-    // UIKit inserts a view behind us which, when we're presented in the left side of a split view controller,
-    // has a single column pixel visible to our right.
-    [self.superview.superview.subviews each:^(UIView *object) {
-        if ([NSStringFromClass([object class]) isEqualToString:@"UIView"]) {
-            object.backgroundColor = [UIColor artsyGraySemibold];
-        }
-    }];
+    if (self.needsLiveAuctionsBackgroundColorFix) {
+        // This is a total hack.
+        // UIKit inserts a view behind us which, when we're presented in the left side of a split view controller,
+        // has a single column pixel visible to our right.
+        [self.superview.superview.subviews each:^(UIView *object) {
+            if ([NSStringFromClass([object class]) isEqualToString:@"UIView"]) {
+                object.backgroundColor = [UIColor artsyGraySemibold];
+            }
+        }];
+    }
 }
 
 - (void)verticallyCenterView:(id)viewOrArray

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -9,6 +9,7 @@ upcoming:
     - Includes artwork blurbs again - ash&jon
     - BN changes from Emission - orta/chris/matt
     - Fixes view-in-room not working - ash
+    - Fixes grey bar on bottom of screen after modal presentations - ash
 
 releases:
   - version: 4.3.1


### PR DESCRIPTION
I couldn't find this ticketed in Jira, but it's been bugging me lately. In certain contexts (details below), presenting a modal view controller and then dismissing it leaves an ugly grey bar underneath the home screen indicator on iPhone X-style devices:

![img_2714](https://user-images.githubusercontent.com/498212/47523358-d44e5500-d865-11e8-8073-1df590d122f4.png)

This bar persists until the app is restarted.

I took a look into this and found that the app's root view controller (`ARTopMenuViewController`) had a view with a background colour set to grey. Using [KVO](https://nshipster.com/key-value-observing/), I found where this was getting set:

https://github.com/artsy/eigen/blob/c956fee683f14c87c8bd7082d8455d3261b00064/Artsy/View_Controllers/ARSerifNavigationViewController.m#L245-L252

This is a fix we made for LAI so our split view looked correct on iPad. This had the unintended consequence of setting our root view controller's view's background colour to grey whenever we presented a modal view controller with an `ARSerifNavigationBar` for its navigation bar class. I added a new property to the class (`BOOL`s in Objective-C default to `NO`) and set it to match on the class name of the presented view controller. I used `containsString:` instead of `isEqualToString:` because we present two different auction view controllers: `LiveAuctionSaleViewController` (for downloading data) and on `LiveAuctionSaleViewController` (for sales with downloaded data, view models, etc). I felt it safest to capture both.