### PR TITLE
[WIP] createdAccount and successfullyLoggedIn events match v2 schema

### DIFF
--- a/Artsy/App/ARAnalyticsConstants.m
+++ b/Artsy/App/ARAnalyticsConstants.m
@@ -14,8 +14,8 @@ NSString *const ARAnalyticsFreshInstall = @"first user install";
 
 NSString *const ARAnalyticsDeepLinkOpened = @"Deep link opened";
 
-NSString *const ARAnalyticsAccountCreated = @"Created account";
-NSString *const ARAnalyticsLoggedIn = @"Successfully logged in";
+NSString *const ARAnalyticsAccountCreated = @"createdAccount";
+NSString *const ARAnalyticsLoggedIn = @"successfullyLoggedIn";
 NSString *const ARAnalyticsAuthError = @"Authentication error";
 
 NSString *const ARAnalyticsSlideshowStarted = @"Slideshow started";

--- a/Artsy/Networking/API_Modules/ARUserManager.m
+++ b/Artsy/Networking/API_Modules/ARUserManager.m
@@ -105,7 +105,7 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
         NSLog(@"Hey, we're logging out!");
         [[self class] logout];
     }];
-    
+
     return self;
 }
 
@@ -347,7 +347,11 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
 
              if (success) success(user);
 
-             [ARAnalytics event:ARAnalyticsAccountCreated withProperties:@{@"context_type" : @"email"}];
+             [ARAnalytics event:ARAnalyticsAccountCreated withProperties:@{
+                 @"service" : @"email",
+                 @"type" : @"signup",
+                 @"user_id": user.userID
+                 }];
 
              ADJEvent *event = [ADJEvent eventWithEventToken:ARAdjustCreatedAnAccount];
              [event addCallbackParameter:@"email" value:email];
@@ -383,7 +387,11 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
 
              if (success) { success(user); }
 
-             [ARAnalytics event:ARAnalyticsAccountCreated withProperties:@{@"context_type" : @"facebook"}];
+             [ARAnalytics event:ARAnalyticsAccountCreated withProperties:@{
+                 @"service" : @"facebook",
+                 @"type" : @"signup",
+                 @"user_id": user.userID
+             }];
 
          } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON) {
              failure(error, JSON);
@@ -413,7 +421,11 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
 
              if (success) { success(user); }
 
-             [ARAnalytics event:ARAnalyticsAccountCreated withProperties:@{@"context_type" : @"apple"}];
+             [ARAnalytics event:ARAnalyticsAccountCreated withProperties:@{
+                 @"service" : @"apple",
+                 @"type" : @"signup",
+                 @"user_id": user.userID
+             }];
 
          } failure:^(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON) {
              failure(error, JSON);
@@ -778,12 +790,17 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
         } else {
             NSDictionary *account = [(__bridge NSArray *)credentials firstObject];
             if (account) {
-                [ARAnalytics event:ARAnalyticsLoggedIn withProperties:@{@"context_type" : @"safari keychain"}];
-
                 [[ARUserManager sharedManager] loginWithUsername:account[(__bridge NSString *)kSecAttrAccount]
                                                         password:account[(__bridge NSString *)kSecSharedPassword]
                                           successWithCredentials:nil
-                                                         gotUser:^(User *currentUser) { completion(nil); }
+                                                         gotUser:^(User *currentUser) {
+                                                            [ARAnalytics event:ARAnalyticsLoggedIn withProperties:@{
+                                                                @"service" : @"safari keychain",
+                                                                @"type" : @"login",
+                                                                @"user_id": currentUser.userID
+                                                            }];
+                                                            completion(nil);
+                                                            }
                                            authenticationFailure:^(NSError *e) { completion(e); }
                                                   networkFailure:^(NSError *e) { completion(e); }
                                         saveSharedWebCredentials:NO];


### PR DESCRIPTION
Because account events are not in React native, we can't enforce type-safety on them via cohesion. 
We did however notice that we are not passing properties consistent to the current schema. Properties passed for `createdAccount` and `successfullyLoggedIn` have been updated to 
- Rename `context_type` as `service` 
- Include `type` and `user_id`
- Update event name (trivial, to indicate we've looked at it since v2)

There was one event fired with `context_type`: `safari keychain`. This is not accounted for in our schema and may be a duplicate fire (as part of email login). @abhitip do you have further context on this event? 
