### PR TITLE
Non-IDV bidder sees copy in the "registration pending" modals about identity verification

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -12,6 +12,7 @@ upcoming:
     - Adds a Zero Artworks screen to handle filters that return no results - ashleyjelks
     - Reorganized home screen - ash
     - Adds analytics tracking to collections artwork filters - ashleyjelks
+    - Non-IDV bidder should see copy about identity verification on the registration result screen - yuki
 
 releases:
   - version: 6.4.0

--- a/src/lib/Components/Bidding/Screens/Registration.tsx
+++ b/src/lib/Components/Bidding/Screens/Registration.tsx
@@ -275,6 +275,7 @@ export class Registration extends React.Component<RegistrationProps, Registratio
       title: "",
       passProps: {
         status,
+        needsIdentityVerification: needsIdentityVerification(this.props.sale, this.props.me)
       },
     })
 

--- a/src/lib/Components/Bidding/Screens/RegistrationResult.tsx
+++ b/src/lib/Components/Bidding/Screens/RegistrationResult.tsx
@@ -1,5 +1,7 @@
+import { Button, Sans } from "@artsy/palette"
 import React from "react"
 import { View } from "react-native"
+import { blockRegex } from "simple-markdown"
 
 import { Icon20 } from "../Components/Icon"
 import { Flex } from "../Elements/Flex"
@@ -9,12 +11,13 @@ import { BiddingThemeProvider } from "../Components/BiddingThemeProvider"
 import { Container } from "../Components/Containers"
 import { Title } from "../Components/Title"
 
-import { Button } from "@artsy/palette"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
-import { Schema, screenTrack } from "../../../utils/track"
+import { defaultRules } from "lib/utils/renderMarkdown"
+import { Schema, screenTrack } from "lib/utils/track"
 
 interface RegistrationResultProps {
   status: RegistrationStatus
+  needsIdentityVerification?: boolean
 }
 
 export enum RegistrationStatus {
@@ -27,12 +30,13 @@ export enum RegistrationStatus {
 const Icons = {
   RegistrationStatusComplete: require("../../../../../images/circle-check-green.png"),
   RegistrationStatusPending: require("../../../../../images/circle-exclamation.png"),
+  RegistrationStatusNetworkError: require("../../../../../images/circle-x-red.png"),
   RegistrationStatusError: require("../../../../../images/circle-x-red.png"),
 }
 
 const registrationCompleteMessage = {
   title: "Registration complete",
-  description: "Thank you for registering. You’re now eligible\n" + "to bid on works in this sale.",
+  description: "Thank you for registering. You’re now eligible to bid on works in this sale.",
 }
 
 const registrationPendingMessage = {
@@ -43,8 +47,18 @@ const registrationPendingMessage = {
     "In the meantime, you can still view works and watch lots you’re interested in.",
 }
 
+const registrationPendingDueToUnverifiedStatusMessage = {
+  title: "Registration pending",
+  description:
+    "This auction requires Artsy to verify your identity before bidding.\n" +
+    "\n" +
+    "For details about identity verification, please see the FAQ or contact [verification@artsy.net](mailto:verification@artsy.net).\n" +
+    "\n" +
+    "A link to complete identity verification has been sent to your email.",
+}
+
 const registrationErrorMessage = {
-  title: "An error occured",
+  title: "An error occurred",
   description: "Please contact [support@artsy.net](mailto:support@artsy.net)\n" + "with any questions.",
 }
 
@@ -52,6 +66,19 @@ const registrationNetworkErrorMessage = {
   title: "An error occurred",
   description: "Please\ncheck your internet connection\nand try again.",
 }
+
+const markdownRules = defaultRules(false, {
+  paragraph: {
+    match: blockRegex(/^((?:[^\n]|\n(?! *\n))+)(?:\n *)/),
+    react: (node, output, state) => {
+      return (
+        <Sans size="4" key={state.key} textAlign="center">
+          {output(node.content, state)}
+        </Sans>
+      )
+    },
+  },
+})
 
 const resultEnumToPageName = (result: RegistrationStatus) => {
   let pageName: Schema.PageNames
@@ -61,6 +88,7 @@ const resultEnumToPageName = (result: RegistrationStatus) => {
       break
     case RegistrationStatus.RegistrationStatusPending:
       pageName = Schema.PageNames.BidFlowRegistrationResultPending
+      break
     default:
       pageName = Schema.PageNames.BidFlowRegistrationResultError
   }
@@ -77,7 +105,7 @@ export class RegistrationResult extends React.Component<RegistrationResultProps,
   }
 
   render() {
-    const status = this.props.status
+    const { status, needsIdentityVerification } = this.props
     let title: string
     let msg: string
 
@@ -87,12 +115,18 @@ export class RegistrationResult extends React.Component<RegistrationResultProps,
         msg = registrationCompleteMessage.description
         break
       case RegistrationStatus.RegistrationStatusPending:
-        title = registrationPendingMessage.title
-        msg = registrationPendingMessage.description
+        if (needsIdentityVerification) {
+          title = registrationPendingDueToUnverifiedStatusMessage.title
+          msg = registrationPendingDueToUnverifiedStatusMessage.description
+        } else {
+          title = registrationPendingMessage.title
+          msg = registrationPendingMessage.description
+        }
         break
       case RegistrationStatus.RegistrationStatusNetworkError:
         title = registrationNetworkErrorMessage.title
         msg = registrationNetworkErrorMessage.description
+        break
       default:
         title = registrationErrorMessage.title
         msg = registrationErrorMessage.description
@@ -108,7 +142,9 @@ export class RegistrationResult extends React.Component<RegistrationResultProps,
               <Title mt={2} mb={4}>
                 {title}
               </Title>
-              <Markdown mb={5}>{msg}</Markdown>
+              <Markdown rules={markdownRules} mb={5}>
+                {msg}
+              </Markdown>
             </Flex>
           </View>
           <Button variant="secondaryOutline" onPress={this.exitBidFlow} block width={100}>

--- a/src/lib/Components/Bidding/Screens/__tests__/Registration-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/Registration-tests.tsx
@@ -313,7 +313,10 @@ describe("when pressing register button", () => {
     jest.runAllTicks()
 
     expect(nextStep.component).toEqual(RegistrationResult)
-    expect(nextStep.passProps).toEqual({ status: RegistrationStatus.RegistrationStatusError })
+    expect(nextStep.passProps).toEqual({
+      status: RegistrationStatus.RegistrationStatusError,
+      needsIdentityVerification: false,
+    })
   })
 
   it("shows the error screen with the default error message if there are unhandled errors from the updateUserProfile mutation", () => {
@@ -404,7 +407,10 @@ describe("when pressing register button", () => {
     jest.runAllTicks()
 
     expect(nextStep.component).toEqual(RegistrationResult)
-    expect(nextStep.passProps).toEqual({ status: RegistrationStatus.RegistrationStatusNetworkError })
+    expect(nextStep.passProps).toEqual({
+      status: RegistrationStatus.RegistrationStatusNetworkError,
+      needsIdentityVerification: false,
+    })
   })
 
   it("displays an error message on a creditCardMutation failure", () => {
@@ -511,7 +517,10 @@ describe("when pressing register button", () => {
     jest.runAllTicks()
 
     expect(nextStep.component).toEqual(RegistrationResult)
-    expect(nextStep.passProps).toEqual({ status: RegistrationStatus.RegistrationStatusNetworkError })
+    expect(nextStep.passProps).toEqual({
+      status: RegistrationStatus.RegistrationStatusNetworkError,
+      needsIdentityVerification: false,
+    })
   })
 
   it("displays an error message on a bidderMutation failure", () => {
@@ -535,7 +544,10 @@ describe("when pressing register button", () => {
     jest.runAllTicks()
 
     expect(nextStep.component).toEqual(RegistrationResult)
-    expect(nextStep.passProps).toEqual({ status: RegistrationStatus.RegistrationStatusError })
+    expect(nextStep.passProps).toEqual({
+      status: RegistrationStatus.RegistrationStatusError,
+      needsIdentityVerification: false,
+    })
   })
 
   it("displays an error message on a network failure", () => {
@@ -558,7 +570,10 @@ describe("when pressing register button", () => {
     jest.runAllTicks()
 
     expect(nextStep.component).toEqual(RegistrationResult)
-    expect(nextStep.passProps).toEqual({ status: RegistrationStatus.RegistrationStatusNetworkError })
+    expect(nextStep.passProps).toEqual({
+      status: RegistrationStatus.RegistrationStatusNetworkError,
+      needsIdentityVerification: false,
+    })
   })
 
   it("displays the pending result when the bidder is not qualified_for_bidding", () => {
@@ -575,7 +590,6 @@ describe("when pressing register button", () => {
 
     component.root.findByType(Checkbox).instance.props.onPress()
     component.root.findAllByType(Button)[1].instance.props.onPress()
-
     jest.runAllTicks()
 
     expect(mockPostNotificationName).toHaveBeenCalledWith("ARAuctionArtworkRegistrationUpdated", {
@@ -583,7 +597,41 @@ describe("when pressing register button", () => {
     })
 
     expect(nextStep.component).toEqual(RegistrationResult)
-    expect(nextStep.passProps).toEqual({ status: RegistrationStatus.RegistrationStatusPending })
+    expect(nextStep.passProps).toEqual({
+      status: RegistrationStatus.RegistrationStatusPending,
+      needsIdentityVerification: false,
+    })
+  })
+
+  it("displays the pending result with needsIdentityVerification: true when the sale requires identity verification", () => {
+    const propsWithIDVSale = {
+      ...initialPropsForUserWithCreditCard,
+      sale: {
+        ...sale,
+        requireIdentityVerification: true,
+      },
+    }
+
+    relay.commitMutation = commitMutationMock((_, { onCompleted }) => {
+      onCompleted({ createBidder: { bidder: { qualified_for_bidding: false } } }, null)
+      return null
+    }) as any
+
+    const component = renderer.create(
+      <BiddingThemeProvider>
+        <Registration {...propsWithIDVSale} />
+      </BiddingThemeProvider>
+    )
+
+    component.root.findByType(Checkbox).instance.props.onPress()
+    component.root.findAllByType(Button)[1].instance.props.onPress()
+    jest.runAllTicks()
+
+    expect(nextStep.component).toEqual(RegistrationResult)
+    expect(nextStep.passProps).toEqual({
+      status: RegistrationStatus.RegistrationStatusPending,
+      needsIdentityVerification: true,
+    })
   })
 
   it("displays the completed result when the bidder is qualified_for_bidding", () => {
@@ -608,7 +656,10 @@ describe("when pressing register button", () => {
     })
 
     expect(nextStep.component).toEqual(RegistrationResult)
-    expect(nextStep.passProps).toEqual({ status: RegistrationStatus.RegistrationStatusComplete })
+    expect(nextStep.passProps).toEqual({
+      status: RegistrationStatus.RegistrationStatusComplete,
+      needsIdentityVerification: false,
+    })
   })
 })
 
@@ -650,6 +701,7 @@ const sale: Partial<Registration_sale> = {
   name: "Phillips New Now",
   start_at: "2018-06-11T01:00:00+00:00",
   is_preview: true,
+  requireIdentityVerification: false,
 }
 
 const mockRequestResponses = {

--- a/src/lib/Components/Bidding/Screens/__tests__/RegistrationResult-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/RegistrationResult-tests.tsx
@@ -21,10 +21,24 @@ describe("Registration result component", () => {
   it("renders registration pending properly", () => {
     const tree = renderer.create(
       <BiddingThemeProvider>
-        <RegistrationResult status={RegistrationStatus.RegistrationStatusPending} />
+        <RegistrationResult status={RegistrationStatus.RegistrationStatusPending} needsIdentityVerification={false} />
       </BiddingThemeProvider>
     )
     expect(extractText(tree.root)).toMatch("Registration pending")
+    expect(extractText(tree.root)).toMatch("Artsy is reviewing your registration and you will receive an email when it has been confirmed. Please email ")
+    expect(extractText(tree.root)).not.toMatch("This auction requires Artsy to verify your identity before bidding.")
+  })
+
+  it("renders registration pending with an explanation about IDV", () => {
+    const tree = renderer.create(
+      <BiddingThemeProvider>
+        <RegistrationResult status={RegistrationStatus.RegistrationStatusPending} needsIdentityVerification />
+      </BiddingThemeProvider>
+    )
+
+    expect(extractText(tree.root)).toMatch("Registration pending")
+    expect(extractText(tree.root)).toMatch("This auction requires Artsy to verify your identity before bidding.")
+    expect(extractText(tree.root)).not.toMatch("Artsy is reviewing your registration and you will receive an email when it has been confirmed. Please email ")
   })
 
   it("does not render the icon when the registration status is pending", () => {
@@ -52,7 +66,22 @@ describe("Registration result component", () => {
         <RegistrationResult status={RegistrationStatus.RegistrationStatusError} />
       </BiddingThemeProvider>
     )
-    expect(extractText(tree.root)).toMatch("An error occured")
+
+    expect(extractText(tree.root)).toMatch("An error occurred")
+    expect(extractText(tree.root)).toMatch("Please contact")
+    expect(extractText(tree.root)).toMatch("with any questions.")
+  })
+
+  it("renders an error screen when the status is a network error", () => {
+    const tree = renderer
+      .create(
+        <BiddingThemeProvider>
+          <RegistrationResult status={RegistrationStatus.RegistrationStatusNetworkError} />
+        </BiddingThemeProvider>
+      )
+
+    expect(extractText(tree.root)).toMatch("An error occurred")
+    expect(extractText(tree.root)).toMatch("Please\ncheck your internet connection\nand try again.")
   })
 
   it("renders registration error and mailto link properly", async () => {

--- a/src/lib/utils/renderMarkdown.tsx
+++ b/src/lib/utils/renderMarkdown.tsx
@@ -11,14 +11,10 @@ interface OurReactRule extends Partial<ParserRule> {
   react?: ReactNodeOutput
 }
 
+type MarkdownRules = Partial<{ [k in keyof SimpleMarkdown.DefaultRules]: OurReactRule }>
+
 // just to get better intellisense when creating the rules
-function createReactRules(
-  rules: Partial<
-    {
-      [k in keyof SimpleMarkdown.DefaultRules]: OurReactRule
-    }
-  >
-): ParserRules {
+function createReactRules(rules: MarkdownRules): ParserRules {
   const result: any = {}
   for (const key of Object.keys(SimpleMarkdown.defaultRules)) {
     if (rules[key]) {
@@ -37,7 +33,7 @@ function createReactRules(
 // https://github.com/CharlesMangwa/react-native-simple-markdown/blob/next/src/rules.js for new functionalities.
 //
 // Default rules: https://github.com/Khan/simple-markdown/blob/f1a75785703832bbff146d0b98e76cd7ac74b8e8/simple-markdown.js#L806
-export function defaultRules(modal: boolean = false): ParserRules {
+export function defaultRules(modal: boolean = false, roleOverrides: MarkdownRules = {}): ParserRules {
   return createReactRules({
     link: {
       react: (node, output, state) => {
@@ -209,6 +205,7 @@ export function defaultRules(modal: boolean = false): ParserRules {
     hr: {
       react: () => <Separator mb={2}></Separator>,
     },
+    ...roleOverrides
   })
 }
 


### PR DESCRIPTION
addresses https://artsyproduct.atlassian.net/browse/AUCT-951 and https://artsyproduct.atlassian.net/browse/AUCT-953.

## Todos

 * [x] Fix type errors
 * [x] Add more test coverage
    * [x] `src/lib/Components/Bidding/Screens/Registration.tsx`
    * [x] `src/lib/Components/Bidding/Screens/RegistrationResult.tsx`
   
## Screenshots

### Registration Pending on iPhone X

![AUCT-953](https://user-images.githubusercontent.com/386234/78296386-aa3d9f80-74fb-11ea-8554-51f7baf15aaf.gif)

### Other screens on iPhone SE

<img width="1900" alt="Screen Shot 2020-04-03 at 12 10 40 PM" src="https://user-images.githubusercontent.com/386234/78688728-8c898500-78c3-11ea-9b2f-eef063ef672a.png">
