### PR TITLE
Moves back to old-style search nav bar behaviour #trivial

### DIFF
--- a/Artsy/View_Controllers/Util/ARNavigationController.m
+++ b/Artsy/View_Controllers/Util/ARNavigationController.m
@@ -16,7 +16,6 @@
 #import "ARTopMenuViewController.h"
 #import "ARScrollNavigationChief.h"
 #import "AREigenMapContainerViewController.h"
-#import "AROptions.h"
 
 #import "ARMacros.h"
 #import "UIDevice-Hardware.h"
@@ -29,7 +28,6 @@
 #import <MultiDelegate/AIMultiDelegate.h>
 #import <Emission/ARMapContainerViewController.h>
 #import <Emission/ARComponentViewController.h>
-#import <Emission/ARSearchComponentViewController.h>
 
 static void *ARNavigationControllerButtonStateContext = &ARNavigationControllerButtonStateContext;
 static void *ARNavigationControllerScrollingChiefContext = &ARNavigationControllerScrollingChiefContext;
@@ -395,12 +393,7 @@ ShouldHideItem(UIViewController *viewController, SEL itemSelector, ...)
 
 - (BOOL)shouldHideToolbarMenuForViewController:(UIViewController *)viewController
 {
-  if (ShouldHideItem(viewController, @selector(hidesToolbarMenu), NULL)) {
-      return YES;
-  }
-
-  // also hide if in search view and other VCs are pushed above root search view
-  return [AROptions boolForOption:AROptionsNewSearch] && [self.viewControllers.firstObject isKindOfClass:ARSearchComponentViewController.class] && self.viewControllers.count > 1;
+    return ShouldHideItem(viewController, @selector(hidesToolbarMenu), NULL);
 }
 
 


### PR DESCRIPTION
Sam, Brittney and I were discussing the behaviour of hiding the bottom tab bar when tapping in a search. In the abstract, the idea made sense, but seeing it play out on-device felt weird. If a user is searching, they might want to tap from a search result back to their Home (or Conversations, or Favourites, etc) and then quickly back to their search result again (see the below GIF).

<details><summary>GIF of the original (now new again) behaviour</summary>

![2020-01-13 16-37-56 2020-01-13 16_39_47](https://user-images.githubusercontent.com/498212/72294537-bcf2b780-3623-11ea-98c2-aed0d88e2a09.gif)

</details> 

This PR changes back the behaviour introduced #2969. I think it was worth trying out, and we learned from it 👍 