### PR TITLE
Fixes WSOD on home feed with artworks that have missing images #trivial

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,6 +3,7 @@ upcoming:
   date: TBD
   dev:
     - Reduce number of images for initial render of for-you page - david
+    - Fixes WSOD on home feed with artworks that have missing images - ash
   user_facing:
     - Fix bug where the Fair page scroll view would jump around while scrolling - david
     - Fix bug where the `Artists` tab scroll view would jump around while scrolling - david

--- a/src/lib/Scenes/Home/Components/ForYou/Components/ArtworkRail.tsx
+++ b/src/lib/Scenes/Home/Components/ForYou/Components/ArtworkRail.tsx
@@ -64,13 +64,13 @@ const ArtworkRail: React.FC<{ rail: ArtworkRail_rail }> = ({ rail }) => {
           renderItem={({ item }) => (
             <TouchableHighlight onPress={() => SwitchBoard.presentNavigationViewController(railRef.current, item.href)}>
               <OpaqueImageView
-                imageURL={item.image.imageURL.replace(":version", "square")}
+                imageURL={item.image?.imageURL.replace(":version", "square")}
                 width={RAIL_HEIGHT}
                 height={RAIL_HEIGHT}
               ></OpaqueImageView>
             </TouchableHighlight>
           )}
-          keyExtractor={item => String(item.image.imageURL)}
+          keyExtractor={(item, index) => String(item.image?.imageURL || index)}
         />
       </View>
     </Theme>


### PR DESCRIPTION
Noticed this while developing locally. Love the new short-circuiting operator! 