### PR TITLE
[ME-83] Initial work for new Search UI

### DIFF
--- a/Artsy/App/AROptions.h
+++ b/Artsy/App/AROptions.h
@@ -16,6 +16,7 @@ extern NSString *const AROptionsRNArtworkNonCommerical;
 extern NSString *const AROptionsRNArtworkNSOInquiry;
 extern NSString *const AROptionsRNArtworkAuctions;
 extern NSString *const AROptionsPriceTransparency;
+extern NSString *const AROptionsNewSearch;
 
 @interface AROptions : NSObject
 

--- a/Artsy/App/AROptions.m
+++ b/Artsy/App/AROptions.m
@@ -25,6 +25,7 @@ NSString *const AROptionsRNArtworkNonCommerical = @"New RN Artwork view (Non-com
 NSString *const AROptionsRNArtworkNSOInquiry = @"New RN Artwork view (NSO&Inquiry)";
 NSString *const AROptionsRNArtworkAuctions = @"New RN Artwork view (Auctions)";
 NSString *const AROptionsPriceTransparency = @"Price Transparency";
+NSString *const AROptionsNewSearch = @"New Search";
 
 @implementation AROptions
 
@@ -43,6 +44,7 @@ NSString *const AROptionsPriceTransparency = @"Price Transparency";
          AROptionsRNArtworkNSOInquiry: AROptionsRNArtworkNSOInquiry,
          AROptionsRNArtworkAuctions: AROptionsRNArtworkAuctions,
          AROptionsPriceTransparency: AROptionsPriceTransparency,
+         AROptionsNewSearch: AROptionsNewSearch,
 
          AROptionsLoadingScreenAlpha: @"Loading screens are transparent",
         };

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuNavigationDataSource.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuNavigationDataSource.m
@@ -8,6 +8,7 @@
 #import <Emission/ARFavoritesComponentViewController.h>
 #import <Emission/ARMyProfileViewController.h>
 #import <Emission/ARMapContainerViewController.h>
+#import <Emission/ARSearchComponentViewController.h>
 
 #import "AREigenMapContainerViewController.h"
 #import "ARTopMenuInternalMobileWebViewController.h"
@@ -32,6 +33,7 @@
 @property (readonly, nonatomic, strong) ArtsyEcho *echo;
 
 @property (readonly, nonatomic, strong) ARNavigationController *feedNavigationController;
+@property (nonatomic, strong) ARNavigationController *searchNavigationController;
 @property (nonatomic, strong) ARNavigationController *favoritesNavigationController;
 @property (nonatomic, strong) ARNavigationController *localDiscoveryNavigationController;
 @property (nonatomic, strong) ARNavigationController *messagingNavigationController;
@@ -65,6 +67,16 @@
     return self;
 }
 
+- (ARNavigationController *)searchNavigationController
+{
+    if (_searchNavigationController) {
+        return _searchNavigationController;
+    }
+
+    ARSearchComponentViewController *searchVC = [[ARSearchComponentViewController alloc] init];
+    _searchNavigationController = [[ARNavigationController alloc] initWithRootViewController:searchVC];
+    return _searchNavigationController;
+}
 
 - (ARNavigationController *)messagingNavigationController
 {
@@ -134,6 +146,11 @@
                 return [self getHomeViewControllerWithArtist:params[@"artist_id"]];
             } else {
                 return [self feedNavigationController];
+            }
+
+        case ARTopTabControllerIndexSearch:
+            if ([AROptions boolForOption:AROptionsNewSearch]) {
+                return self.searchNavigationController;
             }
 
         case ARTopTabControllerIndexMessaging:

--- a/Artsy/Views/Utilities/ARTabContentView.m
+++ b/Artsy/Views/Utilities/ARTabContentView.m
@@ -4,6 +4,7 @@
 #import "ARNavigationController.h"
 #import "UIView+HitTestExpansion.h"
 #import "ARMenuAwareViewController.h"
+#import "AROptions.h"
 
 #import <ObjectiveSugar/ObjectiveSugar.h>
 
@@ -149,14 +150,16 @@ static BOOL ARTabViewDirectionRight = YES;
     BOOL isARNavigationController = [self.currentNavigationController isKindOfClass:ARNavigationController.class];
 
     // If selecting search button, toggle search VC
-    if (isARNavigationController && [self.dataSource searchButtonAtIndex:index]) {
-        [(ARNavigationController *)self.currentNavigationController toggleSearch];
-        return;
-    }
+    if (![AROptions boolForOption:AROptionsNewSearch]) {
+        if (isARNavigationController && [self.dataSource searchButtonAtIndex:index]) {
+            [(ARNavigationController *)self.currentNavigationController toggleSearch];
+            return;
+        }
 
-    // Otherwise, if the search VC is already present, remove it and continue as normal. This part is only necessary if the app is running with a hardware keyboard enabled; the nav bar is covered by the keyboard otherwise.
-    if (isARNavigationController && [(ARNavigationController *)self.currentNavigationController isShowingSearch]) {
-        [(ARNavigationController *)self.currentNavigationController toggleSearch];
+        // Otherwise, if the search VC is already present, remove it and continue as normal. This part is only necessary if the app is running with a hardware keyboard enabled; the nav bar is covered by the keyboard otherwise.
+        if (isARNavigationController && [(ARNavigationController *)self.currentNavigationController isShowingSearch]) {
+            [(ARNavigationController *)self.currentNavigationController toggleSearch];
+        }
     }
 
     [self.buttons each:^(UIButton *button) {

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -12,6 +12,7 @@ upcoming:
     - Fixes close button position on modal nav bars
     - Fixes intermittent crash during Augmented Reality View-in-Room - ash
     - (ME-1) Fixes ARKit showing some random circles during setup on iOS 13 - ash
+    - (ME-83) Infrastructure for new search UI - ash
 
 releases:
   - version: 5.0.8

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -72,7 +72,7 @@ PODS:
   - DHCShakeNotifier (0.2.0)
   - DoubleConversion (1.1.6)
   - EDColor (1.0.0)
-  - Emission (1.18.17):
+  - Emission (1.18.21):
     - "Artsy+UIColors"
     - "Artsy+UIFonts (>= 3.0.0)"
     - DoubleConversion (= 1.1.6)
@@ -543,7 +543,7 @@ SPEC CHECKSUMS:
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
-  Emission: 474232d24e70edcd4ca4837429d083dabec6f6d9
+  Emission: 6f43270ecb7c3f72061bb3f952fbc5befe4ed7ad
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   "Expecta+Snapshots": c343f410c7a6392f3e22e78f94c44b6c0749a516
   Extraction: 2be993a17f8f8c4fac988ebecaed93a409181faf


### PR DESCRIPTION
This PR adds a lab option for selecting the new search component VC as a normal view controller (rather than a weird modal). See: https://github.com/artsy/emission/pull/1958

![2019-11-05 13-53-54 2019-11-05 13_57_34](https://user-images.githubusercontent.com/498212/68236981-3cd12580-ffd4-11e9-96bd-f9c4bb1bbae9.gif)