### PR TITLE
Add react-native-linear-gradient + viewing rooms tweaks

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,6 +5,7 @@ upcoming:
     - Add tracking for homescreen modules - brian
     - Make viewing room header full-bleed and incorporate countdown and partner info - mdole
     - Make viewing room navigation dynamic + link to them on partner shows page - mdole
+    - Add react-native-linear-gradient and use it in viewing room header - mdole
     - Extract common artwork tile independent of the shape of the data source - pepopowitz
   user_facing:
     - Fix for bug with fair booth display when partner profile was empty

--- a/Podfile
+++ b/Podfile
@@ -131,6 +131,8 @@ target 'Artsy' do
   # Used in Live Auctions to hold user-state
   pod 'JWTDecode'
 
+  pod 'BVLinearGradient', :path => './node_modules/react-native-linear-gradient'
+
   target 'Artsy Tests' do
     inherit! :search_paths
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -59,6 +59,8 @@ PODS:
     - Bolts/Tasks
   - Bolts/Tasks (1.9.0)
   - boost-for-react-native (1.63.0)
+  - BVLinearGradient (2.5.6):
+    - React
   - CocoaLumberjack (2.0.1):
     - CocoaLumberjack/Default (= 2.0.1)
     - CocoaLumberjack/Extensions (= 2.0.1)
@@ -471,6 +473,7 @@ DEPENDENCIES:
   - "Artsy+UIFonts"
   - "Artsy+UILabels"
   - Artsy-UIButtons
+  - BVLinearGradient (from `./node_modules/react-native-linear-gradient`)
   - CocoaLumberjack (from `https://github.com/CocoaLumberjack/CocoaLumberjack.git`)
   - DHCShakeNotifier
   - DoubleConversion (from `node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
@@ -618,6 +621,8 @@ EXTERNAL SOURCES:
     :git: https://github.com/ashfurrow/ARCollectionViewMasonryLayout
   ARGenericTableViewController:
     :git: https://github.com/orta/ARGenericTableViewController.git
+  BVLinearGradient:
+    :path: "./node_modules/react-native-linear-gradient"
   CocoaLumberjack:
     :git: https://github.com/CocoaLumberjack/CocoaLumberjack.git
   DoubleConversion:
@@ -766,6 +771,7 @@ SPEC CHECKSUMS:
   Artsy-UIButtons: 3c396f0fad352a7b0332100e0ffcb0ca577e0082
   Bolts: ac6567323eac61e203f6a9763667d0f711be34c8
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
+  BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   CocoaLumberjack: 27ae9abcd376c3e4ee726ecd4adfd7b093ddef3f
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
@@ -852,6 +858,6 @@ SPEC CHECKSUMS:
   "XCTest+OHHTTPStubSuiteCleanUp": 4469ec8863c6bc022c5089a9b94233eb3416c5ee
   Yoga: 50fb6eb13d2152e7363293ff603385db380815b1
 
-PODFILE CHECKSUM: bde362cc9b474c64f2d920484e2086f123a9793a
+PODFILE CHECKSUM: 1db98f52ac11bd0b220f43b4666d25105c259932
 
 COCOAPODS: 1.7.5

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "react": "16.11.0",
     "react-native": "0.62.1",
     "react-native-hyperlink": "0.0.11",
+    "react-native-linear-gradient": "^2.5.6",
     "react-native-modal": "11.5.6",
     "react-native-navigator-ios": "https://github.com/ashfurrow/react-native-navigator-ios#license_podspec",
     "react-native-parallax-scroll-view": "orta/react-native-parallax-scroll-view",

--- a/src/lib/Components/ArtworkTileRail/ArtworkTileRail.tsx
+++ b/src/lib/Components/ArtworkTileRail/ArtworkTileRail.tsx
@@ -20,6 +20,8 @@ export const ArtworkTileRailContainer: React.FC<{
     <View ref={navRef}>
       <FlatList
         horizontal
+        ListHeaderComponent={() => <Spacer mr={2}></Spacer>}
+        ListFooterComponent={() => <Spacer mr={2}></Spacer>}
         ItemSeparatorComponent={() => <Spacer width={15}></Spacer>}
         showsHorizontalScrollIndicator={false}
         data={artworks}

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomArtworkRail.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomArtworkRail.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@artsy/palette"
+import { Box } from "@artsy/palette"
 import { ViewingRoomArtworkRail_viewingRoom } from "__generated__/ViewingRoomArtworkRail_viewingRoom.graphql"
 import { ArtworkTileRail } from "lib/Components/ArtworkTileRail"
 import { SectionTitle } from "lib/Components/SectionTitle"
@@ -22,7 +22,7 @@ export const ViewingRoomArtworkRail: React.FC<ViewingRoomArtworkRailProps> = pro
 
   return (
     <View ref={navRef as any /* STRICTNESS_MIGRATION */}>
-      <Flex>
+      <Box mx="2">
         <SectionTitle
           title={`${totalCount} ${pluralizedArtworksCount}`}
           onPress={() => {
@@ -30,11 +30,11 @@ export const ViewingRoomArtworkRail: React.FC<ViewingRoomArtworkRailProps> = pro
             SwitchBoard.presentNavigationViewController(navRef.current!, `/viewing-room/${viewingRoom.slug}/artworks`)
           }}
         />
-        <ArtworkTileRail
-          artworksConnection={props!.viewingRoom!.artworks!}
-          contextModule={Schema.ContextModules.ViewingRoomArtworkRail}
-        />
-      </Flex>
+      </Box>
+      <ArtworkTileRail
+        artworksConnection={props!.viewingRoom!.artworks!}
+        contextModule={Schema.ContextModules.ViewingRoomArtworkRail}
+      />
     </View>
   )
 }

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
@@ -23,6 +23,10 @@ const CountdownContainer = styled.View`
   bottom: ${space(2)};
   right: ${space(2)};
   width: 45%;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+  height: 20;
 `
 
 const PartnerContainer = styled(Flex)`
@@ -33,6 +37,7 @@ const PartnerContainer = styled(Flex)`
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
+  height: 20;
 `
 
 const Overlay = styled.View`
@@ -88,7 +93,12 @@ export const ViewingRoomHeader: React.FC<ViewingRoomHeaderProps> = props => {
         </PartnerContainer>
         <CountdownContainer>
           <Flex alignItems="flex-end">
-            <CountdownTimer startAt={startAt as string} endAt={endAt as string} countdownComponent={CountdownText} />
+            <Flex flexDirection="row">
+              <Sans size="2" weight="medium" color="white100">
+                Closes{" "}
+              </Sans>
+              <CountdownTimer startAt={startAt as string} endAt={endAt as string} countdownComponent={CountdownText} />
+            </Flex>
           </Flex>
         </CountdownContainer>
       </Box>

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
@@ -5,6 +5,7 @@ import { CountdownProps, CountdownTimer } from "lib/Components/Countdown/Countdo
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import React from "react"
 import { Dimensions } from "react-native"
+import LinearGradient from "react-native-linear-gradient"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components/native"
 
@@ -40,11 +41,11 @@ const PartnerContainer = styled(Flex)`
   height: 20;
 `
 
-const Overlay = styled.View`
-  background-color: rgba(0, 0, 0, 0.3);
+const Overlay = styled(LinearGradient)`
   width: 100%;
   height: 100%;
   position: absolute;
+  opacity: 0.15;
 `
 
 const CountdownText: React.SFC<CountdownProps> = ({ duration }) => (
@@ -70,7 +71,7 @@ export const ViewingRoomHeader: React.FC<ViewingRoomHeaderProps> = props => {
           height={imageHeight}
           width={screenWidth}
         />
-        <Overlay />
+        <Overlay colors={["rgba(255, 255, 255, 0)", "rgba(0, 0, 0, 1)"]} />
         <Flex flexDirection="row" justifyContent="center" alignItems="flex-end" px={2} height={imageHeight - 60}>
           <Flex alignItems="center" flexDirection="column" flexGrow={1}>
             <Sans data-test-id="title" size="6" textAlign="center" color="white100">

--- a/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
@@ -1,4 +1,4 @@
-import { Box, Sans, Serif, Theme } from "@artsy/palette"
+import { Sans, Serif, Theme } from "@artsy/palette"
 import { ViewingRoom_viewingRoom } from "__generated__/ViewingRoom_viewingRoom.graphql"
 import { ViewingRoomQuery } from "__generated__/ViewingRoomQuery.graphql"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
@@ -49,11 +49,7 @@ export const ViewingRoom: React.FC<ViewingRoomProps> = props => {
     },
     {
       key: "artworkRail",
-      content: (
-        <Box mx="2">
-          <ViewingRoomArtworkRailContainer viewingRoom={viewingRoom} />
-        </Box>
-      ),
+      content: <ViewingRoomArtworkRailContainer viewingRoom={viewingRoom} />,
     },
     {
       key: "pullQuote",

--- a/src/lib/Scenes/ViewingRoom/ViewingRoomArtworks.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoomArtworks.tsx
@@ -79,8 +79,7 @@ export const ViewingRoomArtworks: React.FC<ViewingRoomArtworksProps> = ({ viewin
             </Sans>
             <FlatList
               data={sections}
-              ItemSeparatorComponent={() => <Box px={2} my={2} />}
-              contentInset={{ bottom: 40 }}
+              ItemSeparatorComponent={() => <Box px={2} mb={2} />}
               renderItem={({ item }) => <Box>{item.content}</Box>}
               onEndReached={() => {
                 if (isLoadingMore || !relay.hasMore()) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10471,6 +10471,11 @@ react-native-hyperlink@0.0.11:
   dependencies:
     linkify-it "^1.2.0"
 
+react-native-linear-gradient@^2.5.6:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/react-native-linear-gradient/-/react-native-linear-gradient-2.5.6.tgz#96215cbc5ec7a01247a20890888aa75b834d44a0"
+  integrity sha512-HDwEaXcQIuXXCV70O+bK1rizFong3wj+5Q/jSyifKFLg0VWF95xh8XQgfzXwtq0NggL9vNjPKXa016KuFu+VFg==
+
 react-native-modal@11.5.6:
   version "11.5.6"
   resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-11.5.6.tgz#bb25a78c35a5e24f45de060e5f64284397d38a87"


### PR DESCRIPTION
Included in this PR:
- A new dependency, [react-native-linear-gradient](https://github.com/react-native-community/react-native-linear-gradient). Styled components [doesn't support gradients](https://github.com/styled-components/styled-components/issues/1170) and doesn't plan to, so seemed like the best way to achieve one
- Artwork rail on viewing rooms now extends all the way to the edge of the screen
- Countdown clock now says "closes" and is properly vertically aligned