### PR TITLE
Prepares for next version

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.2.0</string>
+	<string>6.2.1</string>
 	<key>CFBundleVersion</key>
 	<string>2019.05.24.09</string>
 	<key>NSExtension</key>

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.2.0</string>
+	<string>6.2.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,17 +1,25 @@
 upcoming:
-  version: 6.2.0
+  version: 6.2.1
   date: TBD
-  emission_version: 1.19.11
+  emission_version: 1.21.11
   dev:
-    - Delete ARFairSearchViewController - brian
-    - Adds basic UI infrastructure for CCPA UI - ash
-    - Upgrates to Xcode 11 - ash
-    - Removes references to legacy artwork view - kieran
+    - 
   user_facing:
-    - Adds log out button to app - brian & ash
-    - Enables new search for all users - ash
+    - 
 
 releases:
+  - version: 6.2.0
+    date: Jan 22, 2020
+    emission_version: 1.21.11
+    dev:
+      - Delete ARFairSearchViewController - brian
+      - Adds basic UI infrastructure for CCPA UI - ash
+      - Upgrates to Xcode 11 - ash
+      - Removes references to legacy artwork view - kieran
+    user_facing:
+      - Adds log out button to app - brian & ash
+      - Enables new search for all users - ash
+
   - version: 6.1.0
     date: Dec 11, 2019
     emission_version: 1.19.11


### PR DESCRIPTION
I went with 6.2.1 as a version number, since I think the next release will be Xcode 11-specific bug fixes (as well as any bugs that fall out of the 6.2.0 release).