### PR TITLE
Prevent false positives in strictness migration check

### DIFF
--- a/scripts/strictness-migration.js
+++ b/scripts/strictness-migration.js
@@ -75,6 +75,12 @@ switch (process.argv[2]) {
 
     break
   case "check-pr":
+    try {
+      execSync("git merge origin/master", { stdio: "inherit" })
+    } catch (e) {
+      console.log("Branch has conflicts with master, aborting strictness migration check")
+      process.exit(0)
+    }
     const current = countIssuesInWholeProject()
     execSync("git checkout origin/master", { stdio: "inherit" })
     const onMaster = countIssuesInWholeProject()


### PR DESCRIPTION
There's a kind of race condition which can cause false positives with the strictness check:

1. you make a PR which doesn't increase the strictness issue count
2. someone else merges a PR which decreases the strictness issue count
3. you update your PR so CI runs again
4. CI fails because your branch has more strictness issues than master

So in this PR I make the script try to merge master in before running to get an accurate notion of how your PR affects strictness issue counts.

#trivial infra change so gonna self-merge.