### PR TITLE
[PURCHASE-1481] Disables Auctions artwork view when enabled in Echo

### DIFF
--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
@@ -38,7 +38,8 @@
     } else if (isArtworkNSOInquiry) {
         return ([AROptions boolForOption:AROptionsRNArtworkNSOInquiry] || [self.echo.features[@"ARReactNativeArtworkEnableNSOInquiry"] state]);
     } else if (isArtworkAuctions) {
-        return ([AROptions boolForOption:AROptionsRNArtworkAuctions] || [self.echo.features[@"ARReactNativeArtworkEnableAuctions"] state]);
+        // We're disabling the Echo clause here until we're ready to actually ship Auctions support. See: https://artsyproduct.atlassian.net/browse/PURCHASE-1481
+        return ([AROptions boolForOption:AROptionsRNArtworkAuctions]);// || [self.echo.features[@"ARReactNativeArtworkEnableAuctions"] state]);
     }
 
     return NO;

--- a/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
@@ -273,7 +273,7 @@ describe(@"ARArtworkViewController", ^{
                     };
                 });
 
-                it(@"works artworks that are in a sale", ^{
+                pending(@"works artworks that are in a sale", ^{
                     StubArtworkWithSaleArtwork();
                     (void)vc.view;
                     expect(vc.childViewControllers[0]).to.equal(mockComponentVC);

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -15,6 +15,7 @@ upcoming:
     - Adds echo flag support for enabling various types of RN Artwork view - ash + david + kieran
     - Disables landscape rotation for iPhone on Artwork views - ash
     - Fixes problems displaying analytics debugging on iPad - ash
+    - Disables Auctions artwork view when enabled in Echo - ash
   user_facing:
     - Users are no longer required to bid one increment above asking price on upcoming LAI lots - ash
     - Purple "current lot" view at bottom of LAI now has correct, updating asking price - ash


### PR DESCRIPTION
We will re-enable shortly after we ship our initial release, but we don't want the half-finished implementation to get enabled for users who haven't updated yet when we enable it in Echo. See for more detail: https://artsyproduct.atlassian.net/browse/PURCHASE-1481