### PR TITLE
[MX-202] - Use additional property for recent search distinction #trivial

### DIFF
--- a/src/lib/Scenes/Search/SearchResult.tsx
+++ b/src/lib/Scenes/Search/SearchResult.tsx
@@ -34,10 +34,9 @@ export const SearchResult: React.FC<{
           }
         }, 20)
         trackEvent({
-          action_type: displayingRecentResult
-            ? Schema.ActionNames.ARAnalyticsSearchRecentItemSelected
-            : Schema.ActionNames.ARAnalyticsSearchItemSelected,
+          action_type: Schema.ActionNames.ARAnalyticsSearchItemSelected,
           query: query.current,
+          recent: displayingRecentResult ? "true" : "false",
           selected_object_type: result.displayType,
           selected_object_slug: result.slug,
         })

--- a/src/lib/utils/track/schema.ts
+++ b/src/lib/utils/track/schema.ts
@@ -309,8 +309,7 @@ export enum ActionNames {
   ARAnalyticsSearchCleared = "Cleared input in search screen",
   // dispatch this on search input focus and again any time they type
   ARAnalyticsSearchStartedQuery = "Searched",
-  ARAnalyticsSearchItemSelected = "Selected result from search screen",
-  ARAnalyticsSearchRecentItemSelected = "selected_recent_item_from_search",
+  ARAnalyticsSearchItemSelected = "selected_result_from_search_screen",
 
   /**
    * Collection page events


### PR DESCRIPTION
Update recent search tracking based on feedback here:
https://github.com/artsy/eigen/pull/3100

- Add Boolean property rather than separate event