### PR TITLE
Update the Echo settings to allow us passing in new people

### DIFF
--- a/Artsy/App/ArtsyEcho+LocalDisco.m
+++ b/Artsy/App/ArtsyEcho+LocalDisco.m
@@ -1,18 +1,19 @@
 #import "ArtsyEcho+LocalDisco.h"
 #import "ARAppStatus.h"
+#import "User.h"
 #import "UIDevice-Hardware.h"
 #import <ObjectiveSugar/ObjectiveSugar.h>
 
 /// To be kept in lock-step with the corresponding echo value, and updated when there is a breaking Maps change.
 /// https://echo-web-production.herokuapp.com/accounts/1/features
 ///
-NSInteger const ARLocalDiscoCurrentVersionCompatibility = 0;
+NSInteger const ARLocalDiscoCurrentVersionCompatibility = 1;
 
 @implementation ArtsyEcho (LocalDiscovery)
 
 - (BOOL)shouldShowLocalDiscovery
 {
-    return (self.features[@"AREnableLocalDiscovery"].state && self.isLocalDiscoCompatible) || [ARAppStatus isAdmin];
+    return (self.features[@"AREnableLocalDiscovery"].state && self.isLocalDiscoCompatible) || [ARAppStatus isAdmin] || [self userIsAllowListed];
 }
 
 - (BOOL)isLocalDiscoCompatible
@@ -25,7 +26,22 @@ NSInteger const ARLocalDiscoCurrentVersionCompatibility = 0;
         return [message.name isEqualToString:@"LocalDiscoveryCurrentVersion"];
     }] firstObject];
 
-    return localDiscoVersion.content.integerValue <= ARLocalDiscoCurrentVersionCompatibility;
+    return localDiscoVersion.content.integerValue >= ARLocalDiscoCurrentVersionCompatibility;
+}
+
+- (BOOL)userIsAllowListed
+{
+    BOOL userInAllowList = NO;
+    Message *allowListMessage = [self.messages find:^BOOL(Message *message) {
+        return [message.name isEqualToString:@"LocalDiscoveryAllowListCSV"];
+    }];
+
+    if (allowListMessage) {
+        User *user = [User currentUser];
+        userInAllowList = [[allowListMessage.content componentsSeparatedByString:@","] containsObject:user.userID];
+    }
+
+    return userInAllowList;
 }
 
 @end

--- a/Artsy/App/ArtsyEcho.m
+++ b/Artsy/App/ArtsyEcho.m
@@ -11,6 +11,10 @@
     NSURL *url = [[NSURL alloc] initWithString:@"https://echo-api-production.herokuapp.com/"];
     self = [self initWithServerURL:url accountID:1 APIKey:[keys artsyEchoProductionToken] localFilename:@"Echo"];
 
+    if (self) {
+        [self setup];
+    }
+
     return self;
 }
 


### PR DESCRIPTION
2 things: 

1. because we were using new echo instances instead of sharing a singleton, it wasn't running the setup function. This means echo would always have failed (because it wouldn't have data) - so glad we were gonna test
2. this adds a message which is a CSV of user ID which we can allow into City Guides

#trivial - there's already a changelog for this