### PR TITLE
[CSGN-189] Placeholder for Sell Tab landing page

### DIFF
--- a/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/index.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/index.tsx
@@ -1,9 +1,10 @@
-import { AuctionIcon, Box, Button, EditIcon, EnvelopeIcon, Flex, Sans, Separator, Spacer } from "@artsy/palette"
+import { AuctionIcon, Box, Button, EditIcon, EnvelopeIcon, Flex, Join, Sans, Separator, Spacer } from "@artsy/palette"
 import { ConsignmentsHome_artists } from "__generated__/ConsignmentsHome_artists.graphql"
 import { ConsignmentsHomeQuery } from "__generated__/ConsignmentsHomeQuery.graphql"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
+import { PlaceholderBox, PlaceholderText } from "lib/utils/placeholders"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
-import React, { RefObject, useRef } from "react"
+import React, { useRef } from "react"
 import { ScrollView } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import styled from "styled-components/native"
@@ -44,7 +45,7 @@ export const ConsignmentsHome: React.FC<Props> = props => {
 
       <Separator my={3} />
 
-      <ArtistsCollectorsAreLookingToBuy artists={artists} />
+      <ArtistsModule artists={artists} />
 
       <Separator my={3} />
 
@@ -130,7 +131,7 @@ const HowItWorks: React.FC = () => {
   )
 }
 
-const ArtistsCollectorsAreLookingToBuy: React.FC<{ artists: ConsignmentsHome_artists }> = ({ artists }) => {
+const ArtistsModule: React.FC<{ artists: ConsignmentsHome_artists }> = ({ artists }) => {
   return (
     <Box px={2}>
       <Box>
@@ -220,13 +221,49 @@ const ConsignmentsHomePlaceholder: React.FC = () => {
       <HowItWorks />
 
       <Separator my={3} />
-
-      <Sans size="3">PLACEHOOLLLDEEERRRR</Sans>
+      <ArtistsModulePlaceholder />
 
       <Separator my={3} />
 
       <FooterCTA handleCTAPress={handleCTAPress} />
     </ScrollView>
+  )
+}
+
+const ArtistsModulePlaceholder: React.FC = () => {
+  return (
+    <Box px={2}>
+      <Box>
+        <Spacer mb={1} />
+
+        <PlaceholderText width={250} />
+
+        <Spacer mb={2} />
+
+        <Flex flexDirection="row">
+          <Flex>
+            <Join separator={<Spacer mb={2} />}>
+              <Flex flexDirection="row" alignItems="center">
+                <PlaceholderBox height={45} width={45} marginRight={10} />
+                <PlaceholderText width={150} />
+              </Flex>
+              <Flex flexDirection="row" alignItems="center">
+                <PlaceholderBox height={45} width={45} marginRight={10} />
+                <PlaceholderText width={130} />
+              </Flex>
+              <Flex flexDirection="row" alignItems="center">
+                <PlaceholderBox height={45} width={45} marginRight={10} />
+                <PlaceholderText width={170} />
+              </Flex>
+              <Flex flexDirection="row" alignItems="center">
+                <PlaceholderBox height={45} width={45} marginRight={10} />
+                <PlaceholderText width={100} />
+              </Flex>
+            </Join>
+          </Flex>
+        </Flex>
+      </Box>
+    </Box>
   )
 }
 

--- a/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/index.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/index.tsx
@@ -3,7 +3,7 @@ import { ConsignmentsHome_artists } from "__generated__/ConsignmentsHome_artists
 import { ConsignmentsHomeQuery } from "__generated__/ConsignmentsHomeQuery.graphql"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
-import React, { useRef } from "react"
+import React, { RefObject, useRef } from "react"
 import { ScrollView } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import styled from "styled-components/native"
@@ -17,9 +17,8 @@ interface Props {
   artists: ConsignmentsHome_artists
 }
 
-export const ConsignmentsHome: React.FC<Props> = props => {
+function useCTA() {
   const navRef = useRef<ScrollView>(null)
-  const { artists } = props
 
   const handleCTAPress = () => {
     if (navRef.current) {
@@ -27,6 +26,13 @@ export const ConsignmentsHome: React.FC<Props> = props => {
       SwitchBoard.presentModalViewController(navRef.current, route)
     }
   }
+
+  return { navRef, handleCTAPress }
+}
+
+export const ConsignmentsHome: React.FC<Props> = props => {
+  const { artists } = props
+  const { navRef, handleCTAPress } = useCTA()
 
   return (
     <ScrollView ref={navRef}>
@@ -202,6 +208,28 @@ const FooterCTA: React.FC<{ handleCTAPress: () => void }> = ({ handleCTAPress })
   )
 }
 
+const ConsignmentsHomePlaceholder: React.FC = () => {
+  const { navRef, handleCTAPress } = useCTA()
+
+  return (
+    <ScrollView ref={navRef}>
+      <HeaderCTA handleCTAPress={handleCTAPress} />
+
+      <Separator my={3} />
+
+      <HowItWorks />
+
+      <Separator my={3} />
+
+      <Sans size="3">PLACEHOOLLLDEEERRRR</Sans>
+
+      <Separator my={3} />
+
+      <FooterCTA handleCTAPress={handleCTAPress} />
+    </ScrollView>
+  )
+}
+
 const FlexChildThatWontStretchOutsideOfParent = styled(Box)`
   flex: 1;
 `
@@ -238,8 +266,4 @@ export const ConsignmentsHomeQueryRenderer: React.FC = () => {
       })}
     />
   )
-}
-
-const ConsignmentsHomePlaceholder: React.FC = () => {
-  return <Sans size="5">Coming soon: a placeholder.</Sans>
 }

--- a/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/index.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/index.tsx
@@ -20,7 +20,8 @@ interface Props {
 export const ConsignmentsHome: React.FC<Props> = props => {
   const navRef = useRef<ScrollView>(null)
   const { artists } = props
-  const handlePress = () => {
+
+  const handleCTAPress = () => {
     if (navRef.current) {
       const route = "/collections/my-collection/artworks/new/submissions/new"
       SwitchBoard.presentModalViewController(navRef.current, route)
@@ -29,151 +30,175 @@ export const ConsignmentsHome: React.FC<Props> = props => {
 
   return (
     <ScrollView ref={navRef}>
-      <Box px={2} py={6}>
-        <Box>
-          <Sans size="8" textAlign="center" px={2}>
-            Sell Art From Your Collection
-          </Sans>
-
-          <Spacer my={0.5} />
-
-          <Sans size="4" textAlign="center">
-            Reach art buyers all over the world.
-          </Sans>
-        </Box>
-
-        <Spacer mb={2} />
-
-        <Button variant="primaryBlack" block onPress={handlePress}>
-          <Sans size="3" weight="medium">
-            Start selling
-          </Sans>
-        </Button>
-      </Box>
+      <HeaderCTA handleCTAPress={handleCTAPress} />
 
       <Separator my={3} />
 
-      <Box px={2}>
-        <Sans size="8">How it works</Sans>
-
-        <Spacer mb={2} />
-        <Flex flexDirection="row">
-          <Box pr={2}>
-            <EditIcon width={30} height={30} />
-          </Box>
-
-          <FlexChildThatWontStretchOutsideOfParent>
-            <Sans size="4">Submit Once</Sans>
-            <Spacer mb={0.3} />
-            <Sans color="black60" size="3t">
-              With a single submission, you'll access art buyers around the world.
-            </Sans>
-          </FlexChildThatWontStretchOutsideOfParent>
-        </Flex>
-        <Spacer mb={2} />
-        <Flex flexDirection="row">
-          <Box pr={2}>
-            <AuctionIcon width={30} height={30} />
-          </Box>
-
-          <FlexChildThatWontStretchOutsideOfParent>
-            <Sans size="4">Make Your Sale</Sans>
-            <Spacer mb={0.3} />
-            <Sans color="black60" size="3t">
-              Choose from several Artsy marketplace resale options.
-            </Sans>
-          </FlexChildThatWontStretchOutsideOfParent>
-        </Flex>
-        <Spacer mb={2} />
-        <Flex flexDirection="row">
-          <Box pr={2}>
-            <EnvelopeIcon width={30} height={30} />
-          </Box>
-
-          <FlexChildThatWontStretchOutsideOfParent>
-            <Sans size="4">Receive Payment</Sans>
-            <Spacer mb={0.3} />
-            <Sans color="black60" size="3t">
-              Keep the work until it sells, ship it with our help, and receive payment.
-            </Sans>
-          </FlexChildThatWontStretchOutsideOfParent>
-        </Flex>
-      </Box>
+      <HowItWorks />
 
       <Separator my={3} />
 
-      <Box px={2}>
-        <Box>
-          <Sans size="4">Artists collectors are looking to buy</Sans>
-
-          <Spacer mb={2} />
-
-          <ScrollView horizontal>
-            <ArtistList artists={artists} />
-          </ScrollView>
-        </Box>
-      </Box>
+      <ArtistsCollectorsAreLookingToBuy artists={artists} />
 
       <Separator my={3} />
 
-      <Box px={2} pb={6}>
-        <Sans size="8">Why sell with Artsy?</Sans>
-
-        <Spacer mb={2} />
-
-        <Flex flexDirection="row">
-          <NumberBox pl={0.5} pr={1}>
-            <Sans size="4">1</Sans>
-          </NumberBox>
-
-          <FlexChildThatWontStretchOutsideOfParent>
-            <Sans size="4">Simple Steps</Sans>
-            <Spacer mb={0.3} />
-            <Sans color="black60" size="3t">
-              Submit your work once, pick the best offer, and ship the work when it sells.
-            </Sans>
-          </FlexChildThatWontStretchOutsideOfParent>
-        </Flex>
-
-        <Spacer mb={2} />
-
-        <Flex flexDirection="row">
-          <NumberBox pl={0.5} pr={1}>
-            <Sans size="4">2</Sans>
-          </NumberBox>
-
-          <FlexChildThatWontStretchOutsideOfParent>
-            <Sans size="4">Industry Expertise</Sans>
-            <Spacer mb={0.3} />
-            <Sans color="black60" size="3t">
-              Receive virtual valuation and expert guidance on the best sales strategies.
-            </Sans>
-          </FlexChildThatWontStretchOutsideOfParent>
-        </Flex>
-
-        <Spacer mb={2} />
-
-        <Flex flexDirection="row">
-          <NumberBox pl={0.5} pr={1}>
-            <Sans size="4">3</Sans>
-          </NumberBox>
-
-          <FlexChildThatWontStretchOutsideOfParent>
-            <Sans size="4">Global Reach</Sans>
-            <Spacer mb={0.3} />
-            <Sans color="black60" size="3t">
-              Your work will reach the world's collectors, galleries, and auction houses.
-            </Sans>
-          </FlexChildThatWontStretchOutsideOfParent>
-        </Flex>
-
-        <Spacer mb={3} />
-
-        <Button variant="primaryBlack" block onPress={handlePress}>
-          <Sans size="3">Start selling</Sans>
-        </Button>
-      </Box>
+      <FooterCTA handleCTAPress={handleCTAPress} />
     </ScrollView>
+  )
+}
+
+const HeaderCTA: React.FC<{ handleCTAPress: () => void }> = ({ handleCTAPress }) => {
+  return (
+    <Box px={2} py={6}>
+      <Box>
+        <Sans size="8" textAlign="center" px={2}>
+          Sell Art From Your Collection
+        </Sans>
+
+        <Spacer my={0.5} />
+
+        <Sans size="4" textAlign="center">
+          Reach art buyers all over the world.
+        </Sans>
+      </Box>
+
+      <Spacer mb={2} />
+
+      <Button variant="primaryBlack" block onPress={handleCTAPress}>
+        <Sans size="3" weight="medium">
+          Start selling
+        </Sans>
+      </Button>
+    </Box>
+  )
+}
+
+const HowItWorks: React.FC = () => {
+  return (
+    <Box px={2}>
+      <Sans size="8">How it works</Sans>
+
+      <Spacer mb={2} />
+      <Flex flexDirection="row">
+        <Box pr={2}>
+          <EditIcon width={30} height={30} />
+        </Box>
+
+        <FlexChildThatWontStretchOutsideOfParent>
+          <Sans size="4">Submit Once</Sans>
+          <Spacer mb={0.3} />
+          <Sans color="black60" size="3t">
+            With a single submission, you'll access art buyers around the world.
+          </Sans>
+        </FlexChildThatWontStretchOutsideOfParent>
+      </Flex>
+      <Spacer mb={2} />
+      <Flex flexDirection="row">
+        <Box pr={2}>
+          <AuctionIcon width={30} height={30} />
+        </Box>
+
+        <FlexChildThatWontStretchOutsideOfParent>
+          <Sans size="4">Make Your Sale</Sans>
+          <Spacer mb={0.3} />
+          <Sans color="black60" size="3t">
+            Choose from several Artsy marketplace resale options.
+          </Sans>
+        </FlexChildThatWontStretchOutsideOfParent>
+      </Flex>
+      <Spacer mb={2} />
+      <Flex flexDirection="row">
+        <Box pr={2}>
+          <EnvelopeIcon width={30} height={30} />
+        </Box>
+
+        <FlexChildThatWontStretchOutsideOfParent>
+          <Sans size="4">Receive Payment</Sans>
+          <Spacer mb={0.3} />
+          <Sans color="black60" size="3t">
+            Keep the work until it sells, ship it with our help, and receive payment.
+          </Sans>
+        </FlexChildThatWontStretchOutsideOfParent>
+      </Flex>
+    </Box>
+  )
+}
+
+const ArtistsCollectorsAreLookingToBuy: React.FC<{ artists: ConsignmentsHome_artists }> = ({ artists }) => {
+  return (
+    <Box px={2}>
+      <Box>
+        <Sans size="4">Artists collectors are looking to buy</Sans>
+
+        <Spacer mb={2} />
+
+        <ScrollView horizontal>
+          <ArtistList artists={artists} />
+        </ScrollView>
+      </Box>
+    </Box>
+  )
+}
+
+const FooterCTA: React.FC<{ handleCTAPress: () => void }> = ({ handleCTAPress }) => {
+  return (
+    <Box px={2} pb={6}>
+      <Sans size="8">Why sell with Artsy?</Sans>
+
+      <Spacer mb={2} />
+
+      <Flex flexDirection="row">
+        <NumberBox pl={0.5} pr={1}>
+          <Sans size="4">1</Sans>
+        </NumberBox>
+
+        <FlexChildThatWontStretchOutsideOfParent>
+          <Sans size="4">Simple Steps</Sans>
+          <Spacer mb={0.3} />
+          <Sans color="black60" size="3t">
+            Submit your work once, pick the best offer, and ship the work when it sells.
+          </Sans>
+        </FlexChildThatWontStretchOutsideOfParent>
+      </Flex>
+
+      <Spacer mb={2} />
+
+      <Flex flexDirection="row">
+        <NumberBox pl={0.5} pr={1}>
+          <Sans size="4">2</Sans>
+        </NumberBox>
+
+        <FlexChildThatWontStretchOutsideOfParent>
+          <Sans size="4">Industry Expertise</Sans>
+          <Spacer mb={0.3} />
+          <Sans color="black60" size="3t">
+            Receive virtual valuation and expert guidance on the best sales strategies.
+          </Sans>
+        </FlexChildThatWontStretchOutsideOfParent>
+      </Flex>
+
+      <Spacer mb={2} />
+
+      <Flex flexDirection="row">
+        <NumberBox pl={0.5} pr={1}>
+          <Sans size="4">3</Sans>
+        </NumberBox>
+
+        <FlexChildThatWontStretchOutsideOfParent>
+          <Sans size="4">Global Reach</Sans>
+          <Spacer mb={0.3} />
+          <Sans color="black60" size="3t">
+            Your work will reach the world's collectors, galleries, and auction houses.
+          </Sans>
+        </FlexChildThatWontStretchOutsideOfParent>
+      </Flex>
+
+      <Spacer mb={3} />
+
+      <Button variant="primaryBlack" block onPress={handleCTAPress}>
+        <Sans size="3">Start selling</Sans>
+      </Button>
+    </Box>
   )
 }
 


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/CSGN-189

Adds a proper placeholder screen for the Sell Tab landing page.

Static content remains static, and only the dynamic pieces are grayed out. Here's what it looks like - note the very bottom, where the "Artists collectors are looking to buy" section fills in:

![placeholder-full](https://user-images.githubusercontent.com/1627089/82341820-86a0bc80-99b6-11ea-8960-9f91210bfe50.gif)

To give a better idea of what that artist list would look like if it were to, say, move up the page some day, here's how that artist section loads when you can see it completely:

![placeholder-artist-list](https://user-images.githubusercontent.com/1627089/82342175-edbe7100-99b6-11ea-80a0-8ff55fc5536f.gif)

There is a slight difference in heights that causes the section below it to jump a couple pixels...I was unable to figure out what was causing that difference. I don't personally think it's a big deal because no one really sees the bottom of the artist section when the full view is loading, but let me know if you feel otherwise.

#trivial