### PR TITLE
Fixes a bug where the "Register To Bid" button displays that IDV is required after begin verified

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -634,6 +634,7 @@
 		B3ECE83C1819D1FD009F5C5B /* SaleArtworkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3ECE83B1819D1FD009F5C5B /* SaleArtworkTests.m */; };
 		B3EFC6391815B41C00F23540 /* BidderPosition.m in Sources */ = {isa = PBXBuildFile; fileRef = B3EFC6381815B41C00F23540 /* BidderPosition.m */; };
 		B4FDD967239ED8FF005A4F9F /* AREigenInquiryComponentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B4FDD965239ED8FE005A4F9F /* AREigenInquiryComponentViewController.m */; };
+		B63EC346244F49EE000C507E /* AuctionUserNetworkModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63EC345244F49EE000C507E /* AuctionUserNetworkModel.swift */; };
 		B9A29FE023EB27BD006EE2EC /* ARReactPackagerHost.m in Sources */ = {isa = PBXBuildFile; fileRef = B9A29FDF23EB27BD006EE2EC /* ARReactPackagerHost.m */; };
 		B9A29FE123EB27BD006EE2EC /* ARReactPackagerHost.m in Sources */ = {isa = PBXBuildFile; fileRef = B9A29FDF23EB27BD006EE2EC /* ARReactPackagerHost.m */; };
 		C594DDCAE943654BE450F2EE /* libPods-Artsy Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C25525BDDBC17429B1334785 /* libPods-Artsy Tests.a */; };
@@ -1712,6 +1713,7 @@
 		B3EFC6381815B41C00F23540 /* BidderPosition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BidderPosition.m; sourceTree = "<group>"; };
 		B4FDD965239ED8FE005A4F9F /* AREigenInquiryComponentViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AREigenInquiryComponentViewController.m; sourceTree = "<group>"; };
 		B4FDD966239ED8FE005A4F9F /* AREigenInquiryComponentViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AREigenInquiryComponentViewController.h; sourceTree = "<group>"; };
+		B63EC345244F49EE000C507E /* AuctionUserNetworkModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AuctionUserNetworkModel.swift; path = Auction/AuctionUserNetworkModel.swift; sourceTree = "<group>"; };
 		B9A29FDE23EB2680006EE2EC /* ARReactPackagerHost.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARReactPackagerHost.h; sourceTree = "<group>"; };
 		B9A29FDF23EB27BD006EE2EC /* ARReactPackagerHost.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARReactPackagerHost.m; sourceTree = "<group>"; };
 		C090E60DA1F8FEC7053193C8 /* Pods-Artsy.demo.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Artsy.demo.xcconfig"; path = "Pods/Target Support Files/Pods-Artsy/Pods-Artsy.demo.xcconfig"; sourceTree = "<group>"; };
@@ -2714,6 +2716,7 @@
 		5EA7BC2A1C60024D009C52C9 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				B63EC345244F49EE000C507E /* AuctionUserNetworkModel.swift */,
 				5EA7BC3E1C612577009C52C9 /* AuctionNetworkModel.swift */,
 				5EA7BC281C600144009C52C9 /* AuctionSaleNetworkModel.swift */,
 				5EA7BC301C612454009C52C9 /* AuctionBiddersNetworkModel.swift */,
@@ -5034,6 +5037,7 @@
 				5E47F35B1C4444A900EC0751 /* SaleViewModel.swift in Sources */,
 				60BC92F31BBEC89B00D13E56 /* ARApplicationShortcutItemDelegate.m in Sources */,
 				E61446B1195A1CDC00BFB7C3 /* ARFollowableNetworkModel.m in Sources */,
+				B63EC346244F49EE000C507E /* AuctionUserNetworkModel.swift in Sources */,
 				3CCCC8A21899B412008015DD /* ArtsyAPI+Fairs.m in Sources */,
 				E667F12C18EC889F00503F50 /* ARLogFormatter.m in Sources */,
 				342F961978DD1D771928472A /* UIDevice-Hardware.m in Sources */,

--- a/Artsy/Networking/API_Modules/ArtsyAPI+CurrentUserFunctions.h
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+CurrentUserFunctions.h
@@ -7,6 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ArtsyAPI (CurrentUserFunctions)
 
 + (void)getMeHEADWithSuccess:(void (^)(void))success failure:(void (^)(NSHTTPURLResponse *response, NSError *error))failure;
++ (void)getMe:(void (^)(User *))success failure:(void (^)(NSError *error))failure;
 
 + (void)updateCurrentUserProperty:(NSString *)property toValue:(id)value success:(void (^)(User *user))success failure:(void (^)(NSError *error))failure;
 

--- a/Artsy/Networking/API_Modules/ArtsyAPI+CurrentUserFunctions.m
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+CurrentUserFunctions.m
@@ -18,6 +18,13 @@
     }];
 }
 
++ (void)getMe:(void (^)(User *))success failure:(void (^)(NSError *error))failure
+{
+    NSURLRequest *request = [ARRouter newUserInfoRequest];
+
+    [self getRequest:request parseIntoAClass:[User class] success:success failure:failure];
+}
+
 + (void)updateCurrentUserProperty:(NSString *)property toValue:(id)value success:(void (^)(User *user))success failure:(void (^)(NSError *error))failure
 {
     NSParameterAssert(value);

--- a/Artsy/View_Controllers/Auction/AuctionUserNetworkModel.swift
+++ b/Artsy/View_Controllers/Auction/AuctionUserNetworkModel.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Interstellar
+
+protocol AuctionUserNetworkModelType {
+    func fetchCurrentUser() -> Observable<Result<User>>
+}
+
+/// Network model responsible for fetching the current user from the API.
+class AuctionUserNetworkModel: AuctionUserNetworkModelType {
+
+    var user: User?
+
+    func fetchCurrentUser() -> Observable<Result<User>> {
+        let observable = Observable<Result<User>>()
+
+        ArtsyAPI.getMe({ [weak self] user in
+                self?.user = user
+                observable.update(.success(user))
+            },
+            failure: { error in
+                observable.update(.error(error as Error))
+            })
+
+        return observable
+    }
+}

--- a/Artsy/View_Controllers/Live_Auctions/LiveAuctionLotSetViewController.swift
+++ b/Artsy/View_Controllers/Live_Auctions/LiveAuctionLotSetViewController.swift
@@ -259,7 +259,7 @@ class LiveAuctionLotSetViewController: UIViewController {
     @objc func moreInfo() {
         guard let sale = saleNetworkModel.sale else { return }
 
-        let saleVM = SaleViewModel(sale: sale, saleArtworks: [], bidders: biddersNetworkModel.bidders, lotStandings: [])
+        let saleVM = SaleViewModel(sale: sale, saleArtworks: [], bidders: biddersNetworkModel.bidders, lotStandings: [], me: User.current())
 
         let saleInfoVC = AuctionInformationViewController(saleViewModel: saleVM)
         saleInfoVC.titleViewDelegate = self

--- a/Artsy/Views/Auction/AuctionTitleView.swift
+++ b/Artsy/Views/Auction/AuctionTitleView.swift
@@ -180,7 +180,7 @@ private extension AuctionTitleView {
         let faqRange = (identityVerificationAttributedString.string as NSString).range(of: "FAQ")
         identityVerificationAttributedString.addAttribute(NSAttributedString.Key.underlineStyle, value:  NSUnderlineStyle.single.rawValue, range: faqRange)
 
-        let showIdentityVerification = !User.current().identityVerified && viewModel.requireIdentityVerification
+        let showIdentityVerification = !viewModel.identityVerified && viewModel.requireIdentityVerification
         let registrationLabel = ARSerifLabel().then {
             $0.attributedText = showIdentityVerification ? identityVerificationAttributedString : NSAttributedString(string: "Registration required to bid")
             $0.font = UIFont.serifFont(withSize: 16)

--- a/Artsy/Views/Auction/SaleViewModel.swift
+++ b/Artsy/Views/Auction/SaleViewModel.swift
@@ -2,18 +2,20 @@ import Foundation
 
 class SaleViewModel: NSObject {
     fileprivate let sale: Sale
+    fileprivate let me: User
     fileprivate let saleArtworks: [SaleArtwork]
     fileprivate var lotStandings: [LotStanding]
     let promotedSaleArtworks: [SaleArtwork]?
 
     var bidders: [Bidder]
 
-    init(sale: Sale, saleArtworks: [SaleArtwork], promotedSaleArtworks: [SaleArtwork]? = nil, bidders: [Bidder], lotStandings: [LotStanding]) {
+    init(sale: Sale, saleArtworks: [SaleArtwork], promotedSaleArtworks: [SaleArtwork]? = nil, bidders: [Bidder], lotStandings: [LotStanding], me: User) {
         self.sale = sale
         self.saleArtworks = saleArtworks
         self.promotedSaleArtworks = promotedSaleArtworks
         self.bidders = bidders
         self.lotStandings = lotStandings
+        self.me = me
     }
 
     var saleIsClosed: Bool {
@@ -43,6 +45,10 @@ class SaleViewModel: NSObject {
 
     var requireIdentityVerification: Bool {
         return sale.requireIdentityVerification
+    }
+
+    var identityVerified: Bool {
+        return me.identityVerified
     }
 
     var auctionState: ARAuctionState {

--- a/Artsy_Tests/View_Controller_Tests/Auction/AuctionInformationViewControllerTests.swift
+++ b/Artsy_Tests/View_Controller_Tests/Auction/AuctionInformationViewControllerTests.swift
@@ -16,7 +16,7 @@ class AuctionInformationViewControllerSpec: QuickSpec {
 
 
         var sale: Sale! = try! Sale(dictionary: ["saleID": "the-tada-sale", "name": "Sotheby’s Boundless Contemporary", "saleDescription": description, "startDate": past, "endDate": future ], error: Void())
-        var saleViewModel: SaleViewModel! = SaleViewModel(sale: sale, saleArtworks: [], bidders: [], lotStandings: [])
+        var saleViewModel: SaleViewModel! = SaleViewModel(sale: sale, saleArtworks: [], bidders: [], lotStandings: [], me: User())
 
         let markdown = "# Other Requests\n## Can you tell me the worth of my artwork?\n\nArtsy does not provide appraisal or authentication services for individual sellers. We recommend reaching out to professional dealers, galleries, and auction houses for assistance.\n\nFor any further questions, please contact [support@artsy.net](mailto:support@artsy.net)."
 
@@ -43,7 +43,7 @@ class AuctionInformationViewControllerSpec: QuickSpec {
         context("a current sale") {
             beforeEach {
                 sale = try! Sale(dictionary: ["saleID": "the-tada-sale", "name": "Sotheby’s Boundless Contemporary", "saleDescription": description, "startDate": past, "endDate": future ], error: Void())
-                saleViewModel = SaleViewModel(sale: sale, saleArtworks: [], bidders: [], lotStandings: [])
+                saleViewModel = SaleViewModel(sale: sale, saleArtworks: [], bidders: [], lotStandings: [], me: User())
                 commonSetup()
             }
 
@@ -57,7 +57,7 @@ class AuctionInformationViewControllerSpec: QuickSpec {
 
             it("shows a button for buyer's premium when needed") {
                 let sale = try! Sale(dictionary: ["saleID": "the-tada-sale", "name": "Sotheby’s Boundless Contemporary", "saleDescription": description, "startDate": past, "endDate": future, "buyersPremium" : [] ], error: Void())
-                let saleViewModel = SaleViewModel(sale: sale, saleArtworks: [], bidders: [], lotStandings: [])
+                let saleViewModel = SaleViewModel(sale: sale, saleArtworks: [], bidders: [], lotStandings: [], me: User())
                 informationController = AuctionInformationViewController(saleViewModel: saleViewModel)
                 navigationController = ARSerifNavigationViewController(rootViewController: informationController)
                 for entry in informationController.FAQEntries {
@@ -82,7 +82,7 @@ class AuctionInformationViewControllerSpec: QuickSpec {
         context("a closed sale") {
             beforeEach {
                 sale = try! Sale(dictionary: ["saleID": "the-tada-sale", "name": "Sotheby’s Boundless Contemporary", "saleDescription": description, "startDate": past, "endDate": past2 ], error: Void())
-                saleViewModel = SaleViewModel(sale: sale, saleArtworks: [], bidders: [], lotStandings: [])
+                saleViewModel = SaleViewModel(sale: sale, saleArtworks: [], bidders: [], lotStandings: [], me: User())
                 commonSetup()
             }
 

--- a/Artsy_Tests/View_Controller_Tests/Auction/AuctionViewControllerTests.swift
+++ b/Artsy_Tests/View_Controller_Tests/Auction/AuctionViewControllerTests.swift
@@ -34,6 +34,7 @@ func unfreezeTime() {
 class AuctionViewControllerTests: QuickSpec {
     override func spec() {
         var sale: Sale!
+        var me: User!
         var saleViewModel: Test_SaleViewModel!
         var dateMock: OCMockObject!
 
@@ -54,7 +55,8 @@ class AuctionViewControllerTests: QuickSpec {
                 dateMock = ARTestContext.freezeTime(now as Date)
 
                 sale = try! Sale(dictionary: ["saleID": "the-tada-sale", "name": "The 🎉 Sale", "endDate": endTime], error: Void())
-                saleViewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [])
+                me = try! User()
+                saleViewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [], me: me)
 
                 horizontalSizeClass = UIUserInterfaceSizeClass(rawValue: context()["horizontalSizeClass"] as! Int)
                 device = ARDeviceType(rawValue: context()["device"] as! Int)
@@ -184,7 +186,7 @@ class AuctionViewControllerTests: QuickSpec {
                         test_saleArtworkWithLotNumber(3, artistName: "Sarah", bidCount: 2, highestBidCents: 50_00),
                         test_saleArtworkWithLotNumber(4, artistName: "Eloy", bidCount: 17, highestBidCents: 1000_000_00),
                         test_saleArtworkWithLotNumber(5, artistName: "Maxim", bidCount: 6, highestBidCents: 5011_00),
-                        ], promotedSaleArtworks: [], bidders: [qualifiedBidder], lotStandings: [])
+                        ], promotedSaleArtworks: [], bidders: [qualifiedBidder], lotStandings: [], me: User())
                     saleViewModel.stubbedAuctionState.insert(.userIsRegistered)
 
                     subject = AuctionViewController(saleID: sale.saleID)
@@ -274,7 +276,7 @@ class AuctionViewControllerTests: QuickSpec {
                         test_saleArtworkWithLotNumber(3, artistName: "Sarah", bidCount: 2, highestBidCents: 50_00, saleState: "closed"),
                         test_saleArtworkWithLotNumber(4, artistName: "Eloy", bidCount: 17, highestBidCents: 1000_000_00, saleState: "closed"),
                         test_saleArtworkWithLotNumber(5, artistName: "Maxim", bidCount: 6, highestBidCents: 5011_00, saleState: "closed"),
-                        ], promotedSaleArtworks: [],  bidders: [qualifiedBidder], lotStandings: [])
+                        ], promotedSaleArtworks: [],  bidders: [qualifiedBidder], lotStandings: [], me: User())
                     saleViewModel.stubbedAuctionState.insert(.userIsRegistered)
 
                     subject = AuctionViewController(saleID: sale.saleID)
@@ -319,7 +321,7 @@ class AuctionViewControllerTests: QuickSpec {
                     "saleID": "the-tada-sale", "name": "The 🎉 Sale",
                     "saleDescription": "This is a description",
                     "startDate": start, "endDate": end], error: Void())
-                saleViewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [])
+                saleViewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [], me: User())
 
                 let subject = AuctionViewController(saleID: sale.saleID)
                 subject.allowAnimations = false
@@ -339,7 +341,7 @@ class AuctionViewControllerTests: QuickSpec {
                     "saleID": "the-tada-sale", "name": "The Sale With The Really Really Looooong Name",
                     "saleDescription": "This is a description",
                     "startDate": start, "endDate": end], error: Void())
-                saleViewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [])
+                saleViewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [], me: User())
 
                 let subject = AuctionViewController(saleID: sale.saleID)
                 subject.allowAnimations = false
@@ -358,7 +360,7 @@ class AuctionViewControllerTests: QuickSpec {
                 "saleID": "the-tada-sale", "name": "The 🎉 Sale",
                 "saleDescription": "This is a description",
                 "startDate": start, "endDate": end], error: Void())
-            saleViewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [])
+            saleViewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [], me: User())
 
             let subject = AuctionViewController(saleID: sale.saleID)
             subject.allowAnimations = false
@@ -376,7 +378,7 @@ class AuctionViewControllerTests: QuickSpec {
                 "saleID": "the-tada-sale", "name": "The 🎉 Sale",
                 "saleDescription": "This is a description",
                 "startDate": start, "endDate": end], error: Void())
-            saleViewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [])
+            saleViewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [], me: User())
 
             let subject = AuctionViewController(saleID: sale.saleID)
             subject.allowAnimations = false
@@ -396,7 +398,7 @@ class AuctionViewControllerTests: QuickSpec {
                     "saleID": "the-tada-sale", "name": "The 🎉 Sale",
                     "saleDescription": "This is a description",
                     "startDate": start, "endDate": end], error: Void())
-                saleViewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [])
+                saleViewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [], me: User())
 
                 let subject = AuctionViewController(saleID: sale.saleID)
                 subject.allowAnimations = false
@@ -418,7 +420,7 @@ class AuctionViewControllerTests: QuickSpec {
                     "saleID": "the-tada-sale", "name": "The 🎉 Sale",
                     "saleDescription": "This is a description",
                     "startDate": start, "endDate": end, "liveAuctionStartDate": liveStart], error: Void())
-                saleViewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [])
+                saleViewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [], me: User())
 
                 let subject = AuctionViewController(saleID: sale.saleID)
                 subject.allowAnimations = false
@@ -439,7 +441,7 @@ class AuctionViewControllerTests: QuickSpec {
                     "name": "Ash Furrow Auctions: Nerds Collect Art",
                     "saleDescription": "This is a description",
                     "startDate": start, "endDate": end], error: Void())
-                saleViewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [])
+                saleViewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [], me: User())
 
                 let subject = AuctionViewController(saleID: sale.saleID)
                 subject.stubHorizontalSizeClass(.compact)
@@ -473,7 +475,7 @@ class AuctionViewControllerTests: QuickSpec {
                         "name": "Ash Furrow Auctions: Nerds Collect Art",
                         "saleDescription": "This is a description",
                         "startDate": start, "endDate": end], error: Void())
-                    saleViewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [])
+                    saleViewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [], me: User())
                     saleViewModel.updateLotStandings(lotStandings)
 
                     let subject = AuctionViewController(saleID: sale.saleID)
@@ -492,30 +494,35 @@ class Test_SaleViewModel: SaleViewModel {
     override var currencySymbol: String { return "$" }
     override var auctionState: ARAuctionState { return stubbedAuctionState }
 
-    override init(sale: Sale, saleArtworks: [SaleArtwork], promotedSaleArtworks: [SaleArtwork]?, bidders: [Bidder], lotStandings: [LotStanding]) {
-        super.init(sale: sale, saleArtworks: saleArtworks, promotedSaleArtworks: promotedSaleArtworks, bidders: bidders, lotStandings: lotStandings)
-
+    override init(sale: Sale, saleArtworks: [SaleArtwork], promotedSaleArtworks: [SaleArtwork]?, bidders: [Bidder], lotStandings: [LotStanding], me: User) {
+        super.init(sale: sale, saleArtworks: saleArtworks, promotedSaleArtworks: promotedSaleArtworks, bidders: bidders, lotStandings: lotStandings, me: me)
     }
 }
 
 class Test_AuctionNetworkModel: AuctionNetworkModelType {
 
+    let me: User
     let sale: Sale
     let saleViewModel: SaleViewModel
     let saleArtworks: [SaleArtwork]
     var bidders: [Bidder]
     var lotStandings: [LotStanding]
 
-    init(sale: Sale, saleViewModel: SaleViewModel, bidders: [Bidder] = [], lotStandings: [LotStanding] = [], saleArtworks: [SaleArtwork] = []) {
+    init(sale: Sale, saleViewModel: SaleViewModel, bidders: [Bidder] = [], lotStandings: [LotStanding] = [], saleArtworks: [SaleArtwork] = [], me: User = User()) {
         self.saleViewModel = saleViewModel
         self.bidders = bidders
         self.lotStandings = lotStandings
         self.sale = sale
         self.saleArtworks = saleArtworks
+        self.me = me
     }
 
     func fetch() -> Observable<Result<SaleViewModel>> {
         return Observable(.success(saleViewModel))
+    }
+
+    func fetchMe() -> Observable<Result<User>> {
+        return Observable(.success(me))
     }
 
     func fetchBidders(_ saleID: String) -> Observable<Result<[Bidder]>> {

--- a/Artsy_Tests/View_Controller_Tests/Auction/RefinementOptionsViewControllerTests.swift
+++ b/Artsy_Tests/View_Controller_Tests/Auction/RefinementOptionsViewControllerTests.swift
@@ -10,7 +10,7 @@ class RefinementOptionsViewControllerSpec: QuickSpec {
     override func spec() {
         let openSale = try! Sale(dictionary: ["saleID": "the-tada-sale", "name": "Sotheby’s Boundless Contemporary", "saleDescription": description, "startDate": Date.distantPast, "endDate": Date.distantFuture ], error: Void())
 
-        let openSaleViewModel = SaleViewModel(sale: openSale, saleArtworks: [], bidders: [], lotStandings: [])
+        let openSaleViewModel = SaleViewModel(sale: openSale, saleArtworks: [], bidders: [], lotStandings: [], me: User())
 
         let defaultSettings = AuctionRefineSettings(ordering: .LotNumber, priceRange: (min: 500_00, max: 100_000_00), saleViewModel: openSaleViewModel)
         let differentSettings = AuctionRefineSettings(ordering: .ArtistAlphabetical, priceRange: (min: 500_00, max: 50_000_00), saleViewModel: openSaleViewModel)

--- a/Artsy_Tests/View_Controller_Tests/Auction/SaleViewModelTests.swift
+++ b/Artsy_Tests/View_Controller_Tests/Auction/SaleViewModelTests.swift
@@ -15,7 +15,7 @@ class SaleViewModelTests: QuickSpec {
             let url = "http://example.com"
             sale.setValue(["wide": url] as NSDictionary, forKey: "imageURLs")
 
-            let subject = SaleViewModel(sale: sale, saleArtworks: saleArtworks, bidders: [], lotStandings: [])
+            let subject = SaleViewModel(sale: sale, saleArtworks: saleArtworks, bidders: [], lotStandings: [], me: User())
 
             expect(subject.backgroundImageURL?.absoluteString) == url
         }
@@ -24,7 +24,7 @@ class SaleViewModelTests: QuickSpec {
             let url = "http://example.com"
             sale.profile = try! Profile(dictionary:  ["iconURLs": ["square": url]], error: Void())
 
-            let subject = SaleViewModel(sale: sale, saleArtworks: saleArtworks, bidders: [], lotStandings: [])
+            let subject = SaleViewModel(sale: sale, saleArtworks: saleArtworks, bidders: [], lotStandings: [], me: User())
 
             expect(subject.profileImageURL?.absoluteString) == url
         }
@@ -33,7 +33,7 @@ class SaleViewModelTests: QuickSpec {
             var subject: SaleViewModel!
 
             beforeEach {
-                subject = SaleViewModel(sale: sale, saleArtworks: saleArtworks, bidders: [], lotStandings: [])
+                subject = SaleViewModel(sale: sale, saleArtworks: saleArtworks, bidders: [], lotStandings: [], me: User())
             }
 
             it("includes high and low inclusive") {
@@ -56,7 +56,7 @@ class SaleViewModelTests: QuickSpec {
         }
 
         it("calculates a lowEstimate range") {
-            let subject = SaleViewModel(sale: sale, saleArtworks: saleArtworks, bidders: [], lotStandings: [])
+            let subject = SaleViewModel(sale: sale, saleArtworks: saleArtworks, bidders: [], lotStandings: [], me: User())
 
             let range = subject.lowEstimateRange
 
@@ -66,34 +66,34 @@ class SaleViewModelTests: QuickSpec {
 
         it("calculates a lowEstimate range when a lowEstimate is nil") {
             let nilInfestedSaleArtworks = saleArtworks + [testSaleArtworkEstimateAt(nil)]
-            let subject = SaleViewModel(sale: sale, saleArtworks: nilInfestedSaleArtworks, bidders: [], lotStandings: [])
+            let subject = SaleViewModel(sale: sale, saleArtworks: nilInfestedSaleArtworks, bidders: [], lotStandings: [], me: User())
 
             expect(subject.lowEstimateRange).notTo( raiseException() )
         }
 
         it("calculates a lowEstimate range when all lowEstimates are nil") {
-            let subject = SaleViewModel(sale: sale, saleArtworks: [testSaleArtworkEstimateAt(nil)], bidders: [], lotStandings: [])
+            let subject = SaleViewModel(sale: sale, saleArtworks: [testSaleArtworkEstimateAt(nil)], bidders: [], lotStandings: [], me: User())
 
             expect(subject.lowEstimateRange).notTo( raiseException() )
         }
 
         it("deals with auctions that have not started ") {
             let sale = testSaleWithDates(NSDate.distantFuture as NSDate, end: NSDate.distantFuture as NSDate)
-            let subject = SaleViewModel(sale: sale, saleArtworks: [], bidders: [], lotStandings: [])
+            let subject = SaleViewModel(sale: sale, saleArtworks: [], bidders: [], lotStandings: [], me: User())
 
             expect(subject.saleAvailability).to( equal(  SaleAvailabilityState.notYetOpen ) )
         }
 
         it("deals with auctions that have finished ") {
             let sale = testSaleWithDates(NSDate.distantPast as NSDate, end: NSDate.distantPast as NSDate)
-            let subject = SaleViewModel(sale: sale, saleArtworks: [], bidders: [], lotStandings: [])
+            let subject = SaleViewModel(sale: sale, saleArtworks: [], bidders: [], lotStandings: [], me: User())
 
             expect(subject.saleAvailability).to( equal( SaleAvailabilityState.closed ) )
         }
 
         it("deals with auctions that are active ") {
             let sale = testSaleWithDates(NSDate.distantPast as NSDate, end: NSDate.distantFuture as NSDate)
-            let subject = SaleViewModel(sale: sale, saleArtworks: [], bidders: [], lotStandings: [])
+            let subject = SaleViewModel(sale: sale, saleArtworks: [], bidders: [], lotStandings: [], me: User())
 
             expect(subject.saleAvailability).to( equal( SaleAvailabilityState.active(liveAuctionDate: nil) ) )
         }
@@ -104,7 +104,7 @@ class SaleViewModelTests: QuickSpec {
 
             let sale = try! Sale(dictionary: ["name": "The 🎉 Sale", "startDate": NSDate.distantPast, "endDate": NSDate.distantFuture, "liveAuctionStartDate": soon, "saleState": NSNumber(value: SaleStatePreview.rawValue)], error: Void())
 
-            let subject = SaleViewModel(sale: sale, saleArtworks: [], bidders: [], lotStandings: [])
+            let subject = SaleViewModel(sale: sale, saleArtworks: [], bidders: [], lotStandings: [], me: User())
 
             expect(subject.saleAvailability).to( equal( SaleAvailabilityState.active(liveAuctionDate: soon as Date) ) )
         }
@@ -114,7 +114,7 @@ class SaleViewModelTests: QuickSpec {
 
             let sale = try! Sale(dictionary: ["name": "The 🎉 Sale", "startDate": NSDate.distantPast, "endDate": NSDate.distantFuture, "liveAuctionStartDate": before, "saleState": NSNumber(value: SaleStateOpen.rawValue)], error: Void())
 
-            let subject = SaleViewModel(sale: sale, saleArtworks: [], bidders: [], lotStandings: [])
+            let subject = SaleViewModel(sale: sale, saleArtworks: [], bidders: [], lotStandings: [], me: User())
 
             expect(subject.isRunningALiveAuction) == true
             expect(subject.shouldShowLiveInterface) == true
@@ -126,19 +126,19 @@ class SaleViewModelTests: QuickSpec {
 
             let sale = try! Sale(dictionary: ["name": "The 🎉 Sale", "startDate": NSDate.distantPast, "endDate": end, "liveAuctionStartDate": before, "saleState": NSNumber(value: SaleStateClosed.rawValue)], error: Void())
 
-            let subject = SaleViewModel(sale: sale, saleArtworks: [], bidders: [], lotStandings: [])
+            let subject = SaleViewModel(sale: sale, saleArtworks: [], bidders: [], lotStandings: [], me: User())
 
             expect(subject.shouldShowLiveInterface) == false
         }
 
         it("returns false for hasLotStandings for empty standings") {
-            let subject = SaleViewModel(sale: sale, saleArtworks: saleArtworks, bidders: [], lotStandings: [])
+            let subject = SaleViewModel(sale: sale, saleArtworks: saleArtworks, bidders: [], lotStandings: [], me: User())
 
             expect(subject.hasLotStandings) == false
         }
 
         it("returns true for hasLotStandings for non-empty standings") {
-            let subject = SaleViewModel(sale: sale, saleArtworks: saleArtworks, bidders: [], lotStandings: [LotStanding()])
+            let subject = SaleViewModel(sale: sale, saleArtworks: saleArtworks, bidders: [], lotStandings: [LotStanding()], me: User())
 
             expect(subject.hasLotStandings) == true
         }

--- a/Artsy_Tests/View_Controller_Tests/Auction/Views/LotStandingsViewTests.swift
+++ b/Artsy_Tests/View_Controller_Tests/Auction/Views/LotStandingsViewTests.swift
@@ -25,7 +25,7 @@ class LotStandingsViewTests: QuickSpec {
 
             beforeEach {
                 sale = try! Sale(dictionary: ["saleID": "the-tada-sale", "name": "The 🎉 Sale"], error: Void())
-                saleViewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: lotStandings)
+                saleViewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: lotStandings, me: User())
 
                 horizontalSizeClass = UIUserInterfaceSizeClass(rawValue: context()["horizontalSizeClass"] as! Int)
                 device = ARDeviceType(rawValue: context()["device"] as! Int)

--- a/Artsy_Tests/View_Tests/Auctions/AuctionTitleViewTests.swift
+++ b/Artsy_Tests/View_Tests/Auctions/AuctionTitleViewTests.swift
@@ -17,7 +17,7 @@ class AuctionTitleViewSpec: QuickSpec {
 
         beforeEach {
             ARUserManager.stubAndLoginWithUsername()
-            viewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [qualifiedBidder], lotStandings: [])
+            viewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [qualifiedBidder], lotStandings: [], me: User())
         }
 
         sharedExamples("title view") { (context: SharedExampleContext) in
@@ -36,7 +36,7 @@ class AuctionTitleViewSpec: QuickSpec {
             }
 
             it("looks good with a not registered registration status") {
-                viewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [])
+                viewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [], me: User())
                 let subject = AuctionTitleView(viewModel: viewModel, delegate: delegate, fullWidth: fullWidth, showAdditionalInformation: true, titleTextAlignment: .left)
                 subject.bounds.size.width = 400
 
@@ -66,37 +66,34 @@ class AuctionTitleViewSpec: QuickSpec {
                     "requireIdentityVerification": true,
                 ]
                 let idVerifySale = try! Sale(dictionary: saleDict, error: Void())
-                let idVerifyViewModel = Test_SaleViewModel(sale: idVerifySale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [])
+                let idVerifyViewModel = Test_SaleViewModel(sale: idVerifySale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [], me: User())
                 let subject = AuctionTitleView(viewModel: idVerifyViewModel, delegate: delegate, fullWidth: fullWidth, showAdditionalInformation: true, titleTextAlignment: .left)
                 expect(subject).to( haveValidSnapshot() )
             }
 
             it("looks good with a sale and user who has already been identity-verified") {
-                // Overrides the earlier call to ARUserManager.stubAndLoginWithUsername()
-                // A bit of a leaky abstraction, but I'm not interested in refactoring ARUserManager+Stubs.m right now.
-                OHHTTPStubs.removeAllStubs()
-                ARUserManager.stubAccessToken(ARUserManager.stubAccessToken(), expiresIn: ARUserManager.stubAccessTokenExpiresIn())
-                OHHTTPStubs.stubJSONResponse(atPath: "/api/v1/me", withResponse:[
-                        "id": ARUserManager.stubUserID(),
+                let me = try! User(dictionary: [
+                        "userID": ARUserManager.stubUserID(),
                         "name": ARUserManager.stubUserName(),
                         "email": ARUserManager.stubUserEmail(),
-                        "identity_verified": true
-                    ])
-                ARUserManager.stubbedLogin(withUsername: ARUserManager.stubUserEmail(), password: ARUserManager.stubUserPassword(), successWithCredentials: nil, gotUser: nil, authenticationFailure: nil, networkFailure: nil)
+                        "identityVerified": true
+                    ], error: Void())
                 let saleDict : [String: Any] = [
                     "name" : "The 🎉 Sale",
                     "requireIdentityVerification": true,
                 ]
                 let idVerifySale = try! Sale(dictionary: saleDict, error: Void())
-                let idVerifyViewModel = Test_SaleViewModel(sale: idVerifySale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [])
+                let idVerifyViewModel = Test_SaleViewModel(sale: idVerifySale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [], me: me)
                 let subject = AuctionTitleView(viewModel: idVerifyViewModel, delegate: delegate, fullWidth: fullWidth, showAdditionalInformation: true, titleTextAlignment: .left)
                 expect(subject).to( haveValidSnapshot() )
             }
         }
+
         describe("with the registration button having side insets") {
             beforeEach {
                 fullWidth = false
             }
+
             itBehavesLike("title view")
         }
 
@@ -104,6 +101,7 @@ class AuctionTitleViewSpec: QuickSpec {
             beforeEach {
                 fullWidth = true
             }
+
             itBehavesLike("title view")
         }
     }

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -11,6 +11,7 @@ upcoming:
     - updates CityGuide BMW logo - ashleyjelks
     - Adds Trending Artist Series Collection Hub Rail - ashleyjelks
     - Fix untappable forgot password bug - brian
+    - Fixes a bug where the "Register To Bid" button still displays that IDV is required after being verified - yuki
 
 releases:
   - version: 6.4.1


### PR DESCRIPTION
fixes https://artsyproduct.atlassian.net/browse/AUCT-986

We have talked about this a couple times, but the current user object is locally stored in the phone and doesn't get updated unless the user explicitly logs out and back in. As a result of this, the identity verification status stays unchanged even after the user completes the verification. This PR adds another call to `/me` to get fresh data about the user to displays the latest information.

We may want to iterate on the `/me` call in general once we merge this PR, so we could use the up-to-date data everywhere else rather than throwing it away after the sale screen is gone. Let me know what you think.

## Todos

 * [x] Add more test coverage
 * [x] ~~Get error handling right: https://github.com/artsy/eigen/pull/3206/files#diff-cc7a410bdaac96a51f5a008b854d4788L169-R200~~ left a comment there
 * [x] ~~Fix the failing specs (they fail only locally due to snapshot mismatch, but they don't in CI)~~ couldn't find the root cause, but might be worth looking into later.

## Screenshots

![AUCT-986-large](https://user-images.githubusercontent.com/386234/79793250-3cc4a800-831e-11ea-844c-aa750c74b4b1.gif)
