### PR TITLE
Adds Brian to thanks.md

### DIFF
--- a/docs/thanks.md
+++ b/docs/thanks.md
@@ -19,3 +19,4 @@ Thanks to all the contributors with 100+ commits from Eigen, and pre-OSS Eigen. 
 - Sarah Weir - [sweir27](https://github.com/sweir27) - [@sweir27](https://twitter.com/sweir27)
 - Yuki Nishijima - [yuki24](https://github.com/yuki24) - [@yuki24](https://twitter.com/yuki24)
 - Jory Steifel - [jorystiefel](https://github.com/jorystiefel)
+- Brian Beckerle - [brainbicycle](https://github.com/brainbicycle)


### PR DESCRIPTION
[thanks.md](https://github.com/artsy/eigen/blob/master/docs/thanks.md) is a file where we thank anyone with > 100 commits in Eigen (or Emission) to thank them for the ongoing impact that their work has on the app. Brian, you crossed over this at some point in the last week, so let's get you properly thank'd 😄 

![Screen Shot 2020-04-21 at 16 35 45](https://user-images.githubusercontent.com/498212/79911439-5fbe8d00-83ee-11ea-907d-53c2db6e0fbf.png)
