### PR TITLE
Show number of full days in emission Ticker, not just number of days in month

### DIFF
--- a/src/lib/Components/Countdown/Ticker.tsx
+++ b/src/lib/Components/Countdown/Ticker.tsx
@@ -11,7 +11,7 @@ interface TimeSectionProps {
 const padWithZero = (number: number) => (number.toString() as any).padStart(2, "0")
 const durationSections = (duration: Duration, labels: [string, string, string, string]) => [
   {
-    time: padWithZero(duration.days()),
+    time: padWithZero(Math.floor(duration.asDays())),
     label: labels[0],
   },
   {

--- a/src/lib/Components/Countdown/__tests__/Ticker-tests.tsx
+++ b/src/lib/Components/Countdown/__tests__/Ticker-tests.tsx
@@ -20,6 +20,13 @@ describe("SimpleTicker", () => {
     const comp = render(<SimpleTicker duration={zeroDuration} separator="  " size="5" />)
     expect(comp.text()).toEqual("00d  00h  00m  00s")
   })
+
+  it("renders properly with days overflowing a single", () => {
+    // 2 years
+    const farOutDuration = moment.duration(63113904000)
+    const comp = render(<SimpleTicker duration={farOutDuration} separator="  " size="5" />)
+    expect(comp.text()).toContain("730d")
+  })
 })
 
 describe("LabeledTicker", () => {

--- a/src/lib/Components/Countdown/__tests__/Ticker-tests.tsx
+++ b/src/lib/Components/Countdown/__tests__/Ticker-tests.tsx
@@ -21,7 +21,7 @@ describe("SimpleTicker", () => {
     expect(comp.text()).toEqual("00d  00h  00m  00s")
   })
 
-  it("renders properly with days overflowing a single", () => {
+  it("renders properly with days overflowing a single month", () => {
     // 2 years
     const farOutDuration = moment.duration(63113904000)
     const comp = render(<SimpleTicker duration={farOutDuration} separator="  " size="5" />)


### PR DESCRIPTION
Completes 🔒 [[AUCT-999]](https://artsyproduct.atlassian.net/browse/AUCT-999)
Paired with @brainbicycle 

This PR updates the react native countdown timer to count number of full days left in the timer using [`Duration.asDays()`](https://momentjs.com/docs/#/durations/days/) - `days()` only returns the number in the current month.

_possible followup: should we ever include the year in the 'timer ends May 6, blah blah blah am EDT' part below the timer? I don't think this is very important since the year would be implied by anything except a multi-year auction - eg if it is november but this sale ends in january, i don't need to know what year, but if it ends in december of the following year that would be relevant._

_by the way: while investigating this I saw a similar bug in the main auction view, which uses the (Objective C) [ARCountdownView.m]() on the same auction, with the live start time set 4 years out- it was just showing `00 days`. Today pairing with Brian we could not reproduce this bug and it was suddenly working correctly._

Fixed version.
![image](https://user-images.githubusercontent.com/9088720/81217774-2a4b9f00-8fab-11ea-9b24-f2d11b19fa3e.png)


[AUCT-999]: https://artsyproduct.atlassian.net/browse/AUCT-999