### PR TITLE
Cleans up unused lab options

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -288,7 +288,7 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
     [options addEntriesFromDictionary:echoFeatures];
 
     // Handle the fact that it's "AREnableBuyNowFlow" in iOS world - and echo, then "enableBuyNowMakeOffer" in Emission world
-    options[AROptionsBuyNow] = echoFeatures[@"AREnableBuyNowFlow"];
+    options[@"enableBuyNowMakeOffer"] = echoFeatures[@"AREnableBuyNowFlow"];
 
     // Lab options come last (as they are admin/dev controlled, giving them a chance to override)
     [options addEntriesFromDictionary:labOptions];

--- a/Artsy/App/AROptions.h
+++ b/Artsy/App/AROptions.h
@@ -11,9 +11,6 @@ extern NSString *const AROptionsDisableNativeLiveAuctions;
 extern NSString *const AROptionsStagingReactEnv;
 extern NSString *const AROptionsDevReactEnv;
 extern NSString *const AROptionsDebugARVIR;
-extern NSString *const AROptionsForceBuyNow;
-extern NSString *const AROptionsBuyNow;
-extern NSString *const AROptionsMakeOffer;
 extern NSString *const AROptionsRNArtwork;
 
 @interface AROptions : NSObject

--- a/Artsy/App/AROptions.m
+++ b/Artsy/App/AROptions.m
@@ -20,13 +20,6 @@ NSString *const AROptionsDevReactEnv = @"Use Dev React ENV";
 // Dev
 NSString *const AROptionsUseVCR = @"Use offline recording";
 
-// These variables may need to replicate the options in Emission
-// See: https://github.com/artsy/emission/blob/master/Example/Emission/ARLabOptions.m
-NSString *const AROptionsForceBuyNow = @"Enable Buy Now Flow via Force";
-NSString *const AROptionsBuyNow = @"enableBuyNowMakeOffer";
-
-NSString *const AROptionsMakeOffer = @"Enable Make Offer";
-
 NSString *const AROptionsRNArtwork = @"Enable React Native Artwork view";
 
 @implementation AROptions
@@ -40,12 +33,9 @@ NSString *const AROptionsRNArtwork = @"Enable React Native Artwork view";
         options = @{
          AROptionsDisableNativeLiveAuctions: @"Disable Native Live Auctions",
          AROptionsDebugARVIR: @"Debug AR View in Room",
-         
-         AROptionsBuyNow: @"Enable Eigen/Emission Buy Now integration",
-         AROptionsForceBuyNow: @"Enable Buy Now purchase flow via Force",
-         AROptionsMakeOffer: @"Enable Make Offer via Force",
+
          AROptionsRNArtwork: AROptionsRNArtwork,
-         
+
          AROptionsLoadingScreenAlpha: @"Loading screens are transparent",
         };
     });
@@ -78,7 +68,6 @@ NSString *const AROptionsRNArtwork = @"Enable React Native Artwork view";
 {
     return @[
         AROptionsDisableNativeLiveAuctions,
-        AROptionsForceBuyNow,   
     ];
 }
 

--- a/Artsy/Views/Artwork/ARArtworkActionsView.m
+++ b/Artsy/Views/Artwork/ARArtworkActionsView.m
@@ -387,7 +387,7 @@ return [navigationButtons copy];
 {
     // We don't have a UI to select from multiple edition sets yet, so don't show the Make Offer UI at all for those works.
     return (self.artwork.isOfferable.boolValue &&
-            (self.echo.isMakeOfferAccessible || [AROptions boolForOption:AROptionsMakeOffer]) &&
+            self.echo.isMakeOfferAccessible &&
             !self.artwork.hasMultipleEditions);
 }
 

--- a/Artsy_Tests/App_Tests/ARAppDelegateEmissionSpec.m
+++ b/Artsy_Tests/App_Tests/ARAppDelegateEmissionSpec.m
@@ -14,7 +14,6 @@ it(@"makes sure that settings are merged correctly", ^{
     NSDictionary *labOptionsConfig = @{
        AROptionsDisableNativeLiveAuctions: @(YES),
        AROptionsDebugARVIR: @(YES),
-       AROptionsBuyNow: @(YES)
     };
 
     ARAppDelegate *delegate = [ARAppDelegate new];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,7 +3,7 @@ upcoming:
   date: TBD
   emission_version: 1.x.y
   dev:
-    - 
+    - Cleans up unused lab options - ash
   user_facing:
     - Adds new React Native Artwork view behind lab option - alloy/david
 


### PR DESCRIPTION
I noticed that we have a few lab options that we aren't using anymore, so I went through and pruned them down. Now the labs screen looks like this:

![Screen Shot 2019-06-28 at 16 58 20](https://user-images.githubusercontent.com/498212/60370989-fcc6ba00-99c5-11e9-8430-8a80d294cd06.png)
