### PR TITLE
[MX-169] Handle remaining markdown element types

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -10,6 +10,7 @@ upcoming:
     - Removes generic genes from For You tab - ash
     - Improves error-handling during signup failures due to password problems - ash
     - Increases minimum required password length from 6 to 8 - ash
+    - Fix WSODs related to markdown elements not being supported in ReadMore - david
 
 releases:
   - version: 6.3.0

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "react-tracking": "7.2.1",
     "relay-runtime": "6.0.0",
     "remove-markdown": "0.1.0",
-    "simple-markdown": "0.4.4",
+    "simple-markdown": "^0.7.2",
     "styled-components": "4.2.0",
     "supercluster": "6.0.1",
     "tipsi-stripe": "https://github.com/ashfurrow/tipsi-stripe.git#fix-infinite-loop"
@@ -123,7 +123,7 @@
     "@types/moment-timezone": "0.5.4",
     "@types/node": "12.7.5",
     "@types/query-string": "5.0.1",
-    "@types/react": "16.8.10",
+    "@types/react": "16.9.22",
     "@types/react-native": "0.57.42",
     "@types/react-relay": "6.0.1",
     "@types/react-test-renderer": "16.8.1",

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/FullScreen/ImageZoomView.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/FullScreen/ImageZoomView.tsx
@@ -108,9 +108,9 @@ function createTransform(
  *
  *  https://css-tricks.com/animating-layouts-with-the-flip-technique/
  */
-export const ImageZoomView: React.RefForwardingComponent<ImageZoomView, ImageZoomViewProps> =
+export const ImageZoomView =
   // need to do this ref forwarding to expose the `resetZoom` method to consumers
-  React.forwardRef(({ image, index }, ref) => {
+  React.forwardRef<ImageZoomView, ImageZoomViewProps>(({ image, index }, ref) => {
     const screenDimensions = useScreenDimensions()
     const { embeddedImageRefs, dispatch, imageIndex, fullScreenState, lastImageIndex } = useContext(
       ImageCarouselContext
@@ -244,23 +244,20 @@ export const ImageZoomView: React.RefForwardingComponent<ImageZoomView, ImageZoo
       )
     )
 
-    useEffect(
-      () => {
-        // hack to get a sane starting contentOffset our ScrollView gives some _whack_ values occasionally
-        // for it's first onScroll before the user has actually done any scrolling
-        contentOffset.current = {
-          x: -imageFittedWithinScreen.marginHorizontal,
-          y: -imageFittedWithinScreen.marginVertical,
-        }
+    useEffect(() => {
+      // hack to get a sane starting contentOffset our ScrollView gives some _whack_ values occasionally
+      // for it's first onScroll before the user has actually done any scrolling
+      contentOffset.current = {
+        x: -imageFittedWithinScreen.marginHorizontal,
+        y: -imageFittedWithinScreen.marginVertical,
+      }
 
-        // opt out of parent scroll events to prevent double transforms while doing vertical dismiss
-        if (fullScreenState.current === "entered" && scrollViewRef.current) {
-          const tag = findNodeHandle(scrollViewRef.current.getNode())
-          ARScrollViewHelpers.optOutOfParentScrollEvents(tag)
-        }
-      },
-      [fullScreenState.current]
-    )
+      // opt out of parent scroll events to prevent double transforms while doing vertical dismiss
+      if (fullScreenState.current === "entered" && scrollViewRef.current) {
+        const tag = findNodeHandle(scrollViewRef.current.getNode())
+        ARScrollViewHelpers.optOutOfParentScrollEvents(tag)
+      }
+    }, [fullScreenState.current])
 
     const viewPortChanges = useNewEventStream<Rect>()
 

--- a/src/lib/Scenes/Collection/Collection.tsx
+++ b/src/lib/Scenes/Collection/Collection.tsx
@@ -99,27 +99,6 @@ export class Collection extends Component<CollectionProps, CollectionState> {
     this.setState(_prevState => {
       return { isFilterArtworksModalVisible: !_prevState.isFilterArtworksModalVisible }
     })
-
-    // tslint:disable: jsdoc-format
-    /**
-    * TODO: Refactor this mutation code to handle filtering artworks by selected fields in the artwork filter modal
-    * const { artwork, relay } = this.props
-    commitMutation<ArtworkActionsSaveMutation>(relay.environment, {
-      mutation: graphql`
-        mutation ArtworkActionsSaveMutation($input: SaveArtworkInput!) {
-          saveArtwork(input: $input) {
-            artwork {
-              id
-              is_saved: isSaved
-            }
-          }
-        }
-      `,
-      variables: { input: { artworkID: artwork.internalID, remove: artwork.is_saved } },
-      optimisticResponse: { saveArtwork: { artwork: { id: artwork.id, is_saved: !artwork.is_saved } } },
-      onCompleted: () => Events.userHadMeaningfulInteraction(),
-    })
-     */
   }
   render() {
     const { isArtworkGridVisible, sections } = this.state

--- a/src/lib/utils/__tests__/markdown-kitchen-sink.md
+++ b/src/lib/utils/__tests__/markdown-kitchen-sink.md
@@ -1,0 +1,414 @@
+# Markdown Kitchen Sink
+
+This file is https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet plus a few fixes and additions. Used by [obedm503/bootmark](https://github.com/obedm503/bootmark) to [demonstrate](https://obedm503.github.io/bootmark/docs/markdown-cheatsheet.html) it's styling features.
+
+This is intended as a quick reference and showcase. For more complete info, see [John Gruber's original spec](http://daringfireball.net/projects/markdown/) and the [Github-flavored Markdown info page](http://github.github.com/github-flavored-markdown/).
+
+Note that there is also a [Cheatsheet specific to Markdown Here](./Markdown-Here-Cheatsheet) if that's what you're looking for. You can also check out [more Markdown tools](./Other-Markdown-Tools).
+
+##### Table of Contents
+
+[Headers](#headers)
+[Emphasis](#emphasis)
+[Lists](#lists)
+[Links](#links)
+[Images](#images)
+[Code and Syntax Highlighting](#code)
+[Tables](#tables)
+[Blockquotes](#blockquotes)
+[Inline HTML](#html)
+[Horizontal Rule](#hr)
+[Line Breaks](#lines)
+[YouTube Videos](#videos)
+
+<a name="headers"></a>
+
+## Headers
+
+```
+# H1
+## H2
+### H3
+#### H4
+##### H5
+###### H6
+
+Alternatively, for H1 and H2, an underline-ish style:
+
+Alt-H1
+======
+
+Alt-H2
+------
+```
+
+# H1
+
+## H2
+
+### H3
+
+#### H4
+
+##### H5
+
+###### H6
+
+Alternatively, for H1 and H2, an underline-ish style:
+
+# Alt-H1
+
+## Alt-H2
+
+<a name="emphasis"></a>
+
+## Emphasis
+
+```
+Emphasis, aka italics, with *asterisks* or _underscores_.
+
+Strong emphasis, aka bold, with **asterisks** or __underscores__.
+
+Combined emphasis with **asterisks and _underscores_**.
+
+Strikethrough uses two tildes. ~~Scratch this.~~
+```
+
+Emphasis, aka italics, with _asterisks_ or _underscores_.
+
+Strong emphasis, aka bold, with **asterisks** or **underscores**.
+
+Combined emphasis with **asterisks and _underscores_**.
+
+Strikethrough uses two tildes. ~~Scratch this.~~
+
+<a name="lists"></a>
+
+## Lists
+
+(In this example, leading and trailing spaces are shown with with dots: ⋅)
+
+```
+1. First ordered list item
+2. Another item
+⋅⋅* Unordered sub-list.
+1. Actual numbers don't matter, just that it's a number
+⋅⋅1. Ordered sub-list
+4. And another item.
+
+⋅⋅⋅You can have properly indented paragraphs within list items. Notice the blank line above, and the leading spaces (at least one, but we'll use three here to also align the raw Markdown).
+
+⋅⋅⋅To have a line break without a paragraph, you will need to use two trailing spaces.⋅⋅
+⋅⋅⋅Note that this line is separate, but within the same paragraph.⋅⋅
+⋅⋅⋅(This is contrary to the typical GFM line break behaviour, where trailing spaces are not required.)
+
+* Unordered list can use asterisks
+- Or minuses
++ Or pluses
+```
+
+1. First ordered list item
+2. Another item
+
+- Unordered sub-list.
+
+1. Actual numbers don't matter, just that it's a number
+1. Ordered sub-list
+1. And another item.
+
+   You can have properly indented paragraphs within list items. Notice the blank line above, and the leading spaces (at least one, but we'll use three here to also align the raw Markdown).
+
+   To have a line break without a paragraph, you will need to use two trailing spaces.
+   Note that this line is separate, but within the same paragraph.
+   (This is contrary to the typical GFM line break behaviour, where trailing spaces are not required.)
+
+- Unordered list can use asterisks
+
+* Or minuses
+
+- Or pluses
+
+<a name="links"></a>
+
+## Links
+
+There are two ways to create links.
+
+```
+[I'm an inline-style link](https://www.google.com)
+
+[I'm an inline-style link with title](https://www.google.com "Google's Homepage")
+
+[I'm a reference-style link][Arbitrary case-insensitive reference text]
+
+[I'm a relative reference to a repository file](../blob/master/LICENSE)
+
+[You can use numbers for reference-style link definitions][1]
+
+Or leave it empty and use the [link text itself].
+
+URLs and URLs in angle brackets will automatically get turned into links.
+http://www.example.com or <http://www.example.com> and sometimes
+example.com (but not on Github, for example).
+
+Some text to show that the reference links can follow later.
+
+[arbitrary case-insensitive reference text]: https://www.mozilla.org
+[1]: http://slashdot.org
+[link text itself]: http://www.reddit.com
+```
+
+[I'm an inline-style link](https://www.google.com)
+
+[I'm an inline-style link with title](https://www.google.com "Google's Homepage")
+
+[I'm a reference-style link][arbitrary case-insensitive reference text]
+
+[I'm a relative reference to a repository file](../blob/master/LICENSE)
+
+[You can use numbers for reference-style link definitions][1]
+
+Or leave it empty and use the [link text itself].
+
+URLs and URLs in angle brackets will automatically get turned into links.
+http://www.example.com or <http://www.example.com> and sometimes
+example.com (but not on Github, for example).
+
+Some text to show that the reference links can follow later.
+
+[arbitrary case-insensitive reference text]: https://www.mozilla.org
+[1]: http://slashdot.org
+[link text itself]: http://www.reddit.com
+
+<a name="images"></a>
+
+## Images
+
+```
+Here's our logo (hover to see the title text):
+
+Inline-style:
+![alt text](https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 1")
+
+Reference-style:
+![alt text][logo]
+
+[logo]: https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 2"
+```
+
+Here's our logo (hover to see the title text):
+
+Inline-style:
+![alt text](https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 1")
+
+Reference-style:
+![alt text][logo]
+
+[logo]: https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 2"
+
+<a name="code"></a>
+
+## Code and Syntax Highlighting
+
+Code blocks are part of the Markdown spec, but syntax highlighting isn't. However, many renderers -- like Github's and _Markdown Here_ -- support syntax highlighting. Which languages are supported and how those language names should be written will vary from renderer to renderer. _Markdown Here_ supports highlighting for dozens of languages (and not-really-languages, like diffs and HTTP headers); to see the complete list, and how to write the language names, see the [highlight.js demo page](http://softwaremaniacs.org/media/soft/highlight/test.html).
+
+```
+Inline `code` has `back-ticks around` it.
+```
+
+Inline `code` has `back-ticks around` it.
+
+Blocks of code are either fenced by lines with three back-ticks <code>```</code>, or are indented with four spaces. I recommend only using the fenced code blocks -- they're easier and only they support syntax highlighting.
+
+<pre lang="no-highlight"><code>```javascript
+var s = "JavaScript syntax highlighting";
+alert(s);
+```
+
+```
+s = "Python syntax highlighting"
+print s
+```
+
+```
+No language indicated, so no syntax highlighting.
+But let's throw in a &lt;b&gt;tag&lt;/b&gt;.
+```
+</code></pre>
+
+```
+var s = "JavaScript syntax highlighting";
+alert(s);
+```
+
+```
+s = "Python syntax highlighting"
+print s
+```
+
+```
+No language indicated, so no syntax highlighting in Markdown Here (varies on Github).
+But let's throw in a <b>tag</b>.
+```
+
+<a name="tables"></a>
+
+## Tables
+
+Tables aren't part of the core Markdown spec, but they are part of GFM and _Markdown Here_ supports them. They are an easy way of adding tables to your email -- a task that would otherwise require copy-pasting from another application.
+
+```
+Colons can be used to align columns.
+
+| Tables        | Are           | Cool  |
+| ------------- |:-------------:| -----:|
+| col 3 is      | right-aligned | $1600 |
+| col 2 is      | centered      |   $12 |
+| zebra stripes | are neat      |    $1 |
+
+There must be at least 3 dashes separating each header cell.
+The outer pipes (|) are optional, and you don't need to make the
+raw Markdown line up prettily. You can also use inline Markdown.
+
+Markdown | Less | Pretty
+--- | --- | ---
+*Still* | `renders` | **nicely**
+1 | 2 | 3
+```
+
+Colons can be used to align columns.
+
+| Tables        |      Are      |   Cool |
+| ------------- | :-----------: | -----: |
+| col 3 is      | right-aligned | \$1600 |
+| col 2 is      |   centered    |   \$12 |
+| zebra stripes |   are neat    |    \$1 |
+
+There must be at least 3 dashes separating each header cell. The outer pipes (|) are optional, and you don't need to make the raw Markdown line up prettily. You can also use inline Markdown.
+
+| Markdown | Less      | Pretty     |
+| -------- | --------- | ---------- |
+| _Still_  | `renders` | **nicely** |
+| 1        | 2         | 3          |
+
+<a name="blockquotes"></a>
+
+## Blockquotes
+
+```
+> Blockquotes are very handy in email to emulate reply text.
+> This line is part of the same quote.
+
+Quote break.
+
+> This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can *put* **Markdown** into a blockquote.
+```
+
+> Blockquotes are very handy in email to emulate reply text.
+> This line is part of the same quote.
+
+Quote break.
+
+> This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can _put_ **Markdown** into a blockquote.
+
+<a name="html"></a>
+
+## Inline HTML
+
+You can also use raw HTML in your Markdown, and it'll mostly work pretty well.
+
+```
+<dl>
+  <dt>Definition list</dt>
+  <dd>Is something people use sometimes.</dd>
+
+  <dt>Markdown in HTML</dt>
+  <dd>Does *not* work **very** well. Use HTML <em>tags</em>.</dd>
+</dl>
+```
+
+<dl>
+  <dt>Definition list</dt>
+  <dd>Is something people use sometimes.</dd>
+
+  <dt>Markdown in HTML</dt>
+  <dd>Does *not* work **very** well. Use HTML <em>tags</em>.</dd>
+</dl>
+
+<a name="hr"></a>
+
+## Horizontal Rule
+
+```
+Three or more...
+
+---
+
+Hyphens
+
+***
+
+Asterisks
+
+___
+
+Underscores
+```
+
+Three or more...
+
+---
+
+Hyphens
+
+---
+
+Asterisks
+
+---
+
+Underscores
+
+<a name="lines"></a>
+
+## Line Breaks
+
+My basic recommendation for learning how line breaks work is to experiment and discover -- hit &lt;Enter&gt; once (i.e., insert one newline), then hit it twice (i.e., insert two newlines), see what happens. You'll soon learn to get what you want. "Markdown Toggle" is your friend.
+
+Here are some things to try out:
+
+```
+Here's a line for us to start with.
+
+This line is separated from the one above by two newlines, so it will be a *separate paragraph*.
+
+This line is also a separate paragraph, but...
+This line is only separated by a single newline, so it's a separate line in the *same paragraph*.
+```
+
+Here's a line for us to start with.
+
+This line is separated from the one above by two newlines, so it will be a _separate paragraph_.
+
+This line is also begins a separate paragraph, but...
+This line is only separated by a single newline, so it's a separate line in the _same paragraph_.
+
+(Technical note: _Markdown Here_ uses GFM line breaks, so there's no need to use MD's two-space line breaks.)
+
+<a name="videos"></a>
+
+## YouTube Videos
+
+They can't be added directly but you can add an image with a link to the video like this:
+
+```
+<a href="http://www.youtube.com/watch?feature=player_embedded&v=YOUTUBE_VIDEO_ID_HERE
+" target="_blank"><img src="http://img.youtube.com/vi/YOUTUBE_VIDEO_ID_HERE/0.jpg"
+alt="IMAGE ALT TEXT HERE" width="240" height="180" border="10" /></a>
+```
+
+Or, in pure Markdown, but losing the image sizing and border:
+
+```
+[![IMAGE ALT TEXT HERE](http://img.youtube.com/vi/YOUTUBE_VIDEO_ID_HERE/0.jpg)](http://www.youtube.com/watch?v=YOUTUBE_VIDEO_ID_HERE)
+```

--- a/src/lib/utils/renderMarkdown.tsx
+++ b/src/lib/utils/renderMarkdown.tsx
@@ -78,7 +78,7 @@ export function defaultRules(modal: boolean = false): ParserRules {
       match: SimpleMarkdown.blockRegex(/^((?:[^\n]|\n(?! *\n))+)(?:\n *)/),
       react: (node, output, state) => {
         return (
-          <Sans size="3t" key={state.key} textAlign="center">
+          <Sans size="3t" color="black60" key={state.key} textAlign="center">
             {output(node.content, state)}
           </Sans>
         )

--- a/src/lib/utils/renderMarkdown.tsx
+++ b/src/lib/utils/renderMarkdown.tsx
@@ -1,20 +1,45 @@
-import { Sans, Serif } from "@artsy/palette"
+import { color, Sans, Separator, Serif, space } from "@artsy/palette"
 import { LinkText } from "lib/Components/Text/LinkText"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import _ from "lodash"
 import React from "react"
 import { Linking, Text, View } from "react-native"
-import SimpleMarkdown from "simple-markdown"
+import SimpleMarkdown, { ParserRule, ParserRules, ReactNodeOutput } from "simple-markdown"
+
+interface OurReactRule extends Partial<ParserRule> {
+  // simpler typings here, for better intellisense
+  react?: ReactNodeOutput
+}
+
+// just to get better intellisense when creating the rules
+function createReactRules(
+  rules: Partial<
+    {
+      [k in keyof SimpleMarkdown.DefaultRules]: OurReactRule
+    }
+  >
+): ParserRules {
+  const result: any = {}
+  for (const key of Object.keys(SimpleMarkdown.defaultRules)) {
+    if (rules[key]) {
+      result[key] = {
+        ...SimpleMarkdown.defaultRules[key],
+        ...rules[key],
+      }
+    } else {
+      result[key] = SimpleMarkdown.defaultRules[key]
+    }
+  }
+  return result
+}
 
 // Rules for rendering parsed markdown. Currently only handles links and text. Add rules similar to
 // https://github.com/CharlesMangwa/react-native-simple-markdown/blob/next/src/rules.js for new functionalities.
 //
 // Default rules: https://github.com/Khan/simple-markdown/blob/f1a75785703832bbff146d0b98e76cd7ac74b8e8/simple-markdown.js#L806
-export function defaultRules(modal: boolean = false) {
-  return {
-    ...SimpleMarkdown.defaultRules,
+export function defaultRules(modal: boolean = false): ParserRules {
+  return createReactRules({
     link: {
-      ...SimpleMarkdown.defaultRules.link,
       react: (node, output, state) => {
         state.withinText = true
         let element
@@ -43,22 +68,17 @@ export function defaultRules(modal: boolean = false) {
         )
       },
     },
-
     text: {
-      ...SimpleMarkdown.defaultRules.text,
-      text: {
-        react: node => {
-          return node.content
-        },
+      react: node => {
+        return node.content
       },
     },
 
     paragraph: {
-      ...SimpleMarkdown.defaultRules.paragraph,
       match: SimpleMarkdown.blockRegex(/^((?:[^\n]|\n(?! *\n))+)(?:\n *)/),
       react: (node, output, state) => {
         return (
-          <Sans size="3t" color="black60" key={state.key} textAlign="center">
+          <Sans size="3t" key={state.key} textAlign="center">
             {output(node.content, state)}
           </Sans>
         )
@@ -66,7 +86,6 @@ export function defaultRules(modal: boolean = false) {
     },
 
     strong: {
-      ...SimpleMarkdown.defaultRules.strong,
       react: (node, output, state) => {
         return (
           <Serif size="3t" weight="semibold" key={state.key}>
@@ -77,7 +96,6 @@ export function defaultRules(modal: boolean = false) {
     },
 
     em: {
-      ...SimpleMarkdown.defaultRules.em,
       react: (node, output, state) => {
         return (
           <Serif size="3t" italic key={state.key}>
@@ -88,22 +106,18 @@ export function defaultRules(modal: boolean = false) {
     },
 
     br: {
-      ...SimpleMarkdown.defaultRules.br,
       react: (_node, _output, state) => {
         return <Text key={state.key} />
       },
     },
 
     newline: {
-      ...SimpleMarkdown.defaultRules.newline,
       react: (_node, _output, state) => {
         return <Text key={state.key} />
       },
     },
 
     list: {
-      ...SimpleMarkdown.defaultRules.list,
-
       react: (node, output, state) => {
         const items = _.map(node.items, (item, i) => {
           let bullet
@@ -118,7 +132,7 @@ export function defaultRules(modal: boolean = false) {
           }
 
           const listItemText = (
-            <Serif size="3t" key={state.key + 1}>
+            <Serif size="3t" key={String(state.key) + 1}>
               {output(item, state)}
             </Serif>
           )
@@ -135,27 +149,26 @@ export function defaultRules(modal: boolean = false) {
     },
 
     codeBlock: {
-      react: (node, output, state) => {
+      react: (node, _output, state) => {
         return (
           <Sans size="3t" key={state.key}>
-            {output(node.content, state)}
+            {node.content}
           </Sans>
         )
       },
     },
 
     inlineCode: {
-      react: (node, output, state) => {
+      react: (node, _output, state) => {
         return (
           <Sans size="3t" key={state.key}>
-            {output(node.content, state)}
+            {node.content}
           </Sans>
         )
       },
     },
 
     heading: {
-      ...SimpleMarkdown.defaultRules.heading,
       react: (node, output, state) => {
         const map = {
           1: "8",
@@ -171,12 +184,39 @@ export function defaultRules(modal: boolean = false) {
         )
       },
     },
-  }
+    u: {
+      react: (node, output, state) => output(node.content, state),
+    },
+    del: {
+      react: (node, output, state) => output(node.content, state),
+    },
+    image: {
+      react: () => null,
+    },
+    table: {
+      react: () => null,
+    },
+    tableSeparator: {
+      react: () => null,
+    },
+    blockQuote: {
+      react: (node, output, state) => (
+        <View style={{ borderLeftColor: color("black10"), borderLeftWidth: 2, paddingLeft: space(1) }}>
+          {output(node.content, state)}
+        </View>
+      ),
+    },
+    hr: {
+      react: () => <Separator mb={2}></Separator>,
+    },
+  })
 }
 
 export function renderMarkdown(markdown: string, rules: any = defaultRules(false)): React.ReactElement {
-  const rawBuiltParser = SimpleMarkdown.parserFor(rules)
-  const reactOutput = SimpleMarkdown.reactFor(SimpleMarkdown.ruleOutput(rules, "react"))
+  const parser = SimpleMarkdown.parserFor(rules)
+  const writer = SimpleMarkdown.outputFor<any, any>(rules, "react")
 
-  return reactOutput(rawBuiltParser(markdown, { inline: false }))
+  const ast = parser(markdown, { inline: false })
+
+  return writer(ast)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2040,10 +2040,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.8.10":
-  version "16.8.10"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.10.tgz#1ccb6fde17f71a62ef055382ec68bdc379d4d8d9"
-  integrity sha512-7bUQeZKP4XZH/aB4i7k1i5yuwymDu/hnLMhD9NjVZvQQH7ZUgRN3d6iu8YXzx4sN/tNr0bj8jgguk8hhObzGvA==
+"@types/react@*", "@types/react@16.9.22", "@types/react@>=16.0.0":
+  version "16.9.22"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.22.tgz#f0288c92d94e93c4b43e3f5633edf788b2c040ae"
+  integrity sha512-7OSt4EGiLvy0h5R7X+r0c7S739TCU/LvWbkNOrm10lUwNHe7XPz5OLhLOSZeCkqO9JSCly1NkYJ7ODTUqVnHJQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -14426,10 +14426,12 @@ signedsource@^1.0.0:
   resolved "https://registry.yarnpkg.com/signedsource/-/signedsource-1.0.0.tgz#1ddace4981798f93bd833973803d80d52e93ad6a"
   integrity sha1-HdrOSYF5j5O9gzlzgD2A1S6TrWo=
 
-simple-markdown@0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/simple-markdown/-/simple-markdown-0.4.4.tgz#9bd597bdd5c2f5a789e56a4dbf06427d76c3834f"
-  integrity sha512-ZmlNUGR1KI12sPHeQ7dQY1qM5KfOgFqClNNVO8zQ9Pg6u7gHLCPFGD+VC7MCwpGDMd1uw3Bb2TfFfR8d6bB34A==
+simple-markdown@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/simple-markdown/-/simple-markdown-0.7.2.tgz#896cc3e3dd9acd068d30e696bce70b0b97655665"
+  integrity sha512-XfCvqqzMyzRj4L7eIxJgGaQ2Gaxr20GhTFMB+1yuY8q3xffjzmOg4Q5tC0kcaJPV42NNUHCQDaRK6jzi3/RhrA==
+  dependencies:
+    "@types/react" ">=16.0.0"
 
 simple-plist@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/MX-169

```md
### About this work

this art work is lovely

----

it's really so so nice

many a work wishes it were as nice as this work

----

> Yes this is a lovely work, thank you. *but* I wish it came in blue.

- Jackson Pollock
```

becomes

![image](https://user-images.githubusercontent.com/1242537/75446349-240fc580-595f-11ea-8d4f-88c1b183ed04.png)

Would it make sense to prevent Partners from including this kind of content in artwork details markdown?