### PR TITLE
[ArtistConsignButton] Visual QA

### DIFF
--- a/src/lib/Components/Artist/ArtistConsignButton.tsx
+++ b/src/lib/Components/Artist/ArtistConsignButton.tsx
@@ -1,11 +1,10 @@
-import { BorderBox, Box, Flex, Sans } from "@artsy/palette"
+import { ArrowRightIcon, BorderBox, Box, Flex, Sans } from "@artsy/palette"
 import React, { useRef } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
 
 import { ArtistConsignButton_artist } from "__generated__/ArtistConsignButton_artist.graphql"
-import ChevronIcon from "lib/Icons/ChevronIcon"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { Router } from "lib/utils/router"
 import { Schema } from "lib/utils/track"
@@ -55,7 +54,7 @@ export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = props => 
                 <Image source={{ uri: imageURL }} />
               </Box>
             )}
-            <Flex justifyContent="center" style={{ flex: 1 }}>
+            <Flex justifyContent="center" style={{ flex: 1, minHeight: 70 }} p={showImage ? 0 : 1}>
               <Sans size="3t" weight="medium" style={{ flexWrap: "wrap" }}>
                 {headline}
               </Sans>
@@ -67,7 +66,7 @@ export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = props => 
             </Flex>
           </Flex>
           <Box px={2}>
-            <ChevronIcon initialDirection="right" color="black100" height={14} />
+            <ArrowRightIcon />
           </Box>
         </Flex>
       </BorderBox>


### PR DESCRIPTION
Address design feedback:

Non-target-supply artists missing padding around text: 

<img width="402" alt="Screen Shot 2020-04-09 at 8 13 43 PM" src="https://user-images.githubusercontent.com/236943/78959055-a632f400-7a9e-11ea-9c63-74555fbbe8ba.png">

Larger Arrow: 

<img width="397" alt="Screen Shot 2020-04-09 at 8 13 52 PM" src="https://user-images.githubusercontent.com/236943/78959068-ad5a0200-7a9e-11ea-8e0d-93a4347d9ce9.png">

#trivial 