### PR TITLE
[MX-96] Remove redundant analytics for Artist screen views

### DIFF
--- a/Artsy/App/ARAnalyticsConstants.h
+++ b/Artsy/App/ARAnalyticsConstants.h
@@ -81,7 +81,6 @@ extern NSString *const ARAnalyticsPartnerShowView;
 
 // Artist
 
-extern NSString *const ARAnalyticsArtistView;
 extern NSString *const ARAnalyticsArtistFollow;
 extern NSString *const ARAnalyticsArtistUnfollow;
 extern NSString *const ARAnalyticsArtistTappedForSale;

--- a/Artsy/App/ARAnalyticsConstants.m
+++ b/Artsy/App/ARAnalyticsConstants.m
@@ -62,7 +62,6 @@ NSString *const ARAnalyticsFairFeaturedLinkSelected = @"fair selected featured l
 NSString *const ARAnalyticsFairPostSelected = @"fair selected post";
 NSString *const ARAnalyticsFairOverviewSelection = @"Tapped fair section from fair overview";
 
-NSString *const ARAnalyticsArtistView = @"artist view";
 NSString *const ARAnalyticsArtistFollow = @"Follow artist";
 NSString *const ARAnalyticsArtistUnfollow = @"Follow artist";
 NSString *const ARAnalyticsArtistTappedForSale = @"artist tapped for sale";

--- a/Artsy/App/ARAppDelegate+Analytics.m
+++ b/Artsy/App/ARAppDelegate+Analytics.m
@@ -91,11 +91,11 @@
         segmentWriteKey = keys.segmentDevWriteKey;
         adjustEnv = ADJEnvironmentSandbox;
     }
-    
+
     if (ARAppStatus.isBeta) {
         sentryEnv = keys.sentryStagingDSN;
     }
-    
+
     if (ARAppStatus.isDev) {
         sentryEnv = nil;
     }
@@ -209,7 +209,7 @@
                                 } else if (context == ARAppNotificationsRequestContextLaunch) {
                                     analyticsContext = @"Launch";
                                 }
-        
+
                                 analyticsContext = [@[@"PushNotification", analyticsContext] componentsJoinedByString:@""];
 
                                 return @{
@@ -232,7 +232,7 @@
                                 } else if (context == ARAppNotificationsRequestContextLaunch) {
                                     analyticsContext = @"Launch";
                                 }
-        
+
                                 analyticsContext = [@[@"PushNotification", analyticsContext] componentsJoinedByString:@""];
 
                                 return @{
@@ -409,20 +409,6 @@
                             },
                         }
                     ]
-                },
-                @{
-                    ARAnalyticsClass: ARArtistComponentViewController.class,
-                    ARAnalyticsDetails: @[
-                        @{
-                            ARAnalyticsEventName: ARAnalyticsArtistView,
-                            ARAnalyticsSelectorName: NSStringFromSelector(@selector(viewDidAppear:)),
-                            ARAnalyticsProperties: ^NSDictionary*(ARArtistComponentViewController *controller, NSArray *_){
-                                return @{
-                                    @"artist_id" : controller.artistID ?: @"",
-                                };
-                            },
-                        },
-                    ],
                 },
                 @{
                     ARAnalyticsClass: ARSharingController.class,
@@ -669,9 +655,7 @@
                             ARAnalyticsProperties: ^NSDictionary *(ARArtistComponentViewController *controller, NSArray *_) {
                                 return @{
                                      @"owner_type": @"artist",
-                                     @"owner_id": @"",
-                                     @"owner_slug": controller.artistID ?: @"",
-                                     @"partial" : @"true"
+                                     @"owner_slug": controller.artistID ?: @""
                                  };
                             }
                         }


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/MX-96

Removing a redundant Artist screen view event and removing redundant properties from the remaining Artist screen view event.

There will be one more PR to emission which removes another redundant artist screen view event!