### PR TITLE
Moved artwork set analytics into artwork set view controller

### DIFF
--- a/Artsy/App/ARAppDelegate+Analytics.m
+++ b/Artsy/App/ARAppDelegate+Analytics.m
@@ -136,45 +136,6 @@
                             ]
                     },
                 @{
-                    ARAnalyticsClass: ARArtworkSetViewController.class,
-                    ARAnalyticsDetails: @[
-                        @{
-                            ARAnalyticsEventName: @"artwork set swipe started",
-                            ARAnalyticsSelectorName: NSStringFromSelector(@selector(pageViewController:willTransitionToViewControllers:)),
-                            ARAnalyticsProperties: ^NSDictionary*(ARArtworkSetViewController *controller, NSArray *args) {
-                                NSString *destinationArtworkID;
-                                ARArtworkViewController *destinationViewController = [args[1] lastObject];
-                                // Let's double-check that it's the right class – don't want to cause a crash.
-                                if ([destinationViewController isKindOfClass:ARArtworkViewController.class]) {
-                                    destinationArtworkID = destinationViewController.artwork.artworkID;
-                                }
-                                return @{
-                                    @"origin artwork id": controller.currentArtworkViewController.artwork.artworkID ?: @"",
-                                    @"destination artwork id": destinationArtworkID ?: @""
-                                };
-                            }
-                        },
-                        @{
-                            ARAnalyticsEventName: @"artwork set swipe finished",
-                            ARAnalyticsSelectorName: NSStringFromSelector(@selector(pageViewController:didFinishAnimating:previousViewControllers:transitionCompleted:)),
-                            ARAnalyticsProperties: ^NSDictionary*(ARArtworkSetViewController *controller, NSArray *args) {
-                                NSString *originArtworkID;
-                                ARArtworkViewController *originViewController = [args[2] lastObject];
-                                // Let's double-check that it's the right class – don't want to cause a crash.
-                                if ([originViewController isKindOfClass:ARArtworkViewController.class]) {
-                                    originArtworkID = originViewController.artwork.artworkID;
-                                }
-                                NSNumber *completed = args[3];
-                                return @{
-                                    @"origin artwork id": originArtworkID ?: @"",
-                                    @"destination artwork id": controller.currentArtworkViewController.artwork.artworkID ?: @"",
-                                    @"status": completed.boolValue ? @"completed" : @"cancelled"
-                                };
-                            }
-                        }
-                    ]
-                },
-                @{
                     ARAnalyticsClass: ARProfileViewController.class,
                     ARAnalyticsDetails: @[
                         @{

--- a/Artsy/View_Controllers/Artwork/ARArtworkSetViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkSetViewController.m
@@ -4,6 +4,8 @@
 #import "ARArtworkViewController.h"
 #import "ARTopMenuViewController.h"
 
+#import <ARAnalytics/ARAnalytics.h>
+
 #import "UIDevice-Hardware.h"
 
 @interface ARArtworkSetViewController () <ARMenuAwareViewController>
@@ -191,13 +193,27 @@
     return [self supportedInterfaceOrientations];
 }
 
-- (void)pageViewController:(UIPageViewController *)pageViewController willTransitionToViewControllers:(NSArray<UIViewController *> *)pendingViewControllers
+- (void)pageViewController:(UIPageViewController *)pageViewController willTransitionToViewControllers:(NSArray *)pendingViewControllers
 {
-    // nop, just used for analytics.
+    ARArtworkViewController *destinationViewController = [pendingViewControllers firstObject];
+    NSString *destinationArtworkID = destinationViewController.artwork.artworkID;
+
+    [ARAnalytics event:@"artwork set swipe started" withProperties:@{
+        @"origin artwork id": self.currentArtworkViewController.artwork.artworkID ?: @"",
+        @"destination artwork id": destinationArtworkID ?: @""
+    }];
 }
 
 - (void)pageViewController:(UIPageViewController *)pageViewController didFinishAnimating:(BOOL)finished previousViewControllers:(NSArray *)previousViewControllers transitionCompleted:(BOOL)completed;
 {
+    ARArtworkViewController *originViewController = [previousViewControllers firstObject];
+    NSString *originArtworkID = originViewController.artwork.artworkID;
+
+    [ARAnalytics event:@"artwork set swipe finished" withProperties:@{
+        @"origin artwork id": originArtworkID ?: @"",
+        @"destination artwork id": self.currentArtworkViewController.artwork.artworkID ?: @"",
+        @"status": completed ? @"completed" : @"cancelled"
+    }];
     if (completed) {
         [self.currentArtworkViewController setHasFinishedScrolling];
     }

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
   emission_version: 1.11.3-consignments-fix
   dev:
     - Adds analytics tracking for artwork set view controller swipes - ash
+    - Moved artwork set analytics into artwork set view controller - ash
   user_facing:
     - 
 


### PR DESCRIPTION
We saw that the analytics for swiping between view controllers weren't firing for artwork set view controllers _opened from an auction_. The others would work no problem, just not the ones presented from the Auction view controller. Super-weird. 

I dug through the ARAnalytics code, and then the ReactiveCocoa code its built on top of, but couldn't find any reason for `rac_signalForSelect:` not to fire for certain instances. I'm a bit worried we might be missing analytics events in other places, though with more and more of our codebase moving to React Native, it might be worth ripping out ARAnalytics+DSL altogether soon. This would also let us remove ReactiveCocoa and get a smaller app size.