### PR TITLE
Changelog update for 6.3.3 #trivial

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.3.2</string>
+	<string>6.3.3</string>
 	<key>CFBundleVersion</key>
 	<string>2019.05.24.09</string>
 	<key>NSExtension</key>

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.3.2</string>
+	<string>6.3.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,20 +1,25 @@
 upcoming:
-  version: 6.3.2
+  version: 6.3.3
   date: TBD
-  emission_version: 1.21.49
   dev:
-    - Combine emission and eigen into one repo - david
-    - Update sentry, add patch - ash, brian, david
-    - Fixes cacheMiddleware to allow ArtworkMarkAsRecentlyViewedQuery mutations without clearing cache - ash
-    - Untrack the query map and emission assets folder - david
+    -
   user_facing:
-    - Removes generic genes from For You tab - ash
-    - Fix WSODs related to markdown elements not being supported in ReadMore - david
-    - Fix grid.artworks null pointer bug - david
-    - Fixes issue with create password screen saying you needed 6 character but you need 8 - ash
     - Fix bug where the `Artists` tab scroll view would jump around while scrolling - david
 
 releases:
+  - version: 6.3.2
+    date: Mar 4, 2020
+    dev:
+      - Combine emission and eigen into one repo - david
+      - Update sentry, add patch - ash, brian, david
+      - Fixes cacheMiddleware to allow ArtworkMarkAsRecentlyViewedQuery mutations without clearing cache - ash
+      - Untrack the query map and emission assets folder - david
+    user_facing:
+      - Removes generic genes from For You tab - ash
+      - Fix WSODs related to markdown elements not being supported in ReadMore - david
+      - Fix grid.artworks null pointer bug - david
+      - Fixes issue with create password screen saying you needed 6 character but you need 8 - ash
+
   - version: 6.3.1
     date: Feb 27, 2020
     emission_version: 1.21.49

--- a/docs/deploy_to_app_store.md
+++ b/docs/deploy_to_app_store.md
@@ -30,7 +30,7 @@ Our App Store releases are done manually, instead of automatically once Apple ap
 1. Create a new version of the app in AppStoreConnect (if you don't do this, beta deployments will fail).
    - Go to "My Apps", click Eigen ("Artsy: Buy & Sell Original Art"), click "+ version or platform", click "iOS", and enter version number.
 1. Run `make next`. This prompts for the next version number. **Use the same version** as the previous step.
-1. Move the release from `upcoming` to `releases` in `CHANGELOG.yml` and add a new, empty entry under `upcoming`. Make sure the `date` and `emission_version` entries are accurate. [Here is a previous commit](https://github.com/artsy/eigen/commit/580db98fa1165e01f81070e9bbc77598a47bcfc9#diff-96801928eca93eea4a5b44f359b868b5).
+1. Move the release from `upcoming` to `releases` in `CHANGELOG.yml` and add a new, empty entry under `upcoming`. Make sure the `date` is accurate. [Here is a previous commit](https://github.com/artsy/eigen/commit/580db98fa1165e01f81070e9bbc77598a47bcfc9#diff-96801928eca93eea4a5b44f359b868b5).
 1. Add and commit the changed files, typically with `-m "Preparing for development, version X.Y.Z."`.
 1. Run `make deploy` to trigger a new beta. (When we add a new version, the first beta goes through additional TestFlight review by Apple. By trigger the beta now, we go through that review early, and avoid delaying future QA sessions.)
 1. PR your changes back into the `master` branch.


### PR DESCRIPTION
I created the new version in AppStoreConnect, and moved the changelog around to account for what we released. Since `emission_version` is no longer a thing, I removed it from the new version and the docs. Self-merging as this will block other PRs (otherwise their changelog entries will be under the wrong version). 