### PR TITLE
Increments ARLocalDiscoCurrentVersionCompatibility #trivial

### DIFF
--- a/Artsy/App/ArtsyEcho+LocalDisco.m
+++ b/Artsy/App/ArtsyEcho+LocalDisco.m
@@ -7,7 +7,7 @@
 /// To be kept in lock-step with the corresponding echo value, and updated when there is a breaking Maps change.
 /// https://echo-web-production.herokuapp.com/accounts/1/features
 ///
-NSInteger const ARLocalDiscoCurrentVersionCompatibility = 1;
+NSInteger const ARLocalDiscoCurrentVersionCompatibility = 2;
 
 @implementation ArtsyEcho (LocalDiscovery)
 


### PR DESCRIPTION
This will allow us to separate out the v1 and v1.1 users (ie: to only allow v1.1 to access LD). We don't _need_ to, but we might _want_ to, so why not ¯\_(ツ)_/¯ 