### PR TITLE
Track a screenview on the Sell Tab

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
   dev:
     - create extractNodes helper for dealing with connections
     - Rewrite selected tab bridge to push tab to react on tap - pepopowitz
+    - Track a screenview when the Sell tab is visited - pepopowitz
   user_facing:
     - Adds Notable Work rail to Artist pages - ashley
 

--- a/src/lib/Scenes/Consignments/v2/SellTabApp.tsx
+++ b/src/lib/Scenes/Consignments/v2/SellTabApp.tsx
@@ -1,3 +1,4 @@
+import { ProvideScreenTracking, Schema } from "lib/utils/track"
 import React from "react"
 import { NativeModules } from "react-native"
 import { ConsignmentsHomeQueryRenderer as ConsignmentsHome } from "./Screens/ConsignmentsHome/ConsignmentsHome"
@@ -8,5 +9,15 @@ import { MyCollectionHome } from "./Screens/MyCollectionHome/MyCollectionHome"
 export const SellTabApp: React.FC = () => {
   const myCollectionEnabled = NativeModules.Emission.options?.AROptionsEnableMyCollection
   const SellTabHome = () => (myCollectionEnabled ? <MyCollectionHome /> : <ConsignmentsHome />)
-  return <SellTabHome />
+
+  return (
+    <ProvideScreenTracking
+      info={{
+        context_screen: Schema.PageNames.Sell,
+        context_screen_owner_type: null,
+      }}
+    >
+      <SellTabHome />
+    </ProvideScreenTracking>
+  )
 }

--- a/src/lib/utils/track/schema.ts
+++ b/src/lib/utils/track/schema.ts
@@ -77,7 +77,7 @@ export interface PageView {
   /**
    * The type of entity (owner), E.g. Artist, Artwork, etc.
    */
-  context_screen_owner_type: OwnerEntityTypes
+  context_screen_owner_type: OwnerEntityTypes | null
 }
 
 export enum PageNames {
@@ -121,6 +121,7 @@ export enum PageNames {
   Home = "Home",
   Auctions = "Auctions",
   Search = "Search",
+  Sell = "Sell",
   SavesAndFollows = "SavesAndFollows",
   ShowAllArtists = "ShowAllArtists",
   ShowAllArtworks = "ShowAllArtworks",


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/CSGN-244, at least temporarily.

We know that the screenview only fires the first time the tab is visited. We're adding a ticket to work with MX to figure out how to get it to happen more frequently, so that we can prioritize that work accordingly.

