### PR TITLE
Update image for nightly job to use macOS #trivial

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,17 +155,22 @@ commands:
 
 jobs:
   deploy-nightly-beta:
-    executor:
-      name: node/default
-      tag: "12.16.2"
+    environment:
+      BUNDLE_PATH: vendor/bundle # path to install gems and use for caching
+
+    macos:
+      xcode: 11.3.0
+
     steps:
       - checkout
+      - install-node
       - run:
           name: Notify if new developer agreement
           command: make notify_if_new_license_agreement
       - run:
           name: Deploy beta
           command: make deploy
+
   update-metaphysics:
     executor:
       name: node/default


### PR DESCRIPTION
https://circleci.com/gh/artsy/eigen/12526

Build failed with new job to check for new developer agreements due to bundler not being on the machine, this changes to use macOS vm as other jobs do. Might be a bit heavy handed, open to suggestions. 

#trivial