### PR TITLE
[CSGN-212] Make consignment landing page rails full-bleed on swipe

### DIFF
--- a/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/Components/ArtistList.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/Components/ArtistList.tsx
@@ -22,15 +22,19 @@ export const ArtistList: React.FC<ArtistListProps> = ({ artists, isLoading }) =>
   const chunksOfArtists = chunk(artists, 4)
 
   return (
-    <Box px={2}>
+    <Box>
       <Box>
-        <Sans size="4">Artists in-demand on Artsy</Sans>
+        <Sans size="4" px={2}>
+          Artists in-demand on Artsy
+        </Sans>
 
         <Spacer mb={2} />
 
         <ScrollView horizontal>
           <FlatList
             horizontal
+            ListHeaderComponent={() => <Spacer mr={2}></Spacer>}
+            ListFooterComponent={() => <Spacer mr={2}></Spacer>}
             ItemSeparatorComponent={() => <Spacer mr={3} />}
             data={chunksOfArtists}
             initialNumToRender={2}
@@ -97,27 +101,27 @@ const ArtistItem: React.FC<{ artist: ArtistList_artists[0] }> = ({ artist }) => 
 
 const ArtistListPlaceholder: React.FC = () => {
   return (
-    <Box px={2}>
-      <Box>
+    <Box>
+      <Box px={2}>
         <PlaceholderText width={250} />
-
-        <Spacer mb={2} />
-
-        <Flex flexDirection="row">
-          <Flex>
-            <Join separator={<Spacer mb={2} />}>
-              {[...new Array(4)].map((_, index) => {
-                return (
-                  <Flex flexDirection="row" alignItems="center" key={index}>
-                    <PlaceholderBox height={45} width={45} marginRight={10} />
-                    <PlaceholderText width={150} />
-                  </Flex>
-                )
-              })}
-            </Join>
-          </Flex>
-        </Flex>
       </Box>
+
+      <Spacer mb={2} />
+
+      <Flex flexDirection="row" pl={2}>
+        <Flex>
+          <Join separator={<Spacer mb={2} />}>
+            {[...new Array(4)].map((_, index) => {
+              return (
+                <Flex flexDirection="row" alignItems="center" key={index}>
+                  <PlaceholderBox height={45} width={45} marginRight={10} />
+                  <PlaceholderText width={150} />
+                </Flex>
+              )
+            })}
+          </Join>
+        </Flex>
+      </Flex>
     </Box>
   )
 }

--- a/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/Components/RecentlySold.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/Components/RecentlySold.tsx
@@ -23,9 +23,9 @@ export const RecentlySold: React.FC<RecentlySoldProps> = ({ artists, isLoading }
   const tracking = useTracking()
 
   return (
-    <Box px={2} ref={navRef}>
+    <Box ref={navRef}>
       <Box>
-        <Sans size="4" mb={2}>
+        <Sans size="4" px={2} mb={2}>
           Recently sold on Artsy
         </Sans>
 
@@ -33,6 +33,8 @@ export const RecentlySold: React.FC<RecentlySoldProps> = ({ artists, isLoading }
           <Join separator={<Spacer mr={0.5} />}>
             <FlatList
               horizontal
+              ListHeaderComponent={() => <Spacer mr={2}></Spacer>}
+              ListFooterComponent={() => <Spacer mr={2}></Spacer>}
               ItemSeparatorComponent={() => <Spacer width={15}></Spacer>}
               showsHorizontalScrollIndicator={false}
               initialNumToRender={5}
@@ -100,27 +102,27 @@ export const RecentlySoldFragmentContainer = createFragmentContainer(RecentlySol
 
 const RecentlySoldPlaceholder: React.FC = () => {
   return (
-    <Box px={2}>
-      <Box>
-        <Sans size="4" mb={2}>
-          Recently sold with Artsy
-        </Sans>
-
-        <Flex flexDirection="row">
-          <Join separator={<Spacer mr={0.5} />}>
-            {[...new Array(4)].map((_, index) => {
-              return (
-                <Box key={index}>
-                  <PlaceholderBox width={120} height={120} marginRight={10} />
-                  <Spacer mb={1} />
-                  <PlaceholderText width={60} />
-                  <PlaceholderText width={40} />
-                </Box>
-              )
-            })}
-          </Join>
-        </Flex>
+    <Box>
+      <Box px={2} py={0.5}>
+        <PlaceholderText width={200} />
       </Box>
+
+      <Spacer mb={2} />
+
+      <Flex flexDirection="row" pl={2}>
+        <Join separator={<Spacer mr={0.5} />}>
+          {[...new Array(4)].map((_, index) => {
+            return (
+              <Box key={index}>
+                <PlaceholderBox width={120} height={120} marginRight={10} />
+                <Spacer mb={1} />
+                <PlaceholderText width={60} />
+                <PlaceholderText width={40} />
+              </Box>
+            )
+          })}
+        </Join>
+      </Flex>
     </Box>
   )
 }


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/CSGN-212

We incorrectly had permanent padding on the rails on the consignment landing page (Recently Sold & Artist List). This PR updates both rails so that they appear left-padded when the screen loads, but on swipe they bleed fully to the left and right edges.

![full-bleed](https://user-images.githubusercontent.com/1627089/83055279-44602680-a019-11ea-81ec-6016511989ff.gif)

It also updates the associated placeholders..which technically didn't _need_ to happen, but I think making similar changes there removes the likelihood of divergence between placeholders and what they represent.

