### PR TITLE
5.0.8 patch, re-disables Echo check for artwork view, Emission update

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.0.0</string>
+	<string>5.0.8</string>
 	<key>CFBundleVersion</key>
 	<string>2019.05.24.09</string>
 	<key>NSExtension</key>

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.0.0</string>
+	<string>5.0.8</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
+++ b/Artsy/View_Controllers/Artwork/ARArtworkViewController.m
@@ -39,7 +39,8 @@
     } else if (isArtworkNSOInquiry) {
         return ([AROptions boolForOption:AROptionsRNArtworkNSOInquiry] || [self.echo.features[@"ARReactNativeArtworkEnableNSOInquiry"] state]);
     } else if (isArtworkAuctions) {
-        return ([AROptions boolForOption:AROptionsRNArtworkAuctions] || [self.echo.features[@"ARReactNativeArtworkEnableAuctions"] state]);
+        // Disabled temporarily until 6.0.0 is released.
+        return ([AROptions boolForOption:AROptionsRNArtworkAuctions]); // || [self.echo.features[@"ARReactNativeArtworkEnableAuctions"] state]);
     }
 
     return NO;

--- a/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Artwork/ARArtworkViewControllerTests.m
@@ -287,7 +287,7 @@ describe(@"ARArtworkViewController", ^{
                     };
                 });
 
-                it(@"works artworks that are in a sale", ^{
+                pending(@"works artworks that are in a sale", ^{
                     StubArtworkWithSaleArtwork();
                     (void)vc.view;
                     expect(vc.childViewControllers[0]).to.equal(mockComponentVC);

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,11 +1,12 @@
 upcoming:
-  version: 6.0.0
+  version: 5.0.8
   date: TBD
-  emission_version: 1.12.x
+  emission_version: 1.17.6
   dev:
     - 
   user_facing:
     - Re-enables Artwork Auctions view to respect Echo flag - ash
+    - Re-disables Artwork Auctions view to respect Echo flag - ash
     - Fixes crashes navigating to view controllers which were already in a navigation stack - ash
 
 releases:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -72,7 +72,7 @@ PODS:
   - DHCShakeNotifier (0.2.0)
   - DoubleConversion (1.1.6)
   - EDColor (1.0.0)
-  - Emission (1.17.3):
+  - Emission (1.17.6):
     - "Artsy+UIColors"
     - "Artsy+UIFonts (>= 3.0.0)"
     - DoubleConversion (= 1.1.6)
@@ -543,7 +543,7 @@ SPEC CHECKSUMS:
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
-  Emission: 4c62c02396327be7286449416776fe56ec0d0875
+  Emission: 327b914e95abe4c3f2cc90bd1fb9bd23891e9195
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   "Expecta+Snapshots": c343f410c7a6392f3e22e78f94c44b6c0749a516
   Extraction: 642a73b8ccc7806e9a7daf95ebb4c14c374829f1

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,1 +1,1 @@
-This release includes a newly redesigned artwork view (for most artworks). We've also worked on improving the Live Auctions experience, and have included a number of small, general bug fixes and performance improvements.
+This release fixes a crash users were seeing on iOS 9. It also fixes a few other bugs.


### PR DESCRIPTION
Patches since we released 5.0.7. It reverts a change here: https://github.com/artsy/eigen/pull/2915