### PR TITLE
Fix auction registration back button layout issue

### DIFF
--- a/Artsy/View_Controllers/ARSerifNavigationViewController.m
+++ b/Artsy/View_Controllers/ARSerifNavigationViewController.m
@@ -107,8 +107,9 @@ static CGFloat exitButtonDimension = 40;
                 [exitButton.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-10]
             ]];
         } else { // iPad
+            UILayoutGuide *safeAreaLayoutGuide = self.view.safeAreaLayoutGuide;
             [NSLayoutConstraint activateConstraints:@[
-                [exitButton.topAnchor constraintEqualToAnchor:self.view.topAnchor constant:16],
+                [exitButton.topAnchor constraintEqualToAnchor:safeAreaLayoutGuide.topAnchor constant:24],
                 [exitButton.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-19]
             ]];
         }

--- a/src/lib/Components/Bidding/Components/BackButton.tsx
+++ b/src/lib/Components/Bidding/Components/BackButton.tsx
@@ -1,3 +1,4 @@
+import { isPad } from "lib/utils/hardware"
 import React from "react"
 import { TouchableWithoutFeedback, ViewProperties } from "react-native"
 import NavigatorIOS from "react-native-navigator-ios"
@@ -17,8 +18,8 @@ export class BackButton extends React.Component<ContainerWithBackButtonProps> {
       <TouchableWithoutFeedback onPress={() => this.goBack()}>
         <Image
           position="absolute"
-          top={"14px"}
-          left={3}
+          top={isPad() ? "10px" : "14px"}
+          left={isPad() ? "20px" : "10px"}
           source={require("../../../../../images/angle-left.png")}
           style={{ zIndex: 10 }} // Here the style prop is intentionally used to avoid making zIndex too handy.
         />

--- a/src/lib/Components/Bidding/Components/BackButton.tsx
+++ b/src/lib/Components/Bidding/Components/BackButton.tsx
@@ -2,7 +2,6 @@ import React from "react"
 import { TouchableWithoutFeedback, ViewProperties } from "react-native"
 import NavigatorIOS from "react-native-navigator-ios"
 import { Image } from "../Elements/Image"
-import { theme } from "../Elements/Theme"
 
 interface ContainerWithBackButtonProps extends ViewProperties {
   navigator: NavigatorIOS
@@ -18,8 +17,8 @@ export class BackButton extends React.Component<ContainerWithBackButtonProps> {
       <TouchableWithoutFeedback onPress={() => this.goBack()}>
         <Image
           position="absolute"
-          top={theme.space[3]}
-          left={theme.space[3]}
+          top={"14px"}
+          left={3}
           source={require("../../../../../images/angle-left.png")}
           style={{ zIndex: 10 }} // Here the style prop is intentionally used to avoid making zIndex too handy.
         />


### PR DESCRIPTION
Fix for back button layout issue in auction registration components that came up in QA session

. I am not crazy about the fix just being updating magic constants but this is complicated a bit by the fact that the close button is added on the native side and the back button is added on the react side and the buttons need to be aligned. I think the better fix would be to have the react side create and manage both buttons but this is a bigger change. Not totally clear on why the `theme.space[3]` broke, possibly palette updates? 

## Before 
**iPhone**
![iPhoneCreditCardsBefore](https://user-images.githubusercontent.com/49686530/84186177-273a4780-aa5e-11ea-80fc-f77ea604bd54.PNG)

## After
**iPhone**
![iPhoneCreditCard](https://user-images.githubusercontent.com/49686530/84186131-0eca2d00-aa5e-11ea-8784-19f5f9bf327f.png)

**iPad**
![iPadBilling](https://user-images.githubusercontent.com/49686530/84186145-17226800-aa5e-11ea-9aee-baa664d04fad.png)