### PR TITLE
Moves pre-flight checklist into Notion #trivial

### DIFF
--- a/docs/deploy_to_app_store.md
+++ b/docs/deploy_to_app_store.md
@@ -13,54 +13,7 @@ It takes about 45 minutes for [Circle CI](https://circleci.com/gh/artsy/eigen) t
 
 ## Test the Beta
 
-Before submitting to the App Store, the binary we submit *must* be tested *on-device*. Install the beta through Testflight and run through the following two groups of scenarios.
-
-### Staging Tests
-
-- [ ] Review `CHANGELOG.yml` entries for the release and run through any parts of the app that seem appropriate.
-- [ ] Check user registration and onboarding works.
-- [ ] As a freshly created user, perform a smoke test of: 
-  - [ ] Eigen's main tab view controllers (Home, Search, Inbox, and Favourites).
-  - [ ] The artwork, artist, and auction view controllers.
-  - [ ] Live Auctions interface (Use the `gravity-staging-create-auction-on-demand` Jenkins job to create a sale, it'll take five minute to open before the interface is accessible in Eigen).
-- [ ] Open an artwork view.
-  - [ ] for an artwork with an attribute class (aka classification: unique, limited edition, etc). Does it display the classification?
-  - [ ] for an artwork with a description (`blurb` in Gravity). Does it display?
-  - [ ] for an artwork with view-in-room enabled. Does view-in-room work? Does AR view-in-room work?
-- [ ] Open a React Native view, then open a modal view controller (LAI interface, inquiry modal), and navigate back to the RN view. Make sure that [the screen isn't blank](https://github.com/artsy/eigen/issues/2439).
-- [ ] Check that the app opens with the correct conversation from a messaging push notification (find the "Invoicing Demo Partner" partner on [Vibrations](https://github.com/artsy/vibrations) staging, publish one one of their artworks, find it in the app, inquire on it as a non-admin, and reply to the conversation from [Volt](https://github.com/artsy/volt) to trigger a push).
-  - [ ] When app is running in the background
-- [ ] After running the conversation push notification test and the conversation tab is populated, smoke test it.
-- [ ] Check that the app opens on the correct Auctions home tab when opened from a sale-opening push notification (in gravity staging console, run `NewSalePushService.notify_user(User.find_by(email: "YOUR_EMAIL@artsymail.com").id, Artist.sample(3).map(&:id), 4)`).
-  - [ ] When app is running in the background
-  - [ ] When app is completely inactive
-
-### Production Tests
-
-- [ ] Open several auctions (Home tab -> Auctions at the top -> pick an auction)
-  - [ ] Do the number of lots in Eigen match the number on the web?
-- [ ] If possible, open the Live Auctions interface while a live auction is ongoing. Does the interface update in response to websocket events?
-- [ ] As a user with populated favourites, follows, etc, perform a smoke test of: 
-  - [ ] Eigen's main tab view controllers (Home, Search, Inbox, and Favourites).
-  - [ ] The artwork, artist, and auctions view controllers.
-- [ ] Check that the app opens on the correct artist page from a Safari (or other web browser) link (artsy.net/artist/someone)
-  - [ ] When app is running in the background
-  - [ ] When app is completely inactive
-
-### Pending Tests
-
-These are tests that currently don't work. Each item here should have a corresponding Jira ticket.
-
-- [ ] Check that the app opens with the correct conversation from a messaging push notification.
-  - [ ] When app is completely inactive ([Jira](https://artsyproduct.atlassian.net/browse/EV-164))
-- [ ] Check that the app opens on the Home feed Works For You tab from a Works For You email (find one in your inbox) ([Jira](https://artsyproduct.atlassian.net/browse/BUGS-176)).
-  - [ ] When app is running in the background
-  - [ ] When app is completely inactive
-- [ ] Check that the app opens on the Home feed Works For You tab from a Works For You push notification (in gravity staging console, run `NewWorkPushService.notify_user(User.find_by(email: "YOUR_EMAIL@artsymail.com"))`) ([Jira](https://artsyproduct.atlassian.net/browse/BUGS-523)).
-  - [ ] When app is running in the background
-  - [ ] When app is completely inactive
-
-It is *critical* that we catch bugs before we submit to the App Store. If a bug gets out, it can take days or weeks for Apple to review any fix. As the submitter, you are the last line of defence – the whole team is counting on you.
+Eigen's beta pre-submission checklist has [moved into Notion](https://www.notion.so/artsy/Pre-submission-QA-Checklist-785e3233fdcf423f95ee239ab3c22ec3).
 
 ## Prepare in iTunesConnect
 


### PR DESCRIPTION
I've put these instructions [into Notion](https://www.notion.so/artsy/Pre-submission-QA-Checklist-785e3233fdcf423f95ee239ab3c22ec3), where our non-engineering colleagues can help improve it.