### PR TITLE
Bump rubyzip from 1.2.1 to 1.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,7 +220,7 @@ GEM
     retriable (2.1.0)
     rouge (1.11.1)
     ruby-macho (1.2.0)
-    rubyzip (1.2.1)
+    rubyzip (1.3.0)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)


### PR DESCRIPTION
Replaces #2918 to get CI green. See: https://github.com/danger/swift/issues/281