### PR TITLE
Make viewing rooms dynamic [GALL-2794]

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
   dev:
     - Add tracking for homescreen modules - brian
     - Make viewing room header full-bleed and incorporate countdown and partner info - mdole
+    - Make viewing room navigation dynamic + link to them on partner shows page - mdole
     - Extract common artwork tile independent of the shape of the data source - pepopowitz
   user_facing:
     - Fix for bug with fair booth display when partner profile was empty

--- a/src/__generated__/PartnerQuery.graphql.ts
+++ b/src/__generated__/PartnerQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 2c309f4496d12ed9798bc4fa43cc0284 */
+/* @relayHash ac33e1fbcc510406f4cd320dd94531e5 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -259,6 +259,14 @@ fragment PartnerShows_partner on Partner {
       cursor
     }
   }
+  viewingRooms: viewingRoomsConnection {
+    edges {
+      node {
+        slug
+        title
+      }
+    }
+  }
   ...PartnerShowsRail_partner
 }
 
@@ -338,32 +346,39 @@ v7 = {
 v8 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "href",
+  "name": "title",
   "args": null,
   "storageKey": null
 },
 v9 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "href",
   "args": null,
   "storageKey": null
 },
 v10 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__typename",
+  "name": "name",
   "args": null,
   "storageKey": null
 },
 v11 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "cursor",
+  "name": "__typename",
   "args": null,
   "storageKey": null
 },
 v12 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "cursor",
+  "args": null,
+  "storageKey": null
+},
+v13 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "pageInfo",
@@ -395,10 +410,10 @@ v12 = {
     }
   ]
 },
-v13 = [
+v14 = [
   "sort"
 ],
-v14 = [
+v15 = [
   (v5/*: any*/),
   {
     "kind": "Literal",
@@ -406,22 +421,22 @@ v14 = [
     "value": "SORTABLE_ID_ASC"
   }
 ],
-v15 = {
+v16 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "url",
   "args": null,
   "storageKey": null
 },
-v16 = [
-  (v15/*: any*/)
+v17 = [
+  (v16/*: any*/)
 ],
-v17 = {
+v18 = {
   "kind": "Literal",
   "name": "status",
   "value": "CURRENT"
 },
-v18 = [
+v19 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -438,18 +453,18 @@ v18 = [
     "value": "CLOSED"
   }
 ],
-v19 = {
+v20 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "exhibitionPeriod",
   "args": null,
   "storageKey": null
 },
-v20 = [
+v21 = [
   "status",
   "sort"
 ],
-v21 = [
+v22 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -460,7 +475,7 @@ v21 = [
     "name": "sort",
     "value": "END_AT_ASC"
   },
-  (v17/*: any*/)
+  (v18/*: any*/)
 ];
 return {
   "kind": "Request",
@@ -605,13 +620,7 @@ return {
                           }
                         ]
                       },
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "title",
-                        "args": null,
-                        "storageKey": null
-                      },
+                      (v8/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -633,7 +642,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v8/*: any*/),
+                      (v9/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -706,18 +715,18 @@ return {
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          (v9/*: any*/),
+                          (v10/*: any*/),
                           (v2/*: any*/)
                         ]
                       },
-                      (v10/*: any*/)
+                      (v11/*: any*/)
                     ]
                   },
-                  (v11/*: any*/),
+                  (v12/*: any*/),
                   (v2/*: any*/)
                 ]
               },
-              (v12/*: any*/)
+              (v13/*: any*/)
             ]
           },
           {
@@ -727,9 +736,9 @@ return {
             "args": (v6/*: any*/),
             "handle": "connection",
             "key": "Partner_artworks",
-            "filters": (v13/*: any*/)
+            "filters": (v14/*: any*/)
           },
-          (v9/*: any*/),
+          (v10/*: any*/),
           {
             "kind": "ScalarField",
             "alias": null,
@@ -767,11 +776,11 @@ return {
             "alias": "artists",
             "name": "artistsConnection",
             "storageKey": "artistsConnection(first:10,sort:\"SORTABLE_ID_ASC\")",
-            "args": (v14/*: any*/),
+            "args": (v15/*: any*/),
             "concreteType": "ArtistPartnerConnection",
             "plural": false,
             "selections": [
-              (v12/*: any*/),
+              (v13/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -793,7 +802,7 @@ return {
                       (v2/*: any*/),
                       (v3/*: any*/),
                       (v4/*: any*/),
-                      (v9/*: any*/),
+                      (v10/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -801,7 +810,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v8/*: any*/),
+                      (v9/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": "is_followed",
@@ -838,12 +847,12 @@ return {
                         "args": null,
                         "concreteType": "Image",
                         "plural": false,
-                        "selections": (v16/*: any*/)
+                        "selections": (v17/*: any*/)
                       },
-                      (v10/*: any*/)
+                      (v11/*: any*/)
                     ]
                   },
-                  (v11/*: any*/),
+                  (v12/*: any*/),
                   (v2/*: any*/)
                 ]
               }
@@ -853,10 +862,10 @@ return {
             "kind": "LinkedHandle",
             "alias": "artists",
             "name": "artistsConnection",
-            "args": (v14/*: any*/),
+            "args": (v15/*: any*/),
             "handle": "connection",
             "key": "Partner_artists",
-            "filters": (v13/*: any*/)
+            "filters": (v14/*: any*/)
           },
           {
             "kind": "LinkedField",
@@ -893,7 +902,7 @@ return {
                 "name": "first",
                 "value": 1
               },
-              (v17/*: any*/)
+              (v18/*: any*/)
             ],
             "concreteType": "ShowConnection",
             "plural": false,
@@ -928,11 +937,11 @@ return {
             "alias": "pastShows",
             "name": "showsConnection",
             "storageKey": "showsConnection(first:32,sort:\"END_AT_DESC\",status:\"CLOSED\")",
-            "args": (v18/*: any*/),
+            "args": (v19/*: any*/),
             "concreteType": "ShowConnection",
             "plural": false,
             "selections": [
-              (v12/*: any*/),
+              (v13/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -952,9 +961,9 @@ return {
                     "plural": false,
                     "selections": [
                       (v2/*: any*/),
-                      (v9/*: any*/),
+                      (v10/*: any*/),
                       (v4/*: any*/),
-                      (v19/*: any*/),
+                      (v20/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -964,15 +973,15 @@ return {
                         "concreteType": "Image",
                         "plural": false,
                         "selections": [
-                          (v15/*: any*/),
+                          (v16/*: any*/),
                           (v7/*: any*/)
                         ]
                       },
-                      (v8/*: any*/),
-                      (v10/*: any*/)
+                      (v9/*: any*/),
+                      (v11/*: any*/)
                     ]
                   },
-                  (v11/*: any*/)
+                  (v12/*: any*/)
                 ]
               }
             ]
@@ -981,21 +990,56 @@ return {
             "kind": "LinkedHandle",
             "alias": "pastShows",
             "name": "showsConnection",
-            "args": (v18/*: any*/),
+            "args": (v19/*: any*/),
             "handle": "connection",
             "key": "Partner_pastShows",
-            "filters": (v20/*: any*/)
+            "filters": (v21/*: any*/)
+          },
+          {
+            "kind": "LinkedField",
+            "alias": "viewingRooms",
+            "name": "viewingRoomsConnection",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "ViewingRoomConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ViewingRoomEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ViewingRoom",
+                    "plural": false,
+                    "selections": [
+                      (v4/*: any*/),
+                      (v8/*: any*/)
+                    ]
+                  }
+                ]
+              }
+            ]
           },
           {
             "kind": "LinkedField",
             "alias": "currentAndUpcomingShows",
             "name": "showsConnection",
             "storageKey": "showsConnection(first:6,sort:\"END_AT_ASC\",status:\"CURRENT\")",
-            "args": (v21/*: any*/),
+            "args": (v22/*: any*/),
             "concreteType": "ShowConnection",
             "plural": false,
             "selections": [
-              (v12/*: any*/),
+              (v13/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1017,8 +1061,8 @@ return {
                       (v2/*: any*/),
                       (v3/*: any*/),
                       (v4/*: any*/),
-                      (v9/*: any*/),
-                      (v19/*: any*/),
+                      (v10/*: any*/),
+                      (v20/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -1034,7 +1078,7 @@ return {
                         "args": null,
                         "concreteType": "Image",
                         "plural": true,
-                        "selections": (v16/*: any*/)
+                        "selections": (v17/*: any*/)
                       },
                       {
                         "kind": "LinkedField",
@@ -1045,21 +1089,21 @@ return {
                         "concreteType": null,
                         "plural": false,
                         "selections": [
-                          (v10/*: any*/),
+                          (v11/*: any*/),
                           (v2/*: any*/),
                           {
                             "kind": "InlineFragment",
                             "type": "Partner",
                             "selections": [
-                              (v9/*: any*/)
+                              (v10/*: any*/)
                             ]
                           }
                         ]
                       },
-                      (v10/*: any*/)
+                      (v11/*: any*/)
                     ]
                   },
-                  (v11/*: any*/)
+                  (v12/*: any*/)
                 ]
               }
             ]
@@ -1068,10 +1112,10 @@ return {
             "kind": "LinkedHandle",
             "alias": "currentAndUpcomingShows",
             "name": "showsConnection",
-            "args": (v21/*: any*/),
+            "args": (v22/*: any*/),
             "handle": "connection",
             "key": "Partner_currentAndUpcomingShows",
-            "filters": (v20/*: any*/)
+            "filters": (v21/*: any*/)
           }
         ]
       }
@@ -1080,7 +1124,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "PartnerQuery",
-    "id": "d9a1de912efabe2c5e75eadfaeb36795",
+    "id": "df36261979d59addf30cc66292b40c61",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/PartnerRefetchQuery.graphql.ts
+++ b/src/__generated__/PartnerRefetchQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash d788b2c210111ba4239aab0361618559 */
+/* @relayHash d527296265c9b56af7be8074f2ebc451 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -260,6 +260,14 @@ fragment PartnerShows_partner on Partner {
       cursor
     }
   }
+  viewingRooms: viewingRoomsConnection {
+    edges {
+      node {
+        slug
+        title
+      }
+    }
+  }
   ...PartnerShowsRail_partner
 }
 
@@ -346,25 +354,32 @@ v8 = {
 v9 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "href",
+  "name": "title",
   "args": null,
   "storageKey": null
 },
 v10 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "href",
   "args": null,
   "storageKey": null
 },
 v11 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "cursor",
+  "name": "name",
   "args": null,
   "storageKey": null
 },
 v12 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "cursor",
+  "args": null,
+  "storageKey": null
+},
+v13 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "pageInfo",
@@ -396,10 +411,10 @@ v12 = {
     }
   ]
 },
-v13 = [
+v14 = [
   "sort"
 ],
-v14 = [
+v15 = [
   (v6/*: any*/),
   {
     "kind": "Literal",
@@ -407,22 +422,22 @@ v14 = [
     "value": "SORTABLE_ID_ASC"
   }
 ],
-v15 = {
+v16 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "url",
   "args": null,
   "storageKey": null
 },
-v16 = [
-  (v15/*: any*/)
+v17 = [
+  (v16/*: any*/)
 ],
-v17 = {
+v18 = {
   "kind": "Literal",
   "name": "status",
   "value": "CURRENT"
 },
-v18 = [
+v19 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -439,18 +454,18 @@ v18 = [
     "value": "CLOSED"
   }
 ],
-v19 = {
+v20 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "exhibitionPeriod",
   "args": null,
   "storageKey": null
 },
-v20 = [
+v21 = [
   "status",
   "sort"
 ],
-v21 = [
+v22 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -461,7 +476,7 @@ v21 = [
     "name": "sort",
     "value": "END_AT_ASC"
   },
-  (v17/*: any*/)
+  (v18/*: any*/)
 ];
 return {
   "kind": "Request",
@@ -611,13 +626,7 @@ return {
                               }
                             ]
                           },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "title",
-                            "args": null,
-                            "storageKey": null
-                          },
+                          (v9/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -639,7 +648,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v9/*: any*/),
+                          (v10/*: any*/),
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -712,18 +721,18 @@ return {
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              (v10/*: any*/),
+                              (v11/*: any*/),
                               (v3/*: any*/)
                             ]
                           },
                           (v2/*: any*/)
                         ]
                       },
-                      (v11/*: any*/),
+                      (v12/*: any*/),
                       (v3/*: any*/)
                     ]
                   },
-                  (v12/*: any*/)
+                  (v13/*: any*/)
                 ]
               },
               {
@@ -733,9 +742,9 @@ return {
                 "args": (v7/*: any*/),
                 "handle": "connection",
                 "key": "Partner_artworks",
-                "filters": (v13/*: any*/)
+                "filters": (v14/*: any*/)
               },
-              (v10/*: any*/),
+              (v11/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -773,11 +782,11 @@ return {
                 "alias": "artists",
                 "name": "artistsConnection",
                 "storageKey": "artistsConnection(first:10,sort:\"SORTABLE_ID_ASC\")",
-                "args": (v14/*: any*/),
+                "args": (v15/*: any*/),
                 "concreteType": "ArtistPartnerConnection",
                 "plural": false,
                 "selections": [
-                  (v12/*: any*/),
+                  (v13/*: any*/),
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -799,7 +808,7 @@ return {
                           (v3/*: any*/),
                           (v4/*: any*/),
                           (v5/*: any*/),
-                          (v10/*: any*/),
+                          (v11/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -807,7 +816,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v9/*: any*/),
+                          (v10/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": "is_followed",
@@ -844,12 +853,12 @@ return {
                             "args": null,
                             "concreteType": "Image",
                             "plural": false,
-                            "selections": (v16/*: any*/)
+                            "selections": (v17/*: any*/)
                           },
                           (v2/*: any*/)
                         ]
                       },
-                      (v11/*: any*/),
+                      (v12/*: any*/),
                       (v3/*: any*/)
                     ]
                   }
@@ -859,10 +868,10 @@ return {
                 "kind": "LinkedHandle",
                 "alias": "artists",
                 "name": "artistsConnection",
-                "args": (v14/*: any*/),
+                "args": (v15/*: any*/),
                 "handle": "connection",
                 "key": "Partner_artists",
-                "filters": (v13/*: any*/)
+                "filters": (v14/*: any*/)
               },
               {
                 "kind": "LinkedField",
@@ -899,7 +908,7 @@ return {
                     "name": "first",
                     "value": 1
                   },
-                  (v17/*: any*/)
+                  (v18/*: any*/)
                 ],
                 "concreteType": "ShowConnection",
                 "plural": false,
@@ -934,11 +943,11 @@ return {
                 "alias": "pastShows",
                 "name": "showsConnection",
                 "storageKey": "showsConnection(first:32,sort:\"END_AT_DESC\",status:\"CLOSED\")",
-                "args": (v18/*: any*/),
+                "args": (v19/*: any*/),
                 "concreteType": "ShowConnection",
                 "plural": false,
                 "selections": [
-                  (v12/*: any*/),
+                  (v13/*: any*/),
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -958,9 +967,9 @@ return {
                         "plural": false,
                         "selections": [
                           (v3/*: any*/),
-                          (v10/*: any*/),
+                          (v11/*: any*/),
                           (v5/*: any*/),
-                          (v19/*: any*/),
+                          (v20/*: any*/),
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -970,15 +979,15 @@ return {
                             "concreteType": "Image",
                             "plural": false,
                             "selections": [
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               (v8/*: any*/)
                             ]
                           },
-                          (v9/*: any*/),
+                          (v10/*: any*/),
                           (v2/*: any*/)
                         ]
                       },
-                      (v11/*: any*/)
+                      (v12/*: any*/)
                     ]
                   }
                 ]
@@ -987,21 +996,56 @@ return {
                 "kind": "LinkedHandle",
                 "alias": "pastShows",
                 "name": "showsConnection",
-                "args": (v18/*: any*/),
+                "args": (v19/*: any*/),
                 "handle": "connection",
                 "key": "Partner_pastShows",
-                "filters": (v20/*: any*/)
+                "filters": (v21/*: any*/)
+              },
+              {
+                "kind": "LinkedField",
+                "alias": "viewingRooms",
+                "name": "viewingRoomsConnection",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ViewingRoomConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "edges",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ViewingRoomEdge",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "node",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "ViewingRoom",
+                        "plural": false,
+                        "selections": [
+                          (v5/*: any*/),
+                          (v9/*: any*/)
+                        ]
+                      }
+                    ]
+                  }
+                ]
               },
               {
                 "kind": "LinkedField",
                 "alias": "currentAndUpcomingShows",
                 "name": "showsConnection",
                 "storageKey": "showsConnection(first:6,sort:\"END_AT_ASC\",status:\"CURRENT\")",
-                "args": (v21/*: any*/),
+                "args": (v22/*: any*/),
                 "concreteType": "ShowConnection",
                 "plural": false,
                 "selections": [
-                  (v12/*: any*/),
+                  (v13/*: any*/),
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -1023,8 +1067,8 @@ return {
                           (v3/*: any*/),
                           (v4/*: any*/),
                           (v5/*: any*/),
-                          (v10/*: any*/),
-                          (v19/*: any*/),
+                          (v11/*: any*/),
+                          (v20/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1040,7 +1084,7 @@ return {
                             "args": null,
                             "concreteType": "Image",
                             "plural": true,
-                            "selections": (v16/*: any*/)
+                            "selections": (v17/*: any*/)
                           },
                           {
                             "kind": "LinkedField",
@@ -1057,7 +1101,7 @@ return {
                                 "kind": "InlineFragment",
                                 "type": "Partner",
                                 "selections": [
-                                  (v10/*: any*/)
+                                  (v11/*: any*/)
                                 ]
                               }
                             ]
@@ -1065,7 +1109,7 @@ return {
                           (v2/*: any*/)
                         ]
                       },
-                      (v11/*: any*/)
+                      (v12/*: any*/)
                     ]
                   }
                 ]
@@ -1074,10 +1118,10 @@ return {
                 "kind": "LinkedHandle",
                 "alias": "currentAndUpcomingShows",
                 "name": "showsConnection",
-                "args": (v21/*: any*/),
+                "args": (v22/*: any*/),
                 "handle": "connection",
                 "key": "Partner_currentAndUpcomingShows",
-                "filters": (v20/*: any*/)
+                "filters": (v21/*: any*/)
               }
             ]
           }
@@ -1088,7 +1132,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "PartnerRefetchQuery",
-    "id": "1c96830251d163c3c23279104b935bdc",
+    "id": "0de52ece45e1497bf5ed1f634b44461f",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/PartnerShowsInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/PartnerShowsInfiniteScrollGridQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 8328f0058c06566c989f013798c3db1d */
+/* @relayHash 5f370576d040248254fe304d05c464bb */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -113,6 +113,14 @@ fragment PartnerShows_partner_1G22uz on Partner {
         __typename
       }
       cursor
+    }
+  }
+  viewingRooms: viewingRoomsConnection {
+    edges {
+      node {
+        slug
+        title
+      }
     }
   }
   ...PartnerShowsRail_partner
@@ -451,6 +459,47 @@ return {
           },
           {
             "kind": "LinkedField",
+            "alias": "viewingRooms",
+            "name": "viewingRoomsConnection",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "ViewingRoomConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ViewingRoomEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ViewingRoom",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "title",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "LinkedField",
             "alias": "currentAndUpcomingShows",
             "name": "showsConnection",
             "storageKey": "showsConnection(first:6,sort:\"END_AT_ASC\",status:\"CURRENT\")",
@@ -546,7 +595,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "PartnerShowsInfiniteScrollGridQuery",
-    "id": "f345b510e9788f180f6f2bcf2ec350c2",
+    "id": "64338bb298400c3725175a87d4bed783",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/PartnerShowsTestsQuery.graphql.ts
+++ b/src/__generated__/PartnerShowsTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash dc66923d03b08c4cf540a7300f1876ce */
+/* @relayHash 36487596becf6bd28578f9d911dd8f11 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -41,6 +41,14 @@ export type PartnerShowsTestsQueryRawResponse = {
                     readonly __typename: "Show";
                 }) | null;
                 readonly cursor: string;
+            }) | null> | null;
+        }) | null;
+        readonly viewingRooms: ({
+            readonly edges: ReadonlyArray<({
+                readonly node: ({
+                    readonly slug: string;
+                    readonly title: string;
+                }) | null;
             }) | null> | null;
         }) | null;
         readonly currentAndUpcomingShows: ({
@@ -172,6 +180,14 @@ fragment PartnerShows_partner on Partner {
         __typename
       }
       cursor
+    }
+  }
+  viewingRooms: viewingRoomsConnection {
+    edges {
+      node {
+        slug
+        title
+      }
     }
   }
   ...PartnerShowsRail_partner
@@ -474,6 +490,47 @@ return {
           },
           {
             "kind": "LinkedField",
+            "alias": "viewingRooms",
+            "name": "viewingRoomsConnection",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "ViewingRoomConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ViewingRoomEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ViewingRoom",
+                    "plural": false,
+                    "selections": [
+                      (v1/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "title",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "LinkedField",
             "alias": "currentAndUpcomingShows",
             "name": "showsConnection",
             "storageKey": "showsConnection(first:6,sort:\"END_AT_ASC\",status:\"CURRENT\")",
@@ -569,7 +626,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "PartnerShowsTestsQuery",
-    "id": "41abbb687c8f1ced2faccc9b29de042e",
+    "id": "9ed2e053a23d9bcabbc739f257ded1cd",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/PartnerShows_partner.graphql.ts
+++ b/src/__generated__/PartnerShows_partner.graphql.ts
@@ -33,6 +33,14 @@ export type PartnerShows_partner = {
             } | null;
         } | null> | null;
     } | null;
+    readonly viewingRooms: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly slug: string;
+                readonly title: string;
+            } | null;
+        } | null> | null;
+    } | null;
     readonly " $fragmentRefs": FragmentRefs<"PartnerShowsRail_partner">;
     readonly " $refType": "PartnerShows_partner";
 };
@@ -282,6 +290,47 @@ return {
       ]
     },
     {
+      "kind": "LinkedField",
+      "alias": "viewingRooms",
+      "name": "viewingRoomsConnection",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "ViewingRoomConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "ViewingRoomEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "ViewingRoom",
+              "plural": false,
+              "selections": [
+                (v0/*: any*/),
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "title",
+                  "args": null,
+                  "storageKey": null
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
       "kind": "FragmentSpread",
       "name": "PartnerShowsRail_partner",
       "args": null
@@ -289,5 +338,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '52ea3baded2f6204ce7a94cf8ac7d685';
+(node as any).hash = '848bfbac831efd7828b84faa9b3791b4';
 export default node;

--- a/src/lib/Scenes/Partner/Components/PartnerShows.tsx
+++ b/src/lib/Scenes/Partner/Components/PartnerShows.tsx
@@ -81,21 +81,23 @@ export const PartnerShows: React.FC<{
     const result: StickyTabSection[] = []
     const isViewingRoomsEnabled = NativeModules.Emission?.options?.AROptionsViewingRooms
     if (isViewingRoomsEnabled) {
-      result.push({
-        key: "viewing_rooms",
-        content: (
-          <Button
-            onPress={() =>
-              SwitchBoard.presentNavigationViewController(
-                // @ts-ignore STRICTNESS_MIGRATION
-                navRef.current,
-                "/viewing-room/this-is-a-test-viewing-room-id"
-              )
-            }
-          >
-            Viewing Room
-          </Button>
-        ),
+      partner?.viewingRooms?.edges?.map(viewingRoom => {
+        result.push({
+          key: "viewing_rooms",
+          content: (
+            <Button
+              onPress={() =>
+                SwitchBoard.presentNavigationViewController(
+                  // @ts-ignore STRICTNESS_MIGRATION
+                  navRef.current,
+                  `/viewing-room/${viewingRoom?.node?.slug}`
+                )
+              }
+            >
+              {viewingRoom?.node?.title}
+            </Button>
+          ),
+        })
       })
     }
 
@@ -225,6 +227,14 @@ export const PartnerShowsFragmentContainer = createPaginationContainer(
               }
               href
               exhibitionPeriod
+            }
+          }
+        }
+        viewingRooms: viewingRoomsConnection {
+          edges {
+            node {
+              slug
+              title
             }
           }
         }

--- a/src/lib/Scenes/Partner/Components/__tests__/PartnerShows-tests.tsx
+++ b/src/lib/Scenes/Partner/Components/__tests__/PartnerShows-tests.tsx
@@ -176,4 +176,14 @@ const PartnerShowsFixture: PartnerShowsTestsQueryRawResponse["partner"] = {
       },
     ],
   },
+  viewingRooms: {
+    edges: [
+      {
+        node: {
+          slug: "david-zwirner-private-party-selected-works-by-nicolas-party",
+          title: "Private Party: Selected Works by Nicolas Party",
+        },
+      },
+    ],
+  },
 }

--- a/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
@@ -135,8 +135,7 @@ export const ViewingRoomFragmentContainer = createFragmentContainer(ViewingRoom,
   `,
 })
 
-// We'll eventually have this take in { viewingRoomID } as props and delete the hardcoded ID
-export const ViewingRoomRenderer: React.SFC<{ viewingRoomID: string }> = () => {
+export const ViewingRoomRenderer: React.SFC<{ viewingRoomID: string }> = ({ viewingRoomID }) => {
   return (
     <QueryRenderer<ViewingRoomQuery>
       environment={defaultEnvironment}
@@ -149,7 +148,7 @@ export const ViewingRoomRenderer: React.SFC<{ viewingRoomID: string }> = () => {
       `}
       cacheConfig={{ force: true }}
       variables={{
-        viewingRoomID: "67397e64-cc49-4200-9367-f4899621c866",
+        viewingRoomID,
       }}
       render={renderWithLoadProgress(ViewingRoomFragmentContainer)}
     />

--- a/src/lib/Scenes/ViewingRoom/ViewingRoomArtworks.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoomArtworks.tsx
@@ -179,7 +179,7 @@ export const ViewingRoomArtworksContainer = createPaginationContainer(
   }
 )
 
-export const ViewingRoomArtworksRenderer: React.SFC<{ viewingRoomID: string }> = () => {
+export const ViewingRoomArtworksRenderer: React.SFC<{ viewingRoomID: string }> = ({ viewingRoomID }) => {
   return (
     <QueryRenderer<ViewingRoomArtworksRendererQuery>
       environment={defaultEnvironment}
@@ -192,7 +192,7 @@ export const ViewingRoomArtworksRenderer: React.SFC<{ viewingRoomID: string }> =
       `}
       cacheConfig={{ force: true }}
       variables={{
-        viewingRoomID: "67397e64-cc49-4200-9367-f4899621c866",
+        viewingRoomID,
       }}
       render={renderWithLoadProgress(ViewingRoomArtworksContainer)}
     />


### PR DESCRIPTION
This PR moves us from a static "test-viewing-room-id" slug to dynamic navigation.

For example, you can now open artsy:///viewing-room/david-zwirner-private-party-selected-works-by-nicolas-party in a simulator Safari and be taken to a VR. This PR also lays the groundwork for displaying VRs on the partner screen (which may or may not be used for a while since we're unclear how we're gating access to/from rooms). Still, should be handy for testing since you can go to a gallery page and tap through to a VR, assuming you have the feature flag.

@starsirius while working on this, I discovered that querying any partner for `vieiwngRooms` returns ALL viewing rooms in existence, regardless of whether or not they're associated with that particular partner. I'm wondering if you might have some insight since you've dealt with similar issues recently. Maybe we can pair on it tomorrow?

Screenshot example of the issue: 
![Screen Shot 2020-05-18 at 10 25 27 PM](https://user-images.githubusercontent.com/5361806/82277750-aa341a80-9956-11ea-9f22-f2b08085d020.png)

[Jira ticket](https://artsyproduct.atlassian.net/browse/GALL-2794)