### PR TITLE
Fix beta build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,6 +221,10 @@ jobs:
             then
               circleci step halt
             fi
+      - run:
+          name: Clear project dir
+          command: |
+            rm -rf /Users/distiller/project
       - checkout
       - attach_workspace:
           at: .


### PR DESCRIPTION
On our first beta build after the CI revamp, the build failed claiming that the project directory was not empty while trying to check out the code from github.

Not sure why this was only a problem on the beta branch, but the fix is straightforward enough: just delete the project directory before it tries to check it out :)