### PR TITLE
Remove recently sold section from Sell Tab landing page

### DIFF
--- a/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/index.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/index.tsx
@@ -1,7 +1,6 @@
-import { AuctionIcon, Box, Button, EditIcon, EnvelopeIcon, Flex, Join, Sans, Separator, Spacer } from "@artsy/palette"
+import { AuctionIcon, Box, Button, EditIcon, EnvelopeIcon, Flex, Sans, Separator, Spacer } from "@artsy/palette"
 import { ConsignmentsHome_artists } from "__generated__/ConsignmentsHome_artists.graphql"
 import { ConsignmentsHomeQuery } from "__generated__/ConsignmentsHomeQuery.graphql"
-import { ArtworkTileRailCard } from "lib/Components/ArtworkTileRail"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import React, { useRef } from "react"
@@ -50,48 +49,6 @@ export const ConsignmentsHome: React.FC<Props> = props => {
             Start selling
           </Sans>
         </Button>
-      </Box>
-
-      <Separator my={3} />
-
-      <Box px={2}>
-        <Box>
-          <Sans size="4" mb={2}>
-            Recently sold with Artsy
-          </Sans>
-
-          <Flex flexDirection="row">
-            <Join separator={<Spacer mr={0.5} />}>
-              <ArtworkTileRailCard
-                saleMessage="Sold for $6,400"
-                artistNames="Kehinde Wiley"
-                imageURL="https://d32dm0rphc51dk.cloudfront.net/JB8GqSuSHtsDHDIQ9nyPUw/square.jpg"
-                key="1"
-                onPress={() => {
-                  console.log("hi")
-                }}
-              />
-              <ArtworkTileRailCard
-                saleMessage="Sold for $1,200"
-                artistNames="Kehinde Wiley"
-                imageURL="https://d32dm0rphc51dk.cloudfront.net/JB8GqSuSHtsDHDIQ9nyPUw/square.jpg"
-                key="1"
-                onPress={() => {
-                  console.log("hi")
-                }}
-              />
-              <ArtworkTileRailCard
-                saleMessage="Sold for $3,100"
-                artistNames="Kehinde Wiley"
-                imageURL="https://d32dm0rphc51dk.cloudfront.net/JB8GqSuSHtsDHDIQ9nyPUw/square.jpg"
-                key="1"
-                onPress={() => {
-                  console.log("hi")
-                }}
-              />
-            </Join>
-          </Flex>
-        </Box>
       </Box>
 
       <Separator my={3} />


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/CSGN-200

In the name of shipping smaller slices iteratively, this PR removes the "Recently sold on Artsy" section of the Sell Tab landing page.

We'll add it back in a future PR.

![image](https://user-images.githubusercontent.com/1627089/82333247-10975800-99ac-11ea-96a1-adf2126f0848.png)

#trivial