### PR TITLE
[ME-3] Fixes opening Terms/Privacy Policy links during onboarding

### DIFF
--- a/Artsy/View_Controllers/Login_and_Onboarding/AROnboardingViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/AROnboardingViewController.m
@@ -244,14 +244,12 @@
 
 - (void)showTermsAndConditions
 {
-    AROnboardingWebViewController *webViewController = [[AROnboardingWebViewController alloc] initWithMobileArtsyPath:@"terms"];
-    [self pushViewController:webViewController animated:YES];
+    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://www.artsy.net/terms"]];
 }
 
 - (void)showPrivacyPolicy
 {
-    AROnboardingWebViewController *webViewController = [[AROnboardingWebViewController alloc] initWithMobileArtsyPath:@"privacy"];
-    [self pushViewController:webViewController animated:YES];
+    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://www.artsy.net/privacy"]];
 }
 
 

--- a/Artsy/View_Controllers/Login_and_Onboarding/AROnboardingWebViewController.h
+++ b/Artsy/View_Controllers/Login_and_Onboarding/AROnboardingWebViewController.h
@@ -1,6 +1,9 @@
 #import <UIKit/UIKit.h>
 
 
+// TODO: This isn't used anymore, as we open Privacy Policy and Terms in Safari rather than the app.
+// We can get rid of the class, unless we want to bring those two views back in the app.
+// See: https://artsyproduct.atlassian.net/browse/ME-3
 @interface AROnboardingWebViewController : UIViewController
 
 - (instancetype)initWithMobileArtsyPath:(NSString *)path;

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -30,6 +30,7 @@ upcoming:
     - Trim whitespace in featured links
     - Improves UX when opening artwork view - ash
     - Removes left-and-right swiping between artwork views - ash
+    - Fixes opening Terms/Privacy Policy links during onboarding - ash
 
 releases:
   - version: 5.0.6


### PR DESCRIPTION
At one point, we supported customizing the navigation bar during onboarding to selectively show a back button, but that stopped working at some point (likely when we added support for the iPhone X notch). Now, when users tap the Terms of Service or Privacy Policy links, they are shown a web view that they can't back out of; the only solution is to force close the app and start the onboarding process again (a terrible UX).

This PR changes the behaviour of these links; users will now be shown the ToS or PP in Safari, rather than the app. This isn't a _great_ UX either, since it takes the user out of the app, but is _significantly_ less work than fixing a navigation bar that is _only_ used during onboarding for these specific links (which we don't expect will get tapped often, anyway). I'm going to confirm with @samchieng that this changes makes sense before merging.