### PR TITLE
[PURCHASE-165] LAI view now updates the number of bids as they come in

### DIFF
--- a/Artsy/View_Controllers/Live_Auctions/ViewModels/LiveAuctionLotViewModel.swift
+++ b/Artsy/View_Controllers/Live_Auctions/ViewModels/LiveAuctionLotViewModel.swift
@@ -133,7 +133,12 @@ class LiveAuctionLotViewModel: NSObject, LiveAuctionLotViewModelType {
         reserveStatusSignal.update(lot.reserveStatus)
         askingPriceSignal.update(lot.askingPriceCents)
 
-        lotStateSignal = biddingStatusSignal.map { (biddingStatus, passed, isHighestBidder) -> LotState in
+        // We merge with the numberOfBidsSignal, then throw away its value in map, so
+        // that the lotStateSignal fires whenever there is a new bid. This lets the UI
+        // update with the current value from the view model.
+        lotStateSignal = numberOfBidsSignal.merge(biddingStatusSignal).map { (_, status) -> BiddingStatus in
+            return status
+        }.map { (biddingStatus, passed, isHighestBidder) -> LotState in
             switch biddingStatus {
             case .upcoming: fallthrough // Case that sale is not yet open
             case .open:                 // Case that lot is open to leave max bids

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -7,6 +7,7 @@ upcoming:
   user_facing:
     - Adds new React Native Artwork view behind lab option - alloy/david
     - Integrates View-in-Room support from React Native Artwork view - ash/steve
+    - LAI view now updates the number of bids as they come in - ash
     - Adds edition information to LAI lot info view - ash/lily
 
 releases:


### PR DESCRIPTION
This is a longstanding bug with the LAI interface (longstanding as in, it's been there since we built the thing in 2016). Funny how taking a few years off of piece of code gives you a new perspective, eh? 

Unit testing this would be... impractical. But I've made sure to document what's going on. And I have a handy gif, which I guess is _almost_ as useful as a unit test?

![2019-07-12 15-23-49 2019-07-12 15_29_09](https://user-images.githubusercontent.com/498212/61153742-26014300-a4ba-11e9-9604-6ca0bb056337.gif)
