### PR TITLE
Upgrade to Emission 1.12.13

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -72,7 +72,7 @@ PODS:
   - DHCShakeNotifier (0.2.0)
   - DoubleConversion (1.1.6)
   - EDColor (1.0.0)
-  - Emission (1.12.12):
+  - Emission (1.12.13):
     - "Artsy+UIColors"
     - "Artsy+UIFonts (>= 3.0.0)"
     - DoubleConversion (= 1.1.6)
@@ -538,7 +538,7 @@ SPEC CHECKSUMS:
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
-  Emission: bf03aa319fb7b4bbabb4f36cbda52d9136f6158e
+  Emission: a65df050267fce88e8449ab950e6cf86ece7ce23
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   "Expecta+Snapshots": c343f410c7a6392f3e22e78f94c44b6c0749a516
   Extraction: 642a73b8ccc7806e9a7daf95ebb4c14c374829f1


### PR DESCRIPTION
This includes:

  * https://github.com/artsy/emission/pull/1767: Cleans up old, duplicated docs
 * https://github.com/artsy/emission/pull/1768: Fix copy on registration pending view

The whole diff: https://github.com/artsy/emission/compare/v1.12.12...v1.12.13

#trivial