### PR TITLE
PURCHASE-1511 PURCHASE-1512 Fix conditions-of-sale sublinks

### DIFF
--- a/Artsy/View_Controllers/Web_Browsing/ARInternalMobileWebViewController.m
+++ b/Artsy/View_Controllers/Web_Browsing/ARInternalMobileWebViewController.m
@@ -75,10 +75,10 @@ static void *ARProgressContext = &ARProgressContext;
 {
     [super viewDidLoad];
     [self showLoading];
-    
+
     // KVO on progress for when we can show the page
     [self.webView addObserver:self forKeyPath:@"estimatedProgress" options:NSKeyValueObservingOptionNew & NSKeyValueObservingOptionOld context:ARProgressContext];
-    
+
     if ([AROptions boolForOption:AROptionsShowMartsyOnScreen]) {
         [self displayDebugMartsyIndicator];
     }
@@ -165,8 +165,14 @@ static void *ARProgressContext = &ARProgressContext;
 
         } else {
             UIViewController *viewController = [ARSwitchBoard.sharedInstance loadURL:URL fair:self.fair];
+
             if (viewController) {
-                [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
+                if ([viewController isKindOfClass:[UINavigationController class]]) {
+                    // Navigation controllers can't be pushed onto regular navigation controllers, only the top menu VC.
+                    [self.ar_TopMenuViewController pushViewController:viewController animated:ARPerformWorkAsynchronously];
+                } else {
+                    [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
+                }
             }
 
             ARActionLog(@"Artsy URL: Denied - %@ - %@", URL, @(navigationAction.navigationType));

--- a/Artsy/View_Controllers/Web_Browsing/ARInternalMobileWebViewController.m
+++ b/Artsy/View_Controllers/Web_Browsing/ARInternalMobileWebViewController.m
@@ -166,7 +166,7 @@ static void *ARProgressContext = &ARProgressContext;
         } else {
             UIViewController *viewController = [ARSwitchBoard.sharedInstance loadURL:URL fair:self.fair];
             if (viewController) {
-                [self.ar_TopMenuViewController pushViewController:viewController animated:ARPerformWorkAsynchronously];
+                [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
             }
 
             ARActionLog(@"Artsy URL: Denied - %@ - %@", URL, @(navigationAction.navigationType));


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-1511
https://artsyproduct.atlassian.net/browse/PURCHASE-1512

I'm not sure about the ramifications of this change. While it fixes the problem and doesn't seem to break other webviews, I don't understand why new pages were originally being pushed onto the top level navigation stack rather than the one that the web view is currently in. Any ideas @ashfurrow ?

Also I noticed that this conditions-of-sale web view doesn't have a back button because it's a modal and it was opened from within a modal. So to go 'back' after visiting a sublink you have to dismiss the modal, going back to a different modal, and then tap back into the conditions of sale modal. We should really rethink these funky navigation flows as part of the mobile experience team.

#trivial