### PR TITLE
[FX-1735] add a new route for the collections featured artists view

### DIFF
--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -46,6 +46,7 @@
 #import <Emission/ARPartnerLocationsComponentViewController.h>
 #import <Emission/ARMyProfileComponentViewController.h>
 #import <Emission/ARPrivacyRequestComponentViewController.h>
+#import <Emission/ARCollectionFullFeaturedArtistListComponentViewController.h>
 
 #import "ArtsyEcho.h"
 #import "Artsy-Swift.h"
@@ -235,6 +236,10 @@ static ARSwitchBoard *sharedInstance = nil;
 
     [self.routes addRoute:@"/collection/:id" handler:JLRouteParams {
         return [[AREigenCollectionComponentViewController alloc] initWithCollectionID:parameters[@"id"]];
+    }];
+    
+    [self.routes addRoute:@"/collection/:id/artists" handler:JLRouteParams {
+        return [[ARCollectionFullFeaturedArtistListComponentViewController alloc] initWithCollectionID:parameters[@"id"]];
     }];
 
     [self.routes addRoute:@"/conversation/:id"

--- a/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
+++ b/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
@@ -121,7 +121,7 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
 - (ARCellData *)generateCollections
 {
     return [self tappableCellDataWithTitle:@"Show Collection" selection:^{
-        AREigenCollectionComponentViewController *viewController = [[AREigenCollectionComponentViewController alloc] initWithCollectionID:@"kerry-james-marshall-portraits"];
+        AREigenCollectionComponentViewController *viewController = [[AREigenCollectionComponentViewController alloc] initWithCollectionID:@"street-art"];
         [[ARTopMenuViewController sharedController] pushViewController:viewController animated:YES];
     }];
 }


### PR DESCRIPTION
Addresses: [FX-1735](https://artsyproduct.atlassian.net/browse/FX-1735)

This supports the [work in emission](https://github.com/artsy/emission/pull/2098) to add a new full featured artist list view for collection pages. The PR adds a new CollectionFullFeaturedArtistListComponent view controller.

![featured artists list](https://user-images.githubusercontent.com/5201004/75057190-786dfd80-54a6-11ea-9e6c-7e65fc1584b8.gif)
