### PR TITLE
Fix build by using UILabel directly

### DIFF
--- a/Artsy/Views/Utilities/ARArtworkThumbnailMetadataView.h
+++ b/Artsy/Views/Utilities/ARArtworkThumbnailMetadataView.h
@@ -11,6 +11,6 @@
 
 @property (nonatomic, readonly) ARSerifLabel *primaryLabel;
 @property (nonatomic, readonly) ARArtworkTitleLabel *secondaryLabel;
-@property (nonatomic, readonly) ARSansSerifLabelUncapitalized *priceLabel;
+@property (nonatomic, readonly) UILabel *priceLabel;
 
 @end

--- a/Artsy/Views/Utilities/ARArtworkThumbnailMetadataView.m
+++ b/Artsy/Views/Utilities/ARArtworkThumbnailMetadataView.m
@@ -18,7 +18,7 @@ static const CGFloat ARMetadataPriceBottomMargin = 4;
 
 @property (nonatomic, strong) ARSerifLabel *primaryLabel;
 @property (nonatomic, strong) ARArtworkTitleLabel *secondaryLabel;
-@property (nonatomic, strong) ARSansSerifLabelUncapitalized *priceLabel;
+@property (nonatomic, strong) UILabel *priceLabel;
 @property (nonatomic, strong) ARSerifLabel *partnerLabel;
 @property (nonatomic, strong) UIImageView *paddleImageView;
 
@@ -46,7 +46,7 @@ static const CGFloat ARMetadataPriceBottomMargin = 4;
     _secondaryLabel = [[ARArtworkTitleLabel alloc] init];
     _secondaryLabel.lineHeight = 1;
     _secondaryLabel.numberOfLines = 1;
-    _priceLabel = [[ARSansSerifLabelUncapitalized alloc] init];
+    _priceLabel = [[UILabel alloc] init];
     _partnerLabel = [[ARSerifLabel alloc] init];
     _showPaddle = NO;
 

--- a/Artsy/Views/Utilities/ARArtworkThumbnailMetadataView.m
+++ b/Artsy/Views/Utilities/ARArtworkThumbnailMetadataView.m
@@ -65,6 +65,7 @@ static const CGFloat ARMetadataPriceBottomMargin = 4;
 
     self.priceLabel.font = [UIFont displayMediumSansSerifFontWithSize:ARMetadataFontSize];
     self.priceLabel.textColor = [UIColor blackColor];
+    self.priceLabel.backgroundColor = [UIColor whiteColor];
     [self addSubview:self.priceLabel];
 
     return self;


### PR DESCRIPTION
Fixes a compilation error causing a failing build introduced in: #2752 

Instead of adding a special-cased uncapitalized sans-serif font to `Artsy+UILabels`, we use `UILabel` directly to the same result.

<img width="200" alt="screen shot 2019-01-08 at 4 47 38 pm" src="https://user-images.githubusercontent.com/5216744/50860981-66de9a80-1365-11e9-84cb-9d5b945564cd.png">
