### PR TITLE
Fixes problem not being able to open LAI sales.

### DIFF
--- a/Artsy/View_Controllers/Live_Auctions/ViewModels/LiveAuctionLotViewModel.swift
+++ b/Artsy/View_Controllers/Live_Auctions/ViewModels/LiveAuctionLotViewModel.swift
@@ -133,12 +133,7 @@ class LiveAuctionLotViewModel: NSObject, LiveAuctionLotViewModelType {
         reserveStatusSignal.update(lot.reserveStatus)
         askingPriceSignal.update(lot.askingPriceCents)
 
-        // We merge with the numberOfBidsSignal, then throw away its value in map, so
-        // that the lotStateSignal fires whenever there is a new bid. This lets the UI
-        // update with the current value from the view model.
-        lotStateSignal = numberOfBidsSignal.merge(biddingStatusSignal).map { (_, status) -> BiddingStatus in
-            return status
-        }.map { (biddingStatus, passed, isHighestBidder) -> LotState in
+        lotStateSignal = biddingStatusSignal.map { (biddingStatus, passed, isHighestBidder) -> LotState in
             switch biddingStatus {
             case .upcoming: fallthrough // Case that sale is not yet open
             case .open:                 // Case that lot is open to leave max bids
@@ -330,11 +325,8 @@ class LiveAuctionLotViewModel: NSObject, LiveAuctionLotViewModelType {
     }
 
     func updateBiddingStatus(_ biddingStatus: String, wasPassed: Bool) {
-        let updated = model.updateBiddingStatus(with: biddingStatus)
-
-        if updated {
-            biddingStatusSignal.update((status: model.biddingStatus, wasPassed: wasPassed, isHighestBidder: self.userIsWinning))
-        }
+        model.updateBiddingStatus(with: biddingStatus)
+        biddingStatusSignal.update((status: model.biddingStatus, wasPassed: wasPassed, isHighestBidder: self.userIsWinning))
     }
 
     func updateOnlineBidCount(_ onlineBidCount: Int) {

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -8,6 +8,7 @@ upcoming:
     - Adds new React Native Artwork view behind lab option - alloy/david
     - Integrates View-in-Room support from React Native Artwork view - ash/steve
     - LAI view now updates the number of bids as they come in - ash
+    - LAI view now opens on all sales - ash
     - Adds edition information to LAI lot info view - ash/lily
     - Don't push same search view if it already exists
     - Live auction current lot now updates current bid - ash/anson


### PR DESCRIPTION
Introduced in #2867, it was caused by a mutex lock. The solution here is, instead of merging signals, we no longer filter non-bidding status updates from our signal. That is to say: we were only letting observers know about new bidding status updates when a subset of fields got updated, and now we send all updates from Causality through the signal.