### PR TITLE
Use maxWorkers: 0 on CI to prevent OOMs during bundle on CI

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -2,4 +2,5 @@ const { FileStore } = require("metro-cache")
 
 module.exports = {
   cacheStores: [new FileStore({ root: "./.metro" })],
+  maxWorkers: process.env.CI == "true" ? 0 : 4,
 }


### PR DESCRIPTION
#trivial config change so going to self-merge and monitor