### PR TITLE
Fixes some fair routing issues

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -221,11 +221,6 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
         }
     };
 
-    // Uncomment the following to simulate Emission calling out to presentModalViewController with whatever route.
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        emission.switchBoardModule.presentModalViewController([UIViewController new], @"https://live-staging.artsy.net/ash-test-sale");
-    });
-
     emission.switchBoardModule.presentArtworkSet = ^(UIViewController * _Nonnull fromViewController, NSArray<NSString *> * _Nonnull artworkIDs, NSNumber * _Nonnull index) {
         UIViewController *viewController = [[ARSwitchBoard sharedInstance] loadArtworkIDSet:artworkIDs inFair:nil atIndex:index.integerValue];
         [[ARTopMenuViewController sharedController] pushViewController:viewController];

--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -211,7 +211,7 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
 
             // When presenting modally, view controller generally have to be wrapped in a navigation controller
             // so the user can hit the close button. Consignments is the exception, and it has its own close button.
-            if (![viewController isKindOfClass:[UINavigationController class]]) {
+            if (!([viewController isKindOfClass:[UINavigationController class]] || [viewController isKindOfClass:[LiveAuctionViewController class]])) {
                 viewController = [[ARSerifNavigationViewController alloc] initWithRootViewController:viewController];
             }
 
@@ -222,9 +222,9 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
     };
 
     // Uncomment the following to simulate Emission calling out to presentModalViewController with whatever route.
-//    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-//        emission.switchBoardModule.presentModalViewController([UIViewController new], @"/conditions-of-sale");
-//    });
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        emission.switchBoardModule.presentModalViewController([UIViewController new], @"https://live-staging.artsy.net/ash-test-sale");
+    });
 
     emission.switchBoardModule.presentArtworkSet = ^(UIViewController * _Nonnull fromViewController, NSArray<NSString *> * _Nonnull artworkIDs, NSNumber * _Nonnull index) {
         UIViewController *viewController = [[ARSwitchBoard sharedInstance] loadArtworkIDSet:artworkIDs inFair:nil atIndex:index.integerValue];

--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -208,11 +208,23 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
             if (targetViewController.presentedViewController) {
                 targetViewController = targetViewController.presentedViewController;
             }
+
+            // When presenting modally, view controller generally have to be wrapped in a navigation controller
+            // so the user can hit the close button. Consignments is the exception, and it has its own close button.
+            if (![viewController isKindOfClass:[UINavigationController class]]) {
+                viewController = [[ARSerifNavigationViewController alloc] initWithRootViewController:viewController];
+            }
+
             [targetViewController presentViewController:viewController
                                                animated:ARPerformWorkAsynchronously
                                              completion:nil];
         }
     };
+
+    // Uncomment the following to simulate Emission calling out to presentModalViewController with whatever route.
+//    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+//        emission.switchBoardModule.presentModalViewController([UIViewController new], @"/conditions-of-sale");
+//    });
 
     emission.switchBoardModule.presentArtworkSet = ^(UIViewController * _Nonnull fromViewController, NSArray<NSString *> * _Nonnull artworkIDs, NSNumber * _Nonnull index) {
         UIViewController *viewController = [[ARSwitchBoard sharedInstance] loadArtworkIDSet:artworkIDs inFair:nil atIndex:index.integerValue];

--- a/Artsy/App/ARSwitchboard+Eigen.m
+++ b/Artsy/App/ARSwitchboard+Eigen.m
@@ -231,11 +231,7 @@
 
 - (UIViewController *)loadProfileWithID:(NSString *)profileID
 {
-    if ([AROptions boolForOption:AROptionsModernShowFairPages]) {
-        return [[ARFairComponentViewController alloc] initWithFairID:profileID];
-    } else {
-        return [[ARProfileViewController alloc] initWithProfileID:profileID];
-    }
+    return [[ARProfileViewController alloc] initWithProfileID:profileID];
 }
 
 #pragma mark -

--- a/Artsy/View_Controllers/Fair/ARProfileViewController.m
+++ b/Artsy/View_Controllers/Fair/ARProfileViewController.m
@@ -3,6 +3,7 @@
 #import "ArtsyAPI+Profiles.h"
 #import "Fair.h"
 #import "Profile.h"
+#import "AROptions.h"
 #import "ARSwitchBoard+Eigen.h"
 #import "ARLogger.h"
 
@@ -15,6 +16,7 @@
 
 #import <ReactiveObjC/ReactiveObjC.h>
 #import <FLKAutoLayout/UIView+FLKAutoLayout.h>
+#import <Emission/ARFairComponentViewController.h>
 
 
 @interface ARProfileViewController () <ARMenuAwareViewController>
@@ -81,11 +83,14 @@
                 NSString * fairID = ((Fair *) profile.profileOwner).fairID;
                 Fair *fair = [[Fair alloc] initWithFairID:fairID];
 
-                ARFairViewController *viewController = [[ARFairViewController alloc] initWithFair:fair andProfile:profile];
-
-                RAC(self, hidesNavigationButtons) = RACObserve(viewController, hidesNavigationButtons);
-
-                [self showViewController:viewController];
+                if ([AROptions boolForOption:AROptionsModernShowFairPages]) {
+                    ARFairComponentViewController *viewController = [[ARFairComponentViewController alloc] initWithFairID:fairID];
+                       [self showViewController:viewController];
+                } else {
+                    ARFairViewController *viewController = [[ARFairViewController alloc] initWithFair:fair andProfile:profile];
+                    RAC(self, hidesNavigationButtons) = RACObserve(viewController, hidesNavigationButtons);
+                    [self showViewController:viewController];
+                }
             }
 
             [self ar_removeIndeterminateLoadingIndicatorAnimated:YES];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,7 +5,7 @@ upcoming:
   dev:
     - Not yet
   user_facing:
-    - Not yet
+    - Fixes issue where non-fair routes would be sent to the new fair component - ash
 
 releases:
   -


### PR DESCRIPTION
The PR fixes [LD-199](https://artsyproduct.atlassian.net/browse/LD-199) by wrapping all not-already-wrapping view controllers in navigation controllers (providing them with a close button, so the user doesn't become trapped in a modal). I still need to test that this works with the following invocations routed from Emission (see the comment in `ARAppDelegate+Emission.m`):

- [x] Bid flow's live bidding exception case
- [x] Bid flow's conditions of sale 
- [x] Bid flow's Registration's conditions of sale
- [x] Search
- [x] Conversation's opening invoices
- [x] Generic markdown links
- [x] Fair's "view site" and "buy tickets" links

This PR also fixes a problem where Eigen would route `/conditions-of-sale` to the new fair component (if enabled, so this bug only presents for our beta testers) with a `fairID` set to `conditions-of-sale`. I described the problem in more detail [in Slack](https://artsy.slack.com/archives/C02BAQ5K7/p1550266403153100).