### PR TITLE
Only updates echo once per switchboard call.

### DIFF
--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -74,6 +74,8 @@ NSInteger const ARLiveAuctionsCurrentWebSocketVersionCompatibility = 4;
 @property (nonatomic, readwrite, strong) Aerodramus *echo;
 @property (nonatomic, strong) NSArray<ARSwitchBoardDomain *> *domains;
 
+@property (nonatomic, assign) BOOL isEchoSetup;
+
 @end
 
 
@@ -118,6 +120,10 @@ NSInteger const ARLiveAuctionsCurrentWebSocketVersionCompatibility = 4;
 
 - (void)setupEcho
 {
+    // Only allow Echo to get set up once per instance.
+    if (self.isEchoSetup) { return; }
+    self.isEchoSetup = YES;
+
     Aerodramus *aero = self.echo;
 
     NSArray *currentRoutes = self.echo.routes.allValues.copy;

--- a/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
+++ b/Artsy_Tests/App_Tests/ARSwitchBoardTests.m
@@ -377,6 +377,19 @@ describe(@"ARSwitchboard", ^{
             expect(classString).to.contain(@"SerifModalWeb");
         });
 
+        it(@"only sets up its echo instance once", ^{
+            switchboard = [[ARSwitchBoard alloc] init];
+            id echoMock = [OCMockObject partialMockForObject:switchboard.echo];
+            [[echoMock expect] checkForUpdates:OCMOCK_ANY];
+
+            [switchboard updateRoutes];
+
+            [echoMock verify];
+
+            [[echoMock reject] checkForUpdates:OCMOCK_ANY];
+            [switchboard updateRoutes];
+        });
+
         it(@"falls back to web views when websocket becomes outdated", ^{
             switchboard = [[ARSwitchBoard alloc] init];
             id echoMock = [OCMockObject partialMockForObject:switchboard.echo];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,7 +5,7 @@ upcoming:
   dev:
     - 
   user_facing:
-    - 
+    - Fixes extraneous calls to Echo setup - ash
 
 releases:
   - version: 4.4.1


### PR DESCRIPTION
This is kind of a follow-up to https://github.com/artsy/Aerodramus/pull/9. I saw some logs that made me suspect that Echo might be getting updated a lot. In fact, if the JSON parsing for the updated Echo config fails (or you comment out that line), you'll see an infinite loop:

![Screen Shot 2019-03-19 at 7 06 56 PM](https://user-images.githubusercontent.com/498212/54648922-732a5680-4a7e-11e9-8f43-247c6f3b2432.png)

That screenshot shows an echo `update:` call invoking its callback, which calls `updateRoutes` on the switchboard, which checks for updates again, and which (if the parsing fails) will repeat forever. 

(The problem where `updateRoutes` is called on a background thread should be fixed by https://github.com/artsy/Aerodramus/pull/9 )

This PR introduces a guard against these repeated calls. I'm still verifying for sure this is the cause of the crash [here](https://sentry.io/organizations/artsynet/issues/942429014/?project=166784&referrer=slack&statsPeriod=14d) but this is a good change to make anyway. 