### PR TITLE
Sends a user agent which includes the device model

### DIFF
--- a/Artsy/Categories/Apple/UIDevice-Hardware.h
+++ b/Artsy/Categories/Apple/UIDevice-Hardware.h
@@ -3,4 +3,5 @@
 @interface UIDevice (Hardware)
 + (BOOL)isPad;
 + (BOOL)isPhone;
++ (NSString *)modelName;
 @end

--- a/Artsy/Categories/Apple/UIDevice-Hardware.m
+++ b/Artsy/Categories/Apple/UIDevice-Hardware.m
@@ -1,5 +1,6 @@
 #import "UIDevice-Hardware.h"
 #import <UIKit/UIKit.h>
+#import <sys/utsname.h>
 
 
 @implementation UIDevice (Hardware)
@@ -14,4 +15,10 @@
     return UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone;
 }
 
++ (NSString *)modelName
+{
+    struct utsname systemInfo;
+    uname(&systemInfo);
+    return [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
+}
 @end

--- a/Artsy/Networking/API_Modules/ARUserManager.m
+++ b/Artsy/Networking/API_Modules/ARUserManager.m
@@ -453,7 +453,14 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
     [[[AREmission sharedInstance] graphQLQueryCacheModule] clearAll];
 
     if (useStaging != nil) {
-        [[NSUserDefaults standardUserDefaults] setValue:useStaging forKey:ARUseStagingDefault];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+
+        if ([useStaging isKindOfClass:NSNumber.class]) {
+            [[NSUserDefaults standardUserDefaults] setValue:useStaging forKey:ARUseStagingDefault];
+        } else {
+            [[NSUserDefaults standardUserDefaults] setBool:useStaging forKey:ARUseStagingDefault];
+        }
+
         [[NSUserDefaults standardUserDefaults] synchronize];
     }
 }

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -230,6 +230,7 @@ static NSString *hostFromString(NSString *string)
     if (cachedUserAgent) {
         return cachedUserAgent;
     }
+
     NSString *version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
     NSString *build = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"];
 
@@ -240,7 +241,8 @@ static NSString *hostFromString(NSString *string)
 
     AFHTTPRequestSerializer *serializer = [[AFHTTPRequestSerializer alloc] init];
     NSString *userAgent = serializer.HTTPRequestHeaders[@"User-Agent"];
-    NSString *agentString = [NSString stringWithFormat:@"Mozilla/5.0 Artsy-Mobile/%@ Eigen/%@", version, build];
+    NSString *model = [UIDevice modelName];
+    NSString *agentString = [NSString stringWithFormat:@"%@ Mozilla/5.0 Artsy-Mobile/%@ Eigen/%@", model, version, build];
     userAgent = [userAgent stringByReplacingOccurrencesOfString:@"Artsy" withString:agentString];
     userAgent = [userAgent stringByAppendingString:@" AppleWebKit/601.1.46 (KHTML, like Gecko)"];
     cachedUserAgent = userAgent;

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,7 +4,7 @@ upcoming:
   signed_of_by: Ash
   emission_version: 1.7.x
   dev:
-    - nothing yet
+    - Sends a user agent which includes the device model for Reaction SSR - orta
     
   user_facing:
     - Uses new search API for the app search - orta


### PR DESCRIPTION
My sim one is: `x86_64 Mozilla/5.0 Artsy-Mobile/4.3.5 Eigen/2018.11.21.11/4.3.5 (iPhone; iOS 10.3.1; Scale/2.00) AppleWebKit/601.1.46 (KHTML, like Gecko)`
 the x64_86 would be replaced with 

```
@"iPhone1,1" on iPhone
@"iPhone1,2" on iPhone 3G
@"iPhone2,1" on iPhone 3GS
@"iPhone3,1" on iPhone 4 (GSM)
@"iPhone3,3" on iPhone 4 (CDMA/Verizon/Sprint)
@"iPhone4,1" on iPhone 4S
@"iPhone5,1" on iPhone 5 (model A1428, AT&T/Canada)
@"iPhone5,2" on iPhone 5 (model A1429, everything else)
@"iPhone5,3" on iPhone 5c (model A1456, A1532 | GSM)
@"iPhone5,4" on iPhone 5c (model A1507, A1516, A1526 (China), A1529 | Global)
@"iPhone6,1" on iPhone 5s (model A1433, A1533 | GSM)
@"iPhone6,2" on iPhone 5s (model A1457, A1518, A1528 (China), A1530 | Global)
```

etc