### PR TITLE
Refactor ViewingRoomHeader to use a fragment container (GALL-2784)

### DIFF
--- a/src/__generated__/ViewingRoomHeaderTestsQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomHeaderTestsQuery.graphql.ts
@@ -1,0 +1,126 @@
+/* tslint:disable */
+/* eslint-disable */
+/* @relayHash d19d7f7b79cb3a92b7cb581bc20e65ee */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ViewingRoomHeaderTestsQueryVariables = {};
+export type ViewingRoomHeaderTestsQueryResponse = {
+    readonly viewingRoom: {
+        readonly " $fragmentRefs": FragmentRefs<"ViewingRoomHeader_viewingRoom">;
+    } | null;
+};
+export type ViewingRoomHeaderTestsQuery = {
+    readonly response: ViewingRoomHeaderTestsQueryResponse;
+    readonly variables: ViewingRoomHeaderTestsQueryVariables;
+};
+
+
+
+/*
+query ViewingRoomHeaderTestsQuery {
+  viewingRoom(id: "unused") {
+    ...ViewingRoomHeader_viewingRoom
+  }
+}
+
+fragment ViewingRoomHeader_viewingRoom on ViewingRoom {
+  title
+  startAt
+  endAt
+  heroImageURL
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "unused"
+  }
+];
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ViewingRoomHeaderTestsQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewingRoom",
+        "storageKey": "viewingRoom(id:\"unused\")",
+        "args": (v0/*: any*/),
+        "concreteType": "ViewingRoom",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ViewingRoomHeader_viewingRoom",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ViewingRoomHeaderTestsQuery",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewingRoom",
+        "storageKey": "viewingRoom(id:\"unused\")",
+        "args": (v0/*: any*/),
+        "concreteType": "ViewingRoom",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "title",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "startAt",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "endAt",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "heroImageURL",
+            "args": null,
+            "storageKey": null
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "ViewingRoomHeaderTestsQuery",
+    "id": "26e6a9ed6ba1a2e1601b21127248a348",
+    "text": null,
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = '0a5636987f0eed565afb1b268ec6f48c';
+export default node;

--- a/src/__generated__/ViewingRoomHeader_viewingRoom.graphql.ts
+++ b/src/__generated__/ViewingRoomHeader_viewingRoom.graphql.ts
@@ -1,0 +1,59 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ViewingRoomHeader_viewingRoom = {
+    readonly title: string;
+    readonly startAt: unknown | null;
+    readonly endAt: unknown | null;
+    readonly heroImageURL: string | null;
+    readonly " $refType": "ViewingRoomHeader_viewingRoom";
+};
+export type ViewingRoomHeader_viewingRoom$data = ViewingRoomHeader_viewingRoom;
+export type ViewingRoomHeader_viewingRoom$key = {
+    readonly " $data"?: ViewingRoomHeader_viewingRoom$data;
+    readonly " $fragmentRefs": FragmentRefs<"ViewingRoomHeader_viewingRoom">;
+};
+
+
+
+const node: ReaderFragment = {
+  "kind": "Fragment",
+  "name": "ViewingRoomHeader_viewingRoom",
+  "type": "ViewingRoom",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "title",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "startAt",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "endAt",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "heroImageURL",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+};
+(node as any).hash = '2db17e8a898636e302ba0523d4624eba';
+export default node;

--- a/src/__generated__/ViewingRoomQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash fef0e3c5c7594d468883beb6d14d9698 */
+/* @relayHash 0fc76257dc40aecd73f6af1317a938fb */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -71,6 +71,13 @@ fragment ViewingRoomArtworks_viewingRoom on ViewingRoom {
   }
 }
 
+fragment ViewingRoomHeader_viewingRoom on ViewingRoom {
+  title
+  startAt
+  endAt
+  heroImageURL
+}
+
 fragment ViewingRoomStatement_viewingRoom on ViewingRoom {
   body
   pullQuote
@@ -92,10 +99,7 @@ fragment ViewingRoomSubsections_viewingRoomSubsections on ViewingRoom {
 }
 
 fragment ViewingRoom_viewingRoom on ViewingRoom {
-  title
-  startAt
-  endAt
-  heroImageURL
+  ...ViewingRoomHeader_viewingRoom
   ...ViewingRoomArtworks_viewingRoom
   ...ViewingRoomStatement_viewingRoom
 }
@@ -504,7 +508,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomQuery",
-    "id": "760b95ef2fd0b748ecd4dfb598b70cc7",
+    "id": "f30386e48ae5ea7e2ca5de9c00630747",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomStatementTestsQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomStatementTestsQuery.graphql.ts
@@ -1,0 +1,300 @@
+/* tslint:disable */
+/* eslint-disable */
+/* @relayHash 107a49d11750ee895b907224369fe26e */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ViewingRoomStatementTestsQueryVariables = {};
+export type ViewingRoomStatementTestsQueryResponse = {
+    readonly viewingRoom: {
+        readonly " $fragmentRefs": FragmentRefs<"ViewingRoomStatement_viewingRoom">;
+    } | null;
+};
+export type ViewingRoomStatementTestsQuery = {
+    readonly response: ViewingRoomStatementTestsQueryResponse;
+    readonly variables: ViewingRoomStatementTestsQueryVariables;
+};
+
+
+
+/*
+query ViewingRoomStatementTestsQuery {
+  viewingRoom(id: "unused") {
+    ...ViewingRoomStatement_viewingRoom
+  }
+}
+
+fragment ViewingRoomArtworkRail_viewingRoomArtworks on ViewingRoom {
+  artworks: artworksConnection(first: 5) {
+    totalCount
+    edges {
+      node {
+        href
+        artistNames
+        image {
+          url(version: "square")
+        }
+        saleMessage
+        id
+      }
+    }
+  }
+}
+
+fragment ViewingRoomStatement_viewingRoom on ViewingRoom {
+  body
+  pullQuote
+  introStatement
+  artworksForCount: artworksConnection(first: 1) {
+    totalCount
+  }
+  ...ViewingRoomSubsections_viewingRoomSubsections
+  ...ViewingRoomArtworkRail_viewingRoomArtworks
+}
+
+fragment ViewingRoomSubsections_viewingRoomSubsections on ViewingRoom {
+  subsections {
+    body
+    title
+    caption
+    imageURL
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "unused"
+  }
+],
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "body",
+  "args": null,
+  "storageKey": null
+},
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "totalCount",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ViewingRoomStatementTestsQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewingRoom",
+        "storageKey": "viewingRoom(id:\"unused\")",
+        "args": (v0/*: any*/),
+        "concreteType": "ViewingRoom",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ViewingRoomStatement_viewingRoom",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ViewingRoomStatementTestsQuery",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewingRoom",
+        "storageKey": "viewingRoom(id:\"unused\")",
+        "args": (v0/*: any*/),
+        "concreteType": "ViewingRoom",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "pullQuote",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "introStatement",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": "artworksForCount",
+            "name": "artworksConnection",
+            "storageKey": "artworksConnection(first:1)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 1
+              }
+            ],
+            "concreteType": "ArtworkConnection",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/)
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "subsections",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "ViewingRoomSubsection",
+            "plural": true,
+            "selections": [
+              (v1/*: any*/),
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "title",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "caption",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "imageURL",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": "artworks",
+            "name": "artworksConnection",
+            "storageKey": "artworksConnection(first:5)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 5
+              }
+            ],
+            "concreteType": "ArtworkConnection",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtworkEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "href",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "artistNames",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "image",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "url",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "square"
+                              }
+                            ],
+                            "storageKey": "url(version:\"square\")"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "saleMessage",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "id",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "ViewingRoomStatementTestsQuery",
+    "id": "076cde295972afd1003ebd3f6d8ddc61",
+    "text": null,
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = '644382552191501117e3feb186684e13';
+export default node;

--- a/src/__generated__/ViewingRoom_viewingRoom.graphql.ts
+++ b/src/__generated__/ViewingRoom_viewingRoom.graphql.ts
@@ -4,11 +4,7 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ViewingRoom_viewingRoom = {
-    readonly title: string;
-    readonly startAt: unknown | null;
-    readonly endAt: unknown | null;
-    readonly heroImageURL: string | null;
-    readonly " $fragmentRefs": FragmentRefs<"ViewingRoomArtworks_viewingRoom" | "ViewingRoomStatement_viewingRoom">;
+    readonly " $fragmentRefs": FragmentRefs<"ViewingRoomHeader_viewingRoom" | "ViewingRoomArtworks_viewingRoom" | "ViewingRoomStatement_viewingRoom">;
     readonly " $refType": "ViewingRoom_viewingRoom";
 };
 export type ViewingRoom_viewingRoom$data = ViewingRoom_viewingRoom;
@@ -27,32 +23,9 @@ const node: ReaderFragment = {
   "argumentDefinitions": [],
   "selections": [
     {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "title",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "startAt",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "endAt",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "heroImageURL",
-      "args": null,
-      "storageKey": null
+      "kind": "FragmentSpread",
+      "name": "ViewingRoomHeader_viewingRoom",
+      "args": null
     },
     {
       "kind": "FragmentSpread",
@@ -66,5 +39,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = 'b4ebbdce5a212cfde3a83fd2e474a6f5';
+(node as any).hash = '0b4a41ad6719aa3e57ee2d1c7949c732';
 export default node;

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
@@ -30,40 +30,38 @@ const Overlay = styled.View`
   position: absolute;
 `
 
-export class ViewingRoomHeader extends React.Component<ViewingRoomHeaderProps> {
-  render() {
-    const { width: screenWidth } = Dimensions.get("window")
-    const imageHeight = 547
-    const { artwork, title } = this.props
+export const ViewingRoomHeader: React.FC<ViewingRoomHeaderProps> = props => {
+  const { width: screenWidth } = Dimensions.get("window")
+  const imageHeight = 547
+  const { artwork, title } = props
 
-    return (
-      <>
-        <Box style={{ height: imageHeight, width: screenWidth, position: "relative" }}>
-          <BackgroundImage imageURL={artwork} height={imageHeight} width={screenWidth} />
-          <Overlay />
-          <Flex flexDirection="row" justifyContent="center" alignItems="flex-start" px={2} py={2} height={100}>
-            <Flex alignItems="center" flexDirection="column" flexGrow={1}>
-              <Sans size="3" textAlign="center" color="white100">
-                Viewing Room
-              </Sans>
-            </Flex>
+  return (
+    <>
+      <Box style={{ height: imageHeight, width: screenWidth, position: "relative" }}>
+        <BackgroundImage imageURL={artwork} height={imageHeight} width={screenWidth} />
+        <Overlay />
+        <Flex flexDirection="row" justifyContent="center" alignItems="flex-start" px={2} py={2} height={100}>
+          <Flex alignItems="center" flexDirection="column" flexGrow={1}>
+            <Sans size="3" textAlign="center" color="white100">
+              Viewing Room
+            </Sans>
           </Flex>
-          <Flex flexDirection="row" justifyContent="center" alignItems="flex-end" px={2} height={imageHeight - 160}>
-            <Flex alignItems="center" flexDirection="column" flexGrow={1}>
-              <Sans size="6" textAlign="center" color="white100">
-                {title}
-              </Sans>
-            </Flex>
+        </Flex>
+        <Flex flexDirection="row" justifyContent="center" alignItems="flex-end" px={2} height={imageHeight - 160}>
+          <Flex alignItems="center" flexDirection="column" flexGrow={1}>
+            <Sans size="6" textAlign="center" color="white100">
+              {title}
+            </Sans>
           </Flex>
-          <CountdownContainer>
-            <CountdownTimer
-              formattedOpeningHours=""
-              startAt="2020-03-10T20:22:42+00:00"
-              endAt="2020-04-22T10:24:31+00:00"
-            />
-          </CountdownContainer>
-        </Box>
-      </>
-    )
-  }
+        </Flex>
+        <CountdownContainer>
+          <CountdownTimer
+            formattedOpeningHours=""
+            startAt="2020-03-10T20:22:42+00:00"
+            endAt="2020-04-22T10:24:31+00:00"
+          />
+        </CountdownContainer>
+      </Box>
+    </>
+  )
 }

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
@@ -1,13 +1,14 @@
 import { Box, Flex, Sans, space } from "@artsy/palette"
+import { ViewingRoomHeader_viewingRoom } from "__generated__/ViewingRoomHeader_viewingRoom.graphql"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { CountdownTimer } from "lib/Scenes/Fair/Components/FairHeader/CountdownTimer"
 import React from "react"
 import { Dimensions } from "react-native"
+import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components/native"
 
 interface ViewingRoomHeaderProps {
-  artwork: string
-  title: string
+  viewingRoom: ViewingRoomHeader_viewingRoom
 }
 
 export const BackgroundImage = styled(OpaqueImageView)<{ height: number; width: number }>`
@@ -33,12 +34,11 @@ const Overlay = styled.View`
 export const ViewingRoomHeader: React.FC<ViewingRoomHeaderProps> = props => {
   const { width: screenWidth } = Dimensions.get("window")
   const imageHeight = 547
-  const { artwork, title } = props
 
   return (
     <>
       <Box style={{ height: imageHeight, width: screenWidth, position: "relative" }}>
-        <BackgroundImage imageURL={artwork} height={imageHeight} width={screenWidth} />
+        <BackgroundImage imageURL={props.viewingRoom.heroImageURL} height={imageHeight} width={screenWidth} />
         <Overlay />
         <Flex flexDirection="row" justifyContent="center" alignItems="flex-start" px={2} py={2} height={100}>
           <Flex alignItems="center" flexDirection="column" flexGrow={1}>
@@ -50,7 +50,7 @@ export const ViewingRoomHeader: React.FC<ViewingRoomHeaderProps> = props => {
         <Flex flexDirection="row" justifyContent="center" alignItems="flex-end" px={2} height={imageHeight - 160}>
           <Flex alignItems="center" flexDirection="column" flexGrow={1}>
             <Sans size="6" textAlign="center" color="white100">
-              {title}
+              {props.viewingRoom.title}
             </Sans>
           </Flex>
         </Flex>
@@ -65,3 +65,14 @@ export const ViewingRoomHeader: React.FC<ViewingRoomHeaderProps> = props => {
     </>
   )
 }
+
+export const ViewingRoomHeaderContainer = createFragmentContainer(ViewingRoomHeader, {
+  viewingRoom: graphql`
+    fragment ViewingRoomHeader_viewingRoom on ViewingRoom {
+      title
+      startAt
+      endAt
+      heroImageURL
+    }
+  `,
+})

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
@@ -38,7 +38,12 @@ export const ViewingRoomHeader: React.FC<ViewingRoomHeaderProps> = props => {
   return (
     <>
       <Box style={{ height: imageHeight, width: screenWidth, position: "relative" }}>
-        <BackgroundImage imageURL={props.viewingRoom.heroImageURL} height={imageHeight} width={screenWidth} />
+        <BackgroundImage
+          data-test-id="background-image"
+          imageURL={props.viewingRoom.heroImageURL}
+          height={imageHeight}
+          width={screenWidth}
+        />
         <Overlay />
         <Flex flexDirection="row" justifyContent="center" alignItems="flex-start" px={2} py={2} height={100}>
           <Flex alignItems="center" flexDirection="column" flexGrow={1}>
@@ -49,7 +54,7 @@ export const ViewingRoomHeader: React.FC<ViewingRoomHeaderProps> = props => {
         </Flex>
         <Flex flexDirection="row" justifyContent="center" alignItems="flex-end" px={2} height={imageHeight - 160}>
           <Flex alignItems="center" flexDirection="column" flexGrow={1}>
-            <Sans size="6" textAlign="center" color="white100">
+            <Sans data-test-id="title" size="6" textAlign="center" color="white100">
               {props.viewingRoom.title}
             </Sans>
           </Flex>

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomStatement.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomStatement.tsx
@@ -25,7 +25,7 @@ export const ViewingRoomStatement: React.FC<ViewingRoomStatementProps> = props =
   sections.push({
     key: "introStatement",
     element: (
-      <Serif size="4" mt="2">
+      <Serif data-test-id="intro-statement" size="4" mt="2">
         {viewingRoom.introStatement}
       </Serif>
     ),
@@ -40,7 +40,7 @@ export const ViewingRoomStatement: React.FC<ViewingRoomStatementProps> = props =
   sections.push({
     key: "pullQuote",
     element: (
-      <Sans size="8" textAlign="center" my="3">
+      <Sans data-test-id="pull-quote" size="8" textAlign="center" my="3">
         {viewingRoom.pullQuote}
       </Sans>
     ),
@@ -49,7 +49,7 @@ export const ViewingRoomStatement: React.FC<ViewingRoomStatementProps> = props =
   sections.push({
     key: "body",
     element: (
-      <Serif size="4" mb="3">
+      <Serif data-test-id="body" size="4" mb="3">
         {viewingRoom.body}
       </Serif>
     ),
@@ -66,6 +66,7 @@ export const ViewingRoomStatement: React.FC<ViewingRoomStatementProps> = props =
     element: (
       <Flex width="100%" mt="2">
         <Button
+          data-test-id="view-works"
           block
           onPress={() =>
             SwitchBoard.presentNavigationViewController(

--- a/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomStatement-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomStatement-tests.tsx
@@ -1,70 +1,92 @@
-import { Box, Button, Sans, Serif } from "@artsy/palette"
-import { mount } from "enzyme"
+import { Theme } from "@artsy/palette"
+import { ViewingRoomStatementTestsQuery } from "__generated__/ViewingRoomStatementTestsQuery.graphql"
+import { extractText } from "lib/tests/extractText"
+import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import ReactTestRenderer from "react-test-renderer"
+import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { ViewingRoomArtworkRail } from "../ViewingRoomArtworkRail"
-import { ViewingRoomStatement } from "../ViewingRoomStatement"
+import { ViewingRoomStatementContainer } from "../ViewingRoomStatement"
 import { ViewingRoomSubsections } from "../ViewingRoomSubsections"
 
+jest.unmock("react-relay")
+
 describe("ViewingRoomStatement", () => {
-  const viewingRoom = {
-    introStatement: "Introduction Statment",
-    body: "Body",
-    pullQuote: "Pull Quote",
-    artworks: {
-      edges: {},
-    },
-    artworksForCount: {
-      totalCount: 51,
-    },
-    subsections: [
-      {
-        title: "First",
-      },
-      {
-        title: "Second",
-      },
-    ],
-    " $fragmentRefs": null,
-    " $refType": null,
-  }
-  it("renders an intro statement", () => {
-    const wrapper = mount(<ViewingRoomStatement viewingRoom={viewingRoom} />)
-    expect(
-      wrapper.findWhere(n => {
-        return n.type() === Serif && n.text() === viewingRoom.introStatement
-      })
-    ).toHaveLength(1)
+  let mockEnvironment
+  const TestRenderer = () => (
+    <Theme>
+      <QueryRenderer<ViewingRoomStatementTestsQuery>
+        environment={mockEnvironment}
+        query={graphql`
+          query ViewingRoomStatementTestsQuery {
+            viewingRoom(id: "unused") {
+              ...ViewingRoomStatement_viewingRoom
+            }
+          }
+        `}
+        render={renderWithLoadProgress(ViewingRoomStatementContainer)}
+        variables={{}}
+      />
+    </Theme>
+  )
+  beforeEach(() => {
+    mockEnvironment = createMockEnvironment()
   })
-  it("renders an artwork rail with the same props", () => {
-    const wrapper = mount(<ViewingRoomStatement viewingRoom={viewingRoom} />)
-    expect(wrapper.find(ViewingRoomArtworkRail)).toHaveLength(1)
-    expect(wrapper.find(ViewingRoomArtworkRail).props().viewingRoomArtworks).toEqual(viewingRoom)
+  it("renders an intro statement", () => {
+    const tree = ReactTestRenderer.create(<TestRenderer />)
+    mockEnvironment.mock.resolveMostRecentOperation(operation => {
+      const result = MockPayloadGenerator.generate(operation, {
+        ViewingRoom: () => ({ introStatement: "Foo" }),
+      })
+      return result
+    })
+    expect(extractText(tree.root.findByProps({ "data-test-id": "intro-statement" }))).toEqual("Foo")
+  })
+  it("renders an artwork rail", () => {
+    const tree = ReactTestRenderer.create(<TestRenderer />)
+    mockEnvironment.mock.resolveMostRecentOperation(operation => {
+      const result = MockPayloadGenerator.generate(operation)
+      return result
+    })
+    expect(tree.root.findAllByType(ViewingRoomArtworkRail)).toHaveLength(1)
   })
   it("renders a pull quote", () => {
-    const wrapper = mount(<ViewingRoomStatement viewingRoom={viewingRoom} />)
-    expect(
-      wrapper.findWhere(n => {
-        return n.type() === Sans && n.text() === viewingRoom.pullQuote
+    const tree = ReactTestRenderer.create(<TestRenderer />)
+    mockEnvironment.mock.resolveMostRecentOperation(operation => {
+      const result = MockPayloadGenerator.generate(operation, {
+        ViewingRoom: () => ({ pullQuote: "Foo" }),
       })
-    ).toHaveLength(1)
+      return result
+    })
+    expect(extractText(tree.root.findByProps({ "data-test-id": "pull-quote" }))).toEqual("Foo")
   })
-  it("renders a body paragraph", () => {
-    const wrapper = mount(<ViewingRoomStatement viewingRoom={viewingRoom} />)
-    expect(
-      wrapper.findWhere(n => {
-        return n.type() === Serif && n.text() === viewingRoom.body
+  it("renders a body", () => {
+    const tree = ReactTestRenderer.create(<TestRenderer />)
+    mockEnvironment.mock.resolveMostRecentOperation(operation => {
+      const result = MockPayloadGenerator.generate(operation, {
+        ViewingRoom: () => ({ body: "Foo" }),
       })
-    ).toHaveLength(1)
+      return result
+    })
+    expect(extractText(tree.root.findByProps({ "data-test-id": "body" }))).toEqual("Foo")
   })
   it("renders the subsections", () => {
-    const wrapper = mount(<ViewingRoomStatement viewingRoom={viewingRoom} />)
-    expect(wrapper.find(ViewingRoomSubsections)).toHaveLength(1)
-    expect(wrapper.find(ViewingRoomSubsections).find(Box)).toHaveLength(2)
+    const tree = ReactTestRenderer.create(<TestRenderer />)
+    mockEnvironment.mock.resolveMostRecentOperation(operation => {
+      const result = MockPayloadGenerator.generate(operation)
+      return result
+    })
+    expect(tree.root.findAllByType(ViewingRoomSubsections)).toHaveLength(1)
   })
   it("renders a button to view artworks", () => {
-    const wrapper = mount(<ViewingRoomStatement viewingRoom={viewingRoom} />)
-    wrapper.findWhere(n => {
-      return n.type() === Button && n.text() === `View works (${viewingRoom.artworksForCount.totalCount})`
+    const tree = ReactTestRenderer.create(<TestRenderer />)
+    mockEnvironment.mock.resolveMostRecentOperation(operation => {
+      const result = MockPayloadGenerator.generate(operation, {
+        ViewingRoom: () => ({ artworksForCount: { totalCount: 42 } }),
+      })
+      return result
     })
+    expect(extractText(tree.root.findByProps({ "data-test-id": "view-works" }))).toMatch("View works (42)")
   })
 })

--- a/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
@@ -7,7 +7,7 @@ import { ProvideScreenTracking, Schema } from "lib/utils/track"
 import React from "react"
 import { ScrollView } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
-import { ViewingRoomHeader } from "./Components/ViewingRoomHeader"
+import { ViewingRoomHeaderContainer } from "./Components/ViewingRoomHeader"
 import { ViewingRoomStatementContainer } from "./Components/ViewingRoomStatement"
 
 interface ViewingRoomProps {
@@ -29,7 +29,7 @@ export const ViewingRoom: React.FC<ViewingRoomProps> = props => {
       <Theme>
         <Flex style={{ flex: 1 }}>
           <ScrollView>
-            <ViewingRoomHeader artwork={viewingRoom.heroImageURL} title={viewingRoom.title} />
+            <ViewingRoomHeaderContainer viewingRoom={viewingRoom} />
             <ViewingRoomStatementContainer viewingRoom={viewingRoom} />
           </ScrollView>
         </Flex>
@@ -41,10 +41,7 @@ export const ViewingRoom: React.FC<ViewingRoomProps> = props => {
 export const ViewingRoomFragmentContainer = createFragmentContainer(ViewingRoom, {
   viewingRoom: graphql`
     fragment ViewingRoom_viewingRoom on ViewingRoom {
-      title
-      startAt
-      endAt
-      heroImageURL
+      ...ViewingRoomHeader_viewingRoom
       ...ViewingRoomArtworks_viewingRoom
       ...ViewingRoomStatement_viewingRoom
     }


### PR DESCRIPTION
The purpose of this PR is to refactor `ViewingRoomHeader` to use a fragment container (instead of receiving its props directly from its parent) so that its test can be written with the `ReactTestRenderer` instead of `enzyme`.