### PR TITLE
[PURCHASE-1537] Fix search transition animation

### DIFF
--- a/Artsy/Navigation_Transitions/ARAppSearchTransition.m
+++ b/Artsy/Navigation_Transitions/ARAppSearchTransition.m
@@ -1,8 +1,6 @@
 #import "ARAppSearchTransition.h"
 #import "ARAppSearchViewController.h"
-#import "ARTopMenuViewController.h"
 
-#import <FLKAutoLayout/FLKAutoLayout.h>
 
 @implementation ARAppSearchTransition
 
@@ -24,16 +22,15 @@
 
     [transitionContext.containerView addSubview:fromVC.view];
     [transitionContext.containerView addSubview:toVC.view];
-    [toVC.view alignToView:transitionContext.containerView];
 
     [UIView animateWithDuration:[self transitionDuration:transitionContext]
         delay:0.0
         options:UIViewAnimationOptionCurveEaseOut
         animations:^{
-            toVC.view.alpha = 1;
+                         toVC.view.alpha = 1;
         }
         completion:^(BOOL finished) {
-            [transitionContext completeTransition:YES];
+                        [transitionContext completeTransition:YES];
         }];
 }
 

--- a/Artsy/Navigation_Transitions/ARAppSearchTransition.m
+++ b/Artsy/Navigation_Transitions/ARAppSearchTransition.m
@@ -17,7 +17,12 @@
     UIGraphicsEndImageContext();
 
     if ([toVC isKindOfClass:[ARAppSearchViewController class]]) {
+        // Showing search
         toVC.backgroundImage = viewImage;
+    } else {
+        // Selecting search result
+        toVC.view.frame = [transitionContext finalFrameForViewController:toVC];
+        toVC.view.transform = CGAffineTransformMakeTranslation(toVC.view.frame.size.width, 0); // Push it offscreen
     }
 
     [transitionContext.containerView addSubview:fromVC.view];
@@ -27,10 +32,11 @@
         delay:0.0
         options:UIViewAnimationOptionCurveEaseOut
         animations:^{
-                         toVC.view.alpha = 1;
+            toVC.view.alpha = 1;
+            toVC.view.transform = CGAffineTransformIdentity;
         }
         completion:^(BOOL finished) {
-                        [transitionContext completeTransition:YES];
+            [transitionContext completeTransition:YES];
         }];
 }
 

--- a/Artsy/Navigation_Transitions/ARDefaultNavigationTransition.m
+++ b/Artsy/Navigation_Transitions/ARDefaultNavigationTransition.m
@@ -51,13 +51,14 @@
 - (void)popTransitionFrom:(UIViewController *)fromVC to:(UIViewController *)toVC withContext:(id<UIViewControllerContextTransitioning>)context
 {
     CGRect fullFrame = [context initialFrameForViewController:fromVC];
+    CGRect offScreen = fullFrame;
+    offScreen.origin.x = offScreen.size.width;
 
     // To = Coming up
     // From = Moving to the Side
 
     [context.containerView addSubview:toVC.view];
     [context.containerView addSubview:fromVC.view];
-    fromVC.view.frame = fullFrame;
 
     UIViewAnimationOptions options = UIViewAnimationOptionCurveEaseOut;
 
@@ -106,7 +107,7 @@
          toVC.view.alpha = 1;
          toVC.view.transform = CGAffineTransformIdentity;
 
-         fromVC.view.transform = CGAffineTransformMakeTranslation(fullFrame.size.width, 0);
+         fromVC.view.frame = offScreen;
 
          backButtonSnapshot.alpha = self.backButtonTargetAlpha;
         }

--- a/Artsy/Navigation_Transitions/ARDefaultNavigationTransition.m
+++ b/Artsy/Navigation_Transitions/ARDefaultNavigationTransition.m
@@ -34,17 +34,16 @@
         delay:0.0
         options:UIViewAnimationOptionCurveEaseOut
         animations:^{
-         fromVC.view.alpha = 0.2;
-         fromVC.view.transform = CGAffineTransformMakeScale(0.9, 0.9);
+            fromVC.view.alpha = 0.2;
+            fromVC.view.transform = CGAffineTransformMakeScale(0.9, 0.9);
 
-         toVC.view.frame = fullFrame;
-
+            toVC.view.frame = fullFrame;
         }
         completion:^(BOOL finished) {
-         fromVC.view.alpha = 1;
-         fromVC.view.transform = CGAffineTransformIdentity;
+            fromVC.view.alpha = 1;
+            fromVC.view.transform = CGAffineTransformIdentity;
 
-         [transitionContext completeTransition:YES];
+            [transitionContext completeTransition:YES];
         }];
 }
 
@@ -98,33 +97,34 @@
     }
 
     toVC.view.alpha = 0.2;
+    toVC.view.frame = [context finalFrameForViewController:toVC];
     toVC.view.transform = CGAffineTransformMakeScale(0.9, 0.9);
 
     [UIView animateWithDuration:[self transitionDuration:context]
         delay:0.0
         options:options
         animations:^{
-         toVC.view.alpha = 1;
-         toVC.view.transform = CGAffineTransformIdentity;
+            toVC.view.alpha = 1;
+            toVC.view.transform = CGAffineTransformIdentity;
 
-         fromVC.view.frame = offScreen;
+            fromVC.view.frame = offScreen;
 
-         backButtonSnapshot.alpha = self.backButtonTargetAlpha;
+            backButtonSnapshot.alpha = self.backButtonTargetAlpha;
         }
         completion:^(BOOL finished) {
-         toVC.view.alpha = 1;
-         toVC.view.transform = CGAffineTransformIdentity;
+            toVC.view.alpha = 1;
+            toVC.view.transform = CGAffineTransformIdentity;
 
-         // Unhide the buttons
-         navigationController.backButton.hidden = NO;
+            // Unhide the buttons
+            navigationController.backButton.hidden = NO;
 
-         [backButtonSnapshot removeFromSuperview];
+            [backButtonSnapshot removeFromSuperview];
 
-         if ([context transitionWasCancelled]) {
-             fromVC.view.frame = fullFrame;
-         }
+            if ([context transitionWasCancelled]) {
+                fromVC.view.frame = fullFrame;
+            }
 
-         [context completeTransition:![context transitionWasCancelled]];
+            [context completeTransition:![context transitionWasCancelled]];
         }];
 }
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -9,6 +9,7 @@ upcoming:
     - Re-disables Artwork Auctions view to respect Echo flag - ash
     - Fixes crashes navigating to view controllers which were already in a navigation stack - ash
     - Fixes problem not being able to select buy now works from an auction - ash
+    - Fixes search result pop transition (empty view bug) - ash & lily
 
 releases:
   - version: 5.0.7


### PR DESCRIPTION
This reverts the change from #2904 because it introduced the problem for PURCHASE-1537. We re-opened ticket 1482 (the extra white padding above the artwork page) and moved it to Mobile Experience's backlog. It's a relatively minor bug compared to what this fixes.

We also tried to clean up code indentation and commenting, I'll comment on the import changes below. 