### PR TITLE
Intelligent fallbacks for packager hostname

### DIFF
--- a/scripts/set_packager_host.sh
+++ b/scripts/set_packager_host.sh
@@ -1,5 +1,34 @@
 #!/usr/bin/env bash
 
+
+# e.g. Davids-MacBook.local
+host=$(hostname)
+
+function can-reach-host () {
+  ping -c1 -t1 $host
+}
+
+# sometimes hostnames are not resolvable.
+if ! can-reach-host
+then
+  # so try local wifi IP instead
+  host=$(ipconfig getifaddr en0)
+
+  # if you're not connected via wifi, and you're feeling retro,
+  # then you might be connected via ethernet?
+  if ! can-reach-host
+  then
+    host=$(ipconfig getifaddr en1)
+
+    # otherwise you're probably not connected to the internet 🤷‍♀️
+    if ! can-reach-host
+    then
+      host=localhost
+    fi
+  fi
+fi
+
+
 OUTPUT=$(cat << EOF
 // this file is generated automatically in a build phase
 #import "ARReactPackagerHost.h"
@@ -10,7 +39,7 @@ OUTPUT=$(cat << EOF
 + (NSString *)hostname
 {
 #if defined(DEBUG)
-    return @"$(hostname)";
+    return @"$host";
 #else
     return @"localhost";
 #endif


### PR DESCRIPTION
@anandaroop [ran into an issue](https://artsy.slack.com/archives/C02BAQ5K7/p1582576904013500) where his macbook's local hostname was not resolvable because he didn't have any sharing options enabled in his system settings. This meant the app couldn't connect to the react packager to load the JS bundle. 

To prevent people running into the same issue in the future, this PR makes the host string fall back to your local wifi IP, or `localhost` if you're not connected to wifi.

#trivial