### PR TITLE
[MX-291] Adds collections to home page

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -23,6 +23,7 @@ upcoming:
     - Updated artwork tile design - ash & brian
     - Improve UX for Home Artist rail - david
     - Fixes missing artworks on partner page - ash
+    - Adds collections to home page - ash
 
 releases:
   - version: 6.4.3

--- a/src/__generated__/CollectionsRailTestsQuery.graphql.ts
+++ b/src/__generated__/CollectionsRailTestsQuery.graphql.ts
@@ -1,0 +1,250 @@
+/* tslint:disable */
+/* eslint-disable */
+/* @relayHash 6f818fa92e4a082d48fa174b44598a3c */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type CollectionsRailTestsQueryVariables = {};
+export type CollectionsRailTestsQueryResponse = {
+    readonly homePage: {
+        readonly marketingCollectionsModule: {
+            readonly " $fragmentRefs": FragmentRefs<"CollectionsRail_collectionsModule">;
+        } | null;
+    } | null;
+};
+export type CollectionsRailTestsQueryRawResponse = {
+    readonly homePage: ({
+        readonly marketingCollectionsModule: ({
+            readonly results: ReadonlyArray<({
+                readonly title: string;
+                readonly slug: string;
+                readonly artworksConnection: ({
+                    readonly edges: ReadonlyArray<({
+                        readonly node: ({
+                            readonly image: ({
+                                readonly url: string | null;
+                            }) | null;
+                            readonly id: string | null;
+                        }) | null;
+                    }) | null> | null;
+                    readonly id: string | null;
+                }) | null;
+                readonly id: string | null;
+            }) | null>;
+        }) | null;
+    }) | null;
+};
+export type CollectionsRailTestsQuery = {
+    readonly response: CollectionsRailTestsQueryResponse;
+    readonly variables: CollectionsRailTestsQueryVariables;
+    readonly rawResponse: CollectionsRailTestsQueryRawResponse;
+};
+
+
+
+/*
+query CollectionsRailTestsQuery {
+  homePage {
+    marketingCollectionsModule {
+      ...CollectionsRail_collectionsModule
+    }
+  }
+}
+
+fragment CollectionsRail_collectionsModule on HomePageMarketingCollectionsModule {
+  results {
+    title
+    slug
+    artworksConnection(first: 3) {
+      edges {
+        node {
+          image {
+            url(version: "large")
+          }
+          id
+        }
+      }
+      id
+    }
+    id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "CollectionsRailTestsQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "homePage",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "HomePage",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "marketingCollectionsModule",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "HomePageMarketingCollectionsModule",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "FragmentSpread",
+                "name": "CollectionsRail_collectionsModule",
+                "args": null
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "CollectionsRailTestsQuery",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "homePage",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "HomePage",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "marketingCollectionsModule",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "HomePageMarketingCollectionsModule",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "results",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "MarketingCollection",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "title",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "slug",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "artworksConnection",
+                    "storageKey": "artworksConnection(first:3)",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "first",
+                        "value": 3
+                      }
+                    ],
+                    "concreteType": "FilterArtworksConnection",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "edges",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "FilterArtworksEdge",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "node",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Artwork",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "image",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "Image",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "url",
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "version",
+                                        "value": "large"
+                                      }
+                                    ],
+                                    "storageKey": "url(version:\"large\")"
+                                  }
+                                ]
+                              },
+                              (v0/*: any*/)
+                            ]
+                          }
+                        ]
+                      },
+                      (v0/*: any*/)
+                    ]
+                  },
+                  (v0/*: any*/)
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "CollectionsRailTestsQuery",
+    "id": "0b809e5e20fad1afa46c121fcfee95e8",
+    "text": null,
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = '1515b35dee6e677382437e445a880a03';
+export default node;

--- a/src/__generated__/CollectionsRail_collectionsModule.graphql.ts
+++ b/src/__generated__/CollectionsRail_collectionsModule.graphql.ts
@@ -1,0 +1,128 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type CollectionsRail_collectionsModule = {
+    readonly results: ReadonlyArray<{
+        readonly title: string;
+        readonly slug: string;
+        readonly artworksConnection: {
+            readonly edges: ReadonlyArray<{
+                readonly node: {
+                    readonly image: {
+                        readonly url: string | null;
+                    } | null;
+                } | null;
+            } | null> | null;
+        } | null;
+    } | null>;
+    readonly " $refType": "CollectionsRail_collectionsModule";
+};
+export type CollectionsRail_collectionsModule$data = CollectionsRail_collectionsModule;
+export type CollectionsRail_collectionsModule$key = {
+    readonly " $data"?: CollectionsRail_collectionsModule$data;
+    readonly " $fragmentRefs": FragmentRefs<"CollectionsRail_collectionsModule">;
+};
+
+
+
+const node: ReaderFragment = {
+  "kind": "Fragment",
+  "name": "CollectionsRail_collectionsModule",
+  "type": "HomePageMarketingCollectionsModule",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "results",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "MarketingCollection",
+      "plural": true,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "title",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "slug",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "artworksConnection",
+          "storageKey": "artworksConnection(first:3)",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "first",
+              "value": 3
+            }
+          ],
+          "concreteType": "FilterArtworksConnection",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "edges",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "FilterArtworksEdge",
+              "plural": true,
+              "selections": [
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "node",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "Artwork",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "LinkedField",
+                      "alias": null,
+                      "name": "image",
+                      "storageKey": null,
+                      "args": null,
+                      "concreteType": "Image",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "kind": "ScalarField",
+                          "alias": null,
+                          "name": "url",
+                          "args": [
+                            {
+                              "kind": "Literal",
+                              "name": "version",
+                              "value": "large"
+                            }
+                          ],
+                          "storageKey": "url(version:\"large\")"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+(node as any).hash = '947dc848bc08a0fc254e02a6497461a1';
+export default node;

--- a/src/__generated__/HomeQuery.graphql.ts
+++ b/src/__generated__/HomeQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash d1939ce1e37065bc840aa6d825db365f */
+/* @relayHash f522c4393e7999525c9db0bfd099d1c1 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -128,6 +128,25 @@ fragment ArtworkRail_rail on HomePageArtworkModule {
   }
 }
 
+fragment CollectionsRail_collectionsModule on HomePageMarketingCollectionsModule {
+  results {
+    title
+    slug
+    artworksConnection(first: 3) {
+      edges {
+        node {
+          image {
+            url(version: "large")
+          }
+          id
+        }
+      }
+      id
+    }
+    id
+  }
+}
+
 fragment FairsRail_fairsModule on HomePageFairsModule {
   results {
     id
@@ -193,6 +212,9 @@ fragment Home_homePage on HomePage {
   }
   salesModule {
     ...SalesRail_salesModule
+  }
+  marketingCollectionsModule {
+    ...CollectionsRail_collectionsModule
   }
 }
 
@@ -961,6 +983,41 @@ return {
                 ]
               }
             ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "marketingCollectionsModule",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "HomePageMarketingCollectionsModule",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "results",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "MarketingCollection",
+                "plural": true,
+                "selections": [
+                  (v1/*: any*/),
+                  (v8/*: any*/),
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "artworksConnection",
+                    "storageKey": "artworksConnection(first:3)",
+                    "args": (v13/*: any*/),
+                    "concreteType": "FilterArtworksConnection",
+                    "plural": false,
+                    "selections": (v18/*: any*/)
+                  },
+                  (v0/*: any*/)
+                ]
+              }
+            ]
           }
         ]
       }
@@ -969,7 +1026,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "HomeQuery",
-    "id": "ef44a7d3039c4852f40eff4b546bc9d6",
+    "id": "713fac9017109a992fa7f573104a3bbb",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/HomeRefetchQuery.graphql.ts
+++ b/src/__generated__/HomeRefetchQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 4c874342e7d1ee951648e6ffc091e39e */
+/* @relayHash b2b477a9ed53bd5d573843e518994484 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -128,6 +128,25 @@ fragment ArtworkRail_rail on HomePageArtworkModule {
   }
 }
 
+fragment CollectionsRail_collectionsModule on HomePageMarketingCollectionsModule {
+  results {
+    title
+    slug
+    artworksConnection(first: 3) {
+      edges {
+        node {
+          image {
+            url(version: "large")
+          }
+          id
+        }
+      }
+      id
+    }
+    id
+  }
+}
+
 fragment FairsRail_fairsModule on HomePageFairsModule {
   results {
     id
@@ -193,6 +212,9 @@ fragment Home_homePage on HomePage {
   }
   salesModule {
     ...SalesRail_salesModule
+  }
+  marketingCollectionsModule {
+    ...CollectionsRail_collectionsModule
   }
 }
 
@@ -961,6 +983,41 @@ return {
                 ]
               }
             ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "marketingCollectionsModule",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "HomePageMarketingCollectionsModule",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "results",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "MarketingCollection",
+                "plural": true,
+                "selections": [
+                  (v1/*: any*/),
+                  (v8/*: any*/),
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "artworksConnection",
+                    "storageKey": "artworksConnection(first:3)",
+                    "args": (v13/*: any*/),
+                    "concreteType": "FilterArtworksConnection",
+                    "plural": false,
+                    "selections": (v18/*: any*/)
+                  },
+                  (v0/*: any*/)
+                ]
+              }
+            ]
           }
         ]
       }
@@ -969,7 +1026,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "HomeRefetchQuery",
-    "id": "a122b6156fda3cb731bc17a9530729b2",
+    "id": "046d26281c1ea9c4491185c4d36a9b3d",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/Home_homePage.graphql.ts
+++ b/src/__generated__/Home_homePage.graphql.ts
@@ -18,6 +18,9 @@ export type Home_homePage = {
     readonly salesModule: {
         readonly " $fragmentRefs": FragmentRefs<"SalesRail_salesModule">;
     } | null;
+    readonly marketingCollectionsModule: {
+        readonly " $fragmentRefs": FragmentRefs<"CollectionsRail_collectionsModule">;
+    } | null;
     readonly " $refType": "Home_homePage";
 };
 export type Home_homePage$data = Home_homePage;
@@ -142,9 +145,25 @@ return {
           "args": null
         }
       ]
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "marketingCollectionsModule",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "HomePageMarketingCollectionsModule",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "FragmentSpread",
+          "name": "CollectionsRail_collectionsModule",
+          "args": null
+        }
+      ]
     }
   ]
 };
 })();
-(node as any).hash = '3aa676d9c93e9800ae52d21a62459000';
+(node as any).hash = 'c00d9858ab02d19c414731dd1469974f';
 export default node;

--- a/src/lib/Scenes/Home/Components/CollectionsRail.tsx
+++ b/src/lib/Scenes/Home/Components/CollectionsRail.tsx
@@ -1,0 +1,110 @@
+import { Flex, Sans } from "@artsy/palette"
+import { CollectionsRail_collectionsModule } from "__generated__/CollectionsRail_collectionsModule.graphql"
+import React, { Component, createRef } from "react"
+import { FlatList, View } from "react-native"
+import { createFragmentContainer, graphql } from "react-relay"
+
+import ImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
+import { SectionTitle } from "lib/Components/SectionTitle"
+import Switchboard from "lib/NativeModules/SwitchBoard"
+
+import {
+  CARD_RAIL_ARTWORKS_HEIGHT as ARTWORKS_HEIGHT,
+  CardRailArtworkImageContainer as ArtworkImageContainer,
+  CardRailCard,
+  CardRailDivision as Division,
+  CardRailMetadataContainer as MetadataContainer,
+} from "lib/Components/Home/CardRailCard"
+import { CardRailFlatList } from "lib/Components/Home/CardRailFlatList"
+import { compact } from "lodash"
+import { RailScrollRef } from "./types"
+
+interface Props {
+  collectionsModule: CollectionsRail_collectionsModule
+}
+
+type Collection = CollectionsRail_collectionsModule["results"][0]
+
+export class CollectionsRail extends Component<Props> implements RailScrollRef {
+  private listRef = createRef<FlatList<any>>()
+
+  scrollToTop() {
+    this.listRef.current?.scrollToOffset({ offset: 0, animated: true })
+  }
+
+  render() {
+    return (
+      <View>
+        <Flex pl="2" pr="2">
+          <SectionTitle title="Collections" subtitle="The newest works curated by Artsy" />
+        </Flex>
+
+        <CardRailFlatList<NonNullable<Collection>>
+          listRef={this.listRef}
+          data={compact(this.props.collectionsModule.results)}
+          keyExtractor={(item, index) => item.slug || String(index)}
+          renderItem={({ item: result }) => {
+            // Collections are expected to always have >= 2 artworks, but we should
+            // still be cautious to avoid crashes if this assumption is broken.
+            const artworkImageURLs = result.artworksConnection?.edges?.map(edge => edge?.node?.image?.url!) || []
+
+            return (
+              <CardRailCard
+                onPress={() =>
+                  result?.slug
+                    ? Switchboard.presentNavigationViewController(this, `/collection/${result.slug}`)
+                    : undefined
+                }
+              >
+                <View>
+                  <ArtworkImageContainer>
+                    <ImageView width={ARTWORKS_HEIGHT} height={ARTWORKS_HEIGHT} imageURL={artworkImageURLs[0]} />
+                    <Division />
+                    <View>
+                      <ImageView
+                        width={ARTWORKS_HEIGHT / 2}
+                        height={ARTWORKS_HEIGHT / 2}
+                        imageURL={artworkImageURLs[1]}
+                      />
+                      <Division horizontal />
+                      <ImageView
+                        width={ARTWORKS_HEIGHT / 2}
+                        height={ARTWORKS_HEIGHT / 2}
+                        imageURL={artworkImageURLs[2]}
+                      />
+                    </View>
+                  </ArtworkImageContainer>
+                  <MetadataContainer>
+                    <Sans numberOfLines={1} weight="medium" size="3t">
+                      {result?.title}
+                    </Sans>
+                  </MetadataContainer>
+                </View>
+              </CardRailCard>
+            )
+          }}
+        />
+      </View>
+    )
+  }
+}
+
+export const CollectionsRailFragmentContainer = createFragmentContainer(CollectionsRail, {
+  collectionsModule: graphql`
+    fragment CollectionsRail_collectionsModule on HomePageMarketingCollectionsModule {
+      results {
+        title
+        slug
+        artworksConnection(first: 3) {
+          edges {
+            node {
+              image {
+                url(version: "large")
+              }
+            }
+          }
+        }
+      }
+    }
+  `,
+})

--- a/src/lib/Scenes/Home/Components/__tests__/CollectionsRail-tests.tsx
+++ b/src/lib/Scenes/Home/Components/__tests__/CollectionsRail-tests.tsx
@@ -1,0 +1,132 @@
+import { cloneDeep, first } from "lodash"
+import React from "react"
+import "react-native"
+import { graphql, QueryRenderer } from "react-relay"
+import ReactTestRenderer, { act } from "react-test-renderer"
+import { createMockEnvironment } from "relay-test-utils"
+
+jest.mock("lib/NativeModules/SwitchBoard", () => ({
+  presentNavigationViewController: jest.fn(),
+}))
+import SwitchBoard from "lib/NativeModules/SwitchBoard"
+
+import { Theme } from "@artsy/palette"
+import { CollectionsRailTestsQuery } from "__generated__/CollectionsRailTestsQuery.graphql"
+import { CardRailCard } from "lib/Components/Home/CardRailCard"
+import { CollectionsRailFragmentContainer } from "../CollectionsRail"
+
+jest.unmock("react-relay")
+
+describe("CollectionsRailFragmentContainer", () => {
+  let env: ReturnType<typeof createMockEnvironment>
+
+  const TestRenderer = () => (
+    <QueryRenderer<CollectionsRailTestsQuery>
+      environment={env}
+      query={graphql`
+        query CollectionsRailTestsQuery @raw_response_type {
+          homePage {
+            marketingCollectionsModule {
+              ...CollectionsRail_collectionsModule
+            }
+          }
+        }
+      `}
+      variables={{}}
+      render={({ props, error }) => {
+        if (props) {
+          return (
+            <Theme>
+              <CollectionsRailFragmentContainer collectionsModule={props.homePage?.marketingCollectionsModule!} />
+            </Theme>
+          )
+        } else if (error) {
+          console.log(error)
+        }
+      }}
+    />
+  )
+
+  beforeEach(() => {
+    env = createMockEnvironment()
+  })
+
+  it("doesn't throw when rendered", () => {
+    ReactTestRenderer.create(<TestRenderer />)
+    act(() => {
+      env.mock.resolveMostRecentOperation({
+        errors: [],
+        data: {
+          homePage: {
+            marketingCollectionsModule: collectionsModuleMock,
+          },
+        },
+      })
+    })
+  })
+
+  it("looks correct when rendered with sales missing artworks", () => {
+    const collectionsCopy = cloneDeep(collectionsModuleMock)
+    collectionsCopy.results.forEach(result => {
+      // @ts-ignore
+      result.artworksConnection.edges = []
+    })
+    ReactTestRenderer.create(<TestRenderer />)
+    act(() => {
+      env.mock.resolveMostRecentOperation({
+        errors: [],
+        data: {
+          homePage: {
+            marketingCollectionsModule: collectionsCopy,
+          },
+        },
+      })
+    })
+  })
+
+  it("routes to collection URL", () => {
+    const tree = ReactTestRenderer.create(<TestRenderer />)
+    act(() => {
+      env.mock.resolveMostRecentOperation({
+        errors: [],
+        data: {
+          homePage: {
+            marketingCollectionsModule: collectionsModuleMock,
+          },
+        },
+      })
+    })
+    // @ts-ignore
+    first(tree.root.findAllByType(CardRailCard)).props.onPress()
+    expect(SwitchBoard.presentNavigationViewController).toHaveBeenCalledWith(
+      expect.anything(),
+      "/collection/test-collection-one"
+    )
+  })
+})
+
+const artworkNode = {
+  node: {
+    artwork: {
+      image: { url: "https://example.com/image.jpg" },
+    },
+  },
+}
+const collectionsModuleMock = {
+  results: [
+    {
+      name: "Test Collection One",
+      slug: "test-collection-one",
+      artworksConnection: {
+        edges: [artworkNode, artworkNode, artworkNode],
+      },
+    },
+    {
+      name: "Test Collection Two",
+      slug: "test-collection-two",
+      artworksConnection: {
+        edges: [artworkNode, artworkNode, artworkNode],
+      },
+    },
+  ],
+}

--- a/src/lib/Scenes/Home/Home.tsx
+++ b/src/lib/Scenes/Home/Home.tsx
@@ -4,6 +4,7 @@ import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from
 
 import { ArtistRailFragmentContainer } from "lib/Components/Home/ArtistRails/ArtistRail"
 import { ArtworkRailFragmentContainer } from "lib/Scenes/Home/Components/ArtworkRail"
+import { CollectionsRailFragmentContainer } from "lib/Scenes/Home/Components/CollectionsRail"
 import { FairsRailFragmentContainer } from "lib/Scenes/Home/Components/FairsRail"
 import { SalesRailFragmentContainer } from "lib/Scenes/Home/Components/SalesRail"
 
@@ -33,6 +34,7 @@ const Home = (props: Props) => {
   const { homePage } = props
   const artworkModules = homePage.artworkModules || []
   const salesModule = homePage.salesModule
+  const collectionsModule = homePage.marketingCollectionsModule
   const artistModules = (homePage.artistModules && homePage.artistModules.concat()) || []
   const fairsModule = homePage.fairsModule
 
@@ -59,6 +61,7 @@ const Home = (props: Props) => {
   - Recently viewed                 -> artworksModule
   - Recently saved                  -> artworksModule
   - Auctions                        -> salesModule
+  - Collections                     -> marketingCollectionsModule
   - Fairs                           -> fairsModule
   - Recommended works for you       -> artworksModule
   - Recommended artists to follow   -> artistModules
@@ -74,6 +77,11 @@ const Home = (props: Props) => {
       ({
         type: "sales",
         data: salesModule,
+      } as const),
+    collectionsModule &&
+      ({
+        type: "collections",
+        data: collectionsModule,
       } as const),
     salesModule &&
       ({
@@ -133,6 +141,13 @@ const Home = (props: Props) => {
                   return <FairsRailFragmentContainer fairsModule={item.data} componentRef={scrollRefs.current[index]} />
                 case "sales":
                   return <SalesRailFragmentContainer salesModule={item.data} componentRef={scrollRefs.current[index]} />
+                case "collections":
+                  return (
+                    <CollectionsRailFragmentContainer
+                      collectionsModule={item.data}
+                      componentRef={scrollRefs.current[index]}
+                    />
+                  )
               }
             }}
             ListFooterComponent={() => <Spacer mb={3} />}
@@ -182,6 +197,9 @@ export const HomeFragmentContainer = createRefetchContainer(
         }
         salesModule {
           ...SalesRail_salesModule
+        }
+        marketingCollectionsModule {
+          ...CollectionsRail_collectionsModule
         }
       }
     `,


### PR DESCRIPTION
This depends on this Metaphysics PR: https://github.com/artsy/metaphysics/pull/2361 ~We'll need to wait for that to merge and for the schema to get updated in Eigen first, but I have included the changes to the generated files in this PR (CI will fail).~

![Screen Shot 2020-05-07 at 13 35 16](https://user-images.githubusercontent.com/498212/81326643-216cd300-9068-11ea-8c28-cab07bf31b53.png)

The `CollectionsRail` component is heavily based on the existing `SalesRail`, so I think it makes sense to create an abstraction for these cards. But we can follow-up with that. 

I'm _very_ excited to see such an important screen like collections finally get a well-earned entry point from the home screen of the app 🎉 /cc @ashleyjelks 