### PR TITLE
Removes Collection Artworks Filters Feature Flag

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -13,6 +13,7 @@ upcoming:
     - Fix for dark mode tracking - brian, david, pavlos, mike
     - Adds a toggle button component - ashley
     - Add city guide entry in search behind flag - brian
+    - Remove feature flag from collections artworks filters - ashley
   user_facing:
     - Fix for deeplinks to search, city guide tabs - brian
     - Improves sticky tab page interaction - david

--- a/src/lib/Components/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/__tests__/FilterModal-tests.tsx
@@ -9,7 +9,6 @@ import { FilterModalTestsQuery } from "__generated__/FilterModalTestsQuery.graph
 import { mount } from "enzyme"
 import { CollectionFixture } from "lib/Scenes/Collection/Components/__fixtures__/CollectionFixture"
 import { CollectionArtworksFragmentContainer } from "lib/Scenes/Collection/Screens/CollectionArtworks"
-import { NativeModules } from "react-native"
 import { useTracking } from "react-tracking"
 import { FakeNavigator as MockNavigator } from "../../../lib/Components/Bidding/__tests__/Helpers/FakeNavigator"
 import {
@@ -45,7 +44,6 @@ beforeEach(() => {
     previouslyAppliedFilters: [],
     applyFilters: false,
   }
-  NativeModules.Emission.options.AROptionsFilterCollectionsArtworks = true
 })
 
 afterEach(() => {

--- a/src/lib/Scenes/Collection/Collection.tsx
+++ b/src/lib/Scenes/Collection/Collection.tsx
@@ -3,7 +3,7 @@ import { CollectionQuery } from "__generated__/CollectionQuery.graphql"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import React, { Component } from "react"
-import { Dimensions, FlatList, NativeModules, TouchableWithoutFeedback, View } from "react-native"
+import { Dimensions, FlatList, TouchableWithoutFeedback, View } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import styled from "styled-components/native"
 import { Collection_collection } from "../../../__generated__/Collection_collection.graphql"
@@ -89,7 +89,6 @@ export class Collection extends Component<CollectionProps, CollectionState> {
 
     const sections = ["collectionFeaturedArtists", "collectionHubsRails", "collectionArtworks"] as const
 
-    const isArtworkFilterEnabled = NativeModules.Emission?.options?.AROptionsFilterCollectionsArtworks
     return (
       <ArtworkFilterGlobalStateProvider>
         <ArtworkFilterContext.Consumer>
@@ -131,7 +130,7 @@ export class Collection extends Component<CollectionProps, CollectionState> {
                       }
                     }}
                   />
-                  {isArtworkGridVisible && isArtworkFilterEnabled && (
+                  {isArtworkGridVisible && (
                     <FilterArtworkButtonContainer>
                       <TouchableWithoutFeedback onPress={this.openFilterArtworksModal.bind(this)}>
                         <FilterArtworkButton


### PR DESCRIPTION
Collections Artworks filters are ready to go out with the next app release. This PR removes the feature flag that had to be enabled in order to interact with the filters.

As we still have filters that in progress/not ready for release, new filter additions will use the `AROptionsFilterCollectionsArtworks` native module, so for now we will keep this flag active, and deprecate completely once the rest of the in-progress and/or upcoming filters don't need to be hidden.

https://artsyproduct.atlassian.net/browse/FX-1942