### PR TITLE
Fixes App Store promotion script #trivial

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require 'yaml'
 require 'spaceship'
 require 'fileutils'
 
-APP_ID = 'net.artsy.artsy'.freeze
+APP_ID = 'net.artsy.artsy'
 
 before_all do
   setup_circle_ci
@@ -17,7 +19,7 @@ lane :ship_beta do
   latest_version = readme_data['upcoming']['version']
 
   client = Spaceship::Tunes.login(ENV['FASTLANE_USERNAME'], ENV['FASTLANE_PASSWORD'])
-  client.team_id = "479887"
+  client.team_id = '479887'
   app = Spaceship::Tunes::Application.find('net.artsy.artsy')
 
   # Fail early if we need to make a new version on iTunes
@@ -51,7 +53,7 @@ lane :ship_beta do
 
   build_ios_app(configuration: 'Store')
 
-  root = File.expand_path('../..', __FILE__)
+  root = File.expand_path('..', __dir__)
   bundle_version = `/usr/libexec/PlistBuddy -c "print CFBundleVersion" #{File.join(root, 'Artsy/App_Resources/Artsy-Info.plist')}`.strip
   tag_and_push(tag: "#{latest_version}-#{bundle_version}")
 
@@ -76,31 +78,30 @@ lane :ship_beta do
                          org_slug: org_slug,
                          project_slug: project_slug,
                          dsym_path: dsym_path
-                         puts "Uploaded dsym for #{project_slug}"
+      puts "Uploaded dsym for #{project_slug}"
     end
 
     begin
       sentry_upload_file auth_token: ENV['SentryUploadAuthKey'],
-      org_slug: org_slug,
-      project_slug: project_slug,
-      version: sentry_version,
-      dist: bundle_version,
-      file: 'emission/Pod/Assets/Emission.js'
+                         org_slug: org_slug,
+                         project_slug: project_slug,
+                         version: sentry_version,
+                         dist: bundle_version,
+                         file: 'emission/Pod/Assets/Emission.js'
       puts "Uploaded Emission.js for #{project_slug}"
 
       sentry_upload_sourcemap auth_token: ENV['SentryUploadAuthKey'],
-      org_slug: org_slug,
-      project_slug: project_slug,
-      version: sentry_version,
-      dist: bundle_version,
-      sourcemap: 'emission/Pod/Assets/Emission.js.map',
-      rewrite: true
+                              org_slug: org_slug,
+                              project_slug: project_slug,
+                              version: sentry_version,
+                              dist: bundle_version,
+                              sourcemap: 'emission/Pod/Assets/Emission.js.map',
+                              rewrite: true
       puts "Uploaded Emission.js.map for #{project_slug}"
-
-    rescue => exception
-      puts "Uploading the JS to sentry failed, this usually only happens when you are shipping many builds to sentry"
-      puts exception.message
-      puts exception.backtrace.join("\n\t")
+    rescue StandardError => e
+      puts 'Uploading the JS to sentry failed, this usually only happens when you are shipping many builds to sentry'
+      puts e.message
+      puts e.backtrace.join("\n\t")
     end
   end
 
@@ -112,18 +113,18 @@ lane :ship_beta do
 
   # Send to the app store
   pilot changelog: beta_readme,
-    itc_provider: 'ArtsyInc',
-    distribute_external: true,
-    groups: ["Artsy"]
+        itc_provider: 'ArtsyInc',
+        distribute_external: true,
+        groups: ['Artsy']
 end
 
 lane :promote_beta do
   client = Spaceship::Tunes.login(ENV['FASTLANE_USERNAME'], ENV['FASTLANE_PASSWORD'])
-  client.team_id = "479887"
+  client.team_id = '479887'
   app = Spaceship::Tunes::Application.find('net.artsy.artsy')
 
-  # app.builds are listed most recently first; we are assuming that we're shipping the most recent beta.
-  beta = app.builds.first
+  # app.builds are listed most recent last; we are assuming that we're shipping the most recent beta.
+  beta = app.builds.last
 
   puts "Let's deliver beta #{beta.train_version} (#{beta.build_version}) with build number #{latest_testflight_build_number}."
   deliver(
@@ -153,19 +154,26 @@ lane :promote_beta do
     }
   )
 
-  puts "Tagging submission and pushing to GitHub."
-  tag_and_push(tag: "#{beta.train_version}-#{beta.build_version}-submission")
+  puts 'Tagging submission and pushing to GitHub.'
+  target_object = "#{beta.train_version}-#{beta.build_version}" # This is computed, we expect it to exist.
+  tag_and_push(tag: "#{original_tag}-submission", target_object: original_tag)
 
-  puts "All done."
+  puts 'All done.'
 end
 
 lane :tag_and_push do |options|
   # Do a tag, we use a http git remote so we can have push access
   # as the default remote for circle is read-only
   tag = options[:tag]
+  target_object = options[:target_object]
   `git tag -d "#{tag}"`
 
-  add_git_tag tag: tag
+  # Allow older commits to get tagged, when promoting to submission.
+  if target_object
+    add_git_tag tag: tag, commit: target_object, message: "Promoting #{tag} to App Store submission"
+  else
+    add_git_tag tag: tag
+  end
   `git remote add http https://github.com/artsy/eigen.git`
   `git push http #{tag} -f`
 end


### PR DESCRIPTION
Prettier changed a bunch of formatting in the `Fastfile` but I didn't notice in time to isolate the changes 😒 At least it's a good demonstration of what Prettier considers "good" Ruby style!

Anyway. I have noticed that we have this one release, `1.6.0-2015.1.5-submission`, that lingers near the top of [Eigen's releases](https://github.com/artsy/eigen/releases). 

![Screen Shot 2020-03-05 at 16 23 24](https://user-images.githubusercontent.com/498212/76027924-80468c80-5eff-11ea-8ff0-bfd59a552089.png)

I took a look and we were constantly re-tagging the _first_ ever releases through TestFlight, instead of the most recent one. Whoopsie. (I'm not entirely willing to take the blame on this, it could be that Apple's APIs reversed the order of their responses at some point.)

What's more, the commit that we're targeting as the submission to the App Store is technically the commit that ran on CI _to_ submit, and not the commit of the beta that we are actually submitting. Since the tags use a predictable format (`version-build_number`) we can compute the tag we used to submit the beta, and then target that as the commit to tag for the submission. Neat!