### PR TITLE
PURCHASE-1203 : Refines logic for showing RN artwork view for all non-commercial works

### DIFF
--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
@@ -20,7 +20,7 @@
 
 - (BOOL)shouldShowNewVersion;
 {
-    return [AROptions boolForOption:AROptionsRNArtwork] && !(self.artwork.availability == ARArtworkAvailabilityForSale) && !(self.artwork.isInquireable);
+    return [AROptions boolForOption:AROptionsRNArtwork] && self.artwork.availability != ARArtworkAvailabilityForSale && !self.artwork.isInquireable;
 }
 
 - (instancetype)initWithArtwork:(Artwork *)artwork fair:(Fair *)fair;

--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
@@ -9,49 +9,48 @@
 
 #import <FLKAutoLayout/UIView+FLKAutoLayout.h>
 
+
 @interface ARArtworkViewController ()
 @property (strong, nonatomic) ARLegacyArtworkViewController *legacyViewController;
 @property (strong, nonatomic) ARSpinner *spinner;
 @end
 
+
 @implementation ARArtworkViewController
 
-// TODO What do we do in the case of loading an artwork in the context of a Fair?
 - (BOOL)shouldShowNewVersion;
 {
-  return [AROptions boolForOption:AROptionsRNArtwork]
-    && self.fair == nil
-    && (self.artwork.availability == ARArtworkAvailabilityNotForSale
-      || self.artwork.availability == ARArtworkAvailabilitySold);
+    return [AROptions boolForOption:AROptionsRNArtwork] && !(self.artwork.availability == ARArtworkAvailabilityForSale) && !(self.artwork.isInquireable);
 }
 
 - (instancetype)initWithArtwork:(Artwork *)artwork fair:(Fair *)fair;
 {
-  if ((self = [super init])) {
-    _artwork = artwork;
-    _fair = fair;
-  }
-  return self;
+    if ((self = [super init])) {
+        _artwork = artwork;
+        _fair = fair;
+    }
+    return self;
 }
 
 - (void)loadView;
 {
-  self.view = [UIView new];
+    self.view = [UIView new];
 
-  ARSpinner *spinner = [[ARSpinner alloc] initWithFrame:CGRectMake(0, 0, 44, 44)];
-  [spinner fadeInAnimated:ARPerformWorkAsynchronously];
-  [spinner constrainHeight:@"100"];
-  [self.view addSubview:spinner];
-  [spinner alignCenterWithView:self.view];
-  self.spinner = spinner;
+    ARSpinner *spinner = [[ARSpinner alloc] initWithFrame:CGRectMake(0, 0, 44, 44)];
+    [spinner fadeInAnimated:ARPerformWorkAsynchronously];
+    [spinner constrainHeight:@"100"];
+    [self.view addSubview:spinner];
+    [spinner alignCenterWithView:self.view];
+    self.spinner = spinner;
 }
 
-- (void)viewDidLoad {
-  [super viewDidLoad];
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
 
-  __weak typeof(self) wself = self;
+    __weak typeof(self) wself = self;
 
-  [self.artwork onArtworkUpdate:^{
+    [self.artwork onArtworkUpdate:^{
     ar_dispatch_main_queue(^{
       NSAssert(wself, @"Did not expect the VC to have been released.");
       if (!wself) {
@@ -81,37 +80,37 @@
         [sself.legacyViewController setHasFinishedScrolling];
       }
     });
-  } failure:^(NSError *error) {
+    } failure:^(NSError *error) {
     // TODO
     NSLog(@"FAILED TO UPDATE: %@", error);
-  }];
+    }];
 
-  [self.artwork updateArtwork];
+    [self.artwork updateArtwork];
 }
 
 - (NSInteger)index;
 {
-  return self.legacyViewController.index;
+    return self.legacyViewController.index;
 }
 
 - (void)setIndex:(NSInteger)index;
 {
-  self.legacyViewController.index = index;
+    self.legacyViewController.index = index;
 }
 
 - (UIImageView *)imageView;
 {
-  return self.legacyViewController.imageView;
+    return self.legacyViewController.imageView;
 }
 
 - (void)setHasFinishedScrolling;
 {
-  [self.legacyViewController setHasFinishedScrolling];
+    [self.legacyViewController setHasFinishedScrolling];
 }
 
 - (CGPoint)imageViewOffset;
 {
-  return self.legacyViewController.imageViewOffset;
+    return self.legacyViewController.imageViewOffset;
 }
 
 @end

--- a/Artsy/Views/Artwork/ARArtworkView.m
+++ b/Artsy/Views/Artwork/ARArtworkView.m
@@ -115,7 +115,7 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
 
 - (void)setUpCallbacks
 {
-    __weak typeof (self) wself = self;
+    __weak typeof(self) wself = self;
 
     void (^completion)(void) = ^{
         __strong typeof (wself) sself = wself;
@@ -136,7 +136,7 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
         __strong typeof (wself) sself = wself;
         if (!sself || !fair) return;
 
-        
+
         [sself.metadataView updateWithFair:fair];
         [sself.stackView layoutIfNeeded];
     } failure:nil];
@@ -161,9 +161,9 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
 - (void)artworkBidUpdated:(NSNotification *)notification;
 {
     if ([notification.userInfo[ARAuctionArtworkIDKey] isEqualToString:self.artwork.artworkID]) {
-        __weak typeof (self) wself = self;
+        __weak typeof(self) wself = self;
         [self.metadataView showActionsViewSpinner];
-        [self.artwork onSaleArtworkUpdate:^(SaleArtwork * _Nonnull saleArtwork) {
+        [self.artwork onSaleArtworkUpdate:^(SaleArtwork *_Nonnull saleArtwork) {
             __strong typeof (wself) sself = wself;
             if (saleArtwork.auctionState & ARAuctionStateUserIsBidder) {
                 [ARAnalytics setUserProperty:@"has_placed_bid" toValue:@"true"];
@@ -175,8 +175,8 @@ static const CGFloat ARArtworkImageHeightAdjustmentForPhone = -56;
                 [sself.metadataView updateUIForSaleArtwork:saleArtwork];
             }
         }
-      failure:nil
-        allowCached:NO];
+                                  failure:nil
+                              allowCached:NO];
         [self.artwork updateSaleArtwork];
     }
 }

--- a/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
@@ -3,8 +3,11 @@
 #import "ARLegacyArtworkViewController.h"
 #import <Emission/ARArtworkComponentViewController.h>
 
+
 @interface _ARLegacyArtworkViewControllerMock : UIViewController
 @end
+
+
 @implementation _ARLegacyArtworkViewControllerMock
 - (void)setHasFinishedScrolling {}
 @end
@@ -12,29 +15,47 @@
 
 @interface _ARArtworkComponentViewControllerMock : UIViewController
 @end
+
+
 @implementation _ARArtworkComponentViewControllerMock
 @end
 
 static void
 StubArtworkWithAvailability(NSString *availability)
 {
-  NSDictionary *response = @{
-                             @"data": @{
-                                 @"artwork": @{
-                                     @"id": @"some-artwork",
-                                     @"title": @"Some Title",
-                                     @"availability": availability
-                                     }
-                                 }
-                             };
-  [OHHTTPStubs stubJSONResponseForHost:@"metaphysics-staging.artsy.net" withResponse:response];
+    NSDictionary *response = @{
+        @"data" : @{
+            @"artwork" : @{
+                @"id" : @"some-artwork",
+                @"title" : @"Some Title",
+                @"availability" : availability
+            }
+        }
+    };
+    [OHHTTPStubs stubJSONResponseForHost:@"metaphysics-staging.artsy.net" withResponse:response];
+}
+
+static void
+StubArtworkWithAvailabilityAndInquireability(NSString *availability, NSString *inquireability)
+{
+    NSDictionary *response = @{
+        @"data" : @{
+            @"artwork" : @{
+                @"id" : @"some-artwork",
+                @"title" : @"Some Title",
+                @"availability" : availability,
+                @"is_inquireable" : inquireability
+            }
+        }
+    };
+    [OHHTTPStubs stubJSONResponseForHost:@"metaphysics-staging.artsy.net" withResponse:response];
 }
 
 SpecBegin(ARArtworkViewController);
 
 describe(@"ARArtworkViewController", ^{
-  NSArray *legacyAvailabilityStates = @[@"for sale", @"on hold"];
-  NSArray *componentAvailabilityStates = @[@"not for sale", @"on loan", @"permanent collection", @"sold"];
+  NSArray *legacyAvailabilityStates = @[@"for sale"];
+  NSArray *componentAvailabilityStates = @[@"not for sale", @"on loan", @"permanent collection", @"sold", @"on hold"];
 
   __block Artwork *artwork = nil;
   __block ARArtworkViewController *vc = nil;
@@ -75,14 +96,14 @@ describe(@"ARArtworkViewController", ^{
       });
     }
 
-    describe(@"when in the context of a fair", ^{
+    describe(@"when inquireable", ^{
       beforeEach(^{
-        vc = [[ARArtworkViewController alloc] initWithArtwork:artwork fair:(id)[NSObject new]];
+        vc = [[ARArtworkViewController alloc] initWithArtwork:artwork fair:nil];
       });
 
       for (NSString *availability in componentAvailabilityStates) {
         it([NSString stringWithFormat:@"shows it with a `%@` artwork", availability], ^{
-          StubArtworkWithAvailability(availability);
+          StubArtworkWithAvailabilityAndInquireability(availability, @"true");
           (void)vc.view;
           expect(vc.childViewControllers[0]).to.equal(mockLegacyVC);
         });

--- a/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
@@ -36,7 +36,7 @@ StubArtworkWithAvailability(NSString *availability)
 }
 
 static void
-StubArtworkWithAvailabilityAndInquireability(NSString *availability, NSString *inquireability)
+StubArtworkWithAvailabilityAndInquireability(NSString *availability, NSNumber *inquireability)
 {
     NSDictionary *response = @{
         @"data" : @{
@@ -103,7 +103,7 @@ describe(@"ARArtworkViewController", ^{
 
       for (NSString *availability in componentAvailabilityStates) {
         it([NSString stringWithFormat:@"shows it with a `%@` artwork", availability], ^{
-          StubArtworkWithAvailabilityAndInquireability(availability, @"true");
+          StubArtworkWithAvailabilityAndInquireability(availability, @(YES));
           (void)vc.view;
           expect(vc.childViewControllers[0]).to.equal(mockLegacyVC);
         });


### PR DESCRIPTION
Our first iteration of the artwork view is just for non-commercial works. This PR updates our logic for whether or not to show the RN view or the legacy view to be the following:
- If the artwork is not "for sale" (different from "not for sale") _and_ the artwork is not "inquireable", we show the RN view as long as a user has the flag enabled.