### PR TITLE
[FX-1916] add border for collection zero state

### DIFF
--- a/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -38,7 +38,12 @@ export const CollectionArtworks: React.SFC<CollectionArtworksProps> = ({ collect
   }, [state.appliedFilters])
 
   if (artworksTotal === 0) {
-    return <CollectionZeroState id={collection.id} slug={collection.slug} />
+    return (
+      <Box mt={isDepartment ? "0px" : "-50px"}>
+        <Separator />
+        <CollectionZeroState id={collection.id} slug={collection.slug} />
+      </Box>
+    )
   }
 
   return artworks ? (


### PR DESCRIPTION
Addresses: [FX-1916](https://artsyproduct.atlassian.net/browse/FX-1916)

This PR adds the border that is missing above the CollectionZeroState #trivial 

**Regular Collection**
<img width="401" alt="Screen Shot 2020-05-06 at 5 25 55 PM" src="https://user-images.githubusercontent.com/5201004/81231293-ea8fb200-8fc0-11ea-89c3-d7c2ec15afe1.png">

**Collection that is a department**
<img width="401" alt="Screen Shot 2020-05-06 at 5 23 06 PM" src="https://user-images.githubusercontent.com/5201004/81231308-f4191a00-8fc0-11ea-843f-c148ada901f4.png">
