### PR TITLE
[MX-159] clear APN token on logout

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -1407,7 +1407,7 @@
 		6008CB00200EA67A0074E11A /* ARGeneFavoritesNetworkModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARGeneFavoritesNetworkModel.h; sourceTree = "<group>"; };
 		6008CB01200EA67B0074E11A /* ARGeneFavoritesNetworkModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARGeneFavoritesNetworkModel.m; sourceTree = "<group>"; };
 		600A734117DE3F3F00E21233 /* ArtsyAPI+DeviceTokens.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ArtsyAPI+DeviceTokens.h"; sourceTree = "<group>"; };
-		600A734217DE3F3F00E21233 /* ArtsyAPI+DeviceTokens.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ArtsyAPI+DeviceTokens.m"; sourceTree = "<group>"; };
+		600A734217DE3F3F00E21233 /* ArtsyAPI+DeviceTokens.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.objc; path = "ArtsyAPI+DeviceTokens.m"; sourceTree = "<group>"; tabWidth = 4; };
 		600B8B3C1C4FCEE000776F84 /* push_notifications.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = push_notifications.md; sourceTree = "<group>"; };
 		600B8B3D1C4FCEE000776F84 /* welcome_to_eigen_beta.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = welcome_to_eigen_beta.md; sourceTree = "<group>"; };
 		600B8B3F1C4FCEE000776F84 /* thanks.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = thanks.md; sourceTree = "<group>"; };

--- a/Artsy/Networking/API_Modules/ArtsyAPI+DeviceTokens.h
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+DeviceTokens.h
@@ -5,4 +5,6 @@
 
 + (AFHTTPRequestOperation *)setAPNTokenForCurrentDevice:(NSString *)token success:(void (^)(id response))success failure:(void (^)(NSError *error))failure;
 
++ (AFHTTPRequestOperation *)deleteAPNTokenForCurrentDeviceWithCompletion:(void (^)(void))completion;
+
 @end

--- a/Artsy/Networking/API_Modules/ArtsyAPI+DeviceTokens.m
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+DeviceTokens.m
@@ -2,6 +2,7 @@
 
 #import "ArtsyAPI+Private.h"
 #import "ARRouter.h"
+#import "ARAppConstants.h"
 
 
 @implementation ArtsyAPI (DeviceTokens)
@@ -9,7 +10,7 @@
 + (AFHTTPRequestOperation *)setAPNTokenForCurrentDevice:(NSString *)token success:(void (^)(id response))success failure:(void (^)(NSError *error))failure
 {
     NSString *name = [[UIDevice currentDevice] name];
-
+    
     if (token && name) {
         NSURLRequest *request = [ARRouter newSetDeviceAPNTokenRequest:token forDevice:name];
         return [ArtsyAPI performRequest:request success:success failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {
@@ -18,8 +19,23 @@
             }
         }];
     }
-
+    
     return nil;
 }
 
++ (AFHTTPRequestOperation *)deleteAPNTokenForCurrentDeviceWithCompletion:(void (^)(void))completion
+{
+    NSString *token = [[NSUserDefaults standardUserDefaults] stringForKey:ARAPNSDeviceTokenKey];
+    if (!token) {
+        completion();
+        return nil;
+    }
+    NSURLRequest *request = [ARRouter newDeleteDeviceRequest:token];
+    return [ArtsyAPI performRequest:request success:^ (id _) {
+        completion();
+    } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error) {
+        completion();
+    }];
+}
 @end
+

--- a/Artsy/Networking/ARNetworkConstants.h
+++ b/Artsy/Networking/ARNetworkConstants.h
@@ -93,6 +93,7 @@ extern NSString *const AROrderedSetItemsURLFormat;
 extern NSString *const ARSiteFeaturesURL;
 
 extern NSString *const ARNewDeviceURL;
+extern NSString *const ARDeleteDeviceURL;
 extern NSString *const ARSiteUpURL;
 
 extern NSString *const ARProfilePostsURLFormat;

--- a/Artsy/Networking/ARNetworkConstants.m
+++ b/Artsy/Networking/ARNetworkConstants.m
@@ -101,6 +101,7 @@ NSString *const ARNotificationsURL = @"/api/v1/me/notifications";
 NSString *const ARSiteFeaturesURL = @"/api/v1/site_features/";
 
 NSString *const ARNewDeviceURL = @"/api/v1/device";
+NSString *const ARDeleteDeviceURL = @"/api/v1/device/%@";
 NSString *const ARSiteUpURL = @"/api/v1/system/up";
 
 NSString *const ARProfilePostsURLFormat = @"/api/v1/profile/%@/posts";

--- a/Artsy/Networking/ARRouter.h
+++ b/Artsy/Networking/ARRouter.h
@@ -204,6 +204,7 @@
 + (NSURLRequest *)newForgotPasswordRequestWithEmail:(NSString *)email;
 + (NSURLRequest *)newSiteFeaturesRequest;
 + (NSURLRequest *)newSetDeviceAPNTokenRequest:(NSString *)token forDevice:(NSString *)device;
++ (NSURLRequest *)newDeleteDeviceRequest:(NSString *)token;
 + (NSURLRequest *)newUptimeURLRequest;
 + (NSURLRequest *)newSystemTimeRequest;
 + (NSURLRequest *)newRequestOutbidNotificationRequest;

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -1043,6 +1043,11 @@ static NSString *hostFromString(NSString *string)
     return [self requestWithMethod:@"POST" path:ARNewDeviceURL parameters:params];
 }
 
++ (NSURLRequest *)newDeleteDeviceRequest:(NSString *)token
+{
+    return [self requestWithMethod:@"DELETE" path:[NSString stringWithFormat:ARDeleteDeviceURL, token]];
+}
+
 + (NSURLRequest *)newUptimeURLRequest
 {
     return [self requestWithMethod:@"GET" path:ARSiteUpURL parameters:nil];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -8,6 +8,7 @@ upcoming:
     - Fix auction toolbar display on iOS 13 - brian
     - Opts out of new iOS 13 modal presentation style on iPhone - ash
     - Opts out of dark mode - david
+    - Clear APN token on logout - david + ash + brian
   user_facing:
     -
 


### PR DESCRIPTION
This won't work until artsy/gravity#12751 gets deployed, but it can be deployed first without disrupting the current behaviour. Worth noting that I haven't tested the happy path yet! Only the sad path.

https://artsyproduct.atlassian.net/browse/MX-159
