### PR TITLE
[Minor Bug Fix] Filter button not appearing on Collection Artworks 

### DIFF
--- a/src/lib/Scenes/Collection/Collection.tsx
+++ b/src/lib/Scenes/Collection/Collection.tsx
@@ -42,7 +42,7 @@ export class Collection extends Component<CollectionProps, CollectionState> {
 
   onViewableItemsChanged = ({ viewableItems }: any /* STRICTNESS_MIGRATION */) => {
     ;(viewableItems || []).map((viewableItem: any) => {
-      const artworksRenderItem = viewableItem?.item?.type || ""
+      const artworksRenderItem = viewableItem?.item ?? ""
       const artworksRenderItemViewable = viewableItem?.isViewable || false
 
       if (artworksRenderItem === "collectionArtworks" && artworksRenderItemViewable) {


### PR DESCRIPTION
This PR fixes a small bug introduced after #3220 was merged causing the filter button to not appear after scrolling through the collections artwork grid. 

https://artsyproduct.atlassian.net/browse/FX-1909


The bug:

![Kapture 2020-04-23 at 15 54 59](https://user-images.githubusercontent.com/10385964/80143457-d5576400-857a-11ea-98e0-57da8abd27d9.gif)


The fix:
![Kapture 2020-04-23 at 15 44 35](https://user-images.githubusercontent.com/10385964/80142811-c91ed700-8579-11ea-8d5f-fbaf1bb500f1.gif)
