### PR TITLE
Link listed VRs into navigation [GALL-2936]

### DIFF
--- a/src/__generated__/ViewingRoomsListQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomsListQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash b3611024d22a23b92d408e6722715411 */
+/* @relayHash ef5fa8335262086d86838c3edd84cb5e */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -33,6 +33,7 @@ fragment ViewingRoomsListItem_item on ViewingRoom {
 fragment ViewingRoomsList_viewingRooms on ViewingRoomConnection {
   edges {
     node {
+      status
       ...ViewingRoomsListItem_item
     }
   }
@@ -101,6 +102,13 @@ const node: ConcreteRequest = {
                   {
                     "kind": "ScalarField",
                     "alias": null,
+                    "name": "status",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
                     "name": "title",
                     "args": null,
                     "storageKey": null
@@ -130,7 +138,7 @@ const node: ConcreteRequest = {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomsListQuery",
-    "id": "65648fb791e437a64a4ca6c302610759",
+    "id": "beba76c0480d2edade751bc663f27899",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomsListTestsQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomsListTestsQuery.graphql.ts
@@ -1,0 +1,147 @@
+/* tslint:disable */
+/* eslint-disable */
+/* @relayHash bddf869d54132ee0c6e2d308f95fe1b1 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ViewingRoomsListTestsQueryVariables = {};
+export type ViewingRoomsListTestsQueryResponse = {
+    readonly viewingRooms: {
+        readonly " $fragmentRefs": FragmentRefs<"ViewingRoomsList_viewingRooms">;
+    } | null;
+};
+export type ViewingRoomsListTestsQuery = {
+    readonly response: ViewingRoomsListTestsQueryResponse;
+    readonly variables: ViewingRoomsListTestsQueryVariables;
+};
+
+
+
+/*
+query ViewingRoomsListTestsQuery {
+  viewingRooms {
+    ...ViewingRoomsList_viewingRooms
+  }
+}
+
+fragment ViewingRoomsListItem_item on ViewingRoom {
+  title
+  slug
+  internalID
+}
+
+fragment ViewingRoomsList_viewingRooms on ViewingRoomConnection {
+  edges {
+    node {
+      status
+      ...ViewingRoomsListItem_item
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ViewingRoomsListTestsQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewingRooms",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "ViewingRoomConnection",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ViewingRoomsList_viewingRooms",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ViewingRoomsListTestsQuery",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewingRooms",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "ViewingRoomConnection",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "edges",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "ViewingRoomEdge",
+            "plural": true,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "node",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ViewingRoom",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "status",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "title",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "slug",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "internalID",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "ViewingRoomsListTestsQuery",
+    "id": "ad015e20e67d10a73506841a2648978a",
+    "text": null,
+    "metadata": {}
+  }
+};
+(node as any).hash = '7757aa832d0e118564694345a4ec37fd';
+export default node;

--- a/src/__generated__/ViewingRoomsList_viewingRooms.graphql.ts
+++ b/src/__generated__/ViewingRoomsList_viewingRooms.graphql.ts
@@ -6,6 +6,7 @@ import { FragmentRefs } from "relay-runtime";
 export type ViewingRoomsList_viewingRooms = {
     readonly edges: ReadonlyArray<{
         readonly node: {
+            readonly status: string;
             readonly " $fragmentRefs": FragmentRefs<"ViewingRoomsListItem_item">;
         } | null;
     } | null> | null;
@@ -45,6 +46,13 @@ const node: ReaderFragment = {
           "plural": false,
           "selections": [
             {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "status",
+              "args": null,
+              "storageKey": null
+            },
+            {
               "kind": "FragmentSpread",
               "name": "ViewingRoomsListItem_item",
               "args": null
@@ -55,5 +63,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = '76161b36f55d4e27e7fbcd26c5e45d80';
+(node as any).hash = '050cc1ec0c6d513e3da27a382ce605ae';
 export default node;

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomsListItem.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomsListItem.tsx
@@ -1,18 +1,61 @@
-import { Sans } from "@artsy/palette"
+import { color, Sans } from "@artsy/palette"
 import { ViewingRoomsListItem_item } from "__generated__/ViewingRoomsListItem_item.graphql"
-import React from "react"
-import { View } from "react-native"
+import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { Schema } from "lib/utils/track"
+import React, { useRef } from "react"
+import { TouchableHighlight, View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
+import { useTracking } from "react-tracking"
 
 interface ViewingRoomsListItemProps {
   item: ViewingRoomsListItem_item
 }
 
-export const ViewingRoomsListItem: React.FC<ViewingRoomsListItemProps> = ({ item: { title } }) => (
-  <View style={{ backgroundColor: "yellow" }}>
-    <Sans size="3t">{title}</Sans>
-  </View>
-)
+export const ViewingRoomsListItem: React.FC<ViewingRoomsListItemProps> = props => {
+  const { slug, title, internalID } = props.item
+  const navRef = useRef(null)
+  const tracking = useTracking()
+  return (
+    <View>
+      <TouchableHighlight
+        ref={navRef}
+        onPress={() => {
+          tracking.trackEvent({
+            ...tracks.context(internalID, slug),
+          })
+          SwitchBoard.presentNavigationViewController(navRef.current!, `viewing-room/${slug!}`)
+        }}
+        underlayColor={color("white100")}
+        activeOpacity={0.8}
+      >
+        <Sans size="3t">{title}</Sans>
+      </TouchableHighlight>
+    </View>
+  )
+}
+
+// TODO: Get Louis' help defining how tracking should look here
+export const tracks = {
+  context: (viewingRoomID: string, viewingRoomSlug: string) => {
+    return {
+      context_screen: Schema.PageNames.ViewingRoomsList,
+      context_screen_owner_type: Schema.OwnerEntityTypes.ViewingRoom,
+      context_screen_owner_id: viewingRoomID,
+      context_screen_owner_slug: viewingRoomSlug,
+    }
+  },
+  tappedViewingRoom: (artworkID: string, artworkSlug: string) => {
+    return {
+      // action_name: Schema.ActionNames.tappedViewingRoom,
+      action_type: Schema.ActionTypes.Tap,
+      context_module: Schema.ContextModules.ArtworkGrid,
+      destination_screen: Schema.PageNames.ArtworkPage,
+      destination_screen_owner_type: Schema.OwnerEntityTypes.Artwork,
+      destination_screen_owner_id: artworkID,
+      destination_screen_owner_slug: artworkSlug,
+    }
+  },
+}
 
 export const ViewingRoomsListItemFragmentContainer = createFragmentContainer(ViewingRoomsListItem, {
   item: graphql`

--- a/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
@@ -56,7 +56,7 @@ export const ViewingRoom: React.FC<ViewingRoomProps> = props => {
       key: "pullQuote",
       content: (
         <>
-          {viewingRoom.pullQuote && (
+          {!!viewingRoom.pullQuote && (
             <Sans data-test-id="pull-quote" size="8" textAlign="center" mx="2">
               {viewingRoom.pullQuote}
             </Sans>

--- a/src/lib/Scenes/ViewingRoom/ViewingRoomsList.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoomsList.tsx
@@ -16,6 +16,7 @@ interface ViewingRoomsListProps {
 
 export const ViewingRoomsList: React.FC<ViewingRoomsListProps> = props => {
   const viewingRooms = extractNodes(props.viewingRooms)
+  const viewingRoomsToDisplay = viewingRooms.filter(vr => vr.status === "live" || vr.status === "scheduled")
 
   return (
     <Theme>
@@ -26,7 +27,7 @@ export const ViewingRoomsList: React.FC<ViewingRoomsListProps> = props => {
           </Sans>
           <Separator />
           <FlatList
-            data={viewingRooms}
+            data={viewingRoomsToDisplay}
             renderItem={({ item }) => <ViewingRoomsListItemFragmentContainer item={item} />}
           />
         </View>
@@ -40,6 +41,7 @@ export const ViewingRoomsListFragmentContainer = createFragmentContainer(Viewing
     fragment ViewingRoomsList_viewingRooms on ViewingRoomConnection {
       edges {
         node {
+          status
           ...ViewingRoomsListItem_item
         }
       }

--- a/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomsList-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomsList-tests.tsx
@@ -1,0 +1,70 @@
+import { ViewingRoomsListTestsQuery } from "__generated__/ViewingRoomsListTestsQuery.graphql"
+import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import ReactTestRenderer from "react-test-renderer"
+import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { ViewingRoomsListItemFragmentContainer } from "../Components/ViewingRoomsListItem"
+import { ViewingRoomsListFragmentContainer } from "../ViewingRoomsList"
+
+jest.unmock("react-relay")
+
+describe("ViewingRoomsList", () => {
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+  const TestRenderer = () => (
+    <QueryRenderer<ViewingRoomsListTestsQuery>
+      environment={mockEnvironment}
+      query={graphql`
+        query ViewingRoomsListTestsQuery {
+          viewingRooms {
+            ...ViewingRoomsList_viewingRooms
+          }
+        }
+      `}
+      render={renderWithLoadProgress(ViewingRoomsListFragmentContainer)}
+      variables={{}}
+    />
+  )
+  beforeEach(() => {
+    mockEnvironment = createMockEnvironment()
+  })
+
+  it("renders scheduled and live viewing rooms", () => {
+    const tree = ReactTestRenderer.create(<TestRenderer />)
+    mockEnvironment.mock.resolveMostRecentOperation(operation => {
+      const result = MockPayloadGenerator.generate(operation, {
+        ViewingRoomConnection: () => ({
+          edges: [
+            {
+              node: {
+                status: "draft",
+              },
+            },
+            {
+              node: {
+                status: "draft",
+              },
+            },
+            {
+              node: {
+                status: "live",
+              },
+            },
+            {
+              node: {
+                status: "closed",
+              },
+            },
+            {
+              node: {
+                status: "scheduled",
+              },
+            },
+          ],
+        }),
+      })
+      return result
+    })
+    expect(tree.root.findAllByType(ViewingRoomsListItemFragmentContainer)).toHaveLength(2)
+  })
+})

--- a/src/lib/utils/track/schema.ts
+++ b/src/lib/utils/track/schema.ts
@@ -128,6 +128,7 @@ export enum PageNames {
   Collection = "Collection",
   ViewingRoom = "ViewingRoom",
   ViewingRoomArtworks = "ViewingRoomArtworks",
+  ViewingRoomsList = "ViewingRoomsList",
 }
 
 export enum OwnerEntityTypes {


### PR DESCRIPTION
Quick lil PR to set us up for navigating to VRs from the list. Included:

- Tapping a VR takes you to the VR
- Only show "scheduled" and "live" VRs on the viewing-rooms page
- Bugfix for VR page (crashed w/o pull quote)
- Basic test for VR list

[Jira ticket](https://artsyproduct.atlassian.net/browse/GALL-2936)