### PR TITLE
Moves to Circle CI jobs to queue MP update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,8 +171,6 @@ jobs:
       - generate-checksums
       - install-node-modules
       - generate-query-map
-      - await-previous-builds:
-          branch: beta
       - run:
           name: Update metaphysics
           command: yarn update-metaphysics
@@ -319,7 +317,7 @@ workflows:
             - build-test-js
       - update-metaphysics:
           requires:
-            - build-test-js
+            - build-test-app
           filters:
             branches:
               only:


### PR DESCRIPTION
Instead of waiting for another job to complete _in_ a job ([which was failing due to a timeout](https://circleci.com/gh/artsy/eigen/8268)), we can use the `requires` on workflows to just not start the MP update job until the beta is deployed.