### PR TITLE
Add yarn relay to MP update steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,9 @@ jobs:
       - run:
           name: Update metaphysics
           command: yarn update-metaphysics
+      - run:
+          name: Update generated files
+          command: yarn relay
 
   check-pr:
     executor:


### PR DESCRIPTION
I noticed that https://github.com/artsy/eigen/pull/3282 initially failed because CI expected us to run `yarn relay` before committing - thought it would be simple enough to just always run that step when we pull updated MP schema.

If folks think we should be pickier and only run it when strictly necessary, I'm not sure exactly how we'd do that but would be happy to pair on it!

[CI failure for reference](https://app.circleci.com/pipelines/github/artsy/eigen/1355/workflows/ceed897e-f0d4-443d-bb2a-ae85281a5f15/jobs/9432/steps)

#trivial