### PR TITLE
Scrolls rails back to starting position without animation #trivial

### DIFF
--- a/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
+++ b/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
@@ -40,7 +40,7 @@ const ArtistRail: React.FC<Props & RailScrollProps> = props => {
 
   const listRef = useRef<FlatList<any>>()
   useImperativeHandle(props.scrollRef, () => ({
-    scrollToTop: () => listRef.current?.scrollToOffset({ offset: 0, animated: true }),
+    scrollToTop: () => listRef.current?.scrollToOffset({ offset: 0, animated: false }),
   }))
 
   const [artists, setArtists] = useState<SuggestedArtist[]>(

--- a/src/lib/Scenes/Home/Components/ArtworkRail.tsx
+++ b/src/lib/Scenes/Home/Components/ArtworkRail.tsx
@@ -44,7 +44,7 @@ const ArtworkRail: React.FC<{ rail: ArtworkRail_rail } & RailScrollProps> = ({ r
   const railRef = useRef<View>(null)
   const listRef = useRef<FlatList<any>>()
   useImperativeHandle(scrollRef, () => ({
-    scrollToTop: () => listRef.current?.scrollToOffset({ offset: 0, animated: true }),
+    scrollToTop: () => listRef.current?.scrollToOffset({ offset: 0, animated: false }),
   }))
 
   const viewAllUrl = getViewAllUrl(rail)

--- a/src/lib/Scenes/Home/Components/CollectionsRail.tsx
+++ b/src/lib/Scenes/Home/Components/CollectionsRail.tsx
@@ -29,7 +29,7 @@ export class CollectionsRail extends Component<Props> implements RailScrollRef {
   private listRef = createRef<FlatList<any>>()
 
   scrollToTop() {
-    this.listRef.current?.scrollToOffset({ offset: 0, animated: true })
+    this.listRef.current?.scrollToOffset({ offset: 0, animated: false })
   }
 
   render() {

--- a/src/lib/Scenes/Home/Components/FairsRail.tsx
+++ b/src/lib/Scenes/Home/Components/FairsRail.tsx
@@ -28,7 +28,7 @@ export class FairsRail extends Component<Props, null> implements RailScrollRef {
   private listRef = createRef<FlatList<any>>()
 
   scrollToTop() {
-    this.listRef.current?.scrollToOffset({ offset: 0, animated: true })
+    this.listRef.current?.scrollToOffset({ offset: 0, animated: false })
   }
 
   render() {

--- a/src/lib/Scenes/Home/Components/SalesRail.tsx
+++ b/src/lib/Scenes/Home/Components/SalesRail.tsx
@@ -30,7 +30,7 @@ export class SalesRail extends Component<Props> implements RailScrollRef {
   private listRef = createRef<FlatList<any>>()
 
   scrollToTop() {
-    this.listRef.current?.scrollToOffset({ offset: 0, animated: true })
+    this.listRef.current?.scrollToOffset({ offset: 0, animated: false })
   }
 
   render() {


### PR DESCRIPTION
I'm 99% sure we don't want to animate these offset changes, since it draws attention to the user interface when pulling-to-refresh.

![1 2020-05-08 14_39_10](https://user-images.githubusercontent.com/498212/81437750-b25faf00-9139-11ea-9b23-0d0f355311f7.gif)

But I've left this in its own commit/PR so we can revert it if I'm wrong 👍 