### PR TITLE
Send users to the new sell tab when they tap on the artist consign CTA

### DIFF
--- a/src/lib/Components/Artist/ArtistConsignButton.tsx
+++ b/src/lib/Components/Artist/ArtistConsignButton.tsx
@@ -8,7 +8,7 @@ import { ArtistConsignButton_artist } from "__generated__/ArtistConsignButton_ar
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { Router } from "lib/utils/router"
 import { Schema } from "lib/utils/track"
-import { TouchableOpacity } from "react-native"
+import { NativeModules, TouchableOpacity } from "react-native"
 
 export interface ArtistConsignButtonProps {
   artist: ArtistConsignButton_artist
@@ -35,6 +35,9 @@ export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = props => 
       // @ts-ignore STRICTNESS_MIGRATION
       ref={buttonRef}
       onPress={() => {
+        const featureFlag = NativeModules?.Emission?.options?.AROptionsMoveCityGuideEnableSales
+        const destination = featureFlag ? "/sales" : Router.ConsignmentsStartSubmission
+
         tracking.trackEvent({
           context_page: Schema.PageNames.ArtistPage,
           context_page_owner_id: props.artist.internalID,
@@ -42,11 +45,11 @@ export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = props => 
           context_page_owner_type: Schema.OwnerEntityTypes.Artist,
           context_module: Schema.ContextModules.ArtistConsignment,
           subject: Schema.ActionNames.ArtistConsignGetStarted,
-          destination_path: Router.ConsignmentsStartSubmission,
+          destination_path: destination,
         })
 
         // @ts-ignore STRICTNESS_MIGRATION
-        SwitchBoard.presentNavigationViewController(buttonRef.current, Router.ConsignmentsStartSubmission)
+        SwitchBoard.presentNavigationViewController(buttonRef.current, destination)
       }}
     >
       <BorderBox p={0}>

--- a/src/lib/Components/Artist/__tests__/ArtistConsignButton-tests.tsx
+++ b/src/lib/Components/Artist/__tests__/ArtistConsignButton-tests.tsx
@@ -144,6 +144,7 @@ describe("ArtistConsignButton", () => {
       })
     })
 
+    // TODO: make this the default case once the feature flag is removed
     it("tracks the sales tab destination if feature flag is enabled", () => {
       NativeModules.Emission.options.AROptionsMoveCityGuideEnableSales = true
 
@@ -212,6 +213,7 @@ describe("ArtistConsignButton", () => {
       })
     })
 
+    // TODO: make this the default case once the feature flag is removed
     it("tracks the sales tab destination if feature flag is enabled", () => {
       NativeModules.Emission.options.AROptionsMoveCityGuideEnableSales = true
 

--- a/src/lib/Components/Artist/__tests__/ArtistConsignButton-tests.tsx
+++ b/src/lib/Components/Artist/__tests__/ArtistConsignButton-tests.tsx
@@ -3,7 +3,7 @@ import { ArtistConsignButtonTestsQuery } from "__generated__/ArtistConsignButton
 import { extractText } from "lib/tests/extractText"
 import { cloneDeep } from "lodash"
 import React from "react"
-import { TouchableOpacity } from "react-native"
+import { NativeModules, TouchableOpacity } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
 import ReactTestRenderer, { act } from "react-test-renderer"
 import { useTracking } from "react-tracking"
@@ -51,6 +51,12 @@ describe("ArtistConsignButton", () => {
         trackEvent,
       }
     })
+
+    NativeModules.Emission.options.AROptionsMoveCityGuideEnableSales = false
+  })
+
+  afterEach(() => {
+    trackEvent.mockClear()
   })
 
   describe("Top 20 Artist ('Microfunnel') or Target Supply button", () => {
@@ -137,6 +143,25 @@ describe("ArtistConsignButton", () => {
         destination_path: "/consign/submission",
       })
     })
+
+    it("tracks the sales tab destination if feature flag is enabled", () => {
+      NativeModules.Emission.options.AROptionsMoveCityGuideEnableSales = true
+
+      const tree = ReactTestRenderer.create(<TestRenderer />)
+      act(() => {
+        env.mock.resolveMostRecentOperation({
+          errors: [],
+          data: response,
+        })
+      })
+
+      tree.root.findByType(TouchableOpacity).props.onPress()
+      expect(trackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          destination_path: "/sales",
+        })
+      )
+    })
   })
 
   describe("Button for artists not in Microfunnel", () => {
@@ -185,6 +210,25 @@ describe("ArtistConsignButton", () => {
         subject: "Get Started",
         destination_path: "/consign/submission",
       })
+    })
+
+    it("tracks the sales tab destination if feature flag is enabled", () => {
+      NativeModules.Emission.options.AROptionsMoveCityGuideEnableSales = true
+
+      const tree = ReactTestRenderer.create(<TestRenderer />)
+      act(() => {
+        env.mock.resolveMostRecentOperation({
+          errors: [],
+          data: response,
+        })
+      })
+
+      tree.root.findByType(TouchableOpacity).props.onPress()
+      expect(trackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          destination_path: "/sales",
+        })
+      )
     })
   })
 })


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/CSGN-210.

When we built out the new sell tab, we forgot that tapping the "consign with Artsy" button on an artist page would direct the user to the new landing page. It wasn't so much a problem that we were sending them there...but they were sent to the landing page in the context of a modal without a mechanism for closing or going back. They were dead-ended, and the only way to escape was to restart the app.

This is what it looked like:

![artist-consign-flow-small-stuck](https://user-images.githubusercontent.com/1627089/83197637-646c1480-a103-11ea-97fd-6838b4bc712d.gif)

This PR updates the destination of that button to be the new sell tab (if the feature flag is enabled). 

This works really well when they tap an artist consign button while browsing within the home or search tabs of the app:

![artist-consign-flow-small-good](https://user-images.githubusercontent.com/1627089/83197375-03444100-a103-11ea-84d4-f590234c7ffb.gif)


It is a little less great when they tap an artist consign button while browsing within the new sell tab: 

![artist-consign-flow-small-confusing](https://user-images.githubusercontent.com/1627089/83197118-9466e800-a102-11ea-8341-32675cd8cc5f.gif)


The main issue there being that when they're brought to the tab landing page, it has retained their previous scroll position, which feels confusing. 

We're in talks amongst the consignments team to figure out what to do about that last issue. For now, even though it may be confusing, it is significantly better than dead-ending them.