### PR TITLE
[CSGN-233] Scroll sales tab to top when already on sales tab and icon is tapped

### DIFF
--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -628,6 +628,7 @@ static ARTopMenuViewController *_sharedManager = nil;
         // Otherwise find the first scrollview and pop to top
         else if (tabType == ARHomeTab ||
                  tabType == ARMessagingTab ||
+                 tabType == ARSalesTab ||
                  tabType == ARFavoritesTab) {
             UIViewController *currentRootViewController = [controller.childViewControllers first];
             UIScrollView *rootScrollView = (id)[self firstScrollToTopScrollViewFromRootView:currentRootViewController.view];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -20,6 +20,7 @@ upcoming:
     - Fix pointy modal and live auction presentation on iPad - brian, damon
     - Artist page facelift - david
     - New "Sell" tab - pepopowitz
+    - Scroll "Sell" tab to top when already on that tab and tapping its icon - pepopowitz
 
 releases:
   - version: 6.4.6


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/CSGN-233

This PR adds the sales tab to the list of tabs that should scroll to top when the user is already on the tab and taps its icon. 

![scroll-to-top](https://user-images.githubusercontent.com/1627089/84193696-77ff6f80-aa61-11ea-8f18-f5c82b698242.gif)
