### PR TITLE
Remove unused feature flag

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -304,9 +304,6 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
 
     [options addEntriesFromDictionary:echoFeatures];
 
-    // Handle the fact that it's "AREnableBuyNowFlow" in iOS world - and echo, then "enableBuyNowMakeOffer" in Emission world
-    options[@"enableBuyNowMakeOffer"] = echoFeatures[@"AREnableBuyNowFlow"];
-
     // Lab options come last (as they are admin/dev controlled, giving them a chance to override)
     [options addEntriesFromDictionary:labOptions];
     return options;

--- a/Artsy_Tests/App_Tests/ARAppDelegateEmissionSpec.m
+++ b/Artsy_Tests/App_Tests/ARAppDelegateEmissionSpec.m
@@ -22,7 +22,6 @@ it(@"makes sure that settings are merged correctly", ^{
       @"ARDisableReactNativeBidFlow": @(NO),
       @"ipad_vir": @(NO),
       @"iphone_vir": @(YES),
-      @"enableBuyNowMakeOffer":@(YES),
       @"AREnableBuyNowFlow": @(YES),
       @"Debug AR View in Room": @(YES),
       @"Disable Native Live Auctions": @(YES)


### PR DESCRIPTION
It's been a long time since we released the Buy Now Make Offer last year, and I don't think we use a feature flag for it at this point. There are only [two occurrences in the entire org](https://github.com/search?q=org%3Aartsy+enableBuyNowMakeOffer&type=Code), both of which are in Eigen, so this should be safe to remove.

#trivial