### PR TITLE
Stop caching derived_data on ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,21 +129,12 @@ jobs:
             - Pods
 
       - run:
-          name: Generate native code checksum
-          command: node scripts/generate-native-code-checksum.js
-
-      - restore_cache:
-          keys:
-            - v4-derived-data-{{ checksum "native-code-checksum.hash" }}
-
-      - run:
           name: Pre-Build App
           command: make ci
 
-      - save_cache:
-          key: v4-derived-data-{{ checksum "native-code-checksum.hash" }}
-          paths:
-            - derived_data
+      - run:
+          name: Generate native code checksum
+          command: node scripts/generate-native-code-checksum.js
 
       - restore_cache:
           keys:

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ Artsy/Networking/ARReactPackagerHost.m
 # COPIED FROM EMISSION
 
 # Xcode
+xcode_build_raw.log
 
 ## Build generated
 dist


### PR DESCRIPTION
~So it turns out that the reason this wasn't working is that xcode detects file changes by inspecting the 'last modified' timestamp of files. Circle's cache restoration does not preserve those timestamps so xcode thinks everything has changed since the last build and rebuilds everything.~

~[this blogpost](https://medium.com/@bitrise/60-faster-builds-force-xcode-to-use-caching-on-bitrise-af8979ca39a6) says you can fix this by just resetting the timestamps, so in this PR I made a script which saves the timestamps before saving the cache, then restores the timestamps after restoring the cache.~

as mentioned [on slack](https://artsy.slack.com/archives/CN8S32FJR/p1583512314109700?thread_ts=1583428005.089000&cid=CN8S32FJR) this was proving to be a serious rabbit hole with no clear evidence that there was a way out, so it doesn't make sense to keep this caching if it's not helping with build times 😞 

#trivial