### PR TITLE
Revert "Add yarn relay to MP update steps"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,9 +174,6 @@ jobs:
       - run:
           name: Update metaphysics
           command: yarn update-metaphysics
-      - run:
-          name: Update generated files
-          command: yarn relay
 
   check-pr:
     executor:


### PR DESCRIPTION
Reverts artsy/eigen#3285

I believe #3285 tried to fix an issue with the automated process we have for updating the schema file in the eigen repo after changes are made to MP. But the area of code changed in that PR actually deals with updates which go in the opposite direction, i.e. changes in the eigen query map being pushed to MP.

In addition, the change in #3285 was a no-op since `yarn relay` was added _after_ the step which actually pushes the query map changes.

The problem that #3285 was intended to address is that sometimes schema changes can affect the files in the `__generated__` folder, but we have a CI check which fails when the `__generated__` folder is out-of-date. So the CI script which pushes schema changes *from MP to eigen* was creating a pull request where the schema file was up-to-date but the `__generated__` folder was not. That script lives here: https://github.com/artsy/metaphysics/blob/6dc1a7a98a367c11b34be53f2c187bf2a0c2d1c0/scripts/push-schema-changes.js#L22-L30

I think it should be safe to automatically update the `__generated__` folder after updating the schema file by running `yarn relay`, so I'll add a ticket to the MX backlog, unless you want to have a go at it @mdole?