### PR TITLE
Fixes show the new RN artwork view for sale artworks (that are inquirable) #trivial

### DIFF
--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
@@ -31,7 +31,8 @@
 
     BOOL isArtworkNonCommerical = self.artwork.availability != ARArtworkAvailabilityForSale && !self.artwork.isInquireable.boolValue;
     BOOL isArtworkAuctions = self.artwork.isInAuction;
-    BOOL isArtworkNSOInquiry = self.artwork.isOfferable || self.artwork.isAcquireable || (self.artwork.isInquireable && !isArtworkAuctions);
+    // Being in an auction excludes artworks from being NSOInquiry.
+    BOOL isArtworkNSOInquiry = !isArtworkAuctions && (self.artwork.isOfferable.boolValue || self.artwork.isAcquireable.boolValue || self.artwork.isInquireable.boolValue);
 
     if (isArtworkNonCommerical) {
         return ([AROptions boolForOption:AROptionsRNArtworkNonCommerical] || [self.echo.features[@"ARReactNativeArtworkEnableNonCommercial"] state]);

--- a/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
@@ -42,7 +42,7 @@ StubArtworkWithAvailability(NSString *availability)
 }
 
 static void
-StubArtworkWithBNMO(BOOL buyable, BOOL offerable)
+StubArtworkWithBNMOInSale(BOOL buyable, BOOL offerable, BOOL inSale)
 {
     NSDictionary *response = @{
         @"data" : @{
@@ -51,12 +51,20 @@ StubArtworkWithBNMO(BOOL buyable, BOOL offerable)
                 @"title" : @"Some Title",
                 @"availability" : @"for sale",
                 @"is_acquireable": @(buyable),
-                @"is_offerable": @(offerable)
+                @"is_offerable": @(offerable),
+                @"is_in_auction": @(inSale)
             }
         }
     };
     [OHHTTPStubs stubJSONResponseForHost:@"metaphysics-staging.artsy.net" withResponse:response];
 }
+
+static void
+StubArtworkWithBNMO(BOOL buyable, BOOL offerable)
+{
+    StubArtworkWithBNMOInSale(buyable, offerable, NO);
+}
+
 
 static void
 StubArtworkWithSaleArtwork()
@@ -229,6 +237,12 @@ describe(@"ARArtworkViewController", ^{
                     StubArtworkWithBNMO(NO, YES);
                     (void)vc.view;
                     expect(vc.childViewControllers[0]).to.equal(mockComponentVC);
+                });
+
+                it(@"doesn't work if the artwork is in a sale", ^{
+                    StubArtworkWithBNMOInSale(YES, YES, YES);
+                    (void)vc.view;
+                    expect(vc.childViewControllers[0]).notTo.equal(mockComponentVC);
                 });
             });
 


### PR DESCRIPTION
@lilyfromseattle and I found this today – basically if an artwork is inquirable _and_ in an auction, we want to show the old view. 