### PR TITLE
[MX-261] Add device tags to volley metrics

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
   dev:
     - Removes requirement for a fromViewController when routing from RN - ash & yuki
     - Starts to fill in Viewing Room skeleton - mdole, iskounen, & ds300
+    - Add device + network tags to volley metrics
   user_facing:
     - sign in with apple - brian
     - Allow manually approved users to bid even when they are not verified - yuki

--- a/emission/Pod/Classes/Core/AREmission.m
+++ b/emission/Pod/Classes/Core/AREmission.m
@@ -9,6 +9,8 @@
 #import "ARGraphQLQueryPreloader.h"
 #import "ARGraphQLQueryCache.h"
 
+@import Darwin.POSIX.sys.utsname;
+
 NSString *const AREnvProduction = @"production";
 NSString *const AREnvStaging = @"staging";
 NSString *const AREnvTest = @"test";
@@ -29,6 +31,45 @@ RCT_EXPORT_MODULE(Emission);
     return NO;
 }
 
+/*
+
+deviceId taken from https://github.com/react-native-community/react-native-device-info/blob/d08f7f6db0407de5dc5252ebf2aa2ec58bd78dfc/ios/RNDeviceInfo/RNDeviceInfo.m
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Rebecca Hughes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+- (NSString *)deviceId;
+{
+  struct utsname systemInfo;
+  uname(&systemInfo);
+  NSString* deviceId = [NSString stringWithCString:systemInfo.machine
+                                          encoding:NSUTF8StringEncoding];
+  if ([deviceId isEqualToString:@"i386"] || [deviceId isEqualToString:@"x86_64"] ) {
+    deviceId = [NSString stringWithFormat:@"%s", getenv("SIMULATOR_MODEL_IDENTIFIER")];
+  }
+  return deviceId;
+}
+
+
 - (NSDictionary *)constantsToExport
 {
   return @{
@@ -43,6 +84,7 @@ RCT_EXPORT_MODULE(Emission);
     @"options": self.options,
     // production | staging | test
     @"env": self.env,
+    @"deviceId": self.deviceId,
 
     // Empty is falsy in JS, so these are fine too.
     @"googleMapsAPIKey": self.googleMapsAPIKey ?: @"",

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,3 +1,4 @@
+global.__TEST__ = false
 require("react-native").unstable_enableLogBox()
 require("./src/lib/ErrorReporting")
 require("./src/lib/AppRegistry")

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -18,3 +18,9 @@ interface StyleSheet {
 interface Node {
   _?: boolean
 }
+
+declare module "" {
+  global {
+    const __TEST__: boolean
+  }
+}

--- a/src/lib/Components/StickyTabPage/StickyTabPage.tsx
+++ b/src/lib/Components/StickyTabPage/StickyTabPage.tsx
@@ -44,7 +44,7 @@ export const StickyTabPage: React.FC<{
   const [headerHeight, setHeaderHeightNativeWrapper] = useState<Animated.Value<number>>(
     // in test files we don't care about getting the right height for the header, so
     // we just set it now to avoid having to trigger an 'onLayout' in every test
-    process.env.NODE_ENV === "test" ? new Animated.Value(300) : null
+    __TEST__ ? new Animated.Value(300) : null
   )
   const tracking = useTracking()
   const headerOffsetY = useAnimatedValue(0)

--- a/src/lib/Components/StickyTabPage/StickyTabPageFlatList.tsx
+++ b/src/lib/Components/StickyTabPage/StickyTabPageFlatList.tsx
@@ -18,7 +18,7 @@ const MOCK_CONTEXT: () => FlatListRequiredContext = () => ({
 })
 
 export const StickyTabPageFlatListContext = React.createContext<FlatListRequiredContext>(
-  process.env.NODE_ENV === "test" ? MOCK_CONTEXT() : null
+  __TEST__ ? MOCK_CONTEXT() : null
 )
 
 const AnimatedFlatList: typeof FlatList = Animated.createAnimatedComponent(FlatList)

--- a/src/lib/tests/MockRelayRenderer.tsx
+++ b/src/lib/tests/MockRelayRenderer.tsx
@@ -172,7 +172,7 @@ export class MockRelayRenderer<T extends OperationType> extends React.Component<
     // TODO: When extracting these test utils to their own package, this check
     //       should probably become a custom TSLint rule, as there’s no good way
     //       to test this in a generic way, plus with the rule we get fixes.
-    if (process.env.NODE_ENV === "test" && QueryRenderer === require("../../../__mocks__/react-relay").QueryRenderer) {
+    if (__TEST__ && QueryRenderer === require("../../../__mocks__/react-relay").QueryRenderer) {
       throw new Error(
         "The `react-relay` module has been mocked, be sure to unmock it with: " + '`jest.unmock("react-relay")`'
       )

--- a/src/lib/utils/AboveTheFoldQueryRenderer.tsx
+++ b/src/lib/utils/AboveTheFoldQueryRenderer.tsx
@@ -47,8 +47,8 @@ export function AboveTheFoldQueryRenderer<AboveQuery extends OperationType, Belo
   // We want to debounce the initial render in case there is a cache hit for both queries
   // If we didn't debounce we'd end up calling render twice in quick succession, once without below-the-fold data and then again with
   // That would create a some nasy jank
-  const [hasFinishedDebouncing, setHasFinishedDebouncing] = useState(process.env.NODE_ENV === "test")
-  if (process.env.NODE_ENV !== "test") {
+  const [hasFinishedDebouncing, setHasFinishedDebouncing] = useState(__TEST__)
+  if (!__TEST__) {
     useEffect(() => {
       setTimeout(() => setHasFinishedDebouncing(true), 30)
     }, [])

--- a/src/lib/utils/__tests__/volleyClient-tests.ts
+++ b/src/lib/utils/__tests__/volleyClient-tests.ts
@@ -10,19 +10,6 @@ jest.mock("lodash", () => ({
   },
 }))
 
-jest.mock("@react-native-community/netinfo", () => {
-  return {
-    fetch: jest.fn(() =>
-      Promise.resolve({
-        type: "cellular",
-        details: {
-          cellularGeneration: "5g",
-        },
-      })
-    ),
-  }
-})
-
 jest.mock("@sentry/react-native", () => ({
   captureMessage: jest.fn(),
 }))

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -121,6 +121,7 @@ function setupEmissionModule() {
     launchCount: 1,
     mapBoxAPIClientKey: "mapBoxAPIClientKey",
     metaphysicsURL: "metaphysicsURL",
+    deviceId: "testDevice",
     options: {
       AROptionsLotConditionReport: false,
       AROptionsFilterCollectionsArtworks: false,
@@ -158,6 +159,9 @@ NativeModules.ARSwitchBoardModule = {
 }
 
 declare const process: any
+
+// @ts-ignore
+global.__TEST__ = true
 
 if (process.env.ALLOW_CONSOLE_LOGS !== "true") {
   const originalLoggers = {

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -33,6 +33,19 @@ const trackEvent = jest.fn()
 // Mock this separately so react-tracking can be unmocked in tests but not result in the `window` global being accessed.
 jest.mock("react-tracking/build/dispatchTrackingEvent")
 
+jest.mock("@react-native-community/netinfo", () => {
+  return {
+    fetch: jest.fn(() =>
+      Promise.resolve({
+        type: "cellular",
+        details: {
+          cellularGeneration: "5g",
+        },
+      })
+    ),
+  }
+})
+
 jest.mock("./lib/NativeModules/NotificationsManager.tsx", () => ({
   NotificationsManager: {
     addListener: jest.fn(),

--- a/typings/emission.d.ts
+++ b/typings/emission.d.ts
@@ -12,6 +12,7 @@ declare module "react-native" {
       userAgent: string
 
       env: "production" | "staging" | "test"
+      deviceId: string
 
       // Empty is falsy in JS, so these are fine too.
       googleMapsAPIKey: string


### PR DESCRIPTION
First step of https://artsyproduct.atlassian.net/browse/MX-261

This PR just add new metrics tags for the device and network. I also added a global `__TEST__` const so we don't need to use `process.env.NODE_ENV === 'test'` for gating behaviour at test time.