### PR TITLE
Updates App Store metadata

### DIFF
--- a/fastlane/metadata/en-US/description.txt
+++ b/fastlane/metadata/en-US/description.txt
@@ -1,16 +1,19 @@
-Artsy is the best way to buy and discover art. Use Artsy to explore and buy over 700,000 artworks from the world’s top galleries and auction houses. Find the perfect work for you, connect with art galleries, and bid in live auctions from wherever you are.
+Artsy is the largest online art marketplace with more than 1 million artworks by over 100,000 artists. Collect art from galleries around the world, bid in live auctions from wherever you are, and sell works from your collection.
 
 DISCOVER ART FROM ALL OVER THE WORLD
-Artsy partners with over 3,000 galleries, 800 museums, 80 art fairs, and the world’s top auction houses to provide the largest art marketplace for buyers around the world.
-
-EXPLORE EVENTS IN THE WORLD'S ART CAPITALS
-Navigate art fairs, museum exhibitions, and gallery shows with this comprehensive guide to the art world. City Guide, in partnership with BMW, helps you discover the world’s top exhibitions and map out events to create a personalized itinerary.
-
-BUY WORKS BY LEADING ARTISTS FROM TOP GALLERIES AND AUCTION HOUSES
-With Artsy, you'll have unprecedented access to works from top galleries and auctions, including transparent pricing information. Find an artwork you’re interested in, view the work in your space, and instantly purchase from the gallery directly from the app, wherever you are.
-
-BID ON WORKS FROM THE TOP AUCTION HOUSES
-Bid in live auctions from world-renowned auction houses like Christie's and Phillips. Bid on works by artists like Banksy, Warhol, Picasso, Koons, Hirst, Kusama, Calder, Lichtenstein, and many more. Artsy allows you to bid with confidence—get real-time updates about your bid status including outbid notifications and alerts when works by artists you follow come up for auction. 
+Artsy partners with 3,000+ galleries, 80+ art fairs, and the world’s top auction houses to create the largest online art marketplace. With Artsy, you'll have unprecedented access to works from premier galleries and auction houses, including transparent pricing information. 
 
 FOLLOW YOUR FAVORITE ARTISTS FOR TAILORED RECOMMENDATIONS
-Be the first to browse new available works by artists you love. Follow artists to get live updates when new works are added to Artsy, and discover new artists related to those you follow.
+Be the first to browse new available works by artists you love. Follow artists to get live updates when their works are added to Artsy, and discover artists related to those you follow.
+
+COLLECT ART FROM TOP GALLERIES, FAIRS, AND AUCTION HOUSES
+Find an artwork you’re interested in and instantly purchase from the gallery directly or inquire. Artsy allows you to bid with confidence: get real-time updates about your bid status, including outbid notifications, and alerts when works by artists you follow come up for auction.
+
+VIEW WORKS VIRTUALLY IN YOUR HOME
+Ever wondered what a painting or print would look like hanging on your wall before you purchased it? With Artsy’s augmented reality feature, you can see how every two-dimensional piece of art on Artsy looks in your home before you inquire or purchase.
+
+EXPLORE EVENTS IN THE WORLD'S ART CAPITALS
+Navigate art fairs, museum exhibitions, and gallery shows with this comprehensive guide to the art world. City Guide, in partnership with BMW, helps you discover the world’s top exhibitions and map out events to create a personalized itinerary in six world-class cultural centers (New York, London, Hong Kong, Los Angeles, Paris, and Berlin).
+
+CONSIGN YOUR COLLECTION WITH ARTSY
+Artsy will connect you with top-tier galleries and auction houses to sell works from your collection. Once you submit your consignment, Artsy will promote your work to our global network of sellers.

--- a/fastlane/metadata/en-US/keywords.txt
+++ b/fastlane/metadata/en-US/keywords.txt
@@ -1,1 +1,1 @@
-gallery,fairs,exhibition,collector,museum,auction,buy,artwork,artist,armory,bid,interior,banksy,fair
+buy,collect,bid,sell,consign,gallery,fair,auction,fine,art,artwork,artist,painting,print,photography

--- a/fastlane/metadata/en-US/subtitle.txt
+++ b/fastlane/metadata/en-US/subtitle.txt
@@ -1,1 +1,1 @@
-Shop from auctions & galleries
+Collect from galleries & auctions


### PR DESCRIPTION
These changes were intended to go live with the 6.0.0 release, but [as I described in Slack](https://artsy.slack.com/archives/CN8S32FJR/p1574799323016500), the new updates were overwritten by the _old_ versions here in the repo. 

Going forward, the metadata in the repo should be considered canonical. 