### PR TITLE
Revert "Update node orb to v2"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@2.0.0
+  node: circleci/node@1.1.6
   queue: eddiewebb/queue@1.0.110
 
 commands:
@@ -164,7 +164,7 @@ jobs:
   update-metaphysics:
     executor:
       name: node/default
-      tag: "12.13"
+      tag: "12.13.1"
     steps:
       - checkout
       - generate-checksums
@@ -179,7 +179,7 @@ jobs:
   build-test-js:
     executor:
       name: node/default
-      tag: "12.13"
+      tag: "12.13.1"
     steps:
       - checkout
       - generate-checksums


### PR DESCRIPTION
Reverts artsy/eigen#3120

This PR seems to have caused a problem with linux builds not being able to restore caches properly, or simply running out of memory. I'm going to revert for now and send CircleCI a message about it.

Here's an example build failure: https://app.circleci.com/pipelines/github/artsy/eigen/487/workflows/81c4aeaa-002f-4af3-a08d-8758485e96f6/jobs/7699

Notice that the cache restorations appear to happen successfully but then the actual files aren't there.