### PR TITLE
Visual QA Launch Blocker Fixes for v2 Collections Filters

### DIFF
--- a/src/lib/Components/ArtworkFilterOptions/SingleSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/SingleSelectOption.tsx
@@ -41,7 +41,7 @@ export const SingleSelectOptionScreen: React.SFC<SingleSelectOptionScreenProps> 
         </Sans>
         <Box></Box>
       </FilterHeader>
-      <SingleSelectOptionsContainer mb={120}>
+      <Flex mb={120} mt={"-20px"}>
         <FlatList<SingleSelectOptions>
           initialNumToRender={12}
           keyExtractor={(_item, index) => String(index)}
@@ -67,15 +67,11 @@ export const SingleSelectOptionScreen: React.SFC<SingleSelectOptionScreenProps> 
             </Box>
           )}
         />
-      </SingleSelectOptionsContainer>
+      </Flex>
       <BackgroundFill />
     </Flex>
   )
 }
-
-export const SingleSelectOptionsContainer = styled(Flex)`
-  margin-top: -20px;
-`
 
 export const FilterHeader = styled(Flex)`
   flex-direction: row;

--- a/src/lib/Components/ArtworkFilterOptions/SingleSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/SingleSelectOption.tsx
@@ -32,16 +32,16 @@ export const SingleSelectOptionScreen: React.SFC<SingleSelectOptionScreenProps> 
     <Flex flexGrow={1}>
       <FilterHeader>
         <Flex alignItems="flex-end" mt={0.5} mb={2}>
-          <ArrowLeftIconContainer onPress={() => handleBackNavigation()}>
+          <NavigateBackIconContainer onPress={() => handleBackNavigation()}>
             <ArrowLeftIcon fill="black100" />
-          </ArrowLeftIconContainer>
+          </NavigateBackIconContainer>
         </Flex>
         <Sans mt={2} weight="medium" size="4" color="black100">
           {filterText}
         </Sans>
         <Box></Box>
       </FilterHeader>
-      <Flex mb={120}>
+      <SingleSelectOptionsContainer mb={120}>
         <FlatList<SingleSelectOptions>
           initialNumToRender={12}
           keyExtractor={(_item, index) => String(index)}
@@ -67,21 +67,24 @@ export const SingleSelectOptionScreen: React.SFC<SingleSelectOptionScreenProps> 
             </Box>
           )}
         />
-      </Flex>
+      </SingleSelectOptionsContainer>
       <BackgroundFill />
     </Flex>
   )
 }
+
+export const SingleSelectOptionsContainer = styled(Flex)`
+  margin-top: -20px;
+`
 
 export const FilterHeader = styled(Flex)`
   flex-direction: row;
   justify-content: space-between;
   padding-right: ${space(2)}px;
 `
-
-export const ArrowLeftIconContainer = styled(TouchableOpacity)`
-  margin-top: ${space(2)}px;
-  margin-left: ${space(2)}px;
+export const NavigateBackIconContainer = styled(TouchableOpacity)`
+  margin: 10px 0px 10px 20px;
+  padding: 10px;
 `
 
 export const InnerOptionListItem = styled(Flex)`

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -190,7 +190,7 @@ export const FilterOptions: React.SFC<FilterOptionsProps> = props => {
           </Sans>
         </ClearAllButton>
       </Flex>
-      <FilterOptionsContainer>
+      <Flex mt={"-50px"}>
         <FlatList<FilterOptions>
           keyExtractor={(_item, index) => String(index)}
           data={filterOptions}
@@ -214,14 +214,11 @@ export const FilterOptions: React.SFC<FilterOptionsProps> = props => {
             </Box>
           )}
         />
-      </FilterOptionsContainer>
+      </Flex>
       <BackgroundFill />
     </Flex>
   )
 }
-export const FilterOptionsContainer = styled(Flex)`
-  margin-top: -50px;
-`
 
 export const FilterHeader = styled(Sans)`
   margin-top: 20px;

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -162,7 +162,7 @@ export const FilterOptions: React.SFC<FilterOptionsProps> = props => {
 
   return (
     <Flex flexGrow={1}>
-      <Flex flexDirection="row" justifyContent="space-between">
+      <Flex flexDirection="row" justifyContent="space-between" mb={3}>
         <Flex alignItems="flex-end" mt={0.5} mb={2}>
           <CloseIconContainer onPress={handleTappingCloseIcon}>
             <CloseIcon fill="black100" />
@@ -190,7 +190,7 @@ export const FilterOptions: React.SFC<FilterOptionsProps> = props => {
           </Sans>
         </ClearAllButton>
       </Flex>
-      <Flex>
+      <FilterOptionsContainer>
         <FlatList<FilterOptions>
           keyExtractor={(_item, index) => String(index)}
           data={filterOptions}
@@ -214,11 +214,14 @@ export const FilterOptions: React.SFC<FilterOptionsProps> = props => {
             </Box>
           )}
         />
-      </Flex>
+      </FilterOptionsContainer>
       <BackgroundFill />
     </Flex>
   )
 }
+export const FilterOptionsContainer = styled(Flex)`
+  margin-top: -50px;
+`
 
 export const FilterHeader = styled(Sans)`
   margin-top: 20px;
@@ -246,8 +249,8 @@ export const FilterArtworkButton = styled(Button)`
 export const TouchableOptionListItemRow = styled(TouchableOpacity)``
 
 export const CloseIconContainer = styled(TouchableOpacity)`
-  margin-left: ${space(2)};
-  margin-top: ${space(2)};
+  margin: 10px 0px 10px 20px;
+  padding: 10px;
 `
 
 export const OptionListItem = styled(Flex)`

--- a/src/lib/Components/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/__tests__/FilterModal-tests.tsx
@@ -21,7 +21,7 @@ import {
   TouchableOptionListItemRow,
 } from "../../../lib/Components/FilterModal"
 import { ArtworkFilterContext, ArtworkFilterContextState, reducer } from "../../utils/ArtworkFiltersStore"
-import { ArrowLeftIconContainer } from "../ArtworkFilterOptions/SingleSelectOption"
+import { NavigateBackIconContainer } from "../ArtworkFilterOptions/SingleSelectOption"
 
 let mockNavigator: MockNavigator
 let state: ArtworkFilterContextState
@@ -239,7 +239,7 @@ describe("Filter modal navigation flow", () => {
     )
 
     sortScreen
-      .find(ArrowLeftIconContainer)
+      .find(NavigateBackIconContainer)
       .props()
       .onPress()
   })

--- a/src/lib/Scenes/Collection/Collection.tsx
+++ b/src/lib/Scenes/Collection/Collection.tsx
@@ -37,7 +37,7 @@ export class Collection extends Component<CollectionProps, CollectionState> {
     isFilterArtworksModalVisible: false,
   }
   viewabilityConfig = {
-    viewAreaCoveragePercentThreshold: 75, // What percentage of the artworks component should be in the screen before toggling the filter button
+    viewAreaCoveragePercentThreshold: 25, // What percentage of the artworks component should be in the screen before toggling the filter button
   }
 
   onViewableItemsChanged = ({ viewableItems }: any /* STRICTNESS_MIGRATION */) => {

--- a/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -54,6 +54,7 @@ export const CollectionArtworks: React.SFC<CollectionArtworksProps> = ({ collect
 
 const ArtworkGridWrapper = styled(Box)<{ isDepartment: boolean }>`
   margin-top: ${(p: any /* STRICTNESS_MIGRATION */) => (p.isDepartment ? 0 : "-50px")};
+  padding-bottom: 50px;
 `
 
 export const CollectionArtworksFragmentContainer = createPaginationContainer(


### PR DESCRIPTION
This PR fixes the following bugs reported from QA-ing the v2 iOS Collections Filters:

- [Increasing the tappable area for the close and back icons](https://artsyproduct.atlassian.net/browse/FX-1910)
- [Decreasing the viewability config of the artworks grid so the filter button animates sooner](https://artsyproduct.atlassian.net/browse/FX-1911)

![Kapture 2020-04-27 at 13 18 32](https://user-images.githubusercontent.com/10385964/80421459-88d99480-88aa-11ea-8975-9fe8338f6e7d.gif)

![Kapture 2020-04-27 at 17 33 54](https://user-images.githubusercontent.com/10385964/80423542-30a49180-88ae-11ea-81f0-b2c583c4b9bb.gif)
