### PR TITLE
[MX-248] Fix works-for-you scrolling

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -12,6 +12,7 @@ upcoming:
     - Fix WSODs related to markdown elements not being supported in ReadMore - david
     - Fix grid.artworks null pointer bug - david
     - Fixes issue with create password screen saying you needed 6 character but you need 8 - ash
+    - Fix bug where the `Artists` tab scroll view would jump around while scrolling
 
 releases:
   - version: 6.3.1

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -12,7 +12,7 @@ upcoming:
     - Fix WSODs related to markdown elements not being supported in ReadMore - david
     - Fix grid.artworks null pointer bug - david
     - Fixes issue with create password screen saying you needed 6 character but you need 8 - ash
-    - Fix bug where the `Artists` tab scroll view would jump around while scrolling
+    - Fix bug where the `Artists` tab scroll view would jump around while scrolling - david
 
 releases:
   - version: 6.3.1

--- a/src/lib/Components/ArtworkGrids/GenericGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/GenericGrid.tsx
@@ -14,6 +14,9 @@ interface Props {
   isLoading?: boolean
   trackingFlow?: string
   contextModule?: string
+
+  // Give explicit width to avoid resizing after mount
+  width?: number
 }
 
 interface State {
@@ -28,21 +31,22 @@ export class GenericArtworksGrid extends React.Component<Props, State> {
     itemMargin: 20,
   }
 
-  state = {
-    sectionDimension: 0,
-    sectionCount: 0,
-  }
+  state = this.props.width
+    ? this.layoutState(this.props.width)
+    : {
+        sectionDimension: 0,
+        sectionCount: 0,
+      }
 
   width = 0
 
-  layoutState(currentLayout): State {
-    const width = currentLayout.width
+  layoutState(width): State {
     const isPad = width > 600
     const isPadHorizontal = width > 900
 
     const sectionCount = isPad ? (isPadHorizontal ? 4 : 3) : 2
     const sectionMargins = this.props.sectionMargin * (sectionCount - 1)
-    const sectionDimension = (currentLayout.width - sectionMargins) / sectionCount
+    const sectionDimension = (width - sectionMargins) / sectionCount
 
     return {
       sectionCount,
@@ -51,11 +55,15 @@ export class GenericArtworksGrid extends React.Component<Props, State> {
   }
 
   onLayout = (event: LayoutChangeEvent) => {
+    if (this.props.width) {
+      // noop because we were given an explicit width
+      return
+    }
     const layout = event.nativeEvent.layout
     if (layout.width !== this.width) {
       // this means we've rotated or are on our initial load
       this.width = layout.width
-      this.setState(this.layoutState(layout))
+      this.setState(this.layoutState(layout.width))
     }
   }
 

--- a/src/lib/Components/WorksForYou/Notification.tsx
+++ b/src/lib/Components/WorksForYou/Notification.tsx
@@ -14,7 +14,10 @@ import { Notification_notification } from "__generated__/Notification_notificati
 interface Props {
   // Special notifications will pass down an artistHref. Otherwise, grab it from the artworks.
   notification: Notification_notification & { artistHref?: string }
+  width: number
 }
+
+const HORIZONTAL_PADDING = 20
 
 export class Notification extends React.Component<Props> {
   handleArtistTap() {
@@ -47,7 +50,10 @@ export class Notification extends React.Component<Props> {
           </View>
         </TouchableWithoutFeedback>
         <View style={styles.gridContainer}>
-          <GenericGrid artworks={notification.artworks.edges.map(({ node }) => node)} />
+          <GenericGrid
+            width={this.props.width - HORIZONTAL_PADDING * 2}
+            artworks={notification.artworks.edges.map(({ node }) => node)}
+          />
         </View>
       </View>
     )
@@ -67,8 +73,7 @@ interface Styles {
 const styles = StyleSheet.create<Styles>({
   container: {
     marginTop: 20,
-    marginLeft: 20,
-    marginRight: 20,
+    marginHorizontal: HORIZONTAL_PADDING,
   },
   header: {
     flexDirection: "row",

--- a/src/lib/Components/WorksForYou/__tests__/Notification-tests.tsx
+++ b/src/lib/Components/WorksForYou/__tests__/Notification-tests.tsx
@@ -32,7 +32,7 @@ const notification = () => {
     artists: "Jean-Michel Basquiat",
     date: "Mar 16",
     summary: "1 Work Added",
-    artworks: { edges: [{ title: "Anti-Product Postcard" }] },
+    artworks: { edges: [{ node: { title: "Anti-Product Postcard" } }] },
     status: "UNREAD",
     image: {
       resized: {

--- a/src/lib/Components/WorksForYou/__tests__/Notification-tests.tsx
+++ b/src/lib/Components/WorksForYou/__tests__/Notification-tests.tsx
@@ -6,7 +6,7 @@ import { Notification } from "../Notification"
 
 it("lays out correctly for unread notification", () => {
   const props = notification()
-  const component = renderWithLayout(<Notification notification={props as any} />, { width: 768 })
+  const component = renderWithLayout(<Notification width={768} notification={props as any} />, { width: 768 })
 
   expect(component).toMatchSnapshot()
 })
@@ -14,7 +14,7 @@ it("lays out correctly for unread notification", () => {
 it("lays out correctly for read notification", () => {
   const props = notification()
   props.status = "READ"
-  const component = renderWithLayout(<Notification notification={props as any} />, { width: 768 })
+  const component = renderWithLayout(<Notification width={768} notification={props as any} />, { width: 768 })
 
   expect(component).toMatchSnapshot()
 })
@@ -22,7 +22,7 @@ it("lays out correctly for read notification", () => {
 it("does not show artist avatar if no avatar image exists", () => {
   const props = notification()
   props.image.resized.url = null
-  const component = renderWithLayout(<Notification notification={props as any} />, { width: 300 })
+  const component = renderWithLayout(<Notification width={300} notification={props as any} />, { width: 300 })
 
   expect(component).toMatchSnapshot()
 })

--- a/src/lib/Components/WorksForYou/__tests__/__snapshots__/Notification-tests.tsx.snap
+++ b/src/lib/Components/WorksForYou/__tests__/__snapshots__/Notification-tests.tsx.snap
@@ -4,8 +4,7 @@ exports[`does not show artist avatar if no avatar image exists 1`] = `
 <View
   style={
     Object {
-      "marginLeft": 20,
-      "marginRight": 20,
+      "marginHorizontal": 20,
       "marginTop": 20,
     }
   }
@@ -108,7 +107,36 @@ exports[`does not show artist avatar if no avatar image exists 1`] = `
             "flexDirection": "row",
           }
         }
-      />
+      >
+        <View
+          accessibilityLabel="Section 0"
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              Object {
+                "marginRight": 20,
+                "width": 120,
+              },
+            ]
+          }
+        />
+        <View
+          accessibilityLabel="Section 1"
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              Object {
+                "marginRight": 0,
+                "width": 120,
+              },
+            ]
+          }
+        />
+      </View>
     </View>
   </View>
 </View>
@@ -118,8 +146,7 @@ exports[`lays out correctly for read notification 1`] = `
 <View
   style={
     Object {
-      "marginLeft": 20,
-      "marginRight": 20,
+      "marginHorizontal": 20,
       "marginTop": 20,
     }
   }
@@ -222,7 +249,50 @@ exports[`lays out correctly for read notification 1`] = `
             "flexDirection": "row",
           }
         }
-      />
+      >
+        <View
+          accessibilityLabel="Section 0"
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              Object {
+                "marginRight": 20,
+                "width": 229.33333333333334,
+              },
+            ]
+          }
+        />
+        <View
+          accessibilityLabel="Section 1"
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              Object {
+                "marginRight": 20,
+                "width": 229.33333333333334,
+              },
+            ]
+          }
+        />
+        <View
+          accessibilityLabel="Section 2"
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              Object {
+                "marginRight": 0,
+                "width": 229.33333333333334,
+              },
+            ]
+          }
+        />
+      </View>
     </View>
   </View>
 </View>
@@ -232,8 +302,7 @@ exports[`lays out correctly for unread notification 1`] = `
 <View
   style={
     Object {
-      "marginLeft": 20,
-      "marginRight": 20,
+      "marginHorizontal": 20,
       "marginTop": 20,
     }
   }
@@ -336,7 +405,50 @@ exports[`lays out correctly for unread notification 1`] = `
             "flexDirection": "row",
           }
         }
-      />
+      >
+        <View
+          accessibilityLabel="Section 0"
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              Object {
+                "marginRight": 20,
+                "width": 229.33333333333334,
+              },
+            ]
+          }
+        />
+        <View
+          accessibilityLabel="Section 1"
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              Object {
+                "marginRight": 20,
+                "width": 229.33333333333334,
+              },
+            ]
+          }
+        />
+        <View
+          accessibilityLabel="Section 2"
+          style={
+            Array [
+              Object {
+                "flexDirection": "column",
+              },
+              Object {
+                "marginRight": 0,
+                "width": 229.33333333333334,
+              },
+            ]
+          }
+        />
+      </View>
     </View>
   </View>
 </View>

--- a/src/lib/Containers/__tests__/WorksForYou-tests.tsx
+++ b/src/lib/Containers/__tests__/WorksForYou-tests.tsx
@@ -67,7 +67,7 @@ interface NotificationsResponse {
             node: {
               artists: string
               summary: string
-              artworks: { edges: [{ title: string }] }
+              artworks: { edges: [{ node: { title: string } }] }
               image: {
                 resized: {
                   url: string
@@ -98,7 +98,7 @@ const notificationsResponse = () => {
                 node: {
                   artists: "Jean-Michel Basquiat",
                   summary: "1 Work Added",
-                  artworks: { edges: [{ title: "Anti-Product Postcard" }] },
+                  artworks: { edges: [{ node: { title: "Anti-Product Postcard" } }] },
                   image: {
                     resized: {
                       url: "cloudfront.url",
@@ -110,7 +110,9 @@ const notificationsResponse = () => {
                 node: {
                   artists: "Ana Mendieta",
                   summary: "2 Works Added",
-                  artworks: { edges: [{ title: "Corazón de Roca con Sangre" }, { title: "Butterfly" }] },
+                  artworks: {
+                    edges: [{ node: { title: "Corazón de Roca con Sangre" } }, { node: { title: "Butterfly" } }],
+                  },
                   image: {
                     resized: {
                       url: "cloudfront.url",

--- a/src/lib/Containers/__tests__/__snapshots__/WorksForYou-tests.tsx.snap
+++ b/src/lib/Containers/__tests__/__snapshots__/WorksForYou-tests.tsx.snap
@@ -2,799 +2,941 @@
 
 exports[`with notifications lays out correctly on larger screens 1`] = `
 <RCTScrollView
-  contentContainerStyle={Object {}}
+  ItemSeparatorComponent={[Function]}
+  ListEmptyComponent={[Function]}
+  ListFooterComponent={null}
+  data={
+    Array [
+      Object {
+        "node": Object {
+          "artists": "Jean-Michel Basquiat",
+          "artworks": Object {
+            "edges": Array [
+              Object {
+                "node": Object {
+                  "title": "Anti-Product Postcard",
+                },
+              },
+            ],
+          },
+          "image": Object {
+            "resized": Object {
+              "url": "cloudfront.url",
+            },
+          },
+          "summary": "1 Work Added",
+        },
+      },
+      Object {
+        "node": Object {
+          "artists": "Ana Mendieta",
+          "artworks": Object {
+            "edges": Array [
+              Object {
+                "node": Object {
+                  "title": "Corazón de Roca con Sangre",
+                },
+              },
+              Object {
+                "node": Object {
+                  "title": "Butterfly",
+                },
+              },
+            ],
+          },
+          "image": Object {
+            "resized": Object {
+              "url": "cloudfront.url",
+            },
+          },
+          "summary": "2 Works Added",
+        },
+      },
+    ]
+  }
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onContentSizeChange={[Function]}
+  onEndReached={[Function]}
+  onEndReachedThreshold={2}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
   onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
   refreshControl={
     <RefreshControlMock
       onRefresh={[Function]}
       refreshing={false}
     />
   }
-  scrollEventThrottle={100}
+  removeClippedSubviews={false}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  updateCellsBatchingPeriod={50}
+  viewabilityConfigCallbackPairs={Array []}
+  windowSize={21}
 >
   <RCTRefreshControl />
   <View>
     <View
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
+      onLayout={[Function]}
+      style={null}
     >
-      <RCTScrollView
-        ItemSeparatorComponent={[Function]}
-        ListFooterComponent={[Function]}
-        data={
-          Array [
-            Object {
-              "node": Object {
-                "artists": "Jean-Michel Basquiat",
-                "artworks": Object {
-                  "edges": Array [
-                    Object {
-                      "title": "Anti-Product Postcard",
-                    },
-                  ],
-                },
-                "image": Object {
-                  "resized": Object {
-                    "url": "cloudfront.url",
-                  },
-                },
-                "summary": "1 Work Added",
-              },
-            },
-            Object {
-              "node": Object {
-                "artists": "Ana Mendieta",
-                "artworks": Object {
-                  "edges": Array [
-                    Object {
-                      "title": "Corazón de Roca con Sangre",
-                    },
-                    Object {
-                      "title": "Butterfly",
-                    },
-                  ],
-                },
-                "image": Object {
-                  "resized": Object {
-                    "url": "cloudfront.url",
-                  },
-                },
-                "summary": "2 Works Added",
-              },
-            },
-          ]
+      <View
+        style={
+          Object {
+            "marginHorizontal": 20,
+            "marginTop": 20,
+          }
         }
-        disableVirtualization={false}
-        getItem={[Function]}
-        getItemCount={[Function]}
-        horizontal={false}
-        initialNumToRender={10}
-        keyExtractor={[Function]}
-        maxToRenderPerBatch={10}
-        numColumns={1}
-        onContentSizeChange={[Function]}
-        onEndReachedThreshold={2}
-        onLayout={[Function]}
-        onMomentumScrollEnd={[Function]}
-        onScroll={[Function]}
-        onScrollBeginDrag={[Function]}
-        onScrollEndDrag={[Function]}
-        removeClippedSubviews={false}
-        renderItem={[Function]}
-        scrollEnabled={false}
-        scrollEventThrottle={50}
-        stickyHeaderIndices={Array []}
-        updateCellsBatchingPeriod={50}
-        viewabilityConfigCallbackPairs={Array []}
-        windowSize={21}
       >
-        <View>
-          <View
-            onLayout={[Function]}
-            style={null}
-          >
-            <View
-              style={
-                Object {
-                  "marginLeft": 20,
-                  "marginRight": 20,
-                  "marginTop": 20,
-                }
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Image
+            source={
+              Object {
+                "uri": "cloudfront.url",
               }
-            >
-              <View
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  Object {
-                    "flexDirection": "row",
-                  }
-                }
-              >
-                <Image
-                  source={
-                    Object {
-                      "uri": "cloudfront.url",
-                    }
-                  }
-                  style={
-                    Object {
-                      "alignSelf": "center",
-                      "backgroundColor": "#f8f8f8",
-                      "borderRadius": 20,
-                      "height": 40,
-                      "marginRight": 10,
-                      "width": 40,
-                    }
-                  }
-                />
-                <View
-                  style={
-                    Object {
-                      "alignSelf": "center",
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <Text
-                    style={
-                      Array [
-                        Object {
-                          "fontSize": 12,
-                        },
-                        Object {
-                          "fontFamily": "AvantGardeGothicITC",
-                        },
-                        Object {
-                          "fontSize": 12,
-                        },
-                      ]
-                    }
-                  >
-                    JEAN-MICHEL BASQUIAT
-                  </Text>
-                  <Text
-                    numberOfLines={1}
-                    style={
-                      Array [
-                        Object {
-                          "fontSize": 17,
-                        },
-                        Object {
-                          "color": "#666666",
-                          "fontSize": 14,
-                          "marginTop": 2,
-                        },
-                        Object {
-                          "fontFamily": "AGaramondPro-Regular",
-                        },
-                      ]
-                    }
-                  >
-                    1 Work Added
-                  </Text>
-                </View>
-              </View>
-              <View
-                style={
-                  Object {
-                    "marginBottom": 20,
-                    "marginTop": 20,
-                  }
-                }
-              >
-                <View
-                  onLayout={[Function]}
-                >
-                  <View
-                    accessibilityLabel="Artworks Content View"
-                    style={
-                      Object {
-                        "flexDirection": "row",
-                      }
-                    }
-                  />
-                </View>
-              </View>
-            </View>
-            <View
-              px={2}
+            }
+            style={
+              Object {
+                "alignSelf": "center",
+                "backgroundColor": "#f8f8f8",
+                "borderRadius": 20,
+                "height": 40,
+                "marginRight": 10,
+                "width": 40,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "alignSelf": "center",
+                "flex": 1,
+              }
+            }
+          >
+            <Text
               style={
                 Array [
                   Object {
-                    "paddingLeft": 20,
-                    "paddingRight": 20,
+                    "fontSize": 12,
+                  },
+                  Object {
+                    "fontFamily": "AvantGardeGothicITC",
+                  },
+                  Object {
+                    "fontSize": 12,
                   },
                 ]
               }
             >
-              <View
-                style={
-                  Array [
-                    Object {
-                      "borderBottomWidth": 0,
-                      "borderColor": "#E5E5E5",
-                      "borderStyle": "solid",
-                      "borderWidth": 1,
-                      "width": "100%",
-                    },
-                  ]
-                }
-                width="100%"
-              />
-            </View>
+              JEAN-MICHEL BASQUIAT
+            </Text>
+            <Text
+              numberOfLines={1}
+              style={
+                Array [
+                  Object {
+                    "fontSize": 17,
+                  },
+                  Object {
+                    "color": "#666666",
+                    "fontSize": 14,
+                    "marginTop": 2,
+                  },
+                  Object {
+                    "fontFamily": "AGaramondPro-Regular",
+                  },
+                ]
+              }
+            >
+              1 Work Added
+            </Text>
           </View>
+        </View>
+        <View
+          style={
+            Object {
+              "marginBottom": 20,
+              "marginTop": 20,
+            }
+          }
+        >
           <View
             onLayout={[Function]}
-            style={null}
           >
             <View
+              accessibilityLabel="Artworks Content View"
               style={
                 Object {
-                  "marginLeft": 20,
-                  "marginRight": 20,
-                  "marginTop": 20,
+                  "flexDirection": "row",
                 }
               }
             >
               <View
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
+                accessibilityLabel="Section 0"
                 style={
-                  Object {
-                    "flexDirection": "row",
-                  }
+                  Array [
+                    Object {
+                      "flexDirection": "column",
+                    },
+                    Object {
+                      "marginRight": 20,
+                      "width": 206.66666666666666,
+                    },
+                  ]
                 }
-              >
-                <Image
-                  source={
-                    Object {
-                      "uri": "cloudfront.url",
-                    }
-                  }
-                  style={
-                    Object {
-                      "alignSelf": "center",
-                      "backgroundColor": "#f8f8f8",
-                      "borderRadius": 20,
-                      "height": 40,
-                      "marginRight": 10,
-                      "width": 40,
-                    }
-                  }
-                />
-                <View
-                  style={
-                    Object {
-                      "alignSelf": "center",
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <Text
-                    style={
-                      Array [
-                        Object {
-                          "fontSize": 12,
-                        },
-                        Object {
-                          "fontFamily": "AvantGardeGothicITC",
-                        },
-                        Object {
-                          "fontSize": 12,
-                        },
-                      ]
-                    }
-                  >
-                    ANA MENDIETA
-                  </Text>
-                  <Text
-                    numberOfLines={1}
-                    style={
-                      Array [
-                        Object {
-                          "fontSize": 17,
-                        },
-                        Object {
-                          "color": "#666666",
-                          "fontSize": 14,
-                          "marginTop": 2,
-                        },
-                        Object {
-                          "fontFamily": "AGaramondPro-Regular",
-                        },
-                      ]
-                    }
-                  >
-                    2 Works Added
-                  </Text>
-                </View>
-              </View>
+              />
               <View
+                accessibilityLabel="Section 1"
                 style={
-                  Object {
-                    "marginBottom": 20,
-                    "marginTop": 20,
-                  }
+                  Array [
+                    Object {
+                      "flexDirection": "column",
+                    },
+                    Object {
+                      "marginRight": 20,
+                      "width": 206.66666666666666,
+                    },
+                  ]
                 }
-              >
-                <View
-                  onLayout={[Function]}
-                >
-                  <View
-                    accessibilityLabel="Artworks Content View"
-                    style={
-                      Object {
-                        "flexDirection": "row",
-                      }
-                    }
-                  />
-                </View>
-              </View>
+              />
+              <View
+                accessibilityLabel="Section 2"
+                style={
+                  Array [
+                    Object {
+                      "flexDirection": "column",
+                    },
+                    Object {
+                      "marginRight": 0,
+                      "width": 206.66666666666666,
+                    },
+                  ]
+                }
+              />
             </View>
           </View>
+        </View>
+      </View>
+      <View
+        px={2}
+        style={
+          Array [
+            Object {
+              "paddingLeft": 20,
+              "paddingRight": 20,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "borderBottomWidth": 0,
+                "borderColor": "#E5E5E5",
+                "borderStyle": "solid",
+                "borderWidth": 1,
+                "width": "100%",
+              },
+            ]
+          }
+          width="100%"
+        />
+      </View>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        style={
+          Object {
+            "marginHorizontal": 20,
+            "marginTop": 20,
+          }
+        }
+      >
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Image
+            source={
+              Object {
+                "uri": "cloudfront.url",
+              }
+            }
+            style={
+              Object {
+                "alignSelf": "center",
+                "backgroundColor": "#f8f8f8",
+                "borderRadius": 20,
+                "height": 40,
+                "marginRight": 10,
+                "width": 40,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "alignSelf": "center",
+                "flex": 1,
+              }
+            }
+          >
+            <Text
+              style={
+                Array [
+                  Object {
+                    "fontSize": 12,
+                  },
+                  Object {
+                    "fontFamily": "AvantGardeGothicITC",
+                  },
+                  Object {
+                    "fontSize": 12,
+                  },
+                ]
+              }
+            >
+              ANA MENDIETA
+            </Text>
+            <Text
+              numberOfLines={1}
+              style={
+                Array [
+                  Object {
+                    "fontSize": 17,
+                  },
+                  Object {
+                    "color": "#666666",
+                    "fontSize": 14,
+                    "marginTop": 2,
+                  },
+                  Object {
+                    "fontFamily": "AGaramondPro-Regular",
+                  },
+                ]
+              }
+            >
+              2 Works Added
+            </Text>
+          </View>
+        </View>
+        <View
+          style={
+            Object {
+              "marginBottom": 20,
+              "marginTop": 20,
+            }
+          }
+        >
           <View
             onLayout={[Function]}
-          />
+          >
+            <View
+              accessibilityLabel="Artworks Content View"
+              style={
+                Object {
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <View
+                accessibilityLabel="Section 0"
+                style={
+                  Array [
+                    Object {
+                      "flexDirection": "column",
+                    },
+                    Object {
+                      "marginRight": 20,
+                      "width": 206.66666666666666,
+                    },
+                  ]
+                }
+              />
+              <View
+                accessibilityLabel="Section 1"
+                style={
+                  Array [
+                    Object {
+                      "flexDirection": "column",
+                    },
+                    Object {
+                      "marginRight": 20,
+                      "width": 206.66666666666666,
+                    },
+                  ]
+                }
+              />
+              <View
+                accessibilityLabel="Section 2"
+                style={
+                  Array [
+                    Object {
+                      "flexDirection": "column",
+                    },
+                    Object {
+                      "marginRight": 0,
+                      "width": 206.66666666666666,
+                    },
+                  ]
+                }
+              />
+            </View>
+          </View>
         </View>
-      </RCTScrollView>
+      </View>
     </View>
+    <View
+      style={
+        Object {
+          "height": 0,
+        }
+      }
+    />
   </View>
 </RCTScrollView>
 `;
 
 exports[`with notifications lays out correctly on small screens 1`] = `
 <RCTScrollView
-  contentContainerStyle={Object {}}
+  ItemSeparatorComponent={[Function]}
+  ListEmptyComponent={[Function]}
+  ListFooterComponent={null}
+  data={
+    Array [
+      Object {
+        "node": Object {
+          "artists": "Jean-Michel Basquiat",
+          "artworks": Object {
+            "edges": Array [
+              Object {
+                "node": Object {
+                  "title": "Anti-Product Postcard",
+                },
+              },
+            ],
+          },
+          "image": Object {
+            "resized": Object {
+              "url": "cloudfront.url",
+            },
+          },
+          "summary": "1 Work Added",
+        },
+      },
+      Object {
+        "node": Object {
+          "artists": "Ana Mendieta",
+          "artworks": Object {
+            "edges": Array [
+              Object {
+                "node": Object {
+                  "title": "Corazón de Roca con Sangre",
+                },
+              },
+              Object {
+                "node": Object {
+                  "title": "Butterfly",
+                },
+              },
+            ],
+          },
+          "image": Object {
+            "resized": Object {
+              "url": "cloudfront.url",
+            },
+          },
+          "summary": "2 Works Added",
+        },
+      },
+    ]
+  }
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onContentSizeChange={[Function]}
+  onEndReached={[Function]}
+  onEndReachedThreshold={2}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
   onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
   refreshControl={
     <RefreshControlMock
       onRefresh={[Function]}
       refreshing={false}
     />
   }
-  scrollEventThrottle={100}
+  removeClippedSubviews={false}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  updateCellsBatchingPeriod={50}
+  viewabilityConfigCallbackPairs={Array []}
+  windowSize={21}
 >
   <RCTRefreshControl />
   <View>
     <View
-      style={
-        Object {
-          "flex": 1,
-        }
-      }
+      onLayout={[Function]}
+      style={null}
     >
-      <RCTScrollView
-        ItemSeparatorComponent={[Function]}
-        ListFooterComponent={[Function]}
-        data={
-          Array [
-            Object {
-              "node": Object {
-                "artists": "Jean-Michel Basquiat",
-                "artworks": Object {
-                  "edges": Array [
-                    Object {
-                      "title": "Anti-Product Postcard",
-                    },
-                  ],
-                },
-                "image": Object {
-                  "resized": Object {
-                    "url": "cloudfront.url",
-                  },
-                },
-                "summary": "1 Work Added",
-              },
-            },
-            Object {
-              "node": Object {
-                "artists": "Ana Mendieta",
-                "artworks": Object {
-                  "edges": Array [
-                    Object {
-                      "title": "Corazón de Roca con Sangre",
-                    },
-                    Object {
-                      "title": "Butterfly",
-                    },
-                  ],
-                },
-                "image": Object {
-                  "resized": Object {
-                    "url": "cloudfront.url",
-                  },
-                },
-                "summary": "2 Works Added",
-              },
-            },
-          ]
+      <View
+        style={
+          Object {
+            "marginHorizontal": 20,
+            "marginTop": 20,
+          }
         }
-        disableVirtualization={false}
-        getItem={[Function]}
-        getItemCount={[Function]}
-        horizontal={false}
-        initialNumToRender={10}
-        keyExtractor={[Function]}
-        maxToRenderPerBatch={10}
-        numColumns={1}
-        onContentSizeChange={[Function]}
-        onEndReachedThreshold={2}
-        onLayout={[Function]}
-        onMomentumScrollEnd={[Function]}
-        onScroll={[Function]}
-        onScrollBeginDrag={[Function]}
-        onScrollEndDrag={[Function]}
-        removeClippedSubviews={false}
-        renderItem={[Function]}
-        scrollEnabled={false}
-        scrollEventThrottle={50}
-        stickyHeaderIndices={Array []}
-        updateCellsBatchingPeriod={50}
-        viewabilityConfigCallbackPairs={Array []}
-        windowSize={21}
       >
-        <View>
-          <View
-            onLayout={[Function]}
-            style={null}
-          >
-            <View
-              style={
-                Object {
-                  "marginLeft": 20,
-                  "marginRight": 20,
-                  "marginTop": 20,
-                }
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Image
+            source={
+              Object {
+                "uri": "cloudfront.url",
               }
-            >
-              <View
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
-                style={
-                  Object {
-                    "flexDirection": "row",
-                  }
-                }
-              >
-                <Image
-                  source={
-                    Object {
-                      "uri": "cloudfront.url",
-                    }
-                  }
-                  style={
-                    Object {
-                      "alignSelf": "center",
-                      "backgroundColor": "#f8f8f8",
-                      "borderRadius": 20,
-                      "height": 40,
-                      "marginRight": 10,
-                      "width": 40,
-                    }
-                  }
-                />
-                <View
-                  style={
-                    Object {
-                      "alignSelf": "center",
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <Text
-                    style={
-                      Array [
-                        Object {
-                          "fontSize": 12,
-                        },
-                        Object {
-                          "fontFamily": "AvantGardeGothicITC",
-                        },
-                        Object {
-                          "fontSize": 12,
-                        },
-                      ]
-                    }
-                  >
-                    JEAN-MICHEL BASQUIAT
-                  </Text>
-                  <Text
-                    numberOfLines={1}
-                    style={
-                      Array [
-                        Object {
-                          "fontSize": 17,
-                        },
-                        Object {
-                          "color": "#666666",
-                          "fontSize": 14,
-                          "marginTop": 2,
-                        },
-                        Object {
-                          "fontFamily": "AGaramondPro-Regular",
-                        },
-                      ]
-                    }
-                  >
-                    1 Work Added
-                  </Text>
-                </View>
-              </View>
-              <View
-                style={
-                  Object {
-                    "marginBottom": 20,
-                    "marginTop": 20,
-                  }
-                }
-              >
-                <View
-                  onLayout={[Function]}
-                >
-                  <View
-                    accessibilityLabel="Artworks Content View"
-                    style={
-                      Object {
-                        "flexDirection": "row",
-                      }
-                    }
-                  />
-                </View>
-              </View>
-            </View>
-            <View
-              px={2}
+            }
+            style={
+              Object {
+                "alignSelf": "center",
+                "backgroundColor": "#f8f8f8",
+                "borderRadius": 20,
+                "height": 40,
+                "marginRight": 10,
+                "width": 40,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "alignSelf": "center",
+                "flex": 1,
+              }
+            }
+          >
+            <Text
               style={
                 Array [
                   Object {
-                    "paddingLeft": 20,
-                    "paddingRight": 20,
+                    "fontSize": 12,
+                  },
+                  Object {
+                    "fontFamily": "AvantGardeGothicITC",
+                  },
+                  Object {
+                    "fontSize": 12,
                   },
                 ]
               }
             >
-              <View
-                style={
-                  Array [
-                    Object {
-                      "borderBottomWidth": 0,
-                      "borderColor": "#E5E5E5",
-                      "borderStyle": "solid",
-                      "borderWidth": 1,
-                      "width": "100%",
-                    },
-                  ]
-                }
-                width="100%"
-              />
-            </View>
+              JEAN-MICHEL BASQUIAT
+            </Text>
+            <Text
+              numberOfLines={1}
+              style={
+                Array [
+                  Object {
+                    "fontSize": 17,
+                  },
+                  Object {
+                    "color": "#666666",
+                    "fontSize": 14,
+                    "marginTop": 2,
+                  },
+                  Object {
+                    "fontFamily": "AGaramondPro-Regular",
+                  },
+                ]
+              }
+            >
+              1 Work Added
+            </Text>
           </View>
+        </View>
+        <View
+          style={
+            Object {
+              "marginBottom": 20,
+              "marginTop": 20,
+            }
+          }
+        >
           <View
             onLayout={[Function]}
-            style={null}
           >
             <View
+              accessibilityLabel="Artworks Content View"
               style={
                 Object {
-                  "marginLeft": 20,
-                  "marginRight": 20,
-                  "marginTop": 20,
+                  "flexDirection": "row",
                 }
               }
             >
               <View
-                accessible={true}
-                focusable={true}
-                onClick={[Function]}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
+                accessibilityLabel="Section 0"
                 style={
-                  Object {
-                    "flexDirection": "row",
-                  }
+                  Array [
+                    Object {
+                      "flexDirection": "column",
+                    },
+                    Object {
+                      "marginRight": 20,
+                      "width": 20,
+                    },
+                  ]
                 }
-              >
-                <Image
-                  source={
-                    Object {
-                      "uri": "cloudfront.url",
-                    }
-                  }
-                  style={
-                    Object {
-                      "alignSelf": "center",
-                      "backgroundColor": "#f8f8f8",
-                      "borderRadius": 20,
-                      "height": 40,
-                      "marginRight": 10,
-                      "width": 40,
-                    }
-                  }
-                />
-                <View
-                  style={
-                    Object {
-                      "alignSelf": "center",
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <Text
-                    style={
-                      Array [
-                        Object {
-                          "fontSize": 12,
-                        },
-                        Object {
-                          "fontFamily": "AvantGardeGothicITC",
-                        },
-                        Object {
-                          "fontSize": 12,
-                        },
-                      ]
-                    }
-                  >
-                    ANA MENDIETA
-                  </Text>
-                  <Text
-                    numberOfLines={1}
-                    style={
-                      Array [
-                        Object {
-                          "fontSize": 17,
-                        },
-                        Object {
-                          "color": "#666666",
-                          "fontSize": 14,
-                          "marginTop": 2,
-                        },
-                        Object {
-                          "fontFamily": "AGaramondPro-Regular",
-                        },
-                      ]
-                    }
-                  >
-                    2 Works Added
-                  </Text>
-                </View>
-              </View>
+              />
               <View
+                accessibilityLabel="Section 1"
                 style={
-                  Object {
-                    "marginBottom": 20,
-                    "marginTop": 20,
-                  }
+                  Array [
+                    Object {
+                      "flexDirection": "column",
+                    },
+                    Object {
+                      "marginRight": 0,
+                      "width": 20,
+                    },
+                  ]
                 }
-              >
-                <View
-                  onLayout={[Function]}
-                >
-                  <View
-                    accessibilityLabel="Artworks Content View"
-                    style={
-                      Object {
-                        "flexDirection": "row",
-                      }
-                    }
-                  />
-                </View>
-              </View>
+              />
             </View>
           </View>
+        </View>
+      </View>
+      <View
+        px={2}
+        style={
+          Array [
+            Object {
+              "paddingLeft": 20,
+              "paddingRight": 20,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "borderBottomWidth": 0,
+                "borderColor": "#E5E5E5",
+                "borderStyle": "solid",
+                "borderWidth": 1,
+                "width": "100%",
+              },
+            ]
+          }
+          width="100%"
+        />
+      </View>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        style={
+          Object {
+            "marginHorizontal": 20,
+            "marginTop": 20,
+          }
+        }
+      >
+        <View
+          accessible={true}
+          focusable={true}
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "flexDirection": "row",
+            }
+          }
+        >
+          <Image
+            source={
+              Object {
+                "uri": "cloudfront.url",
+              }
+            }
+            style={
+              Object {
+                "alignSelf": "center",
+                "backgroundColor": "#f8f8f8",
+                "borderRadius": 20,
+                "height": 40,
+                "marginRight": 10,
+                "width": 40,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "alignSelf": "center",
+                "flex": 1,
+              }
+            }
+          >
+            <Text
+              style={
+                Array [
+                  Object {
+                    "fontSize": 12,
+                  },
+                  Object {
+                    "fontFamily": "AvantGardeGothicITC",
+                  },
+                  Object {
+                    "fontSize": 12,
+                  },
+                ]
+              }
+            >
+              ANA MENDIETA
+            </Text>
+            <Text
+              numberOfLines={1}
+              style={
+                Array [
+                  Object {
+                    "fontSize": 17,
+                  },
+                  Object {
+                    "color": "#666666",
+                    "fontSize": 14,
+                    "marginTop": 2,
+                  },
+                  Object {
+                    "fontFamily": "AGaramondPro-Regular",
+                  },
+                ]
+              }
+            >
+              2 Works Added
+            </Text>
+          </View>
+        </View>
+        <View
+          style={
+            Object {
+              "marginBottom": 20,
+              "marginTop": 20,
+            }
+          }
+        >
           <View
             onLayout={[Function]}
-          />
+          >
+            <View
+              accessibilityLabel="Artworks Content View"
+              style={
+                Object {
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <View
+                accessibilityLabel="Section 0"
+                style={
+                  Array [
+                    Object {
+                      "flexDirection": "column",
+                    },
+                    Object {
+                      "marginRight": 20,
+                      "width": 20,
+                    },
+                  ]
+                }
+              />
+              <View
+                accessibilityLabel="Section 1"
+                style={
+                  Array [
+                    Object {
+                      "flexDirection": "column",
+                    },
+                    Object {
+                      "marginRight": 0,
+                      "width": 20,
+                    },
+                  ]
+                }
+              />
+            </View>
+          </View>
         </View>
-      </RCTScrollView>
+      </View>
     </View>
+    <View
+      style={
+        Object {
+          "height": 0,
+        }
+      }
+    />
   </View>
 </RCTScrollView>
 `;
 
 exports[`without notifications lays out correctly on larger screens 1`] = `
 <RCTScrollView
-  contentContainerStyle={
-    Object {
-      "flex": 1,
-    }
-  }
+  ItemSeparatorComponent={[Function]}
+  ListEmptyComponent={[Function]}
+  ListFooterComponent={null}
+  data={Array []}
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onContentSizeChange={[Function]}
+  onEndReached={[Function]}
+  onEndReachedThreshold={2}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
   onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
   refreshControl={
     <RefreshControlMock
       onRefresh={[Function]}
       refreshing={false}
     />
   }
-  scrollEventThrottle={100}
+  removeClippedSubviews={false}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  updateCellsBatchingPeriod={50}
+  viewabilityConfigCallbackPairs={Array []}
+  windowSize={21}
 >
   <RCTRefreshControl />
   <View>
     <View
       style={
-        Object {
-          "flex": 1,
-        }
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
+            "height": "100%",
+            "justifyContent": "center",
+            "marginLeft": 20,
+            "marginRight": 20,
+            "paddingBottom": 30,
+            "paddingLeft": 30,
+            "paddingRight": 30,
+          },
+        ]
       }
     >
-      <View
+      <Text
         style={
           Array [
             Object {
-              "alignItems": "center",
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
-              "height": "100%",
-              "justifyContent": "center",
-              "marginLeft": 20,
-              "marginRight": 20,
-              "paddingBottom": 30,
-              "paddingLeft": 30,
-              "paddingRight": 30,
+              "fontFamily": "ReactNativeAGaramondPro-Regular",
+              "fontSize": 30,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "textAlign": "center",
             },
           ]
         }
       >
-        <Text
-          style={
-            Array [
-              Object {
-                "fontFamily": "ReactNativeAGaramondPro-Regular",
-                "fontSize": 30,
-                "marginLeft": 10,
-                "marginRight": 10,
-                "textAlign": "center",
-              },
-            ]
-          }
-        >
-          You haven’t followed any artists yet.
-        </Text>
-        <Text
-          numberOfLines={0}
-          style={
-            Array [
-              Object {
-                "fontFamily": "ReactNativeAGaramondPro-Regular",
-                "fontSize": 18,
-                "marginTop": 10,
-                "textAlign": "center",
-              },
-            ]
-          }
-        >
-          Follow artists to see new works that have been added to Artsy
-        </Text>
-      </View>
+        You haven’t followed any artists yet.
+      </Text>
+      <Text
+        numberOfLines={0}
+        style={
+          Array [
+            Object {
+              "fontFamily": "ReactNativeAGaramondPro-Regular",
+              "fontSize": 18,
+              "marginTop": 10,
+              "textAlign": "center",
+            },
+          ]
+        }
+      >
+        Follow artists to see new works that have been added to Artsy
+      </Text>
     </View>
   </View>
 </RCTScrollView>
@@ -802,79 +944,91 @@ exports[`without notifications lays out correctly on larger screens 1`] = `
 
 exports[`without notifications lays out correctly on small screens 1`] = `
 <RCTScrollView
-  contentContainerStyle={
-    Object {
-      "flex": 1,
-    }
-  }
+  ItemSeparatorComponent={[Function]}
+  ListEmptyComponent={[Function]}
+  ListFooterComponent={null}
+  data={Array []}
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onContentSizeChange={[Function]}
+  onEndReached={[Function]}
+  onEndReachedThreshold={2}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
   onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
   refreshControl={
     <RefreshControlMock
       onRefresh={[Function]}
       refreshing={false}
     />
   }
-  scrollEventThrottle={100}
+  removeClippedSubviews={false}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  updateCellsBatchingPeriod={50}
+  viewabilityConfigCallbackPairs={Array []}
+  windowSize={21}
 >
   <RCTRefreshControl />
   <View>
     <View
       style={
-        Object {
-          "flex": 1,
-        }
+        Array [
+          Object {
+            "alignItems": "center",
+            "flexBasis": 0,
+            "flexGrow": 1,
+            "flexShrink": 1,
+            "height": "100%",
+            "justifyContent": "center",
+            "marginLeft": 20,
+            "marginRight": 20,
+            "paddingBottom": 30,
+            "paddingLeft": 30,
+            "paddingRight": 30,
+          },
+        ]
       }
     >
-      <View
+      <Text
         style={
           Array [
             Object {
-              "alignItems": "center",
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
-              "height": "100%",
-              "justifyContent": "center",
-              "marginLeft": 20,
-              "marginRight": 20,
-              "paddingBottom": 30,
-              "paddingLeft": 30,
-              "paddingRight": 30,
+              "fontFamily": "ReactNativeAGaramondPro-Regular",
+              "fontSize": 30,
+              "marginLeft": 10,
+              "marginRight": 10,
+              "textAlign": "center",
             },
           ]
         }
       >
-        <Text
-          style={
-            Array [
-              Object {
-                "fontFamily": "ReactNativeAGaramondPro-Regular",
-                "fontSize": 30,
-                "marginLeft": 10,
-                "marginRight": 10,
-                "textAlign": "center",
-              },
-            ]
-          }
-        >
-          You haven’t followed any artists yet.
-        </Text>
-        <Text
-          numberOfLines={0}
-          style={
-            Array [
-              Object {
-                "fontFamily": "ReactNativeAGaramondPro-Regular",
-                "fontSize": 18,
-                "marginTop": 10,
-                "textAlign": "center",
-              },
-            ]
-          }
-        >
-          Follow artists to see new works that have been added to Artsy
-        </Text>
-      </View>
+        You haven’t followed any artists yet.
+      </Text>
+      <Text
+        numberOfLines={0}
+        style={
+          Array [
+            Object {
+              "fontFamily": "ReactNativeAGaramondPro-Regular",
+              "fontSize": 18,
+              "marginTop": 10,
+              "textAlign": "center",
+            },
+          ]
+        }
+      >
+        Follow artists to see new works that have been added to Artsy
+      </Text>
     </View>
   </View>
 </RCTScrollView>


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/MX-248

Thanks to @alloy for discovering this bug  🙌 

The problem was

1. the `GenericGrid` component initially renders with a height of 0, then measures it's own width before populating the grid with artworks.
2. in `WorksForYou` (Artists tab on home screen) `GenericGrid`s were being rendered in a `FlatList`
3. When you scroll far enough in a `FlatList` things that are off-screen will be unmounted and removed. When you scroll back they will be mounted and shown again.
4. When a component re-mounts with a different height `FlatList` rightly adjusts the top offset of succeeding items to match.
5. Scrolling far down in `WorksForYou` and then scrolling back up was a disco funky janky mess.

This has been a problem since the recent react-native upgrade when all of our `ListView` components were refactored to use `FlatList`. `WorksForYou` was one of those.

The solution: calculate the width at a higher level and pass it down to the `GenericGrid` instances so they can do their layout synchronously on first render. 