### PR TITLE
Extract ArtworkTileRailCard for reuse with other shapes of data

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
   dev:
     - Add tracking for homescreen modules - brian
     - Make viewing room header full-bleed and incorporate countdown and partner info - mdole
+    - Extract common artwork tile independent of the shape of the data source - pepopowitz
   user_facing:
     - Fix for bug with fair booth display when partner profile was empty
     - Adds Ways to Buy filter to Collections - ashley

--- a/src/lib/Components/ArtworkTileRail/ArtworkTileRail-tests.tsx
+++ b/src/lib/Components/ArtworkTileRail/ArtworkTileRail-tests.tsx
@@ -7,7 +7,8 @@ import { graphql, QueryRenderer } from "react-relay"
 import ReactTestRenderer from "react-test-renderer"
 import { useTracking } from "react-tracking"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
-import { ArtworkCard, ArtworkTileRail, tappedArtworkGroupThumbnail } from "../ArtworkTileRail"
+import { ArtworkTileRail, tappedArtworkGroupThumbnail } from "./ArtworkTileRail"
+import { ArtworkTileRailCard } from "./ArtworkTileRailCard"
 
 jest.unmock("react-relay")
 jest.mock("lib/NativeModules/SwitchBoard", () => ({
@@ -72,7 +73,7 @@ describe("ArtworkTileRail", () => {
       return result
     })
 
-    tree.root.findByType(ArtworkCard).props.onPress()
+    tree.root.findByType(ArtworkTileRailCard).props.onPress()
 
     expect(SwitchBoard.presentNavigationViewController).toHaveBeenCalledWith(
       expect.anything(),

--- a/src/lib/Components/ArtworkTileRail/ArtworkTileRail.tsx
+++ b/src/lib/Components/ArtworkTileRail/ArtworkTileRail.tsx
@@ -1,4 +1,4 @@
-import { Box, color, Flex, Sans, Spacer } from "@artsy/palette"
+import { Spacer } from "@artsy/palette"
 import { ArtworkTileRail_artworksConnection } from "__generated__/ArtworkTileRail_artworksConnection.graphql"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { Schema } from "lib/utils/track"
@@ -6,12 +6,7 @@ import React, { useRef } from "react"
 import { FlatList, View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
-import styled from "styled-components/native"
-import OpaqueImageView from "./OpaqueImageView/OpaqueImageView"
-
-const SMALL_TILE_IMAGE_SIZE = 120
-
-export const ArtworkCard = styled.TouchableHighlight.attrs({ underlayColor: color("white100"), activeOpacity: 0.8 })``
+import { ArtworkTileRailCard } from "./ArtworkTileRailCard"
 
 export const ArtworkTileRailContainer: React.FC<{
   artworksConnection: ArtworkTileRail_artworksConnection
@@ -25,35 +20,21 @@ export const ArtworkTileRailContainer: React.FC<{
     <View ref={navRef}>
       <FlatList
         horizontal
-        style={{ borderRadius: 2, overflow: "hidden" }}
         ItemSeparatorComponent={() => <Spacer width={15}></Spacer>}
         showsHorizontalScrollIndicator={false}
         data={artworks}
         initialNumToRender={5}
         windowSize={3}
         renderItem={({ item }) => (
-          <ArtworkCard
+          <ArtworkTileRailCard
             onPress={() => {
               tracking.trackEvent(tappedArtworkGroupThumbnail(contextModule, item!.node!.internalID, item!.node!.slug))
               SwitchBoard.presentNavigationViewController(navRef.current!, item?.node?.href! /* STRICTNESS_MIGRATION */)
             }}
-          >
-            <Flex>
-              <OpaqueImageView
-                imageURL={(item?.node?.image?.imageURL ?? "").replace(":version", "square")}
-                width={SMALL_TILE_IMAGE_SIZE}
-                height={SMALL_TILE_IMAGE_SIZE}
-              />
-              <Box mt={1} width={SMALL_TILE_IMAGE_SIZE}>
-                <Sans size="3t" weight="medium" numberOfLines={1}>
-                  {item?.node?.artistNames}
-                </Sans>
-                <Sans size="3t" color="black60" numberOfLines={1}>
-                  {item?.node?.saleMessage}
-                </Sans>
-              </Box>
-            </Flex>
-          </ArtworkCard>
+            imageURL={item?.node?.image?.imageURL}
+            artistNames={item?.node?.artistNames}
+            saleMessage={item?.node?.saleMessage}
+          />
         )}
         keyExtractor={(item, index) => String(item?.node?.image?.imageURL || index)}
       />

--- a/src/lib/Components/ArtworkTileRail/ArtworkTileRailCard.tsx
+++ b/src/lib/Components/ArtworkTileRail/ArtworkTileRailCard.tsx
@@ -1,0 +1,63 @@
+import { Box, color, Flex, Sans } from "@artsy/palette"
+import React from "react"
+import { GestureResponderEvent } from "react-native"
+import styled from "styled-components/native"
+import OpaqueImageView from "../OpaqueImageView/OpaqueImageView"
+
+const SMALL_TILE_IMAGE_SIZE = 120
+
+const ArtworkCard = styled.TouchableHighlight.attrs({ underlayColor: color("white100"), activeOpacity: 0.8 })``
+
+interface ArtworkTileRailCardProps {
+  onPress: ((event: GestureResponderEvent) => void) | null | undefined
+  imageURL: string | null | undefined
+  artistNames: string | null | undefined
+  saleMessage: string | null | undefined
+}
+
+export const ArtworkTileRailCard: React.FC<ArtworkTileRailCardProps> = ({
+  onPress,
+  imageURL,
+  artistNames,
+  saleMessage,
+}) => {
+  const imageDisplay = imageURL ? (
+    <OpaqueImageView
+      imageURL={imageURL.replace(":version", "square")}
+      width={SMALL_TILE_IMAGE_SIZE}
+      height={SMALL_TILE_IMAGE_SIZE}
+      style={{ borderRadius: 2, overflow: "hidden" }}
+    />
+  ) : (
+    <Box
+      bg={color("black30")}
+      width={SMALL_TILE_IMAGE_SIZE}
+      height={SMALL_TILE_IMAGE_SIZE}
+      style={{ borderRadius: 2 }}
+    />
+  )
+
+  const artistNamesDisplay = artistNames && (
+    <Sans size="3t" weight="medium" numberOfLines={1}>
+      {artistNames}
+    </Sans>
+  )
+
+  const saleMessageDisplay = saleMessage && (
+    <Sans size="3t" color="black60" numberOfLines={1}>
+      {saleMessage}
+    </Sans>
+  )
+
+  return (
+    <ArtworkCard onPress={onPress || undefined}>
+      <Flex>
+        {imageDisplay}
+        <Box mt={1} width={SMALL_TILE_IMAGE_SIZE}>
+          {artistNamesDisplay}
+          {saleMessageDisplay}
+        </Box>
+      </Flex>
+    </ArtworkCard>
+  )
+}

--- a/src/lib/Components/ArtworkTileRail/__tests__/ArtworkTileRail-tests.tsx
+++ b/src/lib/Components/ArtworkTileRail/__tests__/ArtworkTileRail-tests.tsx
@@ -7,8 +7,8 @@ import { graphql, QueryRenderer } from "react-relay"
 import ReactTestRenderer from "react-test-renderer"
 import { useTracking } from "react-tracking"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
-import { ArtworkTileRail, tappedArtworkGroupThumbnail } from "./ArtworkTileRail"
-import { ArtworkTileRailCard } from "./ArtworkTileRailCard"
+import { ArtworkTileRail, tappedArtworkGroupThumbnail } from "../ArtworkTileRail"
+import { ArtworkTileRailCard } from "../ArtworkTileRailCard"
 
 jest.unmock("react-relay")
 jest.mock("lib/NativeModules/SwitchBoard", () => ({

--- a/src/lib/Components/ArtworkTileRail/__tests__/ArtworkTileRailCard-tests.tsx
+++ b/src/lib/Components/ArtworkTileRail/__tests__/ArtworkTileRailCard-tests.tsx
@@ -1,0 +1,67 @@
+import { Theme } from "@artsy/palette"
+// @ts-ignore STRICTNESS_MIGRATION
+import { mount } from "enzyme"
+import React from "react"
+import { ArtworkTileRailCard } from "../ArtworkTileRailCard"
+
+describe("ArtworkTileRailCard", () => {
+  const defaultProps = {
+    onPress: jest.fn(),
+    imageURL: "http://placekitten.com/200/200",
+    artistNames: "Andy Goldsworthy",
+    saleMessage: "Sold for $1,200",
+  }
+
+  it("renders an image with an imageURL", () => {
+    const props = defaultProps
+
+    const result = mount(
+      <Theme>
+        <ArtworkTileRailCard {...props} />
+      </Theme>
+    )
+
+    expect(result.find("AROpaqueImageView").length).toBe(1)
+  })
+
+  it("renders no image without imageURL", () => {
+    const props = {
+      ...defaultProps,
+      imageURL: "",
+    }
+
+    const result = mount(
+      <Theme>
+        <ArtworkTileRailCard {...props} />
+      </Theme>
+    )
+
+    expect(result.find("AROpaqueImageView").length).toBe(0)
+  })
+
+  it("renders without artistNames", () => {
+    const props = {
+      ...defaultProps,
+      artistNames: undefined,
+    }
+
+    mount(
+      <Theme>
+        <ArtworkTileRailCard {...props} />
+      </Theme>
+    )
+  })
+
+  it("renders without saleMessage", () => {
+    const props = {
+      ...defaultProps,
+      saleMessage: undefined,
+    }
+
+    mount(
+      <Theme>
+        <ArtworkTileRailCard {...props} />
+      </Theme>
+    )
+  })
+})

--- a/src/lib/Components/ArtworkTileRail/index.ts
+++ b/src/lib/Components/ArtworkTileRail/index.ts
@@ -1,0 +1,2 @@
+export * from "./ArtworkTileRail"
+export * from "./ArtworkTileRailCard"

--- a/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/index.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/index.tsx
@@ -1,6 +1,7 @@
-import { AuctionIcon, Box, Button, EditIcon, EnvelopeIcon, Flex, Sans, Separator, Spacer } from "@artsy/palette"
+import { AuctionIcon, Box, Button, EditIcon, EnvelopeIcon, Flex, Join, Sans, Separator, Spacer } from "@artsy/palette"
 import { ConsignmentsHome_artists } from "__generated__/ConsignmentsHome_artists.graphql"
 import { ConsignmentsHomeQuery } from "__generated__/ConsignmentsHomeQuery.graphql"
+import { ArtworkTileRailCard } from "lib/Components/ArtworkTileRail"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import React, { useRef } from "react"
@@ -60,30 +61,35 @@ export const ConsignmentsHome: React.FC<Props> = props => {
           </Sans>
 
           <Flex flexDirection="row">
-            <Flex mr={0.5}>
-              <Box bg="black30" width={120} height={120} />
-              <Spacer mb={1} />
-              <Sans size="3t">Kehinde Wiley</Sans>
-              <Sans size="3t" color="black60">
-                Sold for $6,500
-              </Sans>
-            </Flex>
-            <Flex mr={0.5}>
-              <Box bg="black30" width={120} height={120} />
-              <Spacer mb={1} />
-              <Sans size="3t">Kehinde Wiley</Sans>
-              <Sans size="3t" color="black60">
-                Sold for $6,500
-              </Sans>
-            </Flex>
-            <Flex>
-              <Box bg="black30" width={120} height={120} />
-              <Spacer mb={1} />
-              <Sans size="3t">Kehinde Wiley</Sans>
-              <Sans size="3t" color="black60">
-                Sold for $6,500
-              </Sans>
-            </Flex>
+            <Join separator={<Spacer mr={0.5} />}>
+              <ArtworkTileRailCard
+                saleMessage="Sold for $6,400"
+                artistNames="Kehinde Wiley"
+                imageURL="https://d32dm0rphc51dk.cloudfront.net/JB8GqSuSHtsDHDIQ9nyPUw/square.jpg"
+                key="1"
+                onPress={() => {
+                  console.log("hi")
+                }}
+              />
+              <ArtworkTileRailCard
+                saleMessage="Sold for $1,200"
+                artistNames="Kehinde Wiley"
+                imageURL="https://d32dm0rphc51dk.cloudfront.net/JB8GqSuSHtsDHDIQ9nyPUw/square.jpg"
+                key="1"
+                onPress={() => {
+                  console.log("hi")
+                }}
+              />
+              <ArtworkTileRailCard
+                saleMessage="Sold for $3,100"
+                artistNames="Kehinde Wiley"
+                imageURL="https://d32dm0rphc51dk.cloudfront.net/JB8GqSuSHtsDHDIQ9nyPUw/square.jpg"
+                key="1"
+                onPress={() => {
+                  console.log("hi")
+                }}
+              />
+            </Join>
           </Flex>
         </Box>
       </Box>

--- a/src/lib/Scenes/Home/Components/SmallTileRail.tsx
+++ b/src/lib/Scenes/Home/Components/SmallTileRail.tsx
@@ -1,18 +1,15 @@
 import * as Analytics from "@artsy/cohesion"
-import { Box, color, Flex, Sans, Spacer } from "@artsy/palette"
+import { Spacer } from "@artsy/palette"
 import { SmallTileRail_artworks } from "__generated__/SmallTileRail_artworks.graphql"
 import { AboveTheFoldFlatList } from "lib/Components/AboveTheFoldFlatList"
 import { saleMessageOrBidInfo } from "lib/Components/ArtworkGrids/ArtworkGridItem"
-import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
+import { ArtworkTileRailCard } from "lib/Components/ArtworkTileRail"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import React from "react"
 import { FlatList } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
-import styled from "styled-components/native"
 import HomeAnalytics from "../homeAnalytics"
-
-const SMALL_TILE_IMAGE_SIZE = 120
 
 export const SmallTileRailContainer: React.FC<{
   artworks: SmallTileRail_artworks
@@ -32,7 +29,7 @@ export const SmallTileRailContainer: React.FC<{
       initialNumToRender={4}
       windowSize={3}
       renderItem={({ item, index }) => (
-        <ArtworkCard
+        <ArtworkTileRailCard
           onPress={
             item.href
               ? () => {
@@ -45,31 +42,15 @@ export const SmallTileRailContainer: React.FC<{
                 }
               : undefined
           }
-        >
-          <Flex>
-            <OpaqueImageView
-              imageURL={(item.image?.imageURL ?? "").replace(":version", "square")}
-              width={SMALL_TILE_IMAGE_SIZE}
-              height={SMALL_TILE_IMAGE_SIZE}
-              style={{ borderRadius: 2, overflow: "hidden" }}
-            />
-            <Box mt={1} width={SMALL_TILE_IMAGE_SIZE}>
-              <Sans size="3t" weight="medium" numberOfLines={1}>
-                {item.artistNames}
-              </Sans>
-              <Sans size="3t" color="black60" numberOfLines={1}>
-                {saleMessageOrBidInfo(item)}
-              </Sans>
-            </Box>
-          </Flex>
-        </ArtworkCard>
+          imageURL={item.image?.imageURL ?? ""}
+          artistNames={item.artistNames}
+          saleMessage={saleMessageOrBidInfo(item)}
+        />
       )}
       keyExtractor={(item, index) => String(item.image?.imageURL || index)}
     />
   )
 }
-
-const ArtworkCard = styled.TouchableHighlight.attrs({ underlayColor: color("white100"), activeOpacity: 0.8 })``
 
 export const SmallTileRail = createFragmentContainer(SmallTileRailContainer, {
   artworks: graphql`


### PR DESCRIPTION
I will be rendering an artwork rail on the sell tab landing page, and I want it to look like the other artwork rails in the app. The shape of my data is very different from what `ArtworkTileRail` uses, though, so this PR extracts an `ArtworkTileRailCard` that takes things like `artistNames` and `saleMessage` as props. This leaves it up to the parent component to decide how to get those bits of data.

I chose to do this at the card level instead of the rail level because there might be subtle differences between my upcoming rail and the other rails, specifically in the spacing between cards. Perhaps it's confirmation bias, but it also feels nice that the parent can decide if it's rendering a `FlatList`, an `AboveTheFoldFlatList`, or a `Join` to render this rail of cards.

The PR also includes a small fix with border-radius - moving it from the rail level to the card level. I'll point it out with a comment.