### PR TITLE
[ME-1] Fixes ARKit point cloud bug

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -11,6 +11,7 @@ upcoming:
     - Fixes circle badge size on nav when user has messages - kierangillen
     - Fixes close button position on modal nav bars
     - Fixes intermittent crash during Augmented Reality View-in-Room - ash
+    - (ME-1) Fixes ARKit showing some random circles during setup on iOS 13 - ash
 
 releases:
   - version: 5.0.8


### PR DESCRIPTION
I've left a comment explaining the change and how the fix works. Here's the tl;dr

- We use ARKit's `rawFeaturePoints` (which is intended for debugging) to show the user that we're loading the ARKit scene (ie: that ARKit is mapping the world).
- In iOS 13, this "point cloud" started including points that were really close to the camera. [I asked around](https://twitter.com/ashfurrow/status/1189910896920989700) but no one else has been seeing this behaviour. Here's what it looked like:

<details><summary>screenshot of ARKit session start</summary>

![Unknown](https://user-images.githubusercontent.com/498212/68054916-d55e6180-fcc5-11e9-8bfb-286b65aafaf9.png)

</details>

- The docs say that this point cloud isn't stable between versions, so I think iOS is just adding extra points really early in the AR session (they go away after a few seconds, by which time we no longer want to show the point cloud anyway).
- The best solution is to compute the distance from each point to the camera and filter out any that are <20cm away. There are still a few points that seem further from the floor than they should be, but they're far enough away from the camera to not look bad or obscure the actual point cloud.

Open to feedback on this!
