### PR TITLE
Enables full logging #trivial

### DIFF
--- a/Artsy.xcodeproj/xcshareddata/xcschemes/Artsy.xcscheme
+++ b/Artsy.xcodeproj/xcshareddata/xcschemes/Artsy.xcscheme
@@ -131,7 +131,7 @@
          <EnvironmentVariable
             key = "OS_ACTIVITY_MODE"
             value = "disable"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "DYLD_PRINT_STATISTICS"


### PR DESCRIPTION
A few years ago, Apple added a bunch of noise to our app's logs which led us ([and others](https://stackoverflow.com/questions/37800790/hide-strange-unwanted-xcode-logs)) to disable them using the `OS_ACTIVITY_MODE="disable"` environment variable. However, as we ([and others](https://stackoverflow.com/questions/37886600/ios-10-doesnt-print-nslogs/43509270)) discovered, `NSLog` statements weren't printing anything to our console. (But Swift `print` statements _were_ still printed).

This is something @ds300 and I saw a few weeks ago, and that I ran into again yesterday. A noisy log is better than an incomplete log, so I'm disabling this env var (but leaving it there to be easily re-enabled if needed for debugging something). This was accomplished through the "Edit Scheme" UI:

<img width="912" alt="Screen Shot 2019-09-04 at 14 26 51" src="https://user-images.githubusercontent.com/498212/64280918-15040980-cf20-11e9-83d6-adfc7d7029ec.png">

Note: Apple apparently has a new [unified logging system](https://developer.apple.com/documentation/os/logging?language=objc): `os_log`. Seems really unnecessary, but Apple is going to do whatever Apple wants. Fixing the noisy logs doesn't feel like a big enough of a benefit to migrate to `os_log`, especially since `os_log` requires iOS 10+ (and we still support iOS 9). 

#known