### PR TITLE
[ArtistConsignButton] Fix padding

### DIFF
--- a/src/lib/Components/Artist/ArtistConsignButton.tsx
+++ b/src/lib/Components/Artist/ArtistConsignButton.tsx
@@ -54,7 +54,12 @@ export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = props => 
                 <Image source={{ uri: imageURL }} />
               </Box>
             )}
-            <Flex justifyContent="center" style={{ flex: 1, minHeight: 70 }} p={showImage ? 0 : 1}>
+            <Flex
+              justifyContent="center"
+              style={{ flex: 1, minHeight: 70 }}
+              p={showImage ? 0 : 1}
+              pl={showImage ? 0 : 2}
+            >
               <Sans size="3t" weight="medium" style={{ flexWrap: "wrap" }}>
                 {headline}
               </Sans>


### PR DESCRIPTION
Padding didn't quite match the comps on the default button, had to expand it a bit: 

<img width="401" alt="Screen Shot 2020-04-09 at 9 33 48 PM" src="https://user-images.githubusercontent.com/236943/78962709-d46a0100-7aa9-11ea-812d-fbf1bfc730d4.png">

#trivial 