### PR TITLE
Preparing for 6.2.0

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.1.0</string>
+	<string>6.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>2019.05.24.09</string>
 	<key>NSExtension</key>

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.1.0</string>
+	<string>6.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,6 +1,15 @@
 upcoming:
-  version: 6.1.0
+  version: 6.2.0
   date: TBD
+  emission_version: 1.19.11
+  dev:
+    -
+  user_facing:
+    - 
+
+releases:
+  version: 6.1.0
+  date: Dec 11, 2019
   emission_version: 1.19.11
   dev:
     - Switched CocoaPods to use the CDN master spec repo - alloy
@@ -12,11 +21,10 @@ upcoming:
     - Puts new partner page behind an Echo flag - ash
   user_facing:
     - Updates profile and mutable view controllers to use default background if not fair - kierangillen
-    - Fixes an issue where confirm bid screen crashses when the Price Transparncy feature is off - yuki24
+    - Fixes an issue where confirm bid screen crashes when the Price Transparency feature is off - yuki24
     - Increases the minimum iOS version supported by the app to iOS 12 - ash
     - Migrates to iOS app review dialogue - ash
 
-releases:
   - version: 6.0.0
     date: November 14, 2019
     emission_version: 1.18.23

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -8,22 +8,22 @@ upcoming:
     - 
 
 releases:
-  version: 6.1.0
-  date: Dec 11, 2019
-  emission_version: 1.19.11
-  dev:
-    - Switched CocoaPods to use the CDN master spec repo - alloy
-    - Add a new flag for Price Transparency to Echo - yuki24
-    - Increases minimum deploy version to iOS 12 - ash
-    - Adds option to show a collection view controller - ash
-    - Upgrades React Native to 0.61.4 - ash & david & kieran
-    - Add back-button-hiding infra for emission - ash & david & kieran
-    - Puts new partner page behind an Echo flag - ash
-  user_facing:
-    - Updates profile and mutable view controllers to use default background if not fair - kierangillen
-    - Fixes an issue where confirm bid screen crashes when the Price Transparency feature is off - yuki24
-    - Increases the minimum iOS version supported by the app to iOS 12 - ash
-    - Migrates to iOS app review dialogue - ash
+  - version: 6.1.0
+    date: Dec 11, 2019
+    emission_version: 1.19.11
+    dev:
+      - Switched CocoaPods to use the CDN master spec repo - alloy
+      - Add a new flag for Price Transparency to Echo - yuki24
+      - Increases minimum deploy version to iOS 12 - ash
+      - Adds option to show a collection view controller - ash
+      - Upgrades React Native to 0.61.4 - ash & david & kieran
+      - Add back-button-hiding infra for emission - ash & david & kieran
+      - Puts new partner page behind an Echo flag - ash
+    user_facing:
+      - Updates profile and mutable view controllers to use default background if not fair - kierangillen
+      - Fixes an issue where confirm bid screen crashes when the Price Transparency feature is off - yuki24
+      - Increases the minimum iOS version supported by the app to iOS 12 - ash
+      - Migrates to iOS app review dialogue - ash
 
   - version: 6.0.0
     date: November 14, 2019


### PR DESCRIPTION
We released 6.1.0 of the app this morning, which means there is post-release follow-up to take care of. The steps are [outlined in the documentation](https://github.com/artsy/eigen/blob/master/docs/deploy_to_app_store.md#prepare-for-the-next-release) but the quick version is:

- Create a new version (6.2.0) in AppStoreConnect.
- Update changelog, manually.
- Run `make next` to update various `Info.plist` files' version numbers (build numbers are set automatically during beta deploys).

Let me know what I can clarify.