### PR TITLE
Collections Filters Visual QA Fixes

### DIFF
--- a/src/lib/Components/ArtworkFilterOptions/SingleSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/SingleSelectOption.tsx
@@ -94,7 +94,7 @@ export const InnerOptionListItem = styled(Flex)`
   justify-content: space-between;
   flex-grow: 1;
   align-items: flex-end;
-  padding: 20px;
+  padding: ${space(2)}px;
 `
 
 export const SingleSelectOptionListItemRow = styled(TouchableOpacity)``

--- a/src/lib/Components/ArtworkFilterOptions/SingleSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/SingleSelectOption.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeftIcon, Box, CheckIcon, Flex, Sans, space } from "@artsy/palette"
+import { ArrowLeftIcon, Box, CheckIcon, color, Flex, Sans, space } from "@artsy/palette"
 import { MediumOption, PriceRangeOption, SortOption } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import React from "react"
 import { FlatList, TouchableOpacity } from "react-native"
@@ -32,7 +32,10 @@ export const SingleSelectOptionScreen: React.SFC<SingleSelectOptionScreenProps> 
     <Flex flexGrow={1}>
       <FilterHeader>
         <Flex alignItems="flex-end" mt={0.5} mb={2}>
-          <NavigateBackIconContainer onPress={() => handleBackNavigation()}>
+          <NavigateBackIconContainer
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            onPress={() => handleBackNavigation()}
+          >
             <ArrowLeftIcon fill="black100" />
           </NavigateBackIconContainer>
         </Flex>
@@ -77,11 +80,13 @@ export const FilterHeader = styled(Flex)`
   flex-direction: row;
   justify-content: space-between;
   padding-right: ${space(2)}px;
-  height: 70px;
+  border: solid 0.5px ${color("black10")};
+  border-right-width: 0;
+  border-left-width: 0;
+  border-top-width: 0;
 `
 export const NavigateBackIconContainer = styled(TouchableOpacity)`
-  margin: 10px 0px 10px 20px;
-  padding: 10px;
+  margin: 20px 0px 0px 20px;
 `
 
 export const InnerOptionListItem = styled(Flex)`
@@ -89,7 +94,7 @@ export const InnerOptionListItem = styled(Flex)`
   justify-content: space-between;
   flex-grow: 1;
   align-items: flex-end;
-  padding: ${space(2)}px;
+  padding: 20px;
 `
 
 export const SingleSelectOptionListItemRow = styled(TouchableOpacity)``

--- a/src/lib/Components/ArtworkFilterOptions/SingleSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/SingleSelectOption.tsx
@@ -41,7 +41,7 @@ export const SingleSelectOptionScreen: React.SFC<SingleSelectOptionScreenProps> 
         </Sans>
         <Box></Box>
       </FilterHeader>
-      <Flex mb={120} mt={"-20px"}>
+      <Flex mb={120}>
         <FlatList<SingleSelectOptions>
           initialNumToRender={12}
           keyExtractor={(_item, index) => String(index)}
@@ -77,6 +77,7 @@ export const FilterHeader = styled(Flex)`
   flex-direction: row;
   justify-content: space-between;
   padding-right: ${space(2)}px;
+  height: 70px;
 `
 export const NavigateBackIconContainer = styled(TouchableOpacity)`
   margin: 10px 0px 10px 20px;

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -68,7 +68,7 @@ export const FilterModalNavigator: React.SFC<FilterModalProps> = props => {
                   }}
                   style={{ flex: 1 }}
                 />
-                <Box p={2}>
+                <ApplyButtonContainer>
                   <ApplyButton
                     disabled={!isApplyButtonEnabled}
                     onPress={() => {
@@ -93,7 +93,7 @@ export const FilterModalNavigator: React.SFC<FilterModalProps> = props => {
                   >
                     {getApplyButtonCount()}
                   </ApplyButton>
-                </Box>
+                </ApplyButtonContainer>
               </ModalInnerView>
             </ModalBackgroundView>
           </TouchableWithoutFeedback>
@@ -162,9 +162,9 @@ export const FilterOptions: React.SFC<FilterOptionsProps> = props => {
 
   return (
     <Flex flexGrow={1}>
-      <Flex flexDirection="row" justifyContent="space-between" height={"70px"}>
+      <FilterHeaderContainer flexDirection="row" justifyContent="space-between">
         <Flex alignItems="flex-end" mt={0.5} mb={2}>
-          <CloseIconContainer onPress={handleTappingCloseIcon}>
+          <CloseIconContainer hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }} onPress={handleTappingCloseIcon}>
             <CloseIcon fill="black100" />
           </CloseIconContainer>
         </Flex>
@@ -189,7 +189,7 @@ export const FilterOptions: React.SFC<FilterOptionsProps> = props => {
             Clear all
           </Sans>
         </ClearAllButton>
-      </Flex>
+      </FilterHeaderContainer>
       <Flex>
         <FlatList<FilterOptions>
           keyExtractor={(_item, index) => String(index)}
@@ -220,6 +220,13 @@ export const FilterOptions: React.SFC<FilterOptionsProps> = props => {
   )
 }
 
+const FilterHeaderContainer = styled(Flex)`
+  border: solid 0.5px ${color("black10")};
+  border-right-width: 0;
+  border-left-width: 0;
+  border-top-width: 0;
+`
+
 export const FilterHeader = styled(Sans)`
   margin-top: 20px;
   padding-left: 35px;
@@ -246,18 +253,18 @@ export const FilterArtworkButton = styled(Button)`
 export const TouchableOptionListItemRow = styled(TouchableOpacity)``
 
 export const CloseIconContainer = styled(TouchableOpacity)`
-  margin: 10px 0px 10px 20px;
-  padding: 10px;
+  margin: 20px 0px 0px 20px;
 `
 
 export const OptionListItem = styled(Flex)`
   flex-direction: row;
   justify-content: space-between;
-  border: solid 0.5px ${color("black10")};
-  border-right-width: 0;
-  border-left-width: 0;
   flex: 1;
   width: 100%;
+  border: solid 0.5px ${color("black10")};
+  border-right-width: 0;
+  border-top-width: 0;
+  border-left-width: 0;
 `
 
 const ModalBackgroundView = styled.View`
@@ -281,3 +288,9 @@ export const CurrentOption = styled(Sans)`
 `
 export const ClearAllButton = styled(TouchableOpacity)``
 export const ApplyButton = styled(Button)``
+export const ApplyButtonContainer = styled(Box)`
+  padding: 20px;
+  border: solid 0.5px ${color("black10")};
+  border-right-width: 0;
+  border-left-width: 0;
+`

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -162,7 +162,7 @@ export const FilterOptions: React.SFC<FilterOptionsProps> = props => {
 
   return (
     <Flex flexGrow={1}>
-      <Flex flexDirection="row" justifyContent="space-between" mb={3}>
+      <Flex flexDirection="row" justifyContent="space-between" height={"70px"}>
         <Flex alignItems="flex-end" mt={0.5} mb={2}>
           <CloseIconContainer onPress={handleTappingCloseIcon}>
             <CloseIcon fill="black100" />
@@ -190,7 +190,7 @@ export const FilterOptions: React.SFC<FilterOptionsProps> = props => {
           </Sans>
         </ClearAllButton>
       </Flex>
-      <Flex mt={"-50px"}>
+      <Flex>
         <FlatList<FilterOptions>
           keyExtractor={(_item, index) => String(index)}
           data={filterOptions}


### PR DESCRIPTION
Collections Filters Visual QA Fixes

- Adds a border in the filter modals to indicate separation between list row items and the modal header
- Adds a top border to the apply button to indicate separation between Apply button and list row items 
- Removes "double" border between list row items
- [Increases the tappable area for the close and back icons with hitSlop property](https://artsyproduct.atlassian.net/browse/FX-1910)

![Kapture 2020-04-29 at 12 50 35](https://user-images.githubusercontent.com/10385964/80623476-374f1800-8a18-11ea-9ea9-bf5ec8bea0db.gif)

#trivial
