### PR TITLE
PURCHASE-1454 Open web view target='_blank' links by pushing to navigation stack

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,6 +3,7 @@ upcoming:
   date: TBD
   emission_version: 1.12.x
   dev:
+    - Allow opening web view target='_blank' links by pushing onto navigation stack - david + alloy
     - Switch to MP v2 - alloy/justin
     - Cleans up unused lab options - ash
     - Removes concept of a lot's "current value" in favour of using the asking price - ash


### PR DESCRIPTION
Fixes [PURCHASE-1454](https://artsyproduct.atlassian.net/browse/PURCHASE-1454)

For some reason this navigation messes with the close button's position persistently. We already have a QA ticket for that bug on notion because it's affecting the auction views too, so I'm happy to tackle it separately. What do you think @alloy?