### PR TITLE
Fixes crash when AuctionViewController re-appears without a populated view model

### DIFF
--- a/Artsy/App/SwiftExtensions.swift
+++ b/Artsy/App/SwiftExtensions.swift
@@ -34,6 +34,12 @@ extension Occupiable {
     var isNotEmpty: Bool { return !isEmpty }
 }
 
+extension Optional: Occupiable {
+    var isEmpty: Bool {
+        return self == nil
+    }
+}
+
 // Required for Xcode 8/9 compatibility. Can be dropped when we move to Swift 4.
 extension String: Occupiable {
     var isNotEmpty: Bool {

--- a/Artsy/View_Controllers/Auction/AuctionViewController.swift
+++ b/Artsy/View_Controllers/Auction/AuctionViewController.swift
@@ -49,7 +49,7 @@ class AuctionViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        if appeared {
+        if appeared && saleViewModel.isNotEmpty {
             // Re-appearing, so: check if Live has launched, and if not, re-fetch lot standings and update.
             if saleViewModel.shouldShowLiveInterface {
                 setupLiveInterfaceAndPop()

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -17,6 +17,7 @@ upcoming:
     - Fixes problems displaying analytics debugging on iPad - ash
     - Disables Auctions artwork view when enabled in Echo - ash
   user_facing:
+    - Fixes crash when AuctionViewController re-appears without a populated view model - ash
     - Users are no longer required to bid one increment above asking price on upcoming LAI lots - ash
     - Purple "current lot" view at bottom of LAI now has correct, updating asking price - ash
     - Adds new React Native Artwork view behind lab option - alloy/david


### PR DESCRIPTION
I was looking through Sentry and found this crash: https://sentry.io/organizations/artsynet/issues/739658774 I'd seen the crash before, but the solution just kind of clicked so I thought I'd get a fix in quickly. 

The problem is that the `viewWillAppear` callback assumes that the `saleViewModel` is already loaded _if_ the view is re-appearing. If the network is slow, this might not be the case, so I've added a guard to check that the `saleViewModel` is non-nil before trying to access any of its properties. (Note: this would normally be caught by the Swift compiler, but we're using an implicitly-unwrapped optional here. Ideally we'd avoid this and use a view controller containment to deal with the optionality of the view model, but that's a much larger refactor.)