### PR TITLE
[PURCHASE-1481] Removes ARReactNativeArtworkEnableAlways Echo flag #trivial

### DIFF
--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
@@ -25,7 +25,7 @@
 
 - (BOOL)shouldShowNewVersion;
 {
-    if ([AROptions boolForOption:AROptionsRNArtworkAlways] || [self.echo.features[@"ARReactNativeArtworkEnableAlways"] state]) {
+    if ([AROptions boolForOption:AROptionsRNArtworkAlways]) {
         return YES;
     }
 

--- a/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
@@ -312,40 +312,6 @@ describe(@"ARArtworkViewController", ^{
                 expect(vc.childViewControllers[0]).to.equal(mockComponentVC);
             });
         });
-
-        describe(@"when all artworks echo option is enabled", ^{
-            beforeEach(^{
-                echo.features = @{
-                    @"ARReactNativeArtworkEnableAlways" : [[Feature alloc] initWithName:@"" state:@(YES)]
-                };
-            });
-
-            for (NSString *availability in componentAvailabilityStates) {
-                it([NSString stringWithFormat:@"shows it with a `%@` artwork", availability], ^{
-                    StubArtworkWithAvailability(availability);
-                    (void)vc.view;
-                    expect(vc.childViewControllers[0]).to.equal(mockComponentVC);
-                });
-            }
-
-            it(@"works with buy-nowable artworks", ^{
-                StubArtworkWithBNMO(YES, NO);
-                (void)vc.view;
-                expect(vc.childViewControllers[0]).to.equal(mockComponentVC);
-            });
-
-            it(@"works with make-offerable artworks", ^{
-                StubArtworkWithBNMO(NO, YES);
-                (void)vc.view;
-                expect(vc.childViewControllers[0]).to.equal(mockComponentVC);
-            });
-
-            it(@"works artworks that are in a sale", ^{
-                StubArtworkWithSaleArtwork();
-                (void)vc.view;
-                expect(vc.childViewControllers[0]).to.equal(mockComponentVC);
-            });
-        });
     });
 });
 


### PR DESCRIPTION
Follow up from: https://github.com/artsy/eigen/pull/2900

This flag is only a convenience; it complicates the logic around the phased rollout of the RN artwork view so let's remove it.