### PR TITLE
Removes generated files from PR web diffs, hopefully #trivial

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 CHANGELOG.yml merge=union
-src/__generated__/*.graphql.ts linguist-generated
-src/__generated__/*.queryMap.json linguist-generated
+src/__generated__/*.graphql.ts linguist-generated=true
+src/__generated__/*.queryMap.json linguist-generated=true


### PR DESCRIPTION
I was reviewing #3134 and the "mark file as viewed" feature in GitHub PRs was tedious to use. I looked up [the docs](https://help.github.com/en/github/administering-a-repository/customizing-how-changed-files-appear-on-github) and it looks like we had a slight syntax error. This should remove the generated files from the PR review pane, I think.