### PR TITLE
ME-11 Fix conversations push notification handling

### DIFF
--- a/Artsy/App/ARAppDelegate.m
+++ b/Artsy/App/ARAppDelegate.m
@@ -204,12 +204,6 @@ static ARAppDelegate *_sharedInstance = nil;
     }
     [self.window makeKeyAndVisible];
 
-    NSDictionary *remoteNotification = self.initialLaunchOptions[UIApplicationLaunchOptionsRemoteNotificationKey];
-    if (remoteNotification) {
-        // The app was not running, so considering it to be in the UIApplicationStateInactive state.
-        [self.remoteNotificationsDelegate applicationDidReceiveRemoteNotification:remoteNotification
-                                                               inApplicationState:UIApplicationStateInactive];
-    }
 
     [ARWebViewCacheHost startup];
     [self registerNewSessionOpened];
@@ -275,7 +269,7 @@ static ARAppDelegate *_sharedInstance = nil;
     if (echoMinimumBuild != nil && [echoMinimumBuild length] > 0) {
         NSDictionary *infoDictionary = [[[NSBundle mainBundle] infoDictionary] mutableCopy];
         NSString *buildVersion = infoDictionary[@"CFBundleShortVersionString"];
-        
+
         if ([buildVersion compare:echoMinimumBuild options:NSNumericSearch] == NSOrderedDescending) {
             UIAlertController *alert = [UIAlertController
                                          alertControllerWithTitle:@"New app version required"
@@ -292,9 +286,9 @@ static ARAppDelegate *_sharedInstance = nil;
                                                       exit(0);
                                                   });
                                               }];
-            
+
             [alert addAction:linkToAppButton];
-            
+
             [self.window.rootViewController presentViewController:alert animated:YES completion:nil];
         }
     }
@@ -479,7 +473,7 @@ static ARAppDelegate *_sharedInstance = nil;
         ARAdminSettingsViewController *adminSettings = [[ARAdminSettingsViewController alloc] initWithStyle:UITableViewStyleGrouped];
         [navigationController pushViewController:adminSettings animated:YES];
     }
-    
+
 }
 
 - (void)showQuicksilver


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ME-11

I discovered that the push notification was being handled twice at launch. Both here, where this code is being deleted, and in `ARNotificationsDelegate` by way of `didReceiveRemoteNotification` being triggered (presumably by iOS?)

Both of these trigger the [`applicationDidReceiveRemoteNotification` method](https://github.com/artsy/eigen/blob/1708a28de50114ed7d6f90e5d668704be2edb1fc/Artsy/App/ARAppNotificationsDelegate.m#L187) which is very much not idempotent, and the second invocation was causing the strange behaviour we were seeing somehow.

So deleting this code seems to fix the issue for me. Indeed, I wonder how this ever worked or why this code was there in the first place if `didReceiveRemoteNotification` gets triggered when you tap into an app from a push notification. @alloy [you wrote this code 4+ years ago](https://github.com/artsy/eigen/commit/5f40fe44eb43c8d5bd5be894785cddae2db14089) 😅 any idea?

If we don't know the situations where this code is needed, it would be safer to try to make `applicationDidReceiveRemoteNotification` idempotent, but a lot more work obviously which is why I went down this route for now.

#trivial