### PR TITLE
Add switchboard routing for ARFairSearchViewController

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -490,7 +490,6 @@
 		6036B1E1203384DD00763E10 /* ARAugmentRealitySetupViewControllerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 6036B1E0203384DC00763E10 /* ARAugmentRealitySetupViewControllerSpec.m */; };
 		6036B5651760E22E00F1DD01 /* ArtsyAPI+SiteFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6036B5641760E22E00F1DD01 /* ArtsyAPI+SiteFunctions.m */; };
 		6037340420CF1BFF0017A4D9 /* ARVIRShadow.png in Resources */ = {isa = PBXBuildFile; fileRef = 6037340320CF1BFF0017A4D9 /* ARVIRShadow.png */; };
-		6037442516D4227500AE7788 /* ARSwitchBoard.m in Sources */ = {isa = PBXBuildFile; fileRef = 6037442416D4227500AE7788 /* ARSwitchBoard.m */; };
 		60388703189C0F0B00D3EEAA /* ARTiledImageDataSourceWithImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 60388702189C0F0B00D3EEAA /* ARTiledImageDataSourceWithImage.m */; };
 		60388706189C103F00D3EEAA /* ARFairMapZoomManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 60388705189C103F00D3EEAA /* ARFairMapZoomManager.m */; };
 		6038B78A1C2856BA00359F3B /* ARSwitchboard+Eigen.m in Sources */ = {isa = PBXBuildFile; fileRef = 6038B7891C2856BA00359F3B /* ARSwitchboard+Eigen.m */; };
@@ -806,6 +805,7 @@
 		E6FFEABB19C7925600A0D7DE /* splash_4@2x~ipad.jpg in Resources */ = {isa = PBXBuildFile; fileRef = E6FFEAAB19C7925600A0D7DE /* splash_4@2x~ipad.jpg */; };
 		E6FFEABC19C7925600A0D7DE /* splash_4@2x~iphone.jpg in Resources */ = {isa = PBXBuildFile; fileRef = E6FFEAAC19C7925600A0D7DE /* splash_4@2x~iphone.jpg */; };
 		E6FFEABD19C7925600A0D7DE /* splash_5@2x~ipad.jpg in Resources */ = {isa = PBXBuildFile; fileRef = E6FFEAAD19C7925600A0D7DE /* splash_5@2x~ipad.jpg */; };
+		FB994A6B21A5AD1C00AAFD55 /* ARSwitchBoard.m in Sources */ = {isa = PBXBuildFile; fileRef = 6037442416D4227500AE7788 /* ARSwitchBoard.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -5466,6 +5466,7 @@
 				54B7477518A397170050E6C7 /* ARTopMenuViewController+DeveloperExtras.m in Sources */,
 				5EA7BC3F1C612577009C52C9 /* AuctionNetworkModel.swift in Sources */,
 				5EBA3E831DFF4CCB005B4BEE /* ARTwoWayDictionaryTransformer.m in Sources */,
+				FB994A6B21A5AD1C00AAFD55 /* ARSwitchBoard.m in Sources */,
 				1CC9EB971CC0EDBE00A74E3C /* AROnboardingPersonalizeTableViewController.m in Sources */,
 				60647C751A94F71600A45247 /* AREndOfLineInternalMobileWebViewController.m in Sources */,
 				60B6F0F21662AADF007C9587 /* ARAppConstants.m in Sources */,
@@ -5624,7 +5625,6 @@
 				607E2E8417C8CF6B00396120 /* ARArtworkPreviewActionsView.m in Sources */,
 				60A309A81AC999DE000783C1 /* ARInternalShareValidator.m in Sources */,
 				B316E2F418170DF40086CCDB /* SaleArtwork.m in Sources */,
-				6037442516D4227500AE7788 /* ARSwitchBoard.m in Sources */,
 				3C4AE9A419096CED009C0E8B /* ARFairMapAnnotationCallOutView.m in Sources */,
 				60BCE1101FF2B8A500071AA6 /* ARAugmentedFloorBasedVIRViewController.m in Sources */,
 				60D83DE8189EAB82001672E9 /* ARFairShowMapper.m in Sources */,

--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -22,6 +22,7 @@
 #import "ARFairGuideContainerViewController.h"
 #import "ARAuctionWebViewController.h"
 #import "ARFairMapViewController.h"
+#import "ARFairSearchViewController.h"
 #import "ARTopMenuViewController.h"
 #import "ARMutableLinkViewController.h"
 #import "ARTopMenuNavigationDataSource.h"
@@ -190,7 +191,7 @@ NSInteger const ARLiveAuctionsCurrentWebSocketVersionCompatibility = 4;
         __strong typeof (wself) sself = wself;
         return [sself loadConversationWithID:parameters[@"id"]];
     }];
-    
+
     [self.routes addRoute:@"/admin" handler:JLRouteParams {
         return [wself loadAdminMenu];
     }];
@@ -225,6 +226,11 @@ NSInteger const ARLiveAuctionsCurrentWebSocketVersionCompatibility = 4;
             __strong typeof (wself) sself = wself;
             Fair *fair = parameters[@"fair"] ?: [[Fair alloc] initWithFairID:parameters[@"profile_id"]];
             return [sself loadArtistWithID:parameters[@"id"] inFair:fair];
+        }];
+
+        [self.routes addRoute:@"/:fairID/search" handler:JLRouteParams {
+            Fair *fair = [[Fair alloc] initWithFairID:parameters[@"fairID"]];
+            return [[ARFairSearchViewController alloc] initWithFair:fair];
         }];
     }
 

--- a/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
+++ b/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
@@ -19,6 +19,7 @@
 #import "ARFairViewController.h"
 #import "ARFairArtistViewController.h"
 #import "ARFairGuideContainerViewController.h"
+#import "ARFairSearchViewController.h"
 #import "ARTopMenuNavigationDataSource.h"
 #import "ARMutableLinkViewController.h"
 
@@ -300,6 +301,12 @@ describe(@"ARSwitchboard", ^{
                     Fair *fair = [OCMockObject mockForClass:[Fair class]];
                     id viewController = [switchboard routeInternalURL:[[NSURL alloc] initWithString:@"/the-armory-show/browse/artist/artist-id"] fair:fair];
                     expect(viewController).to.beKindOf(ARFairArtistViewController.class);
+                });
+
+                it(@"routes fair search", ^{
+                    Fair *fair = [OCMockObject mockForClass:[Fair class]];
+                    id viewController = [switchboard routeInternalURL:[[NSURL alloc] initWithString:@"/the-armory-show/search"] fair:fair];
+                    expect(viewController).to.beKindOf(ARFairSearchViewController.class);
                 });
 
                 it(@"forwards fair views to martsy for non-native views", ^{

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,7 +3,7 @@ upcoming:
   date: TBD
   emission_version: 1.7.x
   dev:
-    - 
+    - Add SwitchBoard path for ARFairSearchViewController - javamonn
   user_facing:
     - 
 


### PR DESCRIPTION
As part of [LD-28](https://artsyproduct.atlassian.net/browse/LD-28), we're adding a "Find Exhibitors and Artists" link button to the new Fair view that links to a fair-scoped search. This mirrors functionality that exists in Eigen today as part of `ARFairSearchViewController`. This PR aims to expose this screen via SwitchBoard.