### PR TITLE
Updates UI for password requirements #trivial

### DIFF
--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/ARPersonalizeViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/ARPersonalizeViewController.m
@@ -178,7 +178,7 @@
         case AROnboardingStagePersonalizePassword:
             [self.onboardingNavigationItems disableNextStep];
             [self.headerView setupHeaderViewWithTitle:@"Create a password" withLargeLayout:self.useLargeLayout];
-            [self.headerView addHelpText:@"Must be 6 characters or longer" withLargeLayout:self.useLargeLayout];
+            [self.headerView addHelpText:@"Must be 8 characters or longer" withLargeLayout:self.useLargeLayout];
             [self addTextFields];
             [self.onboardingTextFields setupForPasswordWithLargeLayout:self.useLargeLayout];
             [self.onboardingTextFields.passwordField becomeFirstResponder];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -11,6 +11,7 @@ upcoming:
     - Removes generic genes from For You tab - ash
     - Fix WSODs related to markdown elements not being supported in ReadMore - david
     - Fix grid.artworks null pointer bug - david
+    - Fixes issue with create password screen saying you needed 6 character but you need 8 - ash
 
 releases:
   - version: 6.3.1


### PR DESCRIPTION
Just an update to the UI, not the client-side validation:

<img width="762" alt="Screen Shot 2020-02-28 at 15 17 23" src="https://user-images.githubusercontent.com/498212/75584301-70c9ce00-5a3d-11ea-87e6-51246579597c.png">
