### PR TITLE
Preparing for development version 6.4.3 #trivial 

### DIFF
--- a/Artsy Stickers/Info.plist
+++ b/Artsy Stickers/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.4.2</string>
+	<string>6.4.3</string>
 	<key>CFBundleVersion</key>
 	<string>2019.05.24.09</string>
 	<key>NSExtension</key>

--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -36,7 +36,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.4.2</string>
+	<string>6.4.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -1,5 +1,5 @@
 upcoming:
-  version: 6.4.2
+  version: 6.4.3
   date: TBD
   dev:
     - Removes requirement for a fromViewController when routing from RN - ash & yuki
@@ -11,6 +11,13 @@ upcoming:
     - Adds Trending Artist Series Collection Hub Rail - ashleyjelks
 
 releases:
+  - version: 6.4.2
+    date: Apr 22, 2020
+    dev:
+      -
+    user_facing:
+      - fix for bug preventing forgot password dialog from showing - brian
+
   - version: 6.4.1
     date: Apr 15, 2020
     dev:


### PR DESCRIPTION
- Ran `make next`
- Moved all unreleased changes from 6.4.2 to  6.4.3
- Add 6.4.2 to releases in changelog with only bug fix