### PR TITLE
Fix a typo in the email confirmation sash

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -11,6 +11,7 @@ upcoming:
     - Add BMW attribution to city guide cta in explore tab - david
     - Fix jumpy content during navigation - david
     - Fix scroll-to-top when tapping bottom tab - david, brian, pavlos, steve, damon
+    - Add the ability to request an email confirmation - yuki
 
 releases:
   - version: 6.4.6

--- a/src/lib/Scenes/Home/Components/EmailConfirmationBanner.tsx
+++ b/src/lib/Scenes/Home/Components/EmailConfirmationBanner.tsx
@@ -94,7 +94,7 @@ export const EmailConfirmationBanner: React.FC<Props> = ({ me, relay }) => {
       >
         {isLoading ? (
           <>
-            <Text>Sending an confirmation email...</Text>
+            <Text>Sending a confirmation email...</Text>
 
             <Flex pr="1">
               <Spinner size="small" color="white100" />

--- a/src/lib/Scenes/Home/Components/__tests__/EmailConfirmationBanner-tests.tsx
+++ b/src/lib/Scenes/Home/Components/__tests__/EmailConfirmationBanner-tests.tsx
@@ -92,7 +92,7 @@ describe("EmailConfirmationBanner", () => {
 
     getSubmitButton(component).props.onPress()
 
-    expect(extractText(component)).toEqual("Sending an confirmation email...")
+    expect(extractText(component)).toEqual("Sending a confirmation email...")
   })
 
   it("shows a successful message when the request is successful", async () => {


### PR DESCRIPTION
addresses https://artsyproduct.atlassian.net/browse/AUCT-1072

Just fixing a typo in the email confirmation sash and adding a CHANGELOG entry.