### PR TITLE
[Artwork] Put new RN view behind a lab option.

### DIFF
--- a/Artsy/App/AROptions.h
+++ b/Artsy/App/AROptions.h
@@ -14,6 +14,7 @@ extern NSString *const AROptionsDebugARVIR;
 extern NSString *const AROptionsForceBuyNow;
 extern NSString *const AROptionsBuyNow;
 extern NSString *const AROptionsMakeOffer;
+extern NSString *const AROptionsRNArtwork;
 
 @interface AROptions : NSObject
 

--- a/Artsy/App/AROptions.m
+++ b/Artsy/App/AROptions.m
@@ -27,6 +27,8 @@ NSString *const AROptionsBuyNow = @"enableBuyNowMakeOffer";
 
 NSString *const AROptionsMakeOffer = @"Enable Make Offer";
 
+NSString *const AROptionsRNArtwork = @"Enable React Native Artwork view";
+
 @implementation AROptions
 
 // Down here is the user-facing description
@@ -42,6 +44,7 @@ NSString *const AROptionsMakeOffer = @"Enable Make Offer";
          AROptionsBuyNow: @"Enable Eigen/Emission Buy Now integration",
          AROptionsForceBuyNow: @"Enable Buy Now purchase flow via Force",
          AROptionsMakeOffer: @"Enable Make Offer via Force",
+         AROptionsRNArtwork: AROptionsRNArtwork,
          
          AROptionsLoadingScreenAlpha: @"Loading screens are transparent",
         };

--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
@@ -3,6 +3,7 @@
 #import "Artwork.h"
 #import "ARDispatchManager.h"
 #import "ARSpinner.h"
+#import "AROptions.h"
 
 #import <Emission/ARArtworkComponentViewController.h>
 
@@ -18,8 +19,9 @@
 // TODO What do we do in the case of loading an artwork in the context of a Fair?
 - (BOOL)shouldShowNewVersion;
 {
-  return self.fair == nil
-  && (self.artwork.availability == ARArtworkAvailabilityNotForSale
+  return [AROptions boolForOption:AROptionsRNArtwork]
+    && self.fair == nil
+    && (self.artwork.availability == ARArtworkAvailabilityNotForSale
       || self.artwork.availability == ARArtworkAvailabilitySold);
 }
 

--- a/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
@@ -87,9 +87,27 @@ describe(@"ARArtworkViewController", ^{
         });
       }
     });
+
+    describe(@"when the lab option is disabled", ^{
+      beforeEach(^{
+        [AROptions setBool:NO forOption:AROptionsRNArtwork];
+      });
+
+      for (NSString *availability in componentAvailabilityStates) {
+        it([NSString stringWithFormat:@"shows it with a `%@` artwork", availability], ^{
+          StubArtworkWithAvailability(availability);
+          (void)vc.view;
+          expect(vc.childViewControllers[0]).to.equal(mockLegacyVC);
+        });
+      }
+    });
   });
 
   describe(@"concerning artworks for which to show the new component view", ^{
+    beforeEach(^{
+      [AROptions setBool:YES forOption:AROptionsRNArtwork];
+    });
+
     for (NSString *availability in componentAvailabilityStates) {
       it([NSString stringWithFormat:@"shows it with a `%@` artwork", availability], ^{
         StubArtworkWithAvailability(availability);


### PR DESCRIPTION
Closes https://artsyproduct.atlassian.net/browse/PURCHASE-1069 &
https://artsyproduct.atlassian.net/browse/PURCHASE-1070

Again, not adding a CHANGELOG entry right now. We should do so retroactively once 5.0.3 is released.

#trivial