### PR TITLE
Fixes store promotion

### DIFF
--- a/fastlane/Deliverfile
+++ b/fastlane/Deliverfile
@@ -1,3 +1,3 @@
 app_identifier 'net.artsy.artsy'
-apple_id "mobiledeploys@artsymail.com"
+username "mobiledeploys@artsymail.com"
 automatic_release false

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -133,8 +133,6 @@ lane :promote_beta do
     skip_screenshots: true,
     skip_binary_upload: true,
     submit_for_review: true,
-    apple_id: "mobiledeploys@artsymail.com",
-        # Comes from https://github.com/fastlane/fastlane/issues/5542#issuecomment-254201994
     submission_information: {
       add_id_info_limits_tracking: true,
       add_id_info_serves_ads: false,


### PR DESCRIPTION
This commit had a typo that renamed `username` to `apple_id` (`Deliverfile` uses one and `Appfile` uses another):

https://github.com/artsy/eigen/commit/d865463a49b7d3306a777865ab1294d780581c10#diff-915e65323d2a5bb17e964d92abce9497

#2820 tried to fix this but I was getting the same error as it got. I'll keep this as a draft until I verify it works. 