### PR TITLE
Killswitch to ascending

### DIFF
--- a/Artsy/App/ARAppDelegate.m
+++ b/Artsy/App/ARAppDelegate.m
@@ -270,7 +270,7 @@ static ARAppDelegate *_sharedInstance = nil;
         NSDictionary *infoDictionary = [[[NSBundle mainBundle] infoDictionary] mutableCopy];
         NSString *buildVersion = infoDictionary[@"CFBundleShortVersionString"];
 
-        if ([buildVersion compare:echoMinimumBuild options:NSNumericSearch] == NSOrderedDescending) {
+        if ([buildVersion compare:echoMinimumBuild options:NSNumericSearch] == NSOrderedAscending) {
             UIAlertController *alert = [UIAlertController
                                          alertControllerWithTitle:@"New app version required"
                                          message:@"Please update your Artsy app to continue."


### PR DESCRIPTION
- Fixes killswitch to use a minimum version instead of a maximum from echo

#trivial