### PR TITLE
Wire up existing form to new landing

### DIFF
--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -26,6 +26,7 @@
 #import "AREigenCollectionComponentViewController.h"
 #import "AREigenMapContainerViewController.h"
 
+#import <Emission/ARNewSubmissionFormComponentViewController.h>
 #import <Emission/ARShowConsignmentsFlowViewController.h>
 #import <Emission/ARFairComponentViewController.h>
 #import <Emission/ARFairBoothComponentViewController.h>
@@ -273,6 +274,11 @@ static ARSwitchBoard *sharedInstance = nil;
 
     [self.routes addRoute:@"/privacy-request" handler:JLRouteParams {
         return [[ARPrivacyRequestComponentViewController alloc] init];
+    }];
+
+    [self.routes addRoute:@"/collections/my-collection/artworks/new/submissions/new" handler:JLRouteParams {
+        UIViewController *controller = [[ARNewSubmissionFormComponentViewController alloc] init];
+        return [[ARNavigationController alloc] initWithRootViewController:controller];
     }];
 
     [self.routes addRoute:@"/consign/submission" handler:JLRouteParams {

--- a/emission/Pod/Classes/ViewControllers/ARNewSubmissionFormComponentViewController.h
+++ b/emission/Pod/Classes/ViewControllers/ARNewSubmissionFormComponentViewController.h
@@ -1,0 +1,15 @@
+#import <Emission/ARComponentViewController.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARNewSubmissionFormComponentViewController : ARComponentViewController
+
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithEmission:(nullable AREmission *)emission
+                      moduleName:(NSString *)moduleName
+               initialProperties:(nullable NSDictionary *)initialProperties NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/emission/Pod/Classes/ViewControllers/ARNewSubmissionFormComponentViewController.m
+++ b/emission/Pod/Classes/ViewControllers/ARNewSubmissionFormComponentViewController.m
@@ -1,0 +1,17 @@
+#import "ARNewSubmissionFormComponentViewController.h"
+#import "AREmission.h"
+
+@implementation ARNewSubmissionFormComponentViewController
+
+- (instancetype)init
+{
+    return [super initWithEmission:nil moduleName:@"NewSubmissionForm" initialProperties:nil];
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    self.view.backgroundColor = [UIColor whiteColor];
+}
+
+@end

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -33,6 +33,7 @@ import { FairRenderer } from "./Scenes/Fair/Fair"
 import FavoritesScene from "./Scenes/Favorites"
 import { HomeRenderer } from "./Scenes/Home/Home"
 import { MapContainer } from "./Scenes/Map"
+import { NewSubmissionForm } from "./Scenes/MyCollection/NewSubmissionForm"
 import { PartnerRenderer } from "./Scenes/Partner"
 import { PartnerLocationsRenderer } from "./Scenes/Partner/Screens/PartnerLocations"
 import { PrivacyRequest } from "./Scenes/PrivacyRequest"
@@ -248,6 +249,7 @@ const trackWrap = (ComponentToBeWrapped: React.ReactNode) => {
 
 AppRegistry.registerComponent("Auctions", trackWrap(SalesRenderer))
 AppRegistry.registerComponent("WorksForYou", trackWrap(WorksForYouRenderer))
+AppRegistry.registerComponent("NewSubmissionForm", trackWrap(NewSubmissionForm))
 AppRegistry.registerComponent("Consignments", trackWrap(Consignments))
 AppRegistry.registerComponent("Sales", trackWrap(Consignments)) // Placeholder for sales tab!
 AppRegistry.registerComponent("Artist", trackWrap(ArtistQueryRenderer))

--- a/src/lib/Scenes/Consignments/index.tsx
+++ b/src/lib/Scenes/Consignments/index.tsx
@@ -1,10 +1,9 @@
-import React from "react"
-import Welcome from "./Screens/Welcome"
-
 import { Theme } from "@artsy/palette"
 import { ConsignmentSubmissionCategoryAggregation } from "__generated__/createConsignmentSubmissionMutation.graphql"
+import React from "react"
 import { NativeModules, ViewProperties } from "react-native"
 import NavigatorIOS from "react-native-navigator-ios"
+import Welcome from "./Screens/Welcome"
 import { ConsignmentsHomeQueryRenderer as ConsignmentsHome } from "./v2/Screens/ConsignmentsHome"
 
 /** The metadata for a consigned work */

--- a/src/lib/Scenes/Consignments/index.tsx
+++ b/src/lib/Scenes/Consignments/index.tsx
@@ -69,17 +69,14 @@ export default class Consignments extends React.Component<Props, any> {
   render() {
     const featureFlag = NativeModules?.Emission?.options?.AROptionsMoveCityGuideEnableSales
     const ConsignmentsEntrypoint = featureFlag ? ConsignmentsHome : Welcome
+    const initialRoute = {
+      component: ConsignmentsEntrypoint,
+      title: "Welcome",
+    }
 
     return (
       <Theme>
-        <NavigatorIOS
-          navigationBarHidden={true}
-          initialRoute={{
-            component: ConsignmentsEntrypoint,
-            title: "Welcome",
-          }}
-          style={{ flex: 1 }}
-        />
+        <NavigatorIOS initialRoute={initialRoute} navigationBarHidden={true} style={{ flex: 1 }} />
       </Theme>
     )
   }

--- a/src/lib/Scenes/Consignments/index.tsx
+++ b/src/lib/Scenes/Consignments/index.tsx
@@ -67,9 +67,8 @@ interface Props extends ViewProperties, ConsignmentSetup {}
 
 export default class Consignments extends React.Component<Props, any> {
   render() {
-    const ConsignmentsEntrypoint = NativeModules?.Emission?.options?.AROptionsMoveCityGuideEnableSales
-      ? ConsignmentsHome
-      : Welcome
+    const featureFlag = NativeModules?.Emission?.options?.AROptionsMoveCityGuideEnableSales
+    const ConsignmentsEntrypoint = featureFlag ? ConsignmentsHome : Welcome
 
     return (
       <Theme>

--- a/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/index.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/index.tsx
@@ -3,10 +3,11 @@ import { ConsignmentsHome_artists } from "__generated__/ConsignmentsHome_artists
 import { ConsignmentsHomeQuery } from "__generated__/ConsignmentsHomeQuery.graphql"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
-import React from "react"
+import React, { useRef } from "react"
 import { ScrollView } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import styled from "styled-components/native"
+import SwitchBoard from "../../../../../NativeModules/SwitchBoard"
 import { ArtistListFragmentContainer as ArtistList, FOCUSED_20_ARTIST_IDS } from "./ArtistList"
 
 // TODO:
@@ -16,10 +17,19 @@ interface Props {
   artists: ConsignmentsHome_artists
 }
 
-export const ConsignmentsHome: React.FC<Props> = ({ artists }) => {
+export const ConsignmentsHome: React.FC<Props> = props => {
+  const navRef = useRef<ScrollView>(null)
+  const { artists } = props
+  const handlePress = () => {
+    if (navRef.current) {
+      const route = "/collections/my-collection/artworks/new/submissions/new"
+      SwitchBoard.presentModalViewController(navRef.current, route)
+    }
+  }
+
   return (
-    <ScrollView>
-      <Box px={2} pt={6}>
+    <ScrollView ref={navRef}>
+      <Box px={2} py={6}>
         <Box>
           <Sans size="8" textAlign="center" px={2}>
             Sell Art From Your Collection
@@ -34,7 +44,7 @@ export const ConsignmentsHome: React.FC<Props> = ({ artists }) => {
 
         <Spacer mb={2} />
 
-        <Button variant="primaryBlack" block>
+        <Button variant="primaryBlack" block onPress={handlePress}>
           <Sans size="3" weight="medium">
             Start selling
           </Sans>
@@ -196,7 +206,7 @@ export const ConsignmentsHome: React.FC<Props> = ({ artists }) => {
 
         <Spacer mb={3} />
 
-        <Button variant="primaryBlack" block>
+        <Button variant="primaryBlack" block onPress={handlePress}>
           <Sans size="3">Start selling</Sans>
         </Button>
       </Box>

--- a/src/lib/Scenes/MyCollection/NewSubmissionForm/NewSubmissionForm.tsx
+++ b/src/lib/Scenes/MyCollection/NewSubmissionForm/NewSubmissionForm.tsx
@@ -1,0 +1,14 @@
+import { Theme } from "@artsy/palette"
+import React from "react"
+import NavigatorIOS from "react-native-navigator-ios"
+import Overview from "./../../Consignments/Screens/Overview"
+
+export const NewSubmissionForm = () => {
+  const initialRoute = { component: Overview }
+
+  return (
+    <Theme>
+      <NavigatorIOS initialRoute={initialRoute} navigationBarHidden={true} style={{ flex: 1 }} />
+    </Theme>
+  )
+}

--- a/src/lib/Scenes/MyCollection/NewSubmissionForm/index.tsx
+++ b/src/lib/Scenes/MyCollection/NewSubmissionForm/index.tsx
@@ -1,0 +1,1 @@
+export * from "./NewSubmissionForm"


### PR DESCRIPTION
This PR wires up the existing consign flow to the new landing page. I think it's compatible with what you're working on @pepopowitz but lmk if things have diverged enough that we need to look at this again!

Update: turned out that it was not compatible but we figured it out - see the use of `useRef` and `SwitchBoard.presentModalViewController`. 👍 

#skip_new_tests