### PR TITLE
Fixes a problem where the app's back button would become misaligned

### DIFF
--- a/Artsy/View_Controllers/Util/ARNavigationController.m
+++ b/Artsy/View_Controllers/Util/ARNavigationController.m
@@ -133,7 +133,9 @@ static void *ARNavigationControllerMenuAwareScrollViewContext = &ARNavigationCon
 {
     [super viewWillAppear:animated];
 
-    [self updateStatusBar:self.topViewController animated:animated];
+    if (self.view.window) {
+        [self updateStatusBar:self.topViewController animated:animated];
+    }
 }
 
 #pragma mark - Rotation

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,7 +5,7 @@ upcoming:
   dev:
     - Adds analytics tracking for artwork set view controller swipes - ash
   user_facing:
-    - 
+    - Fixes a problem where the app's back button would become misaligned - ash
 
 releases:
   - version: 5.0.4


### PR DESCRIPTION
<details><summary>Screenshot of misaligned back button</summary>

![IMG_4540](https://user-images.githubusercontent.com/498212/59461703-fba36380-8def-11e9-8c7a-703d74e72925.png)

</details>

This would happen when the City Guides controller was in-memory (even if it wasn't in the view hierarchy). It was still getting the `viewWillAppear:` callback and setting state on the ARTopMenuViewController singleton. The fix was to only invoke the callback to update the state if the view has a window (ie: if it is in the on-screen view hierarchy).

/cc @dleve123 @yuki24 