### PR TITLE
[MX-205] Show password error details, increase minimum password length

### DIFF
--- a/Artsy/View_Controllers/Login_and_Onboarding/AROnboardingViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/AROnboardingViewController.m
@@ -486,10 +486,8 @@
         }];
     } failure:^(NSError *error, id JSON) {
         __strong typeof (wself) sself = wself;
-        if (JSON) {
-            if (sself.state == AROnboardingStagePersonalizeName) {
-                [sself displayError:@"Could not create account"];
-            }
+        if ([JSON[@"type"] isEqualToString:@"param_error"]) {
+            [self displayError:JSON[@"message"]];
         } else {
             [sself displayNetworkFailureError];
         }
@@ -671,7 +669,15 @@
 {
     if (self.state == AROnboardingStateAcceptConditions) {
         self.shouldPresentFacebook = NO;
-        [self popViewControllerAnimated:YES];
+        // This is hacky. But the top bar isn't visible so the user doesn't know they can pop back with swipe.
+        // We pop back to the email view controller because the user can tap next from here to the
+        // actual problem.
+        // Can't wait for this to be moved to React Native.
+        if (self.viewControllers.count > 1) {
+            [self popToViewController:self.viewControllers[1] animated:YES];
+        } else {
+            [self popToRootViewControllerAnimated:YES];
+        }
     }
     [(ARPersonalizeViewController *)self.topViewController showErrorWithMessage:errorMessage];
     [ARAnalytics event:ARAnalyticsAuthError withProperties:@{@"error_message" : errorMessage}];

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/ARPersonalizeViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/ARPersonalizeViewController.m
@@ -590,8 +590,8 @@
             return YES;
         }
     } else {
-        // Otherwise, new users signing up require passwords at least 6 chars long.
-        if (password.length >= 6) {
+        // Otherwise, new users signing up require passwords at least 8 chars long.
+        if (password.length >= 8) {
             return YES;
         }
     }

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/ARPersonalizeViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/ARPersonalizeViewController.m
@@ -601,7 +601,9 @@
 
 - (void)showErrorWithMessage:(NSString *)errorMessage
 {
-    [self.onboardingTextFields enableErrorState];
+    // Since the error might not be due to the UI that's currently visible, let's not highlight
+    // text fields in red (since they error is likely unrelated).
+    // [self.onboardingTextFields enableErrorState];
     [self.onboardingNavigationItems showError:errorMessage];
 }
 

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/Views/AROnboardingNavigationItemsView.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/Views/AROnboardingNavigationItemsView.m
@@ -169,15 +169,24 @@
 - (void)showError:(NSString *)text
 {
     [self hideSpinner];
-    
-    self.warningLabel.text = text;
-    
-    self.warningLabel.backgroundColor = [UIColor artsyRedRegular];
-    self.warningLabel.textColor = [UIColor whiteColor];
-    
-    self.warningLabel.hidden = NO;
-    self.next.enabled = NO;
 
+    // Allow short messages to be shown in the bottom button.
+    if (text.length < 25) {
+        self.warningLabel.text = text;
+        self.warningLabel.backgroundColor = [UIColor artsyRedRegular];
+        self.warningLabel.textColor = [UIColor whiteColor];
+
+        self.warningLabel.hidden = NO;
+        self.next.enabled = NO;
+    } else {
+        UIViewController *presentingController = [[[UIApplication sharedApplication] keyWindow] rootViewController];
+
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Error" message:text preferredStyle:UIAlertControllerStyleAlert];
+        [alert addAction:[UIAlertAction actionWithTitle:@"Okay" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+            [presentingController dismissViewControllerAnimated:YES completion:nil];
+        }]];
+        [presentingController presentViewController:alert animated:YES completion:nil];
+    }
 }
 
 - (void)hideError

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -6,6 +6,8 @@ upcoming:
     - combine emission and eigen into one repo - david
   user_facing:
     - Removes generic genes from For You tab - ash
+    - Improves error-handling during signup failures due to password problems - ash
+    - Increases minimum required password length from 6 to 8 - ash
 
 releases:
   - version: 6.3.0


### PR DESCRIPTION
This PR does two things:

- Show the user the error from Gravity when new account creation fails.
- Increases minimum allowed new password length to 8.

The UX is not... ideal. Modifying the error-handling is difficult because of how the code is organized, and tightly coupled. Additionally, while the user _can_ swipe to go back, there is no affordance for this and no back button. So in the case of an error, I decided to take the user back to the first screen where they can take action, where we ask for email. They'll have to go through the process from there. 

<img width="545" alt="Screen Shot 2020-02-24 at 12 35 57" src="https://user-images.githubusercontent.com/498212/75176469-3a6d1580-5702-11ea-9752-5e3cf5b1f440.png">


When it comes to migrating code from Objective-C to React Native, I'd say that the login/signup flow would be a great candidate. Maybe even higher priority than our routing logic, since it's so user-facing and high-impact. Open to feedback on that, though. /cc @ds300 