### PR TITLE
Update artwork tile metadata styling

### DIFF
--- a/Artsy/Views/Collection_View_Cells/ARArtworkWithMetadataThumbnailCell.m
+++ b/Artsy/Views/Collection_View_Cells/ARArtworkWithMetadataThumbnailCell.m
@@ -29,9 +29,9 @@ static const CGFloat ARArtworkCellMetadataMargin = 8;
 + (CGFloat)heightIncludingPriceLabel:(BOOL)includePriceLabel
 {
     if (includePriceLabel) {
-        return [UIDevice isPad] ? 63 : 51;
+        return 60;
     } else {
-        return [UIDevice isPad] ? 42 : 34;
+        return 34;
     }
 }
 

--- a/Artsy/Views/Utilities/ARArtworkThumbnailMetadataView.h
+++ b/Artsy/Views/Utilities/ARArtworkThumbnailMetadataView.h
@@ -11,6 +11,6 @@
 
 @property (nonatomic, readonly) ARSerifLabel *primaryLabel;
 @property (nonatomic, readonly) ARArtworkTitleLabel *secondaryLabel;
-@property (nonatomic, readonly) ARSerifLabel *priceLabel;
+@property (nonatomic, readonly) ARSansSerifLabelUncapitalized *priceLabel;
 
 @end

--- a/Artsy/Views/Utilities/ARArtworkThumbnailMetadataView.m
+++ b/Artsy/Views/Utilities/ARArtworkThumbnailMetadataView.m
@@ -1,6 +1,7 @@
 #import "ARArtworkThumbnailMetadataView.h"
 
 #import "Artist.h"
+#import "Partner.h"
 #import "Artwork.h"
 #import "ARFonts.h"
 #import "Artsy-Swift.h"
@@ -9,14 +10,16 @@
 
 #import <ObjectiveSugar/ObjectiveSugar.h>
 
-static CGFloat ARMetadataFontSize;
+static const CGFloat ARMetadataFontSize = 12;
+static const CGFloat ARMetadataPriceBottomMargin = 4;
 
 
 @interface ARArtworkThumbnailMetadataView ()
 
 @property (nonatomic, strong) ARSerifLabel *primaryLabel;
 @property (nonatomic, strong) ARArtworkTitleLabel *secondaryLabel;
-@property (nonatomic, strong) ARSerifLabel *priceLabel;
+@property (nonatomic, strong) ARSansSerifLabelUncapitalized *priceLabel;
+@property (nonatomic, strong) ARSerifLabel *partnerLabel;
 @property (nonatomic, strong) UIImageView *paddleImageView;
 
 @property (nonatomic, assign) ARArtworkWithMetadataThumbnailCellPriceInfoMode mode;
@@ -26,12 +29,6 @@ static CGFloat ARMetadataFontSize;
 
 
 @implementation ARArtworkThumbnailMetadataView
-
-+ (void)initialize
-{
-    [super initialize];
-    ARMetadataFontSize = [UIDevice isPad] ? 15 : 12;
-}
 
 + (CGFloat)heightForMargin
 {
@@ -49,17 +46,26 @@ static CGFloat ARMetadataFontSize;
     _secondaryLabel = [[ARArtworkTitleLabel alloc] init];
     _secondaryLabel.lineHeight = 1;
     _secondaryLabel.numberOfLines = 1;
-    _priceLabel = [[ARSerifLabel alloc] init];
+    _priceLabel = [[ARSansSerifLabelUncapitalized alloc] init];
+    _partnerLabel = [[ARSerifLabel alloc] init];
     _showPaddle = NO;
 
     _paddleImageView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"paddle"]];
     [self addSubview:_paddleImageView];
 
-    [@[ self.primaryLabel, self.secondaryLabel, self.priceLabel ] each:^(UILabel *label) {
+    [@[ self.secondaryLabel, self.partnerLabel ] each:^(UILabel *label) {
         label.font = [label.font fontWithSize:ARMetadataFontSize];
         label.textColor = [UIColor artsyGraySemibold];
         [self addSubview:label];
     }];
+
+    self.primaryLabel.font = [UIFont serifBoldFontWithSize:ARMetadataFontSize];
+    self.primaryLabel.textColor = [UIColor artsyGraySemibold];
+    [self addSubview:self.primaryLabel];
+
+    self.priceLabel.font = [UIFont displayMediumSansSerifFontWithSize:ARMetadataFontSize];
+    self.priceLabel.textColor = [UIColor blackColor];
+    [self addSubview:self.priceLabel];
 
     return self;
 }
@@ -86,19 +92,21 @@ static CGFloat ARMetadataFontSize;
             if (self.showPaddle) {
                 labelFrame.origin.x += 8;
                 self.paddleImageView.hidden = NO;
-                self.paddleImageView.frame = CGRectMake(self.bounds.origin.x, labelFrame.origin.y+2, 6, 9);
+                self.paddleImageView.frame = CGRectMake(self.bounds.origin.x, labelFrame.origin.y + 2, 6, 9);
             }
             self.priceLabel.frame = labelFrame;
 
             break;
         case ARArtworkWithMetadataThumbnailCellPriceInfoModeSaleMessage:
-            labelFrame.size.height /= 3;
+            labelFrame.size.height /= 4;
 
+            self.priceLabel.frame = labelFrame;
+            labelFrame.origin.y = labelFrame.size.height + ARMetadataPriceBottomMargin;
             self.primaryLabel.frame = labelFrame;
-            labelFrame.origin.y = labelFrame.size.height;
+            labelFrame.origin.y += labelFrame.size.height;
             self.secondaryLabel.frame = labelFrame;
             labelFrame.origin.y += labelFrame.size.height;
-            self.priceLabel.frame = labelFrame;
+            self.partnerLabel.frame = labelFrame;
 
             break;
         case ARArtworkWithMetadataThumbnailCellPriceInfoModeNone:
@@ -136,6 +144,7 @@ static CGFloat ARMetadataFontSize;
         }
         case ARArtworkWithMetadataThumbnailCellPriceInfoModeSaleMessage:
             self.priceLabel.text = artwork.saleMessage;
+            self.partnerLabel.text = artwork.partner.name;
             break;
         case ARArtworkWithMetadataThumbnailCellPriceInfoModeNone:
             // nop

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -6,6 +6,7 @@ upcoming:
   dev:
     - Sends a user agent which includes the device model for Reaction SSR - orta
     - Skips running tests on beta deploys - ash
+    - Updates Related Artworks grid item metadata styling - javamonn
     
   user_facing:
     - Uses new search API for the app search - orta


### PR DESCRIPTION
Updates artwork grid item styling, companion PR to: https://github.com/artsy/emission/pull/1253, implements [LD-104](https://artsyproduct.atlassian.net/browse/LD-104).

Before:
 
<img width="200" alt="screen shot 2019-01-04 at 2 22 14 pm" src="https://user-images.githubusercontent.com/5216744/50706965-72605780-102d-11e9-9a7a-cb0ef108f00a.png">
<img width="400" alt="screen shot 2019-01-04 at 2 25 57 pm" src="https://user-images.githubusercontent.com/5216744/50706966-72605780-102d-11e9-83d1-3f58be354482.png">

After:

<img width="200" alt="screen shot 2019-01-04 at 2 40 32 pm" src="https://user-images.githubusercontent.com/5216744/50707418-c7509d80-102e-11e9-953b-1d5b0c9d1a46.png">
<img width="400" alt="screen shot 2019-01-04 at 2 35 50 pm" src="https://user-images.githubusercontent.com/5216744/50707417-c7509d80-102e-11e9-85af-68d177f54150.png">