### PR TITLE
Fixes error from missing text wrapper on filter artwork button

### DIFF
--- a/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
+++ b/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
@@ -121,7 +121,7 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
 - (ARCellData *)generateCollections
 {
     return [self tappableCellDataWithTitle:@"Show Collection" selection:^{
-        AREigenCollectionComponentViewController *viewController = [[AREigenCollectionComponentViewController alloc] initWithCollectionID:@"kerry-james-marshall-portraits"];
+        AREigenCollectionComponentViewController *viewController = [[AREigenCollectionComponentViewController alloc] initWithCollectionID:@"street-art"];
         [[ARTopMenuViewController sharedController] pushViewController:viewController animated:YES];
     }];
 }

--- a/emission/src/lib/Scenes/Collection/Collection.tsx
+++ b/emission/src/lib/Scenes/Collection/Collection.tsx
@@ -1,11 +1,11 @@
-import { Box, color, FilterIcon, Flex, Sans, Separator, Spacer, Theme } from "@artsy/palette"
+import { Box, color, Flex, Sans, Separator, Spacer, Theme } from "@artsy/palette"
 import { Collection_collection } from "__generated__/Collection_collection.graphql"
 import { FilterModalNavigator } from "lib/Components/FilterModal"
 import { CollectionArtworksFragmentContainer as CollectionArtworks } from "lib/Scenes/Collection/Screens/CollectionArtworks"
 import { CollectionHeaderContainer as CollectionHeader } from "lib/Scenes/Collection/Screens/CollectionHeader"
 import { Schema, screenTrack } from "lib/utils/track"
 import React, { Component } from "react"
-import { FlatList, NativeModules, View } from "react-native"
+import { FlatList, NativeModules, TouchableWithoutFeedback, View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components/native"
 import { CollectionFeaturedArtistsContainer as CollectionFeaturedArtists } from "./Components/FeaturedArtists"
@@ -142,8 +142,12 @@ export class Collection extends Component<CollectionProps, CollectionState> {
           />
           {isArtworkGridVisible && isArtworkFilterEnabled && (
             <FilterArtworkButtonContainer>
-              <FilterArtworkButton variant="primaryBlack" onPress={() => this.handleFilterArtworksModal()}>
-                Filter
+              <FilterArtworkButton variant="primaryBlack">
+                <TouchableWithoutFeedback onPress={() => this.handleFilterArtworksModal()}>
+                  <Sans color={color("white100")} size="3" p={1}>
+                    Filter
+                  </Sans>
+                </TouchableWithoutFeedback>
               </FilterArtworkButton>
             </FilterArtworkButtonContainer>
           )}


### PR DESCRIPTION
This is a follow-up PR to #3029 which adds as text component wrapper around the filter artwork button text to prevent an error that caused the Collection screen not to load.

Bug:
<img width="406" alt="Screen Shot 2020-02-24 at 1 06 17 PM" src="https://user-images.githubusercontent.com/10385964/75151237-7904cf00-5706-11ea-8dc6-1d315b10fe2c.png">

Fix:
<img width="412" alt="Screen Shot 2020-02-24 at 1 05 27 PM" src="https://user-images.githubusercontent.com/10385964/75151243-7efab000-5706-11ea-8103-1b41d1684f09.png">
