### PR TITLE
FX-1811: Updates styling on the filter button for collections

### DIFF
--- a/emission/src/lib/Scenes/Collection/Collection.tsx
+++ b/emission/src/lib/Scenes/Collection/Collection.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Separator, Spacer, Theme } from "@artsy/palette"
+import { Box, color, FilterIcon, Flex, Sans, Separator, Spacer, Theme } from "@artsy/palette"
 import { Collection_collection } from "__generated__/Collection_collection.graphql"
 import { FilterModal } from "lib/Components/FilterModal"
 import { CollectionArtworksFragmentContainer as CollectionArtworks } from "lib/Scenes/Collection/Screens/CollectionArtworks"
@@ -33,7 +33,7 @@ export class Collection extends Component<CollectionProps, CollectionState> {
     isFilterArtworksModalVisible: false,
   }
   viewabilityConfig = {
-    viewAreaCoveragePercentThreshold: 30, // 30% of the artworks component should be in the screen before toggling the filter button
+    viewAreaCoveragePercentThreshold: 75, // What percentage of the artworks component should be in the screen before toggling the filter button
   }
   componentDidMount() {
     const sections = []
@@ -138,8 +138,11 @@ export class Collection extends Component<CollectionProps, CollectionState> {
           />
           {isArtworkGridVisible && isArtworkFilterEnabled && (
             <FilterArtworkButtonContainer>
-              <FilterArtworkButton variant="primaryBlack" onPress={this.handleFilterArtworksModal.bind(this)}>
-                Filter
+              <FilterArtworkButton
+                px="2"
+                onPress={this.handleFilterArtworksModal.bind(this)}>
+                <FilterIcon fill="white100" />
+                <Sans size="3t" pl="1" py="1" color="white100" weight="medium">Filter</Sans>
               </FilterArtworkButton>
             </FilterArtworkButtonContainer>
           )}
@@ -151,16 +154,20 @@ export class Collection extends Component<CollectionProps, CollectionState> {
 
 export const FilterArtworkButtonContainer = styled(Flex)`
   position: absolute;
-  bottom: 50;
+  bottom: 20;
   flex: 1;
   justify-content: center;
   width: 100%;
   flex-direction: row;
 `
 
-export const FilterArtworkButton = styled(Button)`
-  border-radius: 100;
+export const FilterArtworkButton = styled(Flex)`
   width: 110px;
+  border-radius: 20;
+  background-color: ${color("black100")};
+  align-items: center;
+  justify-content: center;
+  flex-direction: row;
 `
 
 export const CollectionContainer = createFragmentContainer(Collection, {

--- a/emission/src/lib/Scenes/Collection/__tests__/__snapshots__/Collection-tests.tsx.snap
+++ b/emission/src/lib/Scenes/Collection/__tests__/__snapshots__/Collection-tests.tsx.snap
@@ -1211,7 +1211,7 @@ exports[`Collection renders a snapshot 1`] = `
     updateCellsBatchingPeriod={50}
     viewabilityConfig={
       Object {
-        "viewAreaCoveragePercentThreshold": 30,
+        "viewAreaCoveragePercentThreshold": 75,
       }
     }
     viewabilityConfigCallbackPairs={
@@ -1219,7 +1219,7 @@ exports[`Collection renders a snapshot 1`] = `
         Object {
           "onViewableItemsChanged": [Function],
           "viewabilityConfig": Object {
-            "viewAreaCoveragePercentThreshold": 30,
+            "viewAreaCoveragePercentThreshold": 75,
           },
         },
       ]


### PR DESCRIPTION
This PR just updates the styles on the filter button (and makes it show up a little later).

Gif
![filter-button](https://user-images.githubusercontent.com/2081340/75074084-e3c8c700-54c8-11ea-84fe-7056b238edcc.gif)

Screenshot
<img width="396" alt="Screen Shot 2020-02-21 at 4 36 47 PM" src="https://user-images.githubusercontent.com/2081340/75074092-e9261180-54c8-11ea-8eaf-150c7a0c94a8.png">

(Side note: the fact that these RN PRs now go to `eigen` makes me feel like a real mobile developer 😻)