### PR TITLE
Adds admin option to show collection view controller

### DIFF
--- a/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
+++ b/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
@@ -24,6 +24,7 @@
 #import <Emission/AREmission.h>
 #import <Emission/ARInboxComponentViewController.h>
 #import <Emission/ARShowConsignmentsFlowViewController.h>
+#import <Emission/ARCollectionComponentViewController.h>
 #import <Sentry/SentryClient.h>
 #import <Emission/ARGraphQLQueryCache.h>
 #import <React/RCTBridge.h>
@@ -69,6 +70,7 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
     [tableViewData addSectionData:userSectionData];
 
     ARSectionData *launcherSections = [[ARSectionData alloc] initWithCellDataArray:@[
+        [self generateCollections],
         [self generateOnboarding],
         [self generateShowAllLiveAuctions],
         [self showConsignmentsFlow],
@@ -114,6 +116,14 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
         [self showAlertViewWithTitle:@"Confirm Log Out" message:@"" actionTitle:@"Continue" actionHandler:^{
             [ARUserManager logout];
         }];
+    }];
+}
+
+- (ARCellData *)generateCollections
+{
+    return [self tappableCellDataWithTitle:@"Show Collection" selection:^{
+        ARCollectionComponentViewController *viewController = [[ARCollectionComponentViewController alloc] initWithCollectionID:@"street-art-now"];
+        [self.navigationController pushViewController:viewController animated:YES];
     }];
 }
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
   emission_version: 1.18.39
   dev:
     - Add a new flag for Price Transparency to Echo - yuki24
+    - Adds option to show a collection view controller - ash
   user_facing:
     - Updates profile and mutable view controllers to use default background if not fair - kierangillen
     - Fixes an issue where confirm bid screen crashses when the Price Transparncy feature is off - yuki24


### PR DESCRIPTION
This PR adds an option to the admin menu (you can get there by shaking your device or hitting the backtick key ` on your keyboard while in the simulator) to show a collection:

![2019-11-26 15-04-19 2019-11-26 15_05_08](https://user-images.githubusercontent.com/498212/69668594-3a576e00-105e-11ea-9341-8a2f0bca6707.gif)

This will unblock our Grow colleagues from QA'ing the in-progress collections work. I'll go into more detail in-person next week in our check-in, but tl;dr tickets in Mobile Experience/Purchase are generally considered "done" once they have been deployed and tested in an Eigen beta. 

- Grow will send PRs to Emission
- After merging, PR's get auto-deployed (thanks @ds300!)
- When ready to QA some tickets, we'll update the version of Emission that Eigen uses (ie: `bundle exec pod update Emission`)
- Then we'll cut a new beta (ie: `make deploy`)