### PR TITLE
Fix no-text-outside-Text issue

### DIFF
--- a/src/lib/Components/ArtworkTileRail/ArtworkTileRailCard.tsx
+++ b/src/lib/Components/ArtworkTileRail/ArtworkTileRailCard.tsx
@@ -37,17 +37,17 @@ export const ArtworkTileRailCard: React.FC<ArtworkTileRailCardProps> = ({
     />
   )
 
-  const artistNamesDisplay = artistNames && (
+  const artistNamesDisplay = artistNames ? (
     <Sans size="3t" weight="medium" numberOfLines={1}>
       {artistNames}
     </Sans>
-  )
+  ) : null
 
-  const saleMessageDisplay = saleMessage && (
+  const saleMessageDisplay = saleMessage ? (
     <Sans size="3t" color="black60" numberOfLines={1}>
       {saleMessage}
     </Sans>
-  )
+  ) : null
 
   return (
     <ArtworkCard onPress={onPress || undefined}>


### PR DESCRIPTION
react-native throws a full-on Error when you pass a string as children to a component which is not  wrapped by a `Text` component.

We got some mysterious sentry reports about this happening on the Home tab in the latest release and after digging through the changes to all components on the home tab I'm 90% sure this is the culprit.

Trivial change so I'll self-merge, but it's good to be aware that this `blah && <Blah />` pattern is very unsafe in react-native when the thing on the left is a string or a number. It's necessary to use `blah ?? <Blah />` if you're not concerned about falsey values (`""` and `0`) or `blah ? <Blah /> : null` if you are.