### PR TITLE
Add Toggle button component

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -9,6 +9,7 @@ upcoming:
     - Fix styled-components typings - david
     - Refactor sticky tab page for extra simplicity and to make the header height dynamic - david
     - Fix for dark mode tracking - brian, david, pavlos, mike
+    - Adds a toggle button component - ashley
   user_facing:
     - Improves sticky tab page interaction - david
     - Adds other collections category collection hub rail - dzucconi

--- a/src/lib/Components/ToggleButton.tsx
+++ b/src/lib/Components/ToggleButton.tsx
@@ -1,0 +1,21 @@
+import { color } from "@artsy/palette"
+import React, { useState } from "react"
+import { Switch, View } from "react-native"
+
+export const ToggleButton = () => {
+  const [isSwitchEnabled, setIsSwitchEnabled] = useState(false)
+
+  const handleToggle = () => {
+    setIsSwitchEnabled(!isSwitchEnabled)
+  }
+
+  return (
+    <View>
+      <Switch
+        trackColor={{ false: color("black10"), true: color("black100") }}
+        onValueChange={handleToggle}
+        value={isSwitchEnabled}
+      />
+    </View>
+  )
+}


### PR DESCRIPTION
Adds a generic toggle button for use in the Ways to Buy Collection filter.

![Kapture 2020-04-30 at 16 38 58](https://user-images.githubusercontent.com/10385964/80757209-c6842a80-8b01-11ea-9a8c-a0d385b9f5b0.gif)

Video shows what the new component looks like, but the button is not yet being used in the app.


https://artsyproduct.atlassian.net/browse/FX-1792

#skip_new_tests