### PR TITLE
Distributes eigen betas to 'external' testers

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -110,7 +110,10 @@ lane :ship_beta do
   # upload_to_sentry.call('eigen-staging')
 
   # Send to the app store
-  pilot changelog: beta_readme, itc_provider: 'ArtsyInc'
+  pilot changelog: beta_readme,
+    itc_provider: 'ArtsyInc',
+    distribute_external: true,
+    groups: ["Artsy"]
 end
 
 lane :promote_beta do


### PR DESCRIPTION
'External' is in square quotes because these are all Artsy staff (but not strictly developers). After being merged, new betas of Eigen should go out to both our engineers and our Artsy colleagues (based on the new `pilot` parameters).

---

This PR replicates the following emission-nebula commits:

https://github.com/artsy/emission-nebula/commit/360d0bdf14e238f05483b0c977e08707b91c4266
https://github.com/artsy/emission-nebula/commit/8cd5e64444f5121b0ee36036a2348d2a6f5d150e

I [already made](https://github.com/artsy/eigen/commit/d304ce5b61180981baf985380e3c12d62d8d0cfe) another necessary change in https://github.com/artsy/emission-nebula/commit/3d281dd01ea40429c371f20ffdf4d9dc0f72ccad to `master` to unblock an earlier beta deploy (see [this tweet for context](https://twitter.com/joshdholtz/status/1095457016758366208)).