### PR TITLE
Fixes path for JS source map #trivial

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ commands:
           key: v5-js_bundle-{{ checksum ".manifests/js_bundle" }}
           paths:
             - emission/Pod/Assets/Emission.js
-            - emission/Pod/Assets/Emission.map.js
+            - emission/Pod/Assets/Emission.js.map
             - emission/Pod/Assets/assets
   install-gems:
     steps:

--- a/src/lib/Scenes/Home/Home.tsx
+++ b/src/lib/Scenes/Home/Home.tsx
@@ -214,7 +214,7 @@ const HomePlaceholder: React.FC<{}> = () => {
             <PlaceholderText width={100 + Math.random() * 100} />
             <Flex flexDirection="row" mt={1}>
               <Join separator={<Spacer ml={0.5} />}>
-                {times(5).map(index => (
+                {times(10).map(index => (
                   <PlaceholderBox key={index} height={100} width={100} />
                 ))}
               </Join>


### PR DESCRIPTION
While investigating a bug, I found Sentry was missing our source maps. Looks like fastlane is set up to log-but-not-fail when this happens ([example build](https://circleci.com/gh/artsy/eigen/9079)). I re-ran the build with ssh enabled and saw the following:

```sh
Distillers-Mac-6:~ distiller$ cd project/
Distillers-Mac-6:project distiller$ ls emission/Pod/Assets/
Emission.js	assets
```

Running the command locally to bundle showed the following contents:

```sh
 ~/code/eigen git:(master) ✗ ls emission/Pod/Assets
Emission.js     Emission.js.map assets
```

It took a little looking, but I found that the file extension here was mixed up. Hoping this fixes it 🤞 