### PR TITLE
Changes status bar icon colors from white to black

### DIFF
--- a/Artsy/View_Controllers/AREigenCollectionComponentViewController.m
+++ b/Artsy/View_Controllers/AREigenCollectionComponentViewController.m
@@ -13,7 +13,7 @@
 
 - (UIStatusBarStyle)preferredStatusBarStyle
 {
-    return UIStatusBarStyleLightContent;
+    return UIStatusBarStyleDefault;
 }
 
 @end


### PR DESCRIPTION
Design requested that the status bar icons in Collections be black, not white. This PR implements that change.

[See comments in FX-1421 for context](https://artsyproduct.atlassian.net/browse/GROW-1421)

<img width="460" alt="Screen Shot 2020-01-13 at 12 32 55 PM" src="https://user-images.githubusercontent.com/10385964/72278112-52c91b00-3601-11ea-8811-0ac3b3e6a1a8.png">


#trivial