### PR TITLE
[MX-308] Fixes Home tab's skeleton loader

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -15,6 +15,7 @@ upcoming:
     - Add city guide entry in search behind flag - brian
     - Remove feature flag from collections artworks filters - ashley
   user_facing:
+    - Fixes Home's skeleton loader on iPad - ash
     - Fix for deeplinks to search, city guide tabs - brian
     - Improves sticky tab page interaction - david
     - Adds other collections category collection hub rail - dzucconi

--- a/src/lib/Scenes/Home/Home.tsx
+++ b/src/lib/Scenes/Home/Home.tsx
@@ -207,14 +207,35 @@ const HomePlaceholder: React.FC<{}> = () => {
           </Flex>
         </Box>
         <Separator />
-        {times(5).map(r => (
+        {// Small tiles to mimic the artwork rails
+        times(3).map(r => (
+          <Box key={r} ml={2} mr={2}>
+            <Spacer mb={3} />
+            <PlaceholderText width={100 + Math.random() * 100} />
+            <Flex flexDirection="row" mt={1}>
+              <Join separator={<Spacer width={15} />}>
+                {times(3 + Math.random() * 10).map(index => (
+                  <Flex key={index}>
+                    <PlaceholderBox height={120} width={120} />
+                    <Spacer mb={2} />
+                    <PlaceholderText width={120} />
+                    <PlaceholderText width={30 + Math.random() * 60} />
+                  </Flex>
+                ))}
+              </Join>
+              <Spacer mb={2} />
+            </Flex>
+          </Box>
+        ))}
+        {// Larger tiles to mimic the fairs, sales, and collections rails
+        times(3).map(r => (
           <Box key={r} ml={2} mr={2}>
             <Spacer mb={3} />
             <PlaceholderText width={100 + Math.random() * 100} />
             <Flex flexDirection="row" mt={1}>
               <Join separator={<Spacer width={15} />}>
                 {times(10).map(index => (
-                  <PlaceholderBox key={index} height={120} width={120} />
+                  <PlaceholderBox key={index} height={270} width={270} />
                 ))}
               </Join>
               <Spacer mb={2} />


### PR DESCRIPTION
This fixes the loader on iPad. I also did some visual cleanup to match the new small tiles from #3271 and forthcoming changes in #3284. Instead of always flowing offscreen, I added an amount of randomness to the horizontal tile rail placeholders to match the content. Here's a side-by-side on both platforms:

| Skeleton | Content |
|---|---|
| ![Simulator Screen Shot - iPhone X - 2020-05-08 at 11 25 50](https://user-images.githubusercontent.com/498212/81421388-6a339300-911f-11ea-85fc-f4149afb4d09.png)  | ![Simulator Screen Shot - iPhone X - 2020-05-08 at 11 23 35](https://user-images.githubusercontent.com/498212/81421410-71f33780-911f-11ea-8770-125265d66ccd.png) |
| ![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2020-05-08 at 11 25 48](https://user-images.githubusercontent.com/498212/81421429-79b2dc00-911f-11ea-9f4a-5cc96a58bdfa.png)  |  ![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2020-05-08 at 11 23 29](https://user-images.githubusercontent.com/498212/81421457-820b1700-911f-11ea-89ca-3f160b2588f6.png) |

