### PR TITLE
Add a bridge to identify the currently selected tab name

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -34,6 +34,7 @@
 #import <Emission/AREventsModule.h>
 #import <Emission/ARTakeCameraPhotoModule.h>
 #import <Emission/ARRefineOptionsModule.h>
+#import <Emission/ARTopMenuModule.h>
 #import <Emission/ARArtistComponentViewController.h>
 #import <Emission/ARHomeComponentViewController.h>
 #import <Emission/ARInboxComponentViewController.h>
@@ -300,6 +301,14 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
             [ARAnalytics pageView:info[@"context_screen"]  withProperties:[properties copy]];
         }
     };
+    
+
+#pragma mark - Native Module: TopMenu
+
+    emission.topMenuModule.getSelectedTabName = ^(RCTPromiseResolveBlock resolve, RCTPromiseRejectBlock reject) {
+        resolve([[ARTopMenuViewController sharedController] selectedTabName]);
+    };
+
 }
 
 - (NSDictionary *)getOptionsForEmission:(NSDictionary *)echoFeatures labOptions:(NSDictionary *)labOptions

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuNavigationDataSource.h
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuNavigationDataSource.h
@@ -27,6 +27,7 @@ typedef NS_ENUM(NSInteger, ARTopTabControllerTabType) {
 - (void)setNotificationCount:(NSUInteger)number forControllerAtTab:(ARTopTabControllerTabType)tabType;
 - (NSUInteger)indexForTabType:(ARTopTabControllerTabType)tabType;
 - (ARTopTabControllerTabType)tabTypeForIndex:(NSInteger)index;
+- (NSString *)tabNameForIndex:(NSInteger)index;
 - (NSArray *)tabOrder;
 
 @end

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuNavigationDataSource.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuNavigationDataSource.m
@@ -219,6 +219,27 @@
     return [self.tabOrder indexOfObject:@(tabType)];
 }
 
+- (NSString *)tabNameForIndex:(NSInteger)index
+{
+    ARTopTabControllerTabType tab = [self tabTypeForIndex:index];
+    switch (tab) {
+        case ARHomeTab:
+            return @"ARHomeTab";
+        case ARSearchTab:
+            return @"ARSearchTab";
+        case ARMessagingTab:
+            return @"ARMessagingTab";
+        case ARLocalDiscoveryTab:
+            return @"ARLocalDiscoveryTab";
+        case ARFavoritesTab:
+            return @"ARFavoritesTab";
+        case ARSalesTab:
+            return @"ARSalesTab";
+        default:
+            return @"Unknown";
+    }
+}
+
 #pragma mark ARTabViewDataSource
 
 - (UINavigationController *)viewControllerForTabContentView:(ARTabContentView *)tabContentView atIndex:(NSInteger)index

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuNavigationDataSource.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuNavigationDataSource.m
@@ -169,6 +169,8 @@
             return @"cityGuide";
         case ARFavoritesTab:
             return @"favorites";
+        case ARSalesTab:
+            return @"sell";
         default:
             return @"unknown";
     }

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.h
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.h
@@ -31,6 +31,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// The content view for the tabbed nav
 @property (readonly, nonatomic, weak) ARTabContentView *tabContentView;
 
+/// Used to identify the currently selected tab
+@property (readonly, nonatomic) NSString *selectedTabName;
+
 /// Pushes the view controller into the current navigation controller or if it’s an existing view controller at the root
 /// of a navigation stack of any of the tabs, it changes to that tab and pop’s to root if necessary.
 ///

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -600,6 +600,11 @@ static ARTopMenuViewController *_sharedManager = nil;
     return [self.navigationDataSource analyticsDescriptionForTabAtIndex:index];
 }
 
+- (NSString *)selectedTabName
+{
+    return [self.navigationDataSource tabNameForIndex:self.selectedTabIndex];
+}
+
 - (BOOL)tabContentView:(ARTabContentView *)tabContentView shouldChangeToIndex:(NSInteger)index
 {
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -7,6 +7,7 @@ upcoming:
     - Add hero unit behind feature flag - david
     - Address viewing room QA bits and bobs - mdole
     - Adds fallback images for sales rail - dzucconi
+    - Add a native module for identifying the currently selected tab - pepopowitz
   user_facing:
     - Add BMW attribution to city guide cta in explore tab - david
     - Fix jumpy content during navigation - david

--- a/emission/Pod/Classes/Core/AREmission.h
+++ b/emission/Pod/Classes/Core/AREmission.h
@@ -2,7 +2,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTBridgeModule.h>
 
-@class AREventsModule, ARSwitchBoardModule, ARTemporaryAPIModule, ARRefineOptionsModule, ARTakeCameraPhotoModule, RCTBridge, ARNotificationsManager, ARGraphQLQueryPreloader, ARGraphQLQueryCache;
+@class AREventsModule, ARSwitchBoardModule, ARTemporaryAPIModule, ARRefineOptionsModule, ARTakeCameraPhotoModule, ARTopMenuModule, RCTBridge, ARNotificationsManager, ARGraphQLQueryPreloader, ARGraphQLQueryCache;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -67,6 +67,7 @@ extern NSString *const AREnvTest;
 @property (nonatomic, strong, readonly) ARTemporaryAPIModule *APIModule;
 @property (nonatomic, strong, readonly) ARRefineOptionsModule *refineModule;
 @property (nonatomic, strong, readonly) ARTakeCameraPhotoModule *cameraModule;
+@property (nonatomic, strong, readonly) ARTopMenuModule *topMenuModule;
 @property (nonatomic, strong, readonly) ARNotificationsManager *notificationsManagerModule;
 @property (nonatomic, strong, readonly) ARGraphQLQueryPreloader *graphQLQueryPreloaderModule;
 @property (nonatomic, strong, readonly) ARGraphQLQueryCache *graphQLQueryCacheModule;

--- a/emission/Pod/Classes/Core/AREmission.m
+++ b/emission/Pod/Classes/Core/AREmission.m
@@ -4,6 +4,7 @@
 #import "ARTemporaryAPIModule.h"
 #import "ARRefineOptionsModule.h"
 #import "ARTakeCameraPhotoModule.h"
+#import "ARTopMenuModule.h"
 #import "ARNotificationsManager.h"
 #import "ARCocoaConstantsModule.h"
 #import "ARGraphQLQueryPreloader.h"
@@ -166,6 +167,7 @@ static AREmission *_sharedInstance = nil;
     _APIModule = [ARTemporaryAPIModule new];
     _refineModule = [ARRefineOptionsModule new];
     _cameraModule = [ARTakeCameraPhotoModule new];
+    _topMenuModule = [ARTopMenuModule new];
     _notificationsManagerModule = [ARNotificationsManager new];
     _graphQLQueryCacheModule = [ARGraphQLQueryCache new];
     _graphQLQueryPreloaderModule = [[ARGraphQLQueryPreloader alloc] initWithConfiguration:config
@@ -180,6 +182,7 @@ static AREmission *_sharedInstance = nil;
         _switchBoardModule,
         _refineModule,
         _cameraModule,
+        _topMenuModule,
         _notificationsManagerModule,
         _graphQLQueryPreloaderModule,
         _graphQLQueryCacheModule,

--- a/emission/Pod/Classes/Core/ARTopMenuModule.h
+++ b/emission/Pod/Classes/Core/ARTopMenuModule.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+#import <React/RCTBridgeModule.h>
+
+typedef void(^ARGetSelectedTabName)(_Nonnull RCTPromiseResolveBlock resolve, _Nonnull RCTPromiseRejectBlock reject);
+
+@interface ARTopMenuModule : NSObject <RCTBridgeModule>
+
+@property (nonatomic, copy, nullable, readwrite) ARGetSelectedTabName getSelectedTabName;
+
+@end

--- a/emission/Pod/Classes/Core/ARTopMenuModule.m
+++ b/emission/Pod/Classes/Core/ARTopMenuModule.m
@@ -1,0 +1,12 @@
+#import "ARTopMenuModule.h"
+
+@implementation ARTopMenuModule
+
+RCT_EXPORT_MODULE()
+
+RCT_EXPORT_METHOD(getSelectedTabName:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+    return self.getSelectedTabName(resolve, reject);
+}
+
+@end

--- a/src/lib/NativeModules/TopMenu.tsx
+++ b/src/lib/NativeModules/TopMenu.tsx
@@ -1,0 +1,7 @@
+import { NativeModules } from "react-native"
+
+const { ARTopMenuModule } = NativeModules
+
+export function getSelectedTabName() {
+  return ARTopMenuModule.getSelectedTabName()
+}


### PR DESCRIPTION
In #3389, I demonstrated a proof of concept on how I'd go about identifying the currently selected tab name from a React component. This PR cleans up that implementation, and is limited to setting up the bridge.

A followup PR will take advantage of this new bridge function to modify user flow within the sell tab landing page.