### PR TITLE
Fix jest flake

### DIFF
--- a/patches/react-dom+16.8.3.patch
+++ b/patches/react-dom+16.8.3.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/react-dom/cjs/react-dom.development.js b/node_modules/react-dom/cjs/react-dom.development.js
+index 13bea1e..8b4105c 100644
+--- a/node_modules/react-dom/cjs/react-dom.development.js
++++ b/node_modules/react-dom/cjs/react-dom.development.js
+@@ -5069,7 +5069,9 @@ function getActiveElement(doc) {
+   try {
+     return doc.activeElement || doc.body;
+   } catch (e) {
+-    return doc.body;
++    // this is causing occasional flaky failures in our test suite
++    // https://github.com/facebook/react/issues/15691
++    return doc && doc.body;
+   }
+ }
+ 


### PR DESCRIPTION
Fixes the 'cannot read property body of null' nondeterministic error that seems to be a bug in the react-dom/jsdom teardown sequence.

see facebook/react#15691