### PR TITLE
[CSGN-172] Update content of consignment submission confirmation

### DIFF
--- a/src/lib/Scenes/Consignments/Screens/Confirmation.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Confirmation.tsx
@@ -1,4 +1,4 @@
-import { Button, color, Flex, Serif, Spacer } from "@artsy/palette"
+import { Box, Button, color, Flex, Sans, Spacer } from "@artsy/palette"
 import Spinner from "lib/Components/Spinner"
 import { Schema, screenTrack } from "lib/utils/track"
 import React from "react"
@@ -62,6 +62,10 @@ export default class Confirmation extends React.Component<Props, State> {
   }
 
   exitModal = () => SwitchBoard.dismissModalViewController(this)
+  exitModalAndGoHome = () => {
+    SwitchBoard.dismissModalViewController(this)
+    SwitchBoard.presentNavigationViewController(this, "/")
+  }
   restart = () => this.props.navigator.push({ component: Welcome })
 
   progressContent = () => (
@@ -72,36 +76,55 @@ export default class Confirmation extends React.Component<Props, State> {
 
   successContent = () => (
     <View>
-      <Serif size="5" style={{ textAlign: "center" }}>
-        Successfully submitted
-      </Serif>
-      <Serif size="4" color={color("black60")} style={{ textAlign: "center" }}>
-        You will receive a confirmation email shortly.
-      </Serif>
-      <Spacer mb={3} />
-      <Flex flexDirection="row" justifyContent="center">
-        <Button onPress={this.exitModal}>Done</Button>
-      </Flex>
+      <Box px={2}>
+        <Sans size="6" style={{ textAlign: "center" }}>
+          Thank you for submitting your consignment
+        </Sans>
+        <Spacer mb={3} />
+        <Sans size="4" color={color("black60")} style={{ textAlign: "center" }}>
+          Our team of specialists are reviewing your work. You'll receive an email update once the status of your
+          submission changes.
+        </Sans>
+        <Spacer mb={3} />
+        <Sans size="4" color={color("black60")} style={{ textAlign: "center" }}>
+          If your work is accepted, Artsy will gather competitive offers and guide you through the selling process.
+        </Sans>
+        <Spacer mb={3} />
+        <Flex alignItems="stretch" flexDirection="column" width="100%">
+          <Button block width={100} onPress={this.exitModal}>
+            Done
+          </Button>
+          <Spacer mb={2} />
+          <Button block width={100} onPress={this.exitModalAndGoHome} variant="secondaryOutline">
+            Browse new works for sale
+          </Button>
+        </Flex>
+      </Box>
     </View>
   )
   failedContent = () => (
     <View>
-      <Serif size="5" style={{ textAlign: "center" }}>
-        Submission failed
-      </Serif>
-      <Serif size="4" color={color("black60")} style={{ textAlign: "center" }}>
-        Please try again.
-      </Serif>
-      <Spacer mb={3} />
-      <Flex flexDirection="row" justifyContent="center">
-        <Button onPress={this.restart}>Try again</Button>
-      </Flex>
-      <Spacer mb={1} />
-      <Flex flexDirection="row" justifyContent="center">
-        <Button variant="noOutline" onPress={this.exitModal}>
-          Quit
-        </Button>
-      </Flex>
+      <Box px={2}>
+        <Sans size="6" style={{ textAlign: "center" }}>
+          Submission failed
+        </Sans>
+        <Spacer mb={2} />
+        <Sans size="4" color={color("black60")} style={{ textAlign: "center" }}>
+          Please try again.
+        </Sans>
+        <Spacer mb={3} />
+        <Flex flexDirection="row" justifyContent="center">
+          <Button block width={100} onPress={this.restart}>
+            Try again
+          </Button>
+        </Flex>
+        <Spacer mb={2} />
+        <Flex flexDirection="row" justifyContent="center">
+          <Button variant="secondaryOutline" block width={100} onPress={this.exitModal}>
+            Quit
+          </Button>
+        </Flex>
+      </Box>
     </View>
   )
 

--- a/src/lib/Scenes/Consignments/Screens/__tests__/Confirmation-tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/__tests__/Confirmation-tests.tsx
@@ -85,7 +85,7 @@ describe("state", () => {
 
 describe("messaging", () => {
   it("Lets you know you've succeeded", () => {
-    const expected = "Successfully submitted"
+    const expected = "Thank you for submitting your consignment"
     const state = SubmissionTypes.SuccessfulSubmission
     const confirmationText = getTextTree(<Confirmation {...emptyProps} initialState={state} />)
     expect(confirmationText).toContain(expected)


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/CSGN-172

This PR updates the content of the consignment submission confirmation, and makes some related small changes to the consignment submission failure.

## Submission confirmation

![image](https://user-images.githubusercontent.com/1627089/83795848-b530bf80-a665-11ea-9df5-92387dbbb831.png)

Tapping "Done" will close the modal; tapping "Browse new works for sale" will close the modal and take you to the home tab.

## Submission failure
 
![image](https://user-images.githubusercontent.com/1627089/83802727-ec589e00-a670-11ea-8659-0f9313402fd5.png)
