### PR TITLE
Fix presence check for echoMinimumBuild

### DIFF
--- a/Artsy/App/ARAppDelegate.m
+++ b/Artsy/App/ARAppDelegate.m
@@ -272,7 +272,7 @@ static ARAppDelegate *_sharedInstance = nil;
 {
     Message *killSwitchVersion = ARSwitchBoard.sharedInstance.echo.messages[@"KillSwitchBuildMinimum"];
     NSString *echoMinimumBuild = killSwitchVersion.content;
-    if(echoMinimumBuild){
+    if (echoMinimumBuild != nil && [echoMinimumBuild length] > 0) {
         NSDictionary *infoDictionary = [[[NSBundle mainBundle] infoDictionary] mutableCopy];
         NSString *buildVersion = infoDictionary[@"CFBundleShortVersionString"];
         


### PR DESCRIPTION
Running eigen locally from master I was unable to interact with the app because the default value for `KillSwitchBuildMinimum` was the empty string, which triggered the kill switch. Here I updated the check for whether or not the `KillSwitchBuildMinimum` is set to fail in the case of the empty string.

Maybe it would make more sense to set the dev value of `KillSwitchBuildMinimum` to `"0.0.0"`?

#trivial