### PR TITLE
Fixes deploy script incorrect tags #trivial

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -51,7 +51,8 @@ lane :ship_beta do
 
   build_ios_app(configuration: 'Store')
 
-  tag_and_push(tag: "#{latest_version}-#{latest_testflight_build_number}")
+  bundle_version = `/usr/libexec/PlistBuddy -c "Print CFBundleVersion" Artsy/App_Resources/Artsy-Info.plist`.strip
+  tag_and_push(tag: "#{latest_version}-#{bundle_version}")
 
   # First make individual dSYM archives available to the sentry-cli tool.
   root = File.expand_path('../..', __FILE__)


### PR DESCRIPTION
Mentioned in Slack: https://artsy.slack.com/archives/C02BAQ5K7/p1552918520142600

We saw the `4.4.1-2019.3.15.11` build get pushed as `4.4.1-2019.3.15.5` in [this build](https://circleci.com/gh/artsy/eigen/6007). I took a look and we were pushing the tag based on [`latest_testflight_build_number`](https://docs.fastlane.tools/actions/latest_testflight_build_number/#latest_testflight_build_number), which is incorrect; it grabs the build number from the latest _already-uploaded_ TestFlight build.

We set the build number in the `Makefile`, so it's already set by the time that Fastlane gets run. So I've modified the `Fastfile` to read the value out of the Info.plist file for the git tag.