### PR TITLE
[AUCT-744] - Add Lot Condition Report lab option

### DIFF
--- a/Artsy/App/AROptions.h
+++ b/Artsy/App/AROptions.h
@@ -13,6 +13,7 @@ extern NSString *const AROptionsDevReactEnv;
 extern NSString *const AROptionsDebugARVIR;
 extern NSString *const AROptionsPriceTransparency;
 extern NSString *const AROptionsNewSearch;
+extern NSString *const AROptionsLotConditionReport;
 
 @interface AROptions : NSObject
 

--- a/Artsy/App/AROptions.m
+++ b/Artsy/App/AROptions.m
@@ -8,6 +8,7 @@ static NSDictionary *options = nil;
 NSString *const AROptionsLoadingScreenAlpha = @"Loading screens are transparent";
 NSString *const AROptionsShowAnalyticsOnScreen = @"AROptionsShowAnalyticsOnScreen";
 NSString *const AROptionsShowMartsyOnScreen = @"AROptionsShowMartsyOnScreen";
+NSString *const AROptionsLotConditionReport = @"AROptionsLotConditionReport";
 
 // UX changes
 NSString *const AROptionsDisableNativeLiveAuctions = @"Disable Native Live Auctions";
@@ -34,6 +35,7 @@ NSString *const AROptionsNewSearch = @"New Search";
         options = @{
          AROptionsDisableNativeLiveAuctions: @"Disable Native Live Auctions",
          AROptionsDebugARVIR: @"Debug AR View in Room",
+         AROptionsLotConditionReport : @"Lot Condition Report",
 
          AROptionsPriceTransparency: AROptionsPriceTransparency,
          AROptionsNewSearch: AROptionsNewSearch,

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
   emission_version: 1.21.32
   dev:
     - Fixes full-bleed collections image rendering - ash & MX Knowledge Share Feb 4 2020
+    - Adds lab option for lot condition report - brian
   user_facing:
     -
 


### PR DESCRIPTION
- Adds a lab option/feature flag for lot condition report in artwork details for biddable artwork

Emission PR here:
https://github.com/artsy/emission/pull/2050