### PR TITLE
Addresses various visual QA items from the collections work

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "react": "16.11.0",
     "react-native": "0.62.1",
     "react-native-hyperlink": "0.0.11",
+    "react-native-modal": "^11.5.6",
     "react-native-navigator-ios": "https://github.com/ashfurrow/react-native-navigator-ios#license_podspec",
     "react-native-parallax-scroll-view": "orta/react-native-parallax-scroll-view",
     "react-native-reanimated": "1.4.0",

--- a/src/lib/Components/ArtworkFilterOptions/SingleSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/SingleSelectOption.tsx
@@ -43,7 +43,7 @@ export const SingleSelectOptionScreen: React.SFC<SingleSelectOptionScreenProps> 
         </Sans>
         <Box></Box>
       </FilterHeader>
-      <Flex mb={120}>
+      <Flex mb="125px">
         <FlatList<SingleSelectOptions>
           initialNumToRender={12}
           keyExtractor={(_item, index) => String(index)}

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -7,7 +7,8 @@ import {
 } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import { Schema } from "lib/utils/track"
 import React, { useContext } from "react"
-import { FlatList, Modal as RNModal, TouchableOpacity, TouchableWithoutFeedback, ViewProperties } from "react-native"
+import { FlatList, TouchableOpacity, TouchableWithoutFeedback, ViewProperties } from "react-native"
+import Modal from "react-native-modal"
 import NavigatorIOS from "react-native-navigator-ios"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
@@ -53,9 +54,9 @@ export const FilterModalNavigator: React.SFC<FilterModalProps> = props => {
   return (
     <>
       {isFilterArtworksModalVisible && (
-        <RNModal animationType="fade" transparent={true} visible={isFilterArtworksModalVisible}>
+        <Modal isVisible={isFilterArtworksModalVisible} style={{ margin: 0 }}>
           <TouchableWithoutFeedback>
-            <ModalBackgroundView>
+            <>
               <TouchableOpacity onPress={handleClosingModal} style={{ flexGrow: 1 }} />
               <ModalInnerView>
                 <NavigatorIOS
@@ -94,9 +95,9 @@ export const FilterModalNavigator: React.SFC<FilterModalProps> = props => {
                   </ApplyButton>
                 </ApplyButtonContainer>
               </ModalInnerView>
-            </ModalBackgroundView>
+            </>
           </TouchableWithoutFeedback>
-        </RNModal>
+        </Modal>
       )}
     </>
   )
@@ -266,20 +267,13 @@ export const OptionListItem = styled(Flex)`
   border-left-width: 0;
 `
 
-const ModalBackgroundView = styled.View`
-  background-color: #00000099;
-  flex: 1;
-  flex-direction: column;
-  border-top-left-radius: ${space(1)};
-  border-top-right-radius: ${space(1)};
-`
-
 const ModalInnerView = styled.View`
   flex-direction: column;
   background-color: ${color("white100")};
   height: 75%;
   border-top-left-radius: ${space(1)};
   border-top-right-radius: ${space(1)};
+  overflow: hidden;
 `
 
 export const CurrentOption = styled(Sans)`
@@ -289,6 +283,7 @@ export const ClearAllButton = styled(TouchableOpacity)``
 export const ApplyButton = styled(Button)``
 export const ApplyButtonContainer = styled(Box)`
   padding: 20px;
+  padding-bottom: 30px;
   border: solid 0.5px ${color("black10")};
   border-right-width: 0;
   border-left-width: 0;

--- a/src/lib/Scenes/Collection/Collection.tsx
+++ b/src/lib/Scenes/Collection/Collection.tsx
@@ -181,6 +181,7 @@ export const FilterArtworkButton = styled(Flex)<{ isFilterCountVisible: boolean 
   align-items: center;
   justify-content: center;
   flex-direction: row;
+  box-shadow: 0px 3px 3px rgba(0, 0, 0, 0.12);
 `
 
 export const CollectionContainer = createFragmentContainer(Collection, {

--- a/src/lib/Scenes/Collection/Components/FeaturedArtists.tsx
+++ b/src/lib/Scenes/Collection/Components/FeaturedArtists.tsx
@@ -5,7 +5,7 @@ import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { Schema, Track, track as _track } from "lib/utils/track"
 import { ContextModules } from "lib/utils/track/schema"
 import React from "react"
-import { TouchableHighlight } from "react-native"
+import { TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { TrackingProp } from "react-tracking"
 import styled from "styled-components/native"
@@ -73,7 +73,7 @@ export class FeaturedArtists extends React.Component<FeaturedArtistsProps, {}> {
         <Flex justifyContent="space-between" pb={15} flexDirection="row">
           <Sans size="4">{headlineLabel}</Sans>
           {artists.length > artistCount && (
-            <TouchableHighlight
+            <TouchableOpacity
               onPress={() => {
                 SwitchBoard.presentNavigationViewController(this, `/collection/${this.props.collection.slug}/artists`)
                 // @ts-ignore STRICTNESS_MIGRATION
@@ -89,7 +89,7 @@ export class FeaturedArtists extends React.Component<FeaturedArtistsProps, {}> {
               <ViewAll size="4" color="black60">
                 View all
               </ViewAll>
-            </TouchableHighlight>
+            </TouchableOpacity>
           )}
         </Flex>
         <Flex flexWrap="wrap">{truncatedArtists}</Flex>

--- a/src/lib/Scenes/Collection/Screens/CollectionHeader.tsx
+++ b/src/lib/Scenes/Collection/Screens/CollectionHeader.tsx
@@ -19,7 +19,7 @@ export const CollectionHeader: React.SFC<CollectionHeaderProps> = props => {
   const defaultHeaderUrl = image?.edges[0]?.node?.image?.url || ""
   const url = headerImage ? headerImage : defaultHeaderUrl
   const { width: screenWidth } = Dimensions.get("window")
-  const collectionTitleMargin = (collectionDescription || "").length < 1 ? 2 : 0
+  const collectionTitleMargin = (collectionDescription || "").length < 1 ? 2 : 1
 
   return (
     <>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10452,12 +10452,27 @@ react-live@^1.12.0:
     prop-types "^15.5.8"
     unescape "^0.2.0"
 
+react-native-animatable@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/react-native-animatable/-/react-native-animatable-1.3.3.tgz#a13a4af8258e3bb14d0a9d839917e9bb9274ec8a"
+  integrity sha512-2ckIxZQAsvWn25Ho+DK3d1mXIgj7tITkrS4pYDvx96WyOttSvzzFeQnM2od0+FUMzILbdHDsDEqZvnz1DYNQ1w==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-native-hyperlink@0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/react-native-hyperlink/-/react-native-hyperlink-0.0.11.tgz#26e2b37d48759545289ad9c8cbec7cf46f1ef482"
   integrity sha1-JuKzfUh1lUUomtnIy+x89G8e9II=
   dependencies:
     linkify-it "^1.2.0"
+
+react-native-modal@^11.5.6:
+  version "11.5.6"
+  resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-11.5.6.tgz#bb25a78c35a5e24f45de060e5f64284397d38a87"
+  integrity sha512-APGNfbvgC4hXbJqcSADu79GLoMKIHUmgR3fDQ7rCGZNBypkStSP8imZ4PKK/OzIZZfjGU9aP49jhMgGbhY9KHA==
+  dependencies:
+    prop-types "^15.6.2"
+    react-native-animatable "1.3.3"
 
 "react-native-navigator-ios@https://github.com/ashfurrow/react-native-navigator-ios#license_podspec":
   version "1.0.0"


### PR DESCRIPTION
This PR addresses a bunch of visual QA items from our last session!

The biggest change is the introduction of [`react-native-modal`](https://github.com/react-native-community/react-native-modal).

Reasoning:
- It appears well-maintained.
- It extends react native's default `Modal` implementation and has a super simple API. Should RN decide to add these features into their implementation, it should be easy enough to go back.
- It makes things like "have a background that fades in + a modal sheet that slides up" _incredibly_ easy (it's built in!). If we want to add more facilities, especially as we built out more interactivity in the app, this feels like a good addition.

Cons:
- It's _one more dep_. I was stuck on getting the behavior mentioned ☝️to feel seamless and it definitely felt cleaner/better to use this library vs. implementing the behavior on our own, but I'd love to get the input of MX folks (@ds300 , @ashfurrow , @pvinis , etc.)

(assigning myself just until we reach a decision on whether or not to include this new dependency!)