### PR TITLE
[MX-214] - Fix sign up on initial sign up with apple failure

### DIFF
--- a/Artsy/Constants/ARDefaults.h
+++ b/Artsy/Constants/ARDefaults.h
@@ -1,3 +1,6 @@
+extern NSString *const ARAppleDisplayNameKeychainKey;
+extern NSString *const ARAppleEmailKeyChainKey;
+
 extern NSString *const ARUsernameKeychainKey;
 extern NSString *const ARPasswordKeychainKey;
 

--- a/Artsy/Constants/ARDefaults.m
+++ b/Artsy/Constants/ARDefaults.m
@@ -10,6 +10,9 @@ NSString *const ARStagingWebURLDefault = @"ARStagingWebURLDefault";
 NSString *const ARStagingMetaphysicsURLDefault = @"ARStagingMetaphysicsURLDefault";
 NSString *const ARStagingLiveAuctionSocketURLDefault = @"ARStagingLiveAuctionSocketURLDefault";
 
+NSString *const ARAppleDisplayNameKeychainKey = @"ARAppleDisplayNameKeychainKey";
+NSString *const ARAppleEmailKeyChainKey = @"ARAppleEmailKeyChainKey";
+
 NSString *const ARUsernameKeychainKey = @"ARUsernameKeychainKey";
 NSString *const ARPasswordKeychainKey = @"ARPasswordKeychainKey";
 NSString *const AROAuthTokenDefault = @"AROAuthToken";

--- a/Artsy/Networking/API_Modules/ARUserManager.h
+++ b/Artsy/Networking/API_Modules/ARUserManager.h
@@ -18,6 +18,12 @@ extern NSString *const ARUserSessionStartedNotification;
 - (User *)currentUser;
 - (void)storeUserData;
 
+@property (nonatomic, strong) NSString *appleEmail;
+@property (nonatomic, strong) NSString *appleDisplayName;
+
+- (void)storeAppleDisplayName:(NSString *)displayName email:(NSString *)email;
+- (void)resetAppleStoredCredentials;
+
 @property (nonatomic, strong) NSString *localTemporaryUserName;
 @property (nonatomic, strong) NSString *localTemporaryUserEmail;
 @property (nonatomic, strong, readonly) NSString *localTemporaryUserUUID;

--- a/Artsy/Networking/API_Modules/ARUserManager.h
+++ b/Artsy/Networking/API_Modules/ARUserManager.h
@@ -18,8 +18,8 @@ extern NSString *const ARUserSessionStartedNotification;
 - (User *)currentUser;
 - (void)storeUserData;
 
-@property (nonatomic, strong) NSString *appleEmail;
-@property (nonatomic, strong) NSString *appleDisplayName;
+@property (nonatomic, readonly) NSString *appleEmail;
+@property (nonatomic, readonly) NSString *appleDisplayName;
 
 - (void)storeAppleDisplayName:(NSString *)displayName email:(NSString *)email;
 - (void)resetAppleStoredCredentials;

--- a/Artsy/Networking/API_Modules/ARUserManager.m
+++ b/Artsy/Networking/API_Modules/ARUserManager.m
@@ -673,6 +673,29 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
     [self.keychain removeKeychainStringForKey:ARLocalTemporaryUserUUID];
 }
 
+#pragma mark - Sign in With Apple
+- (NSString *)appleDisplayName
+{
+    return [self.keychain keychainStringForKey:ARAppleDisplayNameKeychainKey];
+}
+
+- (NSString *)appleEmail
+{
+    return [self.keychain keychainStringForKey:ARAppleEmailKeyChainKey];
+}
+
+- (void)storeAppleDisplayName:(NSString *)displayName email:(NSString *)email
+{
+    [self.keychain setKeychainStringForKey:ARAppleDisplayNameKeychainKey value:displayName];
+    [self.keychain setKeychainStringForKey:ARAppleEmailKeyChainKey value:email];
+}
+
+- (void)resetAppleStoredCredentials
+{
+    [self.keychain removeKeychainStringForKey:ARAppleDisplayNameKeychainKey];
+    [self.keychain removeKeychainStringForKey:ARAppleEmailKeyChainKey];
+}
+
 #pragma mark - Shared Web Credentials
 
 - (void)disableSharedWebCredentials;

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/ARPersonalizeViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/ARPersonalizeViewController.m
@@ -326,21 +326,13 @@
 {
     [self addButtons];
 
-    BOOL signInWithApple = false;
-    if (signInWithApple) {
-        if (@available(iOS 13.0, *)) {
-            [self.onboardingButtonsView setupForThirdPartyLoginsWithLargeLayout:self.useLargeLayout];
-
-            [self.onboardingButtonsView.appleButton addTarget:self action:@selector(appleSignInTapped:)
-                                                           forControlEvents:UIControlEventTouchUpInside];
-            [self.onboardingButtonsView.facebookButton addTarget:self action:@selector(facebookSignInTapped:)
-                                                           forControlEvents:UIControlEventTouchUpInside];
-        }
+    if (@available(iOS 13.0, *)) {
+        [self.onboardingButtonsView setupForThirdPartyLoginsWithLargeLayout:self.useLargeLayout];
+        [self.onboardingButtonsView.appleButton addTarget:self action:@selector(appleSignInTapped:) forControlEvents:UIControlEventTouchUpInside];
+        [self.onboardingButtonsView.facebookButton addTarget:self action:@selector(facebookSignInTapped:) forControlEvents:UIControlEventTouchUpInside];
     } else {
         [self.onboardingButtonsView setupForFacebookWithLargeLayout:self.useLargeLayout];
-        [self.onboardingButtonsView.actionButton addTarget:self
-                  action:@selector(facebookSignInTapped:)
-        forControlEvents:UIControlEventTouchUpInside];
+        [self.onboardingButtonsView.actionButton addTarget:self action:@selector(facebookSignInTapped:) forControlEvents:UIControlEventTouchUpInside];
     }
 }
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,7 +4,7 @@ upcoming:
   dev:
     -
   user_facing:
-    -
+    - sign in with apple - brian
 
 releases:
   - version: 6.4.1


### PR DESCRIPTION
- Reenable sign in with apple
- Workaround for a bug that occurs when first auth fails

Apple only shares user email and name on first authentication so if initial authentication fails to create an artsy user for whatever reason (previously linked account, network error) we need to store the user name and email to enable sign up later. This does that by storing in keychain and deleting once a user is created successfully. 