### PR TITLE
Adds tracking to collections artworks filters

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -10,6 +10,7 @@ upcoming:
     - Non-IDV bidder registering through typical registration form sees information about identity verification - yuki
     - Adds a Zero Artworks screen to handle filters that return no results - ashleyjelks
     - Reorganized home screen - ash
+    - Adds analytics tracking to collections artwork filters - ashleyjelks
 
 releases:
   - version: 6.4.0

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -1,7 +1,11 @@
 import { ArrowRightIcon, Box, Button, CloseIcon, color, Flex, Sans, Serif, space } from "@artsy/palette"
+import { Collection_collection } from "__generated__/Collection_collection.graphql"
+import { filterArtworksParams } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
+import { Schema } from "lib/utils/track"
 import React, { useContext, useState } from "react"
 import { FlatList, Modal as RNModal, TouchableOpacity, TouchableWithoutFeedback, ViewProperties } from "react-native"
 import NavigatorIOS from "react-native-navigator-ios"
+import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
 import { ArtworkFilterContext, FilterOption, useSelectedOptionsDisplay } from "../utils/ArtworkFiltersStore"
 import { MediumOptionsScreen as MediumOptions } from "./ArtworkFilterOptions/MediumOptions"
@@ -9,12 +13,18 @@ import { SortOptionsScreen as SortOptions } from "./ArtworkFilterOptions/SortOpt
 
 interface FilterModalProps extends ViewProperties {
   closeModal?: () => void
+  exitModal?: () => void
   navigator?: NavigatorIOS
   isFilterArtworksModalVisible: boolean
+  collection: Collection_collection
 }
 
-export const FilterModalNavigator: React.SFC<FilterModalProps> = ({ closeModal, isFilterArtworksModalVisible }) => {
+export const FilterModalNavigator: React.SFC<FilterModalProps> = props => {
+  const tracking = useTracking()
+
+  const { closeModal, exitModal, isFilterArtworksModalVisible, collection } = props
   const { dispatch, state } = useContext(ArtworkFilterContext)
+  const { id, slug } = collection
 
   const handleClosingModal = () => {
     dispatch({ type: "resetFilters" })
@@ -23,7 +33,7 @@ export const FilterModalNavigator: React.SFC<FilterModalProps> = ({ closeModal, 
 
   const applyFilters = () => {
     dispatch({ type: "applyFilters" })
-    closeModal()
+    exitModal()
   }
 
   const getApplyButtonCount = () => {
@@ -47,7 +57,7 @@ export const FilterModalNavigator: React.SFC<FilterModalProps> = ({ closeModal, 
                   navigationBarHidden={true}
                   initialRoute={{
                     component: FilterOptions,
-                    passProps: { closeModal },
+                    passProps: { closeModal, id, slug },
                     title: "",
                   }}
                   style={{ flex: 1 }}
@@ -55,7 +65,18 @@ export const FilterModalNavigator: React.SFC<FilterModalProps> = ({ closeModal, 
                 <Box p={2}>
                   <ApplyButton
                     disabled={!isApplyButtonEnabled}
-                    onPress={applyFilters}
+                    onPress={() => {
+                      tracking.trackEvent({
+                        context_screen: Schema.ContextModules.Collection,
+                        context_screen_owner_type: Schema.ContextModules.Collection,
+                        context_screen_owner_id: id,
+                        context_screen_owner_slug: slug,
+                        current: filterArtworksParams(state.appliedFilters),
+                        changed: filterArtworksParams(state.selectedFilters),
+                      })
+
+                      applyFilters()
+                    }}
                     block
                     width={100}
                     variant="primaryBlack"
@@ -76,11 +97,15 @@ export const FilterModalNavigator: React.SFC<FilterModalProps> = ({ closeModal, 
 interface FilterOptionsProps {
   closeModal: () => void
   navigator: NavigatorIOS
+  id: Collection_collection["id"]
+  slug: Collection_collection["slug"]
 }
 
 type FilterOptions = Array<{ filterType: FilterOption; filterText: string; onTap: () => void }>
 
-export const FilterOptions: React.SFC<FilterOptionsProps> = ({ closeModal, navigator }) => {
+export const FilterOptions: React.SFC<FilterOptionsProps> = props => {
+  const tracking = useTracking()
+  const { closeModal, navigator, id, slug } = props
   const FilterScreenComponents = {
     sort: SortOptions,
     medium: MediumOptions,
@@ -129,7 +154,19 @@ export const FilterOptions: React.SFC<FilterOptionsProps> = ({ closeModal, navig
         <FilterHeader weight="medium" size="4" color="black100">
           Filter
         </FilterHeader>
-        <ClearAllButton onPress={clearAllFilters}>
+        <ClearAllButton
+          onPress={() => {
+            tracking.trackEvent({
+              action_name: "clearFilters",
+              context_screen: Schema.ContextModules.Collection,
+              context_screen_owner_type: Schema.OwnerEntityTypes.Collection,
+              context_screen_owner_id: id,
+              context_screen_owner_slug: slug,
+            })
+
+            clearAllFilters()
+          }}
+        >
           <Sans mr={2} mt={2} size="4" color="black100">
             Clear all
           </Sans>

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -68,7 +68,7 @@ export const FilterModalNavigator: React.SFC<FilterModalProps> = props => {
                     onPress={() => {
                       tracking.trackEvent({
                         context_screen: Schema.ContextModules.Collection,
-                        context_screen_owner_type: Schema.ContextModules.Collection,
+                        context_screen_owner_type: Schema.OwnerEntityTypes.Collection,
                         context_screen_owner_id: id,
                         context_screen_owner_slug: slug,
                         current: filterArtworksParams(state.appliedFilters),

--- a/src/lib/Components/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/__tests__/FilterModal-tests.tsx
@@ -8,6 +8,7 @@ import { NativeModules } from "react-native"
 import { graphql, RelayPaginationProp } from "react-relay"
 import { act, create } from "react-test-renderer"
 import * as renderer from "react-test-renderer"
+import { useTracking } from "react-tracking"
 import { ArrowLeftIconContainer } from "../../../lib/Components/ArtworkFilterOptions/SortOptions"
 import { FakeNavigator as MockNavigator } from "../../../lib/Components/Bidding/__tests__/Helpers/FakeNavigator"
 import {
@@ -24,10 +25,17 @@ import { ArtworkFilterContext, ArtworkFilterContextState, reducer } from "../../
 let mockNavigator: MockNavigator
 let state: ArtworkFilterContextState
 const closeModalMock = jest.fn()
+const exitModalMock = jest.fn()
+const trackEvent = jest.fn()
 
 jest.unmock("react-relay")
 
 beforeEach(() => {
+  ;(useTracking as jest.Mock).mockImplementation(() => {
+    return {
+      trackEvent,
+    }
+  })
   mockNavigator = new MockNavigator()
   state = {
     selectedFilters: [],
@@ -57,7 +65,12 @@ const MockFilterModalNavigator = ({ initialState }) => {
           dispatch,
         }}
       >
-        <FilterModalNavigator closeModal={closeModalMock} isFilterArtworksModalVisible />
+        <FilterModalNavigator
+          collection={CollectionFixture}
+          exitModal={exitModalMock}
+          closeModal={closeModalMock}
+          isFilterArtworksModalVisible
+        />
       </ArtworkFilterContext.Provider>
     </Theme>
   )
@@ -74,7 +87,7 @@ const MockFilterScreen = ({ initialState }) => {
           dispatch,
         }}
       >
-        <FilterOptions closeModal={closeModalMock} navigator={mockNavigator as any} />
+        <FilterOptions id="id" slug="slug" closeModal={closeModalMock} navigator={mockNavigator as any} />
       </ArtworkFilterContext.Provider>
     </Theme>
   )
@@ -90,7 +103,7 @@ describe("Filter modal navigation flow", () => {
             dispatch: null,
           }}
         >
-          <FilterOptions closeModal={jest.fn()} navigator={mockNavigator as any} />
+          <FilterOptions id="id" slug="slug" closeModal={jest.fn()} navigator={mockNavigator as any} />
         </ArtworkFilterContext.Provider>
       </Theme>
     )
@@ -136,7 +149,7 @@ describe("Filter modal navigation flow", () => {
             dispatch: null,
           }}
         >
-          <FilterOptions closeModal={jest.fn()} navigator={mockNavigator as any} />
+          <FilterOptions id="id" slug="slug" closeModal={jest.fn()} navigator={mockNavigator as any} />
         </ArtworkFilterContext.Provider>
       </Theme>
     )

--- a/src/lib/Scenes/Collection/Collection.tsx
+++ b/src/lib/Scenes/Collection/Collection.tsx
@@ -78,7 +78,8 @@ export class Collection extends Component<CollectionProps, CollectionState> {
             <FilterModalNavigator
               {...this.props}
               isFilterArtworksModalVisible={this.state.isFilterArtworksModalVisible}
-              closeModal={this.handleFilterArtworksModal.bind(this)}
+              exitModal={this.handleFilterArtworksModal.bind(this)}
+              closeModal={this.closeFilterArtworksModal.bind(this)}
             />
           </>
         )
@@ -99,15 +100,38 @@ export class Collection extends Component<CollectionProps, CollectionState> {
       return this.setState(_prevState => ({ isArtworkGridVisible: false }))
     })
   }
+
   handleFilterArtworksModal() {
     this.setState(_prevState => {
       return { isFilterArtworksModalVisible: !_prevState.isFilterArtworksModalVisible }
     })
   }
+
+  @screenTrack((props: CollectionProps) => ({
+    action_name: "filter",
+    context_screen_owner_type: Schema.OwnerEntityTypes.Collection,
+    context_screen: Schema.PageNames.Collection,
+    context_screen_owner_id: props.collection.id,
+    context_screen_owner_slug: props.collection.slug,
+  }))
+  openFilterArtworksModal() {
+    this.handleFilterArtworksModal()
+  }
+
+  @screenTrack((props: CollectionProps) => ({
+    action_name: "closeFilterWindow",
+    context_screen_owner_type: Schema.OwnerEntityTypes.Collection,
+    context_screen: Schema.PageNames.Collection,
+    context_screen_owner_id: props.collection.id,
+    context_screen_owner_slug: props.collection.slug,
+  }))
+  closeFilterArtworksModal() {
+    this.handleFilterArtworksModal()
+  }
+
   render() {
     const { isArtworkGridVisible, sections } = this.state
     const isArtworkFilterEnabled = NativeModules.Emission?.options?.AROptionsFilterCollectionsArtworks
-
     return (
       <ArtworkFilterGlobalStateProvider>
         <ArtworkFilterContext.Consumer>
@@ -129,7 +153,7 @@ export class Collection extends Component<CollectionProps, CollectionState> {
                   />
                   {isArtworkGridVisible && isArtworkFilterEnabled && (
                     <FilterArtworkButtonContainer>
-                      <TouchableWithoutFeedback onPress={this.handleFilterArtworksModal.bind(this)}>
+                      <TouchableWithoutFeedback onPress={this.openFilterArtworksModal.bind(this)}>
                         <FilterArtworkButton
                           px="2"
                           isFilterCountVisible={value.state.appliedFilters.length > 0 ? true : false}

--- a/src/lib/Scenes/Collection/Components/__fixtures__/CollectionFixture.ts
+++ b/src/lib/Scenes/Collection/Components/__fixtures__/CollectionFixture.ts
@@ -2,6 +2,7 @@ import { FullFeaturedArtistListTestsQueryRawResponse } from "__generated__/FullF
 
 export const CollectionFixture = {
   " $fragmentRefs": null,
+  " $refType": null,
   slug: "street-art-now",
   id: "top-level-id",
   title: "Street Art Now",

--- a/src/lib/Scenes/Collection/Helpers/FilterArtworksHelpers.ts
+++ b/src/lib/Scenes/Collection/Helpers/FilterArtworksHelpers.ts
@@ -1,0 +1,47 @@
+import { FilterArray } from "lib/utils/ArtworkFiltersStore"
+
+export const filterArtworksParams = (appliedFilters: FilterArray) => {
+  // Default params
+  const filterParams = {
+    sort: "-decayed_merch",
+    medium: "*",
+  }
+
+  const filterTypeToParam = {
+    sort: ArtworkSorts,
+    medium: MediumFilters,
+  }
+
+  appliedFilters.forEach(appliedFilterOption => {
+    const paramMapping = filterTypeToParam[appliedFilterOption.filterType]
+    const paramFromFilterType = paramMapping[appliedFilterOption.value]
+    filterParams[appliedFilterOption.filterType] = paramFromFilterType
+  })
+
+  return filterParams
+}
+
+enum ArtworkSorts {
+  "Default" = "-decayed_merch",
+  "Price (high to low)" = "sold,-has_price,-prices",
+  "Price (low to high)" = "sold,-has_price,prices",
+  "Recently updated" = "-partner_updated_at",
+  "Recently added" = "-published_at",
+  "Artwork year (descending)" = "-year",
+  "Artwork year (ascending)" = "year",
+}
+
+enum MediumFilters {
+  "All" = "*",
+  "Painting" = "painting",
+  "Photography" = "photography",
+  "Sculpture" = "sculpture",
+  "Prints & multiples" = "prints",
+  "Works on paper" = "work-on-paper",
+  "Film & video" = "film-slash-video",
+  "Design" = "design",
+  "Jewelry" = "jewelry",
+  "Drawing" = "drawing",
+  "Installation" = "installation",
+  "Performance art" = "performance-art",
+}

--- a/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -3,54 +3,9 @@ import { InfiniteScrollArtworksGridContainer as InfiniteScrollArtworksGrid } fro
 import { get } from "lib/utils/get"
 import React, { useContext, useEffect } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
-import { ArtworkFilterContext, FilterArray } from "../../../utils/ArtworkFiltersStore"
+import { ArtworkFilterContext } from "../../../utils/ArtworkFiltersStore"
+import { filterArtworksParams } from "../Helpers/FilterArtworksHelpers"
 import { CollectionZeroState } from "./CollectionZeroState"
-
-enum ArtworkSorts {
-  "Default" = "-decayed_merch",
-  "Price (high to low)" = "sold,-has_price,-prices",
-  "Price (low to high)" = "sold,-has_price,prices",
-  "Recently updated" = "-partner_updated_at",
-  "Recently added" = "-published_at",
-  "Artwork year (descending)" = "-year",
-  "Artwork year (ascending)" = "year",
-}
-
-enum MediumFilters {
-  "All" = "*",
-  "Painting" = "painting",
-  "Photography" = "photography",
-  "Sculpture" = "sculpture",
-  "Prints & multiples" = "prints",
-  "Works on paper" = "work-on-paper",
-  "Film & video" = "film-slash-video",
-  "Design" = "design",
-  "Jewelry" = "jewelry",
-  "Drawing" = "drawing",
-  "Installation" = "installation",
-  "Performance art" = "performance-art",
-}
-
-const filterTypeToParam = {
-  sort: ArtworkSorts,
-  medium: MediumFilters,
-}
-
-export const filterArtworksParams = (appliedFilters: FilterArray) => {
-  // Default params
-  const filterParams = {
-    sort: "-decayed_merch",
-    medium: "*",
-  }
-
-  appliedFilters.forEach(appliedFilterOption => {
-    const paramMapping = filterTypeToParam[appliedFilterOption.filterType]
-    const paramFromFilterType = paramMapping[appliedFilterOption.value]
-    filterParams[appliedFilterOption.filterType] = paramFromFilterType
-  })
-
-  return filterParams
-}
 
 const PAGE_SIZE = 10
 export const CollectionArtworks: React.FC<{
@@ -77,7 +32,7 @@ export const CollectionArtworks: React.FC<{
   }, [state.appliedFilters])
 
   if (artworksTotal === 0) {
-    return <CollectionZeroState />
+    return <CollectionZeroState id={collection.id} slug={collection.slug} />
   }
 
   return artworks && <InfiniteScrollArtworksGrid connection={artworks} loadMore={relay.loadMore} />

--- a/src/lib/Scenes/Collection/Screens/CollectionZeroState.tsx
+++ b/src/lib/Scenes/Collection/Screens/CollectionZeroState.tsx
@@ -1,10 +1,20 @@
 import { Button, color, Flex, Sans } from "@artsy/palette"
+import { Collection_collection } from "__generated__/Collection_collection.graphql"
+import { ArtworkFilterContext } from "lib/utils/ArtworkFiltersStore"
+import { Schema } from "lib/utils/track"
 import React, { useContext } from "react"
+import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
-import { ArtworkFilterContext } from "../../../utils/ArtworkFiltersStore"
 
-export const CollectionZeroState: React.SFC = () => {
+interface CollectionZeroStateProps {
+  id: Collection_collection["id"]
+  slug: Collection_collection["slug"]
+}
+
+export const CollectionZeroState: React.SFC<CollectionZeroStateProps> = props => {
+  const { id, slug } = props
   const { dispatch } = useContext(ArtworkFilterContext)
+  const tracking = useTracking()
 
   const refetchArtworks = () => {
     dispatch({ type: "clearFiltersZeroState" })
@@ -14,7 +24,21 @@ export const CollectionZeroState: React.SFC = () => {
     <ZeroStateContainer>
       <ZeroStateMessage size="3">Unfortunately, there are no works that meet your criteria.</ZeroStateMessage>
       <ButtonBox>
-        <Button size="medium" variant="secondaryGray" onPress={refetchArtworks}>
+        <Button
+          size="medium"
+          variant="secondaryGray"
+          onPress={() => {
+            tracking.trackEvent({
+              action_name: "clearFilters",
+              context_screen: Schema.ContextModules.Collection,
+              context_screen_owner_type: Schema.OwnerEntityTypes.Collection,
+              context_screen_owner_id: id,
+              context_screen_owner_slug: slug,
+            })
+
+            refetchArtworks()
+          }}
+        >
           Clear filters
         </Button>
       </ButtonBox>

--- a/src/lib/Scenes/Collection/Screens/__tests__/CollectionArtworks-tests.tsx
+++ b/src/lib/Scenes/Collection/Screens/__tests__/CollectionArtworks-tests.tsx
@@ -4,10 +4,8 @@ import {
   CollectionFixture,
   ZeroStateCollectionFixture,
 } from "lib/Scenes/Collection/Components/__fixtures__/CollectionFixture"
-import {
-  CollectionArtworksFragmentContainer as CollectionArtworks,
-  filterArtworksParams,
-} from "lib/Scenes/Collection/Screens/CollectionArtworks"
+import { filterArtworksParams } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
+import { CollectionArtworksFragmentContainer as CollectionArtworks } from "lib/Scenes/Collection/Screens/CollectionArtworks"
 import { renderRelayTree } from "lib/tests/renderRelayTree"
 import { FilterArray } from "lib/utils/ArtworkFiltersStore"
 import { ArtworkFilterContext, ArtworkFilterContextState } from "lib/utils/ArtworkFiltersStore"


### PR DESCRIPTION
Adds analytics tracking for:
- opening filter modal
- closing filter modal
- applying filters
- clearing filters

https://artsyproduct.atlassian.net/browse/FX-1856

<img width="722" alt="Screen Shot 2020-04-07 at 5 19 15 PM" src="https://user-images.githubusercontent.com/10385964/78720636-0c2f4800-78f4-11ea-8605-0592c37f6c7a.png">

<img width="714" alt="Screen Shot 2020-04-07 at 5 19 27 PM" src="https://user-images.githubusercontent.com/10385964/78720638-0cc7de80-78f4-11ea-8b8b-064d6938c756.png">

<img width="718" alt="Screen Shot 2020-04-07 at 5 21 10 PM" src="https://user-images.githubusercontent.com/10385964/78720744-397bf600-78f4-11ea-95f6-6341779a1b76.png">

<img width="710" alt="Screen Shot 2020-04-07 at 5 19 47 PM" src="https://user-images.githubusercontent.com/10385964/78720815-5e706900-78f4-11ea-845b-766b73527e0c.png">



#skip_new_tests