### PR TITLE
Selected sort option

### DIFF
--- a/src/lib/Components/ArtworkFilterOptions/SortOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/SortOptions.tsx
@@ -3,7 +3,7 @@ import React, { useContext } from "react"
 import { FlatList, TouchableOpacity } from "react-native"
 import NavigatorIOS from "react-native-navigator-ios"
 import styled from "styled-components/native"
-import { ArtworkFilterContext, SortOption } from "../../utils/ArtworkFiltersStore"
+import { ArtworkFilterContext, selectedOptionsDisplay, SortOption } from "../../utils/ArtworkFiltersStore"
 import { BackgroundFill, OptionListItem } from "../FilterModal"
 
 interface SortOptionsScreenProps {
@@ -11,11 +11,14 @@ interface SortOptionsScreenProps {
 }
 
 export const SortOptionsScreen: React.SFC<SortOptionsScreenProps> = ({ navigator }) => {
-  const { dispatch, state } = useContext(ArtworkFilterContext)
+  const { dispatch } = useContext(ArtworkFilterContext)
 
   const handleBackNavigation = () => {
     navigator.pop()
   }
+
+  const selectedOptions = selectedOptionsDisplay()
+  const selectedSortOption = selectedOptions.find(option => option.filter === "sort")?.type
 
   const selectSortOption = (selectedOption: SortOption) => {
     dispatch({ type: "selectFilters", payload: { type: selectedOption, filter: "sort" } })
@@ -47,7 +50,7 @@ export const SortOptionsScreen: React.SFC<SortOptionsScreenProps> = ({ navigator
                       <SortSelection color="black100" size="3t">
                         {item}
                       </SortSelection>
-                      {item === state.selectedSortOption && (
+                      {item === selectedSortOption && (
                         <Box mb={0.1}>
                           <CheckIcon fill="black100" />
                         </Box>

--- a/src/lib/Components/ArtworkFilterOptions/SortOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/SortOptions.tsx
@@ -18,10 +18,10 @@ export const SortOptionsScreen: React.SFC<SortOptionsScreenProps> = ({ navigator
   }
 
   const selectedOptions = selectedOptionsDisplay()
-  const selectedSortOption = selectedOptions.find(option => option.filter === "sort")?.type
+  const selectedSortOption = selectedOptions.find(option => option.filterType === "sort")?.value
 
   const selectSortOption = (selectedOption: SortOption) => {
-    dispatch({ type: "selectFilters", payload: { type: selectedOption, filter: "sort" } })
+    dispatch({ type: "selectFilters", payload: { value: selectedOption, filterType: "sort" } })
   }
 
   return (

--- a/src/lib/Components/ArtworkFilterOptions/SortOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/SortOptions.tsx
@@ -3,7 +3,7 @@ import React, { useContext } from "react"
 import { FlatList, TouchableOpacity } from "react-native"
 import NavigatorIOS from "react-native-navigator-ios"
 import styled from "styled-components/native"
-import { ArtworkFilterContext, selectedOptionsDisplay, SortOption } from "../../utils/ArtworkFiltersStore"
+import { ArtworkFilterContext, SortOption, useSelectedOptionsDisplay } from "../../utils/ArtworkFiltersStore"
 import { BackgroundFill, OptionListItem } from "../FilterModal"
 
 interface SortOptionsScreenProps {
@@ -17,7 +17,7 @@ export const SortOptionsScreen: React.SFC<SortOptionsScreenProps> = ({ navigator
     navigator.pop()
   }
 
-  const selectedOptions = selectedOptionsDisplay()
+  const selectedOptions = useSelectedOptionsDisplay()
   const selectedSortOption = selectedOptions.find(option => option.filterType === "sort")?.value
 
   const selectSortOption = (selectedOption: SortOption) => {

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/SortOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/SortOptions-tests.tsx
@@ -3,7 +3,7 @@ import { mount } from "enzyme"
 import React from "react"
 import { FakeNavigator as MockNavigator } from "../../../../lib/Components/Bidding/__tests__/Helpers/FakeNavigator"
 import { OptionListItem } from "../../../../lib/Components/FilterModal"
-import { ArtworkFilterContext } from "../../../utils/ArtworkFiltersStore"
+import { ArtworkFilterContext, ArtworkFilterContextState } from "../../../utils/ArtworkFiltersStore"
 import { InnerOptionListItem, SortOptionsScreen as SortOptions } from "../SortOptions"
 
 describe("Sort Options Screen", () => {
@@ -45,7 +45,7 @@ describe("Sort Options Screen", () => {
 
   describe("selectedSortOption", () => {
     it("returns the default option if there are no selected or applied filters", () => {
-      const state = {
+      const state: ArtworkFilterContextState = {
         selectedFilters: [],
         appliedFilters: [],
         applyFilters: false,
@@ -57,9 +57,9 @@ describe("Sort Options Screen", () => {
     })
 
     it("prefers an applied filter over the default filter", () => {
-      const state = {
+      const state: ArtworkFilterContextState = {
         selectedFilters: [],
-        appliedFilters: [{ filter: "sort", type: "Recently added" }],
+        appliedFilters: [{ filterType: "sort", value: "Recently added" }],
         applyFilters: false,
       }
 
@@ -68,8 +68,8 @@ describe("Sort Options Screen", () => {
       expect(selectedOption.text()).toContain("Recently added")
     })
     it("prefers the selected filter over the default filter", () => {
-      const state = {
-        selectedFilters: [{ filter: "sort", type: "Recently added" }],
+      const state: ArtworkFilterContextState = {
+        selectedFilters: [{ filterType: "sort", value: "Recently added" }],
         appliedFilters: [],
         applyFilters: false,
       }
@@ -79,9 +79,9 @@ describe("Sort Options Screen", () => {
       expect(selectedOption.text()).toContain("Recently added")
     })
     it("prefers the selected filter over an applied filter", () => {
-      const state = {
-        selectedFilters: [{ filter: "sort", type: "Recently added" }],
-        appliedFilters: [{ filter: "sort", type: "Recently updated" }],
+      const state: ArtworkFilterContextState = {
+        selectedFilters: [{ filterType: "sort", value: "Recently added" }],
+        appliedFilters: [{ filterType: "sort", value: "Recently updated" }],
         applyFilters: false,
       }
 

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -4,7 +4,7 @@ import React, { useContext, useState } from "react"
 import { FlatList, Modal as RNModal, TouchableOpacity, TouchableWithoutFeedback, ViewProperties } from "react-native"
 import NavigatorIOS from "react-native-navigator-ios"
 import styled from "styled-components/native"
-import { ArtworkFilterContext } from "../utils/ArtworkFiltersStore"
+import { ArtworkFilterContext, FilterOption, selectedOptionsDisplay } from "../utils/ArtworkFiltersStore"
 import { SortOptionsScreen as SortOptions } from "./ArtworkFilterOptions/SortOptions"
 
 interface FilterModalProps extends ViewProperties {
@@ -77,10 +77,10 @@ interface FilterOptionsProps {
   navigator: NavigatorIOS
 }
 
-type FilterOptions = Array<{ type: string; onTap: () => void }>
+type FilterOptions = Array<{ filterType: FilterOption; filterText: string; onTap: () => void }>
 
 export const FilterOptions: React.SFC<FilterOptionsProps> = ({ closeModal, navigator }) => {
-  const { dispatch, state } = useContext(ArtworkFilterContext)
+  const { dispatch } = useContext(ArtworkFilterContext)
   const handleNavigationToSortScreen = () => {
     navigator.push({
       component: SortOptions,
@@ -88,7 +88,8 @@ export const FilterOptions: React.SFC<FilterOptionsProps> = ({ closeModal, navig
   }
   const [filterOptions] = useState<FilterOptions>([
     {
-      type: "Sort by",
+      filterText: "Sort by",
+      filterType: "sort",
       onTap: handleNavigationToSortScreen,
     },
   ])
@@ -99,6 +100,12 @@ export const FilterOptions: React.SFC<FilterOptionsProps> = ({ closeModal, navig
 
   const handleTappingCloseIcon = () => {
     closeModal()
+  }
+
+  const selectedOptions = selectedOptionsDisplay()
+
+  const selectedOption = (filterType: FilterOption) => {
+    return selectedOptions.find(option => option.filter === filterType)?.type
   }
 
   return (
@@ -119,7 +126,7 @@ export const FilterOptions: React.SFC<FilterOptionsProps> = ({ closeModal, navig
         </ClearAllButton>
       </Flex>
       <Flex>
-        <FlatList<{ onTap: () => void; type: string }>
+        <FlatList<{ onTap: () => void; filterText: string; filterType: FilterOption }>
           keyExtractor={(_item, index) => String(index)}
           data={filterOptions}
           renderItem={({ item }) => (
@@ -129,10 +136,10 @@ export const FilterOptions: React.SFC<FilterOptionsProps> = ({ closeModal, navig
                   <OptionListItem>
                     <Flex p={2} flexDirection="row" justifyContent="space-between" flexGrow={1}>
                       <Serif size="3t" color="black100">
-                        {item.type}
+                        {item.filterText}
                       </Serif>
                       <Flex flexDirection="row">
-                        <CurrentOption size="3">{state.selectedSortOption}</CurrentOption>
+                        <CurrentOption size="3">{selectedOption(item.filterType)}</CurrentOption>
                         <ArrowRightIcon fill="black30" ml={0.3} mt={0.3} />
                       </Flex>
                     </Flex>

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -24,8 +24,8 @@ export const FilterModalNavigator: React.SFC<FilterModalProps> = ({ closeModal, 
   }
 
   const applyFilters = () => {
-    const { type, filter } = head(state.selectedFilters)
-    dispatch({ type: "applyFilters", payload: [{ type, filter }] })
+    const { filterType, value } = head(state.selectedFilters)
+    dispatch({ type: "applyFilters", payload: [{ filterType, value }] })
     closeModal()
   }
 
@@ -105,7 +105,7 @@ export const FilterOptions: React.SFC<FilterOptionsProps> = ({ closeModal, navig
   const selectedOptions = selectedOptionsDisplay()
 
   const selectedOption = (filterType: FilterOption) => {
-    return selectedOptions.find(option => option.filter === filterType)?.type
+    return selectedOptions.find(option => option.filterType === filterType)?.value
   }
 
   return (

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -3,7 +3,7 @@ import React, { useContext, useState } from "react"
 import { FlatList, Modal as RNModal, TouchableOpacity, TouchableWithoutFeedback, ViewProperties } from "react-native"
 import NavigatorIOS from "react-native-navigator-ios"
 import styled from "styled-components/native"
-import { ArtworkFilterContext, FilterOption, selectedOptionsDisplay } from "../utils/ArtworkFiltersStore"
+import { ArtworkFilterContext, FilterOption, useSelectedOptionsDisplay } from "../utils/ArtworkFiltersStore"
 import { SortOptionsScreen as SortOptions } from "./ArtworkFilterOptions/SortOptions"
 
 interface FilterModalProps extends ViewProperties {
@@ -100,7 +100,7 @@ export const FilterOptions: React.SFC<FilterOptionsProps> = ({ closeModal, navig
     closeModal()
   }
 
-  const selectedOptions = selectedOptionsDisplay()
+  const selectedOptions = useSelectedOptionsDisplay()
 
   const selectedOption = (filterType: FilterOption) => {
     return selectedOptions.find(option => option.filterType === filterType)?.value

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -1,5 +1,4 @@
 import { ArrowRightIcon, Box, Button, CloseIcon, color, Flex, Sans, Serif, space } from "@artsy/palette"
-import { head } from "lodash"
 import React, { useContext, useState } from "react"
 import { FlatList, Modal as RNModal, TouchableOpacity, TouchableWithoutFeedback, ViewProperties } from "react-native"
 import NavigatorIOS from "react-native-navigator-ios"
@@ -24,8 +23,7 @@ export const FilterModalNavigator: React.SFC<FilterModalProps> = ({ closeModal, 
   }
 
   const applyFilters = () => {
-    const { filterType, value } = head(state.selectedFilters)
-    dispatch({ type: "applyFilters", payload: [{ filterType, value }] })
+    dispatch({ type: "applyFilters" })
     closeModal()
   }
 

--- a/src/lib/Components/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/__tests__/FilterModal-tests.tsx
@@ -297,6 +297,7 @@ describe("Clearing filters", () => {
 
     applyButton.props().onPress()
 
+    // After applying, we reset the selectedFilters
     expect(applyButton.text()).toContain("Apply")
   })
 })

--- a/src/lib/Components/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/__tests__/FilterModal-tests.tsx
@@ -30,7 +30,6 @@ jest.unmock("react-relay")
 beforeEach(() => {
   mockNavigator = new MockNavigator()
   state = {
-    selectedSortOption: "Default",
     selectedFilters: [],
     appliedFilters: [],
     applyFilters: false,
@@ -144,7 +143,6 @@ describe("Filter modal navigation flow", () => {
 
   xit("allows users to navigate back to filter screen from sort screen ", () => {
     const initialState: ArtworkFilterContextState = {
-      selectedSortOption: "Default",
       selectedFilters: [],
       appliedFilters: [],
       applyFilters: false,
@@ -190,7 +188,6 @@ describe("Filter modal navigation flow", () => {
 
   it("allows users to exit filter modal screen when selecting close icon", () => {
     const initialState: ArtworkFilterContextState = {
-      selectedSortOption: "Price (low to high)",
       selectedFilters: [],
       appliedFilters: [],
       applyFilters: false,
@@ -207,8 +204,7 @@ describe("Filter modal navigation flow", () => {
 
   it("only displays a check mark next to the currently selected sort option on the sort screen", () => {
     const initialState: ArtworkFilterContextState = {
-      selectedSortOption: "Price (high to low)",
-      selectedFilters: [],
+      selectedFilters: [{ filter: "sort", type: "Price (high to low)" }],
       appliedFilters: [],
       applyFilters: false,
     }
@@ -221,20 +217,17 @@ describe("Filter modal navigation flow", () => {
 
   it("displays the currently selected sort option on the filter screen", () => {
     const initialState: ArtworkFilterContextState = {
-      selectedSortOption: "Price (low to high)",
-      selectedFilters: [],
+      selectedFilters: [{ filter: "sort", type: "Price (low to high)" }],
       appliedFilters: [],
       applyFilters: false,
     }
 
     const filterScreen = mount(<MockFilterScreen initialState={initialState} />)
-
     expect(filterScreen.find(CurrentOption).text()).toEqual("Price (low to high)")
   })
 
   it("shows the default sort option on the filter screen", () => {
     const initialState: ArtworkFilterContextState = {
-      selectedSortOption: "Default",
       selectedFilters: [],
       appliedFilters: [],
       applyFilters: false,
@@ -247,7 +240,6 @@ describe("Filter modal navigation flow", () => {
 
   it("displays the filter screen apply button correctly when no filters are selected", () => {
     const initialState: ArtworkFilterContextState = {
-      selectedSortOption: "Price (low to high)",
       selectedFilters: [],
       appliedFilters: [],
       applyFilters: false,
@@ -260,7 +252,6 @@ describe("Filter modal navigation flow", () => {
 
   it("displays the filter screen apply button correctly when filters are selected", () => {
     const initialState: ArtworkFilterContextState = {
-      selectedSortOption: "Price (low to high)",
       selectedFilters: [{ type: "Price (low to high)", filter: "sort" }],
       appliedFilters: [],
       applyFilters: false,
@@ -275,7 +266,6 @@ describe("Filter modal navigation flow", () => {
 describe("Clearing filters", () => {
   it("allows users to clear all filters when selecting clear all", () => {
     const initialState: ArtworkFilterContextState = {
-      selectedSortOption: "Price (low to high)",
       selectedFilters: [{ type: "Price (low to high)", filter: "sort" }],
       appliedFilters: [{ type: "Recently added", filter: "sort" }],
       applyFilters: false,
@@ -295,7 +285,6 @@ describe("Clearing filters", () => {
 
   it("the apply button shows the number of currently selected filters and its count resets after filters are applied", () => {
     const initialState: ArtworkFilterContextState = {
-      selectedSortOption: "Price (high to low)",
       selectedFilters: [{ type: "Price (high to low)", filter: "sort" }],
       appliedFilters: [{ type: "Recently added", filter: "sort" }],
       applyFilters: true,

--- a/src/lib/Components/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/__tests__/FilterModal-tests.tsx
@@ -204,7 +204,7 @@ describe("Filter modal navigation flow", () => {
 
   it("only displays a check mark next to the currently selected sort option on the sort screen", () => {
     const initialState: ArtworkFilterContextState = {
-      selectedFilters: [{ filter: "sort", type: "Price (high to low)" }],
+      selectedFilters: [{ filterType: "sort", value: "Price (high to low)" }],
       appliedFilters: [],
       applyFilters: false,
     }
@@ -217,7 +217,7 @@ describe("Filter modal navigation flow", () => {
 
   it("displays the currently selected sort option on the filter screen", () => {
     const initialState: ArtworkFilterContextState = {
-      selectedFilters: [{ filter: "sort", type: "Price (low to high)" }],
+      selectedFilters: [{ filterType: "sort", value: "Price (low to high)" }],
       appliedFilters: [],
       applyFilters: false,
     }
@@ -252,7 +252,7 @@ describe("Filter modal navigation flow", () => {
 
   it("displays the filter screen apply button correctly when filters are selected", () => {
     const initialState: ArtworkFilterContextState = {
-      selectedFilters: [{ type: "Price (low to high)", filter: "sort" }],
+      selectedFilters: [{ value: "Price (low to high)", filterType: "sort" }],
       appliedFilters: [],
       applyFilters: false,
     }
@@ -266,8 +266,8 @@ describe("Filter modal navigation flow", () => {
 describe("Clearing filters", () => {
   it("allows users to clear all filters when selecting clear all", () => {
     const initialState: ArtworkFilterContextState = {
-      selectedFilters: [{ type: "Price (low to high)", filter: "sort" }],
-      appliedFilters: [{ type: "Recently added", filter: "sort" }],
+      selectedFilters: [{ value: "Price (low to high)", filterType: "sort" }],
+      appliedFilters: [{ value: "Recently added", filterType: "sort" }],
       applyFilters: false,
     }
 
@@ -285,8 +285,8 @@ describe("Clearing filters", () => {
 
   it("the apply button shows the number of currently selected filters and its count resets after filters are applied", () => {
     const initialState: ArtworkFilterContextState = {
-      selectedFilters: [{ type: "Price (high to low)", filter: "sort" }],
-      appliedFilters: [{ type: "Recently added", filter: "sort" }],
+      selectedFilters: [{ value: "Price (high to low)", filterType: "sort" }],
+      appliedFilters: [{ value: "Recently added", filterType: "sort" }],
       applyFilters: true,
     }
 

--- a/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -26,9 +26,9 @@ export const filterArtworksParams = (appliedFilters: FilterArray) => {
   }
 
   appliedFilters.forEach(appliedFilterOption => {
-    const paramMapping = filterTypeToParam[appliedFilterOption.filter]
-    const paramFromFilterType = paramMapping[appliedFilterOption.type]
-    filterParams[appliedFilterOption.filter] = paramFromFilterType
+    const paramMapping = filterTypeToParam[appliedFilterOption.filterType]
+    const paramFromFilterType = paramMapping[appliedFilterOption.value]
+    filterParams[appliedFilterOption.filterType] = paramFromFilterType
   })
 
   return filterParams

--- a/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -3,7 +3,36 @@ import { InfiniteScrollArtworksGridContainer as InfiniteScrollArtworksGrid } fro
 import { get } from "lib/utils/get"
 import React, { useContext, useEffect } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
-import { ArtworkFilterContext, ArtworkSorts } from "../../../utils/ArtworkFiltersStore"
+import { ArtworkFilterContext, FilterArray } from "../../../utils/ArtworkFiltersStore"
+
+enum ArtworkSorts {
+  "Default" = "-decayed_merch",
+  "Price (high to low)" = "sold,-has_price,-prices",
+  "Price (low to high)" = "sold,-has_price,prices",
+  "Recently updated" = "-partner_updated_at",
+  "Recently added" = "-published_at",
+  "Artwork year (descending)" = "-year",
+  "Artwork year (ascending)" = "year",
+}
+
+const filterTypeToParam = {
+  sort: ArtworkSorts,
+}
+
+export const filterArtworksParams = (appliedFilters: FilterArray) => {
+  // Default params
+  const filterParams = {
+    sort: "-decayed-merch",
+  }
+
+  appliedFilters.forEach(appliedFilterOption => {
+    const paramMapping = filterTypeToParam[appliedFilterOption.filter]
+    const paramFromFilterType = paramMapping[appliedFilterOption.type]
+    filterParams[appliedFilterOption.filter] = paramFromFilterType
+  })
+
+  return filterParams
+}
 
 const PAGE_SIZE = 10
 export const CollectionArtworks: React.FC<{
@@ -12,6 +41,8 @@ export const CollectionArtworks: React.FC<{
 }> = ({ collection, relay }) => {
   const artworks = get(collection, p => p.collectionArtworks)
   const { state } = useContext(ArtworkFilterContext)
+
+  const filterParams = filterArtworksParams(state.appliedFilters)
 
   useEffect(() => {
     if (state.applyFilters) {
@@ -22,9 +53,7 @@ export const CollectionArtworks: React.FC<{
             throw new Error("Collection/CollectionArtworks sort: " + error.message)
           }
         },
-        {
-          sort: ArtworkSorts[state.selectedSortOption],
-        }
+        filterParams
       )
     }
   }, [state.appliedFilters])

--- a/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -22,7 +22,7 @@ const filterTypeToParam = {
 export const filterArtworksParams = (appliedFilters: FilterArray) => {
   // Default params
   const filterParams = {
-    sort: "-decayed-merch",
+    sort: "-decayed_merch",
   }
 
   appliedFilters.forEach(appliedFilterOption => {

--- a/src/lib/Scenes/Collection/Screens/__tests__/CollectionArtworks-tests.tsx
+++ b/src/lib/Scenes/Collection/Screens/__tests__/CollectionArtworks-tests.tsx
@@ -2,9 +2,13 @@ import { Theme } from "@artsy/palette"
 import { CollectionArtworks_collection } from "__generated__/CollectionArtworks_collection.graphql"
 import { Artwork as GridItem } from "lib/Components/ArtworkGrids/ArtworkGridItem"
 import { CollectionFixture } from "lib/Scenes/Collection/Components/__fixtures__/CollectionFixture"
-import { CollectionArtworksFragmentContainer as CollectionArtworks } from "lib/Scenes/Collection/Screens/CollectionArtworks"
+import {
+  CollectionArtworksFragmentContainer as CollectionArtworks,
+  filterArtworksParams,
+} from "lib/Scenes/Collection/Screens/CollectionArtworks"
 import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
 import { renderRelayTree } from "lib/tests/renderRelayTree"
+import { FilterArray } from "lib/utils/ArtworkFiltersStore"
 import React from "react"
 import { ScrollView } from "react-native"
 import { graphql, RelayPaginationProp } from "react-relay"
@@ -60,5 +64,17 @@ describe("CollectionArtworks", () => {
     wrapper.update()
     expect(wrapper.find(GridItem).length).toBe(6)
     expect(wrapper.html()).toMatchSnapshot()
+  })
+})
+
+describe("filterArtworksParams", () => {
+  it("returns the default", () => {
+    const appliedFilters = []
+    expect(filterArtworksParams(appliedFilters)).toEqual({ sort: "-decayed-merch" })
+  })
+
+  it("returns the value of appliedFilter", () => {
+    const appliedFilters: FilterArray = [{ filter: "sort", type: "Recently added" }]
+    expect(filterArtworksParams(appliedFilters)).toEqual({ sort: "-published_at" })
   })
 })

--- a/src/lib/Scenes/Collection/Screens/__tests__/CollectionArtworks-tests.tsx
+++ b/src/lib/Scenes/Collection/Screens/__tests__/CollectionArtworks-tests.tsx
@@ -74,7 +74,7 @@ describe("filterArtworksParams", () => {
   })
 
   it("returns the value of appliedFilter", () => {
-    const appliedFilters: FilterArray = [{ filter: "sort", type: "Recently added" }]
+    const appliedFilters: FilterArray = [{ filterType: "sort", value: "Recently added" }]
     expect(filterArtworksParams(appliedFilters)).toEqual({ sort: "-published_at" })
   })
 })

--- a/src/lib/Scenes/Collection/Screens/__tests__/CollectionArtworks-tests.tsx
+++ b/src/lib/Scenes/Collection/Screens/__tests__/CollectionArtworks-tests.tsx
@@ -70,7 +70,7 @@ describe("CollectionArtworks", () => {
 describe("filterArtworksParams", () => {
   it("returns the default", () => {
     const appliedFilters = []
-    expect(filterArtworksParams(appliedFilters)).toEqual({ sort: "-decayed-merch" })
+    expect(filterArtworksParams(appliedFilters)).toEqual({ sort: "-decayed_merch" })
   })
 
   it("returns the value of appliedFilter", () => {

--- a/src/lib/utils/ArtworkFiltersStore.tsx
+++ b/src/lib/utils/ArtworkFiltersStore.tsx
@@ -28,7 +28,7 @@ export const reducer = (
 
       // otherwise remove filters that can only be selected once, e.g. "sort" and merge those with newly applied filters
       const payloadFilters = action.payload
-      sanitizeFilters = filter(previouslyAppliedFilters, prop => prop.filter === "sort")
+      sanitizeFilters = filter(previouslyAppliedFilters, prop => prop.filterType === "sort")
       const appliedFilters = union(differenceWith(previouslyAppliedFilters, sanitizeFilters), payloadFilters)
 
       return {
@@ -41,7 +41,7 @@ export const reducer = (
       const previouslySelectedFilters = artworkFilterState.selectedFilters
       const currentlySelectedFilter = action.payload
       const isFilterAlreadySelected = some(previouslySelectedFilters, currentlySelectedFilter)
-      const selectedFilter: Array<{ type: SortOption; filter: FilterOption }> = []
+      const selectedFilter: Array<{ value: SortOption; filterType: FilterOption }> = []
       const filtersApplied = artworkFilterState.appliedFilters
 
       if (isFilterAlreadySelected) {
@@ -66,13 +66,20 @@ export const reducer = (
   }
 }
 
+const defaultFilterOptions = {
+  sort: "Default",
+}
+
 export const selectedOptionsDisplay = (): FilterArray => {
   const { state } = useContext(ArtworkFilterContext)
-  const defaultOptions = [{ filter: "sort", type: "Default" }]
 
-  return defaultOptions.map(defaultOption => {
-    const selected = state.selectedFilters.find(option => option.filter === defaultOption.filter)
-    const applied = state.appliedFilters.find(option => option.filter === defaultOption.filter)
+  const allFilterOptions: FilterOption[] = ["sort"]
+
+  return allFilterOptions.map(item => {
+    const defaultOptionValue = defaultFilterOptions[item]
+    const defaultOption = { filterType: item, value: defaultOptionValue }
+    const selected = state.selectedFilters.find(option => option.filterType === defaultOption.filterType)
+    const applied = state.appliedFilters.find(option => option.filterType === defaultOption.filterType)
 
     return Object.assign(defaultOption, applied, selected)
   })
@@ -87,12 +94,16 @@ export const ArtworkFilterGlobalStateProvider = ({ children }) => {
 }
 
 export interface ArtworkFilterContextState {
-  readonly appliedFilters: ReadonlyArray<{ readonly type: SortOption; readonly filter: FilterOption }>
-  readonly selectedFilters: ReadonlyArray<{ readonly type: SortOption; readonly filter: FilterOption }>
+  readonly appliedFilters: FilterArray
+  readonly selectedFilters: FilterArray
   readonly applyFilters: boolean
 }
 
-export type FilterArray = ReadonlyArray<{ readonly type: SortOption; readonly filter: FilterOption }>
+interface FilterData {
+  readonly value: SortOption
+  readonly filterType: FilterOption
+}
+export type FilterArray = ReadonlyArray<FilterData>
 
 interface ResetFilters {
   type: "resetFilters"
@@ -100,12 +111,12 @@ interface ResetFilters {
 
 interface ApplyFilters {
   type: "applyFilters"
-  payload: Array<{ type: SortOption; filter: FilterOption }>
+  payload: FilterArray
 }
 
 interface SelectFilters {
   type: "selectFilters"
-  payload: { type: SortOption; filter: FilterOption }
+  payload: FilterData
 }
 
 export type FilterActions = ResetFilters | ApplyFilters | SelectFilters

--- a/src/lib/utils/ArtworkFiltersStore.tsx
+++ b/src/lib/utils/ArtworkFiltersStore.tsx
@@ -1,10 +1,9 @@
 import { differenceWith, filter, some, union } from "lodash"
-import React, { createContext, Dispatch, Reducer, useReducer } from "react"
+import React, { createContext, Dispatch, Reducer, useContext, useReducer } from "react"
 
 const filterState: ArtworkFilterContextState = {
   appliedFilters: [],
   selectedFilters: [],
-  selectedSortOption: "Default",
   applyFilters: false,
 }
 
@@ -24,7 +23,6 @@ export const reducer = (
           applyFilters: true,
           appliedFilters: action.payload,
           selectedFilters: [],
-          selectedSortOption: artworkFilterState.selectedSortOption,
         }
       }
 
@@ -37,7 +35,6 @@ export const reducer = (
         applyFilters: true,
         appliedFilters,
         selectedFilters: [],
-        selectedSortOption: artworkFilterState.selectedSortOption,
       }
 
     case "selectFilters":
@@ -54,7 +51,6 @@ export const reducer = (
           applyFilters: false,
           selectedFilters: mergedFilters,
           appliedFilters: filtersApplied,
-          selectedSortOption: currentlySelectedFilter.type,
         }
       } else {
         selectedFilter.push(currentlySelectedFilter)
@@ -63,12 +59,23 @@ export const reducer = (
           applyFilters: false,
           selectedFilters: selectedFilter,
           appliedFilters: filtersApplied,
-          selectedSortOption: currentlySelectedFilter.type,
         }
       }
     case "resetFilters":
-      return { applyFilters: false, appliedFilters: [], selectedFilters: [], selectedSortOption: "Default" }
+      return { applyFilters: false, appliedFilters: [], selectedFilters: [] }
   }
+}
+
+export const selectedOptionsDisplay = (): FilterArray => {
+  const { state } = useContext(ArtworkFilterContext)
+  const defaultOptions = [{ filter: "sort", type: "Default" }]
+
+  return defaultOptions.map(defaultOption => {
+    const selected = state.selectedFilters.find(option => option.filter === defaultOption.filter)
+    const applied = state.appliedFilters.find(option => option.filter === defaultOption.filter)
+
+    return Object.assign(defaultOption, applied, selected)
+  })
 }
 
 export const ArtworkFilterContext = createContext<ArtworkFilterContext>(null)
@@ -82,9 +89,10 @@ export const ArtworkFilterGlobalStateProvider = ({ children }) => {
 export interface ArtworkFilterContextState {
   readonly appliedFilters: ReadonlyArray<{ readonly type: SortOption; readonly filter: FilterOption }>
   readonly selectedFilters: ReadonlyArray<{ readonly type: SortOption; readonly filter: FilterOption }>
-  readonly selectedSortOption: SortOption
   readonly applyFilters: boolean
 }
+
+export type FilterArray = ReadonlyArray<{ readonly type: SortOption; readonly filter: FilterOption }>
 
 interface ResetFilters {
   type: "resetFilters"
@@ -116,14 +124,4 @@ export type SortOption =
   | "Artwork year (descending)"
   | "Artwork year (ascending)"
 
-export type FilterOption = "sort" | "medium" | "waysToBuy" | "priceRange" | "size" | "color" | "timePeriod"
-
-export enum ArtworkSorts {
-  "Default" = "-decayed_merch",
-  "Price (high to low)" = "sold,-has_price,-prices",
-  "Price (low to high)" = "sold,-has_price,prices",
-  "Recently updated" = "-partner_updated_at",
-  "Recently added" = "-published_at",
-  "Artwork year (descending)" = "-year",
-  "Artwork year (ascending)" = "year",
-}
+export type FilterOption = "sort"

--- a/src/lib/utils/ArtworkFiltersStore.tsx
+++ b/src/lib/utils/ArtworkFiltersStore.tsx
@@ -31,17 +31,19 @@ export const reducer = (
       }
 
     case "selectFilters":
+      // First we update our potential "selectedFilters" based on the option that was selected in the UI
       const filtersToSelect = unionBy([action.payload], artworkFilterState.selectedFilters, "filterType")
 
+      // Then we have to remove any "invalid" choices.
       const selectedFilters = filter(filtersToSelect, ({ filterType, value }) => {
         const appliedFilter = find(artworkFilterState.appliedFilters, option => option.filterType === filterType)
 
+        // Don't re-select options that have already been applied.
+        // In the case where the option hasn't been applied, remove the option if it is the default.
         if (!appliedFilter) {
           return defaultFilterOptions[filterType] !== value
         }
 
-        // Don't re-select options that have already been applied.
-        // In the case where the option hasn't been applied, remove the option if it is the default.
         if (appliedFilter.value === value) {
           return false
         }

--- a/src/lib/utils/ArtworkFiltersStore.tsx
+++ b/src/lib/utils/ArtworkFiltersStore.tsx
@@ -64,7 +64,7 @@ const defaultFilterOptions = {
   sort: "Default",
 }
 
-export const selectedOptionsDisplay = (): FilterArray => {
+export const useSelectedOptionsDisplay = (): FilterArray => {
   const { state } = useContext(ArtworkFilterContext)
 
   const defaultFilters: FilterArray = [{ filterType: "sort", value: "Default" }]

--- a/src/lib/utils/__tests__/ArtworkFiltersStore-tests.tsx
+++ b/src/lib/utils/__tests__/ArtworkFiltersStore-tests.tsx
@@ -12,7 +12,6 @@ describe("Reset Filters", () => {
     filterState = {
       appliedFilters: [{ type: "Recently updated", filter: "sort" }],
       selectedFilters: [{ type: "Artwork year (descending)", filter: "sort" }],
-      selectedSortOption: "Default",
       applyFilters: true,
     }
 
@@ -22,7 +21,6 @@ describe("Reset Filters", () => {
       appliedFilters: [],
       applyFilters: false,
       selectedFilters: [],
-      selectedSortOption: "Default",
     })
   })
 
@@ -30,7 +28,6 @@ describe("Reset Filters", () => {
     filterState = {
       appliedFilters: [{ type: "Price (low to high)", filter: "sort" }],
       selectedFilters: [{ type: "Artwork year (descending)", filter: "sort" }],
-      selectedSortOption: "Artwork year (descending)",
       applyFilters: false,
     }
 
@@ -40,7 +37,6 @@ describe("Reset Filters", () => {
       appliedFilters: [],
       applyFilters: false,
       selectedFilters: [],
-      selectedSortOption: "Default",
     })
   })
 })
@@ -51,7 +47,6 @@ describe("Select Filters", () => {
       applyFilters: false,
       appliedFilters: [],
       selectedFilters: [{ type: "Artwork year (descending)", filter: "sort" }],
-      selectedSortOption: "Recently added",
     }
 
     filterAction = {
@@ -65,7 +60,6 @@ describe("Select Filters", () => {
       applyFilters: false,
       appliedFilters: [],
       selectedFilters: [{ type: "Recently added", filter: "sort" }],
-      selectedSortOption: "Recently added",
     })
   })
 
@@ -74,7 +68,6 @@ describe("Select Filters", () => {
       applyFilters: false,
       appliedFilters: [],
       selectedFilters: [],
-      selectedSortOption: "Artwork year (descending)",
     }
 
     filterAction = {
@@ -88,7 +81,6 @@ describe("Select Filters", () => {
       applyFilters: false,
       appliedFilters: [],
       selectedFilters: [{ type: "Artwork year (descending)", filter: "sort" }],
-      selectedSortOption: "Artwork year (descending)",
     })
   })
 })
@@ -99,7 +91,6 @@ describe("Apply Filters", () => {
       applyFilters: true,
       appliedFilters: [],
       selectedFilters: [],
-      selectedSortOption: "Artwork year (descending)",
     }
 
     filterAction = {
@@ -113,7 +104,6 @@ describe("Apply Filters", () => {
       applyFilters: true,
       appliedFilters: [{ type: "Artwork year (descending)", filter: "sort" }],
       selectedFilters: [],
-      selectedSortOption: "Artwork year (descending)",
     })
   })
 
@@ -122,7 +112,6 @@ describe("Apply Filters", () => {
       applyFilters: true,
       appliedFilters: [{ type: "Recently updated", filter: "sort" }],
       selectedFilters: [{ type: "Recently updated", filter: "sort" }],
-      selectedSortOption: "Recently updated",
     }
 
     filterAction = {
@@ -136,7 +125,6 @@ describe("Apply Filters", () => {
       applyFilters: true,
       appliedFilters: [{ type: "Recently updated", filter: "sort" }],
       selectedFilters: [],
-      selectedSortOption: "Recently updated",
     })
   })
 })

--- a/src/lib/utils/__tests__/ArtworkFiltersStore-tests.tsx
+++ b/src/lib/utils/__tests__/ArtworkFiltersStore-tests.tsx
@@ -10,8 +10,8 @@ describe("Reset Filters", () => {
 
   it("returns empty arrays/default state values ", () => {
     filterState = {
-      appliedFilters: [{ type: "Recently updated", filter: "sort" }],
-      selectedFilters: [{ type: "Artwork year (descending)", filter: "sort" }],
+      appliedFilters: [{ value: "Recently updated", filterType: "sort" }],
+      selectedFilters: [{ value: "Artwork year (descending)", filterType: "sort" }],
       applyFilters: true,
     }
 
@@ -26,8 +26,8 @@ describe("Reset Filters", () => {
 
   it("returns empty arrays/default state values ", () => {
     filterState = {
-      appliedFilters: [{ type: "Price (low to high)", filter: "sort" }],
-      selectedFilters: [{ type: "Artwork year (descending)", filter: "sort" }],
+      appliedFilters: [{ value: "Price (low to high)", filterType: "sort" }],
+      selectedFilters: [{ value: "Artwork year (descending)", filterType: "sort" }],
       applyFilters: false,
     }
 
@@ -46,12 +46,12 @@ describe("Select Filters", () => {
     filterState = {
       applyFilters: false,
       appliedFilters: [],
-      selectedFilters: [{ type: "Artwork year (descending)", filter: "sort" }],
+      selectedFilters: [{ value: "Artwork year (descending)", filterType: "sort" }],
     }
 
     filterAction = {
       type: "selectFilters",
-      payload: { type: "Recently added", filter: "sort" },
+      payload: { value: "Recently added", filterType: "sort" },
     }
 
     const r = reducer(filterState, filterAction)
@@ -59,7 +59,7 @@ describe("Select Filters", () => {
     expect(r).toEqual({
       applyFilters: false,
       appliedFilters: [],
-      selectedFilters: [{ type: "Recently added", filter: "sort" }],
+      selectedFilters: [{ value: "Recently added", filterType: "sort" }],
     })
   })
 
@@ -72,7 +72,7 @@ describe("Select Filters", () => {
 
     filterAction = {
       type: "selectFilters",
-      payload: { type: "Artwork year (descending)", filter: "sort" },
+      payload: { value: "Artwork year (descending)", filterType: "sort" },
     }
 
     const r = reducer(filterState, filterAction)
@@ -80,7 +80,7 @@ describe("Select Filters", () => {
     expect(r).toEqual({
       applyFilters: false,
       appliedFilters: [],
-      selectedFilters: [{ type: "Artwork year (descending)", filter: "sort" }],
+      selectedFilters: [{ value: "Artwork year (descending)", filterType: "sort" }],
     })
   })
 })
@@ -95,14 +95,14 @@ describe("Apply Filters", () => {
 
     filterAction = {
       type: "applyFilters",
-      payload: [{ type: "Artwork year (descending)", filter: "sort" }],
+      payload: [{ value: "Artwork year (descending)", filterType: "sort" }],
     }
 
     const r = reducer(filterState, filterAction)
 
     expect(r).toEqual({
       applyFilters: true,
-      appliedFilters: [{ type: "Artwork year (descending)", filter: "sort" }],
+      appliedFilters: [{ value: "Artwork year (descending)", filterType: "sort" }],
       selectedFilters: [],
     })
   })
@@ -110,20 +110,20 @@ describe("Apply Filters", () => {
   it("keeps the filters that were already applied", () => {
     filterState = {
       applyFilters: true,
-      appliedFilters: [{ type: "Recently updated", filter: "sort" }],
-      selectedFilters: [{ type: "Recently updated", filter: "sort" }],
+      appliedFilters: [{ value: "Recently updated", filterType: "sort" }],
+      selectedFilters: [{ value: "Recently updated", filterType: "sort" }],
     }
 
     filterAction = {
       type: "applyFilters",
-      payload: [{ type: "Recently updated", filter: "sort" }],
+      payload: [{ value: "Recently updated", filterType: "sort" }],
     }
 
     const r = reducer(filterState, filterAction)
 
     expect(r).toEqual({
       applyFilters: true,
-      appliedFilters: [{ type: "Recently updated", filter: "sort" }],
+      appliedFilters: [{ value: "Recently updated", filterType: "sort" }],
       selectedFilters: [],
     })
   })

--- a/src/lib/utils/__tests__/ArtworkFiltersStore-tests.tsx
+++ b/src/lib/utils/__tests__/ArtworkFiltersStore-tests.tsx
@@ -42,7 +42,7 @@ describe("Reset Filters", () => {
 })
 
 describe("Select Filters", () => {
-  it("the previously and newly selected filter option when selectFilters array is not empty ", () => {
+  it("returns the previously and newly selected filter option when selectFilters array is not empty ", () => {
     filterState = {
       applyFilters: false,
       appliedFilters: [],
@@ -63,7 +63,7 @@ describe("Select Filters", () => {
     })
   })
 
-  it("the newly selected filter option is returned when a previously unselected filter is selected", () => {
+  it("returns the newly selected filter option when a previously unselected filter is selected", () => {
     filterState = {
       applyFilters: false,
       appliedFilters: [],
@@ -83,19 +83,81 @@ describe("Select Filters", () => {
       selectedFilters: [{ value: "Artwork year (descending)", filterType: "sort" }],
     })
   })
-})
 
-describe("Apply Filters", () => {
-  it("returns just the applied filter if nothing was previously selected", () => {
+  it("does not select a filter that is already applied", () => {
     filterState = {
-      applyFilters: true,
+      applyFilters: false,
+      appliedFilters: [{ filterType: "sort", value: "Artwork year (descending)" }],
+      selectedFilters: [],
+    }
+
+    filterAction = {
+      type: "selectFilters",
+      payload: { value: "Artwork year (descending)", filterType: "sort" },
+    }
+
+    const r = reducer(filterState, filterAction)
+
+    expect(r).toEqual({
+      applyFilters: false,
+      appliedFilters: [{ filterType: "sort", value: "Artwork year (descending)" }],
+      selectedFilters: [],
+    })
+  })
+
+  it("does not select the default filter when the filter is not applied", () => {
+    filterState = {
+      applyFilters: false,
       appliedFilters: [],
       selectedFilters: [],
     }
 
     filterAction = {
+      type: "selectFilters",
+      payload: { value: "Default", filterType: "sort" },
+    }
+
+    const r = reducer(filterState, filterAction)
+
+    expect(r).toEqual({
+      applyFilters: false,
+      appliedFilters: [],
+      selectedFilters: [],
+    })
+  })
+
+  it("does not select the default filter when the filter is not applied, even if there are existing selected filters", () => {
+    filterState = {
+      applyFilters: false,
+      appliedFilters: [],
+      selectedFilters: [{ filterType: "sort", value: "Artwork year (descending)" }],
+    }
+
+    filterAction = {
+      type: "selectFilters",
+      payload: { value: "Default", filterType: "sort" },
+    }
+
+    const r = reducer(filterState, filterAction)
+
+    expect(r).toEqual({
+      applyFilters: false,
+      appliedFilters: [],
+      selectedFilters: [],
+    })
+  })
+})
+
+describe("Apply Filters", () => {
+  it("applies the selected filters", () => {
+    filterState = {
+      applyFilters: true,
+      appliedFilters: [],
+      selectedFilters: [{ value: "Artwork year (descending)", filterType: "sort" }],
+    }
+
+    filterAction = {
       type: "applyFilters",
-      payload: [{ value: "Artwork year (descending)", filterType: "sort" }],
     }
 
     const r = reducer(filterState, filterAction)
@@ -116,7 +178,6 @@ describe("Apply Filters", () => {
 
     filterAction = {
       type: "applyFilters",
-      payload: [{ value: "Recently updated", filterType: "sort" }],
     }
 
     const r = reducer(filterState, filterAction)
@@ -124,6 +185,26 @@ describe("Apply Filters", () => {
     expect(r).toEqual({
       applyFilters: true,
       appliedFilters: [{ value: "Recently updated", filterType: "sort" }],
+      selectedFilters: [],
+    })
+  })
+
+  it("replaces previously applied filters with newly selected ones", () => {
+    filterState = {
+      applyFilters: true,
+      appliedFilters: [{ value: "Recently updated", filterType: "sort" }],
+      selectedFilters: [{ value: "Artwork year (descending)", filterType: "sort" }],
+    }
+
+    filterAction = {
+      type: "applyFilters",
+    }
+
+    const r = reducer(filterState, filterAction)
+
+    expect(r).toEqual({
+      applyFilters: true,
+      appliedFilters: [{ value: "Artwork year (descending)", filterType: "sort" }],
       selectedFilters: [],
     })
   })


### PR DESCRIPTION
This PR fixes https://artsyproduct.atlassian.net/browse/FX-1851 and makes a few minor refactors to the store (will explain inline)!

To summarize:
- Removed the `selectedSortOption` item from the global state object since this value can be derived from existing properties (the `selectedFilters` and `appliedFilters` arrays).
- Refactored the shape of the `FilterArray`s slightly.
- Fixed the bug described in the ticket!

![filterstates](https://user-images.githubusercontent.com/2081340/77218316-72e4f100-6b00-11ea-8b63-a0fb6a543da3.gif)

#trivial