### PR TITLE
Fixes rotating to open non-AR VIR view

### DIFF
--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
@@ -5,6 +5,9 @@
 #import "ARSpinner.h"
 #import "AROptions.h"
 #import "UIViewController+SimpleChildren.h"
+#import "ARTopMenuViewController.h"
+#import "UIDevice-Hardware.h"
+#import "ARViewInRoomViewController.h"
 
 #import <Emission/ARArtworkComponentViewController.h>
 
@@ -125,6 +128,26 @@
 - (CGPoint)imageViewOffset;
 {
     return self.legacyViewController.imageViewOffset;
+}
+
+- (void)viewWillTransitionToSize:(CGSize)newSize withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
+{
+    [super viewWillTransitionToSize:newSize withTransitionCoordinator:coordinator];
+    BOOL landscape = newSize.width > newSize.height;
+
+    BOOL isTopViewController = self.navigationController.topViewController == self;
+    BOOL isShowingModalViewController = [ARTopMenuViewController sharedController].presentedViewController != nil;
+    BOOL canShowInRoom = self.artwork.canViewInRoom;
+
+    if (![UIDevice isPad] && canShowInRoom && !isShowingModalViewController && isTopViewController) {
+        if (landscape) {
+            ARViewInRoomViewController *viewInRoomVC = [[ARViewInRoomViewController alloc] initWithArtwork:self.artwork];
+            viewInRoomVC.popOnRotation = YES;
+            viewInRoomVC.rotationDelegate = self;
+
+            [self.navigationController pushViewController:viewInRoomVC animated:YES];
+        }
+    }
 }
 
 @end

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -9,6 +9,7 @@ upcoming:
     - Make status bar white on artwork views - ash + david
     - Adds Switchboard-based routing for inquiry, BNMO - kieran + ash
     - Removes ARArtworkSetViewController - ash
+    - Fixes rotating to open non-AR VIR view - ash
   user_facing:
     - Users are no longer required to bid one increment above asking price on upcoming LAI lots - ash
     - Purple "current lot" view at bottom of LAI now has correct, updating asking price - ash


### PR DESCRIPTION
Follow-up from #2884. I copied this from previous implementation: 

https://github.com/artsy/eigen/blob/a3c05dc21bd5bb6af2a95d2c38a99e48cd4102fc/Artsy/View_Controllers/Artwork/ARArtworkSetViewController.m#L93-L117

(Though I did remove the TODO, since it worked without it.)

Old artwork view:

![old](https://user-images.githubusercontent.com/498212/62895875-d367b080-bd1d-11e9-977f-0606bf5cb22c.gif)


New artwork view:

![new](https://user-images.githubusercontent.com/498212/62895885-d9f62800-bd1d-11e9-8ec5-2149c0d17f54.gif)
