### PR TITLE
[MX-255] Fixes problem where artist follows on Artist page weren't being tracked

### DIFF
--- a/Artsy/App/ARAppDelegate+Analytics.m
+++ b/Artsy/App/ARAppDelegate+Analytics.m
@@ -29,7 +29,6 @@
 
 // View Controllers
 #import "ARProfileViewController.h"
-#import <Emission/ARArtworkComponentViewController.h>
 #import "ARInternalMobileWebViewController.h"
 #import "ARSignUpSplashViewController.h"
 #import "ARPersonalizeViewController.h"
@@ -46,7 +45,6 @@
 #import "ARAugmentedFloorBasedVIRViewController.h"
 
 #import <Emission/ARWorksForYouComponentViewController.h>
-#import <Emission/ARArtistComponentViewController.h>
 #import <Emission/ARGeneComponentViewController.h>
 
 // Views
@@ -558,20 +556,6 @@
                     ]
                 }, // ========== PRIMARY NAVIGATION ==========
                 // ========== CORE CONTENT SCREENS ==========
-                @{
-                    ARAnalyticsClass: ARArtistComponentViewController.class,
-                    ARAnalyticsDetails: @[
-                        @{
-                            ARAnalyticsPageName: @"Artist",
-                            ARAnalyticsProperties: ^NSDictionary *(ARArtistComponentViewController *controller, NSArray *_) {
-                                return @{
-                                     @"owner_type": @"artist",
-                                     @"owner_slug": controller.artistID ?: @""
-                                 };
-                            }
-                        }
-                    ]
-                },
                 @{
                     ARAnalyticsClass: ARGeneComponentViewController.class,
                     ARAnalyticsDetails: @[

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -2,6 +2,7 @@ upcoming:
   version: 6.3.3
   date: TBD
   dev:
+    - Fixes problem where artist follows on Artist page weren't being tracked - ash
     - Reduce number of images for initial render of for-you page - david
   user_facing:
     - Fix bug where the Fair page scroll view would jump around while scrolling - david

--- a/src/lib/Containers/Artist.tsx
+++ b/src/lib/Containers/Artist.tsx
@@ -5,7 +5,7 @@ import ArtistArtworks from "lib/Components/Artist/ArtistArtworks"
 import ArtistHeader from "lib/Components/Artist/ArtistHeader"
 import ArtistShows from "lib/Components/Artist/ArtistShows"
 import { StickyTabPage } from "lib/Components/StickyTabPage/StickyTabPage"
-import { track } from "lib/utils/track"
+import { Schema, screenTrack } from "lib/utils/track"
 import { ProvideScreenDimensions } from "lib/utils/useScreenDimensions"
 import React from "react"
 import { ViewProperties } from "react-native"
@@ -19,8 +19,12 @@ interface State {
   tabs: any[]
 }
 
-// screen views are tracked in eigen
-@track()
+@screenTrack<Props>(props => ({
+  context_screen: Schema.PageNames.ArtistPage,
+  context_screen_owner_type: Schema.OwnerEntityTypes.Artist,
+  context_screen_owner_slug: props.artist.slug,
+  context_screen_owner_id: props.artist.internalID,
+}))
 export class Artist extends React.Component<Props, State> {
   state = {
     tabs: [],


### PR DESCRIPTION
Okay so here's what happened. [This PR](https://github.com/artsy/emission/pull/2058) fixed a problem where we were duplicating tracking events of Artist screen views. Later, I saw a runtime error about a missing `@track` decorator, which I fixed [in this PR](https://github.com/artsy/emission/pull/2062). This fixed the runtime error, but not the underlying problem.

I added `@track`, but `@track` and `@screenTrack` are subtly different. `@screenTrack` includes a `dispatch` argument already, which gets shared down the whole component tree:

https://github.com/artsy/eigen/blob/da03b34416d5f5980cafe79350ac86dba3563471/src/lib/utils/track/index.ts#L142

Without this `dispatch`, tracking will technically fire but those events won't be dispatched anywhere. It seems that `react-tracking` will cascade the `dispatch` down the component tree, so it only needs to get specified at the top-level. Since we weren't specifying it, the entire Artist page tracking (except for screen views themselves, which were still tracked in Objective-C) weren't being tracked.

~[I am confirming with Mike](https://artsy.slack.com/archives/CN8S32FJR/p1583863931136700) that we can move the tracking from Objective-C into JS now, and will remove the `[Hold]` once that's done.~ The less code in `ARAppDelegate+Analytics.m`, the better. 

I learned a lot about how `react-tracking` works, and I don't think I'll make the same mistake again. We've already followed up with a discussion of automating detection of analytics event drop-offs, so the only thing left to do is get this merged (once ready).