### PR TITLE
[MX-127] Hide tool bar when in search nav stack

### DIFF
--- a/Artsy/View_Controllers/Util/ARNavigationController.m
+++ b/Artsy/View_Controllers/Util/ARNavigationController.m
@@ -16,6 +16,7 @@
 #import "ARTopMenuViewController.h"
 #import "ARScrollNavigationChief.h"
 #import "AREigenMapContainerViewController.h"
+#import "AROptions.h"
 
 #import "ARMacros.h"
 #import "UIDevice-Hardware.h"
@@ -395,16 +396,11 @@ ShouldHideItem(UIViewController *viewController, SEL itemSelector, ...)
 - (BOOL)shouldHideToolbarMenuForViewController:(UIViewController *)viewController
 {
   if (ShouldHideItem(viewController, @selector(hidesToolbarMenu), NULL)) {
-    return YES;
+      return YES;
   }
-  
+
   // also hide if in search view and other VCs are pushed above root search view
-  for (int i = 0; i < self.viewControllers.count; i++) {
-    if ([self.viewControllers[i] isKindOfClass:ARSearchComponentViewController.class]) {
-      return i < self.viewControllers.count - 1;
-    }
-  }
-  return NO;
+  return [AROptions boolForOption:AROptionsNewSearch] && [self.viewControllers.firstObject isKindOfClass:ARSearchComponentViewController.class] && self.viewControllers.count > 1;
 }
 
 
@@ -472,7 +468,7 @@ ShouldHideItem(UIViewController *viewController, SEL itemSelector, ...)
     } else if (context == ARNavigationControllerScrollingChiefContext) {
         // All hail the chief
         ARScrollNavigationChief *chief = object;
-        
+
         NSAssert(self.visibleViewController == self.topViewController, @"Called by a VC that is not part of this navigation controller's stack.");
         [self showBackButton:[self shouldShowBackButtonForViewController:self.topViewController] && chief.allowsMenuButtons animated:YES];
     } else if (context == ARNavigationControllerMenuAwareScrollViewContext) {
@@ -518,7 +514,7 @@ ShouldHideItem(UIViewController *viewController, SEL itemSelector, ...)
     if (self.searchViewController == nil) {
         self.searchViewController = [ARAppSearchViewController sharedSearchViewController];
     }
-    
+
     if ([[[ARTopMenuViewController sharedController] rootNavigationController] topViewController] != self.searchViewController) {
         [[[ARTopMenuViewController sharedController] rootNavigationController] pushViewController:self.searchViewController animated:ARPerformWorkAsynchronously];
     }

--- a/Artsy/View_Controllers/Util/ARNavigationController.m
+++ b/Artsy/View_Controllers/Util/ARNavigationController.m
@@ -28,6 +28,7 @@
 #import <MultiDelegate/AIMultiDelegate.h>
 #import <Emission/ARMapContainerViewController.h>
 #import <Emission/ARComponentViewController.h>
+#import <Emission/ARSearchComponentViewController.h>
 
 static void *ARNavigationControllerButtonStateContext = &ARNavigationControllerButtonStateContext;
 static void *ARNavigationControllerScrollingChiefContext = &ARNavigationControllerScrollingChiefContext;
@@ -393,7 +394,17 @@ ShouldHideItem(UIViewController *viewController, SEL itemSelector, ...)
 
 - (BOOL)shouldHideToolbarMenuForViewController:(UIViewController *)viewController
 {
-    return ShouldHideItem(viewController, @selector(hidesToolbarMenu), NULL);
+  if (ShouldHideItem(viewController, @selector(hidesToolbarMenu), NULL)) {
+    return YES;
+  }
+  
+  // also hide if in search view and other VCs are pushed above root search view
+  for (int i = 0; i < self.viewControllers.count; i++) {
+    if ([self.viewControllers[i] isKindOfClass:ARSearchComponentViewController.class]) {
+      return i < self.viewControllers.count - 1;
+    }
+  }
+  return NO;
 }
 
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/MX-127

Now that search is it's own page we had a problem in deciding _where_ tapping a search result takes you in our nav system.

This PR implements the decision to copy the twitter app by keeping all search-related activity in the search page. It accomplishes this by hiding the bottom toolbar nav when viewing search results.

Here's how that looks.

![Kapture 2019-12-12 at 14 37 56](https://user-images.githubusercontent.com/1242537/70721172-08e0d280-1ced-11ea-8870-d222656e350b.gif)

Where I've put this logic feels like the wrong place conceptually but also the simplest place practically. I'm curious if you're concerned about that @ashfurrow or maybe you have a suggestion for where else this could go?