### PR TITLE
Small Collections refactors

### DIFF
--- a/src/lib/Scenes/Collection/Collection.tsx
+++ b/src/lib/Scenes/Collection/Collection.tsx
@@ -20,7 +20,6 @@ interface CollectionProps {
 }
 
 interface CollectionState {
-  sections: Array<{ type: string; data: any }>
   isArtworkGridVisible: boolean
   isFilterArtworksModalVisible: boolean
 }
@@ -33,66 +32,11 @@ interface CollectionState {
 }))
 export class Collection extends Component<CollectionProps, CollectionState> {
   state = {
-    sections: [],
     isArtworkGridVisible: false,
     isFilterArtworksModalVisible: false,
   }
   viewabilityConfig = {
     viewAreaCoveragePercentThreshold: 75, // What percentage of the artworks component should be in the screen before toggling the filter button
-  }
-  componentDidMount() {
-    const sections = []
-
-    sections.push({
-      type: "collectionFeaturedArtists",
-      data: {
-        artists: [],
-      },
-    })
-
-    sections.push({
-      type: "collectionHubsRails",
-      data: {
-        artworks: [],
-      },
-    })
-
-    sections.push({
-      type: "collectionArtworks",
-      data: {
-        artworks: [],
-      },
-    })
-
-    this.setState({
-      sections,
-    })
-  }
-
-  renderItem = ({ item: { type } }) => {
-    const { collection } = this.props
-    const { linkedCollections, isDepartment } = collection
-
-    switch (type) {
-      case "collectionFeaturedArtists":
-        return <CollectionFeaturedArtists collection={collection} />
-      case "collectionHubsRails":
-        return isDepartment && <CollectionHubsRails linkedCollections={linkedCollections} {...this.props} />
-      case "collectionArtworks":
-        return (
-          <>
-            <CollectionArtworks collection={collection} />
-            <FilterModalNavigator
-              {...this.props}
-              isFilterArtworksModalVisible={this.state.isFilterArtworksModalVisible}
-              exitModal={this.handleFilterArtworksModal.bind(this)}
-              closeModal={this.closeFilterArtworksModal.bind(this)}
-            />
-          </>
-        )
-      default:
-        return null
-    }
   }
 
   onViewableItemsChanged = ({ viewableItems }) => {
@@ -139,7 +83,25 @@ export class Collection extends Component<CollectionProps, CollectionState> {
   }
 
   render() {
-    const { isArtworkGridVisible, sections } = this.state
+    const { isArtworkGridVisible } = this.state
+    const { collection } = this.props
+    const { linkedCollections, isDepartment } = collection
+
+    const sections = [
+      {
+        type: "collectionFeaturedArtists",
+        data: [],
+      },
+      {
+        type: "collectionHubsRails",
+        data: [],
+      },
+      {
+        type: "collectionArtworks",
+        data: [],
+      },
+    ] as const
+
     const isArtworkFilterEnabled = NativeModules.Emission?.options?.AROptionsFilterCollectionsArtworks
     return (
       <ArtworkFilterGlobalStateProvider>
@@ -154,9 +116,34 @@ export class Collection extends Component<CollectionProps, CollectionState> {
                     keyExtractor={(_item, index) => String(index)}
                     data={sections}
                     ListHeaderComponent={<CollectionHeader collection={this.props.collection} />}
-                    renderItem={item => (
+                    renderItem={({ item }) => (
                       <Box px={2} pb={2}>
-                        {this.renderItem(item)}
+                        {() => {
+                          switch (item.type) {
+                            case "collectionFeaturedArtists":
+                              return <CollectionFeaturedArtists collection={collection} />
+                            case "collectionHubsRails":
+                              return (
+                                isDepartment && (
+                                  <CollectionHubsRails linkedCollections={linkedCollections} {...this.props} />
+                                )
+                              )
+                            case "collectionArtworks":
+                              return (
+                                <>
+                                  <CollectionArtworks collection={collection} />
+                                  <FilterModalNavigator
+                                    {...this.props}
+                                    isFilterArtworksModalVisible={this.state.isFilterArtworksModalVisible}
+                                    exitModal={this.handleFilterArtworksModal.bind(this)}
+                                    closeModal={this.closeFilterArtworksModal.bind(this)}
+                                  />
+                                </>
+                              )
+                            default:
+                              return null
+                          }
+                        }}
                       </Box>
                     )}
                   />

--- a/src/lib/Scenes/Collection/Collection.tsx
+++ b/src/lib/Scenes/Collection/Collection.tsx
@@ -1,4 +1,4 @@
-import { Box, color, FilterIcon, Flex, Sans, Theme } from "@artsy/palette"
+import { Box, color, FilterIcon, Flex, Sans, Spacer, Theme } from "@artsy/palette"
 import { CollectionQuery } from "__generated__/CollectionQuery.graphql"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
@@ -87,20 +87,7 @@ export class Collection extends Component<CollectionProps, CollectionState> {
     const { collection } = this.props
     const { linkedCollections, isDepartment } = collection
 
-    const sections = [
-      {
-        type: "collectionFeaturedArtists",
-        data: [],
-      },
-      {
-        type: "collectionHubsRails",
-        data: [],
-      },
-      {
-        type: "collectionArtworks",
-        data: [],
-      },
-    ] as const
+    const sections = ["collectionFeaturedArtists", "collectionHubsRails", "collectionArtworks"] as const
 
     const isArtworkFilterEnabled = NativeModules.Emission?.options?.AROptionsFilterCollectionsArtworks
     return (
@@ -116,36 +103,37 @@ export class Collection extends Component<CollectionProps, CollectionState> {
                     keyExtractor={(_item, index) => String(index)}
                     data={sections}
                     ListHeaderComponent={<CollectionHeader collection={this.props.collection} />}
-                    renderItem={({ item }) => (
-                      <Box px={2} pb={2}>
-                        {() => {
-                          switch (item.type) {
-                            case "collectionFeaturedArtists":
-                              return <CollectionFeaturedArtists collection={collection} />
-                            case "collectionHubsRails":
-                              return (
-                                isDepartment && (
-                                  <CollectionHubsRails linkedCollections={linkedCollections} {...this.props} />
-                                )
-                              )
-                            case "collectionArtworks":
-                              return (
-                                <>
-                                  <CollectionArtworks collection={collection} />
-                                  <FilterModalNavigator
-                                    {...this.props}
-                                    isFilterArtworksModalVisible={this.state.isFilterArtworksModalVisible}
-                                    exitModal={this.handleFilterArtworksModal.bind(this)}
-                                    closeModal={this.closeFilterArtworksModal.bind(this)}
-                                  />
-                                </>
-                              )
-                            default:
-                              return null
-                          }
-                        }}
-                      </Box>
-                    )}
+                    ItemSeparatorComponent={() => <Spacer mb={2} />}
+                    renderItem={({ item }) => {
+                      switch (item) {
+                        case "collectionFeaturedArtists":
+                          return (
+                            <Box px={2}>
+                              <CollectionFeaturedArtists collection={collection} />
+                            </Box>
+                          )
+                        case "collectionHubsRails":
+                          return (
+                            isDepartment && (
+                              <Box px={2}>
+                                <CollectionHubsRails linkedCollections={linkedCollections} {...this.props} />
+                              </Box>
+                            )
+                          )
+                        case "collectionArtworks":
+                          return (
+                            <Box px={2}>
+                              <CollectionArtworks collection={collection} />
+                              <FilterModalNavigator
+                                {...this.props}
+                                isFilterArtworksModalVisible={this.state.isFilterArtworksModalVisible}
+                                exitModal={this.handleFilterArtworksModal.bind(this)}
+                                closeModal={this.closeFilterArtworksModal.bind(this)}
+                              />
+                            </Box>
+                          )
+                      }
+                    }}
                   />
                   {isArtworkGridVisible && isArtworkFilterEnabled && (
                     <FilterArtworkButtonContainer>

--- a/src/lib/Scenes/Collection/Collection.tsx
+++ b/src/lib/Scenes/Collection/Collection.tsx
@@ -115,9 +115,7 @@ export class Collection extends Component<CollectionProps, CollectionState> {
                         case "collectionHubsRails":
                           return (
                             isDepartment && (
-                              <Box px={2}>
-                                <CollectionHubsRails linkedCollections={linkedCollections} {...this.props} />
-                              </Box>
+                              <CollectionHubsRails linkedCollections={linkedCollections} {...this.props} />
                             )
                           )
                         case "collectionArtworks":

--- a/src/lib/Scenes/Collection/Components/CollectionHubsRails/ArtistSeries/ArtistSeriesRail.tsx
+++ b/src/lib/Scenes/Collection/Components/CollectionHubsRails/ArtistSeries/ArtistSeriesRail.tsx
@@ -1,4 +1,4 @@
-import { color, Flex, Sans } from "@artsy/palette"
+import { color, Flex, Sans, Spacer } from "@artsy/palette"
 import { ArtistSeriesRail_collectionGroup } from "__generated__/ArtistSeriesRail_collectionGroup.graphql"
 import {
   CARD_RAIL_ARTWORKS_HEIGHT as ARTWORKS_HEIGHT,
@@ -26,12 +26,15 @@ export const ArtistSeriesRail: React.SFC<ArtistSeriesRailProps> = props => {
 
   return (
     <ArtistSeriesWrapper>
-      <CollectionName size="4" mb={2} ml={2}>
+      <CollectionName size="4" mb={2} ml={4}>
         {collectionGroup.name}
       </CollectionName>
       <CardRailFlatList<ArtistSeriesItem>
         data={collectionGroup?.members}
         keyExtractor={(_item, index) => String(index)}
+        ListHeaderComponent={() => <Spacer mx={2} />}
+        ListFooterComponent={() => <Spacer mx={2} />}
+        ItemSeparatorComponent={() => <Spacer mx={0.5} />}
         initialNumToRender={3}
         renderItem={({ item: result, index }) => {
           const artworkImageURLs = result?.artworksConnection?.edges?.map(edge => edge?.node?.image?.url) ?? []


### PR DESCRIPTION
Hi Ashley 👋 I've been following your PRs and wanted to say, really great work on the Collections UI! Emission currently uses a few patterns that we're trying to move away from, which have snuck into the Collections work, so I put this PR together to show what we're trying to do instead. All my feedback is open to discussion, too, so please let me know where I can clarify my thinking (or if I got something wrong).

What we're trying to do:

---

Move away from `renderItem()`, `renderSection()`, or `renderThing()` functions. We should put as much of the render logic in the `render()` function as possible. There are a few reasons, but the big one is that TypeScript is a lot less useful when breaking things into smaller, one-off functions. Take a look at the typings first, it's just `any`, which isn't helpful.

![Screen Shot 2020-04-22 at 10 11 34](https://user-images.githubusercontent.com/498212/79996866-ef177f00-8486-11ea-8cb0-d5b3500c4a8c.png)

Now take a look:

![Screen Shot 2020-04-22 at 10 49 49](https://user-images.githubusercontent.com/498212/79996928-00608b80-8487-11ea-82d9-5fdd2abb611a.png)

Not only do we know it's an array of strings, but we know exactly which strings to expect (because of `as const`). 

(I also removed `data` from the sections because it wasn't being used, but we can add it back if it will be 👍)

---

Move away from setting up sections in `componentDidMount()`. We originally used this pattern to perform heavy calculations upfront, instead of in every render. What we've found over the years is that these computations aren't really that expensive, and would be better computed in `render`. This lets us avoid having to add explicit types to a lot of code, because TypeScript will infer the types for us. 

A lot of components still use `this.state.sections`, but we're hoping to get rid of most of them.

---

This isn't a coding refactor, but I also changed the horizontal card rail to go edge-to-edge, to match the home screen:

| Before | After |
|---|---|
| ![Screen Shot 2020-04-22 at 10 38 35](https://user-images.githubusercontent.com/498212/79997520-b0ce8f80-8487-11ea-8113-df59dbb4102c.png) |  ![Screen Shot 2020-04-22 at 10 38 20](https://user-images.githubusercontent.com/498212/79997555-baf08e00-8487-11ea-91ef-62933bb97e91.png) |

I did this using the `ListHeaderComponent`, `ListFooterComponent`, and `ItemSeparatorComponent` props. But I did have to remove the `<Box>` container in `Collection`. I moved the bottom margin from the `<Box>` to the `Collection`'s `ItemSeparatorComponent` prop.

---

Let me know again where I can clarify anything 👍 

