### PR TITLE
[PURCHASE-1542] Fixes problem selecting buy now artworks from auction view

### DIFF
--- a/Artsy/View_Controllers/AuctionBuyNowView.swift
+++ b/Artsy/View_Controllers/AuctionBuyNowView.swift
@@ -56,10 +56,10 @@ class AuctionBuyNowView: ORStackView {
 fileprivate typealias EmbeddedModelCallbacks = AuctionBuyNowView
 extension EmbeddedModelCallbacks: AREmbeddedModelsViewControllerDelegate {
     func embeddedModelsViewController(_ controller: AREmbeddedModelsViewController!, didTapItemAt index: UInt) {
-        guard let saleArtwork = controller.items?[Int(index)] as? SaleArtworkViewModel else {
+        guard let artwork = controller.items?[Int(index)] as? Artwork else {
             return
         }
-        let viewController = ARArtworkViewController(artwork: Artwork(artworkID: saleArtwork.artworkID), fair: nil)
+        let viewController = ARArtworkViewController(artwork: artwork, fair: nil)
         self.actionDelegate?.navigationController?.pushViewController(viewController, animated: true)
     }
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -8,6 +8,7 @@ upcoming:
     - Re-enables Artwork Auctions view to respect Echo flag - ash
     - Re-disables Artwork Auctions view to respect Echo flag - ash
     - Fixes crashes navigating to view controllers which were already in a navigation stack - ash
+    - Fixes problem not being able to select buy now works from an auction - ash
 
 releases:
   - version: 5.0.7


### PR DESCRIPTION
This bug was introduced in #2884 and released on Monday in 5.0.7. It's a quick fix, so let's get it in for 5.0.8.

For context around the bug, the `as?` is a conditional cast in Swift. If the cast fails, then the `else` block gets executed (in this case, `return`). This was causing the UI to not respond. The bug was introduced because there were a bunch of similar changes to remove the swipe controller, and in this code, there are two sources of truth for which model got selected. I switched to the one that made more sense to me, but missed this change while testing the change. 