### PR TITLE
[MX-326] Fix Explore unfocused states

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -14,6 +14,8 @@ upcoming:
   user_facing:
     - Fix for bug with fair booth display when partner profile was empty
     - Adds Ways to Buy filter to Collections - ashley
+    - Update Explore tab unfocused states and typography - david
+    - Show artists with no data without crashing - david
 
 releases:
   - version: 6.4.5

--- a/src/lib/Components/OpaqueImageView/OpaqueImageView.tsx
+++ b/src/lib/Components/OpaqueImageView/OpaqueImageView.tsx
@@ -59,7 +59,7 @@ interface Props extends ViewProps {
 }
 
 interface State {
-  aspectRatio: number
+  aspectRatio?: number
   width?: number
   height?: number
 }
@@ -75,7 +75,7 @@ export default class OpaqueImageView extends React.Component<Props, State> {
     // Unless `aspectRatio` was not specified at all, default the ratio to 1 to prevent illegal layout calculations.
     const ratio = props.aspectRatio
     this.state = {
-      aspectRatio: (ratio === undefined ? undefined : ratio) || 1,
+      aspectRatio: ratio === undefined ? undefined : ratio || 1,
     }
 
     if (__DEV__) {

--- a/src/lib/Containers/Artist.tsx
+++ b/src/lib/Containers/Artist.tsx
@@ -1,4 +1,4 @@
-import { Flex, Separator, Spacer, Theme } from "@artsy/palette"
+import { Flex, Message, Separator, Spacer, Theme } from "@artsy/palette"
 import {
   ArtistAboveTheFoldQuery,
   ArtistAboveTheFoldQueryVariables,
@@ -12,6 +12,7 @@ import ArtistArtworks from "lib/Components/Artist/ArtistArtworks"
 import ArtistHeader from "lib/Components/Artist/ArtistHeader"
 import ArtistShows from "lib/Components/Artist/ArtistShows"
 import { StickyTabPage } from "lib/Components/StickyTabPage/StickyTabPage"
+import { StickyTabPageScrollView } from "lib/Components/StickyTabPage/StickyTabPageScrollView"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { AboveTheFoldQueryRenderer } from "lib/utils/AboveTheFoldQueryRenderer"
 import { PlaceholderButton, PlaceholderImage, PlaceholderText } from "lib/utils/placeholders"
@@ -51,6 +52,20 @@ export const Artist: React.FC<{
     tabs.push({
       title: "Shows",
       content: artistBelowTheFold ? <ArtistShows artist={artistBelowTheFold} /> : <LoadingPage />,
+    })
+  }
+
+  if (tabs.length === 0) {
+    tabs.push({
+      title: "Artworks",
+      content: (
+        <StickyTabPageScrollView>
+          <Message>
+            There aren’t any works available by the artist at this time. Follow to receive notifications when new works
+            are added.
+          </Message>
+        </StickyTabPageScrollView>
+      ),
     })
   }
 

--- a/src/lib/Containers/__tests__/Artist-tests.tsx
+++ b/src/lib/Containers/__tests__/Artist-tests.tsx
@@ -3,6 +3,7 @@ import ArtistArtworks from "lib/Components/Artist/ArtistArtworks"
 import ArtistHeader from "lib/Components/Artist/ArtistHeader"
 import ArtistShows from "lib/Components/Artist/ArtistShows"
 import { StickyTab } from "lib/Components/StickyTabPage/StickyTabPageTabBar"
+import { extractText } from "lib/tests/extractText"
 import _ from "lodash"
 import React from "react"
 import "react-native"
@@ -48,7 +49,7 @@ describe("availableTabs", () => {
     return <ArtistQueryRenderer artistID="ignored" environment={environment} isPad={false} />
   }
 
-  it("returns nothing if artist has no metadata, shows, or works", async () => {
+  it("returns an empty state if artist has no metadata, shows, or works", async () => {
     const tree = create(<TestWrapper />)
     mockMostRecentOperation("ArtistAboveTheFoldQuery", {
       Artist() {
@@ -59,7 +60,10 @@ describe("availableTabs", () => {
       },
     })
     expect(tree.root.findAllByType(ArtistHeader)).toHaveLength(1)
-    expect(tree.root.findAllByType(StickyTab)).toHaveLength(0)
+    expect(tree.root.findAllByType(StickyTab)).toHaveLength(1)
+    expect(extractText(tree.root)).toMatchInlineSnapshot(
+      `"There aren’t any works available by the artist at this time. Follow to receive notifications when new works are added.Artworks"`
+    )
   })
 
   it("returns About tab if artist has metadata", async () => {

--- a/src/lib/Icons/SearchIcon.tsx
+++ b/src/lib/Icons/SearchIcon.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import Svg, { Path } from "react-native-svg"
 
-const SearchIcon = (props: any /* STRICTNESS_MIGRATION */) => (
+const SearchIcon = (props: React.ComponentProps<typeof Svg>) => (
   <Svg width={14} height={14} viewBox="0 0 54 54" {...props}>
     <Path
       d="M49.7 46.9L38.2 35.3c2.5-3.1 4-7 4-11.3C42.1 14 34 5.9 24 5.9S5.9 14 5.9 24C5.9 34 14 42.1 24 42.1c4.3 0 8.2-1.5 11.3-4l11.6 11.6c.4.4 1 .4 1.4 0l1.4-1.4c.4-.4.4-1 0-1.4zM10 24c0-7.7 6.3-14 14-14s14 6.3 14 14-6.3 14-14 14-14-6.3-14-14z"

--- a/src/lib/Scenes/Search/AutosuggestResults.tsx
+++ b/src/lib/Scenes/Search/AutosuggestResults.tsx
@@ -58,12 +58,11 @@ const AutosuggestResultsFlatList: React.FC<{
   /// the fetch/cache-lookup has not completed yet) so we can scroll the user back to
   // the top whenever that happens.
   const lastResults = usePreviousValue(latestResults, undefined)
-  const flatListRef = useRef<FlatList<any>>()
+  const flatListRef = useRef<FlatList<any>>(null)
   useEffect(() => {
     if (lastResults === null && latestResults !== null) {
       // results were updated after a new query, scroll user back to top
-      // @ts-ignore STRICTNESS_MIGRATION
-      flatListRef.current.scrollToOffset({ offset: 0, animated: true })
+      flatListRef.current?.scrollToOffset({ offset: 0, animated: true })
       // (we need to wait for the results to be updated to avoid janky behaviour that
       // happens when the results get updated during a scroll)
     }
@@ -75,14 +74,13 @@ const AutosuggestResultsFlatList: React.FC<{
   const results = useRef(latestResults)
   results.current = latestResults || results.current
 
-  // @ts-ignore STRICTNESS_MIGRATION
-  const nodes = useMemo(() => results.current?.results.edges.map(e => ({ ...e.node, key: e.node.href })), [
-    results.current,
-  ])
+  const nodes: AutosuggestResult[] = useMemo(
+    () => results.current?.results?.edges?.map((e, i) => ({ ...e?.node!, key: e?.node?.href! + i })) ?? [],
+    [results.current]
+  )
 
   // We want to show a loading spinner at the bottom so long as there are more results to be had
-  // @ts-ignore STRICTNESS_MIGRATION
-  const hasMoreResults = results.current && results.current.results.edges.length > 0 && relay.hasMore()
+  const hasMoreResults = results.current && results.current.results?.edges?.length! > 0 && relay.hasMore()
   const ListFooterComponent = useMemo(() => {
     return () => (
       <Flex justifyContent="center" p={3} pb={6}>
@@ -91,11 +89,9 @@ const AutosuggestResultsFlatList: React.FC<{
     )
   }, [hasMoreResults])
 
-  // @ts-ignore STRICTNESS_MIGRATION
-  const noResults = results.current && results.current.results.edges.length === 0
+  const noResults = results.current && results.current.results?.edges?.length === 0
 
   return (
-    // @ts-ignore STRICTNESS_MIGRATION
     <FlatList<AutosuggestResult>
       ref={flatListRef}
       style={{ flex: 1, padding: space(2) }}
@@ -187,11 +183,10 @@ export const AutosuggestResults: React.FC<{ query: string }> = React.memo(
             if (__DEV__) {
               console.error(error)
             } else {
-              // @ts-ignore STRICTNESS_MIGRATION
-              captureMessage(error.stack)
+              captureMessage(error.stack!)
             }
             return (
-              <Flex p={2} alignItems="center" justifyContent="center">
+              <Flex alignItems="center" justifyContent="center">
                 <Flex maxWidth={280}>
                   <Serif size="3" textAlign="center">
                     There seems to be a problem with the connection. Please try again shortly.

--- a/src/lib/Scenes/Search/CityGuideCTA.tsx
+++ b/src/lib/Scenes/Search/CityGuideCTA.tsx
@@ -1,17 +1,15 @@
-import { color, Flex, Sans, Spacer } from "@artsy/palette"
+import { color, Flex, Sans } from "@artsy/palette"
+import { SectionTitle } from "lib/Components/SectionTitle"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import React from "react"
 import { Image, TouchableOpacity } from "react-native"
 
-export class SearchEmptyState extends React.Component {
+export class CityGuideCTA extends React.Component {
   render() {
     const cityGuideMapImage = require("../../../../images/city-guide-bg.png")
     return (
-      <Flex m={20}>
-        <Sans size="4t" weight="regular">
-          Explore Art on View by City
-        </Sans>
-        <Spacer height={15}></Spacer>
+      <Flex>
+        <SectionTitle title="Explore Art on View by City" />
         <TouchableOpacity onPress={() => SwitchBoard.presentNavigationViewController(this, "/local-discovery")}>
           <Flex style={{ borderWidth: 1, borderColor: color("black10"), borderRadius: 4, overflow: "hidden" }}>
             <Image source={cityGuideMapImage} style={{ width: "100%" }} />

--- a/src/lib/Scenes/Search/Input.tsx
+++ b/src/lib/Scenes/Search/Input.tsx
@@ -1,4 +1,4 @@
-import { color, Color, Flex, Sans, Serif, space, Spacer, XCircleIcon } from "@artsy/palette"
+import { color, Color, Flex, Sans, space, Spacer, XCircleIcon } from "@artsy/palette"
 import { fontFamily } from "@artsy/palette/dist/platform/fonts/fontFamily"
 import React, { useImperativeHandle, useRef, useState } from "react"
 import { Text, TextInput, TextInputProps, TouchableOpacity, TouchableWithoutFeedback } from "react-native"
@@ -26,27 +26,21 @@ export const Input = React.forwardRef<TextInput, InputProps & TextInputProps>(
     const [focused, setFocused] = useState(false)
     const [value, setValue] = useState(rest.defaultValue || "")
     const input = useRef<TextInput>()
-    // @ts-ignore STRICTNESS_MIGRATION
-    useImperativeHandle(ref, () => input.current)
+    useImperativeHandle(ref, () => input.current!)
     return (
       <Flex flexGrow={1}>
         {title && (
-          <Serif mb={0.5} size="3">
+          <Sans mb={0.5} size="3">
             {title}
             {required && <Text style={{ color: color("purple100") }}>*</Text>}
-          </Serif>
+          </Sans>
         )}
         {description && (
-          <Serif color="black60" mb={1} size="2">
+          <Sans color="black60" mb={1} size="2">
             {description}
-          </Serif>
+          </Sans>
         )}
-        <TouchableWithoutFeedback
-          onPressIn={() =>
-            // @ts-ignore STRICTNESS_MIGRATION
-            input.current.focus()
-          }
-        >
+        <TouchableWithoutFeedback onPressIn={() => input.current?.focus()}>
           <InputWrapper focused={focused} disabled={disabled} error={!!error}>
             {icon}
             {icon && <Spacer ml={1} />}
@@ -71,8 +65,7 @@ export const Input = React.forwardRef<TextInput, InputProps & TextInputProps>(
             {Boolean(value) && showClearButton && (
               <TouchableOpacity
                 onPress={() => {
-                  // @ts-ignore STRICTNESS_MIGRATION
-                  input.current.clear()
+                  input.current?.clear()
                   setValue("")
                   rest.onChangeText?.("")
                   rest.onClear?.()
@@ -131,13 +124,15 @@ const InputWrapper = styled(Flex)`
       color(computeBorderColor({ disabled, error, focused }))};
   height: ${INPUT_HEIGHT}px;
   padding: ${space(1)}px;
-  background-color: ${(props: any /* STRICTNESS_MIGRATION */) =>
-    props.disabled ? color("black5") : color("white100")};
+  background-color: ${props => (props.disabled ? color("black5") : color("white100"))};
 `
 
 const StyledInput = styled.TextInput<StyledInputProps>`
   padding: 0;
   margin: 0;
-  font-family: ${fontFamily.serif.regular as string};
+
+  /* to center the text */
+  margin-top: 1px;
+  font-family: ${fontFamily.sans.regular as string};
 `
 StyledInput.displayName = "StyledInput"

--- a/src/lib/Scenes/Search/Search.tsx
+++ b/src/lib/Scenes/Search/Search.tsx
@@ -13,8 +13,6 @@ import { Input } from "./Input"
 import { ProvideRecentSearches, RecentSearches, useRecentSearches } from "./RecentSearches"
 import { SearchContext } from "./SearchContext"
 
-const SHOW_CITY_GUIDE = NativeModules.Emission.options.AROptionsMoveCityGuideEnableSales && !isPad()
-
 const SearchPage: React.FC = () => {
   const input = useRef<Input>(null)
   const [query, setQuery] = useState("")
@@ -26,6 +24,8 @@ const SearchPage: React.FC = () => {
     safeAreaInsets: { top },
   } = useScreenDimensions()
   const { trackEvent } = useTracking()
+
+  const showCityGuide = NativeModules.Emission.options.AROptionsMoveCityGuideEnableSales && !isPad()
   return (
     <SearchContext.Provider value={{ inputRef: input, query: queryRef }}>
       <KeyboardAvoidingView style={{ flex: 1 }} behavior="padding" keyboardVerticalOffset={top} enabled>
@@ -82,7 +82,7 @@ const SearchPage: React.FC = () => {
         </Flex>
         {query.length >= 2 ? (
           <AutosuggestResults query={query} />
-        ) : SHOW_CITY_GUIDE ? (
+        ) : showCityGuide ? (
           <Scrollable>
             <RecentSearches />
             <CityGuideCTA />

--- a/src/lib/Scenes/Search/Search.tsx
+++ b/src/lib/Scenes/Search/Search.tsx
@@ -33,7 +33,7 @@ const SearchPage: React.FC = () => {
           <Input
             ref={input}
             placeholder="Search artists, artworks, galleries, etc"
-            icon={<SearchIcon />}
+            icon={<SearchIcon width={18} height={18} />}
             onChangeText={queryText => {
               queryText = queryText.trim()
               setQuery(queryText)

--- a/src/lib/Scenes/Search/Search.tsx
+++ b/src/lib/Scenes/Search/Search.tsx
@@ -1,4 +1,4 @@
-import { color, Flex, Sans, Serif, Theme } from "@artsy/palette"
+import { color, Flex, Sans, Serif, Spacer, Theme } from "@artsy/palette"
 import SearchIcon from "lib/Icons/SearchIcon"
 import { isPad } from "lib/utils/hardware"
 import { Schema } from "lib/utils/track"
@@ -6,6 +6,7 @@ import { ProvideScreenDimensions, useScreenDimensions } from "lib/utils/useScree
 import React, { useRef, useState } from "react"
 import { KeyboardAvoidingView, LayoutAnimation, NativeModules, ScrollView, TouchableOpacity } from "react-native"
 import { useTracking } from "react-tracking"
+import styled from "styled-components/native"
 import { AutosuggestResults } from "./AutosuggestResults"
 import { CityGuideCTA } from "./CityGuideCTA"
 import { Input } from "./Input"
@@ -79,36 +80,38 @@ const SearchPage: React.FC = () => {
             )}
           </Flex>
         </Flex>
-
-        <ScrollView
-          keyboardDismissMode="on-drag"
-          keyboardShouldPersistTaps="handled"
-          style={{ flex: 1 }}
-          contentContainerStyle={{ flex: 1 }}
-        >
-          {query.length >= 2 ? (
-            <AutosuggestResults query={query} />
-          ) : SHOW_CITY_GUIDE ? (
-            <>
-              <RecentSearches />
-              <CityGuideCTA />
-            </>
-          ) : recentSearches.length ? (
-            <Flex px={2}>
-              <RecentSearches />
-            </Flex>
-          ) : (
-            <LegacyEmptyState />
-          )}
-        </ScrollView>
+        {query.length >= 2 ? (
+          <AutosuggestResults query={query} />
+        ) : SHOW_CITY_GUIDE ? (
+          <Scrollable>
+            <RecentSearches />
+            <CityGuideCTA />
+            <Spacer mb="40px" />
+          </Scrollable>
+        ) : recentSearches.length ? (
+          <Scrollable>
+            <RecentSearches />
+            <Spacer mb="40px" />
+          </Scrollable>
+        ) : (
+          <LegacyEmptyState />
+        )}
       </KeyboardAvoidingView>
     </SearchContext.Provider>
   )
 }
 
+const Scrollable = styled(ScrollView).attrs({
+  keyboardDismissMode: "on-drag",
+  keyboardShouldPersistTaps: "handled",
+})`
+  flex: 1;
+  padding: 0 20px;
+`
+
 const LegacyEmptyState: React.FC<{}> = ({}) => {
   return (
-    <Flex p={2} style={{ flex: 1 }} alignItems="center" justifyContent="center">
+    <Flex style={{ flex: 1 }} alignItems="center" justifyContent="center">
       <Flex maxWidth={250}>
         <Serif textAlign="center" size="3">
           Search for artists, artworks, galleries, shows, and more.

--- a/src/lib/Scenes/Search/SearchContext.tsx
+++ b/src/lib/Scenes/Search/SearchContext.tsx
@@ -1,7 +1,7 @@
-import React, { MutableRefObject } from "react"
+import React, { RefObject } from "react"
 import { Input } from "./Input"
 
 export const SearchContext = React.createContext<{
-  inputRef: MutableRefObject<Input>
-  query: MutableRefObject<string>
-}>(null as any /* STRICTNESS_MIGRATION */)
+  inputRef: RefObject<Input>
+  query: RefObject<string>
+}>(null as any)

--- a/src/lib/Scenes/Search/SearchResult.tsx
+++ b/src/lib/Scenes/Search/SearchResult.tsx
@@ -1,4 +1,4 @@
-import { CloseIcon, Flex, Sans, Serif, Spacer } from "@artsy/palette"
+import { CloseIcon, Flex, Sans, Spacer } from "@artsy/palette"
 import GraphemeSplitter from "grapheme-splitter"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
@@ -84,11 +84,20 @@ function removeDiracritics(text: string) {
 const splitter = new GraphemeSplitter()
 
 function applyHighlight(displayLabel: string, highlight: string | undefined) {
-  if (!highlight?.trim()) {
+  // If highlight is not supplied then use medium weight, since the search result
+  // is being rendered in a context that doesn't support highlights
+  if (highlight === undefined) {
     return (
-      <Serif size="3" weight="regular">
+      <Sans size="3" weight="medium">
         {displayLabel}
-      </Serif>
+      </Sans>
+    )
+  }
+  if (!highlight.trim()) {
+    return (
+      <Sans size="3" weight="regular">
+        {displayLabel}
+      </Sans>
     )
   }
   // search for `highlight` in `displayLabel` but ignore diacritics in `displayLabel`
@@ -121,18 +130,18 @@ function applyHighlight(displayLabel: string, highlight: string | undefined) {
   }
   if (!result) {
     return (
-      <Serif size="3" weight="regular">
+      <Sans size="3" weight="regular">
         {displayLabel}
-      </Serif>
+      </Sans>
     )
   }
   return (
-    <Serif size="3" weight="regular">
+    <Sans size="3" weight="regular">
       {result[0]}
-      <Serif size="3" weight="semibold">
+      <Sans size="3" weight="medium" style={{ padding: 0, margin: 0 }}>
         {result[1]}
-      </Serif>
+      </Sans>
       {result[2]}
-    </Serif>
+    </Sans>
   )
 }

--- a/src/lib/Scenes/Search/SearchResult.tsx
+++ b/src/lib/Scenes/Search/SearchResult.tsx
@@ -25,10 +25,10 @@ export const SearchResult: React.FC<{
     <TouchableOpacity
       ref={navRef}
       onPress={() => {
-        inputRef.current.blur()
+        inputRef.current?.blur()
         // need to wait a tick to push next view otherwise the input won't blur ¯\_(ツ)_/¯
         setTimeout(() => {
-          SwitchBoard.presentNavigationViewController(navRef.current, result.href! /* STRICTNESS_MIGRATION */)
+          SwitchBoard.presentNavigationViewController(navRef.current, result.href!)
           if (updateRecentSearchesOnTap) {
             notifyRecentSearch({ type: "AUTOSUGGEST_RESULT_TAPPED", props: result })
           }
@@ -48,7 +48,7 @@ export const SearchResult: React.FC<{
         <Spacer ml={1} />
         <View style={{ flex: 1 }}>
           <Text ellipsizeMode="tail" numberOfLines={1}>
-            {applyHighlight(result.displayLabel! /* STRICTNESS_MIGRATION */, highlight)}
+            {applyHighlight(result.displayLabel!, highlight)}
           </Text>
           {result.displayType && (
             <Sans size="2" color="black60">

--- a/src/lib/Scenes/Search/SearchResult.tsx
+++ b/src/lib/Scenes/Search/SearchResult.tsx
@@ -44,14 +44,17 @@ export const SearchResult: React.FC<{
       }}
     >
       <Flex flexDirection="row" alignItems="center">
-        <OpaqueImageView imageURL={result.imageUrl} style={{ width: 36, height: 36 }} />
+        <OpaqueImageView
+          imageURL={result.imageUrl}
+          style={{ width: 40, height: 40, borderRadius: 2, overflow: "hidden" }}
+        />
         <Spacer ml={1} />
         <View style={{ flex: 1 }}>
           <Text ellipsizeMode="tail" numberOfLines={1}>
             {applyHighlight(result.displayLabel!, highlight)}
           </Text>
           {result.displayType && (
-            <Sans size="2" color="black60">
+            <Sans size="3t" color="black60">
               {result.displayType}
             </Sans>
           )}
@@ -88,14 +91,14 @@ function applyHighlight(displayLabel: string, highlight: string | undefined) {
   // is being rendered in a context that doesn't support highlights
   if (highlight === undefined) {
     return (
-      <Sans size="3" weight="medium">
+      <Sans size="3t" weight="medium">
         {displayLabel}
       </Sans>
     )
   }
   if (!highlight.trim()) {
     return (
-      <Sans size="3" weight="regular">
+      <Sans size="3t" weight="regular">
         {displayLabel}
       </Sans>
     )
@@ -130,15 +133,15 @@ function applyHighlight(displayLabel: string, highlight: string | undefined) {
   }
   if (!result) {
     return (
-      <Sans size="3" weight="regular">
+      <Sans size="3t" weight="regular">
         {displayLabel}
       </Sans>
     )
   }
   return (
-    <Sans size="3" weight="regular">
+    <Sans size="3t" weight="regular">
       {result[0]}
-      <Sans size="3" weight="medium" style={{ padding: 0, margin: 0 }}>
+      <Sans size="3t" weight="medium" style={{ padding: 0, margin: 0 }}>
         {result[1]}
       </Sans>
       {result[2]}

--- a/src/lib/Scenes/Search/SearchResultList.tsx
+++ b/src/lib/Scenes/Search/SearchResultList.tsx
@@ -5,14 +5,14 @@ import { SearchResult } from "./SearchResult"
 
 export const SearchResultList: React.FC<{ results: React.ReactElement[] }> = ({ results }) => {
   return (
-    <Join separator={<Spacer mb={2} />}>
+    <Join separator={<Spacer mb="15px" />}>
       {React.Children.map(results, (child, i) => {
         if (__DEV__ && child.type !== SearchResult) {
           throw new Error("children of SearchResultList should be only of type SearchResult")
         }
         const props = child.props as Parameters<typeof SearchResult>[0]
         return (
-          <FadeIn key={props.result.href! /* STRICTNESS_MIGRATION */} delay={i * 35}>
+          <FadeIn key={props.result.href!} delay={i * 35}>
             {child}
           </FadeIn>
         )

--- a/src/lib/Scenes/Search/__tests__/CityGuideCTA-tests.tsx
+++ b/src/lib/Scenes/Search/__tests__/CityGuideCTA-tests.tsx
@@ -3,7 +3,7 @@ import { extractText } from "lib/tests/extractText"
 import React from "react"
 import { Image, TouchableOpacity } from "react-native"
 import { create } from "react-test-renderer"
-import { SearchEmptyState } from "../SearchEmptyState"
+import { CityGuideCTA } from "../CityGuideCTA"
 
 jest.mock("lib/NativeModules/SwitchBoard", () => ({
   presentNavigationViewController: jest.fn(),
@@ -11,13 +11,13 @@ jest.mock("lib/NativeModules/SwitchBoard", () => ({
 
 describe("Search page empty state", () => {
   it(`renders correctly`, async () => {
-    const tree = create(<SearchEmptyState />)
+    const tree = create(<CityGuideCTA />)
     expect(extractText(tree.root)).toContain("Explore Art on View by City")
     expect(tree.root.findAllByType(Image)).toHaveLength(1)
   })
 
   it(`navigates to cityGuide link`, () => {
-    const tree = create(<SearchEmptyState />)
+    const tree = create(<CityGuideCTA />)
     tree.root.findByType(TouchableOpacity).props.onPress()
     expect(SwitchBoard.presentNavigationViewController).toHaveBeenCalledWith(expect.anything(), "/local-discovery")
   })

--- a/src/lib/Scenes/Search/__tests__/Search-tests.tsx
+++ b/src/lib/Scenes/Search/__tests__/Search-tests.tsx
@@ -6,18 +6,17 @@ import { CatchErrors } from "../../../utils/CatchErrors"
 import { AutosuggestResults } from "../AutosuggestResults"
 import { RecentSearches, useRecentSearches } from "../RecentSearches"
 import { Search } from "../Search"
-import { SearchEmptyState } from "../SearchEmptyState"
 
 jest.mock("lib/utils/hardware", () => ({
   isPad: jest.fn(),
 }))
 import { isPad } from "lib/utils/hardware"
+import { CityGuideCTA } from "../CityGuideCTA"
 
 jest.mock("../AutosuggestResults", () => ({ AutosuggestResults: () => null }))
 jest.mock("../RecentSearches", () => ({
   RecentSearches: () => null,
-  // @ts-ignore STRICTNESS_MIGRATION
-  ProvideRecentSearches: ({ children }) => children,
+  ProvideRecentSearches: ({ children }: any) => children,
   useRecentSearches: jest.fn(() => ({
     recentSearches: [],
     notifyRecentSearch: jest.fn(),
@@ -44,7 +43,7 @@ describe("The Search page", () => {
     const isPadMock = isPad as jest.Mock
     isPadMock.mockImplementationOnce(() => true)
     const tree = ReactTestRenderer.create(<TestWrapper />)
-    expect(tree.root.findAllByType(SearchEmptyState)).toHaveLength(0)
+    expect(tree.root.findAllByType(CityGuideCTA)).toHaveLength(0)
   })
 
   it(`shows city guide entrance when flag is enabled and on iPhone`, async () => {
@@ -52,13 +51,13 @@ describe("The Search page", () => {
     isPadMock.mockImplementationOnce(() => false)
     NativeModules.Emission.options.AROptionsMoveCityGuideEnableSales = true
     const tree = ReactTestRenderer.create(<TestWrapper />)
-    expect(extractText(tree.root.findByType(SearchEmptyState))).toContain("Explore Art on View by City")
+    expect(extractText(tree.root.findByType(CityGuideCTA))).toContain("Explore Art on View by City")
   })
 
   it(`does not show city guide entrance when flag is disabled`, async () => {
     NativeModules.Emission.options.AROptionsMoveCityGuideEnableSales = false
     const tree = ReactTestRenderer.create(<TestWrapper />)
-    expect(tree.root.findAllByType(SearchEmptyState)).toHaveLength(0)
+    expect(tree.root.findAllByType(CityGuideCTA)).toHaveLength(0)
   })
 
   it(`shows recent searches when there are recent searches`, () => {

--- a/src/lib/Scenes/Search/__tests__/Search-tests.tsx
+++ b/src/lib/Scenes/Search/__tests__/Search-tests.tsx
@@ -54,6 +54,29 @@ describe("The Search page", () => {
     expect(extractText(tree.root.findByType(CityGuideCTA))).toContain("Explore Art on View by City")
   })
 
+  it(`shows city guide entrance when flag is enabled and on iPhone and there are recent searches`, async () => {
+    useRecentSearchesMock.mockReturnValueOnce({
+      recentSearches: [
+        {
+          type: "AUTOSUGGEST_RESULT_TAPPED",
+          props: {
+            displayLabel: "Banksy",
+            displayType: "Artist",
+            href: "",
+            imageUrl: "",
+          },
+        },
+      ],
+      notifyRecentSearch: jest.fn(),
+      deleteRecentSearch: jest.fn(),
+    })
+    const isPadMock = isPad as jest.Mock
+    isPadMock.mockImplementationOnce(() => false)
+    NativeModules.Emission.options.AROptionsMoveCityGuideEnableSales = true
+    const tree = ReactTestRenderer.create(<TestWrapper />)
+    expect(extractText(tree.root.findByType(CityGuideCTA))).toContain("Explore Art on View by City")
+  })
+
   it(`does not show city guide entrance when flag is disabled`, async () => {
     NativeModules.Emission.options.AROptionsMoveCityGuideEnableSales = false
     const tree = ReactTestRenderer.create(<TestWrapper />)

--- a/src/lib/Scenes/Search/__tests__/SearchResult-tests.tsx
+++ b/src/lib/Scenes/Search/__tests__/SearchResult-tests.tsx
@@ -78,7 +78,7 @@ describe(SearchResult, () => {
   it(`highlights a part of the string if possible`, async () => {
     const tree = create(<TestWrapper result={result} highlight="an" />)
 
-    expect(extractText(tree.root.findByProps({ weight: "semibold" }))).toBe("an")
+    expect(extractText(tree.root.findByProps({ weight: "medium" }))).toBe("an")
   })
 
   it(`highlights a part of the string even when the string has diacritics but the highlight doesn't`, async () => {
@@ -92,7 +92,7 @@ describe(SearchResult, () => {
       />
     )
 
-    expect(extractText(tree.root.findByProps({ weight: "semibold" }))).toBe("ãn")
+    expect(extractText(tree.root.findByProps({ weight: "medium" }))).toBe("ãn")
 
     tree.update(
       <TestWrapper
@@ -104,7 +104,7 @@ describe(SearchResult, () => {
       />
     )
 
-    expect(extractText(tree.root.findByProps({ weight: "semibold" }))).toBe("Miró")
+    expect(extractText(tree.root.findByProps({ weight: "medium" }))).toBe("Miró")
   })
 
   it(`updates recent searches by default`, async () => {


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/MX-326

spec: https://www.figma.com/file/2Im0qW2WpwQj2BowaFypxG/Explore?node-id=322%3A1143

1. Make sure the city guide call-to-action is visible when there are recent searches
2. Updated the 'Recent Searches' title copy to match the spec.
3. Updated the search page typography to match the spec (serif -> sans)
3. Fix an aspect ratio bug in OpaqueImageView which I introduced yesterday 😬 
4. Fix a crash that happened when artist pages have no tabs (data folks say this shouldn't happen but it does, see, e.g. Jillian Banks) – I used the empty state copy from the web.
5. Strictness migration cleanup

## Screenshots

### Explore with recent searches
![image](https://user-images.githubusercontent.com/1242537/82655014-79cfd300-9c19-11ea-8b5b-83f05e221d47.png)


### Explore without recent searches
![image](https://user-images.githubusercontent.com/1242537/82655059-881def00-9c19-11ea-923a-ec10bcfc6562.png)
