### PR TITLE
[CSGN-203] Replace icon for Receive Payment section of sell tab landing page

### DIFF
--- a/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/index.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/index.tsx
@@ -1,4 +1,4 @@
-import { AuctionIcon, Box, Button, EditIcon, EnvelopeIcon, Flex, Join, Sans, Separator, Spacer } from "@artsy/palette"
+import { AuctionIcon, Box, Button, EditIcon, Flex, Join, PaymentIcon, Sans, Separator, Spacer } from "@artsy/palette"
 import { ConsignmentsHome_artists } from "__generated__/ConsignmentsHome_artists.graphql"
 import { ConsignmentsHomeQuery } from "__generated__/ConsignmentsHomeQuery.graphql"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
@@ -116,7 +116,7 @@ const HowItWorks: React.FC = () => {
       <Spacer mb={2} />
       <Flex flexDirection="row">
         <Box pr={2}>
-          <EnvelopeIcon width={30} height={30} />
+          <PaymentIcon width={30} height={30} />
         </Box>
 
         <FlexChildThatWontStretchOutsideOfParent>


### PR DESCRIPTION
Completes https://artsyproduct.atlassian.net/browse/CSGN-203 

Using the new PaymentIcon from palette, the page now looks like this:

![image](https://user-images.githubusercontent.com/1627089/82465581-11e88380-9a85-11ea-99bb-e1f5b258e033.png)

#trivial