### PR TITLE
Removes unused if statement #trivial

### DIFF
--- a/Artsy/Models/API_Models/Application/SearchSuggestion.m
+++ b/Artsy/Models/API_Models/Application/SearchSuggestion.m
@@ -46,8 +46,6 @@
         return NSStringWithFormat(@"/artwork/%@", self.modelID);
     } else if ([self.model isEqualToString:@"article"]) {
         return NSStringWithFormat(@"/article/%@", self.modelID);
-    } else if ([self.model isEqualToString:@"page"]) {
-        return NSStringWithFormat(@"/artwork/%@", self.modelID);
     } else if ([self.model isEqualToString:@"sale"]) {
         return NSStringWithFormat(@"/auction/%@", self.modelID);
     } else if ([self.model isEqualToString:@"feature"]) {


### PR DESCRIPTION
This is a follow-up from #2830. The `else if` statement will never be reached because an earlier `if` catches it (with the `prefixless` array, which is likely why the static analyzer didn't catch this). 