### PR TITLE
Fixes the update-metaphysics circle job #trivial

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
             - "23:11:82:24:bb:cb:a8:1e:7a:eb:b1:f3:d6:e1:55:32"
       - run:
           name: Generate node_modules checksum
-          command: cat yarn.lock patches/* | md5 > node_modules.hash
+          command: cat yarn.lock patches/* | md5sum > node_modules.hash
 
       - restore_cache:
           keys:


### PR DESCRIPTION
I noticed this was failing: https://circleci.com/gh/artsy/eigen/7398

Seems like Linux (which we use for that job) uses a different command name for generating md5 hashes. TIL!