### PR TITLE
Rename id fields and start consuming metaphysics v2

### DIFF
--- a/Artsy/Constants/ARDefaults.m
+++ b/Artsy/Constants/ARDefaults.m
@@ -52,7 +52,7 @@ NSString *const ARAugmentedRealityHasSuccessfullyRan = @"ARAugmentedRealityHasSu
         ARUseStagingDefault : @(useStagingDefault),
         ARStagingAPIURLDefault : @"https://stagingapi.artsy.net",
         ARStagingWebURLDefault : @"https://staging.artsy.net",
-        ARStagingMetaphysicsURLDefault : @"https://metaphysics-staging.artsy.net",
+        ARStagingMetaphysicsURLDefault : @"https://metaphysics-staging.artsy.net/v2",
         ARStagingLiveAuctionSocketURLDefault : @"wss://causality-staging.artsy.net"
     }];
 }

--- a/Artsy/Networking/artwork.graphql
+++ b/Artsy/Networking/artwork.graphql
@@ -1,11 +1,11 @@
 query OldArtworkQuery($artworkID: String!) {
   artwork(id: $artworkID) {
-    id
-    _id
+    _id: internalID
+    id: gravityID
 
     artist {
-      id
-      _id
+      _id: internalID
+      id: gravityID
       name
       years
       birthday
@@ -19,7 +19,7 @@ query OldArtworkQuery($artworkID: String!) {
 
     partner {
       name
-      id
+      id: gravityID
       default_profile_id
       is_default_profile_public
       type
@@ -27,7 +27,7 @@ query OldArtworkQuery($artworkID: String!) {
     }
 
     images {
-      id
+      id: gravityID
       image_versions
       image_url
       is_default
@@ -51,7 +51,7 @@ query OldArtworkQuery($artworkID: String!) {
     }
 
     edition_sets {
-      id
+      id: gravityID
       sale_message
       is_sold
       is_for_sale

--- a/Artsy/Networking/artworks_in_sale.graphql
+++ b/Artsy/Networking/artworks_in_sale.graphql
@@ -1,28 +1,28 @@
 {
   sale(id: "%@") {
     sale_artworks {
-      id
+      id: gravityID
       bidder_positions_count
       opening_bid_cents
       symbol
       highest_bid {
-        id
+        id: gravityID
         amount_cents
       }
       auction: sale {
-        id
+        id: gravityID
         auction_state: status
         is_auction
       }
       artwork {
-        id
+        id: gravityID
         title
         artist {
-          id
+          id: gravityID
           name
         }
         images {
-          id
+          id: gravityID
           aspect_ratio
           is_default
           image_versions

--- a/Artsy/Networking/create_offer.graphql
+++ b/Artsy/Networking/create_offer.graphql
@@ -1,17 +1,11 @@
-mutation createOfferOrder(
-  $artworkId: String!
-  $quantity: Int
-) {
+mutation createOfferOrder($artworkId: String!, $quantity: Int) {
   ecommerceCreateOfferOrderWithArtwork(
-    input: {
-      artworkId: $artworkId
-      quantity: $quantity
-    }
+    input: { artworkId: $artworkId, quantity: $quantity }
   ) {
     orderOrError {
       ... on OrderWithMutationSuccess {
         order {
-          id
+          id: internalID
         }
       }
       ... on OrderWithMutationFailure {

--- a/Artsy/Networking/create_order.graphql
+++ b/Artsy/Networking/create_order.graphql
@@ -1,13 +1,9 @@
-mutation createOrder(
-  $input: CreateOrderWithArtworkInput!
-) {
-  ecommerceCreateOrderWithArtwork(
-    input: $input
-  ) {
+mutation createOrder($input: CreateOrderWithArtworkInput!) {
+  ecommerceCreateOrderWithArtwork(input: $input) {
     orderOrError {
       ... on OrderWithMutationSuccess {
         order {
-          id
+          id: internalID
         }
       }
       ... on OrderWithMutationFailure {

--- a/Artsy/Networking/favorites.graphql
+++ b/Artsy/Networking/favorites.graphql
@@ -11,26 +11,26 @@
             id
             title
             artist {
-              id
+              id: gravityID
               name
             }
             images {
-              id
+              id: gravityID
               aspect_ratio
               is_default
               image_versions
               image_url
             }
             sale_artwork {
-              id
+              id: gravityID
               bidder_positions_count
               opening_bid_cents
               highest_bid {
-                id
+                id: gravityID
                 amount_cents
               }
               auction: sale {
-                id
+                id: gravityID
                 auction_state: status
                 is_auction
               }

--- a/Artsy/Networking/static_sale_data.graphql
+++ b/Artsy/Networking/static_sale_data.graphql
@@ -1,16 +1,16 @@
 {
   %@
   me {
-    id
+    id: gravityID
     paddle_number
     bidders(sale_id: "%@") {
-      id
+      id: gravityID
       qualified_for_bidding
     }
   }
   sale(id: "%@") {
-    _id
-    id
+    _id: internalID
+    id: gravityID
     start_at
     bid_increments {
       from
@@ -22,7 +22,7 @@
     is_with_buyers_premium
     description
     sale_artworks(all: true) {
-      _id
+      _id: internalID
       currency
       symbol
       reserve_status

--- a/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
@@ -3,8 +3,11 @@
 #import "ARLegacyArtworkViewController.h"
 #import <Emission/ARArtworkComponentViewController.h>
 
+
 @interface _ARLegacyArtworkViewControllerMock : UIViewController
 @end
+
+
 @implementation _ARLegacyArtworkViewControllerMock
 - (void)setHasFinishedScrolling {}
 @end
@@ -12,22 +15,24 @@
 
 @interface _ARArtworkComponentViewControllerMock : UIViewController
 @end
+
+
 @implementation _ARArtworkComponentViewControllerMock
 @end
 
 static void
 StubArtworkWithAvailability(NSString *availability)
 {
-  NSDictionary *response = @{
-                             @"data": @{
-                                 @"artwork": @{
-                                     @"id": @"some-artwork",
-                                     @"title": @"Some Title",
-                                     @"availability": availability
-                                     }
-                                 }
-                             };
-  [OHHTTPStubs stubJSONResponseForHost:@"metaphysics-staging.artsy.net" withResponse:response];
+    NSDictionary *response = @{
+        @"data" : @{
+            @"artwork" : @{
+                @"id" : @"some-artwork",
+                @"title" : @"Some Title",
+                @"availability" : availability
+            }
+        }
+    };
+    [OHHTTPStubs stubJSONResponseForHost:@"metaphysics-staging.artsy.net/v2" withResponse:response];
 }
 
 SpecBegin(ARArtworkViewController);

--- a/Artsy_Tests/View_Controller_Tests/Artwork/ARLegacyArtworkViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Artwork/ARLegacyArtworkViewControllerTests.m
@@ -6,6 +6,7 @@ void stubEmptyBidderPositions(void);
 void stubSaleArtwork(void);
 void stubBidder(BOOL requiresApproval);
 
+
 @interface ARLegacyArtworkViewController ()
 @property (nonatomic, strong) NSTimer *updateInterfaceWhenAuctionChangesTimer;
 @end
@@ -22,14 +23,14 @@ beforeEach(^{
     [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/related/shows" withResponse:@[]];
     [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/collection/saved-artwork/artworks" withResponse:@[]];
     [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/related/layer/synthetic/main/artworks" withResponse:@[]];
-    
+
     // This is the mutation to say "we have seen this artwork"
-    [OHHTTPStubs stubJSONResponseForHost:@"metaphysics-staging.artsy.net" withResponse:@{ }];
+    [OHHTTPStubs stubJSONResponseForHost:@"metaphysics-staging.artsy.net/v2" withResponse:@{ }];
     // ?
-    [OHHTTPStubs stubJSONResponseForHost:@"metaphysics-staging.artsy.net" withResponse:@{ }];
+    [OHHTTPStubs stubJSONResponseForHost:@"metaphysics-staging.artsy.net/v2" withResponse:@{ }];
 
     // This is the artwork request
-    [OHHTTPStubs stubJSONResponseForHost:@"metaphysics-staging.artsy.net" withResponse:@{ @"data": @{ @"artwork" : @{ @"id": @"some-artwork", @"title": @"Some Title" } } }];
+    [OHHTTPStubs stubJSONResponseForHost:@"metaphysics-staging.artsy.net/v2" withResponse:@{ @"data": @{ @"artwork" : @{ @"id": @"some-artwork", @"title": @"Some Title" } } }];
 });
 
 describe(@"no related data", ^{
@@ -60,9 +61,9 @@ describe(@"no related data", ^{
 });
 
 describe(@"with related artworks", ^{
-    
+
     it(@"shows the price when applicable", ^{
-        
+
         [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/related/layer/synthetic/main/artworks"
                                  withParams:@{@"artwork[]": @"some-artwork"}
                                withResponse:@[
@@ -71,15 +72,15 @@ describe(@"with related artworks", ^{
                                               @{ @"id": @"three", @"title": @"Three", @"sale_message": @"Not For Sale" },
                                               @{ @"id": @"four", @"title": @"Four" }
                                               ]];
-        
-        
+
+
         [ARTestContext useDevice:ARDeviceTypePhone6 :^{
-    
+
             vc = [[ARLegacyArtworkViewController alloc] initWithArtworkID:@"some-artwork" fair:nil];
             [vc ar_presentWithFrame:[[UIScreen mainScreen] bounds]];
             [vc setHasFinishedScrolling];
             [vc.view snapshotViewAfterScreenUpdates:YES];
-            
+
             expect([(ARArtworkView *)vc.view relatedArtworksView]).to.haveValidSnapshot();
         }];
     });
@@ -90,7 +91,7 @@ describe(@"with related artworks", ^{
             [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/related/layer/synthetic/main/artworks"
                                      withParams:@{@"artwork[]": @"some-artwork"}
                                    withResponse:@[ @{ @"id": @"one", @"title": @"One" }, @{ @"id": @"two", @"title": @"Two" } ]];
-            
+
 
             [ARTestContext useDevice:ARDeviceTypePhone6 :^{
 
@@ -104,7 +105,7 @@ describe(@"with related artworks", ^{
 
         });
     });
-    
+
     describe(@"iPad", ^{
 
         it(@"related artworks view looks correct", ^{
@@ -137,7 +138,7 @@ it(@"shows an upublished banner", ^{
         @"published" : @NO,
     };
 
-    [OHHTTPStubs stubJSONResponseForHost:@"metaphysics-staging.artsy.net" withResponse:@{ @"data": @{ @"artwork" : artworkDict } }];
+    [OHHTTPStubs stubJSONResponseForHost:@"metaphysics-staging.artsy.net/v2" withResponse:@{ @"data": @{ @"artwork" : artworkDict } }];
 
     Artwork *artwork = [Artwork modelWithJSON:artworkDict];
     CGRect frame = [[UIScreen mainScreen] bounds];
@@ -156,7 +157,8 @@ it(@"shows an upublished banner", ^{
 
 describe(@"at a closed auction", ^{
     before(^{
-        [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/related/sales" withResponse:@[@{
+        [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/related/sales" withResponse:@[
+@{
             @"id": @"some-auction",
             @"name": @"Some Auction",
             @"is_auction": @YES,
@@ -193,16 +195,16 @@ describe(@"at a closed auction", ^{
 
 
             expect(vc.view).to.haveValidSnapshot();
-            
+
         }];
     });
-    
+
     it(@"does not set up a timer", ^{
         [ARTestContext useDevice:ARDeviceTypePad :^{
             vc = [[ARLegacyArtworkViewController alloc] initWithArtworkID:@"some-artwork" fair:nil];
             [vc ar_presentWithFrame:[[UIScreen mainScreen] bounds]];
             [vc setHasFinishedScrolling];
-            
+
             expect(vc.updateInterfaceWhenAuctionChangesTimer).to.beNil();
         }];
     });
@@ -211,7 +213,8 @@ describe(@"at a closed auction", ^{
 
 describe(@"at an auction requireing registration", ^{
     before(^{
-        [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/related/sales" withResponse:@[@{
+        [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/related/sales" withResponse:@[
+@{
             @"id": @"some-auction",
             @"name": @"Some Auction",
             @"is_auction": @YES,
@@ -220,9 +223,9 @@ describe(@"at an auction requireing registration", ^{
             @"auction_state": @"open",
             @"published": @YES,
         }]];
-        
+
         [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/related/layer/synthetic/main/artworks" withResponse:@[]];
-        
+
         stubEmptyBidderPositions();
         stubBidder(YES);
         stubSaleArtwork();
@@ -232,7 +235,7 @@ describe(@"at an auction requireing registration", ^{
         vc = [[ARLegacyArtworkViewController alloc] initWithArtworkID:@"some-artwork" fair:nil];
         [vc ar_presentWithFrame:[[UIScreen mainScreen] bounds]];
         [vc setHasFinishedScrolling];
-        
+
         [vc.view snapshotViewAfterScreenUpdates:YES];
         expect(vc.view).to.haveValidSnapshot();
     });
@@ -256,12 +259,12 @@ describe(@"before a live auction", ^{
         stubBidder(NO);
         stubSaleArtwork();
     });
-    
+
     it(@"sets up an internal timer", ^{
         vc = [[ARLegacyArtworkViewController alloc] initWithArtworkID:@"some-artwork" fair:nil];
         [vc ar_presentWithFrame:[[UIScreen mainScreen] bounds]];
         [vc setHasFinishedScrolling];
-        
+
         expect(vc.updateInterfaceWhenAuctionChangesTimer).toNot.beNil();
     });
 });
@@ -271,7 +274,7 @@ it(@"creates an NSUserActivity", ^{
     [vc ar_presentWithFrame:[[UIScreen mainScreen] bounds]];
     [vc setHasFinishedScrolling];
     [vc.view snapshotViewAfterScreenUpdates:YES];
-    
+
     expect(vc.userActivity).notTo.beNil();
     expect(vc.userActivity.title).to.equal(@"Some Title");
 });
@@ -279,46 +282,49 @@ it(@"creates an NSUserActivity", ^{
 it(@"calls recordViewingOfArtwork within viewDidLoad", ^{
   ARLegacyArtworkViewController *vc = [[ARLegacyArtworkViewController alloc] initWithArtworkID:@"some-artwork" fair:nil];
   id apiMock = [OCMockObject niceMockForClass:ArtsyAPI.class];
-  
+
   [[apiMock expect] recordViewingOfArtwork:@"some-artwork" success:nil failure:nil];
-  
+
   [vc viewWillAppear:NO];
   [apiMock verify];
 });
-
 
 
 pending(@"at a fair");
 
 SpecEnd;
 
-void stubEmptyBidderPositions() {
+void stubEmptyBidderPositions()
+{
     [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/me/bidder_positions" withParams:@{
-        @"artwork_id":@"some-artwork",
-        @"sale_id":@"some-auction"
+        @"artwork_id" : @"some-artwork",
+        @"sale_id" : @"some-auction"
     } withResponse:@[]];
 }
 
-void stubSaleArtwork() {
+void stubSaleArtwork()
+{
     [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/sale/some-auction/sale_artwork/some-artwork" withResponse:@{
-        @"id": @"some-artwork",
-        @"sale_id": @"some-auction",
-        @"bidder_positions_count": @(1),
-        @"opening_bid_cents": @(1700000),
-        @"highest_bid_amount_cents": @(2200000),
-        @"minimum_next_bid_cents": @(2400000),
-        @"highest_bid": @{
-            @"id": @"highest-bid-id",
-            @"amount_cents": @(2200000),
+        @"id" : @"some-artwork",
+        @"sale_id" : @"some-auction",
+        @"bidder_positions_count" : @(1),
+        @"opening_bid_cents" : @(1700000),
+        @"highest_bid_amount_cents" : @(2200000),
+        @"minimum_next_bid_cents" : @(2400000),
+        @"highest_bid" : @{
+            @"id" : @"highest-bid-id",
+            @"amount_cents" : @(2200000),
         }
     }];
 }
 
-void stubBidder(BOOL requiresApproval) {
+void stubBidder(BOOL requiresApproval)
+{
     [OHHTTPStubs stubJSONResponseAtPath:@"/api/v1/me/bidders" withResponse:@[
         @{
-             @"qualified_for_bidding": @(!requiresApproval),
-             @"id":@"asdada",
-             @"sale": @{ @"id" : @"some-auction", @"require_bidder_approval": @(requiresApproval) },
-        }]];
+            @"qualified_for_bidding" : @(!requiresApproval),
+            @"id" : @"asdada",
+            @"sale" : @{@"id" : @"some-auction", @"require_bidder_approval" : @(requiresApproval)},
+        }
+    ]];
 }


### PR DESCRIPTION
This PR updates our graphQL queries to refer to the fields allowed by metaphysics' v2 endpoint.

*For fields that exist in Gravity*
`id` --> `gravityID`
`_id` --> `internalID`

*For fields that exist outside of Gravity*
`id` --> `internalID`

I also changed the default metaphysics URL to `metaphysics-staging.artsy.net/v2`.
