### PR TITLE
Updates artwork filter fonts per QA feedback

### DIFF
--- a/src/lib/Components/ArtworkFilterOptions/SortOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/SortOptions.tsx
@@ -37,7 +37,7 @@ export class SortOptionsScreen extends React.Component<SortOptionsScreenProps, S
               <ArrowLeftIcon fill="black100" />
             </ArrowLeftIconContainer>
           </Flex>
-          <Sans mt={2} weight="medium" size="4">
+          <Sans mt={2} weight="medium" size="4" color="black100">
             Sort
           </Sans>
           <Box></Box>
@@ -52,7 +52,9 @@ export class SortOptionsScreen extends React.Component<SortOptionsScreenProps, S
                   <SortOptionListItemRow onPress={() => this.selectSortOption(item)}>
                     <OptionListItem>
                       <InnerOptionListItem>
-                        <SortSelection size="3">{item}</SortSelection>
+                        <SortSelection color="black100" size="3t">
+                          {item}
+                        </SortSelection>
                         {item === this.state.currentSelection && (
                           <Box mb={0.1}>
                             <CheckIcon fill="black100" />
@@ -76,8 +78,8 @@ const SortOptions: SortTypes[] = [
   "Default",
   "Price (low to high)",
   "Price (high to low)",
-  "Recently Updated",
-  "Recently Added",
+  "Recently updated",
+  "Recently added",
   "Artwork year (descending)",
   "Artwork year (ascending)",
 ]
@@ -105,8 +107,8 @@ export type SortTypes =
   | "Default"
   | "Price (low to high)"
   | "Price (high to low)"
-  | "Recently Updated"
-  | "Recently Added"
+  | "Recently updated"
+  | "Recently added"
   | "Artwork year (descending)"
   | "Artwork year (ascending)"
 

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -130,10 +130,10 @@ export class FilterOptions extends React.Component<FilterOptionsProps, FilterOpt
               <CloseIcon fill="black100" />
             </CloseIconContainer>
           </Flex>
-          <FilterHeader weight="medium" size="4">
+          <FilterHeader weight="medium" size="4" color="black100">
             Filter
           </FilterHeader>
-          <Sans mr={2} mt={2} size="4">
+          <Sans mr={2} mt={2} size="3" color="black100">
             Clear all
           </Sans>
         </Flex>
@@ -147,9 +147,11 @@ export class FilterOptions extends React.Component<FilterOptionsProps, FilterOpt
                   <TouchableOptionListItemRow onPress={() => item.onTap()}>
                     <OptionListItem>
                       <Flex p={2} flexDirection="row" justifyContent="space-between" flexGrow={1}>
-                        <Serif size="3">{item.type}</Serif>
+                        <Serif size="3t" color="black100">
+                          {item.type}
+                        </Serif>
                         <Flex flexDirection="row">
-                          <CurrentOption size="3">{this.state.selectedSortOption}</CurrentOption>
+                          <CurrentOption size="3t">{this.state.selectedSortOption}</CurrentOption>
                           <ArrowRightIcon fill="black30" ml={0.3} mt={0.3} />
                         </Flex>
                       </Flex>


### PR DESCRIPTION
Updates font styling based on feedback from the QA of https://artsyproduct.atlassian.net/browse/FX-1781.

- Can we use consistent casing? – Recently Updated and Added use Title Casing and Artwork year uses sentence casing. Can we use sentence casing?
- “Filter” should be 16px Unica Medium 
- “Clear all” should be 14 px Unica Regular
- “Sort” by and “Default” should be 16px Garamond



