### PR TITLE
MX-115 - Fixes landscape partner page

### DIFF
--- a/Artsy/View_Controllers/ARMutableLinkViewController.m
+++ b/Artsy/View_Controllers/ARMutableLinkViewController.m
@@ -3,7 +3,7 @@
 #import "ARRouter.h"
 #import "ArtsyAPI+HEAD.h"
 #import "ARAppConstants.h"
-
+#import "UIDevice-Hardware.h"
 #import "ARTopMenuViewController.h"
 #import "UIViewController+FullScreenLoading.h"
 #import "UIViewController+SimpleChildren.h"
@@ -28,6 +28,15 @@
     _originalPath = path;
 
     return self;
+}
+
+- (BOOL) shouldAutorotate {
+    return [UIDevice isPad];
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations;
+{
+    return self.shouldAutorotate ? UIInterfaceOrientationMaskAll : UIInterfaceOrientationMaskPortrait;
 }
 
 - (void)viewDidLoad

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -72,7 +72,7 @@ PODS:
   - DHCShakeNotifier (0.2.0)
   - DoubleConversion (1.1.6)
   - EDColor (1.0.0)
-  - Emission (1.18.39):
+  - Emission (1.18.40):
     - "Artsy+UIColors"
     - "Artsy+UIFonts (>= 3.0.0)"
     - DoubleConversion (= 1.1.6)
@@ -552,7 +552,7 @@ SPEC CHECKSUMS:
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
-  Emission: efe143535188a721de52a54d7aafbccf12b8e1ce
+  Emission: e0c151975b30a1842e7efd5787a64038a8cb87c0
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   "Expecta+Snapshots": c343f410c7a6392f3e22e78f94c44b6c0749a516
   Extraction: 2be993a17f8f8c4fac988ebecaed93a409181faf


### PR DESCRIPTION
- https://artsyproduct.atlassian.net/browse/MX-115

## Before

<img width="825" alt="Screen Shot 2019-11-25 at 3 06 36 PM" src="https://user-images.githubusercontent.com/21182806/69575135-a8852d80-0f97-11ea-9b35-7e7189a46b2c.png">

## After

<img width="837" alt="Screen Shot 2019-11-25 at 3 21 29 PM" src="https://user-images.githubusercontent.com/21182806/69575154-b0dd6880-0f97-11ea-9cb1-30ec935d35f6.png">

#trivial
