### PR TITLE
[MX-307] Handles nullability of fair location #trivial

### DIFF
--- a/src/lib/Scenes/Fair/Screens/FairDetail.tsx
+++ b/src/lib/Scenes/Fair/Screens/FairDetail.tsx
@@ -61,7 +61,7 @@ export class FairDetail extends React.Component<Props, State> {
     const { isActive } = fair
     const sections = []
 
-    const coords = fair.location.coordinates
+    const coords = fair.location?.coordinates
     if (coords && coords.lat && coords.lng) {
       sections.push({
         type: "location",


### PR DESCRIPTION
Fairs have two ways they can be missing location. Either:

- `location.coords` is `undefined`, or
- `location` is `undefined`.

The current code crashes in the latter case. This PR should fix it. We've already fixed the issue on the data side, but let's avoid future crashes 👍 