### PR TITLE
Update interface style check to fix dark mode tracking

### DIFF
--- a/Artsy/App/ARAppDelegate+Analytics.m
+++ b/Artsy/App/ARAppDelegate+Analytics.m
@@ -617,7 +617,7 @@
     [ARUserManager identifyAnalyticsUser];
     [ARAnalytics incrementUserProperty:ARAnalyticsAppUsageCountProperty byInt:1];
 
-    switch ([[[[UIApplication sharedApplication] keyWindow] traitCollection] userInterfaceStyle]) {
+    switch ([[[UIScreen mainScreen] traitCollection] userInterfaceStyle]) {
         case UIUserInterfaceStyleUnspecified:
             [ARAnalytics setUserProperty:@"user interface style" toValue:@"unspecified"];
             break;

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -7,8 +7,8 @@ upcoming:
     - Deletes some unused code and image assets - ash
     - Add device + network tags to volley metrics - david
     - Fix styled-components typings - david
-    -
     - Refactor sticky tab page for extra simplicity and to make the header height dynamic - david
+    - Fix for dark mode tracking - brian, david, pavlos, mike
   user_facing:
     - Improves sticky tab page interaction - david
 


### PR DESCRIPTION
We were seeing all users come back with "unspecified" possibly because we were overriding the property on the keyWindow, this check appears to work for the system setting.

Worked on in knowledge share with @pvinis @ds300 @mikehrom 