### PR TITLE
Removes ARSwitchBoardModule requirement that fromViewController lookup succeeds

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -241,13 +241,13 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
         });
     };
 
-    emission.switchBoardModule.presentNavigationViewController = ^(UIViewController *_Nonnull fromViewController,
+    emission.switchBoardModule.presentNavigationViewController = ^(UIViewController *_fromViewController,
                                                                    NSString *_Nonnull route) {
         UIViewController *viewController = [[ARSwitchBoard sharedInstance] loadPath:route];
         [[ARTopMenuViewController sharedController] pushViewController:viewController];
     };
 
-    emission.switchBoardModule.presentModalViewController = ^(UIViewController *_Nonnull fromViewController,
+    emission.switchBoardModule.presentModalViewController = ^(UIViewController *_fromViewController,
                                                               NSString *_Nonnull route) {
         UIViewController *viewController = [[ARSwitchBoard sharedInstance] loadPath:route];
         UIViewController *targetViewController = [ARTopMenuViewController sharedController];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -2,7 +2,7 @@ upcoming:
   version: 6.4.2
   date: TBD
   dev:
-    -
+    - Removes requirement for a fromViewController when routing from RN - ash & yuki
   user_facing:
     - sign in with apple - brian
 

--- a/emission/Pod/Classes/Core/ARSwitchBoardModule.h
+++ b/emission/Pod/Classes/Core/ARSwitchBoardModule.h
@@ -2,7 +2,7 @@
 #import <React/RCTBridgeModule.h>
 
 // Invoked on the main thread.
-typedef void(^ARSwitchBoardPresentViewController)(UIViewController * _Nonnull fromViewController, NSString * _Nonnull route);
+typedef void(^ARSwitchBoardPresentViewController)(UIViewController *fromViewController, NSString * _Nonnull route);
 
 typedef void(^ARSwitchBoardUpdateBackButton)(BOOL shouldHide);
 

--- a/emission/Pod/Classes/Core/ARSwitchBoardModule.m
+++ b/emission/Pod/Classes/Core/ARSwitchBoardModule.m
@@ -9,7 +9,7 @@
 
 
 // Invoked on the main thread.
-typedef void(^ARSwitchBoardPresentInternalViewController)(UIViewController * _Nonnull fromViewController, UIView * _Nonnull originatingView);
+typedef void(^ARSwitchBoardPresentInternalViewController)(UIViewController *fromViewController, UIView * _Nonnull originatingView);
 
 @interface ARSwitchBoardModule () <MFMailComposeViewControllerDelegate>
 @end
@@ -96,7 +96,7 @@ RCT_EXPORT_METHOD(presentEmailComposer:(nonnull NSNumber *)reactTag to:(nonnull 
               reactTag:(nonnull NSNumber *)reactTag
                  route:(nonnull NSString *)route;
 {
-  [self invokeCallback:^(UIViewController * _Nonnull fromViewController, id _) {
+  [self invokeCallback:^(UIViewController *fromViewController, id _) {
     callback(fromViewController, route);
   } reactTag:reactTag];
 }
@@ -110,7 +110,7 @@ RCT_EXPORT_METHOD(presentEmailComposer:(nonnull NSNumber *)reactTag to:(nonnull 
         rootView = rootView.superview;
     }
     UIViewController *viewController = rootView.reactViewController;
-    NSParameterAssert(viewController);
+    // Note that reactViewController could be nil if the top-level component is not backed by a ARComponentViewController.
     callback(viewController, originatingView);
 }
 

--- a/src/lib/Components/Bidding/Screens/RegistrationResult.tsx
+++ b/src/lib/Components/Bidding/Screens/RegistrationResult.tsx
@@ -52,7 +52,7 @@ const registrationPendingDueToUnverifiedStatusMessage = {
   description:
     "This auction requires Artsy to verify your identity before bidding.\n" +
     "\n" +
-    "For details about identity verification, please see the FAQ or contact [verification@artsy.net](mailto:verification@artsy.net).\n" +
+    "For details about identity verification, please see the [FAQ](/identity-verification-faq) or contact [verification@artsy.net](mailto:verification@artsy.net).\n" +
     "\n" +
     "A link to complete identity verification has been sent to your email.",
 }
@@ -67,7 +67,7 @@ const registrationNetworkErrorMessage = {
   description: "Please\ncheck your internet connection\nand try again.",
 }
 
-const markdownRules = defaultRules(false, {
+const markdownRules = defaultRules(true, {
   paragraph: {
     match: blockRegex(/^((?:[^\n]|\n(?! *\n))+)(?:\n *)/),
     react: (node, output, state) => {


### PR DESCRIPTION
Yuki was running into a problem where the `RCTRootView`'s `reactViewController` property was `nil`. This was because the code was being invoked from the Bid Flow interface, which uses its own navigation controller (that's my intuition, anyway).

The thing is, `fromViewController` isn't even used in the `presentNavigationViewController` and `presentModalViewController` blocks. Removing the parameter altogether would be a big refactor, so I opted instead to remove the `_Nonnull` specifier and the `NSParameterAssert` that was causing the crash. I also prefixed the parameter names in the blocks in `ARAppDelegate+Emission.m` to indicate that `_fromViewController` isn't used.

