### PR TITLE
Upgrade to Emission 1.12.8

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -72,7 +72,7 @@ PODS:
   - DHCShakeNotifier (0.2.0)
   - DoubleConversion (1.1.6)
   - EDColor (1.0.0)
-  - Emission (1.12.6):
+  - Emission (1.12.8):
     - "Artsy+UIColors"
     - "Artsy+UIFonts (>= 3.0.0)"
     - DoubleConversion (= 1.1.6)
@@ -538,7 +538,7 @@ SPEC CHECKSUMS:
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
-  Emission: 5cc56d40f17f154f492b750baa5f11765a52f78c
+  Emission: 79d6a12c9492d9106d8d0ba1548c1c4287a93883
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   "Expecta+Snapshots": c343f410c7a6392f3e22e78f94c44b6c0749a516
   Extraction: 642a73b8ccc7806e9a7daf95ebb4c14c374829f1


### PR DESCRIPTION
This includes the last change that the Auctions team wanted to finish this week: https://github.com/artsy/emission/blob/master/CHANGELOG.md#1127