### PR TITLE
Back button hiding bug fix

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -28,17 +28,25 @@
 #import <Emission/AREventsModule.h>
 #import <Emission/ARTakeCameraPhotoModule.h>
 #import <Emission/ARRefineOptionsModule.h>
-#import <Emission/ARFairComponentViewController.h>
 #import <Emission/ARWorksForYouModule.h>
 #import <Emission/ARArtistComponentViewController.h>
 #import <Emission/ARHomeComponentViewController.h>
 #import <Emission/ARWorksForYouComponentViewController.h>
 #import <Emission/ARInboxComponentViewController.h>
 #import <Emission/ARFavoritesComponentViewController.h>
+
+// Fairs
+#import <Emission/ARFairComponentViewController.h>
+#import <Emission/ARFairMoreInfoComponentViewController.h>
+#import <Emission/ARFairArtistsComponentViewController.h>
+#import <Emission/ARFairArtworksComponentViewController.h>
+#import <Emission/ARFairExhibitorsComponentViewController.h>
+
+// Shows
+#import <Emission/ARShowComponentViewController.h>
 #import <Emission/ARShowArtworksComponentViewController.h>
 #import <Emission/ARShowArtistsComponentViewController.h>
 #import <Emission/ARShowMoreInfoComponentViewController.h>
-#import <Emission/ARFairMoreInfoComponentViewController.h>
 
 #import <React/RCTUtils.h>
 #import <React/RCTDevSettings.h>
@@ -381,8 +389,17 @@ static char menuAwareScrollViewKey;
 @end
 
 MakeMenuAware(ARArtistComponentViewController)
-MakeMenuAware(ARFairComponentViewController)
+
+// Make Shows menu-aware
+MakeMenuAware(ARShowComponentViewController)
 MakeMenuAware(ARShowArtworksComponentViewController)
 MakeMenuAware(ARShowArtistsComponentViewController)
 MakeMenuAware(ARShowMoreInfoComponentViewController)
+
+// Make Fairs menu-aware
+MakeMenuAware(ARFairComponentViewController)
 MakeMenuAware(ARFairMoreInfoComponentViewController)
+MakeMenuAware(ARFairArtistsComponentViewController)
+MakeMenuAware(ARFairArtworksComponentViewController)
+MakeMenuAware(ARFairExhibitorsComponentViewController)
+

--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -374,7 +374,10 @@ static char menuAwareScrollViewKey;
 @implementation ControllerClass (ARMenuAwareViewController)\
 - (void)viewDidLayoutSubviews {\
     [super viewDidLayoutSubviews];\
-    self.menuAwareScrollView = FindFirstScrollView(self.view);\
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{\
+        self.menuAwareScrollView = FindFirstScrollView(self.view);\
+        NSLog(@"Making menu-aware scroll view: %@", self.menuAwareScrollView);\
+    });\
 }\
 - (void)setMenuAwareScrollView:(UIScrollView *)scrollView {\
     if (scrollView != self.menuAwareScrollView) {\

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -18,7 +18,7 @@ upcoming:
     - Fixes crash with opening search on Fair/Show components - ash
     - Add routes for Fair sub screens - luc
     - Eliminates API roundtrip for showing fairs in profile views - ash
-    - Fixes back button not hiding on Emission views - ash
+    - Fixes back button not hiding on Emission component views - ash
 
 releases:
   -


### PR DESCRIPTION
This PR fixes a problem where the back button wasn't hiding in some Emission component controllers. Mostly this fix is in this commit: 
https://github.com/artsy/eigen/commit/5e4b265ee480abd7b9d36f9368e61e329112c13f However, this wasn't sufficient.

Our code relies on `viewDidLayoutSubviews`, which _should_ get called when the component controller lays out its subviews. Unfortunately, it's not working for some of our component controllers; it gets called while the view hierarchy is still just the spinner, and isn't called again after the full UI is laid out. This was unexpected. A quick look at the different components doesn't point to any obvious differences why the fair component works but the fair artists component doesn't.

We [already have a ticket](https://artsyproduct.atlassian.net/browse/PLATFORM-1263) to revisit this mechanism in general so, while I dislike the `dispatch_after` hack, it does work for now. Open to discussion.