### PR TITLE
[PURCHASE-1548] Duplicate view controller crash fix

### DIFF
--- a/Artsy/App/ARAppDelegate+Analytics.m
+++ b/Artsy/App/ARAppDelegate+Analytics.m
@@ -51,7 +51,6 @@
 
 #import <Emission/ARWorksForYouComponentViewController.h>
 #import <Emission/ARArtistComponentViewController.h>
-#import <Emission/ARHomeComponentViewController.h>
 #import <Emission/ARGeneComponentViewController.h>
 
 // Views

--- a/Artsy/View_Controllers/Util/ARNavigationController.m
+++ b/Artsy/View_Controllers/Util/ARNavigationController.m
@@ -26,7 +26,6 @@
 #import <FLKAutoLayout/UIView+FLKAutoLayout.h>
 #import <ObjectiveSugar/ObjectiveSugar.h>
 #import <MultiDelegate/AIMultiDelegate.h>
-#import <Emission/ARHomeComponentViewController.h>
 #import <Emission/ARMapContainerViewController.h>
 #import <Emission/ARComponentViewController.h>
 

--- a/Artsy/View_Controllers/Web_Browsing/ARInternalMobileWebViewController.m
+++ b/Artsy/View_Controllers/Web_Browsing/ARInternalMobileWebViewController.m
@@ -170,6 +170,18 @@ static void *ARProgressContext = &ARProgressContext;
                 if ([viewController isKindOfClass:[UINavigationController class]]) {
                     // Navigation controllers can't be pushed onto regular navigation controllers, only the top menu VC.
                     [self.ar_TopMenuViewController pushViewController:viewController animated:ARPerformWorkAsynchronously];
+                } else if (viewController.navigationController) {
+                    // viewController already has a navigation controller set on it, which indicates it's a special case
+                    // where it's already in a navigation stack somewhere. Let's dismiss ourselves (if applicable) and then
+                    // show the VC through the normal ARTopMenuViewController flow, which handles all special cases.
+
+                    if (self.presentingViewController) {
+                        [self.presentingViewController dismissViewControllerAnimated:ARPerformWorkAsynchronously completion:^{
+                            [[ARTopMenuViewController sharedController] pushViewController:viewController animated:ARPerformWorkAsynchronously];
+                        }];
+                    } else {
+                        [self.ar_TopMenuViewController pushViewController:viewController animated:ARPerformWorkAsynchronously];
+                    }
                 } else {
                     [self.navigationController pushViewController:viewController animated:ARPerformWorkAsynchronously];
                 }

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -6,6 +6,7 @@ upcoming:
     - 
   user_facing:
     - Re-enables Artwork Auctions view to respect Echo flag - ash
+    - Fixes crashes navigating to view controllers which were already in a navigation stack - ash
 
 releases:
   - version: 5.0.7


### PR DESCRIPTION
This PR fixes a problem where duplicate view controllers were being pushed onto the stack, first introduced in #2909. The case where this bug happens is:

- Someone opens a profile link, and the profile 404's (ideally this wouldn't happen, but it does sometimes).
- The 404 page has a "go back to Artsy homepage" button, which links to `/`.
- The `ARRouter` routes from `/` to **the existing** `ARHomeComponentViewController`. 
- Normally, `ARTopMenuViewController` knows how to handle this case, but since #2909, it doesn't.

The fix was to check if the view controller we're routing _to_ already has a non-`nil` `navigationController` property, which indicates it's in an existing navigation stack. We dismiss ourselves from modal presentation (if applicable) before routing through the usual `ARTopMenuViewController`. I've made sure to handle the case where we're modally presenting to still accommodate the functionality introduced in #2909. 

I also removed some unused imports, which slowed me down while looking for uses of `ARHomeComponentViewController`.