### PR TITLE
Bumps version to 6.1.0

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.0.1</string>
+	<string>6.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>2019.05.24.09</string>
 	<key>NSExtension</key>

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.0.1</string>
+	<string>6.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,5 +1,5 @@
 upcoming:
-  version: 6.0.1
+  version: 6.1.0
   date: TBD
   emission_version: 1.18.36
   dev:


### PR DESCRIPTION
As discussed [in Slack](https://artsy.slack.com/archives/CN8S32FJR/p1574264726054600?thread_ts=1574264242.052500&cid=CN8S32FJR) and in today's FE iOS Practice meeting. I'll update AppStoreConnect too.

- The changelog was manually edited.
- The rest was done with `make update_bundle_version`.