### PR TITLE
Fixes hard link simulator installation failure #trivial

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -841,14 +841,14 @@
 /* Begin PBXCopyFilesBuildPhase section */
 		606C64B61E32A59400FD13E3 /* Embed App Extensions */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 8;
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
 				606C64B11E32A59400FD13E3 /* Artsy Stickers.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
-			runOnlyForDeploymentPostprocessing = 0;
+			runOnlyForDeploymentPostprocessing = 1;
 		};
 /* End PBXCopyFilesBuildPhase section */
 


### PR DESCRIPTION
I've been seeing [this error](https://twitter.com/ashfurrow/status/1068618230426730502) for months, and @kierangillen began seeing it on his machine, too:

![screen shot 2019-02-19 at 1 27 29 pm](https://user-images.githubusercontent.com/498212/53039501-541fb100-344d-11e9-8d9f-fb4b6ca7d0ca.png)

The solution appears to be the following check box in the main target's build phases:

<img width="437" alt="untitled" src="https://user-images.githubusercontent.com/498212/53039529-60a40980-344d-11e9-8f16-0f2c79832991.png">

I found the solution in one of the many answer is [this StackOverflow post](https://stackoverflow.com/questions/27167020/ios-simulator-could-not-hardlink-copy-wrong-path-in-my-filesystem).