### PR TITLE
[MX-202] Updates tracking for tapping recent search results #trivial

### DIFF
--- a/src/lib/Components/Consignments/Components/__tests__/__snapshots__/TextInput-tests.tsx.snap
+++ b/src/lib/Components/Consignments/Components/__tests__/__snapshots__/TextInput-tests.tsx.snap
@@ -23,6 +23,7 @@ exports[`does not have an activity when searching  1`] = `
     <TextInput
       allowFontScaling={true}
       autoCorrect={false}
+      autoFocus={false}
       clearButtonMode="while-editing"
       keyboardAppearance="dark"
       onBlur={[Function]}
@@ -87,6 +88,7 @@ exports[`shows an activity indicator when searching  1`] = `
     <TextInput
       allowFontScaling={true}
       autoCorrect={false}
+      autoFocus={false}
       clearButtonMode="while-editing"
       keyboardAppearance="dark"
       onBlur={[Function]}

--- a/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/Edition-tests.tsx.snap
+++ b/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/Edition-tests.tsx.snap
@@ -1238,6 +1238,7 @@ exports[`Shows and additional 2 inputs when there's edition info 1`] = `
                     <TextInput
                       allowFontScaling={true}
                       autoCorrect={false}
+                      autoFocus={false}
                       clearButtonMode="while-editing"
                       keyboardAppearance="dark"
                       keyboardType="phone-pad"
@@ -1305,6 +1306,7 @@ exports[`Shows and additional 2 inputs when there's edition info 1`] = `
                     <TextInput
                       allowFontScaling={true}
                       autoCorrect={false}
+                      autoFocus={false}
                       clearButtonMode="while-editing"
                       keyboardAppearance="dark"
                       onBlur={[Function]}

--- a/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/Metadata-tests.tsx.snap
+++ b/src/lib/Components/Consignments/Screens/__tests__/__snapshots__/Metadata-tests.tsx.snap
@@ -31,6 +31,11 @@ exports[`state is set up with empty consignment metadata 1`] = `
       <RCTScrollView
         centerContent={true}
         keyboardShouldPersistTaps="handled"
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
       >
         <View>
           <View
@@ -150,6 +155,7 @@ exports[`state is set up with empty consignment metadata 1`] = `
                   <TextInput
                     allowFontScaling={true}
                     autoCorrect={false}
+                    autoFocus={false}
                     clearButtonMode="while-editing"
                     keyboardAppearance="dark"
                     onBlur={[Function]}
@@ -223,6 +229,7 @@ exports[`state is set up with empty consignment metadata 1`] = `
                   <TextInput
                     allowFontScaling={true}
                     autoCorrect={false}
+                    autoFocus={false}
                     clearButtonMode="while-editing"
                     keyboardAppearance="dark"
                     onBlur={[Function]}
@@ -296,6 +303,7 @@ exports[`state is set up with empty consignment metadata 1`] = `
                   <TextInput
                     allowFontScaling={true}
                     autoCorrect={false}
+                    autoFocus={false}
                     clearButtonMode="while-editing"
                     keyboardAppearance="dark"
                     keyboardType="numeric"
@@ -357,6 +365,7 @@ exports[`state is set up with empty consignment metadata 1`] = `
                   <TextInput
                     allowFontScaling={true}
                     autoCorrect={false}
+                    autoFocus={false}
                     clearButtonMode="while-editing"
                     keyboardAppearance="dark"
                     keyboardType="numeric"
@@ -431,6 +440,7 @@ exports[`state is set up with empty consignment metadata 1`] = `
                   <TextInput
                     allowFontScaling={true}
                     autoCorrect={false}
+                    autoFocus={false}
                     clearButtonMode="while-editing"
                     keyboardAppearance="dark"
                     keyboardType="numeric"
@@ -1097,6 +1107,11 @@ exports[`state is set up with filled consignment metadata 1`] = `
       <RCTScrollView
         centerContent={true}
         keyboardShouldPersistTaps="handled"
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
       >
         <View>
           <View
@@ -1217,6 +1232,7 @@ exports[`state is set up with filled consignment metadata 1`] = `
                   <TextInput
                     allowFontScaling={true}
                     autoCorrect={false}
+                    autoFocus={false}
                     clearButtonMode="while-editing"
                     keyboardAppearance="dark"
                     onBlur={[Function]}
@@ -1291,6 +1307,7 @@ exports[`state is set up with filled consignment metadata 1`] = `
                   <TextInput
                     allowFontScaling={true}
                     autoCorrect={false}
+                    autoFocus={false}
                     clearButtonMode="while-editing"
                     keyboardAppearance="dark"
                     onBlur={[Function]}
@@ -1365,6 +1382,7 @@ exports[`state is set up with filled consignment metadata 1`] = `
                   <TextInput
                     allowFontScaling={true}
                     autoCorrect={false}
+                    autoFocus={false}
                     clearButtonMode="while-editing"
                     keyboardAppearance="dark"
                     keyboardType="numeric"
@@ -1427,6 +1445,7 @@ exports[`state is set up with filled consignment metadata 1`] = `
                   <TextInput
                     allowFontScaling={true}
                     autoCorrect={false}
+                    autoFocus={false}
                     clearButtonMode="while-editing"
                     keyboardAppearance="dark"
                     keyboardType="numeric"
@@ -1502,6 +1521,7 @@ exports[`state is set up with filled consignment metadata 1`] = `
                   <TextInput
                     allowFontScaling={true}
                     autoCorrect={false}
+                    autoFocus={false}
                     clearButtonMode="while-editing"
                     keyboardAppearance="dark"
                     keyboardType="numeric"

--- a/src/lib/Scenes/Search/RecentSearches.tsx
+++ b/src/lib/Scenes/Search/RecentSearches.tsx
@@ -87,6 +87,7 @@ export const RecentSearches: React.FC = () => {
           <SearchResult
             result={result}
             updateRecentSearchesOnTap={false}
+            displayingRecentResult
             onDelete={() => {
               LayoutAnimation.configureNext({ ...LayoutAnimation.Presets.easeInEaseOut, duration: 230 })
               deleteRecentSearch(result)

--- a/src/lib/Scenes/Search/SearchResult.tsx
+++ b/src/lib/Scenes/Search/SearchResult.tsx
@@ -14,8 +14,9 @@ export const SearchResult: React.FC<{
   result: AutosuggestResult
   highlight?: string
   updateRecentSearchesOnTap?: boolean
+  displayingRecentResult?: boolean
   onDelete?(): void
-}> = ({ result, highlight, onDelete, updateRecentSearchesOnTap = true }) => {
+}> = ({ result, highlight, onDelete, displayingRecentResult, updateRecentSearchesOnTap = true }) => {
   const navRef = useRef<any>()
   const { notifyRecentSearch } = useRecentSearches()
   const { inputRef, query } = useContext(SearchContext)
@@ -33,7 +34,9 @@ export const SearchResult: React.FC<{
           }
         }, 20)
         trackEvent({
-          action_type: Schema.ActionNames.ARAnalyticsSearchItemSelected,
+          action_type: displayingRecentResult
+            ? Schema.ActionNames.ARAnalyticsSearchRecentItemSelected
+            : Schema.ActionNames.ARAnalyticsSearchItemSelected,
           query: query.current,
           selected_object_type: result.displayType,
           selected_object_slug: result.slug,

--- a/src/lib/utils/track/schema.ts
+++ b/src/lib/utils/track/schema.ts
@@ -310,6 +310,7 @@ export enum ActionNames {
   // dispatch this on search input focus and again any time they type
   ARAnalyticsSearchStartedQuery = "Searched",
   ARAnalyticsSearchItemSelected = "Selected result from search screen",
+  ARAnalyticsSearchRecentItemSelected = "selected_recent_item_from_search",
 
   /**
    * Collection page events


### PR DESCRIPTION
The [tracking schema](https://github.com/artsy/eigen/blob/master/src/lib/utils/track/schema.ts) is kind of all over the place – some events `have spaces`, some `use_snake_case`, and some `UseCamelCase`. @mikehrom we've previously discussed having the Data team take ownership of this schema, which would let use use the schema y'all define with less back-and-forth. Maybe we can chat about this in Tuesday's Knowledge Share?