### PR TITLE
Fixes issue with tipsi-stripe

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,7 +5,7 @@ upcoming:
   dev:
     - Adds new availability checks and enables new compiler warning for better checking of API availabilities - ash
   user_facing:
-    - 
+    - Fixes a problem entering credit cards for auction registration - ash
 
 releases:
   - version: 5.0.3

--- a/Podfile
+++ b/Podfile
@@ -93,8 +93,8 @@ target 'Artsy' do
   # Emission's dependencies
   # use `cat ~/.cocoapods/repos/artsy/Emission/1.x.x/Emission.podspec.json` to see the Podspec
 
-  # For Stripe integration with Emission
-  pod 'tipsi-stripe', git: 'https://github.com/tipsi/tipsi-stripe.git', tag: '7.5.0'
+  # For Stripe integration with Emission. Using Ash's fork for this issue: https://github.com/tipsi/tipsi-stripe/issues/408
+  pod 'tipsi-stripe', git: 'https://github.com/ashfurrow/tipsi-stripe.git', branch: 'fix-infinite-loop'
   pod 'react-native-mapbox-gl', git: 'https://github.com/l2succes/react-native-mapbox-gl', branch: 'fix-gesture-recognizer'
   pod 'SentryReactNative', git: 'https://github.com/getsentry/react-native-sentry.git', tag: 'v0.30.3'
   pod 'Pulley', :git => 'https://github.com/l2succes/Pulley.git', :branch => 'master'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -345,7 +345,7 @@ DEPENDENCIES:
   - Starscream
   - SwiftyJSON
   - Then
-  - tipsi-stripe (from `https://github.com/tipsi/tipsi-stripe.git`, tag `7.5.0`)
+  - tipsi-stripe (from `https://github.com/ashfurrow/tipsi-stripe.git`, branch `fix-infinite-loop`)
   - UICKeyChainStore
   - "UIView+BooleanAnimations"
   - VCRURLConnection
@@ -461,8 +461,8 @@ EXTERNAL SOURCES:
     :branch: add-axial-support
     :git: https://github.com/alloy/SSFadingScrollView.git
   tipsi-stripe:
-    :git: https://github.com/tipsi/tipsi-stripe.git
-    :tag: 7.5.0
+    :branch: fix-infinite-loop
+    :git: https://github.com/ashfurrow/tipsi-stripe.git
 
 CHECKOUT OPTIONS:
   AFOAuth1Client:
@@ -514,8 +514,8 @@ CHECKOUT OPTIONS:
     :commit: 3920e3582e46c9fe23b0d1200e28614ebd66d801
     :git: https://github.com/alloy/SSFadingScrollView.git
   tipsi-stripe:
-    :git: https://github.com/tipsi/tipsi-stripe.git
-    :tag: 7.5.0
+    :commit: bfebb733fb44d3e1d0522a38a317993f9c686422
+    :git: https://github.com/ashfurrow/tipsi-stripe.git
 
 SPEC CHECKSUMS:
   Adjust: b1f2b0e0b426fa991d69ed7fc9de806cf6dff5a6
@@ -596,6 +596,6 @@ SPEC CHECKSUMS:
   "XCTest+OHHTTPStubSuiteCleanUp": 4469ec8863c6bc022c5089a9b94233eb3416c5ee
   yoga: 4ce3811b3db5f47fe1e125f15383003316a616b8
 
-PODFILE CHECKSUM: 5805fc0d5fff729311b6d94f6f8ba491404980a5
+PODFILE CHECKSUM: c03452c052adadc827dda2ff280a76b98e0a10fc
 
 COCOAPODS: 1.6.0.beta.1


### PR DESCRIPTION
This PR moves `tipsi-stripe` to my fork, which includes [this commit](https://github.com/ashfurrow/tipsi-stripe/commit/bfebb733fb44d3e1d0522a38a317993f9c686422) (copied from [this PR](https://github.com/tipsi/tipsi-stripe/pull/418) that was closed without resolution) which fixes [this bug](https://github.com/tipsi/tipsi-stripe/issues/408). The bug _appears_ related to our recent React Native upgrade (I ruled out the `tipsi-stripe` [upgrade from 7.4.0 -> 7.5.0](https://github.com/tipsi/tipsi-stripe/compare/7.4.0...7.5.0)).

The fix was to remove a callback for when the keyboard appears; the callback that was being executed was this:

```objc
- (void)keyboardWillShow:(NSNotification *)n {
    if (!_jsRequestingFirstResponder && !_isFirstResponder) {
        [_paymentCardTextField resignFirstResponder];
    }
}
```

Which reads: "if the request to become a first respond (focus the text field) doesn't come from JS and if I am not the first responder (I have the keyboard focus) then make sure that the payment card text field subview loses focus." 

I've looked through the git history to figure out the purpose of this code, but it's unclear. My _guess_ is it has to do with supporting credit card inputs in a larger form with other inputs. Our UI has _just_ the credit card input on screen at a time (no other text inputs) so the _only_ way the keyboard shows is if if the `_paymentCardTextField` has been tapped by the user and is becoming the responder. Because the code only ever makes the payment field resign first responder and is only ever invoked when the payment field becomes the first responder, I am comfortable shipping this. (This also explains [the crash](https://sentry.io/organizations/artsynet/issues/1033339009/?project=1403105&referrer=slack) we're seeing: stack overflow from infinite show-and-hide-and-show-etc the keyboard.)

Please let me know what I can clarify. I've verified this works as expected on device by going through the complete bid -> register flow successfully (well, I didn't meet the reserve, but the bid did go through).

I will follow-up on the PR to ask why it was closed and will follow-up here.