### PR TITLE
[dont-merge] Spike on routing/nav for sell tab

### DIFF
--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -26,6 +26,10 @@
 #import "AREigenCollectionComponentViewController.h"
 #import "AREigenMapContainerViewController.h"
 
+#import <Emission/AREditArtworkFormComponentViewController.h>
+#import <Emission/ARNewArtworkFormComponentViewController.h>
+#import <Emission/ARNewSubmissionFormComponentViewController.h>
+
 #import <Emission/ARShowConsignmentsFlowViewController.h>
 #import <Emission/ARFairComponentViewController.h>
 #import <Emission/ARFairBoothComponentViewController.h>
@@ -273,6 +277,30 @@ static ARSwitchBoard *sharedInstance = nil;
 
     [self.routes addRoute:@"/privacy-request" handler:JLRouteParams {
         return [[ARPrivacyRequestComponentViewController alloc] init];
+    }];
+
+    // this route opens a modal that allows the user to add a work to their collection
+    [self.routes addRoute:@"/collections/my-collection/artworks/new" handler:JLRouteParams {
+        UIViewController *controller = [[ARNewArtworkFormComponentViewController alloc] init];
+        return [[ARNavigationController alloc] initWithRootViewController:controller];
+    }];
+
+    // this route opens a modal that allows the user to edit the given work. there are buttons for this on the list page, but also the artwork detail page
+    [self.routes addRoute:@"/collections/my-collection/artworks/:id/edit" handler:JLRouteParams {
+        UIViewController *controller = [[AREditArtworkFormComponentViewController alloc] initWithArtworkID:parameters[@"id"]];
+        return [[ARNavigationController alloc] initWithRootViewController:controller];
+    }];
+
+    // this route opens a modal that allows the user to create an artwork and a submission for that artwork all in one go
+    [self.routes addRoute:@"/collections/my-collection/artworks/new/submissions/new" handler:JLRouteParams {
+        UIViewController *controller = [[ARNewSubmissionFormComponentViewController alloc] init];
+        return [[ARNavigationController alloc] initWithRootViewController:controller];
+    }];
+
+    // this route opens a modal that allows the user to create a submission from an existing artwork
+    [self.routes addRoute:@"/collections/my-collection/artworks/:id/submissions/new" handler:JLRouteParams {
+        UIViewController *controller = [[ARNewSubmissionFormComponentViewController alloc] initWithArtworkID:parameters[@"id"]];
+        return [[ARNavigationController alloc] initWithRootViewController:controller];
     }];
 
     [self.routes addRoute:@"/consign/submission" handler:JLRouteParams {

--- a/emission/Pod/Classes/ViewControllers/AREditArtworkFormComponentViewController.h
+++ b/emission/Pod/Classes/ViewControllers/AREditArtworkFormComponentViewController.h
@@ -1,0 +1,18 @@
+#import <Emission/ARComponentViewController.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AREditArtworkFormComponentViewController : ARComponentViewController
+
+- (instancetype)initWithArtworkID:(NSString *)artworkID;
+
+- (instancetype)initWithArtworkID:(NSString *)artworkID
+                             emission:(nullable AREmission *)emission NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithEmission:(nullable AREmission *)emission
+                      moduleName:(NSString *)moduleName
+               initialProperties:(nullable NSDictionary *)initialProperties NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/emission/Pod/Classes/ViewControllers/AREditArtworkFormComponentViewController.m
+++ b/emission/Pod/Classes/ViewControllers/AREditArtworkFormComponentViewController.m
@@ -1,0 +1,22 @@
+#import "AREditArtworkFormComponentViewController.h"
+#import "AREmission.h"
+
+@implementation AREditArtworkFormComponentViewController
+
+- (instancetype)initWithArtworkID:(NSString *)artworkID
+{
+    return [self initWithArtworkID:artworkID emission:[AREmission sharedInstance]];
+}
+
+- (instancetype)initWithArtworkID:(NSString *)artworkID emission:(nullable AREmission *)emission
+{
+    return [super initWithEmission:emission moduleName:@"EditArtworkForm" initialProperties:@{ @"artworkID": artworkID }];
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    self.view.backgroundColor = [UIColor whiteColor];
+}
+
+@end

--- a/emission/Pod/Classes/ViewControllers/ARNewArtworkFormComponentViewController.h
+++ b/emission/Pod/Classes/ViewControllers/ARNewArtworkFormComponentViewController.h
@@ -1,0 +1,15 @@
+#import <Emission/ARComponentViewController.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARNewArtworkFormComponentViewController : ARComponentViewController
+
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithEmission:(nullable AREmission *)emission
+                      moduleName:(NSString *)moduleName
+               initialProperties:(nullable NSDictionary *)initialProperties NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/emission/Pod/Classes/ViewControllers/ARNewArtworkFormComponentViewController.m
+++ b/emission/Pod/Classes/ViewControllers/ARNewArtworkFormComponentViewController.m
@@ -1,0 +1,16 @@
+#import "ARNewArtworkFormComponentViewController.h"
+
+@implementation ARNewArtworkFormComponentViewController
+
+- (instancetype)init
+{
+    return [super initWithEmission:nil moduleName:@"NewArtworkForm" initialProperties:nil];
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    self.view.backgroundColor = [UIColor whiteColor];
+}
+
+@end

--- a/emission/Pod/Classes/ViewControllers/ARNewSubmissionFormComponentViewController.h
+++ b/emission/Pod/Classes/ViewControllers/ARNewSubmissionFormComponentViewController.h
@@ -1,0 +1,20 @@
+#import <Emission/ARComponentViewController.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARNewSubmissionFormComponentViewController : ARComponentViewController
+
+- (instancetype)initWithArtworkID:(NSString *)artworkID;
+
+- (instancetype)initWithArtworkID:(NSString *)artworkID
+                             emission:(nullable AREmission *)emission;
+
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithEmission:(nullable AREmission *)emission
+                      moduleName:(NSString *)moduleName
+               initialProperties:(nullable NSDictionary *)initialProperties NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/emission/Pod/Classes/ViewControllers/ARNewSubmissionFormComponentViewController.m
+++ b/emission/Pod/Classes/ViewControllers/ARNewSubmissionFormComponentViewController.m
@@ -1,0 +1,27 @@
+#import "ARNewSubmissionFormComponentViewController.h"
+#import "AREmission.h"
+
+@implementation ARNewSubmissionFormComponentViewController
+
+- (instancetype)initWithArtworkID:(NSString *)artworkID
+{
+    return [self initWithArtworkID:artworkID emission:[AREmission sharedInstance]];
+}
+
+- (instancetype)initWithArtworkID:(NSString *)artworkID emission:(nullable AREmission *)emission
+{
+    return [super initWithEmission:emission moduleName:@"NewSubmissionForm" initialProperties:@{ @"artworkID": artworkID }];
+}
+
+- (instancetype)init
+{
+    return [super initWithEmission:nil moduleName:@"NewSubmissionForm" initialProperties:nil];
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    self.view.backgroundColor = [UIColor whiteColor];
+}
+
+@end

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -1,6 +1,9 @@
 import React from "react"
 import { AppRegistry, View, YellowBox } from "react-native"
 
+import { EditArtworkForm } from "./Scenes/MyCollection/EditArtworkForm"
+import { NewArtworkForm } from "./Scenes/MyCollection/NewArtworkForm"
+import { NewSubmissionForm } from "./Scenes/MyCollection/NewSubmissionForm"
 import { SafeAreaInsets } from "lib/types/SafeAreaInsets"
 import { ArtistQueryRenderer } from "./Containers/Artist"
 import { BidFlowRenderer } from "./Containers/BidFlow"
@@ -21,6 +24,7 @@ import { CitySectionListRenderer } from "./Scenes/City/CitySectionList"
 import { CollectionRenderer } from "./Scenes/Collection/Collection"
 import { CollectionFullFeaturedArtistListRenderer } from "./Scenes/Collection/Components/FullFeaturedArtistList"
 import Consignments from "./Scenes/Consignments"
+import { SellDashboard } from "./Scenes/SellDashboard"
 import {
   FairArtistsRenderer,
   FairArtworksRenderer,
@@ -249,7 +253,10 @@ const trackWrap = (ComponentToBeWrapped: React.ReactNode) => {
 AppRegistry.registerComponent("Auctions", trackWrap(SalesRenderer))
 AppRegistry.registerComponent("WorksForYou", trackWrap(WorksForYouRenderer))
 AppRegistry.registerComponent("Consignments", trackWrap(Consignments))
-AppRegistry.registerComponent("Sales", trackWrap(Consignments)) // Placeholder for sales tab!
+AppRegistry.registerComponent("Sales", trackWrap(SellDashboard))
+AppRegistry.registerComponent("EditArtworkForm", trackWrap(EditArtworkForm))
+AppRegistry.registerComponent("NewArtworkForm", trackWrap(NewArtworkForm))
+AppRegistry.registerComponent("NewSubmissionForm", trackWrap(NewSubmissionForm))
 AppRegistry.registerComponent("Artist", trackWrap(ArtistQueryRenderer))
 AppRegistry.registerComponent("Artwork", trackWrap(Artwork))
 AppRegistry.registerComponent("ArtworkAttributionClassFAQ", trackWrap(ArtworkAttributionClassFAQRenderer))

--- a/src/lib/Scenes/ArtworkForm/ArtistSection/index.tsx
+++ b/src/lib/Scenes/ArtworkForm/ArtistSection/index.tsx
@@ -1,0 +1,10 @@
+import React from "react"
+import { Box, Sans } from "@artsy/palette"
+
+export const ArtistSection: React.FC = () => {
+  return (
+    <Box>
+      <Sans size="2">ArtistSection</Sans>
+    </Box>
+  )
+}

--- a/src/lib/Scenes/ArtworkForm/MediumSection/index.tsx
+++ b/src/lib/Scenes/ArtworkForm/MediumSection/index.tsx
@@ -1,0 +1,10 @@
+import React from "react"
+import { Box, Sans } from "@artsy/palette"
+
+export const MediumSection: React.FC = () => {
+  return (
+    <Box>
+      <Sans size="2">MediumSection</Sans>
+    </Box>
+  )
+}

--- a/src/lib/Scenes/ArtworkForm/PhotosSection/index.tsx
+++ b/src/lib/Scenes/ArtworkForm/PhotosSection/index.tsx
@@ -1,0 +1,10 @@
+import React from "react"
+import { Box, Sans } from "@artsy/palette"
+
+export const PhotosSection: React.FC = () => {
+  return (
+    <Box>
+      <Sans size="2">PhotosSection</Sans>
+    </Box>
+  )
+}

--- a/src/lib/Scenes/ArtworkForm/Success/index.tsx
+++ b/src/lib/Scenes/ArtworkForm/Success/index.tsx
@@ -1,0 +1,10 @@
+import React from "react"
+import { Box, Sans } from "@artsy/palette"
+
+export const Success: React.FC = () => {
+  return (
+    <Box>
+      <Sans size="2">Success</Sans>
+    </Box>
+  )
+}

--- a/src/lib/Scenes/ArtworkForm/Summary/index.tsx
+++ b/src/lib/Scenes/ArtworkForm/Summary/index.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from "react"
+import { BorderBox, Button, Sans, Flex } from "@artsy/palette"
+import { PhotosSection } from "../PhotosSection"
+import { ArtistSection } from "../ArtistSection"
+import { MediumSection } from "../MediumSection"
+
+const photosRoute = {
+  component: PhotosSection,
+  title: "Add photos",
+}
+
+const artistRoute = {
+  component: ArtistSection,
+  title: "Artist",
+}
+
+const mediumRoute = {
+  component: MediumSection,
+  title: "Select Medium",
+}
+
+interface SummaryProps {
+  pushRoute: (route: any) => void
+}
+
+export const Summary: React.FC<SummaryProps> = props => {
+  const [photosDone, setPhotosDone] = useState(false)
+  const [artistDone, setArtistDone] = useState(false)
+  const [mediumDone, setMediumDone] = useState(false)
+
+  const handlePhotosPress = () => {
+    props.pushRoute(photosRoute)
+    setPhotosDone(true)
+  }
+
+  const handleArtistPress = () => {
+    props.pushRoute(artistRoute)
+    setArtistDone(true)
+  }
+
+  const handleMediumPress = () => {
+    props.pushRoute(mediumRoute)
+    setMediumDone(true)
+  }
+
+  return (
+    <>
+      <BorderBox height="200" my="4">
+        <Flex flexDirection="row" justifyContent="space-between">
+          <Button inline onPress={handlePhotosPress} variant="noOutline">
+            [camera icon]
+          </Button>
+          {photosDone && <Done />}
+        </Flex>
+      </BorderBox>
+      <BorderBox mb="4">
+        <Flex flexDirection="row" justifyContent="space-between">
+          <Button inline onPress={handleArtistPress} variant="noOutline">
+            Artist*
+          </Button>
+          {artistDone && <Done />}
+        </Flex>
+      </BorderBox>
+      <BorderBox mb="4">
+        <Flex flexDirection="row" justifyContent="space-between">
+          <Button inline onPress={handleMediumPress} variant="noOutline">
+            Medium*
+          </Button>
+          {mediumDone && <Done />}
+        </Flex>
+      </BorderBox>
+    </>
+  )
+}
+
+const Done: React.FC = () => {
+  return <Sans size="2">done!</Sans>
+}

--- a/src/lib/Scenes/ArtworkForm/index.tsx
+++ b/src/lib/Scenes/ArtworkForm/index.tsx
@@ -1,0 +1,30 @@
+import React from "react"
+import { Box, Button, Sans } from "@artsy/palette"
+import NavigatorIOS from "react-native-navigator-ios"
+import { Summary } from "./Summary"
+
+interface ArtworkFormProps {
+  closeForm: () => void
+  navigator: NavigatorIOS
+}
+
+export const ArtworkForm: React.FC<ArtworkFormProps> = props => {
+  const handleClosePress = () => {
+    props.closeForm()
+  }
+
+  const pushRoute = (route: any): void => {
+    props.navigator.push(route)
+  }
+
+  return (
+    <Box p="2" pt="50">
+      <Sans size="5">Add an artwork to your collection</Sans>
+      <Sans size="3">Add works to evaluate, when you're ready, consign.</Sans>
+      <Summary pushRoute={pushRoute} />
+      <Button block onPress={handleClosePress}>
+        Add
+      </Button>
+    </Box>
+  )
+}

--- a/src/lib/Scenes/MyCollection/EditArtworkForm/index.tsx
+++ b/src/lib/Scenes/MyCollection/EditArtworkForm/index.tsx
@@ -1,0 +1,31 @@
+import React from "react"
+import { Box, Button, Sans } from "@artsy/palette"
+import SwitchBoard from "../../../NativeModules/SwitchBoard"
+
+interface EditArtworkFormProps {
+  artworkID: string
+}
+
+export class EditArtworkForm extends React.Component<EditArtworkFormProps> {
+  render() {
+    const { artworkID } = this.props
+
+    const handleClosePress = () => {
+      SwitchBoard.dismissModalViewController(this)
+    }
+
+    return (
+      <Box p="2">
+        <Sans size="10">Edit Artwork</Sans>
+        <Sans size="10">{artworkID}</Sans>
+        <Sans size="2">blah</Sans>
+        <Sans size="2">blah</Sans>
+        <Sans size="2">blah</Sans>
+        <Sans size="2">blah</Sans>
+        <Button block onPress={handleClosePress}>
+          Close
+        </Button>
+      </Box>
+    )
+  }
+}

--- a/src/lib/Scenes/MyCollection/NewArtworkForm/index.tsx
+++ b/src/lib/Scenes/MyCollection/NewArtworkForm/index.tsx
@@ -1,0 +1,25 @@
+import React from "react"
+import NavigatorIOS from "react-native-navigator-ios"
+import { Theme } from "@artsy/palette"
+import SwitchBoard from "../../../NativeModules/SwitchBoard"
+import { ArtworkForm } from "../../ArtworkForm"
+
+export class NewArtworkForm extends React.Component {
+  render() {
+    const closeForm = () => {
+      SwitchBoard.dismissModalViewController(this)
+    }
+
+    const initialRoute = {
+      component: ArtworkForm,
+      passProps: { closeForm },
+      title: "Add a work",
+    }
+
+    return (
+      <Theme>
+        <NavigatorIOS initialRoute={initialRoute} style={{ flex: 1 }} />
+      </Theme>
+    )
+  }
+}

--- a/src/lib/Scenes/MyCollection/NewSubmissionForm/index.tsx
+++ b/src/lib/Scenes/MyCollection/NewSubmissionForm/index.tsx
@@ -1,0 +1,38 @@
+import React from "react"
+import { Box, Button, Sans } from "@artsy/palette"
+import SwitchBoard from "../../../NativeModules/SwitchBoard"
+
+interface NewSubmissionFormProps {
+  artworkID?: string
+}
+
+export class NewSubmissionForm extends React.Component<NewSubmissionFormProps> {
+  render() {
+    const { artworkID } = this.props
+
+    const handleClosePress = () => {
+      SwitchBoard.dismissModalViewController(this)
+    }
+
+    let headline: string
+
+    if (artworkID) {
+      headline = `New Submission for Artwork ${artworkID}`
+    } else {
+      headline = "New Consignment Submission"
+    }
+
+    return (
+      <Box p="2">
+        <Sans size="10">{headline}</Sans>
+        <Sans size="2">blah</Sans>
+        <Sans size="2">blah</Sans>
+        <Sans size="2">blah</Sans>
+        <Sans size="2">blah</Sans>
+        <Button block onPress={handleClosePress}>
+          Close
+        </Button>
+      </Box>
+    )
+  }
+}

--- a/src/lib/Scenes/SellDashboard/Screens/BlankSlate/index.tsx
+++ b/src/lib/Scenes/SellDashboard/Screens/BlankSlate/index.tsx
@@ -1,0 +1,24 @@
+import React from "react"
+import { Box, Button, Sans } from "@artsy/palette"
+
+interface BlankSlateProps {
+  routeTo: (route: string) => void
+}
+
+export const BlankSlate: React.FC<BlankSlateProps> = props => {
+  const route = "/consign/submission/new"
+  const handleStartPress = () => {
+    props.routeTo(route)
+  }
+
+  return (
+    <Box p="2">
+      <Sans py="5" size="10" textAlign="center">
+        Sell Art From Your Collection
+      </Sans>
+      <Button block onPress={handleStartPress}>
+        Start selling
+      </Button>
+    </Box>
+  )
+}

--- a/src/lib/Scenes/SellDashboard/Screens/Dashboard/index.tsx
+++ b/src/lib/Scenes/SellDashboard/Screens/Dashboard/index.tsx
@@ -1,0 +1,65 @@
+import React from "react"
+import { BorderBox, Box, Button, Flex, Sans } from "@artsy/palette"
+
+interface DashboardProps {
+  routeTo: (route: string) => void
+}
+
+export const Dashboard: React.FC<DashboardProps> = props => {
+  const handleAddPress = () => {
+    const route = "/collections/my-collection/artworks/new"
+    props.routeTo(route)
+  }
+
+  const handleSubmitPress = () => {
+    const route = "/collections/my-collection/artworks/new/submissions/new"
+    props.routeTo(route)
+  }
+
+  const handleEditPress = () => {
+    const id = "abc123"
+    const route = `/collections/my-collection/artworks/${id}/edit`
+    props.routeTo(route)
+  }
+
+  const handleConsignPress = () => {
+    const id = "def456"
+    const route = `/collections/my-collection/artworks/${id}/submissions/new`
+    props.routeTo(route)
+  }
+
+  return (
+    <Box p="2">
+      <Sans size="10" mb="3">
+        Evaluate & Sell
+      </Sans>
+      <Button block onPress={handleAddPress} mb="2">
+        Add a work
+      </Button>
+      <Button block onPress={handleSubmitPress} mb="2">
+        Submit a work
+      </Button>
+      <Sans size="6" mb="2" mt="3">
+        Works I Own
+      </Sans>
+      <BorderBox mb="2">
+        <Flex flexDirection="row" justifyContent="space-between">
+          <Box>
+            <Sans size="4">Title of work</Sans>
+            <Sans size="2">This work needs more details!</Sans>
+          </Box>
+          <Button onPress={handleEditPress}>Edit work</Button>
+        </Flex>
+      </BorderBox>
+      <BorderBox mb="2">
+        <Flex flexDirection="row" justifyContent="space-between">
+          <Box>
+            <Sans size="4">Title of another work</Sans>
+            <Sans size="2">This work is ready to consign!</Sans>
+          </Box>
+          <Button onPress={handleConsignPress}>Consign work</Button>
+        </Flex>
+      </BorderBox>
+    </Box>
+  )
+}

--- a/src/lib/Scenes/SellDashboard/index.tsx
+++ b/src/lib/Scenes/SellDashboard/index.tsx
@@ -1,0 +1,33 @@
+import React from "react"
+import { Theme } from "@artsy/palette"
+import NavigatorIOS from "react-native-navigator-ios"
+import { BlankSlate } from "./Screens/BlankSlate"
+import { Dashboard } from "./Screens/Dashboard"
+import SwitchBoard from "../../NativeModules/SwitchBoard"
+
+interface SellDashboardProps {}
+
+export class SellDashboard extends React.Component<SellDashboardProps, any> {
+  render() {
+    const routeTo = (route: string): void => {
+      SwitchBoard.presentModalViewController(this, route)
+    }
+
+    // ultimately i think this will check to see if the "my-collection"
+    // collection exists and if there are any artworks in it.
+    const showBlankSlate = false
+    if (showBlankSlate) return <BlankSlate routeTo={routeTo} />
+
+    const initialRoute = {
+      component: Dashboard,
+      passProps: { routeTo },
+      title: "Evaluate & Sell",
+    }
+
+    return (
+      <Theme>
+        <NavigatorIOS initialRoute={initialRoute} navigationBarHidden={true} style={{ flex: 1 }} />
+      </Theme>
+    )
+  }
+}


### PR DESCRIPTION
Hey pals, this is a spike PR that I intend to close without merging. My goal is to demonstrate the approach I'm pitching for routing and navigating for the new sell tab. I would then expect to refer back to this PR as a reference as we move through the actual implementation. Here's a little taste of what we've got going on in this PR:

<details>
<summary>recording of the flows</summary>

![Kapture 2020-05-12 at 10 01 49](https://user-images.githubusercontent.com/79799/81709671-a9235a80-9437-11ea-88a6-aa83c2583b75.gif)

</details>

The comps I'm working off of are here:

https://www.figma.com/file/yDSHlbJVzBxvSUROD2bfRI/Sell-tab-new-file?node-id=1%3A17

## Routes, modules and folder structure

An important concern for me is keeping myself organized with all the moving pieces here. Sure, I may change my mind as things evolve but it's best to think more widely about how one will structure a line of work so that's why I made this spreadsheet:

https://docs.google.com/spreadsheets/d/10lHDjCsZ1YN8NWiJhUhcAiGvjI7qkuFi7f8Vlb_HYKo/edit?usp=sharing

The idea was to write down the routes, view controllers, modules and then component file paths so that doing the paperwork of making all of these things is easier and more organized. If you take a look at that sheet you'll see that the routes are "RESTful" and I think that's handy for this line of work. Something we have to manage is how the artwork form will behave so now the call sites can convey this by picking which route they are linking to. 😎 

## Making a scene

One thing that might jump out at people while reviewing this PR is the number of scenes that are added. My logic is like this:

* src/lib/Scenes/SellDashboard - this is where we make the choice about whether to show you the blank slate view or the actual dashboard. I expect this to evolve over time and we may want to show things that are not directly related to one's "My Collection" collection, so I chose the "Sell Dashboard" name because it feels more accurate and more flexible.

* src/lib/Scenes/MyCollection - this folder houses the various top-level components that control how the artwork form will behave. I expect this folder to pick up more views too later, things like the list of works in one's "My Collection" collection, a detail view of a work, etc.

* src/lib/Scenes/ArtworkForm - this folder is where we put the building blocks of the artwork form flows. The contract between callers and the ArtworkForm will probably end up looking a little different than what's seen here, but establishing this contract is the point of this spike. Note too that while the sell tab is currently the only place using this form, I'm building it with partners in the back of my mind too. Seems like we could re-use a LOT of this if we build without assumptions about who the user is.

## Call for feedback

This PR won't be merged, but is intended to serve as a reference for the team as we work through the new sell tab so now is a great time for feedback! Any red flags for people? I'll leave it open for a bit to give people some time to comment and then close this sucker at a certain point.