### PR TITLE
Updates for next version of the app #trivial

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.3.0</string>
+	<string>6.3.1</string>
 	<key>CFBundleVersion</key>
 	<string>2019.05.24.09</string>
 	<key>NSExtension</key>

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.3.0</string>
+	<string>6.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,16 +1,24 @@
 upcoming:
-  version: 6.3.0
+  version: 6.3.1
   date: TBD
-  emission_version: 1.21.40
+  emission_version: 1.21.49
   dev:
-    - Fixes full-bleed collections image rendering - ash & MX Knowledge Share Feb 4 2020
-    - Adds lab option for lot condition report - brian
-    - Adds lab option for filtering collections artworks - ashley
-    - Removes a lot of unused code - ash
+    - 
   user_facing:
     -
 
 releases:
+  - version: 6.3.0
+    date: Feb 19, 2020
+    emission_version: 1.21.49
+    dev:
+      - Fixes full-bleed collections image rendering - ash & MX Knowledge Share Feb 4 2020
+      - Adds lab option for lot condition report - brian
+      - Adds lab option for filtering collections artworks - ashley
+      - Removes a lot of unused code - ash
+    user_facing:
+      -
+        
   - version: 6.2.1
     date: Feb 4, 2020
     emission_version: 1.21.32


### PR DESCRIPTION
I went with 6.3.1 as a version number based on upcoming product work. 