### PR TITLE
[CSGN-232] Remove horizontal scrollbar from sell tab artist list & update "submission failed" content

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,7 +3,6 @@ upcoming:
   date: TBD
   dev:
     - Fix for tracking actions with new schema - brian
-    - Finalize development of sell tab landing page (still behind a feature flag) - pepopowitz
     - Add hero unit behind feature flag - david
     - Address viewing room QA bits and bobs - mdole
     - Adds fallback images for sales rail - dzucconi
@@ -20,6 +19,7 @@ upcoming:
     - Add the ability to request an email confirmation - yuki
     - Fix pointy modal and live auction presentation on iPad - brian, damon
     - Artist page facelift - david
+    - New "Sell" tab - pepopowitz
 
 releases:
   - version: 6.4.6

--- a/src/lib/Scenes/Consignments/Screens/Confirmation.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Confirmation.tsx
@@ -110,7 +110,7 @@ export default class Confirmation extends React.Component<Props, State> {
         </Sans>
         <Spacer mb={2} />
         <Sans size="4" color={color("black60")} style={{ textAlign: "center" }}>
-          Please try again.
+          We’re sorry, something went wrong. Please try submitting your consignment again.
         </Sans>
         <Spacer mb={3} />
         <Flex flexDirection="row" justifyContent="center">

--- a/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/Components/ArtistList.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/Components/ArtistList.tsx
@@ -5,7 +5,7 @@ import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { PlaceholderBox, PlaceholderText } from "lib/utils/placeholders"
 import { chunk, shuffle } from "lodash"
 import React, { useRef } from "react"
-import { FlatList, ScrollView, TouchableHighlight } from "react-native"
+import { FlatList, TouchableHighlight } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 
@@ -36,26 +36,25 @@ export const ArtistList: React.FC<ArtistListProps> = ({ targetSupply, isLoading 
 
         <Spacer mb={2} />
 
-        <ScrollView horizontal>
-          <FlatList
-            horizontal
-            ListHeaderComponent={() => <Spacer mr={2}></Spacer>}
-            ListFooterComponent={() => <Spacer mr={2}></Spacer>}
-            ItemSeparatorComponent={() => <Spacer mr={3} />}
-            data={chunksOfArtists}
-            initialNumToRender={2}
-            renderItem={({ item }) => (
-              <Flex>
-                <Join separator={<Spacer mb={2} />}>
-                  {item.map((artist, index) => {
-                    return <ArtistItem artist={artist} key={artist?.name || index} />
-                  })}
-                </Join>
-              </Flex>
-            )}
-            keyExtractor={(_item, index) => String(index)}
-          />
-        </ScrollView>
+        <FlatList
+          horizontal
+          ListHeaderComponent={() => <Spacer mr={2}></Spacer>}
+          ListFooterComponent={() => <Spacer mr={2}></Spacer>}
+          ItemSeparatorComponent={() => <Spacer mr={3} />}
+          showsHorizontalScrollIndicator={false}
+          data={chunksOfArtists}
+          initialNumToRender={2}
+          renderItem={({ item }) => (
+            <Flex>
+              <Join separator={<Spacer mb={2} />}>
+                {item.map((artist, index) => {
+                  return <ArtistItem artist={artist} key={artist?.name || index} />
+                })}
+              </Join>
+            </Flex>
+          )}
+          keyExtractor={(_item, index) => String(index)}
+        />
       </Box>
     </Box>
   )


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/CSGN-232

The horizontal scrollbar was appearing over the bottom artists on the sell tab artist list. This PR removes the horizontal scrollbar from that rail entirely. 

It now looks like this: 

![scroll-without](https://user-images.githubusercontent.com/1627089/84176711-732dc200-aa47-11ea-976a-652a183500ab.gif)

Also included is a small change to some content on the "submission failed" view. 