### PR TITLE
⚠️ Do not merge: Add a new flag for Price Transparency to Echo

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -307,7 +307,7 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
     // Lab options come last (as they are admin/dev controlled, giving them a chance to override)
     [options addEntriesFromDictionary:labOptions];
 
-    options[@"AROptionsPriceTransparency"] = @([labOptions[AROptionsPriceTransparency] boolValue]);
+    options[@"AROptionsPriceTransparency"] = @([options[@"AROptionsPriceTransparency"] boolValue] || [labOptions[AROptionsPriceTransparency] boolValue]);
 
     return options;
 }

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,7 +3,7 @@ upcoming:
   date: TBD
   emission_version: 1.18.23
   dev:
-    - 
+    - Add a new flag for Price Transparency to Echo - yuki24
   user_facing:
     - Updates profile and mutable view controllers to use default background if not fair - kierangillen
 


### PR DESCRIPTION
Following up on https://github.com/artsy/eigen/pull/2934#issuecomment-547111199. This update Eigen to also look at the Echo flag for the new Price Transparecy as well as the lab feature flag.

## Todos

 * [x] Rebase once https://github.com/artsy/eigen/pull/2934 is merged
 * [x] **Do not do this until the feature is ready**: Add `AROptionsPriceTransparency` to [Echo](https://echo-web-production.herokuapp.com/accounts/1/features)