### PR TITLE
Updates version/etc after 5.0.3 release #trivial

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.0.3</string>
+	<string>5.0.4</string>
 	<key>CFBundleVersion</key>
 	<string>2019.02.28.17</string>
 	<key>NSExtension</key>

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.0.3</string>
+	<string>5.0.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,15 +1,23 @@
 upcoming:
-  version: 5.0.3
+  version: 5.0.4
   date: TBD
-  emission_version: 1.10.x
+  emission_version: 1.x.y
   dev:
-    - Updates RN to 0.59 - orta/alloy
-    - Removes Echo.json from git index, moved to post-install CocoaPods hook - Ash & Chung-Yi
+    -
   user_facing:
-    - Clears Relay cache when a PUT, POST, or DELETE is made to our API - ash
-    - Fixes search result selection for features - ash & roop
+    - 
 
 releases:
+  - version: 5.0.3
+    date: May 18, 2019
+    emission_version: 1.11.3
+    dev:
+      - Updates RN to 0.59 - orta/alloy
+      - Removes Echo.json from git index, moved to post-install CocoaPods hook - Ash & Chung-Yi
+    user_facing:
+      - Clears Relay cache when a PUT, POST, or DELETE is made to our API - ash
+      - Fixes search result selection for features - ash & roop
+
   - version: 5.0.2
     date: Apr 13, 2019
     emission_version: 1.9.5

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -549,7 +549,7 @@ SPEC CHECKSUMS:
   Folly: de497beb10f102453a1afa9edbf8cf8a251890de
   Forgeries: 64ced144ea8341d89a7eec9d1d7986f0f1366250
   FXBlurView: 5121730176fd52bcf7bffd0bd8c1485e8aabc3cb
-  glog: aefd1eb5dda2ab95ba0938556f34b98e2da3a60d
+  glog: affb802cb73dc1156005a5fb19085008bf6ffd52
   Interstellar: ab67502af03105f92100a043e178d188a1a437c9
   iRate: 18fd2d3bd7d2ab01dcd801098cc2f5cbe9f25ffb
   ISO8601DateFormatter: 8311a2d4e265b269b2fed7ab4db685dcb0a7ccb2


### PR DESCRIPTION
This PR updates version numbers and changelog for the new 5.0.4 release (which I've already created in AppStoreConnect).