### PR TITLE
[PLATFORM-1653] Prevents admins from customizing API URLs while pointing to production.

### DIFF
--- a/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
+++ b/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
@@ -497,6 +497,7 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
         [[ARGraphQLQueryCache new] clearAll];
     }];
 
+    BOOL usingStaging = [[NSUserDefaults standardUserDefaults] boolForKey:ARUseStagingDefault];
 
     [labsSectionData addCellDataFromArray:@[
         crashCellData,
@@ -505,10 +506,10 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
         [self generateNotificationTokenPasteboardCopy],
         [self requestNotificationsAlert],
 #endif
-        [self editableTextCellDataWithName:@"Gravity API" defaultKey:ARStagingAPIURLDefault],
-        [self editableTextCellDataWithName:@"Web" defaultKey:ARStagingWebURLDefault],
-        [self editableTextCellDataWithName:@"Metaphysics" defaultKey:ARStagingMetaphysicsURLDefault],
-        [self editableTextCellDataWithName:@"Live Auctions Socket" defaultKey:ARStagingLiveAuctionSocketURLDefault],
+        [self editableTextCellDataWithName:@"Gravity API" defaultKey:ARStagingAPIURLDefault enabled:usingStaging],
+        [self editableTextCellDataWithName:@"Web" defaultKey:ARStagingWebURLDefault enabled:usingStaging],
+        [self editableTextCellDataWithName:@"Metaphysics" defaultKey:ARStagingMetaphysicsURLDefault enabled:usingStaging],
+        [self editableTextCellDataWithName:@"Live Auctions Socket" defaultKey:ARStagingLiveAuctionSocketURLDefault enabled:usingStaging],
     ]];
     return labsSectionData;
 }

--- a/Artsy/View_Controllers/Admin/ARAdminTableViewController.h
+++ b/Artsy/View_Controllers/Admin/ARAdminTableViewController.h
@@ -21,6 +21,8 @@ extern NSString *const ARTwoLabelCell;
 
 /// Easy NSUserDefault toggle
 - (ARCellData *)editableTextCellDataWithName:(NSString *)name defaultKey:(NSString *)key;
+/// Same as the above function, but allows you to disable the setting alert prompt.
+- (ARCellData *)editableTextCellDataWithName:(NSString *)name defaultKey:(NSString *)key enabled:(BOOL)enabled;
 
 /// Metadata about the app version etc
 - (NSString *)titleForApp;

--- a/Artsy/View_Controllers/Admin/ARAdminTableViewController.m
+++ b/Artsy/View_Controllers/Admin/ARAdminTableViewController.m
@@ -105,6 +105,11 @@ NSString *const ARTwoLabelCell = @"ARTwoLabelCell";
 
 - (ARCellData *)editableTextCellDataWithName:(NSString *)name defaultKey:(NSString *)key
 {
+    return [self editableTextCellDataWithName:name defaultKey:key enabled:YES];
+}
+
+- (ARCellData *)editableTextCellDataWithName:(NSString *)name defaultKey:(NSString *)key enabled:(BOOL)enabled
+{
     ARCellData *cell = [[ARCellData alloc] initWithIdentifier:ARTwoLabelCell];
     cell.height = 60;
 
@@ -116,26 +121,38 @@ NSString *const ARTwoLabelCell = @"ARTwoLabelCell";
         tableViewCell.detailTextLabel.text = value;
     }];
 
-    [cell setCellSelectionBlock:^(UITableView *tableView, NSIndexPath *indexPath) {
-        UIAlertController *controller = [UIAlertController alertControllerWithTitle:name message:@"" preferredStyle:UIAlertControllerStyleAlert];
+    if (enabled) {
+        [cell setCellSelectionBlock:^(UITableView *tableView, NSIndexPath *indexPath) {
+            UIAlertController *controller = [UIAlertController alertControllerWithTitle:name message:@"" preferredStyle:UIAlertControllerStyleAlert];
 
-        [controller addAction:[UIAlertAction actionWithTitle:@"Save + Restart" style:UIAlertActionStyleDestructive handler:^(UIAlertAction * _Nonnull action) {
-            UITextField *theTextField = [controller textFields].firstObject;
-            [defaults setObject:theTextField.text forKey:key];
-            [defaults synchronize];
-            exit(0);
-        }]];
+            [controller addAction:[UIAlertAction actionWithTitle:@"Save + Restart" style:UIAlertActionStyleDestructive handler:^(UIAlertAction * _Nonnull action) {
+                UITextField *theTextField = [controller textFields].firstObject;
+                [defaults setObject:theTextField.text forKey:key];
+                [defaults synchronize];
+                exit(0);
+            }]];
 
-        [controller addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
-            [controller.presentingViewController dismissViewControllerAnimated:YES completion:nil];
-        }]];
+            [controller addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
+                [controller.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+            }]];
 
-        [controller addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
-            textField.text = value;
+            [controller addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
+                textField.text = value;
+            }];
+
+            [self presentViewController:controller animated:YES completion:nil];
         }];
+    } else {
+        [cell setCellSelectionBlock:^(UITableView *tableView, NSIndexPath *indexPath) {
+            UIAlertController *controller = [UIAlertController alertControllerWithTitle:name message:@"Not editable when in Production. Switch to Staging (above) and then edit these values manually." preferredStyle:UIAlertControllerStyleAlert];
 
-        [self presentViewController:controller animated:YES completion:nil];
-    }];
+            [controller addAction:[UIAlertAction actionWithTitle:@"Ok" style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
+                [controller.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+            }]];
+
+            [self presentViewController:controller animated:YES completion:nil];
+        }];
+    }
     return cell;
 }
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -9,6 +9,7 @@ upcoming:
     - Make status bar white on artwork views - ash + david
     - Adds Switchboard-based routing for inquiry, BNMO - kieran + ash
     - Removes ARArtworkSetViewController - ash
+    - Prevents admins from customizing API URLs while pointing to production - ash
   user_facing:
     - Users are no longer required to bid one increment above asking price on upcoming LAI lots - ash
     - Purple "current lot" view at bottom of LAI now has correct, updating asking price - ash


### PR DESCRIPTION
These were modifiable settings that are ignored while pointing to production. This leads to engineers trying to point the app (in production mode) to custom URLs, which it ignores in favour of a hard-coded constant:

https://github.com/artsy/eigen/blob/55c5b7f9e397b8778d65d53bdabbb3beb099dbd3/Artsy/Networking/ARRouter.m#L76-L84

This PR changes the admin menu to prevent users from trying to customize the URLs:

![Simulator Screen Shot - Unit Test Device 2 - 2019-08-12 at 14 31 28](https://user-images.githubusercontent.com/498212/62888907-49641b80-bd0e-11e9-8e5c-4d9245297ad0.png)
