### PR TITLE
Skips test builds and run on beta deploys #trivial

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
 
       - run:
           name: Run tests
-          command: make test
+          command: make ci-test
 
       - store_artifacts:
           path: xcode_build_raw.log

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,7 +4,7 @@ upcoming:
   signed_of_by: Ash
   emission_version: 1.7.x
   dev:
-    - nothing yet
+    - Skips running tests on beta deploys - ash
     
   user_facing:
     - Uses new search API for the app search - orta

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,12 @@ uitest:
 ### CI
 
 ci: CONFIGURATION = Debug
-ci: build
+ci: 
+	if [ "$(LOCAL_BRANCH)" != "beta" ]; then make build; else echo "Skipping test build on beta deploy."; fi
+
+ci-test: CONFIGURATION = Debug 
+ci-test: 
+	if [ "$(LOCAL_BRANCH)" != "beta" ]; then make test; else echo "Skipping test run on beta deploy."; fi
 
 deploy_if_beta_branch:
 	if [ "$(LOCAL_BRANCH)" == "beta" ]; then make distribute; fi

--- a/Makefile
+++ b/Makefile
@@ -89,13 +89,11 @@ uitest:
 
 ### CI
 
-ci: CONFIGURATION = Debug
 ci: 
-	if [ "$(LOCAL_BRANCH)" != "beta" ]; then make build; else echo "Skipping test build on beta deploy."; fi
+	if [ "$(LOCAL_BRANCH)" != "beta" ]; then CONFIGURATION=Debug make build; else echo "Skipping test build on beta deploy."; fi
 
-ci-test: CONFIGURATION = Debug 
 ci-test: 
-	if [ "$(LOCAL_BRANCH)" != "beta" ]; then make test; else echo "Skipping test run on beta deploy."; fi
+	if [ "$(LOCAL_BRANCH)" != "beta" ]; then CONFIGURATION=Debug make test; else echo "Skipping test run on beta deploy."; fi
 
 deploy_if_beta_branch:
 	if [ "$(LOCAL_BRANCH)" == "beta" ]; then make distribute; fi

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,9 @@ setup_fastlane_env:
 build:
 	set -o pipefail && xcodebuild -workspace $(WORKSPACE) -scheme $(SCHEME) -configuration '$(CONFIGURATION)' -sdk iphonesimulator build -destination $(DEVICE_HOST) $(SWIFT_BUILD_FLAGS) $(DERIVED_DATA) | tee ./xcode_build_raw.log | bundle exec xcpretty -c
 
+build-for-tests:
+	set -o pipefail && xcodebuild -workspace $(WORKSPACE) -scheme $(SCHEME) -configuration Debug -sdk iphonesimulator build -destination $(DEVICE_HOST) $(SWIFT_BUILD_FLAGS) $(DERIVED_DATA) | tee ./xcode_build_raw.log | bundle exec xcpretty -c
+
 test:
 	set -o pipefail && xcodebuild -workspace $(WORKSPACE) -scheme $(SCHEME) -configuration Debug test -sdk iphonesimulator -destination $(DEVICE_HOST) $(DERIVED_DATA) $(OTHER_CFLAGS) | bundle exec second_curtain 2>&1 | tee ./xcode_test_raw.log  | bundle exec xcpretty -c --test --report junit --output ./test-results.xml
 
@@ -90,10 +93,10 @@ uitest:
 ### CI
 
 ci: 
-	if [ "$(LOCAL_BRANCH)" != "beta" ]; then CONFIGURATION=Debug make build; else echo "Skipping test build on beta deploy."; fi
+	if [ "$(LOCAL_BRANCH)" != "beta" ]; then make build-for-tests; else echo "Skipping test build on beta deploy."; fi
 
 ci-test: 
-	if [ "$(LOCAL_BRANCH)" != "beta" ]; then CONFIGURATION=Debug make test; else echo "Skipping test run on beta deploy."; fi
+	if [ "$(LOCAL_BRANCH)" != "beta" ]; then make test; else echo "Skipping test run on beta deploy."; fi
 
 deploy_if_beta_branch:
 	if [ "$(LOCAL_BRANCH)" == "beta" ]; then make distribute; fi


### PR DESCRIPTION
This PR skips running tests (and building for the purposes of running tests) on CI if the branch is `beta`. We ignore any test failures on this branch anyway, so the tests are just taking up time.

@javamonn I meant do pair on this but it kind of folded naturally into some release automation work I'm doing. I've assigned you to the PR, let me know if you'd like to pair on the review. 