### PR TITLE
Removes the position field from a LiveAuctionLot 

### DIFF
--- a/Artsy/Models/API_Models/LiveAuctionLot.h
+++ b/Artsy/Models/API_Models/LiveAuctionLot.h
@@ -33,7 +33,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readonly) NSDictionary *imageDictionary;
 
 @property (nonatomic, copy, readonly) NSString *liveAuctionLotID;
-@property (nonatomic, assign, readonly) NSInteger position;
 @property (nonatomic, assign, readonly) NSString *_Nullable lotLabel;
 
 // Note: These are not parsed from JSON, stored locally.

--- a/Artsy/Models/API_Models/LiveAuctionLot.m
+++ b/Artsy/Models/API_Models/LiveAuctionLot.m
@@ -12,7 +12,6 @@
 
 @end
 
-
 @implementation LiveAuctionLot
 
 - (instancetype)init

--- a/Artsy/Networking/static_sale_data.graphql
+++ b/Artsy/Networking/static_sale_data.graphql
@@ -23,7 +23,6 @@
     description
     sale_artworks(all: true) {
       _id
-      position
       currency
       symbol
       reserve_status

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,10 +3,10 @@ upcoming:
   date: TBD
   emission_version: 1.7.x
   dev:
-    - Nothing yet
+    - Emission update, bringing mapbox sdk and view controllers for local discovery - orta / LD team
 
   user_facing:
-    - Nothing yet
+    - Brings back the consignments sash - orta
 
 releases:
   - version: 4.3.2


### PR DESCRIPTION
As it's not used, and caused a problem. Position is used in MP/ Grab to order, and we don't do custom ordering inline in the app.