### PR TITLE
[CSGN-225] Choose the destination of artist consign taps based on your active tab

### DIFF
--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -29,6 +29,7 @@
 
 #import <Emission/ARNewSubmissionFormComponentViewController.h>
 #import <Emission/ARShowConsignmentsFlowViewController.h>
+#import <Emission/ARSellTabLandingViewController.h>
 #import <Emission/ARFairComponentViewController.h>
 #import <Emission/ARFairBoothComponentViewController.h>
 #import <Emission/ARFairArtworksComponentViewController.h>
@@ -284,6 +285,10 @@ static ARSwitchBoard *sharedInstance = nil;
     [self.routes addRoute:@"/consign/submission" handler:JLRouteParams {
         UIViewController *submissionVC = [[ARShowConsignmentsFlowViewController alloc] init];
         return [[ARNavigationController alloc] initWithRootViewController:submissionVC];
+    }];
+
+    [self.routes addRoute:@"/collections/my-collection/marketing-landing" handler:JLRouteParams {
+        return [[ARSellTabLandingViewController alloc] init];
     }];
 
     [self.routes addRoute:@"/conditions-of-sale" handler:JLRouteParams {

--- a/emission/Pod/Classes/ViewControllers/ARSellTabLandingViewController.h
+++ b/emission/Pod/Classes/ViewControllers/ARSellTabLandingViewController.h
@@ -1,0 +1,15 @@
+#import <Emission/ARComponentViewController.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARSellTabLandingViewController : ARComponentViewController
+
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithEmission:(nullable AREmission *)emission
+                      moduleName:(NSString *)moduleName
+               initialProperties:(nullable NSDictionary *)initialProperties NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/emission/Pod/Classes/ViewControllers/ARSellTabLandingViewController.m
+++ b/emission/Pod/Classes/ViewControllers/ARSellTabLandingViewController.m
@@ -1,0 +1,10 @@
+#import "ARSellTabLandingViewController.h"
+
+@implementation ARSellTabLandingViewController
+
+- (instancetype)init
+{
+    return [super initWithEmission:nil moduleName:@"SellTabLanding" initialProperties:nil];
+}
+
+@end

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -21,6 +21,7 @@ import { CitySectionListRenderer } from "./Scenes/City/CitySectionList"
 import { CollectionRenderer } from "./Scenes/Collection/Collection"
 import { CollectionFullFeaturedArtistListRenderer } from "./Scenes/Collection/Components/FullFeaturedArtistList"
 import Consignments from "./Scenes/Consignments"
+import { SellTabLanding } from "./Scenes/Consignments/SellTabLanding"
 import {
   FairArtistsRenderer,
   FairArtworksRenderer,
@@ -281,6 +282,7 @@ register("CitySavedList", CitySavedListRenderer)
 register("CitySectionList", CitySectionListRenderer)
 register("Collection", CollectionRenderer, { fullBleed: true })
 register("Consignments", Consignments)
+register("SellTabLanding", SellTabLanding)
 register("Conversation", Conversation)
 register("Fair", FairRenderer, { fullBleed: true })
 register("FairArtists", FairArtists)

--- a/src/lib/Components/Artist/ArtistConsignButton.tsx
+++ b/src/lib/Components/Artist/ArtistConsignButton.tsx
@@ -1,14 +1,15 @@
 import { ArrowRightIcon, BorderBox, Box, Flex, Sans } from "@artsy/palette"
 import React, { useRef } from "react"
+import { NativeModules, TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
 
 import { ArtistConsignButton_artist } from "__generated__/ArtistConsignButton_artist.graphql"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { TabName, useSelectedTabName } from "lib/NativeModules/TopMenu"
 import { Router } from "lib/utils/router"
 import { Schema } from "lib/utils/track"
-import { NativeModules, TouchableOpacity } from "react-native"
 
 export interface ArtistConsignButtonProps {
   artist: ArtistConsignButton_artist
@@ -17,6 +18,7 @@ export interface ArtistConsignButtonProps {
 export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = props => {
   const tracking = useTracking()
   const buttonRef = useRef()
+  const selectedTabName = useSelectedTabName()
 
   const {
     artist: {
@@ -35,8 +37,12 @@ export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = props => 
       // @ts-ignore STRICTNESS_MIGRATION
       ref={buttonRef}
       onPress={() => {
+        let destination: Router | string = Router.ConsignmentsStartSubmission
         const featureFlag = NativeModules?.Emission?.options?.AROptionsMoveCityGuideEnableSales
-        const destination = featureFlag ? "/sales" : Router.ConsignmentsStartSubmission
+        if (featureFlag) {
+          destination =
+            selectedTabName === TabName.ARSalesTab ? "/collections/my-collection/marketing-landing" : "/sales"
+        }
 
         tracking.trackEvent({
           context_page: Schema.PageNames.ArtistPage,

--- a/src/lib/NativeModules/TopMenu.tsx
+++ b/src/lib/NativeModules/TopMenu.tsx
@@ -1,7 +1,28 @@
+import { useEffect, useState } from "react"
 import { NativeModules } from "react-native"
 
 const { ARTopMenuModule } = NativeModules
 
-export function getSelectedTabName() {
-  return ARTopMenuModule.getSelectedTabName()
+export enum TabName {
+  ARHomeTab = "ARHomeTab",
+  ARSearchTab = "ARSearchTab",
+  ARMessagingTab = "ARMessagingTab",
+  ARLocalDiscoveryTab = "ARLocalDiscoveryTab",
+  ARFavoritesTab = "ARFavoritesTab",
+  ARSalesTab = "ARSalesTab",
+  Unknown = "Unknown",
+}
+
+export function useSelectedTabName() {
+  const [selectedTabName, setSelectedTabName] = useState(TabName.Unknown)
+
+  useEffect(() => {
+    async function runEffect() {
+      const tabName = await ARTopMenuModule.getSelectedTabName()
+      setSelectedTabName(tabName)
+    }
+    runEffect()
+  }, [])
+
+  return selectedTabName
 }

--- a/src/lib/Scenes/Consignments/SellTabLanding.tsx
+++ b/src/lib/Scenes/Consignments/SellTabLanding.tsx
@@ -1,0 +1,11 @@
+import { Theme } from "@artsy/palette"
+import React from "react"
+import { ConsignmentsHomeQueryRenderer as ConsignmentsHome } from "./v2/Screens/ConsignmentsHome"
+
+export function SellTabLanding() {
+  return (
+    <Theme>
+      <ConsignmentsHome />
+    </Theme>
+  )
+}


### PR DESCRIPTION
This work depends on #3400. The only commits in this diff that are related to this PR are the last two.

Addresses https://artsyproduct.atlassian.net/browse/CSGN-225

This PR uses your currently selected tab to determine where to send you when you tap the artist consign button. 

For users who are on the home or search tab (or anywhere that isn't sell), we'll continue to send them to the sell tab landing page:

![artist-consign-1](https://user-images.githubusercontent.com/1627089/83692278-4bf37280-a5b9-11ea-9d17-4d63a105dd6a.gif)

If you're already in the sell tab, we push another landing page view onto your nav stack. This addresses the experience of tapping on something and not getting enough feedback about where you're going:

![artist-consign-2](https://user-images.githubusercontent.com/1627089/83692612-f66b9580-a5b9-11ea-88c7-2904a4b9ddc4.gif)

#trivial (but not really; it's just covered by another entry that's already in the changelog.)

