### PR TITLE
Add artwork description to Viewing Room artworks view

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -9,6 +9,7 @@ upcoming:
     - Extract common artwork tile independent of the shape of the data source - pepopowitz
     - Initial build of sell tab landing page (behind a feature flag) - pepopowitz
     - Hide consign sash from Home when sell tab feature flag is enabled - pepopowitz
+    - Add artwork description to viewing room artworks view - mdole
   user_facing:
     - Fix for bug with fair booth display when partner profile was empty
     - Adds Ways to Buy filter to Collections - ashley

--- a/src/__generated__/ViewingRoomArtworksQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomArtworksQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash aada3a52a0f7f6ea92349b177d0f4a1e */
+/* @relayHash dd4ffb4964fda8767a0fe34b63eba33d */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -38,6 +38,7 @@ fragment ViewingRoomArtworks_viewingRoom_1G22uz on ViewingRoom {
   artworksConnection(first: $count, after: $cursor) {
     edges {
       node {
+        description
         href
         slug
         internalID
@@ -200,6 +201,13 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
+                        "name": "description",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
                         "name": "href",
                         "args": null,
                         "storageKey": null
@@ -333,7 +341,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomArtworksQuery",
-    "id": "c6a1d56320ba2a13997f3214cd01b450",
+    "id": "a75f5639469cc519fed97124e62f3396",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomArtworksRendererQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomArtworksRendererQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 88a59ae5b833689a165c2cf313018012 */
+/* @relayHash 0b2753ac83766a3f5d95731c4bdec496 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -34,6 +34,7 @@ fragment ViewingRoomArtworks_viewingRoom on ViewingRoom {
   artworksConnection(first: 5, after: "") {
     edges {
       node {
+        description
         href
         slug
         internalID
@@ -173,6 +174,13 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
+                        "name": "description",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
                         "name": "href",
                         "args": null,
                         "storageKey": null
@@ -306,7 +314,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomArtworksRendererQuery",
-    "id": "f6592984c8e11e05ef3c961dddc47383",
+    "id": "5bdbc1e6b538b9e3a4b7959eb733b696",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomArtworksTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash bdd2a0c54b82e1f623fe8a790a064f20 */
+/* @relayHash 6c6a838eaef135f081ee3349ea3fb77b */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -30,6 +30,7 @@ fragment ViewingRoomArtworks_viewingRoom on ViewingRoom {
   artworksConnection(first: 5, after: "") {
     edges {
       node {
+        description
         href
         slug
         internalID
@@ -158,6 +159,13 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "description",
+                        "args": null,
+                        "storageKey": null
+                      },
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -294,7 +302,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomArtworksTestsQuery",
-    "id": "6a73c6e1b6e9cab80637f59ab770d47a",
+    "id": "69a943c5b8f77a04318f9b07874b4a24",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomArtworks_viewingRoom.graphql.ts
+++ b/src/__generated__/ViewingRoomArtworks_viewingRoom.graphql.ts
@@ -9,6 +9,7 @@ export type ViewingRoomArtworks_viewingRoom = {
     readonly artworksConnection: {
         readonly edges: ReadonlyArray<{
             readonly node: {
+                readonly description: string | null;
                 readonly href: string | null;
                 readonly slug: string;
                 readonly internalID: string;
@@ -108,6 +109,13 @@ return {
               "concreteType": "Artwork",
               "plural": false,
               "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "description",
+                  "args": null,
+                  "storageKey": null
+                },
                 {
                   "kind": "ScalarField",
                   "alias": null,
@@ -224,5 +232,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'e9a465def497dfe05894c2f1b16bb515';
+(node as any).hash = '82337c820cd26e57b560a3fd9c51b67e';
 export default node;

--- a/src/__generated__/ViewingRoomQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash ffb15b4ad9fdc21c7e4468c3367e7e35 */
+/* @relayHash a77e115a8a72cdbb301a8bb06e89084c */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -59,6 +59,7 @@ fragment ViewingRoomArtworks_viewingRoom on ViewingRoom {
   artworksConnection(first: 5, after: "") {
     edges {
       node {
+        description
         href
         slug
         internalID
@@ -484,6 +485,13 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "description",
+                        "args": null,
+                        "storageKey": null
+                      },
                       (v9/*: any*/),
                       (v3/*: any*/),
                       (v4/*: any*/),
@@ -590,7 +598,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomQuery",
-    "id": "0a2490a0626f207bcbc129e49544554b",
+    "id": "aa3a8bc2b5db4ec7c283dc38b95eb538",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomTestsQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 6660f547c2a463d308460f6a3aa241b3 */
+/* @relayHash 99cdd9d8cd9b35d7bf2b5bbaac03c3e2 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -55,6 +55,7 @@ fragment ViewingRoomArtworks_viewingRoom on ViewingRoom {
   artworksConnection(first: 5, after: "") {
     edges {
       node {
+        description
         href
         slug
         internalID
@@ -472,6 +473,13 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "description",
+                        "args": null,
+                        "storageKey": null
+                      },
                       (v8/*: any*/),
                       (v2/*: any*/),
                       (v3/*: any*/),
@@ -578,7 +586,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomTestsQuery",
-    "id": "8ab48619227f6459f1721f957a59db84",
+    "id": "9e20b1dfd68a255905564a4bb117333b",
     "text": null,
     "metadata": {}
   }

--- a/src/lib/Scenes/ViewingRoom/ViewingRoomArtworks.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoomArtworks.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Sans, space, Spinner, Theme } from "@artsy/palette"
+import { Box, Flex, Sans, Serif, space, Spinner, Theme } from "@artsy/palette"
 import { ViewingRoomArtworks_viewingRoom } from "__generated__/ViewingRoomArtworks_viewingRoom.graphql"
 import { ViewingRoomArtworksRendererQuery } from "__generated__/ViewingRoomArtworksRendererQuery.graphql"
 import ImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
@@ -35,35 +35,42 @@ export const ViewingRoomArtworks: React.FC<ViewingRoomArtworksProps> = ({ viewin
       return {
         key: `${index}`,
         content: (
-          <TouchableOpacity
-            ref={navRef as any /* STRICTNESS_MIGRATION */}
-            onPress={() => {
-              tracking.trackEvent({
-                ...tracks.context(viewingRoom.internalID, viewingRoom.slug),
-                ...tracks.tappedArtworkGroup(finalArtwork.internalID, finalArtwork.slug),
-              })
-              SwitchBoard.presentNavigationViewController(
-                navRef.current!,
-                finalArtwork.href! /* STRICTNESS_MIGRATION */
-              )
-            }}
-          >
-            <ImageView
-              imageURL={finalArtwork.image! /* STRICTNESS_MIGRATION */.url! /* STRICTNESS_MIGRATION */}
-              aspectRatio={finalArtwork.image!.aspectRatio}
-            />
-            <Box mt="1" mb="2" mx="2">
-              <Sans size="3t" weight="medium">
-                {finalArtwork.artistNames}
-              </Sans>
-              <Sans size="3t" color="black60" key={index}>
-                {finalArtwork.title}
-              </Sans>
-              <Sans size="3t" color="black60">
-                {finalArtwork.saleMessage}
-              </Sans>
-            </Box>
-          </TouchableOpacity>
+          <Box>
+            <TouchableOpacity
+              ref={navRef as any /* STRICTNESS_MIGRATION */}
+              onPress={() => {
+                tracking.trackEvent({
+                  ...tracks.context(viewingRoom.internalID, viewingRoom.slug),
+                  ...tracks.tappedArtworkGroup(finalArtwork.internalID, finalArtwork.slug),
+                })
+                SwitchBoard.presentNavigationViewController(
+                  navRef.current!,
+                  finalArtwork.href! /* STRICTNESS_MIGRATION */
+                )
+              }}
+            >
+              <ImageView
+                imageURL={finalArtwork.image! /* STRICTNESS_MIGRATION */.url! /* STRICTNESS_MIGRATION */}
+                aspectRatio={finalArtwork.image!.aspectRatio}
+              />
+              <Box mt="1" mx="2">
+                <Sans size="3t" weight="medium">
+                  {finalArtwork.artistNames}
+                </Sans>
+                <Sans size="3t" color="black60" key={index}>
+                  {finalArtwork.title}
+                </Sans>
+                <Sans size="3t" color="black60">
+                  {finalArtwork.saleMessage}
+                </Sans>
+              </Box>
+            </TouchableOpacity>
+            {finalArtwork.description && (
+              <Serif size="4" mx="2" mt="1" data-test-id="artwork-description">
+                {finalArtwork.description}
+              </Serif>
+            )}
+          </Box>
         ),
       }
     })
@@ -79,7 +86,7 @@ export const ViewingRoomArtworks: React.FC<ViewingRoomArtworksProps> = ({ viewin
             </Sans>
             <FlatList
               data={sections}
-              ItemSeparatorComponent={() => <Box px={2} mb={2} />}
+              ItemSeparatorComponent={() => <Box px={2} mb={3} />}
               renderItem={({ item }) => <Box>{item.content}</Box>}
               onEndReached={() => {
                 if (isLoadingMore || !relay.hasMore()) {
@@ -140,6 +147,7 @@ export const ViewingRoomArtworksContainer = createPaginationContainer(
         artworksConnection(first: $count, after: $cursor) @connection(key: "ViewingRoomArtworks_artworksConnection") {
           edges {
             node {
+              description
               href
               slug
               internalID

--- a/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomArtworks-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomArtworks-tests.tsx
@@ -1,5 +1,6 @@
 import { ViewingRoomArtworksTestsQuery } from "__generated__/ViewingRoomArtworksTestsQuery.graphql"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { extractText } from "lib/tests/extractText"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import React from "react"
 import { FlatList, TouchableOpacity } from "react-native"
@@ -44,6 +45,30 @@ describe("ViewingRoom", () => {
     })
     expect(tree.root.findAllByType(FlatList)).toHaveLength(1)
     expect(tree.root.findAllByType(TouchableOpacity)).toHaveLength(1)
+  })
+
+  it("renders an artwork description if one exists", () => {
+    const tree = ReactTestRenderer.create(<TestRenderer />)
+    mockEnvironment.mock.resolveMostRecentOperation(operation => {
+      const result = MockPayloadGenerator.generate(operation, {
+        ViewingRoom: () => ({
+          artworksConnection: {
+            edges: [
+              {
+                node: {
+                  title: "Described Work",
+                  description: "Very cool. Love the style.",
+                },
+              },
+            ],
+          },
+        }),
+      })
+      return result
+    })
+    expect(extractText(tree.root.findByProps({ "data-test-id": "artwork-description" }))).toEqual(
+      "Very cool. Love the style."
+    )
   })
 
   it("navigates to artwork screen + calls tracking on press", () => {


### PR DESCRIPTION
Missed this in the spec till now! This PR grabs the artwork description if one exists and puts it below the artwork in the list view.

![Screen Shot 2020-05-20 at 5 32 00 PM](https://user-images.githubusercontent.com/5361806/82499579-e33bce80-9abf-11ea-9cee-6ca67e8aa359.png)
