### PR TITLE
Uses the 'new' search suggestion API for the main app search

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.3.4</string>
+	<string>4.3.5</string>
 	<key>CFBundleVersion</key>
 	<string>2018.11.21.11</string>
 	<key>NSExtension</key>

--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		342F9F5789AD65AD09205030 /* MapFeature.m in Sources */ = {isa = PBXBuildFile; fileRef = 342F93E38025E2D2DA90C6DA /* MapFeature.m */; };
 		342F9FBB86D02FABC8AA9339 /* ARNavigationButtonsViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 342F965F76AA25C6C700FE1C /* ARNavigationButtonsViewControllerTests.m */; };
 		34B1151A2069AA7C0025D925 /* AuctionBuyNowTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34B115192069AA7C0025D925 /* AuctionBuyNowTitleView.swift */; };
+		3A179F5C21BEB38B007705F8 /* SearchSuggestion.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A179F5B21BEB38B007705F8 /* SearchSuggestion.m */; };
 		3A1DDDA3216CFC7100190F84 /* AREigenInquiryComponentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A1DDDA2216CFC7100190F84 /* AREigenInquiryComponentViewController.m */; };
 		3A1DDDA6216D04DB00190F84 /* ARAuthValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A1DDDA5216D04DB00190F84 /* ARAuthValidator.m */; };
 		3A860AD4214C5DD600C7F555 /* artwork.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 3A860AD3214C5DD600C7F555 /* artwork.graphql */; };
@@ -997,6 +998,9 @@
 		342F9FD434A78C36B76A85B6 /* ARFairViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARFairViewControllerTests.m; sourceTree = "<group>"; };
 		342F9FEFF4A1B56EE307467B /* ARFileUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARFileUtils.m; sourceTree = "<group>"; };
 		34B115192069AA7C0025D925 /* AuctionBuyNowTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AuctionBuyNowTitleView.swift; path = ../View_Controllers/AuctionBuyNowTitleView.swift; sourceTree = "<group>"; };
+		3A179F5921BEB383007705F8 /* SearchResultable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SearchResultable.h; sourceTree = "<group>"; };
+		3A179F5A21BEB38B007705F8 /* SearchSuggestion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SearchSuggestion.h; sourceTree = "<group>"; };
+		3A179F5B21BEB38B007705F8 /* SearchSuggestion.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SearchSuggestion.m; sourceTree = "<group>"; };
 		3A1DDDA1216CFC7100190F84 /* AREigenInquiryComponentViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AREigenInquiryComponentViewController.h; sourceTree = "<group>"; };
 		3A1DDDA2216CFC7100190F84 /* AREigenInquiryComponentViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AREigenInquiryComponentViewController.m; sourceTree = "<group>"; };
 		3A1DDDA4216D04DB00190F84 /* ARAuthValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ARAuthValidator.h; sourceTree = "<group>"; };
@@ -3748,8 +3752,11 @@
 				6034EB1C175F68350070478D /* SiteHeroUnit.m */,
 				CB73B48917D2581400891305 /* SiteFeature.h */,
 				CB73B48A17D2581400891305 /* SiteFeature.m */,
+				3A179F5921BEB383007705F8 /* SearchResultable.h */,
 				49A76D0617592C96001D4B81 /* SearchResult.h */,
 				49A76D0717592C96001D4B81 /* SearchResult.m */,
+				3A179F5A21BEB38B007705F8 /* SearchSuggestion.h */,
+				3A179F5B21BEB38B007705F8 /* SearchSuggestion.m */,
 				60D90A0317C2109A0073D5B9 /* FeaturedLink.h */,
 				60D90A0417C2109A0073D5B9 /* FeaturedLink.m */,
 				3C35CC79189FF05E00E3D8DE /* OrderedSet.h */,
@@ -5579,6 +5586,7 @@
 				516CDA631BB32B6A001C02B2 /* ARSpotlight.m in Sources */,
 				5E4E32A71E535D8000C7F724 /* LotStandingsLotListView.swift in Sources */,
 				5E26AF801CE66A7E00C67B7C /* Stringify.swift in Sources */,
+				3A179F5C21BEB38B007705F8 /* SearchSuggestion.m in Sources */,
 				6099F8F9178DBF160004EF04 /* ARModernPartnerShowTableViewCell.m in Sources */,
 				E676B2EE18D11A9B0057B4E1 /* ARImageItemProvider.m in Sources */,
 				3CFBE32D18C3A3F400C781D0 /* ARNetworkErrorView.m in Sources */,

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.3.4</string>
+	<string>4.3.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Artsy/Models/API_Models/Application/SearchResult.h
+++ b/Artsy/Models/API_Models/Application/SearchResult.h
@@ -1,7 +1,7 @@
 #import <Mantle/Mantle.h>
+#import "SearchResultable.h"
 
-
-@interface SearchResult : MTLModel <MTLJSONSerializing>
+@interface SearchResult : MTLModel <MTLJSONSerializing, SearchResultable>
 
 @property (readonly, nonatomic, copy) NSString *modelString;
 @property (readonly, nonatomic, copy) NSString *modelID;

--- a/Artsy/Models/API_Models/Application/SearchResultable.h
+++ b/Artsy/Models/API_Models/Application/SearchResultable.h
@@ -1,0 +1,19 @@
+#import <Foundation/Foundation.h>
+
+@protocol SearchResultable <NSObject>
+/** Text to show */
+@property (readonly, nonatomic, copy) NSString *displayText;
+/** Should we show this? */
+@property (readonly, nonatomic, strong) NSNumber *isPublished;
+
+@optional
+
+/** Optional URL to route */
+@property (readonly, nonatomic, copy) NSString *href;
+
+/** Optional Image URL to use */
+@property (readonly, nonatomic, copy) NSString *imageURL;
+
+/** Optional Image URL Request to use */
+- (NSURLRequest *)imageRequest;
+@end

--- a/Artsy/Models/API_Models/Application/SearchSuggestion.h
+++ b/Artsy/Models/API_Models/Application/SearchSuggestion.h
@@ -1,0 +1,17 @@
+#import <Mantle/Mantle.h>
+#import "SearchResultable.h"
+
+@interface SearchSuggestion : MTLModel <MTLJSONSerializing, SearchResultable>
+
+@property (readonly, nonatomic, copy) NSString *displayText;
+@property (readonly, nonatomic, strong) NSNumber *isPublished;
+
+@property (readonly, nonatomic, copy) NSString *imageURL;
+@property (readonly, nonatomic, copy) NSString *href;
+
+@property (readonly, nonatomic, copy) NSString *modelID;
+@property (readonly, nonatomic, copy) NSString *model;
+
++ (BOOL)searchResultIsSupported:(NSDictionary *)jsonDict;
+
+@end

--- a/Artsy/Models/API_Models/Application/SearchSuggestion.m
+++ b/Artsy/Models/API_Models/Application/SearchSuggestion.m
@@ -19,7 +19,13 @@
 + (BOOL)searchResultIsSupported:(NSDictionary *)jsonDict
 {
     NSArray *allSupported = @[@"artist",  @"profile",  @"gene",  @"city",  @"artwork",  @"fair",  @"tag",  @"feature",  @"article",  @"page",  @"sale"];
-    return [allSupported containsObject:jsonDict[@"model"]];
+    BOOL supported = [allSupported containsObject:jsonDict[@"model"]];
+#ifdef DEBUG
+    if(!supported) {
+        NSLog(@"Found a new type of model from search, please update SearchSuggestion with %@", jsonDict[@"model"]);
+    }
+#endif
+    return supported;
 }
 
 - (NSString *)href
@@ -45,8 +51,8 @@
         return NSStringWithFormat(@"/auction/%@", self.modelID);
     }
 
-    @throw [[NSException alloc]  initWithName:@"Should not get here" reason:@"" userInfo:nil];
-
+    NSAssert(NO, @"Got an unknown model from search");
+    return nil;
 }
 
 @end

--- a/Artsy/Models/API_Models/Application/SearchSuggestion.m
+++ b/Artsy/Models/API_Models/Application/SearchSuggestion.m
@@ -1,0 +1,52 @@
+#import "SearchSuggestion.h"
+#import "ARMacros.h"
+#import <ObjectiveSugar/NSString+ObjectiveSugar.h>
+
+@implementation SearchSuggestion
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+    return @{
+         ar_keypath(SearchSuggestion.new, displayText) : @"display",
+         ar_keypath(SearchSuggestion.new, isPublished) : @"published",
+         ar_keypath(SearchSuggestion.new, imageURL) : @"image_url",
+         ar_keypath(SearchSuggestion.new, model) : @"model",
+         ar_keypath(SearchSuggestion.new, modelID) : @"id",
+    };
+}
+
+// Based on https://github.com/artsy/gravity/blob/a13284a1daa955011afb3505c9864c678ad434a8/app/models/search/queries/global_auto_suggest_query.rb#L52-L67
+
++ (BOOL)searchResultIsSupported:(NSDictionary *)jsonDict
+{
+    NSArray *allSupported = @[@"artist",  @"profile",  @"gene",  @"city",  @"artwork",  @"fair",  @"tag",  @"feature",  @"article",  @"page",  @"sale"];
+    return [allSupported containsObject:jsonDict[@"model"]];
+}
+
+- (NSString *)href
+{
+    NSArray *prefixless = @[@"profile", @"page", @"fair"];
+    if ([prefixless containsObject:self.model]) {
+        return self.modelID;
+    } else if ([self.model isEqualToString:@"tag"] || [self.model isEqualToString:@"gene"]) {
+        return NSStringWithFormat(@"/gene/%@", self.modelID);
+    } else if ([self.model isEqualToString:@"artist"]) {
+        return NSStringWithFormat(@"/artist/%@", self.modelID);
+    } else if ([self.model isEqualToString:@"city"]) {
+        return NSStringWithFormat(@"/shows/%@", self.modelID);
+    } else if ([self.model isEqualToString:@"artwork"]) {
+        return NSStringWithFormat(@"/artwork/%@", self.modelID);
+    } else if ([self.model isEqualToString:@"article"]) {
+        return NSStringWithFormat(@"/article/%@", self.modelID);
+    } else if ([self.model isEqualToString:@"page"]) {
+        return NSStringWithFormat(@"/artwork/%@", self.modelID);
+    } else if ([self.model isEqualToString:@"sale"]) {
+        return NSStringWithFormat(@"/auction/%@", self.modelID);
+    } else if ([self.model isEqualToString:@"feature"]) {
+        return NSStringWithFormat(@"/auction/%@", self.modelID);
+    }
+
+    @throw [[NSException alloc]  initWithName:@"Should not get here" reason:@"" userInfo:nil];
+
+}
+
+@end

--- a/Artsy/Networking/API_Modules/ArtsyAPI+Search.m
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+Search.m
@@ -44,7 +44,10 @@ EnsureQuery(NSString *query) {
         NSMutableArray *returnArray = [NSMutableArray array];
 
         if (fairID) {
-            // Old style obj -> objc class mapping for fairs
+            // Old style obj -> objc class mapping for fair inline-search
+            // This is so that when the new version of the FairVC from Emission deprecates the current version
+            // we can just delete everything related to `SearchResult` safely, including this code.
+            //
             for (NSDictionary *dictionary in jsonDictionaries) {
                 if ([SearchResult searchResultIsSupported:dictionary]) {
                     NSError *error = nil;

--- a/Artsy/Networking/ARNetworkConstants.m
+++ b/Artsy/Networking/ARNetworkConstants.m
@@ -80,7 +80,7 @@ NSString *const ARShowFeedURL = @"/api/v1/shows/feed";
 NSString *const ARShowInformationURLFormat = @"/api/v1/show/%@";
 NSString *const ARShowsURL = @"/api/v1/shows";
 
-NSString *const ARNewSearchURL = @"/api/v1/match";
+NSString *const ARNewSearchURL = @"/api/v1/match/suggest";
 NSString *const ARNewArtistSearchURL = @"/api/v1/match/artists";
 NSString *const ARNewGeneSearchURL = @"/api/v1/match/genes";
 

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -855,7 +855,8 @@ static NSString *hostFromString(NSString *string)
 
 + (NSURLRequest *)newSearchRequestWithQuery:(NSString *)query
 {
-    return [self requestWithMethod:@"GET" path:ARNewSearchURL parameters:@{ @"term" : query }];
+    return [self requestWithMethod:@"GET" path:ARNewSearchURL parameters:@{ @"term" : query, @"visible_to_public": @(YES), @"agg": @(NO) }];
+//    visible_to_public=true&fair_id=&size=7&agg=false&term=ssd
 }
 
 + (NSURLRequest *)newSearchRequestWithFairID:(NSString *)fairID andQuery:(NSString *)query

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -856,7 +856,6 @@ static NSString *hostFromString(NSString *string)
 + (NSURLRequest *)newSearchRequestWithQuery:(NSString *)query
 {
     return [self requestWithMethod:@"GET" path:ARNewSearchURL parameters:@{ @"term" : query, @"visible_to_public": @(YES), @"agg": @(NO) }];
-//    visible_to_public=true&fair_id=&size=7&agg=false&term=ssd
 }
 
 + (NSURLRequest *)newSearchRequestWithFairID:(NSString *)fairID andQuery:(NSString *)query

--- a/Artsy/View_Controllers/App_Navigation/ARAppSearchViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARAppSearchViewController.m
@@ -17,6 +17,7 @@
 #import "UIViewController+TopMenuViewController.h"
 #import "AROptions.h"
 #import "ARFonts.h"
+#import "SearchResult.h"
 
 #import <Emission/ARArtistComponentViewController.h>
 #import <FXBlurView/FXBlurView.h>
@@ -104,25 +105,9 @@ static const NSInteger ARAppSearchParallaxDistance = 20;
     return [ArtsyAPI searchWithQuery:query success:success failure:failure];
 }
 
-- (void)selectedResult:(SearchResult *)result ofType:(NSString *)type fromQuery:(NSString *)query
+- (void)selectedResult:(NSObject <SearchResultable> *)result ofType:(NSString *)type fromQuery:(NSString *)query
 {
-    UIViewController *controller;
-    if (result.model == [Artwork class]) {
-        controller = [[ARArtworkSetViewController alloc] initWithArtworkID:result.modelID];
-    } else if (result.model == [Artist class]) {
-        NSString *path = NSStringWithFormat(@"/artist/%@", result.modelID);
-        controller = [[ARSwitchBoard sharedInstance] loadPath:path];
-    } else if (result.model == [Gene class]) {
-        controller = [[ARSwitchBoard sharedInstance] loadGeneWithID:result.modelID];
-    } else if (result.model == [Profile class]) {
-        controller = [ARSwitchBoard.sharedInstance loadProfileWithID:result.modelID];
-    } else if (result.model == [SiteFeature class]) {
-        NSString *path = NSStringWithFormat(@"/feature/%@", result.modelID);
-        controller = [ARSwitchBoard.sharedInstance loadPath:path];
-    } else if (result.model == [Fair class]) {
-        controller = [ARSwitchBoard.sharedInstance loadProfileWithID:result.modelID];
-    }
-
+    UIViewController *controller = [ARSwitchBoard.sharedInstance loadPath:result.href];
     if (controller) {
         [self.ar_TopMenuViewController pushViewController:controller animated:YES];
     }

--- a/Artsy/View_Controllers/Fair/ARFairSearchViewController.h
+++ b/Artsy/View_Controllers/Fair/ARFairSearchViewController.h
@@ -1,4 +1,5 @@
 #import "ARSearchViewController.h"
+#import "SearchResult.h"
 
 @class ARFairSearchViewController, Fair;
 

--- a/Artsy/View_Controllers/Fair/ARFairSearchViewController.m
+++ b/Artsy/View_Controllers/Fair/ARFairSearchViewController.m
@@ -1,4 +1,5 @@
 #import "ARFairSearchViewController.h"
+#import "SearchResult.h"
 
 #import "ArtsyAPI+Search.h"
 #import "ARFonts.h"

--- a/Artsy/View_Controllers/Fair/ARFairViewController.m
+++ b/Artsy/View_Controllers/Fair/ARFairViewController.m
@@ -30,6 +30,7 @@
 #import "ARScrollNavigationChief.h"
 #import "ARTopMenuViewController.h"
 #import "UIViewController+TopMenuViewController.h"
+#import "SearchResult.h"
 
 #import "UIDevice-Hardware.h"
 

--- a/Artsy/View_Controllers/Search/ARSearchResultsDataSource.h
+++ b/Artsy/View_Controllers/Search/ARSearchResultsDataSource.h
@@ -2,7 +2,6 @@
 
 #import "SearchResultable.h"
 
-
 @interface ARSearchResultsDataSource : NSObject <UITableViewDataSource>
 
 @property (nonatomic) NSOrderedSet *searchResults;

--- a/Artsy/View_Controllers/Search/ARSearchResultsDataSource.h
+++ b/Artsy/View_Controllers/Search/ARSearchResultsDataSource.h
@@ -1,6 +1,6 @@
 #import <UIKit/UIKit.h>
 
-#import "SearchResult.h"
+#import "SearchResultable.h"
 
 
 @interface ARSearchResultsDataSource : NSObject <UITableViewDataSource>
@@ -9,6 +9,6 @@
 @property (nonatomic, readwrite, strong) UIColor *textColor;
 @property (nonatomic, readwrite, strong) UIImage *placeholderImage;
 
-- (SearchResult *)objectAtIndex:(NSInteger)index;
+- (NSObject <SearchResultable> *)objectAtIndex:(NSInteger)index;
 
 @end

--- a/Artsy/View_Controllers/Search/ARSearchResultsDataSource.m
+++ b/Artsy/View_Controllers/Search/ARSearchResultsDataSource.m
@@ -23,7 +23,7 @@
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"SearchCell"];
-    SearchResult *result = self.searchResults[indexPath.row];
+    NSObject <SearchResultable> *result = [self objectAtIndex:indexPath.row];
 
     BOOL published = result.isPublished.boolValue;
     if (!published) {
@@ -39,7 +39,7 @@
     return cell;
 }
 
-- (SearchResult *)objectAtIndex:(NSInteger)index
+- (NSObject <SearchResultable> *)objectAtIndex:(NSInteger)index
 {
     return self.searchResults[index];
 }

--- a/Artsy/View_Controllers/Search/ARSearchViewController.h
+++ b/Artsy/View_Controllers/Search/ARSearchViewController.h
@@ -42,7 +42,7 @@ typedef NS_ENUM(NSInteger, ARMenuState) {
 
 
 - (void)addResults:(NSArray *)results replace:(BOOL)replaceResults;
-- (void)selectedResult:(SearchResult *)result ofType:(NSString *)type fromQuery:(NSString *)query;
+- (void)selectedResult:(NSObject <SearchResultable> *)result ofType:(NSString *)type fromQuery:(NSString *)query;
 
 - (ARSearchViewControllerStylingMode)searchPresentationMode;
 

--- a/Artsy/View_Controllers/Search/ARSearchViewController.m
+++ b/Artsy/View_Controllers/Search/ARSearchViewController.m
@@ -1,6 +1,7 @@
 #import "ARLogger.h"
 #import "ARSearchViewController.h"
 #import "ARSearchViewController+Private.h"
+#import "SearchResult.h"
 
 #import "ARAppConstants.h"
 #import "ARFonts.h"
@@ -404,7 +405,7 @@
     return 1;
 }
 
-- (void)selectedResult:(SearchResult *)result ofType:(NSString *)type fromQuery:(NSString *)query
+- (void)selectedResult:(NSObject <SearchResultable> *)result ofType:(NSString *)type fromQuery:(NSString *)query
 {
     @throw [NSException exceptionWithName:NSInternalInconsistencyException
                                    reason:[NSString stringWithFormat:@"You must override %@ in a subclass", NSStringFromSelector(_cmd)]
@@ -413,9 +414,17 @@
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    SearchResult *result = [self.searchDataSource objectAtIndex:indexPath.row];
-    NSString *type = [NSStringFromClass([result.model class]) lowercaseString];
-    [self selectedResult:result ofType:type fromQuery:self.textField.text];
+    NSObject <SearchResultable >*result = [self.searchDataSource objectAtIndex:indexPath.row];
+    if ([result isKindOfClass:SearchResult.class]) {
+        SearchResult *searchResult = (id)result;
+        NSString *type = [NSStringFromClass([searchResult.model class]) lowercaseString];
+        [self selectedResult:result ofType:type fromQuery:self.textField.text];
+    } else {
+        // Once the Fair search is removed with the new local discovery "SearchResult" can be rm'd
+        // as well as code like above.
+        [self selectedResult:result ofType:@"" fromQuery:self.textField.text];
+    }
+
 }
 
 - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView

--- a/Artsy/View_Controllers/Search/ARSearchViewController.m
+++ b/Artsy/View_Controllers/Search/ARSearchViewController.m
@@ -414,7 +414,7 @@
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    NSObject <SearchResultable >*result = [self.searchDataSource objectAtIndex:indexPath.row];
+    NSObject <SearchResultable > *result = [self.searchDataSource objectAtIndex:indexPath.row];
     if ([result isKindOfClass:SearchResult.class]) {
         SearchResult *searchResult = (id)result;
         NSString *type = [NSStringFromClass([searchResult.model class]) lowercaseString];

--- a/Artsy_Tests/View_Controller_Tests/App_Menu/ARAppSearchViewControllerSpec.m
+++ b/Artsy_Tests/View_Controller_Tests/App_Menu/ARAppSearchViewControllerSpec.m
@@ -1,6 +1,6 @@
 #import "ARAppSearchViewController.h"
 #import "ARTopMenuViewController.h"
-
+#import "SearchResult.h"
 
 @interface ARAppSearchViewController (Testing)
 - (void)clearTapped:(id)sender;
@@ -29,13 +29,11 @@ itHasSnapshotsForDevicesWithName(@"looks correct", ^{
 
 context(@"searching", ^{
     context(@"with results", ^{
-
-
         itHasSnapshotsForDevicesWithName(@"displays search results", ^{
 
             sharedBefore();
 
-            [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/match" withResponse:@[
+            [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/match/suggest" withResponse:@[
                 @{
                     @"model": @"artist",
                     @"id": @"aes-plus-f",
@@ -95,7 +93,7 @@ context(@"searching", ^{
                 @"imageURL" : @"http://api.artsy.net.com",
                 @"highlights": @[]
             }], nil];
-            [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/match" withResponse:@[]];
+            [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/suggest" withResponse:@[]];
             
             sut.textField.text = @"f";
             [sut.textField sendActionsForControlEvents:UIControlEventEditingChanged];

--- a/Artsy_Tests/View_Controller_Tests/App_Menu/ARSearchViewControllerSpec.m
+++ b/Artsy_Tests/View_Controller_Tests/App_Menu/ARSearchViewControllerSpec.m
@@ -1,5 +1,5 @@
 #import "ARSearchViewController.h"
-
+#import "SearchResult.h"
 
 @interface ARSearchViewController (Testing)
 - (void)presentResultsViewAnimated:(BOOL)animated;

--- a/Artsy_Tests/View_Controller_Tests/Fair/ARFairSearchViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/ARFairSearchViewControllerTests.m
@@ -98,7 +98,7 @@ describe(@"init", ^{
 //    });
 
     it(@"without local fair shows - combines results from local and remote search", ^{
-        [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/match"
+        [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/match/suggest"
                                  withParams:@{ @"term" : @"Leila", @"fair_id" : @"fair-id" }
                                withResponse:@[
           @{

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -7,7 +7,7 @@ upcoming:
     - nothing yet
     
   user_facing:
-    - nothing yet
+    - Uses new search API for the app search - orta
 
 releases:
   - version: 4.3.4

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -8,7 +8,7 @@ upcoming:
     
   user_facing:
     - Uses new search API for the app search - orta
-    - nothing yet
+    - AR feature allows tapping on the done state to hide the UI - orta
 
 releases:
   - version: 4.3.4

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,23 +1,33 @@
 upcoming:
-  version: 4.3.4
-  date: TBD
+  version: 4.3.5
+  date: Dec 5, 2018
+  signed_of_by: Ash
   emission_version: 1.7.x
   dev:
-    - Adds AREnableMakeOfferFlow flag to Echo - ash&dlevenson
-    - Adds ExchangeCurrentVersion to gate BNMO - ash
-    - Add SwitchBoard path for ARFairSearchViewController - javamonn
-    - Removes extraneous OS debugging logs from Xcode - ash
-    - Hopefully fixes for adjust install recognition - orta
-    - Adds support for getting your advertising UUID in the admin panel - orta
+    - nothing yet
+    
   user_facing:
-    - Make Offer now accessible - ash
-    - Contact Gallery button doesn't show up with Make Offer button anymore - ash
-    - Adds a cancel option to follow-up push notification prompts - ash
-    - Fixes occasions when the shipping info would not show for buy now works - orta
-    - Fixes button copy problem where Contact gallery buttons would have Buy Now copy - ash
-    - Updates letter casing on "Contact gallery" and "Contact seller" buttons - ash
+    - nothing yet
 
 releases:
+  - version: 4.3.4
+    date: TBD
+    emission_version: 1.7.x
+    dev:
+      - Adds AREnableMakeOfferFlow flag to Echo - ash&dlevenson
+      - Adds ExchangeCurrentVersion to gate BNMO - ash
+      - Add SwitchBoard path for ARFairSearchViewController - javamonn
+      - Removes extraneous OS debugging logs from Xcode - ash
+      - Hopefully fixes for adjust install recognition - orta
+      - Adds support for getting your advertising UUID in the admin panel - orta
+    user_facing:
+      - Make Offer now accessible - ash
+      - Contact Gallery button doesn't show up with Make Offer button anymore - ash
+      - Adds a cancel option to follow-up push notification prompts - ash
+      - Fixes occasions when the shipping info would not show for buy now works - orta
+      - Fixes button copy problem where Contact gallery buttons would have Buy Now copy - ash
+      - Updates letter casing on "Contact gallery" and "Contact seller" buttons - ash
+
   - version: 4.3.3
     date: Nov 21, 2018
     signed_of_by: Ash


### PR DESCRIPTION
Fixes DISCO-550

Moves us to the new suggest API, and conservatively adds support for all the new suggestion types. Note that this code is not aiming for pure elegance, it was built to make it easy to remove the `SearchResult` class etc when Local Discovery is shipped and the SearchVC only has to handle one type of data (suggestions)

☎️ 