### PR TITLE
Move token deletion into logout method

### DIFF
--- a/Artsy/Networking/API_Modules/ARUserManager.m
+++ b/Artsy/Networking/API_Modules/ARUserManager.m
@@ -103,9 +103,7 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
 
     [[NSNotificationCenter defaultCenter] addObserverForName:@"ARUserRequestedLogout" object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
         NSLog(@"Hey, we're logging out!");
-        [ArtsyAPI deleteAPNTokenForCurrentDeviceWithCompletion:^ {
-            [[self class] logout];
-        }];
+        [[self class] logout];
     }];
     
     return self;
@@ -429,14 +427,16 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
 
 + (void)logout
 {
-    [[self class] clearUserData];
-    [AREmission teardownSharedInstance];
-    [ARTopMenuViewController teardownSharedInstance];
-    [ARSwitchBoard teardownSharedInstance];
-    [ArtsyAPI getXappTokenWithCompletion:^(NSString *xappToken, NSDate *expirationDate) {
-        // Sync clock with server
-        [ARSystemTime sync];
-        [[ARAppDelegate sharedInstance] showOnboarding];
+    [ArtsyAPI deleteAPNTokenForCurrentDeviceWithCompletion:^ {
+        [[self class] clearUserData];
+        [AREmission teardownSharedInstance];
+        [ARTopMenuViewController teardownSharedInstance];
+        [ARSwitchBoard teardownSharedInstance];
+        [ArtsyAPI getXappTokenWithCompletion:^(NSString *xappToken, NSDate *expirationDate) {
+            // Sync clock with server
+            [ARSystemTime sync];
+            [[ARAppDelegate sharedInstance] showOnboarding];
+        }];
     }];
 }
 


### PR DESCRIPTION
Tiny followup from #3007, moving the push notification token deletion into the `logout` method so it gets called after session expiration too. Perhaps in gravity we should clear all device tokens associated with a user when they reset their password?

#trivial