### PR TITLE
[MX-152] Opts out of new iOS 13 modal presentation style on iPhone

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -16,6 +16,7 @@
 #import "ARAugmentedVIRSetupViewController.h"
 #import "ARAugmentedRealityConfig.h"
 #import "ARAugmentedFloorBasedVIRViewController.h"
+#import "ARInternalMobileWebViewController.h"
 #import "ARDefaults.h"
 #import "ARNavigationController.h"
 #import "ARTopMenuViewController.h"
@@ -264,6 +265,17 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
             // so the user can hit the close button. Consignments is the exception, and it has its own close button.
             if (!([viewController isKindOfClass:[UINavigationController class]] || [viewController isKindOfClass:[LiveAuctionViewController class]])) {
                 viewController = [[ARSerifNavigationViewController alloc] initWithRootViewController:viewController];
+            }
+            // Explanation for this behaviour is described in ARTopMenuViewController's
+            // pushViewController:animated: method. Once that is removed, we can remove this.
+            if ([UIDevice isPhone]) {
+                viewController.modalPresentationStyle = UIModalPresentationFullScreen;
+            } else {
+                // BNMO goes through this code path instead of the one in ARTopMenuViewController.
+                if ([viewController isKindOfClass:ARSerifNavigationViewController.class] &&
+                    [[[(ARInternalMobileWebViewController *)[(ARSerifNavigationViewController *)viewController topViewController] initialURL] absoluteString] containsString:@"/orders/"]) {
+                    viewController.modalPresentationStyle = UIModalPresentationFormSheet;
+                }
             }
 
             [targetViewController presentViewController:viewController

--- a/Artsy/View_Controllers/ARSerifNavigationViewController.m
+++ b/Artsy/View_Controllers/ARSerifNavigationViewController.m
@@ -205,11 +205,6 @@ static CGFloat exitButtonDimension = 40;
     return YES;
 }
 
-- (UIModalPresentationStyle)modalPresentationStyle
-{
-    return UIModalPresentationFormSheet;
-}
-
 - (BOOL)shouldAutorotate
 {
     return [self traitDependentAutorotateSupport];

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -34,6 +34,8 @@
 #import <Emission/ARWorksForYouComponentViewController.h>
 #import <Emission/ARFavoritesComponentViewController.h>
 #import <Emission/ARMapContainerViewController.h>
+#import <Emission/ARShowConsignmentsFlowViewController.h>
+#import <Emission/ARBidFlowViewController.h>
 #import <React/RCTScrollView.h>
 
 static const CGFloat ARMenuButtonDimension = 50;
@@ -561,6 +563,21 @@ static ARTopMenuViewController *_sharedManager = nil;
     NSAssert(viewController != nil, @"Attempt to push a nil view controller.");
 
     if ([self.class shouldPresentViewControllerAsModal:viewController]) {
+        // iOS 13 introduced a new modal presentation style that are cards. They look cool!
+        // But they break React Native's KeyboardAvoidingView, see this open PR: https://github.com/facebook/react-native/pull/27607
+        // Once that PR is merged and we've upgraded, we can remove the following line
+        // of code, which opts us out of the new modal presentation stylel.
+        if ([UIDevice isPhone]) {
+            viewController.modalPresentationStyle = UIModalPresentationFullScreen;
+        } else {
+            if ([viewController isKindOfClass:UINavigationController.class] && [[(UINavigationController *)viewController topViewController] isKindOfClass:ARBidFlowViewController.class]) {
+                // Bid Flow gets form sheet
+                viewController.modalPresentationStyle = UIModalPresentationFormSheet;
+            } else if ([viewController isKindOfClass:UINavigationController.class] && [[(UINavigationController *)viewController topViewController] isKindOfClass:ARShowConsignmentsFlowViewController.class]) {
+                // Consignments gets full screen
+                viewController.modalPresentationStyle = UIModalPresentationFullScreen;
+            }
+        }
         [self presentViewController:viewController animated:animated completion:completion];
         return;
     }

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
   emission_version: 1.21.11
   dev:
     - Clear AsyncStorage on logout - david
+    - Opts out of new iOS 13 modal presentation style on iPhone - ash
   user_facing:
     -
 


### PR DESCRIPTION
The underlying issue is that React Native's `KeyboardAvoidingView` isn't yet taking into account the additional space added by the iOS 13 modal presentation style ([there is an open pull request](https://github.com/facebook/react-native/pull/27607)). We could adopt this approach, but I'd rather not duplicate logic that will be included in the view itself pretty soon.

Instead, I read more about the transition changes ([this blog post was really helpful](https://medium.com/@hacknicity/view-controller-presentation-changes-in-ios-13-ac8c901ebc4e)) and have opted out of the new transition style on iPhone only. Here's a before-and-after of the behaviour on iOS 13 devices in the different contexts that we present modal view controllers (not including uncommonly-seen views, like the Privacy Policy or Conditions of Sale).

This fixes the bug, though we had to modify the iPad consignments flow to be full screen for now as well (as far as I can tell, the bug was already present in this flow). I don't love all the `isKindOfClass:` code we have here, but until we move routing into Emission, I don't want to rock the boat too much with how this is structured. 

I will also follow-up with an Emission PR that fixes the status bar contents not being legible on the consignments flow, which fell out of https://github.com/artsy/emission/pull/1993

## iPhone

|   | LAI | Bid Flow | Consignments | BNMO  |
|---|---|---|---|---|
| Before |  <img width="584" alt="Old_Phone_LAI" src="https://user-images.githubusercontent.com/498212/73092616-ef65a580-3eaa-11ea-87df-acf2d0ac62d6.png"> |  <img width="584" alt="Old_Phone_Bid Flow" src="https://user-images.githubusercontent.com/498212/73092622-f391c300-3eaa-11ea-80e5-bfb22519d3e0.png"> | <img width="584" alt="Old_Phone_Consignments" src="https://user-images.githubusercontent.com/498212/73092648-f7bde080-3eaa-11ea-829b-585e05283a52.png">  | <img width="584" alt="Old_Phone_BNMO" src="https://user-images.githubusercontent.com/498212/73092657-fb516780-3eaa-11ea-8802-c854f2cd300d.png">  |
| After | <img width="584" alt="New_Phone_LAI" src="https://user-images.githubusercontent.com/498212/73092669-00161b80-3eab-11ea-8f72-0cf04265becf.png">  | <img width="584" alt="New_Phone_Bid Flow" src="https://user-images.githubusercontent.com/498212/73092678-02787580-3eab-11ea-879d-796c7e897448.png">  | <img width="584" alt="New_Phone_Consignments" src="https://user-images.githubusercontent.com/498212/73092680-060bfc80-3eab-11ea-91d1-86ca1afacd38.png">  | <img width="584" alt="New_Phone_BNMO" src="https://user-images.githubusercontent.com/498212/73092690-0906ed00-3eab-11ea-9648-fcb4a3d105de.png">  |

## iPad

|   | LAI | Bid Flow | Consignments | BNMO  |
|---|---|---|---|---|
| Before | <img width="840" alt="Old_Pad_LAI" src="https://user-images.githubusercontent.com/498212/73092373-7d8d5c00-3eaa-11ea-809f-11757310ad6b.png"> | <img width="840" alt="Old_Pad_Bid Flow" src="https://user-images.githubusercontent.com/498212/73092388-84b46a00-3eaa-11ea-8776-b89517001f43.png"> |  <img width="840" alt="Old_Pad_Consignments" src="https://user-images.githubusercontent.com/498212/73092402-8e3dd200-3eaa-11ea-8bbf-7e33e26663e1.png"> |  <img width="840" alt="Old_Pad_BNMO" src="https://user-images.githubusercontent.com/498212/73092410-9269ef80-3eaa-11ea-8da6-b4d9ad72fcdb.png"> |
| After | <img width="840" alt="New_Pad_LAI" src="https://user-images.githubusercontent.com/498212/73092439-a150a200-3eaa-11ea-8c94-84e9bb8f3c13.png">  | <img width="840" alt="Screen Shot 2020-01-24 at 13 25 33" src="https://user-images.githubusercontent.com/498212/73093700-102efa80-3ead-11ea-9d62-4f7dcef4bd00.png"> | <img width="840" alt="New_Pad_Consignments" src="https://user-images.githubusercontent.com/498212/73092447-a7df1980-3eaa-11ea-8139-1d029a606223.png">  |  <img width="840" alt="Screen Shot 2020-01-24 at 13 34 29" src="https://user-images.githubusercontent.com/498212/73094282-46b94500-3eae-11ea-91ef-54e2ed54a36a.png"> |
