### PR TITLE
Adds deploy block check to beta builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ version: 2.1
 orbs:
   node: circleci/node@1.1.6
   queue: eddiewebb/queue@1.0.110
+  horizon: artsy/release@0.0.1
 
 commands:
   await-previous-builds:
@@ -339,6 +340,13 @@ workflows:
             branches:
               ignore:
                 - app_store_submission
+      - horizon/block:
+          context: horizon
+          project_id: 37
+          filters:
+            branches:
+              only:
+                - beta
       - build-test-app:
           filters:
             branches:
@@ -346,6 +354,7 @@ workflows:
                 - app_store_submission
           requires:
             - build-test-js
+            - horizon/block
       - update-metaphysics:
           filters:
             branches:


### PR DESCRIPTION
We created the deploy block test here: https://releases.artsy.net/admin/deploy_blocks/83 This will block beta deploys for us in a way that is familiar to the rest of Artsy Engineering and will make creating a manual deploy easier (ie: no more asking "is it okay to make a beta?", you can just try to make it and if there is no block it will work).