### PR TITLE
Add more tests for viewing room components (GALL-2784)

### DIFF
--- a/src/__generated__/ViewingRoomArtworkRailTestsQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomArtworkRailTestsQuery.graphql.ts
@@ -1,0 +1,206 @@
+/* tslint:disable */
+/* eslint-disable */
+/* @relayHash 10c64d401408c0468a104fd1ed761e9c */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ViewingRoomArtworkRailTestsQueryVariables = {};
+export type ViewingRoomArtworkRailTestsQueryResponse = {
+    readonly viewingRoom: {
+        readonly " $fragmentRefs": FragmentRefs<"ViewingRoomArtworkRail_viewingRoom">;
+    } | null;
+};
+export type ViewingRoomArtworkRailTestsQuery = {
+    readonly response: ViewingRoomArtworkRailTestsQueryResponse;
+    readonly variables: ViewingRoomArtworkRailTestsQueryVariables;
+};
+
+
+
+/*
+query ViewingRoomArtworkRailTestsQuery {
+  viewingRoom(id: "unused") {
+    ...ViewingRoomArtworkRail_viewingRoom
+  }
+}
+
+fragment ViewingRoomArtworkRail_viewingRoom on ViewingRoom {
+  artworks: artworksConnection(first: 5) {
+    totalCount
+    edges {
+      node {
+        href
+        artistNames
+        image {
+          url(version: "square")
+        }
+        saleMessage
+        id
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "unused"
+  }
+];
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ViewingRoomArtworkRailTestsQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewingRoom",
+        "storageKey": "viewingRoom(id:\"unused\")",
+        "args": (v0/*: any*/),
+        "concreteType": "ViewingRoom",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ViewingRoomArtworkRail_viewingRoom",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ViewingRoomArtworkRailTestsQuery",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewingRoom",
+        "storageKey": "viewingRoom(id:\"unused\")",
+        "args": (v0/*: any*/),
+        "concreteType": "ViewingRoom",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": "artworks",
+            "name": "artworksConnection",
+            "storageKey": "artworksConnection(first:5)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 5
+              }
+            ],
+            "concreteType": "ArtworkConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "totalCount",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtworkEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "href",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "artistNames",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "image",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "url",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "square"
+                              }
+                            ],
+                            "storageKey": "url(version:\"square\")"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "saleMessage",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "id",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "ViewingRoomArtworkRailTestsQuery",
+    "id": "f5e8526b59b706c77fa0e374466c189f",
+    "text": null,
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = 'fcc545a29322194f9415c9653529a1ff';
+export default node;

--- a/src/__generated__/ViewingRoomArtworkRail_viewingRoom.graphql.ts
+++ b/src/__generated__/ViewingRoomArtworkRail_viewingRoom.graphql.ts
@@ -3,7 +3,7 @@
 
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type ViewingRoomArtworkRail_viewingRoomArtworks = {
+export type ViewingRoomArtworkRail_viewingRoom = {
     readonly artworks: {
         readonly totalCount: number | null;
         readonly edges: ReadonlyArray<{
@@ -17,19 +17,19 @@ export type ViewingRoomArtworkRail_viewingRoomArtworks = {
             } | null;
         } | null> | null;
     } | null;
-    readonly " $refType": "ViewingRoomArtworkRail_viewingRoomArtworks";
+    readonly " $refType": "ViewingRoomArtworkRail_viewingRoom";
 };
-export type ViewingRoomArtworkRail_viewingRoomArtworks$data = ViewingRoomArtworkRail_viewingRoomArtworks;
-export type ViewingRoomArtworkRail_viewingRoomArtworks$key = {
-    readonly " $data"?: ViewingRoomArtworkRail_viewingRoomArtworks$data;
-    readonly " $fragmentRefs": FragmentRefs<"ViewingRoomArtworkRail_viewingRoomArtworks">;
+export type ViewingRoomArtworkRail_viewingRoom$data = ViewingRoomArtworkRail_viewingRoom;
+export type ViewingRoomArtworkRail_viewingRoom$key = {
+    readonly " $data"?: ViewingRoomArtworkRail_viewingRoom$data;
+    readonly " $fragmentRefs": FragmentRefs<"ViewingRoomArtworkRail_viewingRoom">;
 };
 
 
 
 const node: ReaderFragment = {
   "kind": "Fragment",
-  "name": "ViewingRoomArtworkRail_viewingRoomArtworks",
+  "name": "ViewingRoomArtworkRail_viewingRoom",
   "type": "ViewingRoom",
   "metadata": null,
   "argumentDefinitions": [],
@@ -127,5 +127,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = '5dec46e930c943dc74c147a1239f0090';
+(node as any).hash = '63672d70353e4c8bf2a6e618d627ce17';
 export default node;

--- a/src/__generated__/ViewingRoomArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomArtworksTestsQuery.graphql.ts
@@ -1,0 +1,290 @@
+/* tslint:disable */
+/* eslint-disable */
+/* @relayHash 1d94a06747f7933f2c9b1a6ec140f20a */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ViewingRoomArtworksTestsQueryVariables = {};
+export type ViewingRoomArtworksTestsQueryResponse = {
+    readonly viewingRoom: {
+        readonly " $fragmentRefs": FragmentRefs<"ViewingRoomArtworks_viewingRoom">;
+    } | null;
+};
+export type ViewingRoomArtworksTestsQuery = {
+    readonly response: ViewingRoomArtworksTestsQueryResponse;
+    readonly variables: ViewingRoomArtworksTestsQueryVariables;
+};
+
+
+
+/*
+query ViewingRoomArtworksTestsQuery {
+  viewingRoom(id: "unused") {
+    ...ViewingRoomArtworks_viewingRoom
+  }
+}
+
+fragment ViewingRoomArtworks_viewingRoom on ViewingRoom {
+  internalID
+  artworksConnection(first: 5, after: "") {
+    edges {
+      node {
+        href
+        artistNames
+        date
+        image {
+          url(version: "larger")
+          aspectRatio
+        }
+        saleMessage
+        title
+        id
+        __typename
+      }
+      cursor
+    }
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "unused"
+  }
+],
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "after",
+    "value": ""
+  },
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 5
+  }
+];
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ViewingRoomArtworksTestsQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewingRoom",
+        "storageKey": "viewingRoom(id:\"unused\")",
+        "args": (v0/*: any*/),
+        "concreteType": "ViewingRoom",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ViewingRoomArtworks_viewingRoom",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ViewingRoomArtworksTestsQuery",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewingRoom",
+        "storageKey": "viewingRoom(id:\"unused\")",
+        "args": (v0/*: any*/),
+        "concreteType": "ViewingRoom",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "internalID",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "artworksConnection",
+            "storageKey": "artworksConnection(after:\"\",first:5)",
+            "args": (v1/*: any*/),
+            "concreteType": "ArtworkConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtworkEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "href",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "artistNames",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "date",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "image",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "url",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "larger"
+                              }
+                            ],
+                            "storageKey": "url(version:\"larger\")"
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "aspectRatio",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "saleMessage",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "title",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "id",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "__typename",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "cursor",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageInfo",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "endCursor",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "hasNextPage",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "LinkedHandle",
+            "alias": null,
+            "name": "artworksConnection",
+            "args": (v1/*: any*/),
+            "handle": "connection",
+            "key": "ViewingRoomArtworks_artworksConnection",
+            "filters": null
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "ViewingRoomArtworksTestsQuery",
+    "id": "89fb81e7c3e509460e52b7c9fb031aaa",
+    "text": null,
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = '4ea3bb10e4e9ea741b185255dbea1f18';
+export default node;

--- a/src/__generated__/ViewingRoomQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 9083468df9bce1c844de13030791fa09 */
+/* @relayHash fa6ec872196f0a71e730aec6905ae3a7 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -78,7 +78,7 @@ fragment ViewingRoomHeader_viewingRoom on ViewingRoom {
   heroImageURL
 }
 
-fragment ViewingRoomSubsections_viewingRoomSubsections on ViewingRoom {
+fragment ViewingRoomSubsections_viewingRoom on ViewingRoom {
   subsections {
     body
     title
@@ -94,7 +94,7 @@ fragment ViewingRoom_viewingRoom on ViewingRoom {
   body
   pullQuote
   introStatement
-  ...ViewingRoomSubsections_viewingRoomSubsections
+  ...ViewingRoomSubsections_viewingRoom
   ...ViewingRoomArtworkRail_viewingRoomArtworks
   ...ViewingRoomHeader_viewingRoom
   ...ViewingRoomArtworks_viewingRoom
@@ -504,7 +504,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomQuery",
-    "id": "c8b37fa53f61911cceefd3b4ebaf93e5",
+    "id": "bf6557ec95cf100d0a291c8c0ae7a29f",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash fa6ec872196f0a71e730aec6905ae3a7 */
+/* @relayHash 90343487942b9a95781f331955a2643a */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -28,7 +28,7 @@ query ViewingRoomQuery(
   }
 }
 
-fragment ViewingRoomArtworkRail_viewingRoomArtworks on ViewingRoom {
+fragment ViewingRoomArtworkRail_viewingRoom on ViewingRoom {
   artworks: artworksConnection(first: 5) {
     totalCount
     edges {
@@ -95,7 +95,7 @@ fragment ViewingRoom_viewingRoom on ViewingRoom {
   pullQuote
   introStatement
   ...ViewingRoomSubsections_viewingRoom
-  ...ViewingRoomArtworkRail_viewingRoomArtworks
+  ...ViewingRoomArtworkRail_viewingRoom
   ...ViewingRoomHeader_viewingRoom
   ...ViewingRoomArtworks_viewingRoom
 }
@@ -504,7 +504,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomQuery",
-    "id": "bf6557ec95cf100d0a291c8c0ae7a29f",
+    "id": "c7ae44374ebb6641e699d523a46ade4d",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomSubsectionsTestsQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomSubsectionsTestsQuery.graphql.ts
@@ -1,0 +1,139 @@
+/* tslint:disable */
+/* eslint-disable */
+/* @relayHash 85c4590eb99633891d3b329ed4cf993d */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ViewingRoomSubsectionsTestsQueryVariables = {};
+export type ViewingRoomSubsectionsTestsQueryResponse = {
+    readonly viewingRoom: {
+        readonly " $fragmentRefs": FragmentRefs<"ViewingRoomSubsections_viewingRoom">;
+    } | null;
+};
+export type ViewingRoomSubsectionsTestsQuery = {
+    readonly response: ViewingRoomSubsectionsTestsQueryResponse;
+    readonly variables: ViewingRoomSubsectionsTestsQueryVariables;
+};
+
+
+
+/*
+query ViewingRoomSubsectionsTestsQuery {
+  viewingRoom(id: "unused") {
+    ...ViewingRoomSubsections_viewingRoom
+  }
+}
+
+fragment ViewingRoomSubsections_viewingRoom on ViewingRoom {
+  subsections {
+    body
+    title
+    caption
+    imageURL
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "unused"
+  }
+];
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ViewingRoomSubsectionsTestsQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewingRoom",
+        "storageKey": "viewingRoom(id:\"unused\")",
+        "args": (v0/*: any*/),
+        "concreteType": "ViewingRoom",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ViewingRoomSubsections_viewingRoom",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ViewingRoomSubsectionsTestsQuery",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewingRoom",
+        "storageKey": "viewingRoom(id:\"unused\")",
+        "args": (v0/*: any*/),
+        "concreteType": "ViewingRoom",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "subsections",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "ViewingRoomSubsection",
+            "plural": true,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "body",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "title",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "caption",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "imageURL",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "ViewingRoomSubsectionsTestsQuery",
+    "id": "b8fcf6e70cefed666a95a4949e131c50",
+    "text": null,
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = 'a33182889573fa9c4dc7c3b68ad8d822';
+export default node;

--- a/src/__generated__/ViewingRoomSubsections_viewingRoom.graphql.ts
+++ b/src/__generated__/ViewingRoomSubsections_viewingRoom.graphql.ts
@@ -3,26 +3,26 @@
 
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type ViewingRoomSubsections_viewingRoomSubsections = {
+export type ViewingRoomSubsections_viewingRoom = {
     readonly subsections: ReadonlyArray<{
         readonly body: string | null;
         readonly title: string | null;
         readonly caption: string | null;
         readonly imageURL: string | null;
     }> | null;
-    readonly " $refType": "ViewingRoomSubsections_viewingRoomSubsections";
+    readonly " $refType": "ViewingRoomSubsections_viewingRoom";
 };
-export type ViewingRoomSubsections_viewingRoomSubsections$data = ViewingRoomSubsections_viewingRoomSubsections;
-export type ViewingRoomSubsections_viewingRoomSubsections$key = {
-    readonly " $data"?: ViewingRoomSubsections_viewingRoomSubsections$data;
-    readonly " $fragmentRefs": FragmentRefs<"ViewingRoomSubsections_viewingRoomSubsections">;
+export type ViewingRoomSubsections_viewingRoom$data = ViewingRoomSubsections_viewingRoom;
+export type ViewingRoomSubsections_viewingRoom$key = {
+    readonly " $data"?: ViewingRoomSubsections_viewingRoom$data;
+    readonly " $fragmentRefs": FragmentRefs<"ViewingRoomSubsections_viewingRoom">;
 };
 
 
 
 const node: ReaderFragment = {
   "kind": "Fragment",
-  "name": "ViewingRoomSubsections_viewingRoomSubsections",
+  "name": "ViewingRoomSubsections_viewingRoom",
   "type": "ViewingRoom",
   "metadata": null,
   "argumentDefinitions": [],
@@ -68,5 +68,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = 'c545dee6732225eb462fbec9ae077e83';
+(node as any).hash = '08f8e7cd7d009a04567971e127e9b86f';
 export default node;

--- a/src/__generated__/ViewingRoomTestsQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 7455920947216fc4f4c432a795b508e4 */
+/* @relayHash eab8210e6841ac850c7f426cfa9b19de */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -24,7 +24,7 @@ query ViewingRoomTestsQuery {
   }
 }
 
-fragment ViewingRoomArtworkRail_viewingRoomArtworks on ViewingRoom {
+fragment ViewingRoomArtworkRail_viewingRoom on ViewingRoom {
   artworks: artworksConnection(first: 5) {
     totalCount
     edges {
@@ -91,7 +91,7 @@ fragment ViewingRoom_viewingRoom on ViewingRoom {
   pullQuote
   introStatement
   ...ViewingRoomSubsections_viewingRoom
-  ...ViewingRoomArtworkRail_viewingRoomArtworks
+  ...ViewingRoomArtworkRail_viewingRoom
   ...ViewingRoomHeader_viewingRoom
   ...ViewingRoomArtworks_viewingRoom
 }
@@ -492,7 +492,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomTestsQuery",
-    "id": "f4f32464ab69ab4729a41bb9b7bc8df5",
+    "id": "d0b3583d80678e384f6414bc3200dfae",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomTestsQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 54c5ec7e9d2094a6616cb08734cb6cea */
+/* @relayHash 7455920947216fc4f4c432a795b508e4 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -74,7 +74,7 @@ fragment ViewingRoomHeader_viewingRoom on ViewingRoom {
   heroImageURL
 }
 
-fragment ViewingRoomSubsections_viewingRoomSubsections on ViewingRoom {
+fragment ViewingRoomSubsections_viewingRoom on ViewingRoom {
   subsections {
     body
     title
@@ -90,7 +90,7 @@ fragment ViewingRoom_viewingRoom on ViewingRoom {
   body
   pullQuote
   introStatement
-  ...ViewingRoomSubsections_viewingRoomSubsections
+  ...ViewingRoomSubsections_viewingRoom
   ...ViewingRoomArtworkRail_viewingRoomArtworks
   ...ViewingRoomHeader_viewingRoom
   ...ViewingRoomArtworks_viewingRoom
@@ -492,7 +492,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomTestsQuery",
-    "id": "d5603298b76ac919fa184f1b6e17ee57",
+    "id": "f4f32464ab69ab4729a41bb9b7bc8df5",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoom_viewingRoom.graphql.ts
+++ b/src/__generated__/ViewingRoom_viewingRoom.graphql.ts
@@ -10,7 +10,7 @@ export type ViewingRoom_viewingRoom = {
     readonly body: string | null;
     readonly pullQuote: string | null;
     readonly introStatement: string | null;
-    readonly " $fragmentRefs": FragmentRefs<"ViewingRoomSubsections_viewingRoom" | "ViewingRoomArtworkRail_viewingRoomArtworks" | "ViewingRoomHeader_viewingRoom" | "ViewingRoomArtworks_viewingRoom">;
+    readonly " $fragmentRefs": FragmentRefs<"ViewingRoomSubsections_viewingRoom" | "ViewingRoomArtworkRail_viewingRoom" | "ViewingRoomHeader_viewingRoom" | "ViewingRoomArtworks_viewingRoom">;
     readonly " $refType": "ViewingRoom_viewingRoom";
 };
 export type ViewingRoom_viewingRoom$data = ViewingRoom_viewingRoom;
@@ -80,7 +80,7 @@ const node: ReaderFragment = {
     },
     {
       "kind": "FragmentSpread",
-      "name": "ViewingRoomArtworkRail_viewingRoomArtworks",
+      "name": "ViewingRoomArtworkRail_viewingRoom",
       "args": null
     },
     {
@@ -95,5 +95,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = 'f9f80754d0a93d763133b7c17573c6b0';
+(node as any).hash = '78047b1d16e7a75c09212089c3842024';
 export default node;

--- a/src/__generated__/ViewingRoom_viewingRoom.graphql.ts
+++ b/src/__generated__/ViewingRoom_viewingRoom.graphql.ts
@@ -10,7 +10,7 @@ export type ViewingRoom_viewingRoom = {
     readonly body: string | null;
     readonly pullQuote: string | null;
     readonly introStatement: string | null;
-    readonly " $fragmentRefs": FragmentRefs<"ViewingRoomSubsections_viewingRoomSubsections" | "ViewingRoomArtworkRail_viewingRoomArtworks" | "ViewingRoomHeader_viewingRoom" | "ViewingRoomArtworks_viewingRoom">;
+    readonly " $fragmentRefs": FragmentRefs<"ViewingRoomSubsections_viewingRoom" | "ViewingRoomArtworkRail_viewingRoomArtworks" | "ViewingRoomHeader_viewingRoom" | "ViewingRoomArtworks_viewingRoom">;
     readonly " $refType": "ViewingRoom_viewingRoom";
 };
 export type ViewingRoom_viewingRoom$data = ViewingRoom_viewingRoom;
@@ -75,7 +75,7 @@ const node: ReaderFragment = {
     },
     {
       "kind": "FragmentSpread",
-      "name": "ViewingRoomSubsections_viewingRoomSubsections",
+      "name": "ViewingRoomSubsections_viewingRoom",
       "args": null
     },
     {
@@ -95,5 +95,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = 'e1b271fd713bfc8daa31260efea2f8f2';
+(node as any).hash = 'f9f80754d0a93d763133b7c17573c6b0';
 export default node;

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomArtworkRail.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomArtworkRail.tsx
@@ -13,7 +13,7 @@ interface ViewingRoomArtworkRailProps {
   viewingRoom: ViewingRoomArtworkRail_viewingRoom
 }
 
-const ArtworkCard = styled.TouchableHighlight`
+export const ArtworkCard = styled.TouchableHighlight`
   border-radius: 2px;
   overflow: hidden;
 `
@@ -42,7 +42,7 @@ export const ViewingRoomArtworkRail: React.FC<ViewingRoomArtworkRailProps> = pro
           ItemSeparatorComponent={() => <Spacer mr={0.5}></Spacer>}
           showsHorizontalScrollIndicator={false}
           data={artworks}
-          initialNumToRender={4}
+          initialNumToRender={5}
           windowSize={3}
           renderItem={({ item }) => (
             <ArtworkCard

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomArtworkRail.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomArtworkRail.tsx
@@ -1,5 +1,5 @@
 import { Flex, Spacer } from "@artsy/palette"
-import { ViewingRoomArtworkRail_viewingRoomArtworks } from "__generated__/ViewingRoomArtworkRail_viewingRoomArtworks.graphql"
+import { ViewingRoomArtworkRail_viewingRoom } from "__generated__/ViewingRoomArtworkRail_viewingRoom.graphql"
 import { AboveTheFoldFlatList } from "lib/Components/AboveTheFoldFlatList"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { SectionTitle } from "lib/Components/SectionTitle"
@@ -10,7 +10,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components/native"
 
 interface ViewingRoomArtworkRailProps {
-  viewingRoomArtworks: ViewingRoomArtworkRail_viewingRoomArtworks
+  viewingRoom: ViewingRoomArtworkRail_viewingRoom
 }
 
 const ArtworkCard = styled.TouchableHighlight`
@@ -19,9 +19,8 @@ const ArtworkCard = styled.TouchableHighlight`
 `
 
 export const ViewingRoomArtworkRail: React.FC<ViewingRoomArtworkRailProps> = props => {
-  const artworks = props.viewingRoomArtworks.artworks! /* STRICTNESS_MIGRATION */.edges! /* STRICTNESS_MIGRATION */
-  const totalCount = props.viewingRoomArtworks.artworks! /* STRICTNESS_MIGRATION */
-    .totalCount! /* STRICTNESS_MIGRATION */
+  const artworks = props.viewingRoom.artworks! /* STRICTNESS_MIGRATION */.edges! /* STRICTNESS_MIGRATION */
+  const totalCount = props.viewingRoom.artworks! /* STRICTNESS_MIGRATION */.totalCount! /* STRICTNESS_MIGRATION */
   const navRef = useRef()
   const pluralizedArtworksCount = totalCount === 1 ? "artwork" : "artworks"
 
@@ -65,8 +64,8 @@ export const ViewingRoomArtworkRail: React.FC<ViewingRoomArtworkRailProps> = pro
 }
 
 export const ViewingRoomArtworkRailContainer = createFragmentContainer(ViewingRoomArtworkRail, {
-  viewingRoomArtworks: graphql`
-    fragment ViewingRoomArtworkRail_viewingRoomArtworks on ViewingRoom {
+  viewingRoom: graphql`
+    fragment ViewingRoomArtworkRail_viewingRoom on ViewingRoom {
       artworks: artworksConnection(first: 5) {
         totalCount
         edges {

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomSubsections.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomSubsections.tsx
@@ -1,18 +1,18 @@
 import { Box, Sans, Serif } from "@artsy/palette"
-import { ViewingRoomSubsections_viewingRoomSubsections } from "__generated__/ViewingRoomSubsections_viewingRoomSubsections.graphql"
+import { ViewingRoomSubsections_viewingRoom } from "__generated__/ViewingRoomSubsections_viewingRoom.graphql"
 import ImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
 interface ViewingRoomSubsectionProps {
-  viewingRoomSubsections: ViewingRoomSubsections_viewingRoomSubsections
+  viewingRoom: ViewingRoomSubsections_viewingRoom
 }
 
-export class ViewingRoomSubsections extends React.Component<ViewingRoomSubsectionProps> {
-  render() {
-    const subsections = this.props.viewingRoomSubsections.subsections! /* STRICTNESS_MIGRATION */
-    return subsections.map((subsection, index) => {
-      return (
+export const ViewingRoomSubsections: React.FC<ViewingRoomSubsectionProps> = props => {
+  const subsections = props.viewingRoom.subsections! /* STRICTNESS_MIGRATION */
+  return (
+    <>
+      {subsections.map((subsection, index) => (
         <Box key={index} mt="3">
           {subsection.title && (
             <Sans size="4" mb="1" mx="2">
@@ -31,14 +31,14 @@ export class ViewingRoomSubsections extends React.Component<ViewingRoomSubsectio
             </Sans>
           )}
         </Box>
-      )
-    })
-  }
+      ))}
+    </>
+  )
 }
 
 export const ViewingRoomSubsectionsContainer = createFragmentContainer(ViewingRoomSubsections, {
-  viewingRoomSubsections: graphql`
-    fragment ViewingRoomSubsections_viewingRoomSubsections on ViewingRoom {
+  viewingRoom: graphql`
+    fragment ViewingRoomSubsections_viewingRoom on ViewingRoom {
       subsections {
         body
         title

--- a/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomArtworkRail-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomArtworkRail-tests.tsx
@@ -1,5 +1,53 @@
-describe("ViewingRoomArtworkRail", () => {
-  it("expects true to be true", () => {
-    expect(true).toBe(true)
+import { Theme } from "@artsy/palette"
+import { ViewingRoomArtworkRailTestsQuery } from "__generated__/ViewingRoomArtworkRailTestsQuery.graphql"
+import { SectionTitle } from "lib/Components/SectionTitle"
+import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import ReactTestRenderer from "react-test-renderer"
+import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { ArtworkCard, ViewingRoomArtworkRailContainer } from "../ViewingRoomArtworkRail"
+
+jest.unmock("react-relay")
+
+describe("ViewingRoomSubsections", () => {
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+  const TestRenderer = () => (
+    <Theme>
+      <QueryRenderer<ViewingRoomArtworkRailTestsQuery>
+        environment={mockEnvironment}
+        query={graphql`
+          query ViewingRoomArtworkRailTestsQuery {
+            viewingRoom(id: "unused") {
+              ...ViewingRoomArtworkRail_viewingRoom
+            }
+          }
+        `}
+        render={renderWithLoadProgress(ViewingRoomArtworkRailContainer)}
+        variables={{}}
+      />
+    </Theme>
+  )
+  beforeEach(() => {
+    mockEnvironment = createMockEnvironment()
+  })
+  it("renders a title for the rail", () => {
+    const tree = ReactTestRenderer.create(<TestRenderer />)
+    mockEnvironment.mock.resolveMostRecentOperation(operation => {
+      const result = MockPayloadGenerator.generate(operation)
+      return result
+    })
+    expect(tree.root.findAllByType(SectionTitle)).toHaveLength(1)
+  })
+
+  it("renders one artwork card per edge", () => {
+    const tree = ReactTestRenderer.create(<TestRenderer />)
+    mockEnvironment.mock.resolveMostRecentOperation(operation => {
+      const result = MockPayloadGenerator.generate(operation, {
+        ViewingRoom: () => ({ artworks: { edges: ["1", "2", "3"] } }),
+      })
+      return result
+    })
+    expect(tree.root.findAllByType(ArtworkCard)).toHaveLength(3)
   })
 })

--- a/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomHeader-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomHeader-tests.tsx
@@ -55,9 +55,7 @@ describe("ViewingRoomHeader", () => {
   it("renders a countdown timer", () => {
     const tree = ReactTestRenderer.create(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation => {
-      const result = MockPayloadGenerator.generate(operation, {
-        ViewingRoom: () => ({ heroImageURL: "Foo" }),
-      })
+      const result = MockPayloadGenerator.generate(operation)
       return result
     })
     expect(tree.root.findAllByType(CountdownTimer)).toHaveLength(1)

--- a/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomSubsections-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomSubsections-tests.tsx
@@ -1,6 +1,41 @@
-// TODO:
+import { Box, Theme } from "@artsy/palette"
+import { ViewingRoomSubsectionsTestsQuery } from "__generated__/ViewingRoomSubsectionsTestsQuery.graphql"
+import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import ReactTestRenderer from "react-test-renderer"
+import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { ViewingRoomSubsectionsContainer } from "../ViewingRoomSubsections"
+
+jest.unmock("react-relay")
+
 describe("ViewingRoomSubsections", () => {
-  it("expects true to be true", () => {
-    expect(true).toBe(true)
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+  const TestRenderer = () => (
+    <Theme>
+      <QueryRenderer<ViewingRoomSubsectionsTestsQuery>
+        environment={mockEnvironment}
+        query={graphql`
+          query ViewingRoomSubsectionsTestsQuery {
+            viewingRoom(id: "unused") {
+              ...ViewingRoomSubsections_viewingRoom
+            }
+          }
+        `}
+        render={renderWithLoadProgress(ViewingRoomSubsectionsContainer)}
+        variables={{}}
+      />
+    </Theme>
+  )
+  beforeEach(() => {
+    mockEnvironment = createMockEnvironment()
+  })
+  it("renders a Box for each subsection", () => {
+    const tree = ReactTestRenderer.create(<TestRenderer />)
+    mockEnvironment.mock.resolveMostRecentOperation(operation => {
+      const result = MockPayloadGenerator.generate(operation)
+      return result
+    })
+    expect(tree.root.findAllByType(Box)).toHaveLength(1)
   })
 })

--- a/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
@@ -44,7 +44,7 @@ export const ViewingRoom: React.FC<ViewingRoomProps> = props => {
       key: "artworkRail",
       content: (
         <Box mx="2">
-          <ViewingRoomArtworkRailContainer viewingRoomArtworks={viewingRoom} />
+          <ViewingRoomArtworkRailContainer viewingRoom={viewingRoom} />
         </Box>
       ),
     },
@@ -146,7 +146,7 @@ export const ViewingRoomFragmentContainer = createFragmentContainer(ViewingRoom,
       pullQuote
       introStatement
       ...ViewingRoomSubsections_viewingRoom
-      ...ViewingRoomArtworkRail_viewingRoomArtworks
+      ...ViewingRoomArtworkRail_viewingRoom
       ...ViewingRoomHeader_viewingRoom
       ...ViewingRoomArtworks_viewingRoom
     }

--- a/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
@@ -66,7 +66,7 @@ export const ViewingRoom: React.FC<ViewingRoomProps> = props => {
     },
     {
       key: "subsections",
-      content: <ViewingRoomSubsectionsContainer viewingRoomSubsections={viewingRoom} />,
+      content: <ViewingRoomSubsectionsContainer viewingRoom={viewingRoom} />,
     },
   ]
 
@@ -145,7 +145,7 @@ export const ViewingRoomFragmentContainer = createFragmentContainer(ViewingRoom,
       body
       pullQuote
       introStatement
-      ...ViewingRoomSubsections_viewingRoomSubsections
+      ...ViewingRoomSubsections_viewingRoom
       ...ViewingRoomArtworkRail_viewingRoomArtworks
       ...ViewingRoomHeader_viewingRoom
       ...ViewingRoomArtworks_viewingRoom

--- a/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
@@ -167,7 +167,7 @@ export const ViewingRoomRenderer: React.SFC<{ viewingRoomID: string }> = () => {
       `}
       cacheConfig={{ force: true }}
       variables={{
-        viewingRoomID: "1489f6b2-39f2-449d-9cc2-6baa5782c756",
+        viewingRoomID: "edc1ac72-fcb7-42fd-acfc-3c11d6e146a3",
       }}
       render={renderWithLoadProgress(ViewingRoomFragmentContainer)}
     />

--- a/src/lib/Scenes/ViewingRoom/ViewingRoomArtworks.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoomArtworks.tsx
@@ -180,7 +180,7 @@ export const ViewingRoomArtworksRenderer: React.SFC<{ viewingRoomID: string }> =
       `}
       cacheConfig={{ force: true }}
       variables={{
-        viewingRoomID: "1489f6b2-39f2-449d-9cc2-6baa5782c756",
+        viewingRoomID: "edc1ac72-fcb7-42fd-acfc-3c11d6e146a3",
       }}
       render={renderWithLoadProgress(ViewingRoomArtworksContainer)}
     />

--- a/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoom-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoom-tests.tsx
@@ -49,6 +49,7 @@ describe("ViewingRoom", () => {
       return result
     })
     expect(tree.root.findAllByType(ViewingRoomArtworkRail)).toHaveLength(1)
+    // TODO: add check that navigation + tracking has been called when tapping artworks/header
   })
   it("renders a pull quote", () => {
     const tree = ReactTestRenderer.create(<TestRenderer />)
@@ -91,6 +92,7 @@ describe("ViewingRoom", () => {
     act(() => {
       tree.root.findByType(FlatList).props.onViewableItemsChanged({ viewableItems: [{ item: { key: "pullQuote" } }] })
     })
+    // TODO: add check that tracking has been called
     expect(extractText(tree.root.findByProps({ "data-test-id": "view-works" }))).toMatch("View works (42)")
   })
 })

--- a/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomArtworks-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomArtworks-tests.tsx
@@ -1,5 +1,43 @@
-describe("ViewingRoomArtworks", () => {
-  it("expects true to be true", () => {
-    expect(true).toBe(true)
+import { ViewingRoomArtworksTestsQuery } from "__generated__/ViewingRoomArtworksTestsQuery.graphql"
+import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
+import React from "react"
+import { FlatList, TouchableOpacity } from "react-native"
+import { graphql, QueryRenderer } from "react-relay"
+import ReactTestRenderer from "react-test-renderer"
+import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { ViewingRoomArtworksContainer } from "../ViewingRoomArtworks"
+
+jest.unmock("react-relay")
+
+describe("ViewingRoom", () => {
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+  const TestRenderer = () => (
+    <QueryRenderer<ViewingRoomArtworksTestsQuery>
+      environment={mockEnvironment}
+      query={graphql`
+        query ViewingRoomArtworksTestsQuery {
+          viewingRoom(id: "unused") {
+            ...ViewingRoomArtworks_viewingRoom
+          }
+        }
+      `}
+      render={renderWithLoadProgress(ViewingRoomArtworksContainer)}
+      variables={{}}
+    />
+  )
+  beforeEach(() => {
+    mockEnvironment = createMockEnvironment()
+  })
+
+  it("renders a flatlist with one artwork", () => {
+    const tree = ReactTestRenderer.create(<TestRenderer />)
+    mockEnvironment.mock.resolveMostRecentOperation(operation => {
+      const result = MockPayloadGenerator.generate(operation, {
+        ViewingRoom: () => ({ artworksConnection: { edges: ["Foo"] } }),
+      })
+      return result
+    })
+    expect(tree.root.findAllByType(FlatList)).toHaveLength(1)
+    expect(tree.root.findAllByType(TouchableOpacity)).toHaveLength(1)
   })
 })


### PR DESCRIPTION
This is a continuation of the work to write tests for the new viewing room components, which was started in #3221. That code was merged before its time so that we could merge the newly refactored `ViewingRoomHeader` functional component.