### PR TITLE
Artist Series Rail QA Fixes + Center Collection Header Titles

### DIFF
--- a/src/lib/Components/GenericArtistSeriesRail.tsx
+++ b/src/lib/Components/GenericArtistSeriesRail.tsx
@@ -30,6 +30,14 @@ export const GenericArtistSeriesRail: React.FC<GenericArtistSeriesRailProps> = (
     return SwitchBoard.presentNavigationViewController(navRef.current, `/collection/${slug}`)
   }
 
+  const validateArtworkImageURL = (
+    url: string | null | undefined,
+    firstFallbackUrl: string | null | undefined,
+    secondFallbackUrl: string | null | undefined = null
+  ) => {
+    return url ? url : firstFallbackUrl ? firstFallbackUrl : secondFallbackUrl
+  }
+
   return (
     <CardRailFlatList<GenericArtistSeriesItem>
       data={collections as GenericArtistSeriesItem[]}
@@ -61,13 +69,24 @@ export const GenericArtistSeriesRail: React.FC<GenericArtistSeriesRailProps> = (
                   <ImageView
                     width={ARTWORKS_HEIGHT / 2}
                     height={ARTWORKS_HEIGHT / 2}
-                    imageURL={artworkImageURLs[1] as any /* STRICTNESS_MIGRATION */}
+                    imageURL={
+                      validateArtworkImageURL(
+                        artworkImageURLs[1],
+                        artworkImageURLs[0]
+                      ) as any /* STRICTNESS_MIGRATION */
+                    }
                   />
                   <Division horizontal />
                   <ImageView
                     width={ARTWORKS_HEIGHT / 2}
                     height={ARTWORKS_HEIGHT / 2 - 2}
-                    imageURL={artworkImageURLs[2] as any /* STRICTNESS_MIGRATION */}
+                    imageURL={
+                      validateArtworkImageURL(
+                        artworkImageURLs[2],
+                        artworkImageURLs[1],
+                        artworkImageURLs[0]
+                      ) as any /* STRICTNESS_MIGRATION */
+                    }
                   />
                 </View>
               </ArtworkImageContainer>

--- a/src/lib/Scenes/Collection/Components/CollectionHubsRails/ArtistSeries/CollectionArtistSeriesRail.tsx
+++ b/src/lib/Scenes/Collection/Components/CollectionHubsRails/ArtistSeries/CollectionArtistSeriesRail.tsx
@@ -15,20 +15,14 @@ export const CollectionArtistSeriesRail: React.SFC<CollectionArtistSeriesRailPro
   const collections = collectionGroup?.members ?? []
 
   return (
-    <CollectionArtistSeriesWrapper>
-      <CollectionName size="4" mb={2} ml={4}>
+    <Flex ml={"-20px"}>
+      <Sans size="4" mb={2} ml={4}>
         {collectionGroup.name}
-      </CollectionName>
+      </Sans>
       <GenericArtistSeriesRail collections={collections} />
-    </CollectionArtistSeriesWrapper>
+    </Flex>
   )
 }
-
-const CollectionArtistSeriesWrapper = styled(Flex)`
-  margin-left: -20px;
-`
-
-export const CollectionName = styled(Sans)``
 
 export const CollectionArtistSeriesRailContainer = createFragmentContainer(CollectionArtistSeriesRail, {
   collectionGroup: graphql`

--- a/src/lib/Scenes/Collection/Components/CollectionHubsRails/ArtistSeries/__tests__/CollectionArtistSeriesRail-tests.tsx
+++ b/src/lib/Scenes/Collection/Components/CollectionHubsRails/ArtistSeries/__tests__/CollectionArtistSeriesRail-tests.tsx
@@ -1,4 +1,5 @@
 import { Theme } from "@artsy/palette"
+import { Sans } from "@artsy/palette"
 // @ts-ignore STRICTNESS_MIGRATION
 import { mount } from "enzyme"
 import {
@@ -13,7 +14,6 @@ import { CollectionHubRailsArtistSeriesFixture } from "lib/Scenes/Collection/Com
 import {
   CollectionArtistSeriesRail,
   CollectionArtistSeriesRailContainer,
-  CollectionName,
 } from "lib/Scenes/Collection/Components/CollectionHubsRails/ArtistSeries/CollectionArtistSeriesRail"
 import { renderRelayTree } from "lib/tests/renderRelayTree"
 import React from "react"
@@ -151,7 +151,7 @@ describe("Trending Artists Rail", () => {
       </Theme>
     )
 
-    expect(wrapper.find(CollectionName).text()).toBe("Trending Artist Series")
+    expect(wrapper.find(Sans).text()).toBe("Trending Artist Series")
   })
 
   it("renders each artist series' title", () => {

--- a/src/lib/Scenes/Collection/Screens/CollectionHeader.tsx
+++ b/src/lib/Scenes/Collection/Screens/CollectionHeader.tsx
@@ -26,8 +26,10 @@ export const CollectionHeader: React.SFC<CollectionHeaderProps> = props => {
       <Box mb={2}>
         <OpaqueImageView imageURL={url} height={HEADER_IMAGE_HEIGHT} width={screenWidth} />
       </Box>
-      <Flex mb={collectionTitleMargin} justifyContent="center" flexDirection="row">
-        <Sans size="8">{title}</Sans>
+      <Flex mb={collectionTitleMargin} flexDirection="row" justifyContent="center" mx={2}>
+        <Sans size="8" textAlign="center">
+          {title}
+        </Sans>
       </Flex>
       {!!collectionDescription && (
         <Box mx="2" mb="2" mt="0.3">


### PR DESCRIPTION
Visual QA Fixes from Artist Series:

- Renders a default image in the artwork grids on Artist Series rails when collections have only 1-2 artworks
- Centers collection header title text

**Before:**
![Screen Shot 2020-04-29 at 6 04 11 PM](https://user-images.githubusercontent.com/10385964/80651582-287e5a80-8a44-11ea-810d-2bc1db09642f.png)

![Screen Shot 2020-04-29 at 6 04 17 PM](https://user-images.githubusercontent.com/10385964/80651584-2916f100-8a44-11ea-8cc2-fdb33712a61c.png)

**After:**
![Screen Shot 2020-04-29 at 5 47 11 PM](https://user-images.githubusercontent.com/10385964/80651565-23b9a680-8a44-11ea-83e2-888edf08f16c.png)

![Screen Shot 2020-04-29 at 5 47 19 PM](https://user-images.githubusercontent.com/10385964/80651574-261c0080-8a44-11ea-9443-0a957f6a9bc4.png)




**Before:**
![Screen Shot 2020-04-29 at 6 04 45 PM](https://user-images.githubusercontent.com/10385964/80651591-2a481e00-8a44-11ea-92e6-a96fa8aeea06.png)
**After:**
![Screen Shot 2020-04-29 at 5 54 00 PM](https://user-images.githubusercontent.com/10385964/80651578-26b49700-8a44-11ea-85c2-3a186335bd2d.png)


**Before:**
![Screen Shot 2020-04-29 at 6 04 38 PM](https://user-images.githubusercontent.com/10385964/80651590-29af8780-8a44-11ea-9714-5541ca2a95ca.png)
**After:**
![Screen Shot 2020-04-29 at 5 54 15 PM](https://user-images.githubusercontent.com/10385964/80651580-274d2d80-8a44-11ea-8e82-dd0234e6946f.png)



**Before:**
![Screen Shot 2020-04-29 at 6 04 30 PM](https://user-images.githubusercontent.com/10385964/80651587-29af8780-8a44-11ea-9e2d-8b6370e1bd3a.png)

**After:** 
![Screen Shot 2020-04-29 at 5 55 34 PM](https://user-images.githubusercontent.com/10385964/80651581-287e5a80-8a44-11ea-8513-532b3e376263.png)





https://artsyproduct.atlassian.net/browse/FX-1929
https://artsyproduct.atlassian.net/browse/FX-1928
