### PR TITLE
Updates version number

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.0.5</string>
+	<string>5.0.6</string>
 	<key>CFBundleVersion</key>
 	<string>2019.05.24.09</string>
 	<key>NSExtension</key>

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.0.5</string>
+	<string>5.0.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,5 +1,5 @@
 upcoming:
-  version: 5.0.5
+  version: 5.0.6
   date: TBD
   emission_version: 1.x.y
   dev:


### PR DESCRIPTION
After 5.0.5 was released, we need to do two things:

- Add a new version (5.0.6 in this case) to Apple's AppStoreConnect dashboard, and
- Edit our changelog and Xcode projects to match that new version.

More details are [in the docs](https://github.com/artsy/eigen/blob/master/docs/deploy_to_app_store.md#prepare-for-the-next-release).

We will also need to pull the changes from the `5.0.5-develop` branch into `master`, which I'll take care of later today.