### PR TITLE
Clears Relay cache when a PUT, POST, or DELETE is made to our API.

### DIFF
--- a/Artsy/Networking/API_Modules/ARUserManager.m
+++ b/Artsy/Networking/API_Modules/ARUserManager.m
@@ -417,13 +417,19 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
 + (void)logout
 {
     [self clearUserData];
-    exit(0);
+    // Clearning the Relay cache is an asynchonous operation, let's give it 0.5s to finish.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        exit(0);
+    });
 }
 
 + (void)logoutAndSetUseStaging:(BOOL)useStaging
 {
     [self clearUserData:[self sharedManager] useStaging:@(useStaging)];
-    exit(0);
+    // Clearning the Relay cache is an asynchonous operation, let's give it 0.5s to finish.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        exit(0);
+    });
 }
 
 + (void)clearUserData

--- a/Artsy_Tests/Networking_Tests/API_Modules/ArtsyAPI+PrivateTests.m
+++ b/Artsy_Tests/Networking_Tests/API_Modules/ArtsyAPI+PrivateTests.m
@@ -4,9 +4,14 @@
 #import "MutableNSURLResponse.h"
 #import "AFHTTPRequestOperation+JSON.h"
 
+#import <Emission/AREmission.h>
+#import <Emission/ARGraphQLQueryCache.h>
 
 @interface ArtsyAPI (TestsPrivate)
 + (ArtsyAPI *)sharedAPI;
+
+- (AFHTTPRequestOperation *)requestOperation:(NSURLRequest *)request removeNullsFromResponse:(BOOL)removeNulls success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, id JSON))success failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON))failure;
+- (AFHTTPRequestOperation *)performRequest:(NSURLRequest *)request removeNullsFromResponse:(BOOL)removeNulls success:(void (^)(id))success failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure;
 @end
 
 SpecBegin(ArtsyAPIPrivate);
@@ -70,6 +75,64 @@ it(@"removes JSON nulls when specified to", ^{
         failure(@"block unexepectedly invoked");
     }];
 
+    [apiMock verify];
+    [apiMock stopMocking];
+});
+
+sharedExamplesFor(@"API writes", ^(NSDictionary *data) {
+    it(@"clears the Relay cache", ^{
+        NSMutableURLRequest *postRequest = [request mutableCopy];
+        postRequest.HTTPMethod = data[@"method"];
+        id apiMock = [OCMockObject partialMockForObject:ArtsyAPI.sharedAPI];
+        [[[apiMock expect] andReturn:nil] requestOperation:OCMOCK_ANY removeNullsFromResponse:YES success:[OCMArg checkWithBlock:^BOOL(void (^callback)(NSURLRequest *request, NSHTTPURLResponse *response, id JSON)) {
+            callback(postRequest, [[NSHTTPURLResponse alloc] init], @{});
+            return YES;
+        }] failure:OCMOCK_ANY];
+
+        id mockCacheModule = [OCMockObject mockForClass:[ARGraphQLQueryCache class]];
+        id emissionMock = [OCMockObject partialMockForObject:[AREmission sharedInstance]];
+        [[[emissionMock stub] andReturn:mockCacheModule] graphQLQueryCacheModule];
+        [[mockCacheModule expect] clearAll];
+
+        [ArtsyAPI.sharedAPI performRequest:request removeNullsFromResponse:YES success:^(id json) {
+            // Nop
+        } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {
+            failure(@"block unexepectedly invoked");
+        }];
+
+        [mockCacheModule verify];
+        [emissionMock stopMocking];
+        [apiMock verify];
+        [apiMock stopMocking];
+    });
+});
+
+itBehavesLike(@"API writes", @{@"method": @"POST"});
+itBehavesLike(@"API writes", @{@"method": @"PUT"});
+itBehavesLike(@"API writes", @{@"method": @"DELETE"});
+
+it(@"does not clears the Relay cache on GET requests", ^{
+    NSMutableURLRequest *postRequest = [request mutableCopy];
+    postRequest.HTTPMethod = @"GET";
+    id apiMock = [OCMockObject partialMockForObject:ArtsyAPI.sharedAPI];
+    [[[apiMock expect] andReturn:nil] requestOperation:OCMOCK_ANY removeNullsFromResponse:YES success:[OCMArg checkWithBlock:^BOOL(void (^callback)(NSURLRequest *request, NSHTTPURLResponse *response, id JSON)) {
+        callback(postRequest, [[NSHTTPURLResponse alloc] init], @{});
+        return YES;
+    }] failure:OCMOCK_ANY];
+
+    id mockCacheModule = [OCMockObject mockForClass:[ARGraphQLQueryCache class]];
+    id emissionMock = [OCMockObject partialMockForObject:[AREmission sharedInstance]];
+    [[[emissionMock stub] andReturn:mockCacheModule] graphQLQueryCacheModule];
+    [[mockCacheModule reject] clearAll];
+
+    [ArtsyAPI.sharedAPI performRequest:request removeNullsFromResponse:YES success:^(id json) {
+        // Nop
+    } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {
+        failure(@"block unexepectedly invoked");
+    }];
+
+    [mockCacheModule verify];
+    [emissionMock stopMocking];
     [apiMock verify];
     [apiMock stopMocking];
 });

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,7 +5,7 @@ upcoming:
   dev:
     - Updates RN to 0.59 - orta/alloy
   user_facing:
-    - 
+    - Clears Relay cache when a PUT, POST, or DELETE is made to our API - ash
 
 releases:
   - version: 5.0.2


### PR DESCRIPTION
This is a follow-up to https://github.com/artsy/emission/pull/1583 and related to [DISCO-978](https://artsyproduct.atlassian.net/browse/DISCO-978). This PR changes Eigen to clear the Relay cache whenever we make a write to our API; this mirrors the existing behaviour of clearing the (same) cache on Emission whenever we make a GraphQL mutation. 