### PR TITLE
[PURCHASE-1277] Improves UX and TX for new artwork view

### DIFF
--- a/Artsy/App/AROptions.h
+++ b/Artsy/App/AROptions.h
@@ -11,7 +11,10 @@ extern NSString *const AROptionsDisableNativeLiveAuctions;
 extern NSString *const AROptionsStagingReactEnv;
 extern NSString *const AROptionsDevReactEnv;
 extern NSString *const AROptionsDebugARVIR;
-extern NSString *const AROptionsRNArtwork;
+extern NSString *const AROptionsRNArtworkAlways;
+extern NSString *const AROptionsRNArtworkNonCommerical;
+extern NSString *const AROptionsRNArtworkNSOInquiry;
+extern NSString *const AROptionsRNArtworkAuctions;
 
 @interface AROptions : NSObject
 

--- a/Artsy/App/AROptions.m
+++ b/Artsy/App/AROptions.m
@@ -20,7 +20,10 @@ NSString *const AROptionsDevReactEnv = @"Use Dev React ENV";
 // Dev
 NSString *const AROptionsUseVCR = @"Use offline recording";
 
-NSString *const AROptionsRNArtwork = @"Enable React Native Artwork view";
+NSString *const AROptionsRNArtworkAlways = @"New RN Artwork view (Always)";
+NSString *const AROptionsRNArtworkNonCommerical = @"New RN Artwork view (Non-commerical)";
+NSString *const AROptionsRNArtworkNSOInquiry = @"New RN Artwork view (NSO&Inquiry)";
+NSString *const AROptionsRNArtworkAuctions = @"New RN Artwork view (Auctions)";
 
 @implementation AROptions
 
@@ -34,7 +37,10 @@ NSString *const AROptionsRNArtwork = @"Enable React Native Artwork view";
          AROptionsDisableNativeLiveAuctions: @"Disable Native Live Auctions",
          AROptionsDebugARVIR: @"Debug AR View in Room",
 
-         AROptionsRNArtwork: AROptionsRNArtwork,
+         AROptionsRNArtworkAlways: AROptionsRNArtworkAlways,
+         AROptionsRNArtworkNonCommerical: AROptionsRNArtworkNonCommerical,
+         AROptionsRNArtworkNSOInquiry: AROptionsRNArtworkNSOInquiry,
+         AROptionsRNArtworkAuctions: AROptionsRNArtworkAuctions,
 
          AROptionsLoadingScreenAlpha: @"Loading screens are transparent",
         };

--- a/Artsy/Models/API_Models/Partner_Metadata/Artwork.h
+++ b/Artsy/Models/API_Models/Partner_Metadata/Artwork.h
@@ -84,6 +84,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy) NSString *saleMessage;
 
+/** Note that this field is only populated from Metaphysics requests. */
+@property (nonatomic, assign) BOOL isInAuction;
+
 /// An artwork is BuyNowable if it isAcquirable but doesn't have multiple editions.
 @property (nonatomic, assign, readonly) BOOL isBuyNowable;
 

--- a/Artsy/Models/API_Models/Partner_Metadata/Artwork.m
+++ b/Artsy/Models/API_Models/Partner_Metadata/Artwork.m
@@ -112,6 +112,7 @@
         ar_keypath(Artwork.new, gravIsPriceHidden) : @"price_hidden",
         
         ar_keypath(Artwork.new, mpSold) : @"is_sold",
+        ar_keypath(Artwork.new, isInAuction) : @"is_in_auction",
         ar_keypath(Artwork.new, mpIsAcquirable) : @"is_acquireable",
         ar_keypath(Artwork.new, mpIsInquirable) : @"is_inquireable",
         ar_keypath(Artwork.new, mpIsOfferable) : @"is_offerable",

--- a/Artsy/Models/API_Models/Partner_Metadata/Artwork.m
+++ b/Artsy/Models/API_Models/Partner_Metadata/Artwork.m
@@ -89,6 +89,7 @@
         ar_keypath(Artwork.new, dimensionsInches) : @"dimensions.in",
         ar_keypath(Artwork.new, mpAttributionClass) : @"mp_attribution_class.name",
         ar_keypath(Artwork.new, gravAttributionClass) : @"attribution_class",
+        ar_keypath(Artwork.new, saleArtwork) : @"sale_artwork",
         
         ar_keypath(Artwork.new, editionSets) : @"edition_sets",
         ar_keypath(Artwork.new, editionOf) : @"edition_of",
@@ -144,6 +145,11 @@
 + (NSValueTransformer *)partnerJSONTransformer
 {
     return [MTLValueTransformer mtl_JSONDictionaryTransformerWithModelClass:[Partner class]];
+}
+
++ (NSValueTransformer *)saleArtworkJSONTransformer
+{
+    return [MTLValueTransformer mtl_JSONDictionaryTransformerWithModelClass:[SaleArtwork class]];
 }
 
 + (NSValueTransformer *)defaultImageJSONTransformer

--- a/Artsy/Networking/artwork.graphql
+++ b/Artsy/Networking/artwork.graphql
@@ -17,10 +17,7 @@ query OldArtworkQuery($artworkID: String!) {
       sortable_id
     }
 
-    sale_artwork {
-      id
-      _id
-    }
+    is_in_auction
 
     partner {
       name

--- a/Artsy/Networking/artwork.graphql
+++ b/Artsy/Networking/artwork.graphql
@@ -17,6 +17,11 @@ query OldArtworkQuery($artworkID: String!) {
       sortable_id
     }
 
+    sale_artwork {
+      id
+      _id
+    }
+
     partner {
       name
       id

--- a/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
+++ b/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
@@ -452,7 +452,7 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
     ARSectionData *labsSectionData = [[ARSectionData alloc] init];
     labsSectionData.headerTitle = @"Labs";
     
-    NSArray *options = [AROptions labsOptions];
+    NSArray *options = [[AROptions labsOptions] sortedArrayUsingSelector:@selector(compare:)];
     for (NSInteger index = 0; index < options.count; index++) {
         NSString *key = options[index];
         NSString *title = [AROptions descriptionForOption:key];

--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
@@ -21,7 +21,24 @@
 
 - (BOOL)shouldShowNewVersion;
 {
-    return [AROptions boolForOption:AROptionsRNArtwork] && self.artwork.availability != ARArtworkAvailabilityForSale && !self.artwork.isInquireable.boolValue;
+    if ([AROptions boolForOption:AROptionsRNArtworkAlways]) {
+        return YES;
+    }
+
+    BOOL isArtworkNonCommerical = self.artwork.availability != ARArtworkAvailabilityForSale && !self.artwork.isInquireable.boolValue;
+    BOOL isArtworkNSOInquiry = self.artwork.isOfferable || self.artwork.isAcquireable || self.artwork.isInquireable;
+    BOOL isArtworkAuctions = self.artwork.saleArtwork;
+
+    if ([AROptions boolForOption:AROptionsRNArtworkNonCommerical] && isArtworkNonCommerical) {
+        return YES;
+    } else if ([AROptions boolForOption:AROptionsRNArtworkNSOInquiry] && isArtworkNSOInquiry) {
+        return YES;
+    } else if ([AROptions boolForOption:AROptionsRNArtworkAuctions] && isArtworkAuctions) {
+        return YES;
+    }
+
+    // Should never get here, but let's return NO to satisfy the compiler.
+    return NO;
 }
 
 - (instancetype)initWithArtwork:(Artwork *)artwork fair:(Fair *)fair;

--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
@@ -27,7 +27,7 @@
 
     BOOL isArtworkNonCommerical = self.artwork.availability != ARArtworkAvailabilityForSale && !self.artwork.isInquireable.boolValue;
     BOOL isArtworkNSOInquiry = self.artwork.isOfferable || self.artwork.isAcquireable || self.artwork.isInquireable;
-    BOOL isArtworkAuctions = self.artwork.saleArtwork;
+    BOOL isArtworkAuctions = self.artwork.isInAuction;
 
     if ([AROptions boolForOption:AROptionsRNArtworkNonCommerical] && isArtworkNonCommerical) {
         return YES;

--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
@@ -37,7 +37,6 @@
         return YES;
     }
 
-    // Should never get here, but let's return NO to satisfy the compiler.
     return NO;
 }
 
@@ -65,6 +64,7 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+    self.view.backgroundColor = [UIColor whiteColor];
 
     __weak typeof(self) wself = self;
 

--- a/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
@@ -61,7 +61,7 @@ StubArtworkWithSaleArtwork()
                 @"id" : @"some-artwork",
                 @"title" : @"Some Title",
                 @"availability" : @"for sale",
-                @"sale_artwork": @{@"id": @"some-sale-artwork-id"}
+                @"is_in_auction": @(YES)
             }
         }
     };

--- a/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
@@ -36,6 +36,39 @@ StubArtworkWithAvailability(NSString *availability)
 }
 
 static void
+StubArtworkWithBNMO(BOOL buyable, BOOL offerable)
+{
+    NSDictionary *response = @{
+        @"data" : @{
+            @"artwork" : @{
+                @"id" : @"some-artwork",
+                @"title" : @"Some Title",
+                @"availability" : @"for sale",
+                @"is_acquireable": @(buyable),
+                @"is_offerable": @(offerable)
+            }
+        }
+    };
+    [OHHTTPStubs stubJSONResponseForHost:@"metaphysics-staging.artsy.net" withResponse:response];
+}
+
+static void
+StubArtworkWithSaleArtwork()
+{
+    NSDictionary *response = @{
+        @"data" : @{
+            @"artwork" : @{
+                @"id" : @"some-artwork",
+                @"title" : @"Some Title",
+                @"availability" : @"for sale",
+                @"sale_artwork": @{@"id": @"some-sale-artwork-id"}
+            }
+        }
+    };
+    [OHHTTPStubs stubJSONResponseForHost:@"metaphysics-staging.artsy.net" withResponse:response];
+}
+
+static void
 StubArtworkWithAvailabilityAndInquireability(NSString *availability, NSNumber *inquireability)
 {
     NSDictionary *response = @{
@@ -54,90 +87,166 @@ StubArtworkWithAvailabilityAndInquireability(NSString *availability, NSNumber *i
 SpecBegin(ARArtworkViewController);
 
 describe(@"ARArtworkViewController", ^{
-  NSArray *legacyAvailabilityStates = @[@"for sale"];
-  NSArray *componentAvailabilityStates = @[@"not for sale", @"on loan", @"permanent collection", @"sold", @"on hold"];
+    NSArray *legacyAvailabilityStates = @[@"for sale"];
+    NSArray *componentAvailabilityStates = @[@"not for sale", @"on loan", @"permanent collection", @"sold", @"on hold"];
 
-  __block Artwork *artwork = nil;
-  __block ARArtworkViewController *vc = nil;
+    __block Artwork *artwork = nil;
+    __block ARArtworkViewController *vc = nil;
 
-  __block id mockLegacyVCClass = nil;
-  __block _ARLegacyArtworkViewControllerMock *mockLegacyVC = nil;
+    __block id mockLegacyVCClass = nil;
+    __block _ARLegacyArtworkViewControllerMock *mockLegacyVC = nil;
 
-  __block id mockComponentVCClass = nil;
-  __block _ARArtworkComponentViewControllerMock *mockComponentVC = nil;
+    __block id mockComponentVCClass = nil;
+    __block _ARArtworkComponentViewControllerMock *mockComponentVC = nil;
 
-  beforeEach(^{
-    artwork = [[Artwork alloc] initWithArtworkID:@"some-artwork"];
-
-    mockLegacyVC = [_ARLegacyArtworkViewControllerMock new];
-    mockLegacyVCClass = [OCMockObject mockForClass:ARLegacyArtworkViewController.class];
-    (void)[[[mockLegacyVCClass stub] andReturn:mockLegacyVCClass] alloc];
-    (void)[[[mockLegacyVCClass stub] andReturn:mockLegacyVC] initWithArtwork:artwork fair:OCMOCK_ANY];
-
-    mockComponentVC = [_ARArtworkComponentViewControllerMock new];
-    mockComponentVCClass = [OCMockObject mockForClass:ARArtworkComponentViewController.class];
-    (void)[[[mockComponentVCClass stub] andReturn:mockComponentVCClass] alloc];
-    (void)[[[mockComponentVCClass stub] andReturn:mockComponentVC] initWithArtworkID:artwork.artworkID];
-
-    vc = [[ARArtworkViewController alloc] initWithArtwork:artwork fair:nil];
-  });
-
-  afterEach(^{
-    [mockLegacyVCClass stopMocking];
-    [mockComponentVCClass stopMocking];
-  });
-
-  describe(@"concerning artworks for which to show the legacy view", ^{
-    for (NSString *availability in legacyAvailabilityStates) {
-      it([NSString stringWithFormat:@"shows it with a `%@` artwork", availability], ^{
-        StubArtworkWithAvailability(availability);
-        (void)vc.view;
-        expect(vc.childViewControllers[0]).to.equal(mockLegacyVC);
-      });
-    }
-
-    describe(@"when inquireable", ^{
-      beforeEach(^{
-        vc = [[ARArtworkViewController alloc] initWithArtwork:artwork fair:nil];
-      });
-
-      for (NSString *availability in componentAvailabilityStates) {
-        it([NSString stringWithFormat:@"shows it with a `%@` artwork", availability], ^{
-          StubArtworkWithAvailabilityAndInquireability(availability, @(YES));
-          (void)vc.view;
-          expect(vc.childViewControllers[0]).to.equal(mockLegacyVC);
-        });
-      }
-    });
-
-    describe(@"when the lab option is disabled", ^{
-      beforeEach(^{
-        [AROptions setBool:NO forOption:AROptionsRNArtwork];
-      });
-
-      for (NSString *availability in componentAvailabilityStates) {
-        it([NSString stringWithFormat:@"shows it with a `%@` artwork", availability], ^{
-          StubArtworkWithAvailability(availability);
-          (void)vc.view;
-          expect(vc.childViewControllers[0]).to.equal(mockLegacyVC);
-        });
-      }
-    });
-  });
-
-  describe(@"concerning artworks for which to show the new component view", ^{
     beforeEach(^{
-      [AROptions setBool:YES forOption:AROptionsRNArtwork];
+        artwork = [[Artwork alloc] initWithArtworkID:@"some-artwork"];
+
+        mockLegacyVC = [_ARLegacyArtworkViewControllerMock new];
+        mockLegacyVCClass = [OCMockObject mockForClass:ARLegacyArtworkViewController.class];
+        (void)[[[mockLegacyVCClass stub] andReturn:mockLegacyVCClass] alloc];
+        (void)[[[mockLegacyVCClass stub] andReturn:mockLegacyVC] initWithArtwork:artwork fair:OCMOCK_ANY];
+
+        mockComponentVC = [_ARArtworkComponentViewControllerMock new];
+        mockComponentVCClass = [OCMockObject mockForClass:ARArtworkComponentViewController.class];
+        (void)[[[mockComponentVCClass stub] andReturn:mockComponentVCClass] alloc];
+        (void)[[[mockComponentVCClass stub] andReturn:mockComponentVC] initWithArtworkID:artwork.artworkID];
+
+        vc = [[ARArtworkViewController alloc] initWithArtwork:artwork fair:nil];
+
+        // Reset all options to default states
+        [AROptions setBool:NO forOption:AROptionsRNArtworkNonCommerical];
+        [AROptions setBool:NO forOption:AROptionsRNArtworkNSOInquiry];
+        [AROptions setBool:NO forOption:AROptionsRNArtworkAuctions];
+        [AROptions setBool:NO forOption:AROptionsRNArtworkAlways];
     });
 
-    for (NSString *availability in componentAvailabilityStates) {
-      it([NSString stringWithFormat:@"shows it with a `%@` artwork", availability], ^{
-        StubArtworkWithAvailability(availability);
-        (void)vc.view;
-        expect(vc.childViewControllers[0]).to.equal(mockComponentVC);
-      });
-    }
-  });
+    afterEach(^{
+        [mockLegacyVCClass stopMocking];
+        [mockComponentVCClass stopMocking];
+    });
+
+    describe(@"concerning artworks for which to show the legacy view", ^{
+        for (NSString *availability in legacyAvailabilityStates) {
+            it([NSString stringWithFormat:@"shows it with a `%@` artwork", availability], ^{
+                StubArtworkWithAvailability(availability);
+                (void)vc.view;
+                expect(vc.childViewControllers[0]).to.equal(mockLegacyVC);
+            });
+        }
+
+        describe(@"when inquireable", ^{
+            beforeEach(^{
+                vc = [[ARArtworkViewController alloc] initWithArtwork:artwork fair:nil];
+            });
+
+            for (NSString *availability in componentAvailabilityStates) {
+                it([NSString stringWithFormat:@"shows it with a `%@` artwork", availability], ^{
+                    StubArtworkWithAvailabilityAndInquireability(availability, @(YES));
+                    (void)vc.view;
+                    expect(vc.childViewControllers[0]).to.equal(mockLegacyVC);
+                });
+            }
+        });
+
+        describe(@"NSO/inquiry artworks", ^{
+            it(@"works with buy-nowable artworks", ^{
+                StubArtworkWithBNMO(YES, NO);
+                (void)vc.view;
+                expect(vc.childViewControllers[0]).to.equal(mockLegacyVC);
+            });
+
+            it(@"works with make-offerable artworks", ^{
+                StubArtworkWithBNMO(NO, YES);
+                (void)vc.view;
+                expect(vc.childViewControllers[0]).to.equal(mockLegacyVC);
+            });
+        });
+
+        it(@"works artworks that are in a sale", ^{
+            StubArtworkWithSaleArtwork();
+            (void)vc.view;
+            expect(vc.childViewControllers[0]).to.equal(mockLegacyVC);
+        });
+    });
+
+    describe(@"concerning artworks for which to show the new component view", ^{
+        describe(@"commerical artworks", ^{
+            beforeEach(^{
+                [AROptions setBool:YES forOption:AROptionsRNArtworkNonCommerical];
+            });
+
+            for (NSString *availability in componentAvailabilityStates) {
+                it([NSString stringWithFormat:@"shows it with a `%@` artwork", availability], ^{
+                    StubArtworkWithAvailability(availability);
+                    (void)vc.view;
+                    expect(vc.childViewControllers[0]).to.equal(mockComponentVC);
+                });
+            }
+        });
+
+        describe(@"NSO/inquiry artworks", ^{
+            beforeEach(^{
+                [AROptions setBool:YES forOption:AROptionsRNArtworkNSOInquiry];
+            });
+
+            it(@"works with buy-nowable artworks", ^{
+                StubArtworkWithBNMO(YES, NO);
+                (void)vc.view;
+                expect(vc.childViewControllers[0]).to.equal(mockComponentVC);
+            });
+
+            it(@"works with make-offerable artworks", ^{
+                StubArtworkWithBNMO(NO, YES);
+                (void)vc.view;
+                expect(vc.childViewControllers[0]).to.equal(mockComponentVC);
+            });
+        });
+
+        describe(@"auctions artworks", ^{
+            beforeEach(^{
+                [AROptions setBool:YES forOption:AROptionsRNArtworkAuctions];
+            });
+
+            it(@"works artworks that are in a sale", ^{
+                StubArtworkWithSaleArtwork();
+                (void)vc.view;
+                expect(vc.childViewControllers[0]).to.equal(mockComponentVC);
+            });
+        });
+
+        describe(@"when all artworks lab option is enabled", ^{
+            beforeEach(^{
+                [AROptions setBool:YES forOption:AROptionsRNArtworkAlways];
+            });
+
+            for (NSString *availability in componentAvailabilityStates) {
+                it([NSString stringWithFormat:@"shows it with a `%@` artwork", availability], ^{
+                    StubArtworkWithAvailability(availability);
+                    (void)vc.view;
+                    expect(vc.childViewControllers[0]).to.equal(mockComponentVC);
+                });
+            }
+
+            it(@"works with buy-nowable artworks", ^{
+                StubArtworkWithBNMO(YES, NO);
+                (void)vc.view;
+                expect(vc.childViewControllers[0]).to.equal(mockComponentVC);
+            });
+
+            it(@"works with make-offerable artworks", ^{
+                StubArtworkWithBNMO(NO, YES);
+                (void)vc.view;
+                expect(vc.childViewControllers[0]).to.equal(mockComponentVC);
+            });
+
+            it(@"works artworks that are in a sale", ^{
+                StubArtworkWithSaleArtwork();
+                (void)vc.view;
+                expect(vc.childViewControllers[0]).to.equal(mockComponentVC);
+            });
+        });
+    });
 });
 
 SpecEnd;

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -13,6 +13,7 @@ upcoming:
     - Don't push same search view if it already exists
     - Live auction current lot now updates current bid - ash/anson
     - Trim whitespace in featured links
+    - Improves UX when opening artwork view - ash
 
 releases:
   - version: 5.0.5

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
   emission_version: 1.12.x
   dev:
     - Cleans up unused lab options - ash
+    - Adds more granular lab options for testing new RN artwork view - ash
   user_facing:
     - Adds new React Native Artwork view behind lab option - alloy/david
     - Integrates View-in-Room support from React Native Artwork view - ash/steve

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -72,7 +72,7 @@ PODS:
   - DHCShakeNotifier (0.2.0)
   - DoubleConversion (1.1.6)
   - EDColor (1.0.0)
-  - Emission (1.12.6):
+  - Emission (1.12.8):
     - "Artsy+UIColors"
     - "Artsy+UIFonts (>= 3.0.0)"
     - DoubleConversion (= 1.1.6)
@@ -538,7 +538,7 @@ SPEC CHECKSUMS:
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
-  Emission: 5cc56d40f17f154f492b750baa5f11765a52f78c
+  Emission: 79d6a12c9492d9106d8d0ba1548c1c4287a93883
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   "Expecta+Snapshots": c343f410c7a6392f3e22e78f94c44b6c0749a516
   Extraction: 642a73b8ccc7806e9a7daf95ebb4c14c374829f1


### PR DESCRIPTION
This PR improves the user experience and tester experience of the new artwork view. It does a bunch of little things, so here's the summary:

- The artwork view, which appears on-screen while we do an MP call to determine which _actual_ artwork view to present, is now opaque white. It shows the spinner immediately instead of fading it in (the fade animation was taking longer than the MP request).
- There are new, more gradual lab options for testing the view. The lab options will now always appear in the same order, too (alphabetized). See the screenshot below.
- Applies consistent indentation to the `ARArtworkViewController` class and its tests (looks like we were mixing-and-matching 2 and 4 tab widths). For this reason, I recommend reviewing this PR with GitHub's "ignore whitespace" option.

<img width="559" alt="Screen Shot 2019-07-18 at 11 28 04" src="https://user-images.githubusercontent.com/498212/61470447-1ddc5400-a94f-11e9-9cd3-f26a84f9f69f.png">
