### PR TITLE
Fixes intermittent crash during Augmented Reality View-in-Room

### DIFF
--- a/Artsy/View_Controllers/ARVIR/Views/ARInformationView.m
+++ b/Artsy/View_Controllers/ARVIR/Views/ARInformationView.m
@@ -83,7 +83,7 @@
 
     // Bump the index and repeat if it's past the top
     self.index++;
-    if (self.index > self.states.count) {
+    if (self.index >= self.states.count) {
         self.index = 0;
     }
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -9,6 +9,7 @@ upcoming:
     - Re-enables Auctions Artwork Echo flag - ash
     - Fixes circle badge size on nav when user has messages - kierangillen
     - Fixes close button position on modal nav bars
+    - Fixes intermittent crash during Augmented Reality View-in-Room - ash
 
 releases:
   - version: 5.0.8


### PR DESCRIPTION
This came up during knowledge-share this morning. Here's the Sentry report (no Jira ticket): https://sentry.io/organizations/artsynet/issues/1150547566/events/6b17772e38404324965147e32d05e93b/?project=166784

I think what happens is that sometimes this method gets involved repeatedly, asynchronously. This can cause `self.index` to overflow the array bounds, which we _are_ checking for, but with `>` instead of `>=`. This should fix it. 