### PR TITLE
[Bugfix/Consignments] Ensure inner button triggers action

### DIFF
--- a/src/lib/Components/Artist/ArtistConsignButton.tsx
+++ b/src/lib/Components/Artist/ArtistConsignButton.tsx
@@ -28,23 +28,22 @@ export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = props => 
   const imageURL = image?.cropped?.url
   const headline = isInMicrofunnel ? `Sell your ${name}` : "Sell art from your collection"
 
-  return (
-    <TouchableOpacity
-      ref={buttonRef}
-      onPress={() => {
-        tracking.trackEvent({
-          context_page: Schema.PageNames.ArtistPage,
-          context_page_owner_id: props.artist.internalID,
-          context_page_owner_slug: props.artist.slug,
-          context_page_owner_type: Schema.OwnerEntityTypes.Artist,
-          context_module: Schema.ContextModules.ArtistConsignment,
-          subject: Schema.ActionNames.ArtistConsignGetStarted,
-          destination_path: Router.ConsignmentsStartSubmission,
-        })
+  const onConsignButtonPress = () => {
+    tracking.trackEvent({
+      context_page: Schema.PageNames.ArtistPage,
+      context_page_owner_id: props.artist.internalID,
+      context_page_owner_slug: props.artist.slug,
+      context_page_owner_type: Schema.OwnerEntityTypes.Artist,
+      context_module: Schema.ContextModules.ArtistConsignment,
+      subject: Schema.ActionNames.ArtistConsignGetStarted,
+      destination_path: Router.ConsignmentsStartSubmission,
+    })
 
-        SwitchBoard.presentNavigationViewController(buttonRef.current, Router.ConsignmentsStartSubmission)
-      }}
-    >
+    SwitchBoard.presentNavigationViewController(buttonRef.current, Router.ConsignmentsStartSubmission)
+  }
+
+  return (
+    <TouchableOpacity ref={buttonRef} onPress={onConsignButtonPress}>
       <BorderBox p={1}>
         <Flex alignItems="center" flexDirection="row">
           {isInMicrofunnel && imageURL && (
@@ -62,7 +61,7 @@ export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = props => 
               </Sans>
             </Box>
             <Box>
-              <Button size="small" variant="secondaryGray">
+              <Button size="small" variant="secondaryGray" onPress={onConsignButtonPress}>
                 Get started
               </Button>
             </Box>

--- a/src/lib/Components/Artist/__tests__/ArtistConsignButton-tests.tsx
+++ b/src/lib/Components/Artist/__tests__/ArtistConsignButton-tests.tsx
@@ -1,4 +1,4 @@
-import { Theme } from "@artsy/palette"
+import { Button, Theme } from "@artsy/palette"
 import { ArtistConsignButtonTestsQuery } from "__generated__/ArtistConsignButtonTestsQuery.graphql"
 import { extractText } from "lib/tests/extractText"
 import { cloneDeep } from "lodash"
@@ -105,7 +105,7 @@ describe("ArtistConsignButton", () => {
       expect(image).toHaveLength(0)
     })
 
-    it("tracks clicks", async () => {
+    it("tracks clicks on outer container", async () => {
       const tree = ReactTestRenderer.create(<TestRenderer />)
       act(() => {
         env.mock.resolveMostRecentOperation({
@@ -114,6 +114,26 @@ describe("ArtistConsignButton", () => {
         })
       })
       tree.root.findByType(TouchableOpacity).props.onPress()
+      expect(trackEvent).toHaveBeenCalledWith({
+        context_page: "Artist",
+        context_page_owner_id: response.artist.internalID,
+        context_page_owner_slug: response.artist.slug,
+        context_page_owner_type: "Artist",
+        context_module: "ArtistConsignment",
+        subject: "Get Started",
+        destination_path: "/consign/submission",
+      })
+    })
+
+    it("tracks clicks on inner button", async () => {
+      const tree = ReactTestRenderer.create(<TestRenderer />)
+      act(() => {
+        env.mock.resolveMostRecentOperation({
+          errors: [],
+          data: response,
+        })
+      })
+      tree.root.findByType(Button).props.onPress()
       expect(trackEvent).toHaveBeenCalledWith({
         context_page: "Artist",
         context_page_owner_id: response.artist.internalID,
@@ -153,7 +173,7 @@ describe("ArtistConsignButton", () => {
       expect(extractText(tree.root)).toContain("Sell art from your collection")
     })
 
-    it("tracks clicks", async () => {
+    it("tracks clicks on outer container", async () => {
       const tree = ReactTestRenderer.create(<TestRenderer />)
       act(() => {
         env.mock.resolveMostRecentOperation({
@@ -162,6 +182,26 @@ describe("ArtistConsignButton", () => {
         })
       })
       tree.root.findByType(TouchableOpacity).props.onPress()
+      expect(trackEvent).toHaveBeenCalledWith({
+        context_page: "Artist",
+        context_page_owner_id: response.artist.internalID,
+        context_page_owner_slug: response.artist.slug,
+        context_page_owner_type: "Artist",
+        context_module: "ArtistConsignment",
+        subject: "Get Started",
+        destination_path: "/consign/submission",
+      })
+    })
+
+    it("tracks clicks on inner button", async () => {
+      const tree = ReactTestRenderer.create(<TestRenderer />)
+      act(() => {
+        env.mock.resolveMostRecentOperation({
+          errors: [],
+          data: response,
+        })
+      })
+      tree.root.findByType(Button).props.onPress()
       expect(trackEvent).toHaveBeenCalledWith({
         context_page: "Artist",
         context_page_owner_id: response.artist.internalID,

--- a/src/lib/Components/Artist/__tests__/__snapshots__/ArtistConsignButton-tests.tsx.snap
+++ b/src/lib/Components/Artist/__tests__/__snapshots__/ArtistConsignButton-tests.tsx.snap
@@ -137,6 +137,7 @@ exports[`ArtistConsignButton Top 20 Artist ('Microfunnel') Button renders a snap
             }
           >
             <View
+              onPress={[Function]}
               px={1}
               size="small"
               style={


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/CSGN-125

We had a click action on the outer container, but this isn't web; the inner button will capture the event if touched.

![button](https://user-images.githubusercontent.com/236943/78615032-32d27d80-7825-11ea-94eb-0f4baa47b048.gif)

#trivial 