### PR TITLE
Confirm there are no artworks left to render before ending loadMore Relay call

### DIFF
--- a/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -81,9 +81,12 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
   }
 
   fetchNextPage = () => {
-    if (this.state.fetchingNextPage || this.state.completed) {
+    const hasMoreWorksToFetch = this.props.connection.pageInfo.hasNextPage
+
+    if (!hasMoreWorksToFetch && (this.state.fetchingNextPage || this.state.completed)) {
       return
     }
+
     this.setState({ fetchingNextPage: true })
     this.props.loadMore(PAGE_SIZE, error => {
       if (error) {
@@ -91,7 +94,7 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
         console.error("InfiniteScrollGrid.tsx", error.message)
       }
       this.setState({ fetchingNextPage: false })
-      if (!this.props.connection.pageInfo.hasNextPage) {
+      if (!hasMoreWorksToFetch) {
         if (this.props.onComplete) {
           this.props.onComplete()
         }

--- a/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -83,6 +83,7 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
   fetchNextPage = () => {
     const hasMoreWorksToFetch = this.props.connection.pageInfo.hasNextPage
 
+    // TODO: Can we remove this.state.completed and return when relay returns false for hasNextPage?
     if (!hasMoreWorksToFetch && (this.state.fetchingNextPage || this.state.completed)) {
       return
     }


### PR DESCRIPTION
This bug in the Infinite Scroll Artworks grid on Collections pages was reported:
 - user filters artworks in the grid that have fewer than 10 works
 - this causes the grid component to enter a state where it no longer fetches artworks from Relay 
 (end of pagination reached)
 - Attempting to fetch additional artworks after this point fails because the logic indicating if the  component should load more is set to false and the component returns without fetching additional artworks
- The proposed fix is to add an additional check before this return confirming that the artworks connection has no more artworks to fetch. 

https://artsyproduct.atlassian.net/browse/FX-1912

**The Fix:**
![Kapture 2020-04-28 at 19 00 16](https://user-images.githubusercontent.com/10385964/80545983-88acc800-8982-11ea-8944-a9cd773e58a9.gif)

**The Bug:**
![Kapture 2020-04-28 at 19 02 32](https://user-images.githubusercontent.com/10385964/80546154-efca7c80-8982-11ea-8446-b7d131d94562.gif)
