### PR TITLE
Add a feature flag for Price Transparency

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -309,6 +309,11 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
 
     // Lab options come last (as they are admin/dev controlled, giving them a chance to override)
     [options addEntriesFromDictionary:labOptions];
+
+    if (labOptions[AROptionsPriceTransparency] != nil) {
+        options[@"AROptionsPriceTransparency"] = labOptions[AROptionsPriceTransparency];
+    }
+
     return options;
 }
 

--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -310,7 +310,7 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
     // Lab options come last (as they are admin/dev controlled, giving them a chance to override)
     [options addEntriesFromDictionary:labOptions];
 
-    options[@"AROptionsPriceTransparency"] = @([options[@"AROptionsPriceTransparency"] boolValue] || [labOptions[AROptionsPriceTransparency] boolValue]);
+    options[@"AROptionsPriceTransparency"] = @([labOptions[AROptionsPriceTransparency] boolValue]);
 
     return options;
 }

--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -310,9 +310,7 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
     // Lab options come last (as they are admin/dev controlled, giving them a chance to override)
     [options addEntriesFromDictionary:labOptions];
 
-    if (labOptions[AROptionsPriceTransparency] != nil) {
-        options[@"AROptionsPriceTransparency"] = labOptions[AROptionsPriceTransparency];
-    }
+    options[@"AROptionsPriceTransparency"] = @([options[@"AROptionsPriceTransparency"] boolValue] || [labOptions[AROptionsPriceTransparency] boolValue]);
 
     return options;
 }

--- a/Artsy/App/AROptions.h
+++ b/Artsy/App/AROptions.h
@@ -15,6 +15,7 @@ extern NSString *const AROptionsRNArtworkAlways;
 extern NSString *const AROptionsRNArtworkNonCommerical;
 extern NSString *const AROptionsRNArtworkNSOInquiry;
 extern NSString *const AROptionsRNArtworkAuctions;
+extern NSString *const AROptionsPriceTransparency;
 
 @interface AROptions : NSObject
 

--- a/Artsy/App/AROptions.m
+++ b/Artsy/App/AROptions.m
@@ -24,7 +24,7 @@ NSString *const AROptionsRNArtworkAlways = @"New RN Artwork view (Always)";
 NSString *const AROptionsRNArtworkNonCommerical = @"New RN Artwork view (Non-commerical)";
 NSString *const AROptionsRNArtworkNSOInquiry = @"New RN Artwork view (NSO&Inquiry)";
 NSString *const AROptionsRNArtworkAuctions = @"New RN Artwork view (Auctions)";
-NSString *const AROptionsPriceTransparency = @"Price Transpareny";
+NSString *const AROptionsPriceTransparency = @"Price Transparency";
 
 @implementation AROptions
 

--- a/Artsy/App/AROptions.m
+++ b/Artsy/App/AROptions.m
@@ -24,6 +24,7 @@ NSString *const AROptionsRNArtworkAlways = @"New RN Artwork view (Always)";
 NSString *const AROptionsRNArtworkNonCommerical = @"New RN Artwork view (Non-commerical)";
 NSString *const AROptionsRNArtworkNSOInquiry = @"New RN Artwork view (NSO&Inquiry)";
 NSString *const AROptionsRNArtworkAuctions = @"New RN Artwork view (Auctions)";
+NSString *const AROptionsPriceTransparency = @"Price Transpareny";
 
 @implementation AROptions
 
@@ -41,6 +42,7 @@ NSString *const AROptionsRNArtworkAuctions = @"New RN Artwork view (Auctions)";
          AROptionsRNArtworkNonCommerical: AROptionsRNArtworkNonCommerical,
          AROptionsRNArtworkNSOInquiry: AROptionsRNArtworkNSOInquiry,
          AROptionsRNArtworkAuctions: AROptionsRNArtworkAuctions,
+         AROptionsPriceTransparency: AROptionsPriceTransparency,
 
          AROptionsLoadingScreenAlpha: @"Loading screens are transparent",
         };

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
   emission_version: 1.17.7
   dev:
     - Update emission, sending the new 'env' parameter
+    - Add a feature flag for the new Price Transparency work - yuki24
   user_facing:
     - Adds killswitch based on Eigen version set in echo - kierangillen
     - Re-enables Auctions Artwork Echo flag - ash


### PR DESCRIPTION
addresses https://artsyproduct.atlassian.net/browse/AUCT-697

This adds a new feature flag `AROptionsPriceTransparency` to Eigen so we can toggle the entire feature either globally or per admin basis. I've already [added a new flag that has the consistent name in Echo](https://echo-web-production.herokuapp.com/accounts/1/features/13), so in theory it should work fine. Though this is my first Eigen PR for the first time in a while, so let me know if there's anything wrong.

## Todos

 * [x] Merge https://github.com/artsy/emission/pull/1936
 * [x] ~Make sure Echo's feature flag is properly loaded?~ We will do this in a separate PR: https://github.com/artsy/eigen/pull/2937