### PR TITLE
Disables landscape rotation, cleans up ARArtworkViewController

### DIFF
--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.h
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, readonly) Artwork *artwork;
 @property (strong, nonatomic, readonly, nullable) Fair *fair;
 
-- (instancetype)initWithArtwork:(Artwork *)artwork fair:(nullable Fair *)fair NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithArtwork:(Artwork *)artwork fair:(nullable Fair *)fair;
 
 - (UIImageView *)imageView;
 - (void)setHasFinishedScrolling;

--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
@@ -6,6 +6,7 @@
 #import "AROptions.h"
 #import "ArtsyEcho.h"
 #import "ARSwitchboard.h"
+#import "UIDevice-Hardware.h"
 #import "UIViewController+SimpleChildren.h"
 
 #import <Emission/ARArtworkComponentViewController.h>
@@ -104,6 +105,11 @@
     }];
 
     [self.artwork updateArtwork];
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations;
+{
+    return [UIDevice isPad] ? UIInterfaceOrientationMaskAll : UIInterfaceOrientationMaskPortrait;
 }
 
 - (NSInteger)index;

--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
@@ -112,16 +112,6 @@
     return [UIDevice isPad] ? UIInterfaceOrientationMaskAll : UIInterfaceOrientationMaskPortrait;
 }
 
-- (NSInteger)index;
-{
-    return self.legacyViewController.index;
-}
-
-- (void)setIndex:(NSInteger)index;
-{
-    self.legacyViewController.index = index;
-}
-
 - (UIImageView *)imageView;
 {
     return self.legacyViewController.imageView;

--- a/Artsy/View_Controllers/Artwork/ARLegacyArtworkViewController.h
+++ b/Artsy/View_Controllers/Artwork/ARLegacyArtworkViewController.h
@@ -13,9 +13,6 @@
 @property (nonatomic, strong, readonly) Artwork *artwork;
 @property (nonatomic, strong, readonly) Fair *fair;
 
-/// The index in the current set of artworks
-@property (nonatomic, assign) NSInteger index;
-
 /// Echo config. Useful for unit testing.
 @property (nonatomic, strong, readonly) ArtsyEcho *echo;
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -11,6 +11,7 @@ upcoming:
     - Removes ARArtworkSetViewController - ash
     - Prevents admins from customizing API URLs while pointing to production - ash
     - Adds echo flag support for enabling various types of RN Artwork view - ash + david + kieran
+    - Disables landscape rotation for iPhone on Artwork views - ash
   user_facing:
     - Users are no longer required to bid one increment above asking price on upcoming LAI lots - ash
     - Purple "current lot" view at bottom of LAI now has correct, updating asking price - ash


### PR DESCRIPTION
This PR replaces #2886. It:

- Removes landscape capability on `ARArtworkViewController` (was previously left in to support non-AR view-in-room).
- Cleans up an unused property left over from #2884. 
- Cleans up a bunch of compiler warnings.

The last one is kind of weird, so I've left a note in the commit message with more details. 