### PR TITLE
Use relay's hasMore and isLoading for more robust pagination on infinite scroll grid

### DIFF
--- a/src/lib/Components/Artist/ArtistArtworks/index.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/index.tsx
@@ -20,6 +20,8 @@ const ArtworksGrid: React.FC<Props> = ({ artist, relay, ...props }) => (
       // @ts-ignore STRICTNESS_MIGRATION
       connection={artist.artworks}
       loadMore={relay.loadMore}
+      hasMore={relay.hasMore}
+      isLoading={relay.isLoading}
       {...props}
     />
   </StickyTabPageScrollView>

--- a/src/lib/Components/FilteredInfiniteScrollGrid/FilteredInfiniteScrollGrid.tsx
+++ b/src/lib/Components/FilteredInfiniteScrollGrid/FilteredInfiniteScrollGrid.tsx
@@ -82,6 +82,8 @@ export class FilteredInfiniteScrollGrid extends React.Component<Props, State> {
             // @ts-ignore STRICTNESS_MIGRATION
             connection={filterArtworksConnection}
             loadMore={this.props.relay.loadMore}
+            hasMore={this.props.relay.hasMore}
+            isLoading={this.props.relay.isLoading}
             shouldAddPadding={true}
             HeaderComponent={
               <Box px={2}>

--- a/src/lib/Containers/Gene.tsx
+++ b/src/lib/Containers/Gene.tsx
@@ -111,8 +111,15 @@ export class Gene extends React.Component<Props, State> {
       case TABS.ABOUT:
         return <About gene={this.props.gene} />
       case TABS.WORKS:
-        // @ts-ignore STRICTNESS_MIGRATION
-        return <InfiniteScrollArtworksGrid connection={this.props.gene.artworks} loadMore={this.props.relay.loadMore} />
+        return (
+          <InfiniteScrollArtworksGrid
+            // @ts-ignore STRICTNESS_MIGRATION
+            connection={this.props.gene.artworks}
+            loadMore={this.props.relay.loadMore}
+            hasMore={this.props.relay.hasMore}
+            isLoading={this.props.relay.isLoading}
+          />
+        )
     }
   }
 

--- a/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -54,7 +54,12 @@ export const CollectionArtworks: React.SFC<CollectionArtworksProps> = ({ collect
       <Box mb={3} mt={1}>
         <Separator />
       </Box>
-      <InfiniteScrollArtworksGrid connection={artworks} loadMore={relay.loadMore} />
+      <InfiniteScrollArtworksGrid
+        connection={artworks}
+        loadMore={relay.loadMore}
+        hasMore={relay.hasMore}
+        isLoading={relay.isLoading}
+      />
     </ArtworkGridWrapper>
   ) : null
 }

--- a/src/lib/Scenes/Partner/Components/PartnerArtwork.tsx
+++ b/src/lib/Scenes/Partner/Components/PartnerArtwork.tsx
@@ -15,7 +15,12 @@ export const PartnerArtwork: React.FC<{
   return (
     <StickyTabPageScrollView>
       {artworks ? (
-        <InfiniteScrollArtworksGrid connection={artworks} loadMore={relay.loadMore} />
+        <InfiniteScrollArtworksGrid
+          connection={artworks}
+          loadMore={relay.loadMore}
+          hasMore={relay.hasMore}
+          isLoading={relay.isLoading}
+        />
       ) : (
         <TabEmptyState text="There is no artwork from this gallery yet" />
       )}

--- a/src/lib/Scenes/Sales/Components/LotsByFollowedArtists.tsx
+++ b/src/lib/Scenes/Sales/Components/LotsByFollowedArtists.tsx
@@ -27,6 +27,8 @@ export class LotsByFollowedArtists extends Component<Props> {
         <Box px={2}>
           <InfiniteScrollArtworksGrid
             loadMore={this.props.relay.loadMore}
+            hasMore={this.props.relay.hasMore}
+            isLoading={this.props.relay.isLoading}
             // @ts-ignore STRICTNESS_MIGRATION
             connection={this.props.me.lotsByFollowedArtistsConnection}
             HeaderComponent={<SectionTitle title={title} />}


### PR DESCRIPTION
This PR is in response to a bug that was introduced in https://github.com/artsy/eigen/pull/3249 which caused us to send _many_ concurrent requests for data on each refetch. I believe it's because the `! hasMoreWorksToFetch &&`  conditional meant that we would _always_ fetch for more if we could (instead we need to also verify that we're not in the middle of loading).

This component is pretty old and used to do its own management of loading + completed state. I updated this to fully embrace relay's `isLoading` and `hasMore` which both fixes the current bug and the one that the original PR was aiming to fix.