### PR TITLE
[WIP] Toggle the destination of an artist consign tap based on the currently selected tab

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -245,6 +245,10 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
         });
     };
 
+    emission.switchBoardModule.getSelectedTabName = ^(RCTPromiseResolveBlock resolve, RCTPromiseRejectBlock reject) {
+        resolve([[ARTopMenuViewController sharedController] selectedTabName]);
+    };
+
     emission.switchBoardModule.presentNavigationViewController = ^(UIViewController *_fromViewController,
                                                                    NSString *_Nonnull route) {
         UIViewController *viewController = [[ARSwitchBoard sharedInstance] loadPath:route];

--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -29,6 +29,7 @@
 
 #import <Emission/ARNewSubmissionFormComponentViewController.h>
 #import <Emission/ARShowConsignmentsFlowViewController.h>
+#import <Emission/ARSellTabLandingViewController.h>
 #import <Emission/ARFairComponentViewController.h>
 #import <Emission/ARFairBoothComponentViewController.h>
 #import <Emission/ARFairArtworksComponentViewController.h>
@@ -284,6 +285,10 @@ static ARSwitchBoard *sharedInstance = nil;
     [self.routes addRoute:@"/consign/submission" handler:JLRouteParams {
         UIViewController *submissionVC = [[ARShowConsignmentsFlowViewController alloc] init];
         return [[ARNavigationController alloc] initWithRootViewController:submissionVC];
+    }];
+
+    [self.routes addRoute:@"/collections/my-collection/landing" handler:JLRouteParams {
+        return [[ARSellTabLandingViewController alloc] init];
     }];
 
     [self.routes addRoute:@"/conditions-of-sale" handler:JLRouteParams {

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuNavigationDataSource.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuNavigationDataSource.m
@@ -169,6 +169,8 @@
             return @"cityGuide";
         case ARFavoritesTab:
             return @"favorites";
+        case ARSalesTab:
+            return @"sell";
         default:
             return @"unknown";
     }

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.h
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.h
@@ -31,6 +31,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// The content view for the tabbed nav
 @property (readonly, nonatomic, weak) ARTabContentView *tabContentView;
 
+/// Used to identify the currently selected tab
+@property (readonly, nonatomic) NSString *selectedTabName;
+
 /// Pushes the view controller into the current navigation controller or if it’s an existing view controller at the root
 /// of a navigation stack of any of the tabs, it changes to that tab and pop’s to root if necessary.
 ///

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -590,6 +590,11 @@ static ARTopMenuViewController *_sharedManager = nil;
 
 #pragma mark - ARTabViewDelegate
 
+- (NSString *)selectedTabName
+{
+    return [self.navigationDataSource analyticsDescriptionForTabAtIndex:self.selectedTabIndex];
+}
+
 - (void)tabContentView:(ARTabContentView *)tabContentView didChangeSelectedIndex:(NSInteger)index
 {
     self.selectedTabIndex = index;

--- a/emission/Pod/Classes/Core/ARSwitchBoardModule.h
+++ b/emission/Pod/Classes/Core/ARSwitchBoardModule.h
@@ -6,9 +6,12 @@ typedef void(^ARSwitchBoardPresentViewController)(UIViewController *fromViewCont
 
 typedef void(^ARSwitchBoardUpdateBackButton)(BOOL shouldHide);
 
+typedef void(^ARGetSelectedTabName)(_Nonnull RCTPromiseResolveBlock resolve, _Nonnull RCTPromiseRejectBlock reject);
+
 @interface ARSwitchBoardModule : NSObject <RCTBridgeModule>
 @property (nonatomic, copy, nullable, readwrite) ARSwitchBoardPresentViewController presentNavigationViewController;
 @property (nonatomic, copy, nullable, readwrite) ARSwitchBoardPresentViewController presentModalViewController;
 @property (nonatomic, copy, nullable, readwrite) ARSwitchBoardUpdateBackButton updateShouldHideBackButton;
+@property (nonatomic, copy, nullable, readwrite) ARGetSelectedTabName getSelectedTabName;
 
 @end

--- a/emission/Pod/Classes/Core/ARSwitchBoardModule.m
+++ b/emission/Pod/Classes/Core/ARSwitchBoardModule.m
@@ -63,6 +63,11 @@ RCT_EXPORT_METHOD(updateShouldHideBackButton:(BOOL)shouldHide)
   self.updateShouldHideBackButton(shouldHide);
 }
 
+RCT_EXPORT_METHOD(getSelectedTabName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+    return self.getSelectedTabName(resolve, reject);
+}
+
 RCT_EXPORT_METHOD(presentEmailComposer:(nonnull NSNumber *)reactTag to:(nonnull NSString *)toAddress subject:(nonnull NSString *)subject body:(NSString *)body)
 {
 

--- a/emission/Pod/Classes/ViewControllers/ARSellTabLandingViewController.h
+++ b/emission/Pod/Classes/ViewControllers/ARSellTabLandingViewController.h
@@ -1,0 +1,15 @@
+#import <Emission/ARComponentViewController.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARSellTabLandingViewController : ARComponentViewController
+
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithEmission:(nullable AREmission *)emission
+                      moduleName:(NSString *)moduleName
+               initialProperties:(nullable NSDictionary *)initialProperties NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/emission/Pod/Classes/ViewControllers/ARSellTabLandingViewController.m
+++ b/emission/Pod/Classes/ViewControllers/ARSellTabLandingViewController.m
@@ -1,0 +1,10 @@
+#import "ARSellTabLandingViewController.h"
+
+@implementation ARSellTabLandingViewController
+
+- (instancetype)init
+{
+    return [super initWithEmission:nil moduleName:@"SellTabLanding" initialProperties:nil];
+}
+
+@end

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -21,6 +21,7 @@ import { CitySectionListRenderer } from "./Scenes/City/CitySectionList"
 import { CollectionRenderer } from "./Scenes/Collection/Collection"
 import { CollectionFullFeaturedArtistListRenderer } from "./Scenes/Collection/Components/FullFeaturedArtistList"
 import Consignments from "./Scenes/Consignments"
+import { SellTabLanding } from "./Scenes/Consignments/SellTabLanding"
 import {
   FairArtistsRenderer,
   FairArtworksRenderer,
@@ -281,6 +282,7 @@ register("CitySavedList", CitySavedListRenderer)
 register("CitySectionList", CitySectionListRenderer)
 register("Collection", CollectionRenderer, { fullBleed: true })
 register("Consignments", Consignments)
+register("SellTabLanding", SellTabLanding)
 register("Conversation", Conversation)
 register("Fair", FairRenderer, { fullBleed: true })
 register("FairArtists", FairArtists)

--- a/src/lib/Components/Artist/ArtistConsignButton.tsx
+++ b/src/lib/Components/Artist/ArtistConsignButton.tsx
@@ -35,8 +35,8 @@ export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = props => 
       // @ts-ignore STRICTNESS_MIGRATION
       ref={buttonRef}
       onPress={() => {
-        const featureFlag = NativeModules?.Emission?.options?.AROptionsMoveCityGuideEnableSales
-        const destination = featureFlag ? "/sales" : Router.ConsignmentsStartSubmission
+        // const featureFlag = NativeModules?.Emission?.options?.AROptionsMoveCityGuideEnableSales
+        const destination = "/collections/my-collection/landing" // featureFlag ? "/sales" : Router.ConsignmentsStartSubmission
 
         tracking.trackEvent({
           context_page: Schema.PageNames.ArtistPage,

--- a/src/lib/Components/Artist/ArtistConsignButton.tsx
+++ b/src/lib/Components/Artist/ArtistConsignButton.tsx
@@ -1,5 +1,5 @@
 import { ArrowRightIcon, BorderBox, Box, Flex, Sans } from "@artsy/palette"
-import React, { useEffect, useRef } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { NativeModules, TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -18,10 +18,12 @@ export interface ArtistConsignButtonProps {
 export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = props => {
   const tracking = useTracking()
   const buttonRef = useRef()
+  const [selectedTabName, setSelectedTabName] = useState("")
 
   useEffect(() => {
     async function doStuff() {
       const tabName = await ARSwitchBoardModule.getSelectedTabName()
+      setSelectedTabName(tabName)
       console.log("sjhhhhhhh", tabName)
     }
     doStuff()
@@ -44,8 +46,11 @@ export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = props => 
       // @ts-ignore STRICTNESS_MIGRATION
       ref={buttonRef}
       onPress={() => {
-        // const featureFlag = NativeModules?.Emission?.options?.AROptionsMoveCityGuideEnableSales
-        const destination = "/collections/my-collection/landing" // featureFlag ? "/sales" : Router.ConsignmentsStartSubmission
+        let destination: Router | string = Router.ConsignmentsStartSubmission
+        const featureFlag = NativeModules?.Emission?.options?.AROptionsMoveCityGuideEnableSales
+        if (featureFlag) {
+          destination = selectedTabName === "sell" ? "/collections/my-collection/landing" : "/sales"
+        }
 
         tracking.trackEvent({
           context_page: Schema.PageNames.ArtistPage,

--- a/src/lib/Components/Artist/ArtistConsignButton.tsx
+++ b/src/lib/Components/Artist/ArtistConsignButton.tsx
@@ -1,5 +1,6 @@
 import { ArrowRightIcon, BorderBox, Box, Flex, Sans } from "@artsy/palette"
-import React, { useRef } from "react"
+import React, { useEffect, useRef } from "react"
+import { NativeModules, TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
@@ -8,7 +9,7 @@ import { ArtistConsignButton_artist } from "__generated__/ArtistConsignButton_ar
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { Router } from "lib/utils/router"
 import { Schema } from "lib/utils/track"
-import { NativeModules, TouchableOpacity } from "react-native"
+const { ARSwitchBoardModule } = NativeModules
 
 export interface ArtistConsignButtonProps {
   artist: ArtistConsignButton_artist
@@ -17,6 +18,14 @@ export interface ArtistConsignButtonProps {
 export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = props => {
   const tracking = useTracking()
   const buttonRef = useRef()
+
+  useEffect(() => {
+    async function doStuff() {
+      const tabName = await ARSwitchBoardModule.getSelectedTabName()
+      console.log("sjhhhhhhh", tabName)
+    }
+    doStuff()
+  }, [])
 
   const {
     artist: {

--- a/src/lib/NativeModules/SwitchBoard.tsx
+++ b/src/lib/NativeModules/SwitchBoard.tsx
@@ -78,6 +78,10 @@ function presentEmailComposer(component: React.Component<any, any>, to: string, 
   ARSwitchBoardModule.presentEmailComposer(reactTag, to, subject, body)
 }
 
+function getSelectedTabName() {
+  return ARSwitchBoardModule.getSelectedTabName()
+}
+
 export default {
   presentEmailComposer,
   presentNavigationViewController,
@@ -85,4 +89,5 @@ export default {
   presentModalViewController,
   dismissModalViewController,
   dismissNavigationViewController,
+  getSelectedTabName,
 }

--- a/src/lib/Scenes/Consignments/SellTabLanding.tsx
+++ b/src/lib/Scenes/Consignments/SellTabLanding.tsx
@@ -1,0 +1,11 @@
+import { Theme } from "@artsy/palette"
+import React from "react"
+import { ConsignmentsHomeQueryRenderer as ConsignmentsHome } from "./v2/Screens/ConsignmentsHome"
+
+export function SellTabLanding() {
+  return (
+    <Theme>
+      <ConsignmentsHome />
+    </Theme>
+  )
+}


### PR DESCRIPTION
This is a WIP because it's kind of mess, things are probably mis-named, I didn't put everything in the right places, and I am heavily cargo-culting my objective-C code. I wanted to get eyes on it to review the approach before I clean it up. I'll also add supporting videos.

## The initial problem

When you are in the Sell tab, and you tap an artist consign button, it takes you to the Sell tab landing page....but retains the scroll position of when you were last there. This is because the route associated with the Sell tab is _also_ the route associated with sending you to the Sell tab landing page. The experience would be better if when you tapped artist consign from the Sell tab, it pushed another visit to the landing page onto the navigation stack. We wouldn't have to worry about your scroll position during the previous visit, and you could interact with that page visit in a way that's familiar to you (e.g. tap `back` to go to the previous page).

## The initial solution

This PR adds a new route for visiting the sell tab landing page aside from the sell tab itself. This solves the navigation problem when you're in the Sell tab.

## The wrench

Having done that, it now becomes important to know where you currently are in the app. We don't want these changes to affect your experience while you're on the Home or Search tab. If you're on any tab but Sell, we still want you to go to `/sales`....if you're on the Sales tab, we want you to go to `/collections/my-collection/landing` (there's probably a better path for that).

## The wrench's solution

This PR also adds a bridge between React and the selected nav item. It currently takes advantage of the analytics tab name and passes that through; that certainly doesn't have to be the final solution. Once the React component has the currently selected tab name, it can choose the destination when you tap on an artist consign button.

## Analytics issue

I noticed that the analytics tab name wasn't being set for the new sell tab, so I updated that too.
