### PR TITLE
Fixes email autocomplete during login/signup

### DIFF
--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/ARPersonalizeViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/ARPersonalizeViewController.m
@@ -527,7 +527,9 @@
 
 - (void)emailTextChanged
 {
-    NSString *email = self.onboardingTextFields.emailField.text;
+    // iOS Autocomplete includes a space after inserting the email, we need to remove it.
+    NSString *email = [self.onboardingTextFields.emailField.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    self.onboardingTextFields.emailField.text = email;
     
     if ([self validEmail:email]) {
         [self.onboardingTextFields disableErrorState];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,7 +5,7 @@ upcoming:
   dev:
     - Fixes logic for Local Discovery Echo flag - ash
   user_facing:
-    - 
+    - Fixes email autocomplete during login/signup - ash
 
 releases:
   - version: 5.0.0


### PR DESCRIPTION
When iOS inserts an autocomplete email address, it adds a space at the end. Which isn't good, and other engineers have filed radars, but alas it breaks our current signup/signin flow (the "next" button gets disabled):

![ScreenRecording_03-26-2019 13-27-55 gifcask 2019-03-26 13_30_43](https://user-images.githubusercontent.com/498212/55019477-5f757780-4fcb-11e9-88d8-95c41af74496.gif)

The solution is to trim whitespace characters. It's not clear how data flows through the UI flow, so I made the change in the top-level text field notification-handler.