### PR TITLE
Fixes crash with opening search on Fair/Show components

### DIFF
--- a/Artsy/View_Controllers/Util/ARNavigationController.m
+++ b/Artsy/View_Controllers/Util/ARNavigationController.m
@@ -495,7 +495,7 @@ ShouldHideItem(UIViewController *viewController, SEL itemSelector, ...)
 
 - (BOOL)isShowingSearch
 {
-    return self.ar_innermostTopViewController.navigationController.topViewController == self.searchViewController;
+    return [[[ARTopMenuViewController sharedController] rootNavigationController] topViewController] == self.searchViewController;
 }
 
 - (void)showSearch
@@ -504,9 +504,7 @@ ShouldHideItem(UIViewController *viewController, SEL itemSelector, ...)
         self.searchViewController = [ARAppSearchViewController sharedSearchViewController];
     }
 
-    UINavigationController *navigationController = self.ar_innermostTopViewController.navigationController;
-    [navigationController pushViewController:self.searchViewController
-                                    animated:ARPerformWorkAsynchronously];
+    [[[ARTopMenuViewController sharedController] rootNavigationController] pushViewController:self.searchViewController animated:ARPerformWorkAsynchronously];
 }
 
 - (void)closeSearch

--- a/Artsy_Tests/View_Controller_Tests/Util/ARNavigationControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Util/ARNavigationControllerTests.m
@@ -132,6 +132,8 @@ describe(@"presenting pending operation layover", ^{
 describe(@"search", ^{
     before(^{
         navigationController.searchViewController = [ARAppSearchViewController new];
+        id mockTopViewController = [OCMockObject partialMockForObject:[ARTopMenuViewController sharedController]];
+        [[[mockTopViewController stub] andReturn:navigationController] rootNavigationController];
     });
 
     it(@"presents the search VC", ^{

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -14,6 +14,7 @@ upcoming:
     - Non-symbol currencies aren't forced into lowercase - orta + sarah
     - Fixes issue where non-fair routes would be sent to the new fair component - ash
     - Fixes search on Fair component - ash
+    - Fixes crash with opening search on Fair/Show components - ash
 
 releases:
   -


### PR DESCRIPTION
Opening search while looking at a fair/show view was crashing because we were sending the `pushViewController:animated:` message to the `NavigatorIOS` that the fair/show components are using. This was due to our use of `self.ar_innermostTopViewController.navigationController`, which looks from the git history like a copy/paste thing and not a conscious decision. I've look for other uses of `ar_innermostTopViewController` that might cause trouble, but I think we're good 👍 

In the long run, we really need to get those components doing their routing through Eigen's switchboard instead of having their own navigation controller. I wouldn't be surprised if there are more edge case bugs like this one that we might run into.

Fixes [LD-242](https://artsyproduct.atlassian.net/browse/LD-242).