### PR TITLE
Fix missing Emission.js

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,13 @@ jobs:
             # Fall back to using the latest cache if no exact match is found.
             - v4-pods-
 
+      # Make sure that these files exist so that `pod install` picks up on them, so
+      # that the generated Xcode project knows about them. We'll bundle them later,
+      # so the contents right now don't matter – only that they exist.
+      - run:
+          name: Touch Emission Assets
+          command: touch emission/Pod/Assets/Emission.js && touch emission/Pod/Assets/Emission.js.map
+
       - run:
           name: Install Pods
           command: bundle exec pod check || bundle exec pod install
@@ -97,10 +104,6 @@ jobs:
           key: v4-pods-{{ checksum "Podfile.lock" }}
           paths:
             - Pods
-
-      - run:
-          name: Copy emission bundle to Pods folder
-          command: cp emission/Pod/Assets/Emission.js* Pods/Emission/Pod/Assets/
 
       - run:
           name: Pre-Build App

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,10 @@ jobs:
           key: v4-pods-{{ checksum "Podfile.lock" }}
           paths:
             - Pods
-            - rn_pods
+
+      - run:
+          name: Copy emission bundle to Pods folder
+          command: cp emission/Pod/Assets/Emission.js* Pods/Emission/Pod/Assets/
 
       - run:
           name: Pre-Build App


### PR DESCRIPTION
We were having a problem where the `Emission.js` was not being included in beta builds. That's because the `Emission.js` file was being built *after* `pod install` had run, which means that it wasn't copied over from `emission/Pod/Assets` to `Pods/Emission/Assets` which is where it needs to be at build time.

This PR fixes that by manually copying `Emission.js` to `Pods/Emission/Assets`.

> But why not just bundle the JS before running `pod install` so it gets copied over automatically? 

Because then we'd need to invalidate our `Pods` cache whenever `Emission.js` changes, which is _pretty much always_.

![ain't nobody got time for that](https://media.giphy.com/media/10PcMWwtZSYk2k/giphy.gif)

#trivial