### PR TITLE
[My Collection] Stub out skeleton nav flow 

### DIFF
--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -28,32 +28,36 @@
 #import "AREigenViewingRoomComponentViewController.h"
 #import "ARFavoritesComponentViewController.h"
 
-#import <Emission/ARNewSubmissionFormComponentViewController.h>
-#import <Emission/ARShowConsignmentsFlowViewController.h>
-#import <Emission/ARSellTabLandingViewController.h>
-#import <Emission/ARFairComponentViewController.h>
-#import <Emission/ARFairBoothComponentViewController.h>
-#import <Emission/ARFairArtworksComponentViewController.h>
+#import <Emission/ARArtworkAttributionClassFAQViewController.h>
+#import <Emission/ARAuctionsComponentViewController.h>
+#import <Emission/ARCityBMWListComponentViewController.h>
+#import <Emission/ARCityFairListComponentViewController.h>
+#import <Emission/ARCitySavedListComponentViewController.h>
+#import <Emission/ARCitySectionListComponentViewController.h>
+#import <Emission/ARCollectionFullFeaturedArtistListComponentViewController.h>
 #import <Emission/ARFairArtistsComponentViewController.h>
+#import <Emission/ARFairComponentViewController.h>
+#import <Emission/ARFairComponentViewController.h>
 #import <Emission/ARFairExhibitorsComponentViewController.h>
+#import <Emission/ARFairMoreInfoComponentViewController.h>
+
+// Breadcrumb
+#import <Emission/ARMyCollectionAddArtworkComponentViewController.h>
+#import <Emission/ARMyCollectionArtworkDetailComponentViewController.h>
+#import <Emission/ARMyCollectionArtworkListComponentViewController.h>
+#import <Emission/ARMyCollectionHomeComponentViewController.h>
+
+#import <Emission/ARMyProfileComponentViewController.h>
+#import <Emission/ARNewSubmissionFormComponentViewController.h>
+#import <Emission/ARPartnerLocationsComponentViewController.h>
+#import <Emission/ARPrivacyRequestComponentViewController.h>
+#import <Emission/ARSellTabLandingViewController.h>
+#import <Emission/ARShowArtistsComponentViewController.h>
+#import <Emission/ARShowArtworksComponentViewController.h>
+#import <Emission/ARShowConsignmentsFlowViewController.h>
+#import <Emission/ARShowMoreInfoComponentViewController.h>
 #import <Emission/ARViewingRoomArtworksComponentViewController.h>
 #import <Emission/ARViewingRoomsComponentViewController.h>
-#import <Emission/ARFairComponentViewController.h>
-#import <Emission/ARShowArtworksComponentViewController.h>
-#import <Emission/ARShowArtistsComponentViewController.h>
-#import <Emission/ARShowMoreInfoComponentViewController.h>
-#import <Emission/ARFairMoreInfoComponentViewController.h>
-#import <Emission/ARCitySectionListComponentViewController.h>
-#import <Emission/ARCityFairListComponentViewController.h>
-#import <Emission/ARCityBMWListComponentViewController.h>
-#import <Emission/ARFairBMWArtActivationComponentViewController.h>
-#import <Emission/ARCitySavedListComponentViewController.h>
-#import <Emission/ARArtworkAttributionClassFAQViewController.h>
-#import <Emission/ARPartnerLocationsComponentViewController.h>
-#import <Emission/ARMyProfileComponentViewController.h>
-#import <Emission/ARPrivacyRequestComponentViewController.h>
-#import <Emission/ARCollectionFullFeaturedArtistListComponentViewController.h>
-#import <Emission/ARAuctionsComponentViewController.h>
 #import <Emission/ARWorksForYouComponentViewController.h>
 
 #import "ArtsyEcho.h"
@@ -282,7 +286,7 @@ static ARSwitchBoard *sharedInstance = nil;
     [self.routes addRoute:@"/admin" handler:JLRouteParams {
         return [wself loadAdminMenu];
     }];
-    
+
     if ([AROptions boolForOption:AROptionsEnableNewProfileTab]) {
         [self.routes addRoute:@"/favorites" handler:JLRouteParams {
             return [[ARFavoritesComponentViewController alloc] init];
@@ -301,18 +305,39 @@ static ARSwitchBoard *sharedInstance = nil;
         return [[ARPrivacyRequestComponentViewController alloc] init];
     }];
 
-    [self.routes addRoute:@"/collections/my-collection/artworks/new/submissions/new" handler:JLRouteParams {
-        UIViewController *controller = [[ARNewSubmissionFormComponentViewController alloc] init];
-        return [[ARNavigationController alloc] initWithRootViewController:controller];
-    }];
-
     [self.routes addRoute:@"/consign/submission" handler:JLRouteParams {
         UIViewController *submissionVC = [[ARShowConsignmentsFlowViewController alloc] init];
         return [[ARNavigationController alloc] initWithRootViewController:submissionVC];
     }];
 
+    // Breadcrumb
+
+    [self.routes addRoute:@"/my-collection/add-artwork" handler:JLRouteParams {
+        return [[ARMyCollectionAddArtworkViewController alloc] init];
+    }];
+
+    [self.routes addRoute:@"/my-collection/artwork-detail" handler:JLRouteParams {
+        return [[ARMyCollectionArtworkDetailViewController alloc] init];
+    }];
+
+    [self.routes addRoute:@"/my-collection/artwork-list" handler:JLRouteParams {
+        return [[ARMyCollectionArtworkListViewController alloc] init];
+    }];
+
+    [self.routes addRoute:@"/my-collection/home" handler:JLRouteParams {
+        return [[ARMyCollectionHomeViewController alloc] init];
+    }];
+
+
+    // TODO: Follow-up about below route names
+
     [self.routes addRoute:@"/collections/my-collection/marketing-landing" handler:JLRouteParams {
         return [[ARSellTabLandingViewController alloc] init];
+    }];
+
+    [self.routes addRoute:@"/collections/my-collection/artworks/new/submissions/new" handler:JLRouteParams {
+        UIViewController *controller = [[ARNewSubmissionFormComponentViewController alloc] init];
+        return [[ARNavigationController alloc] initWithRootViewController:controller];
     }];
 
     [self.routes addRoute:@"/conditions-of-sale" handler:JLRouteParams {

--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -41,7 +41,7 @@
 #import <Emission/ARFairExhibitorsComponentViewController.h>
 #import <Emission/ARFairMoreInfoComponentViewController.h>
 
-// Breadcrumb
+// My Collection
 #import <Emission/ARMyCollectionAddArtworkComponentViewController.h>
 #import <Emission/ARMyCollectionArtworkDetailComponentViewController.h>
 #import <Emission/ARMyCollectionArtworkListComponentViewController.h>
@@ -310,22 +310,22 @@ static ARSwitchBoard *sharedInstance = nil;
         return [[ARNavigationController alloc] initWithRootViewController:submissionVC];
     }];
 
-    // Breadcrumb
+    // My Collection
 
     [self.routes addRoute:@"/my-collection/add-artwork" handler:JLRouteParams {
-        return [[ARMyCollectionAddArtworkViewController alloc] init];
+        return [[ARMyCollectionAddArtworkComponentViewController alloc] init];
     }];
 
     [self.routes addRoute:@"/my-collection/artwork-detail" handler:JLRouteParams {
-        return [[ARMyCollectionArtworkDetailViewController alloc] init];
+        return [[ARMyCollectionArtworkDetailComponentViewController alloc] init];
     }];
 
     [self.routes addRoute:@"/my-collection/artwork-list" handler:JLRouteParams {
-        return [[ARMyCollectionArtworkListViewController alloc] init];
+        return [[ARMyCollectionArtworkListComponentViewController alloc] init];
     }];
 
     [self.routes addRoute:@"/my-collection/home" handler:JLRouteParams {
-        return [[ARMyCollectionHomeViewController alloc] init];
+        return [[ARMyCollectionHomeComponentViewController alloc] init];
     }];
 
 

--- a/emission/Pod/Classes/ViewControllers/ARMyCollectionAddArtworkComponentViewController.h
+++ b/emission/Pod/Classes/ViewControllers/ARMyCollectionAddArtworkComponentViewController.h
@@ -1,0 +1,15 @@
+#import <Emission/ARComponentViewController.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARMyCollectionAddArtworkComponentViewController : ARComponentViewController
+
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithEmission:(nullable AREmission *)emission
+                      moduleName:(NSString *)moduleName
+               initialProperties:(nullable NSDictionary *)initialProperties NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/emission/Pod/Classes/ViewControllers/ARMyCollectionAddArtworkComponentViewController.m
+++ b/emission/Pod/Classes/ViewControllers/ARMyCollectionAddArtworkComponentViewController.m
@@ -1,0 +1,10 @@
+#import "ARMyCollectionAddArtworkComponentViewController.h"
+
+@implementation ARMyCollectionAddArtworkComponentViewController
+
+- (instancetype)init
+{
+    return [super initWithEmission:nil moduleName:@"MyCollectionAddArtwork" initialProperties:nil];
+}
+
+@end

--- a/emission/Pod/Classes/ViewControllers/ARMyCollectionArtworkDetailComponentViewController.h
+++ b/emission/Pod/Classes/ViewControllers/ARMyCollectionArtworkDetailComponentViewController.h
@@ -1,0 +1,15 @@
+#import <Emission/ARComponentViewController.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARMyCollectionArtworkDetailComponentViewController : ARComponentViewController
+
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithEmission:(nullable AREmission *)emission
+                      moduleName:(NSString *)moduleName
+               initialProperties:(nullable NSDictionary *)initialProperties NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/emission/Pod/Classes/ViewControllers/ARMyCollectionArtworkDetailComponentViewController.m
+++ b/emission/Pod/Classes/ViewControllers/ARMyCollectionArtworkDetailComponentViewController.m
@@ -1,0 +1,10 @@
+#import "ARMyCollectionArtworkDetailComponentViewController.h"
+
+@implementation ARMyCollectionArtworkDetailComponentViewController
+
+- (instancetype)init
+{
+    return [super initWithEmission:nil moduleName:@"MyCollectionArtworkDetail" initialProperties:nil];
+}
+
+@end

--- a/emission/Pod/Classes/ViewControllers/ARMyCollectionArtworkListComponentViewController.h
+++ b/emission/Pod/Classes/ViewControllers/ARMyCollectionArtworkListComponentViewController.h
@@ -1,0 +1,15 @@
+#import <Emission/ARComponentViewController.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARMyCollectionArtworkListComponentViewController : ARComponentViewController
+
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithEmission:(nullable AREmission *)emission
+                      moduleName:(NSString *)moduleName
+               initialProperties:(nullable NSDictionary *)initialProperties NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/emission/Pod/Classes/ViewControllers/ARMyCollectionArtworkListComponentViewController.m
+++ b/emission/Pod/Classes/ViewControllers/ARMyCollectionArtworkListComponentViewController.m
@@ -1,0 +1,10 @@
+#import "ARMyCollectionArtworkListComponentViewController.h"
+
+@implementation ARMyCollectionArtworkListComponentViewController
+
+- (instancetype)init
+{
+    return [super initWithEmission:nil moduleName:@"MyCollectionArtworkList" initialProperties:nil];
+}
+
+@end

--- a/emission/Pod/Classes/ViewControllers/ARMyCollectionHomeComponentViewController.h
+++ b/emission/Pod/Classes/ViewControllers/ARMyCollectionHomeComponentViewController.h
@@ -1,0 +1,15 @@
+#import <Emission/ARMyCollectionHomeComponentViewController.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARMyCollectionHomeComponentViewController : ARComponentViewController
+
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithEmission:(nullable AREmission *)emission
+                      moduleName:(NSString *)moduleName
+               initialProperties:(nullable NSDictionary *)initialProperties NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/emission/Pod/Classes/ViewControllers/ARMyCollectionHomeComponentViewController.h
+++ b/emission/Pod/Classes/ViewControllers/ARMyCollectionHomeComponentViewController.h
@@ -1,4 +1,4 @@
-#import <Emission/ARMyCollectionHomeComponentViewController.h>
+#import <Emission/ARComponentViewController.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/emission/Pod/Classes/ViewControllers/ARMyCollectionHomeComponentViewController.m
+++ b/emission/Pod/Classes/ViewControllers/ARMyCollectionHomeComponentViewController.m
@@ -1,0 +1,10 @@
+#import "ARMyCollectionHomeComponentViewController.h"
+
+@implementation ARMyCollectionHomeComponentViewController
+
+- (instancetype)init
+{
+    return [super initWithEmission:nil moduleName:@"MyCollectionHome" initialProperties:nil];
+}
+
+@end

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -21,8 +21,15 @@ import { CitySavedListQueryRenderer } from "./Scenes/City/CitySavedList"
 import { CitySectionListQueryRenderer } from "./Scenes/City/CitySectionList"
 import { CollectionQueryRenderer } from "./Scenes/Collection/Collection"
 import { CollectionFullFeaturedArtistListQueryRenderer } from "./Scenes/Collection/Components/FullFeaturedArtistList"
+
+// Consignments / My Collection
 import Consignments from "./Scenes/Consignments"
 import { SellTabLanding } from "./Scenes/Consignments/v2"
+import { MyCollectionAddArtwork } from "./Scenes/Consignments/v2/Screens/MyCollectionAddArtwork"
+import { MyCollectionArtworkDetail } from "./Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail"
+import { MyCollectionArtworkList } from "./Scenes/Consignments/v2/Screens/MyCollectionArtworkList"
+import { MyCollectionHome } from "./Scenes/Consignments/v2/Screens/MyCollectionHome"
+
 import {
   FairArtistsQueryRenderer,
   FairArtworksQueryRenderer,
@@ -302,6 +309,13 @@ register("Home", HomeQueryRenderer)
 register("Inbox", Inbox)
 register("Inquiry", Inquiry)
 register("Map", MapContainer, { fullBleed: true })
+
+// My Collection
+register("MyCollectionAddArtwork", MyCollectionAddArtwork)
+register("MyCollectionArtworkDetail", MyCollectionArtworkDetail)
+register("MyCollectionArtworkList", MyCollectionArtworkList)
+register("MyCollectionHome", MyCollectionHome)
+
 register("MyProfile", MyProfileQueryRenderer)
 register("MySellingProfile", View)
 register("NewSubmissionForm", NewSubmissionForm)

--- a/src/lib/Scenes/Consignments/v2/Screens/MyCollectionAddArtwork/index.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/MyCollectionAddArtwork/index.tsx
@@ -2,7 +2,7 @@ import { Sans } from "@artsy/palette"
 import React from "react"
 import { View } from "react-native"
 
-export const MyCollectionAddWork = () => {
+export const MyCollectionAddArtwork = () => {
   return (
     <View>
       <Sans size="3">Add Work</Sans>

--- a/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkList/index.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkList/index.tsx
@@ -2,7 +2,7 @@ import { Sans } from "@artsy/palette"
 import React from "react"
 import { View } from "react-native"
 
-export const MyCollectionListView = () => {
+export const MyCollectionArtworkList = () => {
   return (
     <View>
       <Sans size="3">List View</Sans>

--- a/src/lib/Scenes/Consignments/v2/Screens/MyCollectionHome/index.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/MyCollectionHome/index.tsx
@@ -1,18 +1,31 @@
-import { Button, Sans } from "@artsy/palette"
+import { Button, Join, Sans, Spacer } from "@artsy/palette"
 import { useStoreActions } from "lib/Scenes/Consignments/v2/State/hooks"
-import React, { useRef } from "react"
+import React, { useEffect, useRef } from "react"
 import { View } from "react-native"
 
 export const MyCollectionHome = () => {
   const navRef = useRef<View>(null)
-  const { navigateToAddWork } = useStoreActions(actions => actions.navigation)
+  const navActions = useStoreActions(actions => actions.navigation)
+
+  useEffect(() => {
+    navActions.setupNavigation(navRef)
+  }, [])
 
   return (
     <View ref={navRef}>
-      <Sans size="3">My Collection Home</Sans>
-      <Button block onPress={() => navigateToAddWork(navRef)}>
-        Add a work
-      </Button>
+      <Sans size="3">My Collection Static Build</Sans>
+
+      <Join separator={<Spacer my={2} />}>
+        <Button block onPress={() => navActions.navigateToAddArtwork()}>
+          Add a work
+        </Button>
+        <Button block onPress={() => navActions.navigateToArtworkDetail()}>
+          Artwork Detail
+        </Button>
+        <Button block onPress={() => navActions.navigateToArtworkList()}>
+          Artwork List
+        </Button>
+      </Join>
     </View>
   )
 }

--- a/src/lib/Scenes/Consignments/v2/Screens/MyCollectionHome/index.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/MyCollectionHome/index.tsx
@@ -1,11 +1,18 @@
-import { Sans } from "@artsy/palette"
-import React from "react"
+import { Button, Sans } from "@artsy/palette"
+import { useStoreActions } from "lib/Scenes/Consignments/v2/State/hooks"
+import React, { useRef } from "react"
 import { View } from "react-native"
 
 export const MyCollectionHome = () => {
+  const navRef = useRef<View>(null)
+  const { navigateToAddWork } = useStoreActions(actions => actions.navigation)
+
   return (
-    <View>
+    <View ref={navRef}>
       <Sans size="3">My Collection Home</Sans>
+      <Button block onPress={() => navigateToAddWork(navRef)}>
+        Add a work
+      </Button>
     </View>
   )
 }

--- a/src/lib/Scenes/Consignments/v2/State/navigationState.ts
+++ b/src/lib/Scenes/Consignments/v2/State/navigationState.ts
@@ -3,11 +3,38 @@ import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { RefObject } from "react"
 
 export interface NavigationState {
-  navigateToAddWork: Action<NavigationState, RefObject<any>> // FIXME: any
+  navRef: RefObject<any>
+  setupNavigation: Action<NavigationState, RefObject<any>>
+
+  // Nav actions
+  navigateToAddArtwork: Action<NavigationState>
+  navigateToArtworkDetail: Action<NavigationState>
+  navigateToArtworkList: Action<NavigationState>
+  navigateToHome: Action<NavigationState>
 }
 
 export const navigationState: NavigationState = {
-  navigateToAddWork: action((_state, navRef) => {
-    SwitchBoard.presentModalViewController(navRef.current, "/collections/my-collection/artworks/new/submissions/new")
+  navRef: {
+    current: null,
+  },
+
+  setupNavigation: action((state, navRef) => {
+    state.navRef = navRef
+  }),
+
+  navigateToAddArtwork: action(state => {
+    SwitchBoard.presentNavigationViewController(state.navRef.current, "/my-collection/add-artwork")
+  }),
+
+  navigateToArtworkDetail: action(state => {
+    SwitchBoard.presentNavigationViewController(state.navRef.current, "/my-collection/artwork-detail")
+  }),
+
+  navigateToArtworkList: action(state => {
+    SwitchBoard.presentNavigationViewController(state.navRef.current, "/my-collection/artwork-list")
+  }),
+
+  navigateToHome: action(state => {
+    SwitchBoard.presentNavigationViewController(state.navRef.current, "/my-collection/home")
   }),
 }

--- a/src/lib/Scenes/Consignments/v2/State/navigationState.ts
+++ b/src/lib/Scenes/Consignments/v2/State/navigationState.ts
@@ -1,13 +1,13 @@
 import { Action, action } from "easy-peasy"
+import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { RefObject } from "react"
 
 export interface NavigationState {
-  hello: string
-  setHello: Action<NavigationState, string>
+  navigateToAddWork: Action<NavigationState, RefObject<any>> // FIXME: any
 }
 
 export const navigationState: NavigationState = {
-  hello: "world",
-  setHello: action((state, payload) => {
-    state.hello = payload
+  navigateToAddWork: action((_state, navRef) => {
+    SwitchBoard.presentModalViewController(navRef.current, "/collections/my-collection/artworks/new/submissions/new")
   }),
 }

--- a/src/lib/Scenes/Consignments/v2/State/store.tsx
+++ b/src/lib/Scenes/Consignments/v2/State/store.tsx
@@ -13,7 +13,7 @@ export const store = createStore<StoreState, EasyPeasyConfig<any, StoreState>>(
   {
     middleware: [
       createLogger({
-        collapsed: true,
+        collapsed: false,
       }),
     ],
   }


### PR DESCRIPTION
This gets us to a place where we can start building out static views by sketching in the bones of our navigation flow. Things **will** change. 

The flow: 

- Created primitive view controllers and routes for each view: `add-artwork`, `artwork-details`, `artwork-list`, `home`. These routes are basically placeholder stubs and aren't dynamic at all (we're not yet ready to start that phase) 
- Started establishing nav patterns for moving between various sections. (See [flow diagram here](https://www.figma.com/file/yDSHlbJVzBxvSUROD2bfRI/Sell-tab?node-id=1308%3A0). 
- Right now i'm just pushing view controllers so that we can easily move between sections / dismiss while we build out designs. In the future this will change. 
- In the future we'll be needing to check various conditions before proceeding / cancelling / saving, etc, etc, so a centralized navigation center is imperative, versus managing control flow at the component level. 

#### Next Steps
- With this PR in place we can now do a rough pass over the latest comps and get the rough visual feel in via static layouts 
- Once the rough static layouts are in we can start connecting the buttons to navigation actions as established in the patterns in this PR
- Then we can start encoding the business logic and really get to work 
- At some point we might find that some of the view controllers created in this PR are no longer necessary; at that point we can delete, etc. 

![stub](https://user-images.githubusercontent.com/236943/84331365-d0586f00-ab3e-11ea-9417-f82716f891ac.gif)

#trivial 
#skip_new_tests