### PR TITLE
Update Viewing Rooms artwork rail

### DIFF
--- a/src/__generated__/ArtworkTileRailTestsQuery.graphql.ts
+++ b/src/__generated__/ArtworkTileRailTestsQuery.graphql.ts
@@ -1,26 +1,30 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 08dedd7cb54d85e1545a58e6c1746daa */
+/* @relayHash b36f5a0f8f92debbd72737a5c3584fd1 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type ViewingRoomArtworkRailTestsQueryVariables = {};
-export type ViewingRoomArtworkRailTestsQueryResponse = {
+export type ArtworkTileRailTestsQueryVariables = {};
+export type ArtworkTileRailTestsQueryResponse = {
     readonly viewingRoom: {
-        readonly " $fragmentRefs": FragmentRefs<"ViewingRoomArtworkRail_viewingRoom">;
+        readonly artworksConnection: {
+            readonly " $fragmentRefs": FragmentRefs<"ArtworkTileRail_artworksConnection">;
+        } | null;
     } | null;
 };
-export type ViewingRoomArtworkRailTestsQuery = {
-    readonly response: ViewingRoomArtworkRailTestsQueryResponse;
-    readonly variables: ViewingRoomArtworkRailTestsQueryVariables;
+export type ArtworkTileRailTestsQuery = {
+    readonly response: ArtworkTileRailTestsQueryResponse;
+    readonly variables: ArtworkTileRailTestsQueryVariables;
 };
 
 
 
 /*
-query ViewingRoomArtworkRailTestsQuery {
-  viewingRoom(id: "unused") {
-    ...ViewingRoomArtworkRail_viewingRoom
+query ArtworkTileRailTestsQuery {
+  viewingRoom(id: "whatever") {
+    artworksConnection {
+      ...ArtworkTileRail_artworksConnection
+    }
   }
 }
 
@@ -39,15 +43,6 @@ fragment ArtworkTileRail_artworksConnection on ArtworkConnection {
     }
   }
 }
-
-fragment ViewingRoomArtworkRail_viewingRoom on ViewingRoom {
-  slug
-  internalID
-  artworks: artworksConnection(first: 5) {
-    totalCount
-    ...ArtworkTileRail_artworksConnection
-  }
-}
 */
 
 const node: ConcreteRequest = (function(){
@@ -55,28 +50,14 @@ var v0 = [
   {
     "kind": "Literal",
     "name": "id",
-    "value": "unused"
+    "value": "whatever"
   }
-],
-v1 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "slug",
-  "args": null,
-  "storageKey": null
-},
-v2 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "internalID",
-  "args": null,
-  "storageKey": null
-};
+];
 return {
   "kind": "Request",
   "fragment": {
     "kind": "Fragment",
-    "name": "ViewingRoomArtworkRailTestsQuery",
+    "name": "ArtworkTileRailTestsQuery",
     "type": "Query",
     "metadata": null,
     "argumentDefinitions": [],
@@ -85,15 +66,26 @@ return {
         "kind": "LinkedField",
         "alias": null,
         "name": "viewingRoom",
-        "storageKey": "viewingRoom(id:\"unused\")",
+        "storageKey": "viewingRoom(id:\"whatever\")",
         "args": (v0/*: any*/),
         "concreteType": "ViewingRoom",
         "plural": false,
         "selections": [
           {
-            "kind": "FragmentSpread",
-            "name": "ViewingRoomArtworkRail_viewingRoom",
-            "args": null
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "artworksConnection",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "ArtworkConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "FragmentSpread",
+                "name": "ArtworkTileRail_artworksConnection",
+                "args": null
+              }
+            ]
           }
         ]
       }
@@ -101,42 +93,27 @@ return {
   },
   "operation": {
     "kind": "Operation",
-    "name": "ViewingRoomArtworkRailTestsQuery",
+    "name": "ArtworkTileRailTestsQuery",
     "argumentDefinitions": [],
     "selections": [
       {
         "kind": "LinkedField",
         "alias": null,
         "name": "viewingRoom",
-        "storageKey": "viewingRoom(id:\"unused\")",
+        "storageKey": "viewingRoom(id:\"whatever\")",
         "args": (v0/*: any*/),
         "concreteType": "ViewingRoom",
         "plural": false,
         "selections": [
-          (v1/*: any*/),
-          (v2/*: any*/),
           {
             "kind": "LinkedField",
-            "alias": "artworks",
+            "alias": null,
             "name": "artworksConnection",
-            "storageKey": "artworksConnection(first:5)",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 5
-              }
-            ],
+            "storageKey": null,
+            "args": null,
             "concreteType": "ArtworkConnection",
             "plural": false,
             "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "totalCount",
-                "args": null,
-                "storageKey": null
-              },
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -155,8 +132,20 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v1/*: any*/),
-                      (v2/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "slug",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "internalID",
+                        "args": null,
+                        "storageKey": null
+                      },
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -215,12 +204,12 @@ return {
   },
   "params": {
     "operationKind": "query",
-    "name": "ViewingRoomArtworkRailTestsQuery",
-    "id": "9df1fec930cf20758903ae5977653538",
+    "name": "ArtworkTileRailTestsQuery",
+    "id": "bbe321f22d3f63b3427b91cd1f8484ec",
     "text": null,
     "metadata": {}
   }
 };
 })();
-(node as any).hash = 'fcc545a29322194f9415c9653529a1ff';
+(node as any).hash = 'fcab0ab86834640c969a7a7cd7297ad2';
 export default node;

--- a/src/__generated__/ArtworkTileRail_artworksConnection.graphql.ts
+++ b/src/__generated__/ArtworkTileRail_artworksConnection.graphql.ts
@@ -1,0 +1,114 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtworkTileRail_artworksConnection = {
+    readonly edges: ReadonlyArray<{
+        readonly node: {
+            readonly slug: string;
+            readonly internalID: string;
+            readonly href: string | null;
+            readonly artistNames: string | null;
+            readonly image: {
+                readonly imageURL: string | null;
+            } | null;
+            readonly saleMessage: string | null;
+        } | null;
+    } | null> | null;
+    readonly " $refType": "ArtworkTileRail_artworksConnection";
+};
+export type ArtworkTileRail_artworksConnection$data = ArtworkTileRail_artworksConnection;
+export type ArtworkTileRail_artworksConnection$key = {
+    readonly " $data"?: ArtworkTileRail_artworksConnection$data;
+    readonly " $fragmentRefs": FragmentRefs<"ArtworkTileRail_artworksConnection">;
+};
+
+
+
+const node: ReaderFragment = {
+  "kind": "Fragment",
+  "name": "ArtworkTileRail_artworksConnection",
+  "type": "ArtworkConnection",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "edges",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "ArtworkEdge",
+      "plural": true,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "node",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "Artwork",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "slug",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "internalID",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "href",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "artistNames",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "image",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "Image",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "imageURL",
+                  "args": null,
+                  "storageKey": null
+                }
+              ]
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "saleMessage",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+(node as any).hash = '8e817d114e27d6cc5f4df4790d88d310';
+export default node;

--- a/src/__generated__/ViewingRoomArtworkRailTestsQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomArtworkRailTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 9eaef2da5306ee058ca16d124844ad26 */
+/* @relayHash b589634c265209243b3d7acb67646a06 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -36,7 +36,7 @@ fragment ViewingRoomArtworkRail_viewingRoom on ViewingRoom {
         href
         artistNames
         image {
-          url(version: "square")
+          imageURL
         }
         saleMessage
         id
@@ -179,15 +179,9 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "url",
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "version",
-                                "value": "square"
-                              }
-                            ],
-                            "storageKey": "url(version:\"square\")"
+                            "name": "imageURL",
+                            "args": null,
+                            "storageKey": null
                           }
                         ]
                       },
@@ -218,7 +212,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomArtworkRailTestsQuery",
-    "id": "03ff08ff66732b74a32b1169004d2143",
+    "id": "dec8ec88c7933111785422a3b25259e2",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomArtworkRail_viewingRoom.graphql.ts
+++ b/src/__generated__/ViewingRoomArtworkRail_viewingRoom.graphql.ts
@@ -15,7 +15,7 @@ export type ViewingRoomArtworkRail_viewingRoom = {
                 readonly href: string | null;
                 readonly artistNames: string | null;
                 readonly image: {
-                    readonly url: string | null;
+                    readonly imageURL: string | null;
                 } | null;
                 readonly saleMessage: string | null;
             } | null;
@@ -123,15 +123,9 @@ return {
                     {
                       "kind": "ScalarField",
                       "alias": null,
-                      "name": "url",
-                      "args": [
-                        {
-                          "kind": "Literal",
-                          "name": "version",
-                          "value": "square"
-                        }
-                      ],
-                      "storageKey": "url(version:\"square\")"
+                      "name": "imageURL",
+                      "args": null,
+                      "storageKey": null
                     }
                   ]
                 },
@@ -151,5 +145,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '911b0b1c0aa9bbeebc3cddc30080da9f';
+(node as any).hash = 'd5953f8988883df86adbaf768959b820';
 export default node;

--- a/src/__generated__/ViewingRoomArtworkRail_viewingRoom.graphql.ts
+++ b/src/__generated__/ViewingRoomArtworkRail_viewingRoom.graphql.ts
@@ -8,18 +8,7 @@ export type ViewingRoomArtworkRail_viewingRoom = {
     readonly internalID: string;
     readonly artworks: {
         readonly totalCount: number | null;
-        readonly edges: ReadonlyArray<{
-            readonly node: {
-                readonly slug: string;
-                readonly internalID: string;
-                readonly href: string | null;
-                readonly artistNames: string | null;
-                readonly image: {
-                    readonly imageURL: string | null;
-                } | null;
-                readonly saleMessage: string | null;
-            } | null;
-        } | null> | null;
+        readonly " $fragmentRefs": FragmentRefs<"ArtworkTileRail_artworksConnection">;
     } | null;
     readonly " $refType": "ViewingRoomArtworkRail_viewingRoom";
 };
@@ -31,30 +20,27 @@ export type ViewingRoomArtworkRail_viewingRoom$key = {
 
 
 
-const node: ReaderFragment = (function(){
-var v0 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "slug",
-  "args": null,
-  "storageKey": null
-},
-v1 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "internalID",
-  "args": null,
-  "storageKey": null
-};
-return {
+const node: ReaderFragment = {
   "kind": "Fragment",
   "name": "ViewingRoomArtworkRail_viewingRoom",
   "type": "ViewingRoom",
   "metadata": null,
   "argumentDefinitions": [],
   "selections": [
-    (v0/*: any*/),
-    (v1/*: any*/),
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "slug",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "internalID",
+      "args": null,
+      "storageKey": null
+    },
     {
       "kind": "LinkedField",
       "alias": "artworks",
@@ -78,72 +64,13 @@ return {
           "storageKey": null
         },
         {
-          "kind": "LinkedField",
-          "alias": null,
-          "name": "edges",
-          "storageKey": null,
-          "args": null,
-          "concreteType": "ArtworkEdge",
-          "plural": true,
-          "selections": [
-            {
-              "kind": "LinkedField",
-              "alias": null,
-              "name": "node",
-              "storageKey": null,
-              "args": null,
-              "concreteType": "Artwork",
-              "plural": false,
-              "selections": [
-                (v0/*: any*/),
-                (v1/*: any*/),
-                {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "href",
-                  "args": null,
-                  "storageKey": null
-                },
-                {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "artistNames",
-                  "args": null,
-                  "storageKey": null
-                },
-                {
-                  "kind": "LinkedField",
-                  "alias": null,
-                  "name": "image",
-                  "storageKey": null,
-                  "args": null,
-                  "concreteType": "Image",
-                  "plural": false,
-                  "selections": [
-                    {
-                      "kind": "ScalarField",
-                      "alias": null,
-                      "name": "imageURL",
-                      "args": null,
-                      "storageKey": null
-                    }
-                  ]
-                },
-                {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "saleMessage",
-                  "args": null,
-                  "storageKey": null
-                }
-              ]
-            }
-          ]
+          "kind": "FragmentSpread",
+          "name": "ArtworkTileRail_artworksConnection",
+          "args": null
         }
       ]
     }
   ]
 };
-})();
-(node as any).hash = 'd5953f8988883df86adbaf768959b820';
+(node as any).hash = '3086d7fb3cfee740b8ea41fd654fee7f';
 export default node;

--- a/src/__generated__/ViewingRoomQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 7a6be67a2e74f1567f3ba19464432306 */
+/* @relayHash 460f4df59328b27f044d77fe89d1984a */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -40,7 +40,7 @@ fragment ViewingRoomArtworkRail_viewingRoom on ViewingRoom {
         href
         artistNames
         image {
-          url(version: "square")
+          imageURL
         }
         saleMessage
         id
@@ -168,45 +168,52 @@ v6 = {
   "storageKey": null
 },
 v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "imageURL",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
   "kind": "Literal",
   "name": "first",
   "value": 5
 },
-v8 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v9 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "artistNames",
   "args": null,
   "storageKey": null
 },
-v10 = {
+v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "saleMessage",
   "args": null,
   "storageKey": null
 },
-v11 = {
+v12 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v12 = [
+v13 = [
   {
     "kind": "Literal",
     "name": "after",
     "value": ""
   },
-  (v7/*: any*/)
+  (v8/*: any*/)
 ];
 return {
   "kind": "Request",
@@ -302,13 +309,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "imageURL",
-                "args": null,
-                "storageKey": null
-              }
+              (v7/*: any*/)
             ]
           },
           {
@@ -317,7 +318,7 @@ return {
             "name": "artworksConnection",
             "storageKey": "artworksConnection(first:5)",
             "args": [
-              (v7/*: any*/)
+              (v8/*: any*/)
             ],
             "concreteType": "ArtworkConnection",
             "plural": false,
@@ -343,8 +344,8 @@ return {
                     "selections": [
                       (v3/*: any*/),
                       (v4/*: any*/),
-                      (v8/*: any*/),
                       (v9/*: any*/),
+                      (v10/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -354,23 +355,11 @@ return {
                         "concreteType": "Image",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "url",
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "version",
-                                "value": "square"
-                              }
-                            ],
-                            "storageKey": "url(version:\"square\")"
-                          }
+                          (v7/*: any*/)
                         ]
                       },
-                      (v10/*: any*/),
-                      (v11/*: any*/)
+                      (v11/*: any*/),
+                      (v12/*: any*/)
                     ]
                   }
                 ]
@@ -404,7 +393,7 @@ return {
             "alias": null,
             "name": "artworksConnection",
             "storageKey": "artworksConnection(after:\"\",first:5)",
-            "args": (v12/*: any*/),
+            "args": (v13/*: any*/),
             "concreteType": "ArtworkConnection",
             "plural": false,
             "selections": [
@@ -426,10 +415,10 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v8/*: any*/),
+                      (v9/*: any*/),
                       (v3/*: any*/),
                       (v4/*: any*/),
-                      (v9/*: any*/),
+                      (v10/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -468,9 +457,9 @@ return {
                           }
                         ]
                       },
-                      (v10/*: any*/),
-                      (v6/*: any*/),
                       (v11/*: any*/),
+                      (v6/*: any*/),
+                      (v12/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -520,7 +509,7 @@ return {
             "kind": "LinkedHandle",
             "alias": null,
             "name": "artworksConnection",
-            "args": (v12/*: any*/),
+            "args": (v13/*: any*/),
             "handle": "connection",
             "key": "ViewingRoomArtworks_artworksConnection",
             "filters": null
@@ -532,7 +521,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomQuery",
-    "id": "eb2a950fc6106a7e9e4935960e747455",
+    "id": "7c0ca55f0232c1691cbe230a60d3c5f2",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 460f4df59328b27f044d77fe89d1984a */
+/* @relayHash 7dd4a997bad660c807d008ea8e912eaf */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -28,24 +28,28 @@ query ViewingRoomQuery(
   }
 }
 
+fragment ArtworkTileRail_artworksConnection on ArtworkConnection {
+  edges {
+    node {
+      slug
+      internalID
+      href
+      artistNames
+      image {
+        imageURL
+      }
+      saleMessage
+      id
+    }
+  }
+}
+
 fragment ViewingRoomArtworkRail_viewingRoom on ViewingRoom {
   slug
   internalID
   artworks: artworksConnection(first: 5) {
     totalCount
-    edges {
-      node {
-        slug
-        internalID
-        href
-        artistNames
-        image {
-          imageURL
-        }
-        saleMessage
-        id
-      }
-    }
+    ...ArtworkTileRail_artworksConnection
   }
 }
 
@@ -521,7 +525,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomQuery",
-    "id": "7c0ca55f0232c1691cbe230a60d3c5f2",
+    "id": "30d750389ce5c71bd6fc503b9ae727da",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomTestsQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash f600c222c0df6ebc6c65c6295ec2daf0 */
+/* @relayHash bae25f651fd33b806710968a747d74e5 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -36,7 +36,7 @@ fragment ViewingRoomArtworkRail_viewingRoom on ViewingRoom {
         href
         artistNames
         image {
-          url(version: "square")
+          imageURL
         }
         saleMessage
         id
@@ -156,45 +156,52 @@ v5 = {
   "storageKey": null
 },
 v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "imageURL",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
   "kind": "Literal",
   "name": "first",
   "value": 5
 },
-v7 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "href",
   "args": null,
   "storageKey": null
 },
-v8 = {
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "artistNames",
   "args": null,
   "storageKey": null
 },
-v9 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "saleMessage",
   "args": null,
   "storageKey": null
 },
-v10 = {
+v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v11 = [
+v12 = [
   {
     "kind": "Literal",
     "name": "after",
     "value": ""
   },
-  (v6/*: any*/)
+  (v7/*: any*/)
 ];
 return {
   "kind": "Request",
@@ -290,13 +297,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "imageURL",
-                "args": null,
-                "storageKey": null
-              }
+              (v6/*: any*/)
             ]
           },
           {
@@ -305,7 +306,7 @@ return {
             "name": "artworksConnection",
             "storageKey": "artworksConnection(first:5)",
             "args": [
-              (v6/*: any*/)
+              (v7/*: any*/)
             ],
             "concreteType": "ArtworkConnection",
             "plural": false,
@@ -331,8 +332,8 @@ return {
                     "selections": [
                       (v2/*: any*/),
                       (v3/*: any*/),
-                      (v7/*: any*/),
                       (v8/*: any*/),
+                      (v9/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -342,23 +343,11 @@ return {
                         "concreteType": "Image",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "url",
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "version",
-                                "value": "square"
-                              }
-                            ],
-                            "storageKey": "url(version:\"square\")"
-                          }
+                          (v6/*: any*/)
                         ]
                       },
-                      (v9/*: any*/),
-                      (v10/*: any*/)
+                      (v10/*: any*/),
+                      (v11/*: any*/)
                     ]
                   }
                 ]
@@ -392,7 +381,7 @@ return {
             "alias": null,
             "name": "artworksConnection",
             "storageKey": "artworksConnection(after:\"\",first:5)",
-            "args": (v11/*: any*/),
+            "args": (v12/*: any*/),
             "concreteType": "ArtworkConnection",
             "plural": false,
             "selections": [
@@ -414,10 +403,10 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v7/*: any*/),
+                      (v8/*: any*/),
                       (v2/*: any*/),
                       (v3/*: any*/),
-                      (v8/*: any*/),
+                      (v9/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -456,9 +445,9 @@ return {
                           }
                         ]
                       },
-                      (v9/*: any*/),
-                      (v5/*: any*/),
                       (v10/*: any*/),
+                      (v5/*: any*/),
+                      (v11/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -508,7 +497,7 @@ return {
             "kind": "LinkedHandle",
             "alias": null,
             "name": "artworksConnection",
-            "args": (v11/*: any*/),
+            "args": (v12/*: any*/),
             "handle": "connection",
             "key": "ViewingRoomArtworks_artworksConnection",
             "filters": null
@@ -520,7 +509,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomTestsQuery",
-    "id": "e5094609e56f6a4301bdd2933b2d8684",
+    "id": "f75b679f1121295b8ef916eb594675d2",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomTestsQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash bae25f651fd33b806710968a747d74e5 */
+/* @relayHash 801fb9664258328a912d87dd9d7e1649 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -24,24 +24,28 @@ query ViewingRoomTestsQuery {
   }
 }
 
+fragment ArtworkTileRail_artworksConnection on ArtworkConnection {
+  edges {
+    node {
+      slug
+      internalID
+      href
+      artistNames
+      image {
+        imageURL
+      }
+      saleMessage
+      id
+    }
+  }
+}
+
 fragment ViewingRoomArtworkRail_viewingRoom on ViewingRoom {
   slug
   internalID
   artworks: artworksConnection(first: 5) {
     totalCount
-    edges {
-      node {
-        slug
-        internalID
-        href
-        artistNames
-        image {
-          imageURL
-        }
-        saleMessage
-        id
-      }
-    }
+    ...ArtworkTileRail_artworksConnection
   }
 }
 
@@ -509,7 +513,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomTestsQuery",
-    "id": "f75b679f1121295b8ef916eb594675d2",
+    "id": "edb1a3a8c80c6aac7a5d7dfa993bc7a0",
     "text": null,
     "metadata": {}
   }

--- a/src/lib/Components/ArtworkTileRail.tsx
+++ b/src/lib/Components/ArtworkTileRail.tsx
@@ -3,16 +3,15 @@ import { ArtworkTileRail_artworksConnection } from "__generated__/ArtworkTileRai
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { Schema } from "lib/utils/track"
 import React, { useRef } from "react"
-import { View } from "react-native"
+import { FlatList, View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
-import { AboveTheFoldFlatList } from "./AboveTheFoldFlatList"
 import OpaqueImageView from "./OpaqueImageView/OpaqueImageView"
 
 const SMALL_TILE_IMAGE_SIZE = 120
 
-const ArtworkCard = styled.TouchableHighlight.attrs({ underlayColor: color("white100"), activeOpacity: 0.8 })``
+export const ArtworkCard = styled.TouchableHighlight.attrs({ underlayColor: color("white100"), activeOpacity: 0.8 })``
 
 export const ArtworkTileRailContainer: React.FC<{
   artworksConnection: ArtworkTileRail_artworksConnection
@@ -24,7 +23,7 @@ export const ArtworkTileRailContainer: React.FC<{
 
   return (
     <View ref={navRef}>
-      <AboveTheFoldFlatList
+      <FlatList
         horizontal
         style={{ borderRadius: 2, overflow: "hidden" }}
         ItemSeparatorComponent={() => <Spacer width={15}></Spacer>}

--- a/src/lib/Components/ArtworkTileRail.tsx
+++ b/src/lib/Components/ArtworkTileRail.tsx
@@ -1,0 +1,81 @@
+import { Box, color, Flex, Sans, Spacer } from "@artsy/palette"
+import { ArtworkTileRail_artworksConnection } from "__generated__/ArtworkTileRail_artworksConnection.graphql"
+import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { tracks } from "lib/Scenes/ViewingRoom/Components/ViewingRoomArtworkRail"
+import React, { useRef } from "react"
+import { View } from "react-native"
+import { createFragmentContainer, graphql } from "react-relay"
+import { useTracking } from "react-tracking"
+import styled from "styled-components/native"
+import { AboveTheFoldFlatList } from "./AboveTheFoldFlatList"
+import OpaqueImageView from "./OpaqueImageView/OpaqueImageView"
+
+const SMALL_TILE_IMAGE_SIZE = 120
+
+const ArtworkCard = styled.TouchableHighlight.attrs({ underlayColor: color("white100"), activeOpacity: 0.8 })``
+
+export const ArtworkTileRailContainer: React.FC<{ artworksConnection: ArtworkTileRail_artworksConnection }> = ({
+  artworksConnection,
+}) => {
+  const artworks = artworksConnection.edges
+  const tracking = useTracking()
+  const navRef = useRef<any>()
+
+  return (
+    <View ref={navRef}>
+      <AboveTheFoldFlatList
+        horizontal
+        style={{ borderRadius: 2, overflow: "hidden" }}
+        ItemSeparatorComponent={() => <Spacer width={15}></Spacer>}
+        showsHorizontalScrollIndicator={false}
+        data={artworks}
+        initialNumToRender={5}
+        windowSize={3}
+        renderItem={({ item }) => (
+          <ArtworkCard
+            onPress={() => {
+              tracking.trackEvent(tracks.tappedArtworkGroupThumbnail(item!.node!.internalID, item!.node!.slug))
+              SwitchBoard.presentNavigationViewController(navRef.current!, item?.node?.href! /* STRICTNESS_MIGRATION */)
+            }}
+          >
+            <Flex>
+              <OpaqueImageView
+                imageURL={(item?.node?.image?.imageURL ?? "").replace(":version", "square")}
+                width={SMALL_TILE_IMAGE_SIZE}
+                height={SMALL_TILE_IMAGE_SIZE}
+              />
+              <Box mt={1} width={SMALL_TILE_IMAGE_SIZE}>
+                <Sans size="3t" weight="medium" numberOfLines={1}>
+                  {item?.node?.artistNames}
+                </Sans>
+                <Sans size="3t" color="black60" numberOfLines={1}>
+                  {item?.node?.saleMessage}
+                </Sans>
+              </Box>
+            </Flex>
+          </ArtworkCard>
+        )}
+        keyExtractor={(item, index) => String(item?.node?.image?.imageURL || index)}
+      />
+    </View>
+  )
+}
+
+export const ArtworkTileRail = createFragmentContainer(ArtworkTileRailContainer, {
+  artworksConnection: graphql`
+    fragment ArtworkTileRail_artworksConnection on ArtworkConnection {
+      edges {
+        node {
+          slug
+          internalID
+          href
+          artistNames
+          image {
+            imageURL
+          }
+          saleMessage
+        }
+      }
+    }
+  `,
+})

--- a/src/lib/Components/ArtworkTileRail.tsx
+++ b/src/lib/Components/ArtworkTileRail.tsx
@@ -1,7 +1,7 @@
 import { Box, color, Flex, Sans, Spacer } from "@artsy/palette"
 import { ArtworkTileRail_artworksConnection } from "__generated__/ArtworkTileRail_artworksConnection.graphql"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
-import { tracks } from "lib/Scenes/ViewingRoom/Components/ViewingRoomArtworkRail"
+import { Schema } from "lib/utils/track"
 import React, { useRef } from "react"
 import { View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -14,9 +14,10 @@ const SMALL_TILE_IMAGE_SIZE = 120
 
 const ArtworkCard = styled.TouchableHighlight.attrs({ underlayColor: color("white100"), activeOpacity: 0.8 })``
 
-export const ArtworkTileRailContainer: React.FC<{ artworksConnection: ArtworkTileRail_artworksConnection }> = ({
-  artworksConnection,
-}) => {
+export const ArtworkTileRailContainer: React.FC<{
+  artworksConnection: ArtworkTileRail_artworksConnection
+  contextModule: Schema.ContextModules
+}> = ({ artworksConnection, contextModule }) => {
   const artworks = artworksConnection.edges
   const tracking = useTracking()
   const navRef = useRef<any>()
@@ -34,7 +35,7 @@ export const ArtworkTileRailContainer: React.FC<{ artworksConnection: ArtworkTil
         renderItem={({ item }) => (
           <ArtworkCard
             onPress={() => {
-              tracking.trackEvent(tracks.tappedArtworkGroupThumbnail(item!.node!.internalID, item!.node!.slug))
+              tracking.trackEvent(tappedArtworkGroupThumbnail(contextModule, item!.node!.internalID, item!.node!.slug))
               SwitchBoard.presentNavigationViewController(navRef.current!, item?.node?.href! /* STRICTNESS_MIGRATION */)
             }}
           >
@@ -59,6 +60,18 @@ export const ArtworkTileRailContainer: React.FC<{ artworksConnection: ArtworkTil
       />
     </View>
   )
+}
+
+export const tappedArtworkGroupThumbnail = (contextModule: Schema.ContextModules, internalID: string, slug: string) => {
+  return {
+    action_name: Schema.ActionNames.TappedArtworkGroup,
+    context_module: contextModule,
+    destination_screen: Schema.PageNames.ArtworkPage,
+    destination_screen_owner_type: Schema.OwnerEntityTypes.Artwork,
+    destination_screen_owner_id: internalID,
+    destination_screen_owner_slug: slug,
+    type: "thumbnail",
+  }
 }
 
 export const ArtworkTileRail = createFragmentContainer(ArtworkTileRailContainer, {

--- a/src/lib/Components/__tests__/ArtworkTileRail-tests.tsx
+++ b/src/lib/Components/__tests__/ArtworkTileRail-tests.tsx
@@ -1,0 +1,89 @@
+import { Theme } from "@artsy/palette"
+import { ArtworkTileRailTestsQuery } from "__generated__/ArtworkTileRailTestsQuery.graphql"
+import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { Schema } from "lib/utils/track"
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import ReactTestRenderer from "react-test-renderer"
+import { useTracking } from "react-tracking"
+import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { ArtworkCard, ArtworkTileRail, tappedArtworkGroupThumbnail } from "../ArtworkTileRail"
+
+jest.unmock("react-relay")
+jest.mock("lib/NativeModules/SwitchBoard", () => ({
+  presentNavigationViewController: jest.fn(),
+}))
+
+describe("ArtworkTileRail", () => {
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+  const TestRenderer = () => (
+    <Theme>
+      <QueryRenderer<ArtworkTileRailTestsQuery>
+        environment={mockEnvironment}
+        query={graphql`
+          query ArtworkTileRailTestsQuery {
+            viewingRoom(id: "whatever") {
+              artworksConnection {
+                ...ArtworkTileRail_artworksConnection
+              }
+            }
+          }
+        `}
+        render={({ props, error }) => {
+          if (props?.viewingRoom) {
+            return (
+              <Theme>
+                <ArtworkTileRail
+                  artworksConnection={props.viewingRoom.artworksConnection! /* STRICTNESS_MIGRATION */}
+                  contextModule={Schema.ContextModules.ViewingRoomArtworkRail}
+                />
+              </Theme>
+            )
+          } else if (error) {
+            console.log(error)
+          }
+        }}
+        variables={{}}
+      />
+    </Theme>
+  )
+  beforeEach(() => {
+    mockEnvironment = createMockEnvironment()
+  })
+
+  it("navigates to an artwork + calls tracking when a card is tapped", () => {
+    const tree = ReactTestRenderer.create(<TestRenderer />)
+    mockEnvironment.mock.resolveMostRecentOperation(operation => {
+      const result = MockPayloadGenerator.generate(operation, {
+        ViewingRoom: () => ({
+          artworksConnection: {
+            edges: [
+              {
+                node: {
+                  href: "/artwork/nicolas-party-rocks-ii",
+                  internalID: "5deff4b96fz7e7000f36ce37",
+                  slug: "nicolas-party-rocks-ii",
+                },
+              },
+            ],
+          },
+        }),
+      })
+      return result
+    })
+
+    tree.root.findByType(ArtworkCard).props.onPress()
+
+    expect(SwitchBoard.presentNavigationViewController).toHaveBeenCalledWith(
+      expect.anything(),
+      "/artwork/nicolas-party-rocks-ii"
+    )
+    expect(useTracking().trackEvent).toHaveBeenCalledWith(
+      tappedArtworkGroupThumbnail(
+        Schema.ContextModules.ViewingRoomArtworkRail,
+        "5deff4b96fz7e7000f36ce37",
+        "nicolas-party-rocks-ii"
+      )
+    )
+  })
+})

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomArtworkRail.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomArtworkRail.tsx
@@ -31,7 +31,7 @@ export const ViewingRoomArtworkRail: React.FC<ViewingRoomArtworkRailProps> = pro
           }}
         />
         <ArtworkTileRail
-          artworksConnection={props.viewingRoom.artworks}
+          artworksConnection={props!.viewingRoom!.artworks!}
           contextModule={Schema.ContextModules.ViewingRoomArtworkRail}
         />
       </Flex>
@@ -60,18 +60,7 @@ export const ViewingRoomArtworkRailContainer = createFragmentContainer(ViewingRo
       internalID
       artworks: artworksConnection(first: 5) {
         totalCount
-        edges {
-          node {
-            slug
-            internalID
-            href
-            artistNames
-            image {
-              imageURL
-            }
-            saleMessage
-          }
-        }
+        ...ArtworkTileRail_artworksConnection
       }
     }
   `,

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomArtworkRail.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomArtworkRail.tsx
@@ -1,7 +1,6 @@
-import { Box, color, Flex, Sans, Spacer } from "@artsy/palette"
+import { Flex } from "@artsy/palette"
 import { ViewingRoomArtworkRail_viewingRoom } from "__generated__/ViewingRoomArtworkRail_viewingRoom.graphql"
-import { AboveTheFoldFlatList } from "lib/Components/AboveTheFoldFlatList"
-import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
+import { ArtworkTileRail } from "lib/Components/ArtworkTileRail"
 import { SectionTitle } from "lib/Components/SectionTitle"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { Schema } from "lib/utils/track"
@@ -9,22 +8,13 @@ import React, { useRef } from "react"
 import { View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
-import styled from "styled-components/native"
-
-const SMALL_TILE_IMAGE_SIZE = 120
 
 interface ViewingRoomArtworkRailProps {
   viewingRoom: ViewingRoomArtworkRail_viewingRoom
 }
 
-export const ArtworkCard = styled.TouchableHighlight.attrs({ underlayColor: color("white100"), activeOpacity: 0.8 })`
-  border-radius: 2px;
-  overflow: hidden;
-`
-
 export const ViewingRoomArtworkRail: React.FC<ViewingRoomArtworkRailProps> = props => {
   const viewingRoom = props.viewingRoom
-  const artworks = viewingRoom.artworks! /* STRICTNESS_MIGRATION */.edges! /* STRICTNESS_MIGRATION */
   const totalCount = viewingRoom.artworks! /* STRICTNESS_MIGRATION */.totalCount! /* STRICTNESS_MIGRATION */
   const tracking = useTracking()
   const navRef = useRef()
@@ -40,42 +30,7 @@ export const ViewingRoomArtworkRail: React.FC<ViewingRoomArtworkRailProps> = pro
             SwitchBoard.presentNavigationViewController(navRef.current!, `/viewing-room/${viewingRoom.slug}/artworks`)
           }}
         />
-        <AboveTheFoldFlatList
-          horizontal
-          ItemSeparatorComponent={() => <Spacer width={15}></Spacer>}
-          showsHorizontalScrollIndicator={false}
-          data={artworks}
-          initialNumToRender={5}
-          windowSize={3}
-          renderItem={({ item }) => (
-            <ArtworkCard
-              onPress={() => {
-                tracking.trackEvent(tracks.tappedArtworkGroupThumbnail(item!.node!.internalID, item!.node!.slug))
-                SwitchBoard.presentNavigationViewController(
-                  navRef.current!,
-                  item?.node?.href! /* STRICTNESS_MIGRATION */
-                )
-              }}
-            >
-              <Flex>
-                <OpaqueImageView
-                  imageURL={(item?.node?.image?.imageURL ?? "").replace(":version", "square")}
-                  width={SMALL_TILE_IMAGE_SIZE}
-                  height={SMALL_TILE_IMAGE_SIZE}
-                />
-                <Box mt={1} width={SMALL_TILE_IMAGE_SIZE}>
-                  <Sans size="3t" weight="medium" numberOfLines={1}>
-                    {item?.node?.artistNames}
-                  </Sans>
-                  <Sans size="3t" color="black60" numberOfLines={1}>
-                    {item?.node?.saleMessage}
-                  </Sans>
-                </Box>
-              </Flex>
-            </ArtworkCard>
-          )}
-          keyExtractor={(item, index) => String(item?.node?.image?.imageURL || index)}
-        />
+        <ArtworkTileRail artworksConnection={props.viewingRoom.artworks} />
       </Flex>
     </View>
   )

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomArtworkRail.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomArtworkRail.tsx
@@ -1,4 +1,4 @@
-import { Flex, Spacer } from "@artsy/palette"
+import { Box, color, Flex, Sans, Spacer } from "@artsy/palette"
 import { ViewingRoomArtworkRail_viewingRoom } from "__generated__/ViewingRoomArtworkRail_viewingRoom.graphql"
 import { AboveTheFoldFlatList } from "lib/Components/AboveTheFoldFlatList"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
@@ -11,14 +11,17 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
 
+const SMALL_TILE_IMAGE_SIZE = 120
+
 interface ViewingRoomArtworkRailProps {
   viewingRoom: ViewingRoomArtworkRail_viewingRoom
 }
 
-export const ArtworkCard = styled.TouchableHighlight`
+export const ArtworkCard = styled.TouchableHighlight.attrs({ underlayColor: color("white100"), activeOpacity: 0.8 })`
   border-radius: 2px;
   overflow: hidden;
 `
+
 export const ViewingRoomArtworkRail: React.FC<ViewingRoomArtworkRailProps> = props => {
   const viewingRoom = props.viewingRoom
   const artworks = viewingRoom.artworks! /* STRICTNESS_MIGRATION */.edges! /* STRICTNESS_MIGRATION */
@@ -39,8 +42,7 @@ export const ViewingRoomArtworkRail: React.FC<ViewingRoomArtworkRailProps> = pro
         />
         <AboveTheFoldFlatList
           horizontal
-          style={{ height: 100 }}
-          ItemSeparatorComponent={() => <Spacer mr={0.5}></Spacer>}
+          ItemSeparatorComponent={() => <Spacer width={15}></Spacer>}
           showsHorizontalScrollIndicator={false}
           data={artworks}
           initialNumToRender={5}
@@ -55,10 +57,24 @@ export const ViewingRoomArtworkRail: React.FC<ViewingRoomArtworkRailProps> = pro
                 )
               }}
             >
-              <OpaqueImageView imageURL={item?.node?.image?.url} width={100} height={100} />
+              <Flex>
+                <OpaqueImageView
+                  imageURL={(item?.node?.image?.imageURL ?? "").replace(":version", "square")}
+                  width={SMALL_TILE_IMAGE_SIZE}
+                  height={SMALL_TILE_IMAGE_SIZE}
+                />
+                <Box mt={1} width={SMALL_TILE_IMAGE_SIZE}>
+                  <Sans size="3t" weight="medium" numberOfLines={1}>
+                    {item?.node?.artistNames}
+                  </Sans>
+                  <Sans size="3t" color="black60" numberOfLines={1}>
+                    {item?.node?.saleMessage}
+                  </Sans>
+                </Box>
+              </Flex>
             </ArtworkCard>
           )}
-          keyExtractor={(item, index) => String(item?.node?.href ?? index)}
+          keyExtractor={(item, index) => String(item?.node?.image?.imageURL || index)}
         />
       </Flex>
     </View>
@@ -104,7 +120,7 @@ export const ViewingRoomArtworkRailContainer = createFragmentContainer(ViewingRo
             href
             artistNames
             image {
-              url(version: "square")
+              imageURL
             }
             saleMessage
           }

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomArtworkRail.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomArtworkRail.tsx
@@ -30,24 +30,16 @@ export const ViewingRoomArtworkRail: React.FC<ViewingRoomArtworkRailProps> = pro
             SwitchBoard.presentNavigationViewController(navRef.current!, `/viewing-room/${viewingRoom.slug}/artworks`)
           }}
         />
-        <ArtworkTileRail artworksConnection={props.viewingRoom.artworks} />
+        <ArtworkTileRail
+          artworksConnection={props.viewingRoom.artworks}
+          contextModule={Schema.ContextModules.ViewingRoomArtworkRail}
+        />
       </Flex>
     </View>
   )
 }
 
 export const tracks = {
-  tappedArtworkGroupThumbnail: (internalID: string, slug: string) => {
-    return {
-      action_name: Schema.ActionNames.TappedArtworkGroup,
-      context_module: Schema.ContextModules.ViewingRoomArtworkRail,
-      destination_screen: Schema.PageNames.ArtworkPage,
-      destination_screen_owner_type: Schema.OwnerEntityTypes.Artwork,
-      destination_screen_owner_id: internalID,
-      destination_screen_owner_slug: slug,
-      type: "thumbnail",
-    }
-  },
   tappedArtworkGroupHeader: (internalID: string, slug: string) => {
     return {
       action_name: Schema.ActionNames.TappedArtworkGroup,

--- a/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomArtworkRail-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomArtworkRail-tests.tsx
@@ -1,5 +1,6 @@
 import { Theme } from "@artsy/palette"
 import { ViewingRoomArtworkRailTestsQuery } from "__generated__/ViewingRoomArtworkRailTestsQuery.graphql"
+import { ArtworkTileRail } from "lib/Components/ArtworkTileRail"
 import { SectionTitle } from "lib/Components/SectionTitle"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { extractText } from "lib/tests/extractText"
@@ -9,7 +10,7 @@ import { graphql, QueryRenderer } from "react-relay"
 import ReactTestRenderer from "react-test-renderer"
 import { useTracking } from "react-tracking"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
-import { ArtworkCard, tracks, ViewingRoomArtworkRailContainer } from "../ViewingRoomArtworkRail"
+import { tracks, ViewingRoomArtworkRailContainer } from "../ViewingRoomArtworkRail"
 
 jest.unmock("react-relay")
 jest.mock("lib/NativeModules/SwitchBoard", () => ({
@@ -105,40 +106,8 @@ describe("ViewingRoomArtworkRail", () => {
       })
       return result
     })
-    expect(tree.root.findAllByType(ArtworkCard)).toHaveLength(2)
+    expect(tree.root.findAllByType(ArtworkTileRail)).toHaveLength(1)
     expect(extractText(tree.root)).toMatch(/Nicolas Party\$20,000/)
     expect(extractText(tree.root)).toMatch(/Nicolas Party\$25,000/)
-  })
-
-  it("navigates to an artwork + calls tracking when a card is tapped", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
-    mockEnvironment.mock.resolveMostRecentOperation(operation => {
-      const result = MockPayloadGenerator.generate(operation, {
-        ViewingRoom: () => ({
-          artworks: {
-            edges: [
-              {
-                node: {
-                  href: "/artwork/nicolas-party-rocks-ii",
-                  internalID: "5deff4b96fz7e7000f36ce37",
-                  slug: "nicolas-party-rocks-ii",
-                },
-              },
-            ],
-          },
-        }),
-      })
-      return result
-    })
-
-    tree.root.findByType(ArtworkCard).props.onPress()
-
-    expect(SwitchBoard.presentNavigationViewController).toHaveBeenCalledWith(
-      expect.anything(),
-      "/artwork/nicolas-party-rocks-ii"
-    )
-    expect(useTracking().trackEvent).toHaveBeenCalledWith(
-      tracks.tappedArtworkGroupThumbnail("5deff4b96fz7e7000f36ce37", "nicolas-party-rocks-ii")
-    )
   })
 })

--- a/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomArtworkRail-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomArtworkRail-tests.tsx
@@ -2,6 +2,7 @@ import { Theme } from "@artsy/palette"
 import { ViewingRoomArtworkRailTestsQuery } from "__generated__/ViewingRoomArtworkRailTestsQuery.graphql"
 import { SectionTitle } from "lib/Components/SectionTitle"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { extractText } from "lib/tests/extractText"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
@@ -45,7 +46,7 @@ describe("ViewingRoomArtworkRail", () => {
     expect(tree.root.findAllByType(SectionTitle)).toHaveLength(1)
   })
 
-  it("navigates to the artworks screen + calls tracking when tapped", () => {
+  it("navigates to the artworks screen + calls tracking when title is tapped", () => {
     const tree = ReactTestRenderer.create(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation => {
       const result = MockPayloadGenerator.generate(operation, {
@@ -71,11 +72,42 @@ describe("ViewingRoomArtworkRail", () => {
     const tree = ReactTestRenderer.create(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation => {
       const result = MockPayloadGenerator.generate(operation, {
-        ViewingRoom: () => ({ artworks: { edges: ["1", "2", "3"] } }),
+        ViewingRoom: () => ({
+          artworks: {
+            edges: [
+              {
+                node: {
+                  href: "/artwork/nicolas-party-rocks-ii",
+                  internalID: "5deff4b96fz7e7000f36ce37",
+                  slug: "nicolas-party-rocks-ii",
+                  artistNames: ["Nicolas Party"],
+                  image: {
+                    imageURL: "https://d32dm0rphc51dk.cloudfront.net/Tc9k2ROn55SxNHWjYxxnrg/:version.jpg",
+                  },
+                  saleMessage: "$20,000",
+                },
+              },
+              {
+                node: {
+                  internalID: "5d14c764d2f1db001243a81e",
+                  slug: "nicolas-party-still-life-no-011",
+                  artistNames: "Nicolas Party",
+                  href: "/artwork/nicolas-party-still-life-no-011",
+                  saleMessage: "$25,000",
+                  image: {
+                    imageURL: "https://d32dm0rphc51dk.cloudfront.net/Tc9k2ROn55SxNHWjYxxnrg/:version.jpg",
+                  },
+                },
+              },
+            ],
+          },
+        }),
       })
       return result
     })
-    expect(tree.root.findAllByType(ArtworkCard)).toHaveLength(3)
+    expect(tree.root.findAllByType(ArtworkCard)).toHaveLength(2)
+    expect(extractText(tree.root)).toMatch(/Nicolas Party\$20,000/)
+    expect(extractText(tree.root)).toMatch(/Nicolas Party\$25,000/)
   })
 
   it("navigates to an artwork + calls tracking when a card is tapped", () => {

--- a/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
@@ -149,7 +149,7 @@ export const ViewingRoomRenderer: React.SFC<{ viewingRoomID: string }> = () => {
       `}
       cacheConfig={{ force: true }}
       variables={{
-        viewingRoomID: "2955dc33-c205-44ea-93d2-514cd7ee2bcd",
+        viewingRoomID: "67397e64-cc49-4200-9367-f4899621c866",
       }}
       render={renderWithLoadProgress(ViewingRoomFragmentContainer)}
     />

--- a/src/lib/Scenes/ViewingRoom/ViewingRoomArtworks.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoomArtworks.tsx
@@ -192,7 +192,7 @@ export const ViewingRoomArtworksRenderer: React.SFC<{ viewingRoomID: string }> =
       `}
       cacheConfig={{ force: true }}
       variables={{
-        viewingRoomID: "2955dc33-c205-44ea-93d2-514cd7ee2bcd",
+        viewingRoomID: "67397e64-cc49-4200-9367-f4899621c866",
       }}
       render={renderWithLoadProgress(ViewingRoomArtworksContainer)}
     />


### PR DESCRIPTION
This PR adds artist name and price to the rail in viewing rooms. The code is mostly copy/pasted from `SmallTileRail`, with a few tweaks to make it work with this flatlist.

@ashfurrow I'd love your perspective on the copy/paste-ness of this since I believe it was you who worked on implementing the home rail version. My thinking is that I would ideally like every place we use the same rail to rely on the same component so we don't get out of sync. However, I feel like that gets tricky when the Relay fragments are slightly different for each one, unless we're comfortable passing a bunch of stuff as props.

One thought I had was around making the `ArtworkCard` an all-purpose component that could be reused by both rails as a step in that direction.

What do you think? 

![Screen Shot 2020-05-11 at 1 33 48 PM](https://user-images.githubusercontent.com/5361806/81592647-4628b980-938c-11ea-831a-fee172bef4ff.png)

#trivial