### PR TITLE
Attempt to fix an issue where whatsNew in AppStore can not be updated

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,7 +4,7 @@ upcoming:
   dev:
     - Directly track lotViewed instead of using legacy `session` tracking - bhoggard & dleve123
   user_facing:
-    - Adds <ArtistConsignButton> to Artist page - chris
+    - Adds ArtistConsignButton to Artist page - chris
     - Show verification text and FAQ link in auctions - brian
 
 releases:


### PR DESCRIPTION
Updating whatsNew in the App Store [started failing](https://circleci.com/gh/artsy/eigen/7852) due to:

> Could not set changelog: An attribute value has invalid text. - Text for whatsNew contains invalid characters/formats.

Here is my attempt to fix it. Let's see how it goes...

#trivial