### PR TITLE
enable full bleed on artist series rail

### DIFF
--- a/src/lib/Components/Artist/ArtistArtworks/ArtistCollectionsRail.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistCollectionsRail.tsx
@@ -40,7 +40,7 @@ export const ArtistCollectionsRail: React.FC<ArtistCollectionsRailProps> = props
 }
 
 const ArtistSeriesRailWrapper = styled(Box)`
-  margin: 0px 0px 20px -40px;
+  margin: 0px -20px 20px -40px;
 `
 
 export const ArtistCollectionsRailFragmentContainer = createFragmentContainer(ArtistCollectionsRail, {


### PR DESCRIPTION
UI Bug Fix where the Iconic Collections rail wasn't doing a full bleed across the screen:

https://artsyproduct.atlassian.net/browse/FX-1975

![Kapture 2020-05-26 at 12 33 35](https://user-images.githubusercontent.com/10385964/82926771-ac493b00-9f4d-11ea-87f6-9c9bcaf587fa.gif)


#trivial