### PR TITLE
FX-1873: Allows user to "Clear All" and apply changes in collections filter

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,6 +3,7 @@ upcoming:
   date: TBD
   dev:
     - Added shell for Galleries development of Viewing Rooms - ash
+    - Fixes Clear All functionality in collections filtering - sweir27
   user_facing:
     -
 

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/SortOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/SortOptions-tests.tsx
@@ -33,9 +33,10 @@ describe("Sort Options Screen", () => {
   }
 
   it("renders the correct number of sort options", () => {
-    const state = {
+    const state: ArtworkFilterContextState = {
       selectedFilters: [],
       appliedFilters: [],
+      previouslyAppliedFilters: [],
       applyFilters: false,
     }
 
@@ -48,6 +49,7 @@ describe("Sort Options Screen", () => {
       const state: ArtworkFilterContextState = {
         selectedFilters: [],
         appliedFilters: [],
+        previouslyAppliedFilters: [],
         applyFilters: false,
       }
 
@@ -60,6 +62,7 @@ describe("Sort Options Screen", () => {
       const state: ArtworkFilterContextState = {
         selectedFilters: [],
         appliedFilters: [{ filterType: "sort", value: "Recently added" }],
+        previouslyAppliedFilters: [{ filterType: "sort", value: "Recently added" }],
         applyFilters: false,
       }
 
@@ -67,10 +70,12 @@ describe("Sort Options Screen", () => {
       const selectedOption = selectedSortOption(component)
       expect(selectedOption.text()).toContain("Recently added")
     })
+
     it("prefers the selected filter over the default filter", () => {
       const state: ArtworkFilterContextState = {
         selectedFilters: [{ filterType: "sort", value: "Recently added" }],
         appliedFilters: [],
+        previouslyAppliedFilters: [],
         applyFilters: false,
       }
 
@@ -78,10 +83,12 @@ describe("Sort Options Screen", () => {
       const selectedOption = selectedSortOption(component)
       expect(selectedOption.text()).toContain("Recently added")
     })
+
     it("prefers the selected filter over an applied filter", () => {
       const state: ArtworkFilterContextState = {
         selectedFilters: [{ filterType: "sort", value: "Recently added" }],
         appliedFilters: [{ filterType: "sort", value: "Recently updated" }],
+        previouslyAppliedFilters: [{ filterType: "sort", value: "Recently updated" }],
         applyFilters: false,
       }
 

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -16,9 +16,7 @@ export const FilterModalNavigator: React.SFC<FilterModalProps> = ({ closeModal, 
   const { dispatch, state } = useContext(ArtworkFilterContext)
 
   const handleClosingModal = () => {
-    if (!state.appliedFilters) {
-      dispatch({ type: "resetFilters" })
-    }
+    dispatch({ type: "resetFilters" })
     closeModal()
   }
 
@@ -31,6 +29,9 @@ export const FilterModalNavigator: React.SFC<FilterModalProps> = ({ closeModal, 
     const selectedFiltersSum = state.selectedFilters.length
     return selectedFiltersSum > 0 ? `Apply (${selectedFiltersSum})` : "Apply"
   }
+
+  const isApplyButtonEnabled =
+    state.selectedFilters.length > 0 || (state.previouslyAppliedFilters.length === 0 && state.appliedFilters.length > 0)
 
   return (
     <>
@@ -51,7 +52,7 @@ export const FilterModalNavigator: React.SFC<FilterModalProps> = ({ closeModal, 
                 />
                 <Box p={2}>
                   <ApplyButton
-                    disabled={state.selectedFilters.length < 1}
+                    disabled={!isApplyButtonEnabled}
                     onPress={applyFilters}
                     block
                     width={100}
@@ -93,7 +94,7 @@ export const FilterOptions: React.SFC<FilterOptionsProps> = ({ closeModal, navig
   ])
 
   const clearAllFilters = () => {
-    dispatch({ type: "resetFilters" })
+    dispatch({ type: "clearAll" })
   }
 
   const handleTappingCloseIcon = () => {

--- a/src/lib/Components/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/__tests__/FilterModal-tests.tsx
@@ -36,6 +36,7 @@ beforeEach(() => {
   state = {
     selectedFilters: [],
     appliedFilters: [],
+    previouslyAppliedFilters: [],
     applyFilters: false,
   }
   NativeModules.Emission = {
@@ -149,6 +150,7 @@ describe("Filter modal navigation flow", () => {
     const initialState: ArtworkFilterContextState = {
       selectedFilters: [],
       appliedFilters: [],
+      previouslyAppliedFilters: [],
       applyFilters: false,
     }
 
@@ -194,6 +196,7 @@ describe("Filter modal navigation flow", () => {
     const initialState: ArtworkFilterContextState = {
       selectedFilters: [],
       appliedFilters: [],
+      previouslyAppliedFilters: [],
       applyFilters: false,
     }
 
@@ -210,6 +213,7 @@ describe("Filter modal navigation flow", () => {
     const initialState: ArtworkFilterContextState = {
       selectedFilters: [{ filterType: "sort", value: "Price (high to low)" }],
       appliedFilters: [],
+      previouslyAppliedFilters: [],
       applyFilters: false,
     }
     const sortScreen = mount(<MockSortScreen initialState={initialState} />)
@@ -223,6 +227,7 @@ describe("Filter modal navigation flow", () => {
     const initialState: ArtworkFilterContextState = {
       selectedFilters: [{ filterType: "sort", value: "Price (low to high)" }],
       appliedFilters: [],
+      previouslyAppliedFilters: [],
       applyFilters: false,
     }
 
@@ -234,6 +239,7 @@ describe("Filter modal navigation flow", () => {
     const initialState: ArtworkFilterContextState = {
       selectedFilters: [],
       appliedFilters: [],
+      previouslyAppliedFilters: [],
       applyFilters: false,
     }
 
@@ -246,6 +252,7 @@ describe("Filter modal navigation flow", () => {
     const initialState: ArtworkFilterContextState = {
       selectedFilters: [],
       appliedFilters: [],
+      previouslyAppliedFilters: [],
       applyFilters: false,
     }
 
@@ -258,6 +265,7 @@ describe("Filter modal navigation flow", () => {
     const initialState: ArtworkFilterContextState = {
       selectedFilters: [{ value: "Price (low to high)", filterType: "sort" }],
       appliedFilters: [],
+      previouslyAppliedFilters: [],
       applyFilters: false,
     }
 
@@ -272,6 +280,7 @@ describe("Clearing filters", () => {
     const initialState: ArtworkFilterContextState = {
       selectedFilters: [{ value: "Price (low to high)", filterType: "sort" }],
       appliedFilters: [{ value: "Recently added", filterType: "sort" }],
+      previouslyAppliedFilters: [{ value: "Recently added", filterType: "sort" }],
       applyFilters: false,
     }
 
@@ -287,10 +296,34 @@ describe("Clearing filters", () => {
     expect(filterScreen.find(CurrentOption).text()).toEqual("Default")
   })
 
+  it("enables the apply button when clearing all if no other options are selected", () => {
+    const initialState: ArtworkFilterContextState = {
+      selectedFilters: [],
+      appliedFilters: [{ value: "Recently added", filterType: "sort" }],
+      previouslyAppliedFilters: [{ value: "Recently added", filterType: "sort" }],
+      applyFilters: false,
+    }
+
+    const filterModal = mount(<MockFilterModalNavigator initialState={initialState} />)
+
+    expect(filterModal.find(CurrentOption).text()).toEqual("Recently added")
+    expect(filterModal.find(ApplyButton).props().disabled).toEqual(true)
+
+    filterModal
+      .find(ClearAllButton)
+      .props()
+      .onPress()
+
+    filterModal.update()
+    expect(filterModal.find(CurrentOption).text()).toEqual("Default")
+    expect(filterModal.find(ApplyButton).props().disabled).toEqual(false)
+  })
+
   it("the apply button shows the number of currently selected filters and its count resets after filters are applied", () => {
     const initialState: ArtworkFilterContextState = {
       selectedFilters: [{ value: "Price (high to low)", filterType: "sort" }],
       appliedFilters: [{ value: "Recently added", filterType: "sort" }],
+      previouslyAppliedFilters: [{ value: "Recently added", filterType: "sort" }],
       applyFilters: true,
     }
 
@@ -311,6 +344,7 @@ describe("Applying filters", () => {
     const initialState: ArtworkFilterContextState = {
       selectedFilters: [{ value: "Price (high to low)", filterType: "sort" }],
       appliedFilters: [{ value: "Price (high to low)", filterType: "sort" }],
+      previouslyAppliedFilters: [{ value: "Price (high to low)", filterType: "sort" }],
       applyFilters: true,
     }
 

--- a/src/lib/utils/__tests__/ArtworkFiltersStore-tests.tsx
+++ b/src/lib/utils/__tests__/ArtworkFiltersStore-tests.tsx
@@ -3,24 +3,66 @@ import { ArtworkFilterContextState, FilterActions, reducer } from "lib/utils/Art
 let filterState: ArtworkFilterContextState
 let filterAction: FilterActions
 
-describe("Reset Filters", () => {
-  filterAction = {
-    type: "resetFilters",
-  }
-
-  it("returns empty arrays/default state values ", () => {
+describe("Clear All Filters", () => {
+  it("clears out the previouslyAppliedFilters if nothing has been applied", () => {
     filterState = {
-      appliedFilters: [{ value: "Recently updated", filterType: "sort" }],
-      selectedFilters: [{ value: "Artwork year (descending)", filterType: "sort" }],
-      applyFilters: true,
+      appliedFilters: [],
+      selectedFilters: [],
+      previouslyAppliedFilters: [],
+      applyFilters: false,
     }
 
-    const r = reducer(filterState, filterAction)
+    const r = reducer(filterState, {
+      type: "clearAll",
+    })
 
     expect(r).toEqual({
       appliedFilters: [],
       applyFilters: false,
       selectedFilters: [],
+      previouslyAppliedFilters: [],
+    })
+  })
+
+  it("clears out the previouslyAppliedFilters and selectedFilters", () => {
+    filterState = {
+      appliedFilters: [{ value: "Recently updated", filterType: "sort" }],
+      selectedFilters: [{ value: "Artwork year (descending)", filterType: "sort" }],
+      previouslyAppliedFilters: [{ value: "Recently updated", filterType: "sort" }],
+      applyFilters: true,
+    }
+
+    const r = reducer(filterState, {
+      type: "clearAll",
+    })
+
+    expect(r).toEqual({
+      appliedFilters: [{ value: "Recently updated", filterType: "sort" }],
+      applyFilters: false,
+      selectedFilters: [],
+      previouslyAppliedFilters: [],
+    })
+  })
+})
+
+describe("Reset Filters", () => {
+  it("returns empty arrays/default state values ", () => {
+    filterState = {
+      appliedFilters: [{ value: "Recently updated", filterType: "sort" }],
+      selectedFilters: [{ value: "Artwork year (descending)", filterType: "sort" }],
+      previouslyAppliedFilters: [{ value: "Recently updated", filterType: "sort" }],
+      applyFilters: true,
+    }
+
+    const r = reducer(filterState, {
+      type: "resetFilters",
+    })
+
+    expect(r).toEqual({
+      appliedFilters: [{ value: "Recently updated", filterType: "sort" }],
+      applyFilters: false,
+      selectedFilters: [],
+      previouslyAppliedFilters: [{ value: "Recently updated", filterType: "sort" }],
     })
   })
 
@@ -29,14 +71,18 @@ describe("Reset Filters", () => {
       appliedFilters: [{ value: "Price (low to high)", filterType: "sort" }],
       selectedFilters: [{ value: "Artwork year (descending)", filterType: "sort" }],
       applyFilters: false,
+      previouslyAppliedFilters: [{ value: "Price (low to high)", filterType: "sort" }],
     }
 
-    const r = reducer(filterState, filterAction)
+    const r = reducer(filterState, {
+      type: "resetFilters",
+    })
 
     expect(r).toEqual({
-      appliedFilters: [],
+      appliedFilters: [{ value: "Price (low to high)", filterType: "sort" }],
       applyFilters: false,
       selectedFilters: [],
+      previouslyAppliedFilters: [{ value: "Price (low to high)", filterType: "sort" }],
     })
   })
 })
@@ -46,6 +92,7 @@ describe("Select Filters", () => {
     filterState = {
       applyFilters: false,
       appliedFilters: [],
+      previouslyAppliedFilters: [],
       selectedFilters: [{ value: "Artwork year (descending)", filterType: "sort" }],
     }
 
@@ -59,6 +106,7 @@ describe("Select Filters", () => {
     expect(r).toEqual({
       applyFilters: false,
       appliedFilters: [],
+      previouslyAppliedFilters: [],
       selectedFilters: [{ value: "Recently added", filterType: "sort" }],
     })
   })
@@ -67,6 +115,7 @@ describe("Select Filters", () => {
     filterState = {
       applyFilters: false,
       appliedFilters: [],
+      previouslyAppliedFilters: [],
       selectedFilters: [],
     }
 
@@ -80,6 +129,7 @@ describe("Select Filters", () => {
     expect(r).toEqual({
       applyFilters: false,
       appliedFilters: [],
+      previouslyAppliedFilters: [],
       selectedFilters: [{ value: "Artwork year (descending)", filterType: "sort" }],
     })
   })
@@ -88,6 +138,7 @@ describe("Select Filters", () => {
     filterState = {
       applyFilters: false,
       appliedFilters: [{ filterType: "sort", value: "Artwork year (descending)" }],
+      previouslyAppliedFilters: [{ filterType: "sort", value: "Artwork year (descending)" }],
       selectedFilters: [],
     }
 
@@ -101,6 +152,7 @@ describe("Select Filters", () => {
     expect(r).toEqual({
       applyFilters: false,
       appliedFilters: [{ filterType: "sort", value: "Artwork year (descending)" }],
+      previouslyAppliedFilters: [{ filterType: "sort", value: "Artwork year (descending)" }],
       selectedFilters: [],
     })
   })
@@ -109,6 +161,7 @@ describe("Select Filters", () => {
     filterState = {
       applyFilters: false,
       appliedFilters: [],
+      previouslyAppliedFilters: [],
       selectedFilters: [],
     }
 
@@ -122,6 +175,7 @@ describe("Select Filters", () => {
     expect(r).toEqual({
       applyFilters: false,
       appliedFilters: [],
+      previouslyAppliedFilters: [],
       selectedFilters: [],
     })
   })
@@ -130,6 +184,7 @@ describe("Select Filters", () => {
     filterState = {
       applyFilters: false,
       appliedFilters: [],
+      previouslyAppliedFilters: [],
       selectedFilters: [{ filterType: "sort", value: "Artwork year (descending)" }],
     }
 
@@ -143,6 +198,7 @@ describe("Select Filters", () => {
     expect(r).toEqual({
       applyFilters: false,
       appliedFilters: [],
+      previouslyAppliedFilters: [],
       selectedFilters: [],
     })
   })
@@ -153,6 +209,7 @@ describe("Apply Filters", () => {
     filterState = {
       applyFilters: true,
       appliedFilters: [],
+      previouslyAppliedFilters: [],
       selectedFilters: [{ value: "Artwork year (descending)", filterType: "sort" }],
     }
 
@@ -165,6 +222,7 @@ describe("Apply Filters", () => {
     expect(r).toEqual({
       applyFilters: true,
       appliedFilters: [{ value: "Artwork year (descending)", filterType: "sort" }],
+      previouslyAppliedFilters: [{ value: "Artwork year (descending)", filterType: "sort" }],
       selectedFilters: [],
     })
   })
@@ -173,6 +231,7 @@ describe("Apply Filters", () => {
     filterState = {
       applyFilters: true,
       appliedFilters: [{ value: "Recently updated", filterType: "sort" }],
+      previouslyAppliedFilters: [{ value: "Recently updated", filterType: "sort" }],
       selectedFilters: [{ value: "Recently updated", filterType: "sort" }],
     }
 
@@ -185,6 +244,7 @@ describe("Apply Filters", () => {
     expect(r).toEqual({
       applyFilters: true,
       appliedFilters: [{ value: "Recently updated", filterType: "sort" }],
+      previouslyAppliedFilters: [{ value: "Recently updated", filterType: "sort" }],
       selectedFilters: [],
     })
   })
@@ -193,6 +253,7 @@ describe("Apply Filters", () => {
     filterState = {
       applyFilters: true,
       appliedFilters: [{ value: "Recently updated", filterType: "sort" }],
+      previouslyAppliedFilters: [{ value: "Recently updated", filterType: "sort" }],
       selectedFilters: [{ value: "Artwork year (descending)", filterType: "sort" }],
     }
 
@@ -205,6 +266,7 @@ describe("Apply Filters", () => {
     expect(r).toEqual({
       applyFilters: true,
       appliedFilters: [{ value: "Artwork year (descending)", filterType: "sort" }],
+      previouslyAppliedFilters: [{ value: "Artwork year (descending)", filterType: "sort" }],
       selectedFilters: [],
     })
   })


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/FX-1873

When a user clicks "Clear All", we want to re-set their current UI state in the filter modal to the default, but also allow them to:
- X out of the modal entirely, in which case if they re-open it's as if they'd never clicked "Clear all" at all
- Apply the changes, in which case everything is returned to the default upon re-opening the modal.

In order to do this, I added an additional piece of state (currently named `previouslyAppliedFilters`). The updated definition of our `ArtworkContextFilterState` is:
- `selectedFilters`: Options that are selected within the filter modal UI. Gets re-set to `[]` when the modal is closed.
- `appliedFilters`: Always represents the filters that are applied to the artwork grid. Only changes when new filters are applied.
- `previouslyAppliedFilters`: Always equal to `appliedFilters` when the modal is opened. Gets re-set to `[]` when "Clear All" is selected.

I don't _think_ there's a way to achieve what we want without this added piece of state (but could be wrong!!). `appliedFilters` is our source of truth for what is _actually_ "applied", so it can only be updated when a change is _actually_ applied. `selectedFilters` represents the diff between what is currently applied and what the user has selected in the UI. In the case of "Clear All", it's possible you won't have selected _anything_ at the time when you click it, so I don't think we can use that.

Let me know if this is confusing! 

![clearall](https://user-images.githubusercontent.com/2081340/77804366-b639e500-7055-11ea-88fe-835be8185cef.gif)
