### PR TITLE
Avoid swizzling debug method again on logout

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -154,7 +154,10 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
     AREmission *emission = [[AREmission alloc] initWithConfiguration:config packagerURL:packagerURL];
 
     // Disable default React Native dev menu shake motion handler
-    RCTSwapInstanceMethods([UIWindow class], @selector(RCT_motionEnded:withEvent:), @selector(motionEnded:withEvent:));
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        RCTSwapInstanceMethods([UIWindow class], @selector(RCT_motionEnded:withEvent:), @selector(motionEnded:withEvent:));
+    });
 
     [AREmission setSharedInstance:emission];
 


### PR DESCRIPTION
To disable react native default debug menu and present our own we are swizzling out the RCT_motionEnded method in Emission setup, with new logout flow this is occurring multiple times so needs to be wrapped in a dispatch_once block. Long term we should probably look into other ways of doing this but I can't see an obvious solution right now.

https://github.com/facebook/react-native/issues/4330
https://github.com/facebook/react-native/blob/master/React/CoreModules/RCTDevMenu.mm#L108