### PR TITLE
Update Podfile.lock

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -72,7 +72,7 @@ PODS:
   - DHCShakeNotifier (0.2.0)
   - DoubleConversion (1.1.5)
   - EDColor (1.0.0)
-  - Emission (1.8.15):
+  - Emission (1.8.18):
     - "Artsy+UIColors"
     - "Artsy+UIFonts (>= 3.0.0)"
     - DoubleConversion (= 1.1.5)
@@ -509,7 +509,7 @@ SPEC CHECKSUMS:
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
-  Emission: 4e12667c5efda692f0b161e496c1ebc016f6060f
+  Emission: 752eca33a4558c2c44207f6c3363b3b2bfc1c375
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   "Expecta+Snapshots": c343f410c7a6392f3e22e78f94c44b6c0749a516
   Extraction: 642a73b8ccc7806e9a7daf95ebb4c14c374829f1


### PR DESCRIPTION

- Only shows open, or upcoming fairs in the fairs tab - orta
- Support filtering the map based on the selected tab - orta
- Shows fairs on the map - orta
- Update city coordinates (to fix Los Angeles bug) - anandaroop
- Fixes warning about missing viewer prop - ash
- Removes touchable feedback on fair cards - ash
- Fixes warning about duplicate keys in list - ash
- Adds zero state to CityTab - kieran
- Renames SavedShowItemRow to ShowItemRow - kieran
- Adds Save button functionality to button in All tab - kieran
- Fixes top buttons re-appearing behind city picker - ash
- Fixes map not re-centering on new city when changed - ash
- Handles text spillover bug on narrow iphone screens in Saved Shows view - ashley
- Fixes saving not updating props in city view - kieran
- Disables navigation to Gallery pages from Shows view on stub shows - ashley
- Fixes memory leak by unsubscribing components from the EventEmitter - alloy
- Disables navigation to Gallery pages from Shows view on stub shows - ashley
- Adjusts styling on city picker - ashley
- Adds city section list for museum/gallery shows - kieran & ash
- Adds city section list support for upcoming/closing shows - ash
- Moves city list scroll view enabled-ness management to ObjC - ash
- Updates styling for cluster and pin show cards - luc
- Decrease likelihood of getting a blank view while scrolling fast in city tabs - alloy
- Hook up save functionality for show card - luc
- Adds loading screen for Map view - luc
- Adds analytics to map and city view - kieran
- Move ShapeLayers to PinsShapeLayer - luc
- Add loading indicator when data is downloading - luc
- Add safeAreaInsets to handle various screen sizes - luc
- Set min zoom size on map - luc
- Fixes map background sizing - luc
- Adds styling on single map points and clusters to indicate selection - ashley