### PR TITLE
[CSGN-118] Require images for consignment submissions

### DIFF
--- a/src/lib/Components/Consignments/Screens/Overview.tsx
+++ b/src/lib/Components/Consignments/Screens/Overview.tsx
@@ -225,7 +225,8 @@ export default class Overview extends React.Component<Props, State> {
       this.state.metadata.medium &&
       this.state.metadata.height &&
       this.state.metadata.width &&
-      this.state.editionScreenViewed
+      this.state.editionScreenViewed &&
+      this.state.photos?.length > 0
     )
 
   render() {

--- a/src/lib/Components/Consignments/Screens/SelectFromPhotoLibrary.tsx
+++ b/src/lib/Components/Consignments/Screens/SelectFromPhotoLibrary.tsx
@@ -206,7 +206,7 @@ export default class SelectFromPhotoLibrary extends React.Component<Props, State
               <View style={{ paddingTop: 40 }}>
                 <Box px={2}>
                   <Serif size="4" style={{ textAlign: "center" }}>
-                    We suggest adding a few photos of the work including the front and back as well as the signature.
+                    Please add photos of the work. We suggest including the front and back as well as the signature.
                   </Serif>
                 </Box>
                 <Spacer mb={2} />

--- a/src/lib/Components/Consignments/Screens/__tests__/Overview-tests.tsx
+++ b/src/lib/Components/Consignments/Screens/__tests__/Overview-tests.tsx
@@ -131,8 +131,8 @@ describe("Updating State", () => {
   })
 })
 
-it("requires the same metadata props as force", () => {
-  const requiredProps: any = {
+describe("required data", () => {
+  const requiredState: any = {
     artist: {},
     location: {},
     editionScreenViewed: true,
@@ -148,17 +148,67 @@ it("requires the same metadata props as force", () => {
       unit: "CM",
       displayString: "A work",
     },
+    photos: [
+      {
+        file: "some-image-file",
+        uploaded: true,
+      },
+    ],
   }
-  const overview = new Overview({ setup: requiredProps })
-  expect(overview.canSubmit()).toBeTruthy()
-})
 
-it("does not allow submission without all the right options", () => {
-  const requiredProps: any = {
-    artist: {},
-    location: {},
-    editionScreenViewed: true,
-  }
-  const overview = new Overview({ setup: requiredProps })
-  expect(overview.canSubmit()).toBeFalsy()
+  it("allows submission when all data is provided", () => {
+    const setup = { ...requiredState }
+    const overview = new Overview({ setup })
+    expect(overview.canSubmit()).toBeTruthy()
+  })
+
+  it("does not allow submission without artist", () => {
+    const setup = {
+      ...requiredState,
+      artist: undefined,
+    }
+
+    const overview = new Overview({ setup })
+    expect(overview.canSubmit()).toBeFalsy()
+  })
+
+  it("does not allow submission without location", () => {
+    const setup = {
+      ...requiredState,
+      location: undefined,
+    }
+
+    const overview = new Overview({ setup })
+    expect(overview.canSubmit()).toBeFalsy()
+  })
+
+  it("does not allow submission without editionScreenViewed", () => {
+    const setup = {
+      ...requiredState,
+      editionScreenViewed: false,
+    }
+
+    const overview = new Overview({ setup })
+    expect(overview.canSubmit()).toBeFalsy()
+  })
+
+  it("does not allow submission without metadata", () => {
+    const setup = {
+      ...requiredState,
+      metadata: undefined,
+    }
+
+    const overview = new Overview({ setup })
+    expect(overview.canSubmit()).toBeFalsy()
+  })
+
+  it("does not allow submission without any photos", () => {
+    const setup = {
+      ...requiredState,
+      photos: [],
+    }
+
+    const overview = new Overview({ setup })
+    expect(overview.canSubmit()).toBeFalsy()
+  })
 })


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/CSGN-118

This PR updates the consignment submission flow to require at least one photo. In the animated gif below, I demonstrate a submission where everything _but_ a photo is included. The `Submit` button does not become enabled until my second visit into the `Photos` screen, when I select a photo to attach to the submission.

![ios-consignment-submissions](https://user-images.githubusercontent.com/1627089/80007936-9a770280-848c-11ea-8b0a-b4b9444004c9.gif)

The language on the photo selection screen is updated to make it more clear that photos are required. (Though I made that change _after_ recording the above video 😅 ) 

I also refactored an existing test that covers the `Submit` button disabled state. I split it into several more intentional tests. 