### PR TITLE
Fix auction toolbar display on iOS 13

### DIFF
--- a/Artsy/View_Controllers/Live_Auctions/LiveAuctionLotViewController.swift
+++ b/Artsy/View_Controllers/Live_Auctions/LiveAuctionLotViewController.swift
@@ -136,9 +136,7 @@ extension PrivateFunctions {
         lotMetadataStack.constrainBottomSpace(toView: metadataStack, predicate: "0")
 
         // Info toolbar setup
-        let infoToolbar = LiveAuctionToolbarView()
-        infoToolbar.lotViewModel = lotViewModel
-        infoToolbar.auctionViewModel = salesPerson.auctionViewModel
+        let infoToolbar = LiveAuctionToolbarView(lotViewModel: lotViewModel, auctionViewModel: salesPerson.auctionViewModel)
 
         metadataStack.addSubview(infoToolbar, withTopMargin: "28", sideMargin: sideMargin)
         infoToolbar.constrainHeight("38")

--- a/Artsy/View_Controllers/Live_Auctions/Views/LiveAuctionToolbarView.swift
+++ b/Artsy/View_Controllers/Live_Auctions/Views/LiveAuctionToolbarView.swift
@@ -13,6 +13,17 @@ class LiveAuctionToolbarView: UIView {
     var lotStateObserver: ObserverToken<LotState>?
     var numberOfBidsObserver: ObserverToken<Int>?
 
+    init(lotViewModel: LiveAuctionLotViewModelType, auctionViewModel: LiveAuctionViewModelType) {
+        super.init(frame: CGRect.zero)
+        self.lotViewModel = lotViewModel
+        self.auctionViewModel = auctionViewModel
+        self.setupViews()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         setupViews()

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,6 +5,7 @@ upcoming:
   dev:
     - Clear AsyncStorage on logout - david
     - Fix auction banner display on iOS 13 - brian
+    - Fix auction toolbar display on iOS 13 - brian
     - Opts out of new iOS 13 modal presentation style on iPhone - ash
   user_facing:
     -


### PR DESCRIPTION
Same issue as https://github.com/artsy/eigen/pull/2996 causing toolbar to be hidden on iOS 13. 


**Before:**
![LiveAuctionToolbarBug](https://user-images.githubusercontent.com/49686530/73108726-0c13d480-3ecf-11ea-994b-07221507412b.png)



**After:**
![LiveAuctionToolbarBugFixed](https://user-images.githubusercontent.com/49686530/73108687-f6061400-3ece-11ea-94ba-840d9b63e92f.png)



