### PR TITLE
[MX-384] Adds proof of concept for RN modals opting into iOS 13 modal styles

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -44,6 +44,9 @@
 #import <Emission/ARSalesComponentViewController.h>
 #import <SDWebImage/SDImageCache.h>
 
+// Import is only to make the newModalStyle selector visible.
+#import <Emission/ARComponentViewController.h>
+
 // Fairs
 #import <Emission/ARFairComponentViewController.h>
 #import <Emission/ARFairMoreInfoComponentViewController.h>
@@ -271,7 +274,16 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
         // Explanation for this behaviour is described in ARTopMenuViewController's
         // pushViewController:animated: method. Once that is removed, we can remove this.
         if ([UIDevice isPhone]) {
-            viewController.modalPresentationStyle = UIModalPresentationFullScreen;
+            BOOL wantsNewModalStyle = NO;
+            wantsNewModalStyle |= [viewController respondsToSelector:@selector(newModalStyle)] && [(id)viewController newModalStyle];
+            wantsNewModalStyle |= [viewController isKindOfClass:UINavigationController.class] && [[(UINavigationController *)viewController topViewController] respondsToSelector:@selector(newModalStyle)] && [(id)[(UINavigationController *)viewController topViewController] newModalStyle];
+            if (wantsNewModalStyle) {
+                if (@available(iOS 13.0, *)) {
+                    viewController.modalPresentationStyle = UIModalPresentationAutomatic;
+                }
+            } else {
+                viewController.modalPresentationStyle = UIModalPresentationFullScreen;
+            }
         } else {
             // BNMO goes through this code path instead of the one in ARTopMenuViewController.
             if ([viewController isKindOfClass:ARSerifNavigationViewController.class] &&

--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -28,6 +28,7 @@
 #import "ARTopMenuNavigationDataSource.h"
 #import "ARTopMenuViewController.h"
 
+#import <Emission/ARNewModalComponentViewController.h>
 #import <Emission/ARArtworkAttributionClassFAQViewController.h>
 #import <Emission/ARAuctionsComponentViewController.h>
 #import <Emission/ARCityBMWListComponentViewController.h>
@@ -334,6 +335,10 @@ static ARSwitchBoard *sharedInstance = nil;
 
      [self.routes addRoute:@"/my-collection/marketing-home" handler:JLRouteParams {
         return [[ARMyCollectionMarketingHomeComponentViewController alloc] init];
+    }];
+
+    [self.routes addRoute:@"/new-modal" handler:JLRouteParams {
+        return [[ARNewModalComponentViewController alloc] init];
     }];
 
     // TODO: Follow-up about below route names

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -30,6 +30,8 @@
 #import <FLKAutoLayout/UIViewController+FLKAutoLayout.h>
 #import <ObjectiveSugar/ObjectiveSugar.h>
 
+// Import is only to make the newModalStyle selector visible.
+#import <Emission/ARNewModalComponentViewController.h>
 #import <Emission/ARHomeComponentViewController.h>
 #import <Emission/ARInboxComponentViewController.h>
 #import <Emission/ARFavoritesComponentViewController.h>
@@ -459,7 +461,7 @@ static ARTopMenuViewController *_sharedManager = nil;
 
 + (BOOL)shouldPresentViewControllerAsModal:(UIViewController *)viewController
 {
-    NSArray *modalClasses = @[ UINavigationController.class, UISplitViewController.class, LiveAuctionViewController.class ];
+    NSArray *modalClasses = @[ UINavigationController.class, UISplitViewController.class, LiveAuctionViewController.class, ARNewModalComponentViewController.class ];
     for (Class klass in modalClasses) {
         if ([viewController isKindOfClass:klass]) {
             return YES;
@@ -482,7 +484,16 @@ static ARTopMenuViewController *_sharedManager = nil;
         // Once that PR is merged and we've upgraded, we can remove the following line
         // of code, which opts us out of the new modal presentation stylel.
         if ([UIDevice isPhone]) {
-            viewController.modalPresentationStyle = UIModalPresentationFullScreen;
+            BOOL wantsNewModalStyle = NO;
+            wantsNewModalStyle |= [viewController respondsToSelector:@selector(newModalStyle)] && [(id)viewController newModalStyle];
+            wantsNewModalStyle |= [viewController isKindOfClass:UINavigationController.class] && [[(UINavigationController *)viewController topViewController] respondsToSelector:@selector(newModalStyle)] && [(id)[(UINavigationController *)viewController topViewController] newModalStyle];
+            if (wantsNewModalStyle) {
+                if (@available(iOS 13.0, *)) {
+                    viewController.modalPresentationStyle = UIModalPresentationAutomatic;
+                }
+            } else {
+                viewController.modalPresentationStyle = UIModalPresentationFullScreen;
+            }
         } else {
             if ([viewController isKindOfClass:UINavigationController.class] && [[(UINavigationController *)viewController topViewController] isKindOfClass:ARBidFlowViewController.class]) {
                 // Bid Flow gets form sheet

--- a/emission/Pod/Classes/ViewControllers/ARComponentViewController.h
+++ b/emission/Pod/Classes/ViewControllers/ARComponentViewController.h
@@ -29,6 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// This sets a prop on the rootView, or sets a prop to be passed in on rootView initialization.
 - (void)setProperty:(id)value forKey:(NSString *)key;
 
+- (BOOL)newModalStyle;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/emission/Pod/Classes/ViewControllers/ARComponentViewController.m
+++ b/emission/Pod/Classes/ViewControllers/ARComponentViewController.m
@@ -90,6 +90,8 @@
                                 multiplier:1
                                   constant:0]
   ]];
+
+  // This might be a good spot to inject safe area insets, if necessary.
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -134,6 +136,10 @@
         appProperties[key] = value;
         self.initialProperties = appProperties;
     }
+}
+
+- (BOOL)newModalStyle {
+    return YES;
 }
 
 @end

--- a/emission/Pod/Classes/ViewControllers/ARNewModalComponentViewController.h
+++ b/emission/Pod/Classes/ViewControllers/ARNewModalComponentViewController.h
@@ -1,0 +1,15 @@
+#import <Emission/ARComponentViewController.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ARNewModalComponentViewController : ARComponentViewController
+
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithEmission:(nullable AREmission *)emission
+                      moduleName:(NSString *)moduleName
+               initialProperties:(nullable NSDictionary *)initialProperties NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/emission/Pod/Classes/ViewControllers/ARNewModalComponentViewController.m
+++ b/emission/Pod/Classes/ViewControllers/ARNewModalComponentViewController.m
@@ -1,0 +1,33 @@
+#import "ARNewModalComponentViewController.h"
+
+// Normally, we would wrap this in a SerifNavigationController to opt it
+// into a modal presentation (using presentModalViewController) and to
+// give it a standard close button. But the design in MX-384 shows
+// different close buttons.
+
+@implementation ARNewModalComponentViewController
+
+- (instancetype)init
+{
+  return [self initWithEmission:nil];
+}
+
+- (instancetype)initWithEmission:(AREmission *)emission
+{
+    return [super initWithEmission:emission
+                        moduleName:@"NewModal"
+                 initialProperties:@{}];
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    // Neccary to not show bottom grey bar on iPhone X
+    self.view.backgroundColor = [UIColor whiteColor];
+}
+
+- (BOOL)newModalStyle {
+    return YES;
+}
+
+@end

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -1,7 +1,7 @@
-import React from "react"
+import React, { useRef } from "react"
 import { AppRegistry, View, YellowBox } from "react-native"
 
-import { Theme } from "@artsy/palette"
+import { Button, Sans, Theme } from "@artsy/palette"
 import { SafeAreaInsets } from "lib/types/SafeAreaInsets"
 import { ArtistQueryRenderer } from "./Containers/Artist"
 import { BidFlowQueryRenderer } from "./Containers/BidFlow"
@@ -33,6 +33,7 @@ import { MyCollectionHome } from "./Scenes/Consignments/v2/Screens/MyCollectionH
 import { MyCollectionMarketingHome } from "./Scenes/Consignments/v2/Screens/MyCollectionHome/MyCollectionMarketingHome"
 import { SellTabApp } from "./Scenes/Consignments/v2/SellTabApp"
 
+import SwitchBoard from "./NativeModules/SwitchBoard"
 import {
   FairArtistsQueryRenderer,
   FairArtworksQueryRenderer,
@@ -346,3 +347,20 @@ register("ViewingRooms", ViewingRoomsListQueryRenderer)
 register("ViewingRoom", ViewingRoomQueryRenderer, { fullBleed: true })
 register("ViewingRoomArtworks", ViewingRoomArtworksQueryRenderer)
 register("WorksForYou", WorksForYouQueryRenderer)
+
+// Ideally we would inject in safeAreaInsets rather than use ARDynamicScreenDimensions,
+// because the new modal layout is "pushed down" beyond the window's safe area.
+// This might be solved in another way by React Native, I'm not sure.
+// Or maybe it's not a problem at all. Just a head's up.
+const NewModal: React.FC = () => {
+  const dismissRef = useRef(null)
+
+  return (
+    <View ref={dismissRef}>
+      <Sans size="3t">Hi there</Sans>
+      <Button onPress={() => SwitchBoard.dismissModalViewController(dismissRef.current!)}>Dismiss</Button>
+    </View>
+  )
+}
+
+register("NewModal", NewModal)

--- a/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/ConsignmentsHome.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/ConsignmentsHome.tsx
@@ -1,5 +1,5 @@
 import { tappedConsign, TappedConsignArgs } from "@artsy/cohesion"
-import { Join, Separator } from "@artsy/palette"
+import { Button, Join, Separator } from "@artsy/palette"
 import { ConsignmentsHome_targetSupply } from "__generated__/ConsignmentsHome_targetSupply.graphql"
 import { ConsignmentsHomeQuery } from "__generated__/ConsignmentsHomeQuery.graphql"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
@@ -33,10 +33,18 @@ export const ConsignmentsHome: React.FC<Props> = ({ targetSupply, isLoading }) =
     }
   }
 
+  const handleNewModal = () => {
+    if (navRef.current) {
+      const route = "/new-modal"
+      SwitchBoard.presentNavigationViewController(navRef.current, route)
+    }
+  }
+
   return (
     <ScrollView ref={navRef}>
       <Join separator={<Separator my={3} />}>
         <Header onConsignPress={handleConsignPress} />
+        <Button onPress={handleNewModal}>New Modal Style</Button>
         <RecentlySold targetSupply={targetSupply} isLoading={isLoading} />
         <HowItWorks />
         <ArtistList targetSupply={targetSupply} isLoading={isLoading} />


### PR DESCRIPTION
This is only a proof of concept. I wasn't sure where the modal you wanted to show with the new style were, so I just created a small component to show.

![Screen Shot 2020-06-18 at 11 57 50](https://user-images.githubusercontent.com/498212/85044098-2e96da80-b15b-11ea-9491-8ec4c7fc3504.png)

Here's a gif:

<details><summary>gif</summary>

![2020-06-18 12-03-38 2020-06-18 12_03_59](https://user-images.githubusercontent.com/498212/85044584-d44a4980-b15b-11ea-8274-5028bf03e98b.gif)

</details>

I've tried to leave comments to be helpful. The key bits are the new `newModalStyle` function, the two `wantsNewModalStyle` uses (they are duplicated, I know it's not great but we're working on it 😅)  and `shouldPresentViewControllerAsModal:`. These would be the changes you'd need to pull in.