### PR TITLE
Alignment + size adjustment on Filter header

### DIFF
--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -133,7 +133,7 @@ export class FilterOptions extends React.Component<FilterOptionsProps, FilterOpt
           <FilterHeader weight="medium" size="4" color="black100">
             Filter
           </FilterHeader>
-          <Sans mr={2} mt={2} size="3" color="black100">
+          <Sans mr={2} mt={2} size="4" color="black100">
             Clear all
           </Sans>
         </Flex>


### PR DESCRIPTION
After last week's QA Jeffrey modified the font size on the filter header, which slightly deviates from the design spec, this PR makes that change.

<img width="398" alt="Screen Shot 2020-03-03 at 10 49 05 AM" src="https://user-images.githubusercontent.com/10385964/75792918-a07a1e00-5d3c-11ea-93b9-b239309b0a41.png">
