### PR TITLE
[Consignments] Update ArtistConsignButton with targetSupply check

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -186,9 +186,7 @@ type AnalyticsPartnerInquiryStats {
   period: AnalyticsQueryPeriodEnum!
 
   # Partner inquiry count time series
-  timeSeries(
-    cumulative: Boolean = false
-  ): [AnalyticsPartnerInquiryCountTimeSeriesStats!]
+  timeSeries(cumulative: Boolean = false): [AnalyticsPartnerInquiryCountTimeSeriesStats!]
 }
 
 # Sales stats of a partner
@@ -199,9 +197,7 @@ type AnalyticsPartnerSalesStats {
   period: AnalyticsQueryPeriodEnum!
 
   # Partner sales time series
-  timeSeries(
-    cumulative: Boolean = false
-  ): [AnalyticsPartnerSalesTimeSeriesStats!]
+  timeSeries(cumulative: Boolean = false): [AnalyticsPartnerSalesTimeSeriesStats!]
   totalCents: Int!
   total(
     decimal: String = "."
@@ -230,9 +226,7 @@ type AnalyticsPartnerSalesTimeSeriesStats {
 # Partner Stats
 type AnalyticsPartnerStats {
   # Time series data on number of artworks published
-  artworksPublished(
-    period: AnalyticsQueryPeriodEnum!
-  ): AnalyticsArtworksPublishedStats
+  artworksPublished(period: AnalyticsQueryPeriodEnum!): AnalyticsArtworksPublishedStats
 
   # Audience stats
   audience(period: AnalyticsQueryPeriodEnum!): AnalyticsPartnerAudienceStats
@@ -295,8 +289,7 @@ type AnalyticsPartnerStats {
 
     # Returns the last _n_ elements from the list.
     last: Int
-  ): AnalyticsRankedStatsConnection
-    @deprecated(reason: "Use rankedStats(objectType: ) instead")
+  ): AnalyticsRankedStatsConnection @deprecated(reason: "Use rankedStats(objectType: ) instead")
 
   # Number of unique visitors
   uniqueVisitors(period: AnalyticsQueryPeriodEnum!): Int
@@ -447,10 +440,7 @@ enum AnalyticsRankedStatsObjectTypeEnum {
 }
 
 # An artwork, artist, or show
-union AnalyticsRankedStatsUnion =
-    AnalyticsArtist
-  | AnalyticsArtwork
-  | AnalyticsShow
+union AnalyticsRankedStatsUnion = AnalyticsArtist | AnalyticsArtwork | AnalyticsShow
 
 type AnalyticsShow {
   entityId: String!
@@ -701,7 +691,6 @@ type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInt
   isFollowed: Boolean
   isPublic: Boolean
   isShareable: Boolean
-  isTargetSupply: Boolean
   displayLabel: String
   location: String
   meta: ArtistMeta
@@ -765,12 +754,7 @@ type ArtistArtworkGrid implements ArtworkContextGrid {
   title: String
   ctaTitle: String
   ctaHref: String
-  artworksConnection(
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): ArtworkConnection
+  artworksConnection(after: String, first: Int, before: String, last: Int): ArtworkConnection
 }
 
 enum ArtistArtworksFilters {
@@ -972,7 +956,7 @@ type ArtistTargetSupply {
   # True if artist is in target supply list.
   isTargetSupply: Boolean
 
-  # True if an artist is in within the microfunnel list.
+  # True if an artist is in the microfunnel list.
   isInMicrofunnel: Boolean
   microfunnel: ArtistTargetSupplyMicrofunnel
 }
@@ -1119,9 +1103,7 @@ type Artwork implements Node & Searchable & Sellable {
 
   # Is this work available for shipping only within the Contenental US?
   shipsToContinentalUSOnly: Boolean
-    @deprecated(
-      reason: "Prefer to use `onlyShipsDomestically`. [Will be removed in v2]"
-    )
+    @deprecated(reason: "Prefer to use `onlyShipsDomestically`. [Will be removed in v2]")
 
   # Is this work only available for shipping domestically?
   onlyShipsDomestically: Boolean
@@ -1214,12 +1196,7 @@ interface ArtworkContextGrid {
   title: String
   ctaTitle: String
   ctaHref: String
-  artworksConnection(
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): ArtworkConnection
+  artworksConnection(after: String, first: Int, before: String, last: Int): ArtworkConnection
 }
 
 # An edge in a connection.
@@ -1285,12 +1262,7 @@ type ArtworkLayer {
   internalID: ID!
 
   # A connection of artworks from a Layer.
-  artworksConnection(
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): ArtworkConnection
+  artworksConnection(after: String, first: Int, before: String, last: Int): ArtworkConnection
   description: String
   href: String
   name: String
@@ -1397,12 +1369,7 @@ type AuctionArtworkGrid implements ArtworkContextGrid {
   title: String
   ctaTitle: String
   ctaHref: String
-  artworksConnection(
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): ArtworkConnection
+  artworksConnection(after: String, first: Int, before: String, last: Int): ArtworkConnection
 }
 
 # In centimeters.
@@ -3119,6 +3086,28 @@ type ConsignmentOffer {
   state: String
 }
 
+type ConsignmentPageCursor {
+  # first cursor on the page
+  cursor: String!
+
+  # is this the current page?
+  isCurrent: Boolean!
+
+  # page number out of totalPages
+  page: Int!
+}
+
+type ConsignmentPageCursors {
+  around: [ConsignmentPageCursor!]!
+
+  # optional, may be included in field around
+  first: ConsignmentPageCursor
+
+  # optional, may be included in field around
+  last: ConsignmentPageCursor
+  previous: ConsignmentPageCursor
+}
+
 # Consignment Submission
 type ConsignmentSubmission {
   additionalInfo: String
@@ -3196,9 +3185,12 @@ type ConsignmentSubmissionConnection {
 
   # A list of nodes.
   nodes: [ConsignmentSubmission]
+  pageCursors: ConsignmentPageCursors
 
   # Information to aid in pagination.
   pageInfo: PageInfo!
+  totalCount: Int
+  totalPages: Int
 }
 
 enum ConsignmentSubmissionStateAggregation {
@@ -3269,13 +3261,7 @@ type Conversation implements Node {
   items: [ConversationItem]
 
   # A connection for all messages in a single conversation
-  messages(
-    sort: sort
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): MessageConnection
+  messages(sort: sort, after: String, first: Int, before: String, last: Int): MessageConnection
 
   # True if there is an unread message by the user.
   unread: Boolean
@@ -3371,9 +3357,7 @@ type CreateAccountRequestMutationSuccess {
   accountRequest: AccountRequest
 }
 
-union CreateAccountRequestMutationType =
-    CreateAccountRequestMutationSuccess
-  | CreateAccountRequestMutationFailure
+union CreateAccountRequestMutationType = CreateAccountRequestMutationSuccess | CreateAccountRequestMutationFailure
 
 input CreateBidderInput {
   saleID: String!
@@ -3561,9 +3545,7 @@ type CreditCardMutationSuccess {
   creditCardEdge: CreditCardEdge
 }
 
-union CreditCardMutationType =
-    CreditCardMutationSuccess
-  | CreditCardMutationFailure
+union CreditCardMutationType = CreditCardMutationSuccess | CreditCardMutationFailure
 
 type CreditCardPayload {
   creditCardOrError: CreditCardMutationType
@@ -4110,8 +4092,7 @@ type FilterArtworksConnection implements Node & ArtworkConnectionInterface {
   counts: FilterArtworksCounts
 
   # Artwork results.
-  hits: [Artwork]
-    @deprecated(reason: "Prefer to use `edges`. [Will be removed in v2]")
+  hits: [Artwork] @deprecated(reason: "Prefer to use `edges`. [Will be removed in v2]")
 
   # Returns a list of merchandisable artists sorted by merch score.
   merchandisableArtists(
@@ -4222,12 +4203,7 @@ type FollowedArtistsArtworksGroup implements Node {
   # A globally unique ID.
   id: ID!
   href: String
-  artworksConnection(
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): ArtworkConnection
+  artworksConnection(after: String, first: Int, before: String, last: Int): ArtworkConnection
   artists: String
   summary: String
   image: Image
@@ -4359,12 +4335,7 @@ type FollowsAndSaves {
   ): FollowedArtistsArtworksGroupConnection
 
   # A Connection of followed artists by current user
-  artistsConnection(
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): FollowArtistConnection
+  artistsConnection(after: String, first: Int, before: String, last: Int): FollowArtistConnection
   artworksConnection(
     after: String
     first: Int
@@ -4392,20 +4363,10 @@ type FollowsAndSaves {
   ): FollowedShowConnection
 
   # A list of the current user’s currently followed fair profiles
-  fairsConnection(
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): FollowedFairConnection
+  fairsConnection(after: String, first: Int, before: String, last: Int): FollowedFairConnection
 
   # A list of the current user’s inquiry requests
-  genesConnection(
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): FollowGeneConnection
+  genesConnection(after: String, first: Int, before: String, last: Int): FollowGeneConnection
 }
 
 input FollowShowInput {
@@ -4453,12 +4414,7 @@ type Gene implements Node & Searchable {
   # A type-specific ID likely used as a database ID.
   internalID: ID!
   cached: Int
-  artistsConnection(
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): ArtistConnection
+  artistsConnection(after: String, first: Int, before: String, last: Int): ArtistConnection
 
   # Artworks Elastic Search results
   filterArtworksConnection(
@@ -5077,8 +5033,7 @@ type MarketingCollection {
   showOnEditorial: Boolean!
 
   # Collection has prioritized connection to artist
-  is_featured_artist_content: Boolean!
-    @deprecated(reason: "Prefer isFeaturedArtistContent")
+  is_featured_artist_content: Boolean! @deprecated(reason: "Prefer isFeaturedArtistContent")
 
   # Collection has prioritized connection to artist
   isFeaturedArtistContent: Boolean!
@@ -5158,14 +5113,11 @@ type MarketingCollectionQuery {
   color: String
   dimension_range: String @deprecated(reason: "Prefer dimensionRange")
   dimensionRange: String
-  extra_aggregation_gene_ids: [String!]
-    @deprecated(reason: "prefer extraAggregationGeneIDs")
+  extra_aggregation_gene_ids: [String!] @deprecated(reason: "prefer extraAggregationGeneIDs")
   extraAggregationGeneIDs: [String!]
-  include_artworks_by_followed_artists: Boolean
-    @deprecated(reason: "Prefer includeArtworksByFollowedArtists")
+  include_artworks_by_followed_artists: Boolean @deprecated(reason: "Prefer includeArtworksByFollowedArtists")
   includeArtworksByFollowedArtists: Boolean
-  include_medium_filter_in_aggregation: Boolean
-    @deprecated(reason: "Prefer includeMediumFilterInAggregation")
+  include_medium_filter_in_aggregation: Boolean @deprecated(reason: "Prefer includeMediumFilterInAggregation")
   includeMediumFilterInAggregation: Boolean
   inquireable_only: Boolean @deprecated(reason: "Prefer inquireableOnly")
   inquireableOnly: Boolean
@@ -5215,12 +5167,7 @@ type Me implements Node {
   internalID: ID!
 
   # A list of the current user’s inquiry requests
-  artworkInquiriesConnection(
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): ArtworkInquiryConnection
+  artworkInquiriesConnection(after: String, first: Int, before: String, last: Int): ArtworkInquiryConnection
 
   # A list of the current user’s bidder registrations
   bidders(
@@ -5256,12 +5203,7 @@ type Me implements Node {
   ): Conversation
 
   # Conversations, usually between a user and partner.
-  conversationsConnection(
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): ConversationConnection
+  conversationsConnection(after: String, first: Int, before: String, last: Int): ConversationConnection
   createdAt(
     format: String
 
@@ -5270,12 +5212,7 @@ type Me implements Node {
   ): String
 
   # A list of the current user’s credit cards
-  creditCards(
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): CreditCardConnection
+  creditCards(after: String, first: Int, before: String, last: Int): CreditCardConnection
   email: String
   followsAndSaves: FollowsAndSaves
   hasCreditCards: Boolean
@@ -5317,11 +5254,7 @@ type Me implements Node {
   ): SaleArtworksConnection
 
   # The current user's status relating to bids on artworks
-  lotStanding(
-    artworkID: String
-    saleID: String
-    saleArtworkID: String
-  ): LotStanding
+  lotStanding(artworkID: String, saleID: String, saleArtworkID: String): LotStanding
 
   # A list of the current user's auction standings for given lots
   lotStandings(
@@ -5344,12 +5277,7 @@ type Me implements Node {
   recentlyViewedArtworkIds: [String]!
 
   # A list of the current user’s recently viewed artworks.
-  recentlyViewedArtworksConnection(
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): ArtworkConnection
+  recentlyViewedArtworksConnection(after: String, first: Int, before: String, last: Int): ArtworkConnection
   type: String
 
   # A count of unread notifications.
@@ -5449,11 +5377,12 @@ type Money {
   ): Float!
 }
 
+# A money object with amount in minor currency and a currency code, or an error object
+union MoneyOrErrorUnion = Error
+
 type Mutation {
   # Create an account request
-  createAccountRequest(
-    input: CreateAccountRequestMutationInput!
-  ): CreateAccountRequestMutationPayload
+  createAccountRequest(input: CreateAccountRequestMutationInput!): CreateAccountRequestMutationPayload
 
   # Create a bidder
   createBidder(input: CreateBidderInput!): CreateBidderPayload
@@ -5480,22 +5409,16 @@ type Mutation {
   followShow(input: FollowShowInput!): FollowShowPayload
 
   # Updating a collector profile (loyalty applicant status).
-  updateCollectorProfile(
-    input: UpdateCollectorProfileInput!
-  ): UpdateCollectorProfilePayload
+  updateCollectorProfile(input: UpdateCollectorProfileInput!): UpdateCollectorProfilePayload
 
   # Update the current logged in user.
   updateMyUserProfile(input: UpdateMyProfileInput!): UpdateMyProfilePayload
 
   # Update a conversation.
-  updateConversation(
-    input: UpdateConversationMutationInput!
-  ): UpdateConversationMutationPayload
+  updateConversation(input: UpdateConversationMutationInput!): UpdateConversationMutationPayload
 
   # Appending a message to a conversation thread
-  sendConversationMessage(
-    input: SendConversationMessageMutationInput!
-  ): SendConversationMessageMutationPayload
+  sendConversationMessage(input: SendConversationMessageMutationInput!): SendConversationMessageMutationPayload
 
   # Send a feedback message
   sendFeedback(input: SendFeedbackMutationInput!): SendFeedbackMutationPayload
@@ -5512,92 +5435,42 @@ type Mutation {
   ): RequestCredentialsForAssetUploadPayload
 
   # Attach an gemini asset to a consignment submission
-  createGeminiEntryForAsset(
-    input: CreateGeminiEntryForAssetInput!
-  ): CreateGeminiEntryForAssetPayload
+  createGeminiEntryForAsset(input: CreateGeminiEntryForAssetInput!): CreateGeminiEntryForAssetPayload
 
   # Start an identity verification flow for a pending identity verification
-  startIdentityVerification(
-    input: startIdentityVerificationMutationInput!
-  ): startIdentityVerificationMutationPayload
+  startIdentityVerification(input: startIdentityVerificationMutationInput!): startIdentityVerificationMutationPayload
   captureHold(input: CaptureHoldInput!): CaptureHoldPayload
   holdInventory(input: HoldInventoryInput!): HoldInventoryPayload
   recordArtworkView(input: RecordArtworkViewInput!): RecordArtworkViewPayload
-  requestConditionReport(
-    input: RequestConditionReportInput!
-  ): RequestConditionReportPayload
-  commerceAddInitialOfferToOrder(
-    input: CommerceAddInitialOfferToOrderInput!
-  ): CommerceAddInitialOfferToOrderPayload
-  commerceApproveOrder(
-    input: CommerceApproveOrderInput!
-  ): CommerceApproveOrderPayload
-  commerceBuyerAcceptOffer(
-    input: CommerceBuyerAcceptOfferInput!
-  ): CommerceBuyerAcceptOfferPayload
-  commerceBuyerCounterOffer(
-    input: CommerceBuyerCounterOfferInput!
-  ): CommerceBuyerCounterOfferPayload
-  commerceBuyerRejectOffer(
-    input: CommerceBuyerRejectOfferInput!
-  ): CommerceBuyerRejectOfferPayload
-  commerceConfirmFulfillment(
-    input: CommerceConfirmFulfillmentInput!
-  ): CommerceConfirmFulfillmentPayload
-  commerceConfirmPickup(
-    input: CommerceConfirmPickupInput!
-  ): CommerceConfirmPickupPayload
+  requestConditionReport(input: RequestConditionReportInput!): RequestConditionReportPayload
+  commerceAddInitialOfferToOrder(input: CommerceAddInitialOfferToOrderInput!): CommerceAddInitialOfferToOrderPayload
+  commerceApproveOrder(input: CommerceApproveOrderInput!): CommerceApproveOrderPayload
+  commerceBuyerAcceptOffer(input: CommerceBuyerAcceptOfferInput!): CommerceBuyerAcceptOfferPayload
+  commerceBuyerCounterOffer(input: CommerceBuyerCounterOfferInput!): CommerceBuyerCounterOfferPayload
+  commerceBuyerRejectOffer(input: CommerceBuyerRejectOfferInput!): CommerceBuyerRejectOfferPayload
+  commerceConfirmFulfillment(input: CommerceConfirmFulfillmentInput!): CommerceConfirmFulfillmentPayload
+  commerceConfirmPickup(input: CommerceConfirmPickupInput!): CommerceConfirmPickupPayload
   commerceCreateOfferOrderWithArtwork(
     input: CommerceCreateOfferOrderWithArtworkInput!
   ): CommerceCreateOfferOrderWithArtworkPayload
-  commerceCreateOrderWithArtwork(
-    input: CommerceCreateOrderWithArtworkInput!
-  ): CommerceCreateOrderWithArtworkPayload
-  commerceFixFailedPayment(
-    input: CommerceFixFailedPaymentInput!
-  ): CommerceFixFailedPaymentPayload
+  commerceCreateOrderWithArtwork(input: CommerceCreateOrderWithArtworkInput!): CommerceCreateOrderWithArtworkPayload
+  commerceFixFailedPayment(input: CommerceFixFailedPaymentInput!): CommerceFixFailedPaymentPayload
 
   # Fulfill an order with one Fulfillment, it sets this fulfillment to each line item in order
-  commerceFulfillAtOnce(
-    input: CommerceFulfillAtOnceInput!
-  ): CommerceFulfillAtOncePayload
-  commerceRejectOrder(
-    input: CommerceRejectOrderInput!
-  ): CommerceRejectOrderPayload
-  commerceSellerAcceptOffer(
-    input: CommerceSellerAcceptOfferInput!
-  ): CommerceSellerAcceptOfferPayload
-  commerceSellerCounterOffer(
-    input: CommerceSellerCounterOfferInput!
-  ): CommerceSellerCounterOfferPayload
-  commerceSellerRejectOffer(
-    input: CommerceSellerRejectOfferInput!
-  ): CommerceSellerRejectOfferPayload
+  commerceFulfillAtOnce(input: CommerceFulfillAtOnceInput!): CommerceFulfillAtOncePayload
+  commerceRejectOrder(input: CommerceRejectOrderInput!): CommerceRejectOrderPayload
+  commerceSellerAcceptOffer(input: CommerceSellerAcceptOfferInput!): CommerceSellerAcceptOfferPayload
+  commerceSellerCounterOffer(input: CommerceSellerCounterOfferInput!): CommerceSellerCounterOfferPayload
+  commerceSellerRejectOffer(input: CommerceSellerRejectOfferInput!): CommerceSellerRejectOfferPayload
   commerceSetPayment(input: CommerceSetPaymentInput!): CommerceSetPaymentPayload
-  commerceSetShipping(
-    input: CommerceSetShippingInput!
-  ): CommerceSetShippingPayload
-  commerceSubmitOrder(
-    input: CommerceSubmitOrderInput!
-  ): CommerceSubmitOrderPayload
-  commerceSubmitOrderWithOffer(
-    input: CommerceSubmitOrderWithOfferInput!
-  ): CommerceSubmitOrderWithOfferPayload
-  commerceSubmitPendingOffer(
-    input: CommerceSubmitPendingOfferInput!
-  ): CommerceSubmitPendingOfferPayload
-  addAssetToConsignmentSubmission(
-    input: AddAssetToConsignmentSubmissionInput!
-  ): AddAssetToConsignmentSubmissionPayload
-  createConsignmentOffer(
-    input: CreateOfferMutationInput!
-  ): CreateOfferMutationPayload
-  createConsignmentSubmission(
-    input: CreateSubmissionMutationInput!
-  ): CreateSubmissionMutationPayload
-  updateConsignmentSubmission(
-    input: UpdateSubmissionMutationInput!
-  ): UpdateSubmissionMutationPayload
+  commerceSetShipping(input: CommerceSetShippingInput!): CommerceSetShippingPayload
+  commerceSubmitOrder(input: CommerceSubmitOrderInput!): CommerceSubmitOrderPayload
+  commerceSubmitOrderWithOffer(input: CommerceSubmitOrderWithOfferInput!): CommerceSubmitOrderWithOfferPayload
+  commerceSubmitPendingOffer(input: CommerceSubmitPendingOfferInput!): CommerceSubmitPendingOfferPayload
+  addAssetToConsignmentSubmission(input: AddAssetToConsignmentSubmissionInput!): AddAssetToConsignmentSubmissionPayload
+  createConsignmentOffer(input: CreateOfferMutationInput!): CreateOfferMutationPayload
+  createConsignmentSubmission(input: CreateSubmissionMutationInput!): CreateSubmissionMutationPayload
+  updateConsignmentSubmission(input: UpdateSubmissionMutationInput!): UpdateSubmissionMutationPayload
 }
 
 input Near {
@@ -5635,12 +5508,7 @@ type OrderedSet {
   items: [OrderedSetItem]
 
   # Returns a connection of the items. Only Artwork supported right now.
-  itemsConnection(
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): ArtworkConnection
+  itemsConnection(after: String, first: Int, before: String, last: Int): ArtworkConnection
   name: String
 }
 
@@ -5742,17 +5610,10 @@ type Partner implements Node {
 
   # This field is deprecated and is being used in Eigen release predating the 6.0 release
   locations(size: Int = 25): [Location]
-    @deprecated(
-      reason: "Prefer to use `locationsConnection`. [Will be removed in v2]"
-    )
+    @deprecated(reason: "Prefer to use `locationsConnection`. [Will be removed in v2]")
 
   # A connection of locations from a Partner.
-  locationsConnection(
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): LocationConnection
+  locationsConnection(after: String, first: Int, before: String, last: Int): LocationConnection
   name: String
   profile: Profile
 
@@ -5845,12 +5706,7 @@ type PartnerArtworkGrid implements ArtworkContextGrid {
   title: String
   ctaTitle: String
   ctaHref: String
-  artworksConnection(
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): ArtworkConnection
+  artworksConnection(after: String, first: Int, before: String, last: Int): ArtworkConnection
 }
 
 type PartnerCategory {
@@ -6311,12 +6167,7 @@ type Query {
   viewer: Viewer
 
   # Autocomplete resolvers.
-  _unused_gravity_matchPartners(
-    matchType: String
-    page: Int = 1
-    size: Int = 5
-    term: String!
-  ): [DoNotUseThisPartner!]
+  _unused_gravity_matchPartners(matchType: String, page: Int = 1, size: Int = 5, term: String!): [DoNotUseThisPartner!]
 
   # Autocomplete resolvers.
   _unused_gravity_match_partners(
@@ -6328,6 +6179,9 @@ type Query {
 
   # Find partners by IDs
   _unused_gravity_partners(ids: [ID!]!): [DoNotUseThisPartner!]
+
+  # Find a viewing room by ID
+  viewingRoom(id: ID!): ViewingRoom
 
   # Find list of competing orders
   commerceCompetingOrders(
@@ -6477,12 +6331,7 @@ type RelatedArtworkGrid implements ArtworkContextGrid {
   title: String
   ctaTitle: String
   ctaHref: String
-  artworksConnection(
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): ArtworkConnection
+  artworksConnection(after: String, first: Int, before: String, last: Int): ArtworkConnection
 }
 
 # Autogenerated input type of RequestConditionReport
@@ -7113,9 +6962,7 @@ type SendFeedbackMutationSuccess {
   feedback: Feedback
 }
 
-union SendFeedbackMutationType =
-    SendFeedbackMutationSuccess
-  | SendFeedbackMutationFailure
+union SendFeedbackMutationType = SendFeedbackMutationSuccess | SendFeedbackMutationFailure
 
 type Services {
   convection: ConvectionService!
@@ -7323,24 +7170,14 @@ type Show implements Node & EntityWithFilterArtworksConnectionInterface {
   type: String
 
   # A Connection of followed artists by current user for this show
-  followedArtistsConnection(
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): ShowFollowArtistConnection
+  followedArtistsConnection(after: String, first: Int, before: String, last: Int): ShowFollowArtistConnection
 }
 
 type ShowArtworkGrid implements ArtworkContextGrid {
   title: String
   ctaTitle: String
   ctaHref: String
-  artworksConnection(
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): ArtworkConnection
+  artworksConnection(after: String, first: Int, before: String, last: Int): ArtworkConnection
 }
 
 # A connection to a list of items.
@@ -7458,9 +7295,7 @@ type startIdentityVerificationMutationPayload {
   clientMutationId: String
 }
 
-union StartIdentityVerificationResponseOrError =
-    StartIdentityVerificationSuccess
-  | StartIdentityVerificationFailure
+union StartIdentityVerificationResponseOrError = StartIdentityVerificationSuccess | StartIdentityVerificationFailure
 
 type StartIdentityVerificationSuccess {
   # Primary ID of the started identity verification
@@ -8034,6 +7869,98 @@ type Viewer {
     showOnEditorial: Boolean
     artistID: String
   ): [MarketingCollection]
+}
+
+# An artwork viewing room
+type ViewingRoom {
+  artworksConnection(
+    # Returns the elements in the list that come after the specified cursor.
+    after: String
+
+    # Returns the elements in the list that come before the specified cursor.
+    before: String
+
+    # Returns the first _n_ elements from the list.
+    first: Int
+
+    # Returns the last _n_ elements from the list.
+    last: Int
+  ): ViewingRoomArtworkConnection
+
+  # Body copy
+  body: String
+
+  # Datetime after which the viewing room is no longer viewable
+  endAt: ISO8601DateTime
+
+  # Image URL for hero image on viewing room home screen
+  heroImageURL: String
+
+  # Unique ID for this room
+  internalID: ID!
+
+  # Introductory paragraph
+  introStatement: String
+
+  # ID of the partner associated with this viewing room
+  partnerID: String!
+  pullQuote: String
+
+  # Datetime when the viewing room is viewable
+  startAt: ISO8601DateTime
+  subsections: [ViewingRoomSubsection!]
+  timeZone: String
+
+  # Viewing room name
+  title: String!
+}
+
+# An artwork associated with a viewing room. Note that the full artwork is stitched in in Metaphysics!
+type ViewingRoomArtwork {
+  artworkID: String!
+
+  # Unique ID
+  internalID: ID!
+  artwork: Artwork
+}
+
+# The connection type for ViewingRoomArtwork.
+type ViewingRoomArtworkConnection {
+  # A list of edges.
+  edges: [ViewingRoomArtworkEdge]
+
+  # A list of nodes.
+  nodes: [ViewingRoomArtwork]
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+}
+
+# An edge in a connection.
+type ViewingRoomArtworkEdge {
+  # A cursor for use in pagination.
+  cursor: String!
+
+  # The item at the end of the edge.
+  node: ViewingRoomArtwork
+}
+
+# Title, image, text, and caption for a viewing room section
+type ViewingRoomSubsection {
+  # Body copy
+  body: String
+
+  # Image caption
+  caption: String
+
+  # Image URL
+  imageURL: String
+
+  # Unique ID for this subsection
+  internalID: ID!
+
+  # Section header
+  title: String
 }
 
 type YearRange {

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -186,7 +186,9 @@ type AnalyticsPartnerInquiryStats {
   period: AnalyticsQueryPeriodEnum!
 
   # Partner inquiry count time series
-  timeSeries(cumulative: Boolean = false): [AnalyticsPartnerInquiryCountTimeSeriesStats!]
+  timeSeries(
+    cumulative: Boolean = false
+  ): [AnalyticsPartnerInquiryCountTimeSeriesStats!]
 }
 
 # Sales stats of a partner
@@ -197,7 +199,9 @@ type AnalyticsPartnerSalesStats {
   period: AnalyticsQueryPeriodEnum!
 
   # Partner sales time series
-  timeSeries(cumulative: Boolean = false): [AnalyticsPartnerSalesTimeSeriesStats!]
+  timeSeries(
+    cumulative: Boolean = false
+  ): [AnalyticsPartnerSalesTimeSeriesStats!]
   totalCents: Int!
   total(
     decimal: String = "."
@@ -226,7 +230,9 @@ type AnalyticsPartnerSalesTimeSeriesStats {
 # Partner Stats
 type AnalyticsPartnerStats {
   # Time series data on number of artworks published
-  artworksPublished(period: AnalyticsQueryPeriodEnum!): AnalyticsArtworksPublishedStats
+  artworksPublished(
+    period: AnalyticsQueryPeriodEnum!
+  ): AnalyticsArtworksPublishedStats
 
   # Audience stats
   audience(period: AnalyticsQueryPeriodEnum!): AnalyticsPartnerAudienceStats
@@ -289,7 +295,8 @@ type AnalyticsPartnerStats {
 
     # Returns the last _n_ elements from the list.
     last: Int
-  ): AnalyticsRankedStatsConnection @deprecated(reason: "Use rankedStats(objectType: ) instead")
+  ): AnalyticsRankedStatsConnection
+    @deprecated(reason: "Use rankedStats(objectType: ) instead")
 
   # Number of unique visitors
   uniqueVisitors(period: AnalyticsQueryPeriodEnum!): Int
@@ -440,7 +447,10 @@ enum AnalyticsRankedStatsObjectTypeEnum {
 }
 
 # An artwork, artist, or show
-union AnalyticsRankedStatsUnion = AnalyticsArtist | AnalyticsArtwork | AnalyticsShow
+union AnalyticsRankedStatsUnion =
+    AnalyticsArtist
+  | AnalyticsArtwork
+  | AnalyticsShow
 
 type AnalyticsShow {
   entityId: String!
@@ -691,6 +701,7 @@ type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInt
   isFollowed: Boolean
   isPublic: Boolean
   isShareable: Boolean
+  isTargetSupply: Boolean
   displayLabel: String
   location: String
   meta: ArtistMeta
@@ -740,14 +751,26 @@ type Artist implements Node & Searchable & EntityWithFilterArtworksConnectionInt
   statuses: ArtistStatuses
   targetSupply: ArtistTargetSupply
   years: String
-  marketingCollections(size: Int): [MarketingCollection]
+  marketingCollections(
+    slugs: [String!]
+    category: String
+    randomizationSeed: String
+    size: Int
+    isFeaturedArtistContent: Boolean
+    showOnEditorial: Boolean
+  ): [MarketingCollection]
 }
 
 type ArtistArtworkGrid implements ArtworkContextGrid {
   title: String
   ctaTitle: String
   ctaHref: String
-  artworksConnection(after: String, first: Int, before: String, last: Int): ArtworkConnection
+  artworksConnection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
 }
 
 enum ArtistArtworksFilters {
@@ -946,7 +969,10 @@ type ArtistStatuses {
 }
 
 type ArtistTargetSupply {
-  # Returns whether an artist is in within the microfunnel list.
+  # True if artist is in target supply list.
+  isTargetSupply: Boolean
+
+  # True if an artist is in within the microfunnel list.
   isInMicrofunnel: Boolean
   microfunnel: ArtistTargetSupplyMicrofunnel
 }
@@ -1093,7 +1119,9 @@ type Artwork implements Node & Searchable & Sellable {
 
   # Is this work available for shipping only within the Contenental US?
   shipsToContinentalUSOnly: Boolean
-    @deprecated(reason: "Prefer to use `onlyShipsDomestically`. [Will be removed in v2]")
+    @deprecated(
+      reason: "Prefer to use `onlyShipsDomestically`. [Will be removed in v2]"
+    )
 
   # Is this work only available for shipping domestically?
   onlyShipsDomestically: Boolean
@@ -1186,7 +1214,12 @@ interface ArtworkContextGrid {
   title: String
   ctaTitle: String
   ctaHref: String
-  artworksConnection(after: String, first: Int, before: String, last: Int): ArtworkConnection
+  artworksConnection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
 }
 
 # An edge in a connection.
@@ -1252,7 +1285,12 @@ type ArtworkLayer {
   internalID: ID!
 
   # A connection of artworks from a Layer.
-  artworksConnection(after: String, first: Int, before: String, last: Int): ArtworkConnection
+  artworksConnection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
   description: String
   href: String
   name: String
@@ -1359,7 +1397,12 @@ type AuctionArtworkGrid implements ArtworkContextGrid {
   title: String
   ctaTitle: String
   ctaHref: String
-  artworksConnection(after: String, first: Int, before: String, last: Int): ArtworkConnection
+  artworksConnection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
 }
 
 # In centimeters.
@@ -3226,7 +3269,13 @@ type Conversation implements Node {
   items: [ConversationItem]
 
   # A connection for all messages in a single conversation
-  messages(sort: sort, after: String, first: Int, before: String, last: Int): MessageConnection
+  messages(
+    sort: sort
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): MessageConnection
 
   # True if there is an unread message by the user.
   unread: Boolean
@@ -3322,7 +3371,9 @@ type CreateAccountRequestMutationSuccess {
   accountRequest: AccountRequest
 }
 
-union CreateAccountRequestMutationType = CreateAccountRequestMutationSuccess | CreateAccountRequestMutationFailure
+union CreateAccountRequestMutationType =
+    CreateAccountRequestMutationSuccess
+  | CreateAccountRequestMutationFailure
 
 input CreateBidderInput {
   saleID: String!
@@ -3510,7 +3561,9 @@ type CreditCardMutationSuccess {
   creditCardEdge: CreditCardEdge
 }
 
-union CreditCardMutationType = CreditCardMutationSuccess | CreditCardMutationFailure
+union CreditCardMutationType =
+    CreditCardMutationSuccess
+  | CreditCardMutationFailure
 
 type CreditCardPayload {
   creditCardOrError: CreditCardMutationType
@@ -4017,6 +4070,19 @@ type FairSponsoredContent {
   pressReleaseUrl: String
 }
 
+type FeaturedLink {
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: String
+  href: String
+  image: Image
+  initials(length: Int = 3): String
+  subtitle: String
+  title: String
+}
+
 type Feedback {
   # A globally unique ID.
   id: ID!
@@ -4044,7 +4110,8 @@ type FilterArtworksConnection implements Node & ArtworkConnectionInterface {
   counts: FilterArtworksCounts
 
   # Artwork results.
-  hits: [Artwork] @deprecated(reason: "Prefer to use `edges`. [Will be removed in v2]")
+  hits: [Artwork]
+    @deprecated(reason: "Prefer to use `edges`. [Will be removed in v2]")
 
   # Returns a list of merchandisable artists sorted by merch score.
   merchandisableArtists(
@@ -4155,7 +4222,12 @@ type FollowedArtistsArtworksGroup implements Node {
   # A globally unique ID.
   id: ID!
   href: String
-  artworksConnection(after: String, first: Int, before: String, last: Int): ArtworkConnection
+  artworksConnection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
   artists: String
   summary: String
   image: Image
@@ -4287,7 +4359,12 @@ type FollowsAndSaves {
   ): FollowedArtistsArtworksGroupConnection
 
   # A Connection of followed artists by current user
-  artistsConnection(after: String, first: Int, before: String, last: Int): FollowArtistConnection
+  artistsConnection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): FollowArtistConnection
   artworksConnection(
     after: String
     first: Int
@@ -4315,10 +4392,20 @@ type FollowsAndSaves {
   ): FollowedShowConnection
 
   # A list of the current user’s currently followed fair profiles
-  fairsConnection(after: String, first: Int, before: String, last: Int): FollowedFairConnection
+  fairsConnection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): FollowedFairConnection
 
   # A list of the current user’s inquiry requests
-  genesConnection(after: String, first: Int, before: String, last: Int): FollowGeneConnection
+  genesConnection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): FollowGeneConnection
 }
 
 input FollowShowInput {
@@ -4366,7 +4453,12 @@ type Gene implements Node & Searchable {
   # A type-specific ID likely used as a database ID.
   internalID: ID!
   cached: Int
-  artistsConnection(after: String, first: Int, before: String, last: Int): ArtistConnection
+  artistsConnection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtistConnection
 
   # Artworks Elastic Search results
   filterArtworksConnection(
@@ -4985,7 +5077,8 @@ type MarketingCollection {
   showOnEditorial: Boolean!
 
   # Collection has prioritized connection to artist
-  is_featured_artist_content: Boolean! @deprecated(reason: "Prefer isFeaturedArtistContent")
+  is_featured_artist_content: Boolean!
+    @deprecated(reason: "Prefer isFeaturedArtistContent")
 
   # Collection has prioritized connection to artist
   isFeaturedArtistContent: Boolean!
@@ -5065,11 +5158,14 @@ type MarketingCollectionQuery {
   color: String
   dimension_range: String @deprecated(reason: "Prefer dimensionRange")
   dimensionRange: String
-  extra_aggregation_gene_ids: [String!] @deprecated(reason: "prefer extraAggregationGeneIDs")
+  extra_aggregation_gene_ids: [String!]
+    @deprecated(reason: "prefer extraAggregationGeneIDs")
   extraAggregationGeneIDs: [String!]
-  include_artworks_by_followed_artists: Boolean @deprecated(reason: "Prefer includeArtworksByFollowedArtists")
+  include_artworks_by_followed_artists: Boolean
+    @deprecated(reason: "Prefer includeArtworksByFollowedArtists")
   includeArtworksByFollowedArtists: Boolean
-  include_medium_filter_in_aggregation: Boolean @deprecated(reason: "Prefer includeMediumFilterInAggregation")
+  include_medium_filter_in_aggregation: Boolean
+    @deprecated(reason: "Prefer includeMediumFilterInAggregation")
   includeMediumFilterInAggregation: Boolean
   inquireable_only: Boolean @deprecated(reason: "Prefer inquireableOnly")
   inquireableOnly: Boolean
@@ -5119,7 +5215,12 @@ type Me implements Node {
   internalID: ID!
 
   # A list of the current user’s inquiry requests
-  artworkInquiriesConnection(after: String, first: Int, before: String, last: Int): ArtworkInquiryConnection
+  artworkInquiriesConnection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkInquiryConnection
 
   # A list of the current user’s bidder registrations
   bidders(
@@ -5155,7 +5256,12 @@ type Me implements Node {
   ): Conversation
 
   # Conversations, usually between a user and partner.
-  conversationsConnection(after: String, first: Int, before: String, last: Int): ConversationConnection
+  conversationsConnection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ConversationConnection
   createdAt(
     format: String
 
@@ -5164,7 +5270,12 @@ type Me implements Node {
   ): String
 
   # A list of the current user’s credit cards
-  creditCards(after: String, first: Int, before: String, last: Int): CreditCardConnection
+  creditCards(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): CreditCardConnection
   email: String
   followsAndSaves: FollowsAndSaves
   hasCreditCards: Boolean
@@ -5188,6 +5299,8 @@ type Me implements Node {
 
   # Sale Artworks search results
   lotsByFollowedArtistsConnection(
+    includeArtworksByFollowedArtists: Boolean
+    artistIDs: [String]
     aggregations: [SaleArtworkAggregation]
     liveSale: Boolean
     isAuction: Boolean
@@ -5195,6 +5308,8 @@ type Me implements Node {
     estimateRange: String
     saleID: ID
     sort: String
+    page: Int
+    size: Int
     after: String
     first: Int
     before: String
@@ -5202,7 +5317,11 @@ type Me implements Node {
   ): SaleArtworksConnection
 
   # The current user's status relating to bids on artworks
-  lotStanding(artworkID: String, saleID: String, saleArtworkID: String): LotStanding
+  lotStanding(
+    artworkID: String
+    saleID: String
+    saleArtworkID: String
+  ): LotStanding
 
   # A list of the current user's auction standings for given lots
   lotStandings(
@@ -5225,7 +5344,12 @@ type Me implements Node {
   recentlyViewedArtworkIds: [String]!
 
   # A list of the current user’s recently viewed artworks.
-  recentlyViewedArtworksConnection(after: String, first: Int, before: String, last: Int): ArtworkConnection
+  recentlyViewedArtworksConnection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
   type: String
 
   # A count of unread notifications.
@@ -5327,7 +5451,9 @@ type Money {
 
 type Mutation {
   # Create an account request
-  createAccountRequest(input: CreateAccountRequestMutationInput!): CreateAccountRequestMutationPayload
+  createAccountRequest(
+    input: CreateAccountRequestMutationInput!
+  ): CreateAccountRequestMutationPayload
 
   # Create a bidder
   createBidder(input: CreateBidderInput!): CreateBidderPayload
@@ -5354,16 +5480,22 @@ type Mutation {
   followShow(input: FollowShowInput!): FollowShowPayload
 
   # Updating a collector profile (loyalty applicant status).
-  updateCollectorProfile(input: UpdateCollectorProfileInput!): UpdateCollectorProfilePayload
+  updateCollectorProfile(
+    input: UpdateCollectorProfileInput!
+  ): UpdateCollectorProfilePayload
 
   # Update the current logged in user.
   updateMyUserProfile(input: UpdateMyProfileInput!): UpdateMyProfilePayload
 
   # Update a conversation.
-  updateConversation(input: UpdateConversationMutationInput!): UpdateConversationMutationPayload
+  updateConversation(
+    input: UpdateConversationMutationInput!
+  ): UpdateConversationMutationPayload
 
   # Appending a message to a conversation thread
-  sendConversationMessage(input: SendConversationMessageMutationInput!): SendConversationMessageMutationPayload
+  sendConversationMessage(
+    input: SendConversationMessageMutationInput!
+  ): SendConversationMessageMutationPayload
 
   # Send a feedback message
   sendFeedback(input: SendFeedbackMutationInput!): SendFeedbackMutationPayload
@@ -5380,42 +5512,92 @@ type Mutation {
   ): RequestCredentialsForAssetUploadPayload
 
   # Attach an gemini asset to a consignment submission
-  createGeminiEntryForAsset(input: CreateGeminiEntryForAssetInput!): CreateGeminiEntryForAssetPayload
+  createGeminiEntryForAsset(
+    input: CreateGeminiEntryForAssetInput!
+  ): CreateGeminiEntryForAssetPayload
 
   # Start an identity verification flow for a pending identity verification
-  startIdentityVerification(input: startIdentityVerificationMutationInput!): startIdentityVerificationMutationPayload
+  startIdentityVerification(
+    input: startIdentityVerificationMutationInput!
+  ): startIdentityVerificationMutationPayload
   captureHold(input: CaptureHoldInput!): CaptureHoldPayload
   holdInventory(input: HoldInventoryInput!): HoldInventoryPayload
   recordArtworkView(input: RecordArtworkViewInput!): RecordArtworkViewPayload
-  requestConditionReport(input: RequestConditionReportInput!): RequestConditionReportPayload
-  commerceAddInitialOfferToOrder(input: CommerceAddInitialOfferToOrderInput!): CommerceAddInitialOfferToOrderPayload
-  commerceApproveOrder(input: CommerceApproveOrderInput!): CommerceApproveOrderPayload
-  commerceBuyerAcceptOffer(input: CommerceBuyerAcceptOfferInput!): CommerceBuyerAcceptOfferPayload
-  commerceBuyerCounterOffer(input: CommerceBuyerCounterOfferInput!): CommerceBuyerCounterOfferPayload
-  commerceBuyerRejectOffer(input: CommerceBuyerRejectOfferInput!): CommerceBuyerRejectOfferPayload
-  commerceConfirmFulfillment(input: CommerceConfirmFulfillmentInput!): CommerceConfirmFulfillmentPayload
-  commerceConfirmPickup(input: CommerceConfirmPickupInput!): CommerceConfirmPickupPayload
+  requestConditionReport(
+    input: RequestConditionReportInput!
+  ): RequestConditionReportPayload
+  commerceAddInitialOfferToOrder(
+    input: CommerceAddInitialOfferToOrderInput!
+  ): CommerceAddInitialOfferToOrderPayload
+  commerceApproveOrder(
+    input: CommerceApproveOrderInput!
+  ): CommerceApproveOrderPayload
+  commerceBuyerAcceptOffer(
+    input: CommerceBuyerAcceptOfferInput!
+  ): CommerceBuyerAcceptOfferPayload
+  commerceBuyerCounterOffer(
+    input: CommerceBuyerCounterOfferInput!
+  ): CommerceBuyerCounterOfferPayload
+  commerceBuyerRejectOffer(
+    input: CommerceBuyerRejectOfferInput!
+  ): CommerceBuyerRejectOfferPayload
+  commerceConfirmFulfillment(
+    input: CommerceConfirmFulfillmentInput!
+  ): CommerceConfirmFulfillmentPayload
+  commerceConfirmPickup(
+    input: CommerceConfirmPickupInput!
+  ): CommerceConfirmPickupPayload
   commerceCreateOfferOrderWithArtwork(
     input: CommerceCreateOfferOrderWithArtworkInput!
   ): CommerceCreateOfferOrderWithArtworkPayload
-  commerceCreateOrderWithArtwork(input: CommerceCreateOrderWithArtworkInput!): CommerceCreateOrderWithArtworkPayload
-  commerceFixFailedPayment(input: CommerceFixFailedPaymentInput!): CommerceFixFailedPaymentPayload
+  commerceCreateOrderWithArtwork(
+    input: CommerceCreateOrderWithArtworkInput!
+  ): CommerceCreateOrderWithArtworkPayload
+  commerceFixFailedPayment(
+    input: CommerceFixFailedPaymentInput!
+  ): CommerceFixFailedPaymentPayload
 
   # Fulfill an order with one Fulfillment, it sets this fulfillment to each line item in order
-  commerceFulfillAtOnce(input: CommerceFulfillAtOnceInput!): CommerceFulfillAtOncePayload
-  commerceRejectOrder(input: CommerceRejectOrderInput!): CommerceRejectOrderPayload
-  commerceSellerAcceptOffer(input: CommerceSellerAcceptOfferInput!): CommerceSellerAcceptOfferPayload
-  commerceSellerCounterOffer(input: CommerceSellerCounterOfferInput!): CommerceSellerCounterOfferPayload
-  commerceSellerRejectOffer(input: CommerceSellerRejectOfferInput!): CommerceSellerRejectOfferPayload
+  commerceFulfillAtOnce(
+    input: CommerceFulfillAtOnceInput!
+  ): CommerceFulfillAtOncePayload
+  commerceRejectOrder(
+    input: CommerceRejectOrderInput!
+  ): CommerceRejectOrderPayload
+  commerceSellerAcceptOffer(
+    input: CommerceSellerAcceptOfferInput!
+  ): CommerceSellerAcceptOfferPayload
+  commerceSellerCounterOffer(
+    input: CommerceSellerCounterOfferInput!
+  ): CommerceSellerCounterOfferPayload
+  commerceSellerRejectOffer(
+    input: CommerceSellerRejectOfferInput!
+  ): CommerceSellerRejectOfferPayload
   commerceSetPayment(input: CommerceSetPaymentInput!): CommerceSetPaymentPayload
-  commerceSetShipping(input: CommerceSetShippingInput!): CommerceSetShippingPayload
-  commerceSubmitOrder(input: CommerceSubmitOrderInput!): CommerceSubmitOrderPayload
-  commerceSubmitOrderWithOffer(input: CommerceSubmitOrderWithOfferInput!): CommerceSubmitOrderWithOfferPayload
-  commerceSubmitPendingOffer(input: CommerceSubmitPendingOfferInput!): CommerceSubmitPendingOfferPayload
-  addAssetToConsignmentSubmission(input: AddAssetToConsignmentSubmissionInput!): AddAssetToConsignmentSubmissionPayload
-  createConsignmentOffer(input: CreateOfferMutationInput!): CreateOfferMutationPayload
-  createConsignmentSubmission(input: CreateSubmissionMutationInput!): CreateSubmissionMutationPayload
-  updateConsignmentSubmission(input: UpdateSubmissionMutationInput!): UpdateSubmissionMutationPayload
+  commerceSetShipping(
+    input: CommerceSetShippingInput!
+  ): CommerceSetShippingPayload
+  commerceSubmitOrder(
+    input: CommerceSubmitOrderInput!
+  ): CommerceSubmitOrderPayload
+  commerceSubmitOrderWithOffer(
+    input: CommerceSubmitOrderWithOfferInput!
+  ): CommerceSubmitOrderWithOfferPayload
+  commerceSubmitPendingOffer(
+    input: CommerceSubmitPendingOfferInput!
+  ): CommerceSubmitPendingOfferPayload
+  addAssetToConsignmentSubmission(
+    input: AddAssetToConsignmentSubmissionInput!
+  ): AddAssetToConsignmentSubmissionPayload
+  createConsignmentOffer(
+    input: CreateOfferMutationInput!
+  ): CreateOfferMutationPayload
+  createConsignmentSubmission(
+    input: CreateSubmissionMutationInput!
+  ): CreateSubmissionMutationPayload
+  updateConsignmentSubmission(
+    input: UpdateSubmissionMutationInput!
+  ): UpdateSubmissionMutationPayload
 }
 
 input Near {
@@ -5439,6 +5621,30 @@ type OpeningHoursText {
 }
 
 union OpeningHoursUnion = OpeningHoursArray | OpeningHoursText
+
+type OrderedSet {
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID.
+  internalID: ID!
+  cached: Int
+  description: String
+  key: String
+  itemType: String
+  items: [OrderedSetItem]
+
+  # Returns a connection of the items. Only Artwork supported right now.
+  itemsConnection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
+  name: String
+}
+
+union OrderedSetItem = Artist | Artwork | FeaturedLink | Gene
 
 union OrderParty = Partner | User
 
@@ -5536,10 +5742,17 @@ type Partner implements Node {
 
   # This field is deprecated and is being used in Eigen release predating the 6.0 release
   locations(size: Int = 25): [Location]
-    @deprecated(reason: "Prefer to use `locationsConnection`. [Will be removed in v2]")
+    @deprecated(
+      reason: "Prefer to use `locationsConnection`. [Will be removed in v2]"
+    )
 
   # A connection of locations from a Partner.
-  locationsConnection(after: String, first: Int, before: String, last: Int): LocationConnection
+  locationsConnection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): LocationConnection
   name: String
   profile: Profile
 
@@ -5632,7 +5845,12 @@ type PartnerArtworkGrid implements ArtworkContextGrid {
   title: String
   ctaTitle: String
   ctaHref: String
-  artworksConnection(after: String, first: Int, before: String, last: Int): ArtworkConnection
+  artworksConnection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
 }
 
 type PartnerCategory {
@@ -5813,14 +6031,31 @@ type Query {
   # List of all artwork attribution classes
   artworkAttributionClasses: [AttributionClass]
 
+  # An Article
+  article(
+    # The ID of the Article
+    id: String!
+  ): Article
+
+  # A list of Articles
+  articles(
+    auctionID: String
+
+    #
+    #         Only return articles matching specified ids.
+    #         Accepts list of ids.
+    #
+    ids: [String]
+    published: Boolean = true
+    showID: String
+    sort: ArticleSorts
+  ): [Article]
+
   # An Artwork
   artwork(
     # The slug or ID of the Artwork
     id: String!
   ): Artwork
-
-  # A list of artworks by internalID.
-  artworksByInternalID(ids: [String]!): [Artwork]
 
   # Artworks Elastic Search results
   artworksConnection(
@@ -5914,6 +6149,25 @@ type Query {
     # The slug or ID of the Fair
     id: String!
   ): Fair
+
+  # A list of Fairs
+  fairs(
+    fairOrganizerID: String
+    hasFullFeature: Boolean
+    hasHomepageSection: Boolean
+    hasListing: Boolean
+
+    #
+    #         Only return fairs matching specified ids.
+    #         Accepts list of ids.
+    #
+    ids: [String]
+    near: Near
+    page: Int
+    size: Int
+    sort: FairSorts
+    status: EventStatus
+  ): [Fair]
   gene(
     # The slug or ID of the Gene
     id: String!
@@ -5941,6 +6195,12 @@ type Query {
     id: ID!
   ): Node
 
+  # An OrderedSet
+  orderedSet(
+    # The ID of the OrderedSet
+    id: String!
+  ): OrderedSet
+
   # A Partner
   partner(
     # The slug or ID of the Partner
@@ -5953,8 +6213,39 @@ type Query {
     id: String!
   ): Sale
 
+  # A Sale Artwork
+  saleArtwork(
+    # The slug or ID of the SaleArtwork
+    id: String!
+  ): SaleArtwork
+
+  # Sale Artworks search results
+  saleArtworksConnection(
+    includeArtworksByFollowedArtists: Boolean
+    artistIDs: [String]
+    aggregations: [SaleArtworkAggregation]
+    liveSale: Boolean
+    isAuction: Boolean
+    geneIDs: [String]
+    estimateRange: String
+    saleID: ID
+    sort: String
+    page: Int
+    size: Int
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): SaleArtworksConnection
+
   # A list of Sales
   salesConnection(
+    #
+    #         Only return sales matching specified ids.
+    #         Accepts list of ids.
+    #
+    ids: [String]
+
     # Limit by auction.
     isAuction: Boolean = true
 
@@ -6020,7 +6311,12 @@ type Query {
   viewer: Viewer
 
   # Autocomplete resolvers.
-  _unused_gravity_matchPartners(matchType: String, page: Int = 1, size: Int = 5, term: String!): [DoNotUseThisPartner!]
+  _unused_gravity_matchPartners(
+    matchType: String
+    page: Int = 1
+    size: Int = 5
+    term: String!
+  ): [DoNotUseThisPartner!]
 
   # Autocomplete resolvers.
   _unused_gravity_match_partners(
@@ -6139,6 +6435,7 @@ type Query {
   # Find PartnerStats
   analyticsPartnerStats(partnerId: String!): AnalyticsPartnerStats
   marketingCollections(
+    slugs: [String!]
     category: String
     randomizationSeed: String
     size: Int
@@ -6180,7 +6477,12 @@ type RelatedArtworkGrid implements ArtworkContextGrid {
   title: String
   ctaTitle: String
   ctaHref: String
-  artworksConnection(after: String, first: Int, before: String, last: Int): ArtworkConnection
+  artworksConnection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
 }
 
 # Autogenerated input type of RequestConditionReport
@@ -6811,7 +7113,9 @@ type SendFeedbackMutationSuccess {
   feedback: Feedback
 }
 
-union SendFeedbackMutationType = SendFeedbackMutationSuccess | SendFeedbackMutationFailure
+union SendFeedbackMutationType =
+    SendFeedbackMutationSuccess
+  | SendFeedbackMutationFailure
 
 type Services {
   convection: ConvectionService!
@@ -7019,14 +7323,24 @@ type Show implements Node & EntityWithFilterArtworksConnectionInterface {
   type: String
 
   # A Connection of followed artists by current user for this show
-  followedArtistsConnection(after: String, first: Int, before: String, last: Int): ShowFollowArtistConnection
+  followedArtistsConnection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ShowFollowArtistConnection
 }
 
 type ShowArtworkGrid implements ArtworkContextGrid {
   title: String
   ctaTitle: String
   ctaHref: String
-  artworksConnection(after: String, first: Int, before: String, last: Int): ArtworkConnection
+  artworksConnection(
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): ArtworkConnection
 }
 
 # A connection to a list of items.
@@ -7144,7 +7458,9 @@ type startIdentityVerificationMutationPayload {
   clientMutationId: String
 }
 
-union StartIdentityVerificationResponseOrError = StartIdentityVerificationSuccess | StartIdentityVerificationFailure
+union StartIdentityVerificationResponseOrError =
+    StartIdentityVerificationSuccess
+  | StartIdentityVerificationFailure
 
 type StartIdentityVerificationSuccess {
   # Primary ID of the started identity verification
@@ -7434,14 +7750,31 @@ type Viewer {
   # List of all artwork attribution classes
   artworkAttributionClasses: [AttributionClass]
 
+  # An Article
+  article(
+    # The ID of the Article
+    id: String!
+  ): Article
+
+  # A list of Articles
+  articles(
+    auctionID: String
+
+    #
+    #         Only return articles matching specified ids.
+    #         Accepts list of ids.
+    #
+    ids: [String]
+    published: Boolean = true
+    showID: String
+    sort: ArticleSorts
+  ): [Article]
+
   # An Artwork
   artwork(
     # The slug or ID of the Artwork
     id: String!
   ): Artwork
-
-  # A list of artworks by internalID.
-  artworksByInternalID(ids: [String]!): [Artwork]
 
   # Artworks Elastic Search results
   artworksConnection(
@@ -7535,6 +7868,25 @@ type Viewer {
     # The slug or ID of the Fair
     id: String!
   ): Fair
+
+  # A list of Fairs
+  fairs(
+    fairOrganizerID: String
+    hasFullFeature: Boolean
+    hasHomepageSection: Boolean
+    hasListing: Boolean
+
+    #
+    #         Only return fairs matching specified ids.
+    #         Accepts list of ids.
+    #
+    ids: [String]
+    near: Near
+    page: Int
+    size: Int
+    sort: FairSorts
+    status: EventStatus
+  ): [Fair]
   gene(
     # The slug or ID of the Gene
     id: String!
@@ -7562,6 +7914,12 @@ type Viewer {
     id: ID!
   ): Node
 
+  # An OrderedSet
+  orderedSet(
+    # The ID of the OrderedSet
+    id: String!
+  ): OrderedSet
+
   # A Partner
   partner(
     # The slug or ID of the Partner
@@ -7574,8 +7932,39 @@ type Viewer {
     id: String!
   ): Sale
 
+  # A Sale Artwork
+  saleArtwork(
+    # The slug or ID of the SaleArtwork
+    id: String!
+  ): SaleArtwork
+
+  # Sale Artworks search results
+  saleArtworksConnection(
+    includeArtworksByFollowedArtists: Boolean
+    artistIDs: [String]
+    aggregations: [SaleArtworkAggregation]
+    liveSale: Boolean
+    isAuction: Boolean
+    geneIDs: [String]
+    estimateRange: String
+    saleID: ID
+    sort: String
+    page: Int
+    size: Int
+    after: String
+    first: Int
+    before: String
+    last: Int
+  ): SaleArtworksConnection
+
   # A list of Sales
   salesConnection(
+    #
+    #         Only return sales matching specified ids.
+    #         Accepts list of ids.
+    #
+    ids: [String]
+
     # Limit by auction.
     isAuction: Boolean = true
 
@@ -7636,6 +8025,15 @@ type Viewer {
     # ID of the user
     id: String
   ): User
+  marketingCollections(
+    slugs: [String!]
+    category: String
+    randomizationSeed: String
+    size: Int
+    isFeaturedArtistContent: Boolean
+    showOnEditorial: Boolean
+    artistID: String
+  ): [MarketingCollection]
 }
 
 type YearRange {

--- a/src/__generated__/ArtistBelowTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtistBelowTheFoldQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash d78d87b7c53a3699d755446b598fdb08 */
+/* @relayHash d6865b61f64a63a22ca70b54df32149c */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -78,6 +78,7 @@ fragment ArtistAbout_artist on Artist {
 fragment ArtistConsignButton_artist on Artist {
   targetSupply {
     isInMicrofunnel
+    isTargetSupply
   }
   internalID
   slug
@@ -488,6 +489,13 @@ return {
                 "name": "isInMicrofunnel",
                 "args": null,
                 "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "isTargetSupply",
+                "args": null,
+                "storageKey": null
               }
             ]
           },
@@ -770,7 +778,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistBelowTheFoldQuery",
-    "id": "ac253aeb550888b6b5e561837286c242",
+    "id": "72c7b4c4ac8d7e1d253d7b6f70cd7c48",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistConsignButtonTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistConsignButtonTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 020a66e100c1afb25228c6c0f21e78f5 */
+/* @relayHash cc9ab7d8f5407011762383bca4717345 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -28,6 +28,7 @@ query ArtistConsignButtonTestsQuery {
 fragment ArtistConsignButton_artist on Artist {
   targetSupply {
     isInMicrofunnel
+    isTargetSupply
   }
   internalID
   slug
@@ -56,6 +57,12 @@ v1 = {
 },
 v2 = {
   "type": "String",
+  "enumValues": null,
+  "plural": false,
+  "nullable": true
+},
+v3 = {
+  "type": "Boolean",
   "enumValues": null,
   "plural": false,
   "nullable": true
@@ -114,6 +121,13 @@ return {
                 "kind": "ScalarField",
                 "alias": null,
                 "name": "isInMicrofunnel",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "isTargetSupply",
                 "args": null,
                 "storageKey": null
               }
@@ -194,7 +208,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistConsignButtonTestsQuery",
-    "id": "c90bc21b145b79c0bdedf5df08e72af1",
+    "id": "12125805ab6a122d91732b715be527e3",
     "text": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -225,12 +239,8 @@ return {
           "plural": false,
           "nullable": true
         },
-        "artist.targetSupply.isInMicrofunnel": {
-          "type": "Boolean",
-          "enumValues": null,
-          "plural": false,
-          "nullable": true
-        },
+        "artist.targetSupply.isInMicrofunnel": (v3/*: any*/),
+        "artist.targetSupply.isTargetSupply": (v3/*: any*/),
         "artist.image.cropped": {
           "type": "CroppedImageUrl",
           "enumValues": null,

--- a/src/__generated__/ArtistConsignButton_artist.graphql.ts
+++ b/src/__generated__/ArtistConsignButton_artist.graphql.ts
@@ -6,6 +6,7 @@ import { FragmentRefs } from "relay-runtime";
 export type ArtistConsignButton_artist = {
     readonly targetSupply: {
         readonly isInMicrofunnel: boolean | null;
+        readonly isTargetSupply: boolean | null;
     } | null;
     readonly internalID: string;
     readonly slug: string;
@@ -45,6 +46,13 @@ const node: ReaderFragment = {
           "kind": "ScalarField",
           "alias": null,
           "name": "isInMicrofunnel",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "isTargetSupply",
           "args": null,
           "storageKey": null
         }
@@ -113,5 +121,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = '205cc16cfdba9a68ea7a59d1d1a054c5';
+(node as any).hash = '23da8ebb4f46afb4d72e5014c4f9f2b5';
 export default node;

--- a/src/lib/Components/Artist/ArtistConsignButton.tsx
+++ b/src/lib/Components/Artist/ArtistConsignButton.tsx
@@ -20,13 +20,14 @@ export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = props => 
 
   const {
     artist: {
-      targetSupply: { isInMicrofunnel },
+      targetSupply: { isInMicrofunnel, isTargetSupply },
       name,
       image,
     },
   } = props
   const imageURL = image?.cropped?.url
-  const headline = isInMicrofunnel ? `Sell your ${name}` : "Sell art from your collection"
+  const showImage = imageURL && (isInMicrofunnel || isTargetSupply)
+  const headline = isInMicrofunnel || isTargetSupply ? `Sell your ${name}` : "Sell art from your collection"
 
   const onConsignButtonPress = () => {
     tracking.trackEvent({
@@ -46,7 +47,7 @@ export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = props => 
     <TouchableOpacity ref={buttonRef} onPress={onConsignButtonPress}>
       <BorderBox p={1}>
         <Flex alignItems="center" flexDirection="row">
-          {isInMicrofunnel && imageURL && (
+          {showImage && (
             <Box pr={2}>
               <Image source={{ uri: imageURL }} />
             </Box>
@@ -77,6 +78,7 @@ export const ArtistConsignButtonFragmentContainer = createFragmentContainer(Arti
     fragment ArtistConsignButton_artist on Artist {
       targetSupply {
         isInMicrofunnel
+        isTargetSupply
       }
       internalID
       slug

--- a/src/lib/Components/Artist/ArtistConsignButton.tsx
+++ b/src/lib/Components/Artist/ArtistConsignButton.tsx
@@ -1,10 +1,11 @@
-import { BorderBox, Box, Button, Flex, Sans } from "@artsy/palette"
+import { BorderBox, Box, Flex, Sans } from "@artsy/palette"
 import React, { useRef } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
 
 import { ArtistConsignButton_artist } from "__generated__/ArtistConsignButton_artist.graphql"
+import ChevronIcon from "lib/Icons/ChevronIcon"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { Router } from "lib/utils/router"
 import { Schema } from "lib/utils/track"
@@ -27,46 +28,47 @@ export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = props => 
   } = props
   const imageURL = image?.cropped?.url
   const showImage = imageURL && (isInMicrofunnel || isTargetSupply)
-  const headline = isInMicrofunnel || isTargetSupply ? `Sell your ${name}` : "Sell art from your collection"
-
-  const onConsignButtonPress = () => {
-    tracking.trackEvent({
-      context_page: Schema.PageNames.ArtistPage,
-      context_page_owner_id: props.artist.internalID,
-      context_page_owner_slug: props.artist.slug,
-      context_page_owner_type: Schema.OwnerEntityTypes.Artist,
-      context_module: Schema.ContextModules.ArtistConsignment,
-      subject: Schema.ActionNames.ArtistConsignGetStarted,
-      destination_path: Router.ConsignmentsStartSubmission,
-    })
-
-    SwitchBoard.presentNavigationViewController(buttonRef.current, Router.ConsignmentsStartSubmission)
-  }
+  const headline = isInMicrofunnel ? `Sell your ${name}` : "Sell art from your collection"
 
   return (
-    <TouchableOpacity ref={buttonRef} onPress={onConsignButtonPress}>
-      <BorderBox p={1}>
-        <Flex alignItems="center" flexDirection="row">
-          {showImage && (
-            <Box pr={2}>
-              <Image source={{ uri: imageURL }} />
-            </Box>
-          )}
-          <Flex justifyContent="center">
-            <Sans size="3t" weight="medium">
-              {headline}
-            </Sans>
-            <Box top="-2px" position="relative">
-              <Sans size="3t" color="black60">
-                Consign with Artsy
+    <TouchableOpacity
+      ref={buttonRef}
+      onPress={() => {
+        tracking.trackEvent({
+          context_page: Schema.PageNames.ArtistPage,
+          context_page_owner_id: props.artist.internalID,
+          context_page_owner_slug: props.artist.slug,
+          context_page_owner_type: Schema.OwnerEntityTypes.Artist,
+          context_module: Schema.ContextModules.ArtistConsignment,
+          subject: Schema.ActionNames.ArtistConsignGetStarted,
+          destination_path: Router.ConsignmentsStartSubmission,
+        })
+
+        SwitchBoard.presentNavigationViewController(buttonRef.current, Router.ConsignmentsStartSubmission)
+      }}
+    >
+      <BorderBox p={0}>
+        <Flex flexDirection="row" alignItems="center">
+          <Flex alignItems="center" flexDirection="row" style={{ flex: 1 }}>
+            {showImage && (
+              <Box pr={2}>
+                <Image source={{ uri: imageURL }} />
+              </Box>
+            )}
+            <Flex justifyContent="center" style={{ flex: 1 }}>
+              <Sans size="3t" weight="medium" style={{ flexWrap: "wrap" }}>
+                {headline}
               </Sans>
-            </Box>
-            <Box>
-              <Button size="small" variant="secondaryGray" onPress={onConsignButtonPress}>
-                Get started
-              </Button>
-            </Box>
+              <Box position="relative">
+                <Sans size="3t" color="black60">
+                  Consign with Artsy
+                </Sans>
+              </Box>
+            </Flex>
           </Flex>
+          <Box px={2}>
+            <ChevronIcon initialDirection="right" color="black100" height={14} />
+          </Box>
         </Flex>
       </BorderBox>
     </TouchableOpacity>
@@ -93,8 +95,8 @@ export const ArtistConsignButtonFragmentContainer = createFragmentContainer(Arti
 })
 
 const Image = styled.Image`
-  height: 66;
-  width: 66;
+  width: 76;
+  height: 70;
 `
 
 export const tests = {

--- a/src/lib/Components/Artist/__tests__/ArtistConsignButton-tests.tsx
+++ b/src/lib/Components/Artist/__tests__/ArtistConsignButton-tests.tsx
@@ -1,4 +1,4 @@
-import { Button, Theme } from "@artsy/palette"
+import { Theme } from "@artsy/palette"
 import { ArtistConsignButtonTestsQuery } from "__generated__/ArtistConsignButtonTestsQuery.graphql"
 import { extractText } from "lib/tests/extractText"
 import { cloneDeep } from "lodash"
@@ -97,7 +97,7 @@ describe("ArtistConsignButton", () => {
         })
       })
       expect(tree.root.findAllByType(tests.Image)).toHaveLength(1)
-      expect(extractText(tree.root)).toContain("Sell your Alex Katz")
+      expect(extractText(tree.root)).toContain("Sell art from your collection")
     })
 
     it("guards against missing imageURL", async () => {
@@ -123,26 +123,6 @@ describe("ArtistConsignButton", () => {
         })
       })
       tree.root.findByType(TouchableOpacity).props.onPress()
-      expect(trackEvent).toHaveBeenCalledWith({
-        context_page: "Artist",
-        context_page_owner_id: response.artist.internalID,
-        context_page_owner_slug: response.artist.slug,
-        context_page_owner_type: "Artist",
-        context_module: "ArtistConsignment",
-        subject: "Get Started",
-        destination_path: "/consign/submission",
-      })
-    })
-
-    it("tracks clicks on inner button", async () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
-      act(() => {
-        env.mock.resolveMostRecentOperation({
-          errors: [],
-          data: response,
-        })
-      })
-      tree.root.findByType(Button).props.onPress()
       expect(trackEvent).toHaveBeenCalledWith({
         context_page: "Artist",
         context_page_owner_id: response.artist.internalID,
@@ -192,26 +172,6 @@ describe("ArtistConsignButton", () => {
         })
       })
       tree.root.findByType(TouchableOpacity).props.onPress()
-      expect(trackEvent).toHaveBeenCalledWith({
-        context_page: "Artist",
-        context_page_owner_id: response.artist.internalID,
-        context_page_owner_slug: response.artist.slug,
-        context_page_owner_type: "Artist",
-        context_module: "ArtistConsignment",
-        subject: "Get Started",
-        destination_path: "/consign/submission",
-      })
-    })
-
-    it("tracks clicks on inner button", async () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
-      act(() => {
-        env.mock.resolveMostRecentOperation({
-          errors: [],
-          data: response,
-        })
-      })
-      tree.root.findByType(Button).props.onPress()
       expect(trackEvent).toHaveBeenCalledWith({
         context_page: "Artist",
         context_page_owner_id: response.artist.internalID,

--- a/src/lib/Components/Artist/__tests__/ArtistConsignButton-tests.tsx
+++ b/src/lib/Components/Artist/__tests__/ArtistConsignButton-tests.tsx
@@ -50,11 +50,12 @@ describe("ArtistConsignButton", () => {
     })
   })
 
-  describe("Top 20 Artist ('Microfunnel') Button", () => {
+  describe("Top 20 Artist ('Microfunnel') or Target Supply button", () => {
     const response = {
       artist: {
         targetSupply: {
           isInMicrofunnel: true,
+          isTargetSupply: true,
         },
         internalID: "fooBarBaz",
         slug: "alex-katz",
@@ -70,13 +71,29 @@ describe("ArtistConsignButton", () => {
       },
     }
 
-    it("renders with data", () => {
+    it("renders microfunnel correctly", () => {
       const tree = ReactTestRenderer.create(<TestRenderer />)
       expect(env.mock.getMostRecentOperation().request.node.operation.name).toBe("ArtistConsignButtonTestsQuery")
       act(() => {
         env.mock.resolveMostRecentOperation({
           errors: [],
           data: response,
+        })
+      })
+      expect(tree.root.findAllByType(tests.Image)).toHaveLength(1)
+      expect(extractText(tree.root)).toContain("Sell your Alex Katz")
+    })
+
+    it("renders target supply correctly", () => {
+      const tree = ReactTestRenderer.create(<TestRenderer />)
+      expect(env.mock.getMostRecentOperation().request.node.operation.name).toBe("ArtistConsignButtonTestsQuery")
+      act(() => {
+        const targetSupplyResponse = cloneDeep(response)
+        targetSupplyResponse.artist.targetSupply.isInMicrofunnel = false
+        targetSupplyResponse.artist.targetSupply.isTargetSupply = true
+        env.mock.resolveMostRecentOperation({
+          errors: [],
+          data: targetSupplyResponse,
         })
       })
       expect(tree.root.findAllByType(tests.Image)).toHaveLength(1)
@@ -143,6 +160,7 @@ describe("ArtistConsignButton", () => {
       artist: {
         targetSupply: {
           isInMicrofunnel: false,
+          isTargetSupply: false,
         },
         internalID: "fooBarBaz",
         slug: "alex-katz",


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/CSGN-98
Depends on https://github.com/artsy/metaphysics/pull/2284 
Related https://github.com/artsy/reaction/pull/3364

Updates the Consign button with new `isTargetSupply` check. 

#trivial (changelog entry already has sufficient description) 