### PR TITLE
[PURCHASE-1482] Adds explicit layout specification for default pop and search push animation

### DIFF
--- a/Artsy/Navigation_Transitions/ARAppSearchTransition.m
+++ b/Artsy/Navigation_Transitions/ARAppSearchTransition.m
@@ -1,6 +1,8 @@
 #import "ARAppSearchTransition.h"
 #import "ARAppSearchViewController.h"
+#import "ARTopMenuViewController.h"
 
+#import <FLKAutoLayout/FLKAutoLayout.h>
 
 @implementation ARAppSearchTransition
 
@@ -22,15 +24,16 @@
 
     [transitionContext.containerView addSubview:fromVC.view];
     [transitionContext.containerView addSubview:toVC.view];
+    [toVC.view alignToView:transitionContext.containerView];
 
     [UIView animateWithDuration:[self transitionDuration:transitionContext]
         delay:0.0
         options:UIViewAnimationOptionCurveEaseOut
         animations:^{
-                         toVC.view.alpha = 1;
+            toVC.view.alpha = 1;
         }
         completion:^(BOOL finished) {
-                        [transitionContext completeTransition:YES];
+            [transitionContext completeTransition:YES];
         }];
 }
 

--- a/Artsy/Navigation_Transitions/ARDefaultNavigationTransition.m
+++ b/Artsy/Navigation_Transitions/ARDefaultNavigationTransition.m
@@ -51,14 +51,13 @@
 - (void)popTransitionFrom:(UIViewController *)fromVC to:(UIViewController *)toVC withContext:(id<UIViewControllerContextTransitioning>)context
 {
     CGRect fullFrame = [context initialFrameForViewController:fromVC];
-    CGRect offScreen = fullFrame;
-    offScreen.origin.x = offScreen.size.width;
 
     // To = Coming up
     // From = Moving to the Side
 
     [context.containerView addSubview:toVC.view];
     [context.containerView addSubview:fromVC.view];
+    fromVC.view.frame = fullFrame;
 
     UIViewAnimationOptions options = UIViewAnimationOptionCurveEaseOut;
 
@@ -107,7 +106,7 @@
          toVC.view.alpha = 1;
          toVC.view.transform = CGAffineTransformIdentity;
 
-         fromVC.view.frame = offScreen;
+         fromVC.view.transform = CGAffineTransformMakeTranslation(fullFrame.size.width, 0);
 
          backButtonSnapshot.alpha = self.backButtonTargetAlpha;
         }


### PR DESCRIPTION
Previously, these were using default values from iOS, which worked _most_ of the time. By being explicit about what we want in terms of layout, we get a more reliable animation. I also had to change from animating with `frame` (which is a bad idea because [`frame` is complicated](https://ashfurrow.com/blog/you-probably-dont-understand-frames-and-bounds/)) to using `transform`.

Previously:

![IMG_0587](https://user-images.githubusercontent.com/498212/64985296-8df55080-d892-11e9-9daa-52180d7809bb.PNG)

Now:

![2019-09-16 14-58-24 2019-09-16 14_59_27](https://user-images.githubusercontent.com/498212/64985318-9a79a900-d892-11e9-8ddc-bffbbd313b2c.gif)