### PR TITLE
Upgrade to Emission 1.12.10

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -72,7 +72,7 @@ PODS:
   - DHCShakeNotifier (0.2.0)
   - DoubleConversion (1.1.6)
   - EDColor (1.0.0)
-  - Emission (1.12.9):
+  - Emission (1.12.10):
     - "Artsy+UIColors"
     - "Artsy+UIFonts (>= 3.0.0)"
     - DoubleConversion (= 1.1.6)
@@ -538,7 +538,7 @@ SPEC CHECKSUMS:
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
-  Emission: 051b55d0b464324d7ea51ed1f9f4c4823d7e910b
+  Emission: d3f0bab12bb44d8b4dbff662a40e003e46c124bd
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   "Expecta+Snapshots": c343f410c7a6392f3e22e78f94c44b6c0749a516
   Extraction: 642a73b8ccc7806e9a7daf95ebb4c14c374829f1


### PR DESCRIPTION
This includes the following changes:

 * https://github.com/artsy/emission/pull/1743: Display an error message when polling fails on bidding
 * https://github.com/artsy/emission/pull/1742: Fixes an issue where placing a bid hangs