### PR TITLE
Don't show loading spinner or load next page for inactive fairs

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -15,6 +15,7 @@ upcoming:
     - Fix for deeplinks to search, city guide tabs - brian
     - Improves sticky tab page interaction - david
     - Adds other collections category collection hub rail - dzucconi
+    - Fix for infinite spinner on inactive fairs - brian
 
 releases:
   - version: 6.4.3

--- a/src/lib/Scenes/Fair/Screens/FairDetail.tsx
+++ b/src/lib/Scenes/Fair/Screens/FairDetail.tsx
@@ -201,9 +201,9 @@ export class FairDetail extends React.Component<Props, State> {
   }
 
   fetchNextPage = () => {
-    const { relay } = this.props
+    const { relay, fair } = this.props
 
-    if (!relay.hasMore() || relay.isLoading()) {
+    if (!relay.hasMore() || relay.isLoading() || !fair.isActive) {
       return
     }
 
@@ -231,7 +231,7 @@ export class FairDetail extends React.Component<Props, State> {
               {this.renderItem(item)}
             </Box>
           )}
-          ListFooterComponent={this.props.relay.hasMore() ? Loading : null}
+          ListFooterComponent={this.props.relay.hasMore() && fair.isActive ? Loading : null}
           onEndReached={this.fetchNextPage}
           automaticallyAdjustContentInsets={false}
         />


### PR DESCRIPTION
Fix for one part of issue Sam reported in slack: 
https://artsy.slack.com/archives/CN8S32FJR/p1588353744112800