### PR TITLE
[MX-240] Consignments ui fixes

### DIFF
--- a/src/lib/Components/Consignments/Components/TextInput.tsx
+++ b/src/lib/Components/Consignments/Components/TextInput.tsx
@@ -1,7 +1,16 @@
 import { Box, color } from "@artsy/palette"
 import { Fonts } from "lib/data/fonts"
 import React, { FunctionComponent } from "react"
-import { ActivityIndicator, Image, ImageURISource, Text, TextInputProperties, View, ViewProperties } from "react-native"
+import {
+  ActivityIndicator,
+  Image,
+  ImageURISource,
+  Text,
+  TextInput,
+  TextInputProperties,
+  View,
+  ViewProperties,
+} from "react-native"
 import styled from "styled-components/native"
 
 interface ReffableTextInputProps extends TextInputProperties {
@@ -53,10 +62,25 @@ const ReadOnlyInput = (props: TextInputProps) => (
 )
 
 export default class TextInputField extends React.Component<TextInputProps, State> {
+  inputRef: TextInput | null
+  timeout: number | null
   constructor(props) {
     super(props)
     this.state = { focused: false }
   }
+
+  componentDidMount() {
+    if (this.props.text?.autoFocus) {
+      this.inputRef?.focus()
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.timeout) {
+      clearTimeout(this.timeout)
+    }
+  }
+
   render() {
     const LocationIcon = this.props.LocationIcon
     return (
@@ -76,12 +100,14 @@ export default class TextInputField extends React.Component<TextInputProps, Stat
             ReadOnlyInput(this.props)
           ) : (
             <Input
+              ref={ref => (this.inputRef = ref)}
               autoCorrect={false}
               clearButtonMode="while-editing"
               keyboardAppearance="dark"
               placeholderTextColor={color("black60")}
               selectionColor={color("black60")}
               {...this.props.text}
+              autoFocus={false}
               onFocus={e =>
                 this.setState(
                   { focused: true },

--- a/src/lib/Components/Consignments/Screens/Metadata.tsx
+++ b/src/lib/Components/Consignments/Screens/Metadata.tsx
@@ -128,7 +128,7 @@ export default class Metadata extends React.Component<Props, State> {
       <Theme>
         <View style={{ flex: 1 }}>
           <BottomAlignedButton onPress={this.doneTapped} buttonText="Done">
-            <ScrollView keyboardShouldPersistTaps="handled" centerContent>
+            <ScrollView keyboardShouldPersistTaps="handled" centerContent style={{ flex: 1 }}>
               <View style={{ padding: 10 }}>
                 <Row>
                   <Text


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/MX-240

- Fix a bug where navigator push transitions were duplicated, by making sure `.focus` is called on a TextInput synchronously after mounting rather than during the transition animation (though not sure why the animation was being restarted as a result of that. The animation was handled by CA so I didn't feel it was worth digging into.)
- Fix another bug I found where the submit button on the Metadata step of the consignments flow was being hidden behind the keyboard.

Before:

![image](https://user-images.githubusercontent.com/1242537/76886773-2a67d200-6879-11ea-9ce1-f9ff4808feee.png)

After:

![image](https://user-images.githubusercontent.com/1242537/76886813-3489d080-6879-11ea-94d5-b00a8456d3c8.png)
