### PR TITLE
[MX-189] - Fix for auctions pointy modal corner and non-fullscreen display

### DIFF
--- a/Artsy/View_Controllers/ARSerifNavigationViewController.m
+++ b/Artsy/View_Controllers/ARSerifNavigationViewController.m
@@ -85,9 +85,6 @@ static CGFloat exitButtonDimension = 40;
 {
     [super viewWillAppear:animated];
 
-    self.view.layer.cornerRadius = 0;
-    self.view.superview.layer.cornerRadius = 0;
-
     if (self.navigationBarHidden) {
         // No nav bar means we need to show something under the status bar manually. Might as well be our own view with a white background.
         self.view.backgroundColor = [UIColor whiteColor];

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.h
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.h
@@ -72,8 +72,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// Not all view controllers should be presented as a push, use this to determine whether the topVC will present modally or push.
 + (BOOL)shouldPresentViewControllerAsModal:(UIViewController *)viewController;
 
-- (BOOL)isShowingStatusBar;
-
 /// Used by analytics to get the tab name for a particular index
 - (NSString *)descriptionForNavIndex:(NSInteger)index;
 

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -461,13 +461,7 @@ static ARTopMenuViewController *_sharedManager = nil;
 }
 
 + (BOOL)shouldPresentModalFullScreen:(UIViewController *)viewController {
-    NSArray *fullScreenClasses = @[LiveAuctionViewController.class];
-    for (Class klass in fullScreenClasses) {
-        if ([viewController isKindOfClass:klass]) {
-            return YES;
-        }
-    }
-    return NO;
+    return [viewController isKindOfClass:LiveAuctionViewController.class];
 }
 
 - (void)pushViewController:(UIViewController *)viewController animated:(BOOL)animated completion:(void (^__nullable)(void))completion
@@ -490,7 +484,7 @@ static ARTopMenuViewController *_sharedManager = nil;
                 viewController.modalPresentationStyle = UIModalPresentationFullScreen;
             } else if ([self.class shouldPresentModalFullScreen:viewController]) {
                 viewController.modalPresentationStyle = UIModalPresentationFullScreen;
-            } else {}
+            }
         }
         [self presentViewController:viewController animated:animated completion:completion];
         return;

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -460,6 +460,16 @@ static ARTopMenuViewController *_sharedManager = nil;
     return NO;
 }
 
++ (BOOL)shouldPresentModalFullScreen:(UIViewController *)viewController {
+    NSArray *fullScreenClasses = @[LiveAuctionViewController.class];
+    for (Class klass in fullScreenClasses) {
+        if ([viewController isKindOfClass:klass]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
 - (void)pushViewController:(UIViewController *)viewController animated:(BOOL)animated completion:(void (^__nullable)(void))completion
 {
     NSAssert(viewController != nil, @"Attempt to push a nil view controller.");
@@ -478,7 +488,9 @@ static ARTopMenuViewController *_sharedManager = nil;
             } else if ([viewController isKindOfClass:UINavigationController.class] && [[(UINavigationController *)viewController topViewController] isKindOfClass:ARShowConsignmentsFlowViewController.class]) {
                 // Consignments gets full screen
                 viewController.modalPresentationStyle = UIModalPresentationFullScreen;
-            }
+            } else if ([self.class shouldPresentModalFullScreen:viewController]) {
+                viewController.modalPresentationStyle = UIModalPresentationFullScreen;
+            } else {}
         }
         [self presentViewController:viewController animated:animated completion:completion];
         return;
@@ -517,7 +529,6 @@ static ARTopMenuViewController *_sharedManager = nil;
         return;
     }
 
-    NSInteger homeIndex = [self.navigationDataSource indexForTabType:ARHomeTab];
     ARTopTabControllerTabType tabType = [self.navigationDataSource tabTypeForIndex:index];
 
     // If there is an existing instance at that index, use it. Otherwise use the instance passed in as viewController.
@@ -532,8 +543,11 @@ static ARTopMenuViewController *_sharedManager = nil;
         case ARFavoritesTab:
             presentableController = [self rootNavigationControllerAtIndex:index];
             break;
-        default:
+        default: {
+            NSInteger homeIndex = [self.navigationDataSource indexForTabType:ARHomeTab];
             presentableController = [self rootNavigationControllerAtIndex:homeIndex];
+        }
+
     }
 
     if (presentableController.viewControllers.count > 1) {

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -11,6 +11,7 @@ upcoming:
     - Add BMW attribution to city guide cta in explore tab - david
     - Fix jumpy content during navigation - david
     - Fix scroll-to-top when tapping bottom tab - david, brian, pavlos, steve, damon
+    - Fix pointy modal and live auction presentation on iPad - brian, damon
 
 releases:
   - version: 6.4.6


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/MX-189

- Fixes pointy corner of modals in auctions flows
- Makes live auctions views presentation full screen on iPad + iOS 13

While we were working on the pointy corner Damon noticed that the LiveAuctions VC was not being presented correctly on iPad, this is due to the new card presentation style for modals in iOS 13. Fix is to add an exception for this view controller in our presentation code. There may be more layout issues associated with our native modals on iOS 13 that might be worth looking into. 

**Co-authored with @dzucconi** 

**Before**
![pointyModal](https://user-images.githubusercontent.com/49686530/83696073-7f3dfd80-a5c9-11ea-8db4-7233c4dc3ee1.png)

![notFullScreenLiveAuction](https://user-images.githubusercontent.com/49686530/83696049-6b929700-a5c9-11ea-9e89-366b1132badc.png)


**After**
![fixedPointyModal](https://user-images.githubusercontent.com/49686530/83696108-97158180-a5c9-11ea-8136-8ebd261977dd.png)

![fullScreenLiveAuction](https://user-images.githubusercontent.com/49686530/83696033-65041f80-a5c9-11ea-9505-c0a65826f685.png)