### PR TITLE
Add cron job to deploy beta at 6am UTC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,15 @@ commands:
             - derived_data
 
 jobs:
+  deploy-nightly-beta:
+    executor:
+      name: node/default
+      tag: "12.13.1"
+    steps:
+      - checkout
+      - run:
+          name: Deploy beta
+          command: make deploy
   update-metaphysics:
     executor:
       name: node/default
@@ -284,6 +293,16 @@ jobs:
 
 workflows:
   version: 2
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 6 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - deploy-nightly-beta
   promote:
     jobs:
       - promote-beta-to-app-store:


### PR DESCRIPTION
6am UTC is currently 2am in NY and 7am in London so it should be finished by the time I start working, and it shouldn't be started while y'all are still awake.

Paired on this with @brainbicycle during knowledge share 🎓 