### PR TITLE
[MX-54] Migrates to new Emission-based, native iOS ratings prompt

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -5140,7 +5140,6 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/MARKRangeSlider/MARKRangeSlider.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/NPKeyboardLayoutGuide/NPKeyboardLayoutGuide.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/Stripe/Stripe.bundle",
-				"${PODS_ROOT}/iRate/iRate/iRate.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -5166,7 +5165,6 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MARKRangeSlider.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/NPKeyboardLayoutGuide.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Stripe.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/iRate.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -139,7 +139,7 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
     NSDictionary *options = [self getOptionsForEmission:[aero featuresMap] labOptions:[AROptions labOptionsMap]];
     AREmissionConfiguration *config = [[AREmissionConfiguration alloc] initWithUserID:userID
                                                                   authenticationToken:authenticationToken
-                                                                          launchCount:2
+                                                                          launchCount:launchCount
                                                                             sentryDSN:sentryDSN
                                                                  stripePublishableKey:stripePublishableKey
                                                                      googleMapsAPIKey:[keys googleMapsAPIKey]

--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -134,20 +134,22 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
       env = AREnvProduction;
     }
 
+    NSInteger launchCount = [[NSUserDefaults standardUserDefaults] integerForKey:ARAnalyticsAppUsageCountProperty];
 
     NSDictionary *options = [self getOptionsForEmission:[aero featuresMap] labOptions:[AROptions labOptionsMap]];
     AREmissionConfiguration *config = [[AREmissionConfiguration alloc] initWithUserID:userID
-                                                                      authenticationToken:authenticationToken
-                                                                                sentryDSN:sentryDSN
-                                                                     stripePublishableKey:stripePublishableKey
-                                                                         googleMapsAPIKey:[keys googleMapsAPIKey]
-                                                                       mapBoxAPIClientKey:[keys mapBoxAPIClientKey]
-                                                                               gravityURL:gravity
-                                                                           metaphysicsURL:metaphysics
-                                                                            predictionURL:liveAuctionsURL
-                                                                                userAgent:ARRouter.userAgent
-                                                                                      env:env
-                                                                                  options:options];
+                                                                  authenticationToken:authenticationToken
+                                                                          launchCount:2
+                                                                            sentryDSN:sentryDSN
+                                                                 stripePublishableKey:stripePublishableKey
+                                                                     googleMapsAPIKey:[keys googleMapsAPIKey]
+                                                                   mapBoxAPIClientKey:[keys mapBoxAPIClientKey]
+                                                                           gravityURL:gravity
+                                                                       metaphysicsURL:metaphysics
+                                                                        predictionURL:liveAuctionsURL
+                                                                            userAgent:ARRouter.userAgent
+                                                                                  env:env
+                                                                              options:options];
 
     AREmission *emission = [[AREmission alloc] initWithConfiguration:config packagerURL:packagerURL];
 

--- a/Artsy/App/ARAppDelegate.m
+++ b/Artsy/App/ARAppDelegate.m
@@ -1,7 +1,6 @@
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #import <FBSDKLoginKit/FBSDKLoginKit.h>
 #import <ORKeyboardReactingApplication/ORKeyboardReactingApplication.h>
-#import <iRate/iRate.h>
 #import <AFOAuth1Client/AFOAuth1Client.h>
 #import <UICKeyChainStore/UICKeyChainStore.h>
 #import <Adjust/Adjust.h>
@@ -141,7 +140,6 @@ static ARAppDelegate *_sharedInstance = nil;
 
     [self setupAdminTools];
 
-    [self setupRatingTool];
     [self countNumberOfRuns];
 
     _landingURLRepresentation = self.landingURLRepresentation ?: @"https://artsy.net";
@@ -360,15 +358,6 @@ static ARAppDelegate *_sharedInstance = nil;
     [ORKeyboardReactingApplication registerForCallbackOnKeyDown:ORDeleteKey:^{
         [ARTopMenuViewController.sharedController.rootNavigationController popViewControllerAnimated:YES];
     }];
-}
-
-- (void)setupRatingTool
-{
-    BOOL isLoggedIn = [[ARUserManager sharedManager] hasExistingAccount];
-    if (isLoggedIn) {
-        [iRate sharedInstance].promptForNewVersionIfUserRated = NO;
-        [iRate sharedInstance].verboseLogging = NO;
-    }
 }
 
 // For pre-iOS 10

--- a/Artsy_Tests/Supporting_Files/ARTestHelper.m
+++ b/Artsy_Tests/Supporting_Files/ARTestHelper.m
@@ -5,7 +5,6 @@
 #import "ARSpotlight.h"
 #import "ARUserManager.h"
 
-#import <iRate/iRate.h>
 #import <SDWebImage/SDWebImageManager.h>
 #import "ARFonts.h"
 #import <Emission/AREmission.h>
@@ -36,9 +35,6 @@
     // Shared Web Credentials involve async processes that trigger OS alerts and are generally hard to deal with.
     // The related ARUserManager methods can still be invoked, they will just silently do nothing.
     [[ARUserManager sharedManager] disableSharedWebCredentials];
-
-    /// Never run in tests
-    [[iRate sharedInstance] setRatedThisVersion:YES];
 
     /// Not really sure what this is for
     [[ARLogger sharedLogger] startLogging];

--- a/Artsy_Tests/Supporting_Files/ARTestHelper.m
+++ b/Artsy_Tests/Supporting_Files/ARTestHelper.m
@@ -58,6 +58,7 @@
     NSString *metaphysics = [ARRouter baseMetaphysicsApiURLString];
     AREmissionConfiguration *config = [[AREmissionConfiguration alloc] initWithUserID:@""
                                                                   authenticationToken:@""
+                                                                          launchCount:0
                                                                             sentryDSN:@""
                                                                  stripePublishableKey:@""
                                                                      googleMapsAPIKey:@""

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -13,6 +13,7 @@ upcoming:
     - Updates profile and mutable view controllers to use default background if not fair - kierangillen
     - Fixes an issue where confirm bid screen crashses when the Price Transparncy feature is off - yuki24
     - Increases the minimum iOS version supported by the app to iOS 12 - ash
+    - Migrates to iOS app review dialogue - ash
 
 releases:
   - version: 6.0.0

--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,7 @@ source 'https://cdn.cocoapods.org/'
 platform :ios, '12.0'
 inhibit_all_warnings!
 
-EMISSION_VERSION = '1.19.5'
+EMISSION_VERSION = '1.19.7'
 require 'down'
 require 'json'
 require 'fileutils'
@@ -101,7 +101,6 @@ target 'Artsy' do
   pod 'CocoaLumberjack', git: 'https://github.com/CocoaLumberjack/CocoaLumberjack.git' # Unreleased > 2.0.1 version has a CP modulemap fix
   pod 'FLKAutoLayout', git: 'https://github.com/orta/FLKAutoLayout.git', branch: 'v1'
   pod 'FXBlurView'
-  pod 'iRate'
   pod 'ISO8601DateFormatter', git: 'https://github.com/orta/iso-8601-date-formatter'
   pod 'JLRoutes', git: 'https://github.com/orta/JLRoutes.git'
   pod 'JSDecoupledAppDelegate'
@@ -135,7 +134,10 @@ target 'Artsy' do
   pod 'Artsy+UILabels'
   pod 'Extraction'
 
+  # To link to Emission locally, for development, comment out the line below, and uncomment the line below it.
   pod 'Emission', EMISSION_VERSION
+#  pod 'Emission', path: '../emission' # Local Development Emission
+
   npm_vendored_podspecs.each do |pod_name, props|
     pod pod_name.to_s, props
   end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -72,7 +72,7 @@ PODS:
   - DHCShakeNotifier (0.2.0)
   - DoubleConversion (1.1.6)
   - EDColor (1.0.0)
-  - Emission (1.19.5):
+  - Emission (1.19.7):
     - "Artsy+UIColors"
     - "Artsy+UIFonts (>= 3.0.0)"
     - DoubleConversion (= 1.1.6)
@@ -164,7 +164,6 @@ PODS:
   - INTUAnimationEngine (1.4.2):
     - INTUAnimationEngine/SpringSolver (= 1.4.2)
   - INTUAnimationEngine/SpringSolver (1.4.2)
-  - iRate (1.10.2)
   - ISO8601DateFormatter (0.7.1)
   - JLRoutes (2.0.0)
   - JSDecoupledAppDelegate (1.2.0)
@@ -467,7 +466,7 @@ DEPENDENCIES:
   - DHCShakeNotifier
   - DoubleConversion (from `./rn_pods/node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - EDColor
-  - Emission (= 1.19.5)
+  - Emission (= 1.19.7)
   - Expecta
   - "Expecta+Snapshots"
   - Extraction
@@ -482,7 +481,6 @@ DEPENDENCIES:
   - FXBlurView
   - glog (from `./rn_pods/node_modules/react-native/third-party-podspecs/glog.podspec`)
   - Interstellar/Core (from `https://github.com/ashfurrow/Interstellar.git`, branch `observable-unsubscribe`)
-  - iRate
   - ISO8601DateFormatter (from `https://github.com/orta/iso-8601-date-formatter`)
   - JLRoutes (from `https://github.com/orta/JLRoutes.git`)
   - JSDecoupledAppDelegate
@@ -565,7 +563,6 @@ SPEC REPOS:
     - Forgeries
     - FXBlurView
     - INTUAnimationEngine
-    - iRate
     - JSDecoupledAppDelegate
     - JWTDecode
     - KSCrash
@@ -765,7 +762,7 @@ SPEC CHECKSUMS:
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
-  Emission: 40f5fdb088a0e2e39fec1472b0b13fc0716f66c4
+  Emission: 81b02533308067df751c7aa5324660b2db0c90d7
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   "Expecta+Snapshots": c343f410c7a6392f3e22e78f94c44b6c0749a516
   Extraction: 2be993a17f8f8c4fac988ebecaed93a409181faf
@@ -781,7 +778,6 @@ SPEC CHECKSUMS:
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   Interstellar: ab67502af03105f92100a043e178d188a1a437c9
   INTUAnimationEngine: 3a7d63738cd51af573d16848a771feedea7cc9f2
-  iRate: 18fd2d3bd7d2ab01dcd801098cc2f5cbe9f25ffb
   ISO8601DateFormatter: 8311a2d4e265b269b2fed7ab4db685dcb0a7ccb2
   JLRoutes: 63d64c28b26bcdeb5f5b29e436f75b8358e8d6d1
   JSDecoupledAppDelegate: 5905e144cbe6e0c889248eebbee6784510f315e1
@@ -848,6 +844,6 @@ SPEC CHECKSUMS:
   "XCTest+OHHTTPStubSuiteCleanUp": 4469ec8863c6bc022c5089a9b94233eb3416c5ee
   Yoga: ba3d99dbee6c15ea6bbe3783d1f0cb1ffb79af0f
 
-PODFILE CHECKSUM: fe237de2988698761ab935fa622bdcb6223cd0cc
+PODFILE CHECKSUM: 22b89491ff093ae4207eb4cf6aafb2136acd7713
 
 COCOAPODS: 1.7.5


### PR DESCRIPTION
See: https://github.com/artsy/emission/pull/1995

I've already pushed a beta with these changes, so no rush to get this merged.