### PR TITLE
[PURCHASE-1414] Fixes Analytics

### DIFF
--- a/Artsy/App/ARAnalyticsVisualizer.m
+++ b/Artsy/App/ARAnalyticsVisualizer.m
@@ -11,27 +11,38 @@
 
 - (void)event:(NSString *)event withProperties:(NSDictionary *)properties
 {
-    NSString *title = [self alertTitleForEvent:event withProperties:properties];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSString *title = [self alertTitleForEvent:event withProperties:properties];
 
-    [ARNotificationView showNoticeInView:[self findVisibleWindow] title:title time:1.5 response:^{
-        UIAlertController *alert = [UIAlertController alertControllerWithTitle:title message:[properties description] preferredStyle:UIAlertControllerStyleActionSheet];
-        
-        [alert addAction:[UIAlertAction actionWithTitle:@"Copy Description" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-            [[UIPasteboard generalPasteboard] setValue:[properties description]forPasteboardType:(NSString *)kUTTypePlainText];
-        }]];
+        [ARNotificationView showNoticeInView:[self findVisibleWindow] title:title time:1.5 response:^{
+            UIAlertController *alert = [UIAlertController alertControllerWithTitle:title message:[properties description] preferredStyle:UIAlertControllerStyleActionSheet];
 
-        [alert addAction:[UIAlertAction actionWithTitle:@"Copy Stack Trace for Devs" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-            NSString *stack = [NSString stringWithFormat:@"%@", [NSThread callStackSymbols]];
-            [[UIPasteboard generalPasteboard] setValue:stack forPasteboardType:(NSString *)kUTTypePlainText];
-        }]];
+            [alert addAction:[UIAlertAction actionWithTitle:@"Copy Description" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+                [[UIPasteboard generalPasteboard] setValue:[properties description]forPasteboardType:(NSString *)kUTTypePlainText];
+            }]];
 
-        [alert addAction:[UIAlertAction actionWithTitle:@"Great, continue." style:UIAlertActionStyleCancel handler:nil]];
+            [alert addAction:[UIAlertAction actionWithTitle:@"Copy Stack Trace for Devs" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+                NSString *stack = [NSString stringWithFormat:@"%@", [NSThread callStackSymbols]];
+                [[UIPasteboard generalPasteboard] setValue:stack forPasteboardType:(NSString *)kUTTypePlainText];
+            }]];
 
-        // Sometimes the TopVC is being presented, e.g. for onboarding/ showing login, or the alerts
-        UIViewController *topVC = [ARTopMenuViewController sharedController];
-        topVC = topVC.presentedViewController ?: topVC;
-        [topVC presentViewController:alert animated:YES completion:nil];
-    }];
+            [alert addAction:[UIAlertAction actionWithTitle:@"Great, continue." style:UIAlertActionStyleCancel handler:nil]];
+
+            // Sometimes the TopVC is being presented, e.g. for onboarding/ showing login, or the alerts
+            UIViewController *topVC = [ARTopMenuViewController sharedController];
+            topVC = topVC.presentedViewController ?: topVC;
+
+            if (alert.popoverPresentationController) {
+                // Being presented on an iPad, so it needs some further configuration.
+                // See: https://stackoverflow.com/questions/31577140/uialertcontroller-is-crashed-ipad
+                alert.popoverPresentationController.sourceView = topVC.view;
+                alert.popoverPresentationController.sourceRect = topVC.view.bounds;
+                alert.popoverPresentationController.permittedArrowDirections = 0;
+            }
+
+            [topVC presentViewController:alert animated:YES completion:nil];
+        }];
+    });
 }
 
 - (NSString *)alertTitleForEvent:(NSString *)event withProperties:(NSDictionary *)properties

--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
@@ -30,8 +30,8 @@
     }
 
     BOOL isArtworkNonCommerical = self.artwork.availability != ARArtworkAvailabilityForSale && !self.artwork.isInquireable.boolValue;
-    BOOL isArtworkNSOInquiry = self.artwork.isOfferable || self.artwork.isAcquireable || self.artwork.isInquireable;
     BOOL isArtworkAuctions = self.artwork.isInAuction;
+    BOOL isArtworkNSOInquiry = self.artwork.isOfferable || self.artwork.isAcquireable || (self.artwork.isInquireable && !isArtworkAuctions);
 
     if (isArtworkNonCommerical) {
         return ([AROptions boolForOption:AROptionsRNArtworkNonCommerical] || [self.echo.features[@"ARReactNativeArtworkEnableNonCommercial"] state]);

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -14,6 +14,7 @@ upcoming:
     - Prevents admins from customizing API URLs while pointing to production - ash
     - Adds echo flag support for enabling various types of RN Artwork view - ash + david + kieran
     - Disables landscape rotation for iPhone on Artwork views - ash
+    - Fixes problems displaying analytics debugging on iPad - ash
   user_facing:
     - Users are no longer required to bid one increment above asking price on upcoming LAI lots - ash
     - Purple "current lot" view at bottom of LAI now has correct, updating asking price - ash


### PR DESCRIPTION
A few things in this PR:

- Fixed a problem where we were showing users the new Artwork page for Auctions artworks /cc @sweir27 
- The UI for analytics debugging was being presented from a background thread, likely causing the delays and other UI bugs. I moved it to the main thread with `dispatch_async`.
- Presenting the detail view on iPad required some additional UIAlertController configuration. I added a link for further reading in a comment.

I also investigated the errant `"tap"` events being tracked:

<img width="341" alt="Screen Shot 2019-09-03 at 15 26 29" src="https://user-images.githubusercontent.com/498212/64202477-3ea92c00-ce5f-11e9-9453-78e7649f4f9a.png">

One of the most used components in Emission, `GenericGrid`, fires this event _on layout_:

https://github.com/artsy/emission/blob/ce9ce5eaa143216fc9cd8a6fc41bee2eba3e2bf7/src/lib/Components/ArtworkGrids/GenericGrid.tsx#L42-L48

This seems like a bug to me, but I need to do more digging. I've verified that duplicate events are _not_ being generated, and that these extra events are coming from bugs in how we use tracking in Emission. I'll keep the Jira ticket open, but will follow-up with an Emission PR.