### PR TITLE
Prepares for 6.4.0 release #trivial

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.3.3</string>
+	<string>6.4.0</string>
 	<key>CFBundleVersion</key>
 	<string>2019.05.24.09</string>
 	<key>NSExtension</key>

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.3.3</string>
+	<string>6.4.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,22 +1,29 @@
 upcoming:
-  version: 6.3.3
+  version: 6.4.0
   date: TBD
   dev:
-    - Fixes problem where artist follows on Artist page weren't being tracked - ash
-    - Reduce number of images for initial render of for-you page - david
-    - Fixes WSOD on home feed with artworks that have missing images - ash
-    - Upgrade relay - david
-    - Fix bug in relay data management for below-the-fold content on Artwork page - david
+    -
   user_facing:
-    - Fix bug where the Fair page scroll view would jump around while scrolling - david
-    - Fix bug where the `Artists` tab scroll view would jump around while scrolling - david
-    - Replace for-you artwork carousel with horizontal rail - david
-    - Refresh for-you header styling - david
-    - All new fair cards - ash
-    - Add a sale-level toggle to the request lot condition report feature - yuki
-    - Improve loading UX on Artist page - david
+    -
 
 releases:
+  - version: 6.3.3
+    date: Mar 23, 2020
+    dev:
+      - Fixes problem where artist follows on Artist page weren't being tracked - ash
+      - Reduce number of images for initial render of for-you page - david
+      - Fixes WSOD on home feed with artworks that have missing images - ash
+      - Upgrade relay - david
+      - Fix bug in relay data management for below-the-fold content on Artwork page - david
+    user_facing:
+      - Fix bug where the Fair page scroll view would jump around while scrolling - david
+      - Fix bug where the `Artists` tab scroll view would jump around while scrolling - david
+      - Replace for-you artwork carousel with horizontal rail - david
+      - Refresh for-you header styling - david
+      - All new fair cards - ash
+      - Add a sale-level toggle to the request lot condition report feature - yuki
+      - Improve loading UX on Artist page - david
+
   - version: 6.3.2
     date: Mar 4, 2020
     dev:


### PR DESCRIPTION
- Moved changelog entries down.
- Ran `make next`.

Went with 6.4.0 since we have some larger, user-facing changes to Home coming up.