### PR TITLE
Don't show 'sold for' message if no realized price

### DIFF
--- a/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/Components/RecentlySold.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/Components/RecentlySold.tsx
@@ -40,12 +40,15 @@ export const RecentlySold: React.FC<RecentlySoldProps> = ({ artists, isLoading }
               data={artists}
               renderItem={({ item }) => {
                 const artwork = item.targetSupply?.microfunnel?.artworksConnection?.edges?.[0]
+                const saleMessage = artwork?.node?.realizedPrice
+                  ? `Sold for ${artwork?.node?.realizedPrice}`
+                  : undefined
 
                 return (
                   <ArtworkTileRailCard
                     imageURL={artwork?.node?.image?.imageURL}
                     artistNames={artwork?.node?.artistNames}
-                    saleMessage={`Sold for ${artwork?.node?.realizedPrice}`}
+                    saleMessage={saleMessage}
                     key={artwork?.node?.internalID}
                     onPress={() => {
                       tracking.trackEvent(

--- a/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/Components/__tests__/RecentlySold-tests.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/Components/__tests__/RecentlySold-tests.tsx
@@ -1,0 +1,73 @@
+import { Theme } from "@artsy/palette"
+import React from "react"
+import "react-native"
+import { create } from "react-test-renderer"
+
+import { RecentlySold_artists } from "__generated__/RecentlySold_artists.graphql"
+import { extractText } from "lib/tests/extractText"
+import { RecentlySold } from "../RecentlySold"
+
+describe("RecentlySold", () => {
+  const defaultArtist: any = {
+    artistNames: "Andy Goldsworthy",
+    href: "/artist/andy-goldsworthy",
+    image: {
+      imageURL: "http://placekitten.com/200/200",
+    },
+    internalID: "1235",
+    realizedPrice: "$1,200",
+    slug: "andy-goldsworthy",
+  }
+
+  it("renders sale message if artwork has realized price", () => {
+    const artist = {
+      ...defaultArtist,
+      realizedPrice: "$1,200",
+    }
+    const artists = makeArtists(artist)
+
+    const tree = create(
+      <Theme>
+        <RecentlySold artists={artists} />
+      </Theme>
+    )
+
+    expect(extractText(tree.root)).toContain("Sold for $1,200")
+  })
+
+  it("does not render any sale message if artwork has no realized price", () => {
+    const artist = {
+      ...defaultArtist,
+      realizedPrice: null,
+    }
+    const artists = makeArtists(artist)
+
+    const tree = create(
+      <Theme>
+        <RecentlySold artists={artists} />
+      </Theme>
+    )
+
+    expect(extractText(tree.root)).not.toContain("Sold for")
+  })
+})
+
+function makeArtists(artist: any): RecentlySold_artists {
+  return [
+    {
+      " $refType": "RecentlySold_artists",
+      internalID: "1234",
+      targetSupply: {
+        microfunnel: {
+          artworksConnection: {
+            edges: [
+              {
+                node: artist,
+              },
+            ],
+          },
+        },
+      },
+    },
+  ]
+}


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/CSGN-205

Artworks in our recently sold rail may or may not have a realized price. This PR protects against artworks that don't, by suppressing the "Sold for" message if there is no `realizedPrice` property.

## Before

![image](https://user-images.githubusercontent.com/1627089/82919394-96cb1580-9f3b-11ea-93c4-ffefbacfdfbc.png)

## After

![image](https://user-images.githubusercontent.com/1627089/82919221-5b304b80-9f3b-11ea-9ee4-563c5b029cdc.png)
