### PR TITLE
Version bump and type fix

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.3.2</string>
+	<string>4.3.3</string>
 	<key>CFBundleVersion</key>
 	<string>2018.10.19.16</string>
 	<key>NSExtension</key>

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.3.2</string>
+	<string>4.3.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Artsy/View_Controllers/Auction/AuctionNetworkModel.swift
+++ b/Artsy/View_Controllers/Auction/AuctionNetworkModel.swift
@@ -84,11 +84,14 @@ extension AuctionNetworkModel: AuctionNetworkModelType {
                         self.fetchLotStanding(self.saleID)
                     )
                 case .error(let error):
-                    print(error)
-
-                    // FIXME: Update this return value
-                    // return Observable<Any>(Result.error(error), Result.error(error), Result.error(error), Result.error(error), Result.error(error))
-                    fatalError()
+                    print("Error fetching sale: \(error)")
+                    return combine(
+                        Observable(Result.error(error)),
+                        Observable(Result.error(error)),
+                        Observable(Result.error(error)),
+                        Observable(Result.error(error)),
+                        Observable(Result.error(error))
+                    )
                 }
             }
             .flatMap { [weak self] (

--- a/Artsy_Tests/View_Controller_Tests/Auction/AuctionNetworkModelTests.swift
+++ b/Artsy_Tests/View_Controller_Tests/Auction/AuctionNetworkModelTests.swift
@@ -32,6 +32,12 @@ class AuctionNetworkModelSpec: QuickSpec {
             expect(subject.saleID) == saleID
         }
 
+        it("returns an error when encountering a problem with sale fetch") {
+            class TestError: Error {}
+            subject.saleNetworkModel = Test_AuctionSaleNetworkModel(result: Result.error(TestError()))
+            expect(subject.saleModel).to( beNil() )
+        }
+
         describe("registrationStatus") {
             it("works when bidders fetch errors") {
                 bidderNetworkModel.result = .error(TestError.testing)

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,17 +1,26 @@
 upcoming:
-  version: 4.3.2
+  version: 4.3.3
   date: TBD
   emission_version: 1.7.x
   dev:
     - Nothing yet
 
   user_facing:
-    - Includes artwork blurbs again - ash&jon
-    - BN changes from Emission - orta/chris/matt
-    - Fixes view-in-room not working - ash
-    - Fixes grey bar on bottom of screen after modal presentations - ash
+    - Nothing yet
 
 releases:
+  - version: 4.3.2
+    date: Oct 25, 2018
+    emission_version: 1.7.x
+    dev:
+      - Nothing yet
+
+    user_facing:
+      - Includes artwork blurbs again - ash&jon
+      - BN changes from Emission - orta/chris/matt
+      - Fixes view-in-room not working - ash
+      - Fixes grey bar on bottom of screen after modal presentations - ash
+
   - version: 4.3.1
     date: Oct 18, 2018
     emission_version: 1.6.x


### PR DESCRIPTION
I ran into an issue where a sale was 404'ing and crashing the app. Looks like a `FIXME` made it through review, so I cleaned it up. Also added a test.

This is the first PR since 4.3.2 got released, so I updated our changelog and version numbers too.