### PR TITLE
Viewing rooms header updates [GALL-2845]

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0631FA6F1705E77F000A5ED3 /* mail.html in Resources */ = {isa = PBXBuildFile; fileRef = 0631FA6E1705E77F000A5ED3 /* mail.html */; };
+		07288BF4246D7F69001789D2 /* AREigenViewingRoomComponentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 07288BF3246D7F69001789D2 /* AREigenViewingRoomComponentViewController.m */; };
 		0C93322A1BA1FA6B00F3CE95 /* ARUserActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C9332291BA1FA6B00F3CE95 /* ARUserActivity.m */; };
 		0CAC95391BA9E1D0008E9848 /* ARUserActivityAndSpotlightTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CAC95371BA9E18B008E9848 /* ARUserActivityAndSpotlightTests.m */; };
 		0CD4E9B51BC43198005F0913 /* AREmbeddedModelPreviewViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CD4E9B31BC43160005F0913 /* AREmbeddedModelPreviewViewControllerTests.m */; };
@@ -724,6 +725,8 @@
 /* Begin PBXFileReference section */
 		0631FA6E1705E77F000A5ED3 /* mail.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = mail.html; sourceTree = "<group>"; };
 		06E44EB8170235D8001B2EBF /* MessageUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
+		07288BF2246D7F69001789D2 /* AREigenViewingRoomComponentViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AREigenViewingRoomComponentViewController.h; sourceTree = "<group>"; };
+		07288BF3246D7F69001789D2 /* AREigenViewingRoomComponentViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AREigenViewingRoomComponentViewController.m; sourceTree = "<group>"; };
 		0C9332281BA1FA6B00F3CE95 /* ARUserActivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARUserActivity.h; sourceTree = "<group>"; };
 		0C9332291BA1FA6B00F3CE95 /* ARUserActivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARUserActivity.m; sourceTree = "<group>"; };
 		0CAC95371BA9E18B008E9848 /* ARUserActivityAndSpotlightTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARUserActivityAndSpotlightTests.m; sourceTree = "<group>"; };
@@ -3343,6 +3346,8 @@
 				5E4386171D0764ED0034E671 /* SerifModalWebNavigationController.swift */,
 				CB27391823C9196C005D71DF /* AREigenCollectionComponentViewController.h */,
 				CB27391923C9196C005D71DF /* AREigenCollectionComponentViewController.m */,
+				07288BF2246D7F69001789D2 /* AREigenViewingRoomComponentViewController.h */,
+				07288BF3246D7F69001789D2 /* AREigenViewingRoomComponentViewController.m */,
 			);
 			name = "View Controllers";
 			path = View_Controllers;
@@ -4915,6 +4920,7 @@
 				342F9D9296B47F66184FA760 /* NSDate+DateRange.m in Sources */,
 				60CC97351EC3203D00793566 /* ARSentryAnalyticsProvider.m in Sources */,
 				5E47F35B1C4444A900EC0751 /* SaleViewModel.swift in Sources */,
+				07288BF4246D7F69001789D2 /* AREigenViewingRoomComponentViewController.m in Sources */,
 				60BC92F31BBEC89B00D13E56 /* ARApplicationShortcutItemDelegate.m in Sources */,
 				E61446B1195A1CDC00BFB7C3 /* ARFollowableNetworkModel.m in Sources */,
 				B63EC346244F49EE000C507E /* AuctionUserNetworkModel.swift in Sources */,

--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -25,6 +25,7 @@
 #import "AREigenInquiryComponentViewController.h"
 #import "AREigenCollectionComponentViewController.h"
 #import "AREigenMapContainerViewController.h"
+#import "AREigenViewingRoomComponentViewController.h"
 
 #import <Emission/ARShowConsignmentsFlowViewController.h>
 #import <Emission/ARFairComponentViewController.h>
@@ -32,7 +33,6 @@
 #import <Emission/ARFairArtworksComponentViewController.h>
 #import <Emission/ARFairArtistsComponentViewController.h>
 #import <Emission/ARFairExhibitorsComponentViewController.h>
-#import <Emission/ARViewingRoomComponentViewController.h>
 #import <Emission/ARViewingRoomArtworksComponentViewController.h>
 #import <Emission/ARFairComponentViewController.h>
 #import <Emission/ARShowArtworksComponentViewController.h>
@@ -238,7 +238,7 @@ static ARSwitchBoard *sharedInstance = nil;
     }];
 
     [self.routes addRoute:@"/viewing-room/:id" handler:JLRouteParams {
-        return [[ARViewingRoomComponentViewController alloc] initWithViewingRoomID:parameters[@"id"]];
+        return [[AREigenViewingRoomComponentViewController alloc] initWithViewingRoomID:parameters[@"id"]];
     }];
 
     [self.routes addRoute:@"/viewing-room/:id/artworks" handler:JLRouteParams {

--- a/Artsy/View_Controllers/AREigenViewingRoomComponentViewController.h
+++ b/Artsy/View_Controllers/AREigenViewingRoomComponentViewController.h
@@ -1,0 +1,10 @@
+#import "ARViewingRoomComponentViewController.h"
+#import "ARTopMenuViewController.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AREigenViewingRoomComponentViewController : ARViewingRoomComponentViewController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Artsy/View_Controllers/AREigenViewingRoomComponentViewController.m
+++ b/Artsy/View_Controllers/AREigenViewingRoomComponentViewController.m
@@ -1,0 +1,15 @@
+#import "AREigenViewingRoomComponentViewController.h"
+
+@interface AREigenViewingRoomComponentViewController () <ARMenuAwareViewController>
+
+@end
+
+@implementation AREigenViewingRoomComponentViewController
+
+- (BOOL)hidesStatusBarBackground
+{
+    return YES;
+}
+
+@end
+

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,7 +3,7 @@ upcoming:
   date: TBD
   dev:
     - Add tracking for homescreen modules - brian
-    - 
+    - Make viewing room header full-bleed and incorporate countdown and partner info - mdole
   user_facing:
     - Fix for bug with fair booth display when partner profile was empty
     - Adds Ways to Buy filter to Collections - ashley

--- a/emission/Pod/Classes/ViewControllers/ARViewingRoomComponentViewController.h
+++ b/emission/Pod/Classes/ViewControllers/ARViewingRoomComponentViewController.h
@@ -2,7 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface ARViewingRoomComponentViewController : ARComponentViewController
+@interface ARViewingRoomComponentViewController : ARComponentViewController <ARComponentFullBleedViewSizing>
 
 - (instancetype)initWithViewingRoomID:(NSString *)viewingRoomID;
 

--- a/emission/Pod/Classes/ViewControllers/ARViewingRoomComponentViewController.m
+++ b/emission/Pod/Classes/ViewControllers/ARViewingRoomComponentViewController.m
@@ -13,4 +13,8 @@
     return [super initWithEmission:emission moduleName:@"ViewingRoom" initialProperties:@{ @"viewingRoomID": viewingRoomID }];
 }
 
+- (BOOL)fullBleed {
+    return YES;
+}
+
 @end

--- a/src/__generated__/ViewingRoomHeaderTestsQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomHeaderTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash d19d7f7b79cb3a92b7cb581bc20e65ee */
+/* @relayHash a1dd6228b01467ac5a6ef77ab85184b7 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -29,6 +29,10 @@ fragment ViewingRoomHeader_viewingRoom on ViewingRoom {
   startAt
   endAt
   heroImageURL
+  partner {
+    name
+    id
+  }
 }
 */
 
@@ -108,6 +112,31 @@ return {
             "name": "heroImageURL",
             "args": null,
             "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "partner",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Partner",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "name",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "id",
+                "args": null,
+                "storageKey": null
+              }
+            ]
           }
         ]
       }
@@ -116,7 +145,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomHeaderTestsQuery",
-    "id": "26e6a9ed6ba1a2e1601b21127248a348",
+    "id": "299faec0ff2fee9948c0d3d180f68758",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomHeaderTestsQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomHeaderTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash a1dd6228b01467ac5a6ef77ab85184b7 */
+/* @relayHash f6b0af28e46c4907c43b9e40896ab740 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -31,6 +31,12 @@ fragment ViewingRoomHeader_viewingRoom on ViewingRoom {
   heroImageURL
   partner {
     name
+    profile {
+      icon {
+        url(version: "square")
+      }
+      id
+    }
     id
   }
 }
@@ -43,7 +49,14 @@ var v0 = [
     "name": "id",
     "value": "unused"
   }
-];
+],
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+};
 return {
   "kind": "Request",
   "fragment": {
@@ -130,12 +143,42 @@ return {
                 "storageKey": null
               },
               {
-                "kind": "ScalarField",
+                "kind": "LinkedField",
                 "alias": null,
-                "name": "id",
+                "name": "profile",
+                "storageKey": null,
                 "args": null,
-                "storageKey": null
-              }
+                "concreteType": "Profile",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "icon",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "url",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": "square"
+                          }
+                        ],
+                        "storageKey": "url(version:\"square\")"
+                      }
+                    ]
+                  },
+                  (v1/*: any*/)
+                ]
+              },
+              (v1/*: any*/)
             ]
           }
         ]
@@ -145,7 +188,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomHeaderTestsQuery",
-    "id": "299faec0ff2fee9948c0d3d180f68758",
+    "id": "af0f4dce9399836e2c6b89f36e9bb8f1",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomHeader_viewingRoom.graphql.ts
+++ b/src/__generated__/ViewingRoomHeader_viewingRoom.graphql.ts
@@ -8,6 +8,9 @@ export type ViewingRoomHeader_viewingRoom = {
     readonly startAt: unknown;
     readonly endAt: unknown;
     readonly heroImageURL: string;
+    readonly partner: {
+        readonly name: string | null;
+    } | null;
     readonly " $refType": "ViewingRoomHeader_viewingRoom";
 };
 export type ViewingRoomHeader_viewingRoom$data = ViewingRoomHeader_viewingRoom;
@@ -52,8 +55,26 @@ const node: ReaderFragment = {
       "name": "heroImageURL",
       "args": null,
       "storageKey": null
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "partner",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Partner",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "name",
+          "args": null,
+          "storageKey": null
+        }
+      ]
     }
   ]
 };
-(node as any).hash = '2db17e8a898636e302ba0523d4624eba';
+(node as any).hash = 'f17c86052a9db91c800d142e6f5bdcfd';
 export default node;

--- a/src/__generated__/ViewingRoomHeader_viewingRoom.graphql.ts
+++ b/src/__generated__/ViewingRoomHeader_viewingRoom.graphql.ts
@@ -10,6 +10,11 @@ export type ViewingRoomHeader_viewingRoom = {
     readonly heroImageURL: string;
     readonly partner: {
         readonly name: string | null;
+        readonly profile: {
+            readonly icon: {
+                readonly url: string | null;
+            } | null;
+        } | null;
     } | null;
     readonly " $refType": "ViewingRoomHeader_viewingRoom";
 };
@@ -71,10 +76,45 @@ const node: ReaderFragment = {
           "name": "name",
           "args": null,
           "storageKey": null
+        },
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "profile",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "Profile",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "icon",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "Image",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "url",
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "version",
+                      "value": "square"
+                    }
+                  ],
+                  "storageKey": "url(version:\"square\")"
+                }
+              ]
+            }
+          ]
         }
       ]
     }
   ]
 };
-(node as any).hash = 'f17c86052a9db91c800d142e6f5bdcfd';
+(node as any).hash = 'd2431770564e4b69e4101945751c4b07';
 export default node;

--- a/src/__generated__/ViewingRoomQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash e50395d66b2653b5c86e0b946810f45a */
+/* @relayHash ffb15b4ad9fdc21c7e4468c3367e7e35 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -89,6 +89,12 @@ fragment ViewingRoomHeader_viewingRoom on ViewingRoom {
   heroImageURL
   partner {
     name
+    profile {
+      icon {
+        url(version: "square")
+      }
+      id
+    }
     id
   }
 }
@@ -412,6 +418,42 @@ return {
                 "args": null,
                 "storageKey": null
               },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "profile",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Profile",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "icon",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "url",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": "square"
+                          }
+                        ],
+                        "storageKey": "url(version:\"square\")"
+                      }
+                    ]
+                  },
+                  (v12/*: any*/)
+                ]
+              },
               (v12/*: any*/)
             ]
           },
@@ -548,7 +590,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomQuery",
-    "id": "ec7d5deb1a016e985b3e803f61478701",
+    "id": "0a2490a0626f207bcbc129e49544554b",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 7dd4a997bad660c807d008ea8e912eaf */
+/* @relayHash e50395d66b2653b5c86e0b946810f45a */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -87,6 +87,10 @@ fragment ViewingRoomHeader_viewingRoom on ViewingRoom {
   startAt
   endAt
   heroImageURL
+  partner {
+    name
+    id
+  }
 }
 
 fragment ViewingRoomSubsections_viewingRoom on ViewingRoom {
@@ -395,6 +399,25 @@ return {
           {
             "kind": "LinkedField",
             "alias": null,
+            "name": "partner",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Partner",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "name",
+                "args": null,
+                "storageKey": null
+              },
+              (v12/*: any*/)
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
             "name": "artworksConnection",
             "storageKey": "artworksConnection(after:\"\",first:5)",
             "args": (v13/*: any*/),
@@ -525,7 +548,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomQuery",
-    "id": "30d750389ce5c71bd6fc503b9ae727da",
+    "id": "ec7d5deb1a016e985b3e803f61478701",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomTestsQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 801fb9664258328a912d87dd9d7e1649 */
+/* @relayHash 7048b0f6f27725f5b848da42683f0a53 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -83,6 +83,10 @@ fragment ViewingRoomHeader_viewingRoom on ViewingRoom {
   startAt
   endAt
   heroImageURL
+  partner {
+    name
+    id
+  }
 }
 
 fragment ViewingRoomSubsections_viewingRoom on ViewingRoom {
@@ -383,6 +387,25 @@ return {
           {
             "kind": "LinkedField",
             "alias": null,
+            "name": "partner",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Partner",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "name",
+                "args": null,
+                "storageKey": null
+              },
+              (v11/*: any*/)
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
             "name": "artworksConnection",
             "storageKey": "artworksConnection(after:\"\",first:5)",
             "args": (v12/*: any*/),
@@ -513,7 +536,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomTestsQuery",
-    "id": "edb1a3a8c80c6aac7a5d7dfa993bc7a0",
+    "id": "cd1790d1b767e640dbbd5f7b11dd891b",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomTestsQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 7048b0f6f27725f5b848da42683f0a53 */
+/* @relayHash 6660f547c2a463d308460f6a3aa241b3 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -85,6 +85,12 @@ fragment ViewingRoomHeader_viewingRoom on ViewingRoom {
   heroImageURL
   partner {
     name
+    profile {
+      icon {
+        url(version: "square")
+      }
+      id
+    }
     id
   }
 }
@@ -400,6 +406,42 @@ return {
                 "args": null,
                 "storageKey": null
               },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "profile",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Profile",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "icon",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "url",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": "square"
+                          }
+                        ],
+                        "storageKey": "url(version:\"square\")"
+                      }
+                    ]
+                  },
+                  (v11/*: any*/)
+                ]
+              },
               (v11/*: any*/)
             ]
           },
@@ -536,7 +578,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomTestsQuery",
-    "id": "cd1790d1b767e640dbbd5f7b11dd891b",
+    "id": "8ab48619227f6459f1721f957a59db84",
     "text": null,
     "metadata": {}
   }

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
@@ -46,7 +46,7 @@ const CountdownText: React.SFC<CountdownProps> = ({ duration }) => (
   <SimpleTicker duration={duration} separator="  " size="2" weight="medium" color="white100" />
 )
 
-const PartnerIconImage = styled.Image`
+export const PartnerIconImage = styled.Image`
   border-radius: 100;
 `
 
@@ -76,10 +76,13 @@ export const ViewingRoomHeader: React.FC<ViewingRoomHeaderProps> = props => {
         <PartnerContainer>
           {partnerIconImageURL && (
             <Box mr={0.5}>
-              <PartnerIconImage source={{ uri: partnerIconImageURL, width: 20, height: 20 }} />
+              <PartnerIconImage
+                source={{ uri: partnerIconImageURL, width: 20, height: 20 }}
+                data-test-id="partner-icon"
+              />
             </Box>
           )}
-          <Sans data-test-id="partner-name" size="2" weight="medium" numberOfLines={1} color="white100">
+          <Sans size="2" weight="medium" numberOfLines={1} color="white100" data-test-id="partner-name">
             {partner!.name}
           </Sans>
         </PartnerContainer>

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
@@ -20,9 +20,16 @@ export const BackgroundImage = styled(OpaqueImageView)<{ height: number; width: 
 
 const CountdownContainer = styled.View`
   position: absolute;
-  bottom: ${space(1)};
-  right: 0;
-  width: 50%;
+  bottom: ${space(2)};
+  right: ${space(2)};
+  width: 45%;
+`
+
+const PartnerContainer = styled.View`
+  position: absolute;
+  bottom: ${space(2)};
+  left: ${space(2)};
+  width: 45%;
 `
 
 const Overlay = styled.View`
@@ -58,6 +65,11 @@ export const ViewingRoomHeader: React.FC<ViewingRoomHeaderProps> = props => {
             </Sans>
           </Flex>
         </Flex>
+        <PartnerContainer>
+          <Sans data-test-id="partner-name" size="2" weight="medium" numberOfLines={1} color="white100">
+            {props.viewingRoom.partner.name}
+          </Sans>
+        </PartnerContainer>
         <CountdownContainer>
           <Flex alignItems="flex-end">
             <CountdownTimer startAt={startAt as string} endAt={endAt as string} countdownComponent={CountdownText} />
@@ -75,6 +87,9 @@ export const ViewingRoomHeaderContainer = createFragmentContainer(ViewingRoomHea
       startAt
       endAt
       heroImageURL
+      partner {
+        name
+      }
     }
   `,
 })

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
@@ -25,11 +25,14 @@ const CountdownContainer = styled.View`
   width: 45%;
 `
 
-const PartnerContainer = styled.View`
+const PartnerContainer = styled(Flex)`
   position: absolute;
   bottom: ${space(2)};
   left: ${space(2)};
   width: 45%;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
 `
 
 const Overlay = styled.View`
@@ -43,8 +46,13 @@ const CountdownText: React.SFC<CountdownProps> = ({ duration }) => (
   <SimpleTicker duration={duration} separator="  " size="2" weight="medium" color="white100" />
 )
 
+const PartnerIconImage = styled.Image`
+  border-radius: 100;
+`
+
 export const ViewingRoomHeader: React.FC<ViewingRoomHeaderProps> = props => {
-  const { heroImageURL, title, startAt, endAt } = props.viewingRoom
+  const { heroImageURL, title, partner, startAt, endAt } = props.viewingRoom
+  const partnerIconImageURL = partner?.profile?.icon?.url
   const { width: screenWidth } = Dimensions.get("window")
   const imageHeight = 547
 
@@ -66,8 +74,13 @@ export const ViewingRoomHeader: React.FC<ViewingRoomHeaderProps> = props => {
           </Flex>
         </Flex>
         <PartnerContainer>
+          {partnerIconImageURL && (
+            <Box mr={0.5}>
+              <PartnerIconImage source={{ uri: partnerIconImageURL, width: 20, height: 20 }} />
+            </Box>
+          )}
           <Sans data-test-id="partner-name" size="2" weight="medium" numberOfLines={1} color="white100">
-            {props.viewingRoom.partner.name}
+            {partner!.name}
           </Sans>
         </PartnerContainer>
         <CountdownContainer>
@@ -89,6 +102,11 @@ export const ViewingRoomHeaderContainer = createFragmentContainer(ViewingRoomHea
       heroImageURL
       partner {
         name
+        profile {
+          icon {
+            url(version: "square")
+          }
+        }
       }
     }
   `,

--- a/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomHeader-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomHeader-tests.tsx
@@ -76,14 +76,14 @@ describe("ViewingRoomHeader", () => {
       const result = MockPayloadGenerator.generate(operation, {
         ViewingRoom: () => ({
           partner: {
-            profile: { icon: { url: "https://d32dm0rphc51dk.cloudfront.net/tCz27C7EXasbRkeGJMyq2Q/square.jpg" } },
+            profile: { icon: { url: "https://example.com/image.jpg" } },
           },
         }),
       })
       return result
     })
     expect(tree.root.findByProps({ "data-test-id": "partner-icon" }).props.source.uri).toBe(
-      "https://d32dm0rphc51dk.cloudfront.net/tCz27C7EXasbRkeGJMyq2Q/square.jpg"
+      "https://example.com/image.jpg"
     )
   })
   it("doesn't render logo (and doesn't crash) if partner profile is null", () => {

--- a/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomHeader-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomHeader-tests.tsx
@@ -7,7 +7,7 @@ import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import ReactTestRenderer from "react-test-renderer"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
-import { ViewingRoomHeaderContainer } from "../ViewingRoomHeader"
+import { PartnerIconImage, ViewingRoomHeaderContainer } from "../ViewingRoomHeader"
 
 jest.unmock("react-relay")
 
@@ -59,5 +59,45 @@ describe("ViewingRoomHeader", () => {
       return result
     })
     expect(tree.root.findAllByType(CountdownTimer)).toHaveLength(1)
+  })
+  it("renders partner name", () => {
+    const tree = ReactTestRenderer.create(<TestRenderer />)
+    mockEnvironment.mock.resolveMostRecentOperation(operation => {
+      const result = MockPayloadGenerator.generate(operation, {
+        ViewingRoom: () => ({ partner: { name: "Foo" } }),
+      })
+      return result
+    })
+    expect(extractText(tree.root.findByProps({ "data-test-id": "partner-name" }))).toBe("Foo")
+  })
+  it("renders partner logo", () => {
+    const tree = ReactTestRenderer.create(<TestRenderer />)
+    mockEnvironment.mock.resolveMostRecentOperation(operation => {
+      const result = MockPayloadGenerator.generate(operation, {
+        ViewingRoom: () => ({
+          partner: {
+            profile: { icon: { url: "https://d32dm0rphc51dk.cloudfront.net/tCz27C7EXasbRkeGJMyq2Q/square.jpg" } },
+          },
+        }),
+      })
+      return result
+    })
+    expect(tree.root.findByProps({ "data-test-id": "partner-icon" }).props.source.uri).toBe(
+      "https://d32dm0rphc51dk.cloudfront.net/tCz27C7EXasbRkeGJMyq2Q/square.jpg"
+    )
+  })
+  it("doesn't render logo (and doesn't crash) if partner profile is null", () => {
+    const tree = ReactTestRenderer.create(<TestRenderer />)
+    mockEnvironment.mock.resolveMostRecentOperation(operation => {
+      const result = MockPayloadGenerator.generate(operation, {
+        ViewingRoom: () => ({
+          partner: {
+            profile: null,
+          },
+        }),
+      })
+      return result
+    })
+    expect(tree.root.findAllByType(PartnerIconImage)).toHaveLength(0)
   })
 })


### PR DESCRIPTION
This PR adds the partner name and logo to the VR header and makes the header full bleed, AKA it extends into the "horns" that iPhone X and later have.

<img width="586" alt="Screen Shot 2020-05-14 at 10 17 40 AM" src="https://user-images.githubusercontent.com/5361806/81945952-c2114480-95cc-11ea-980c-37767b561482.png">

[Jira ticket](https://artsyproduct.atlassian.net/browse/GALL-2845)