### PR TITLE
Updates release notes for 5.0.7 public release

### DIFF
--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,0 +1,1 @@
+This release includes a newly redesigned artwork view (for most artworks). We've also worked on improving the Live Auctions experience, and have included a number of small, general bug fixes and performance improvements.


### PR DESCRIPTION
(Normally we replace the release notes from the previous version in this file, which [gets uploaded to AppStoreConnect when we promote a beta to an App Store submission](https://github.com/artsy/eigen/blob/0dfd9962311e3a691ff6d732e0ed02525d2ecdea/fastlane/Fastfile#L120-L160). The file was empty because during the last submission, the 5.0.6 hot fix, Circle CI had a partial outage so I had to promote the beta manually.)