### PR TITLE
Prep for 6.3.2 release

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.3.1</string>
+	<string>6.3.2</string>
 	<key>CFBundleVersion</key>
 	<string>2019.05.24.09</string>
 	<key>NSExtension</key>

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.3.1</string>
+	<string>6.3.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,5 +1,5 @@
 upcoming:
-  version: 6.3.1
+  version: 6.3.2
   date: TBD
   emission_version: 1.21.49
   dev:
@@ -8,12 +8,19 @@ upcoming:
     - Fixes cacheMiddleware to allow ArtworkMarkAsRecentlyViewedQuery mutations without clearing cache - ash
   user_facing:
     - Removes generic genes from For You tab - ash
-    - Improves error-handling during signup failures due to password problems - ash
-    - Increases minimum required password length from 6 to 8 - ash
     - Fix WSODs related to markdown elements not being supported in ReadMore - david
     - Fix grid.artworks null pointer bug - david
 
 releases:
+  - version: 6.3.1
+    date: Feb 27, 2020
+    emission_version: 1.21.49
+    dev:
+      -
+    user_facing:
+      - Improves error-handling during signup failures due to password problems - ash
+      - Increases minimum required password length from 6 to 8 - ash
+
   - version: 6.3.0
     date: Feb 19, 2020
     emission_version: 1.21.49


### PR DESCRIPTION
I've created 6.3.2 in AppStoreConnect, and that leaves this PR as follow-up. We need to do this so betas work. This involves:

- Running `make next` to update versions.
- Moving Changelog entries around (usually pretty simple, but with the cherry-picking for the [6.3.1 release](https://github.com/artsy/eigen/releases/tag/6.3.1-2020.02.27.16) it was a little more involved).