### PR TITLE
Use static width for GenericGrid on Fairs page

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
   dev:
     - Reduce number of images for initial render of for-you page - david
   user_facing:
+    - Fix bug where the Fair page scroll view would jump around while scrolling - david
     - Fix bug where the `Artists` tab scroll view would jump around while scrolling - david
     - Replace for-you artwork carousel with horizontal rail - david
     - Refresh for-you header styling - david

--- a/src/lib/Scenes/Fair/Components/FairBoothPreview/index.tsx
+++ b/src/lib/Scenes/Fair/Components/FairBoothPreview/index.tsx
@@ -12,6 +12,7 @@ import { FairBoothPreviewHeader } from "./Components/FairBoothPreviewHeader"
 interface Props {
   show: FairBoothPreview_show
   relay: RelayProp
+  width: number
 }
 
 interface State {
@@ -162,7 +163,7 @@ export class FairBoothPreview extends React.Component<Props, State> {
           url={coverImage && coverImage.url}
           onViewFairBoothPressed={this.viewFairBoothPressed.bind(this)}
         />
-        <Box mt={1}>{<GenericGrid artworks={artworks.edges.map(a => a.node) as any} />}</Box>
+        <Box mt={1}>{<GenericGrid width={this.props.width} artworks={artworks.edges.map(a => a.node) as any} />}</Box>
         <Box mt={2}>
           <CaretButton
             text={artworkCount > 1 ? `View all ${artworkCount} works` : `View 1 work`}

--- a/src/lib/data/constants.ts
+++ b/src/lib/data/constants.ts
@@ -1,2 +1,2 @@
 export const PAGE_SIZE = 10
-export const FAIR_SHOW_PAGE_SIZE = 5
+export const FAIR_SHOW_PAGE_SIZE = 20


### PR DESCRIPTION
This is the only other place where `GenericGrid` could cause glitchy scrolling... for now  👀 It would be good to find some other way of laying out images. I *think* it's possible to do without knowing width as long as we know the image aspect ratios.