### PR TITLE
[MX-340] Fixes promotion script #trivial

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -185,8 +185,7 @@ lane :promote_beta do
   latest_version = readme_data['upcoming']['version']
   bundle_version = `/usr/libexec/PlistBuddy -c "print CFBundleVersion" #{File.join(root, 'Artsy/App_Resources/Artsy-Info.plist')}`.strip
 
-  target_object = "#{latest_version}-#{bundle_version}" # This is computed, we expect it to exist.
-  tag_and_push(tag: "#{target_object}-submission", target_object: target_object)
+  tag_and_push(tag: "#{latest_version}-#{bundle_version}-submission")
 
   puts 'All done.'
 end
@@ -196,7 +195,7 @@ lane :notify_if_new_license_agreement do
   client.team_id = '479887'
   messages = Spaceship::Tunes.client.fetch_program_license_agreement_messages
 
-  if messages.length > 0
+  if !messages.empty?
     message = ':apple: :handshake: :pencil:\n'\
               'There is a new developer program agreement that needs to be signed to continue shipping!\n'\
               'Reach out to legal :scales: for approval before signing.\n'\
@@ -206,10 +205,10 @@ lane :notify_if_new_license_agreement do
     slack(
       message: message,
       success: false,
-      default_payloads: [],
+      default_payloads: []
     )
   else
-    puts "No new developer agreements"
+    puts 'No new developer agreements'
   end
 end
 
@@ -217,15 +216,8 @@ lane :tag_and_push do |options|
   # Do a tag, we use a http git remote so we can have push access
   # as the default remote for circle is read-only
   tag = options[:tag]
-  target_object = options[:target_object]
   `git tag -d "#{tag}"`
-
-  # Allow older commits to get tagged, when promoting to submission.
-  if target_object
-    add_git_tag tag: tag, commit: target_object, message: "Promoting #{tag} to App Store submission"
-  else
-    add_git_tag tag: tag
-  end
+  add_git_tag tag: tag
   `git remote add http https://github.com/artsy/eigen.git`
   `git push http #{tag} -f`
 end


### PR DESCRIPTION
So what we _were_ trying to do before is figure out which git tag was created by the beta which we were trying to submit to App Store Review. The thinking was that we could "target" this tag so that both the beta deploy tag _and_ the App Store Review promotion tag would point to the same commit.

This turns out to be difficult because most months and many days begin with 0, and different tools treat that leading zero differently. AppStoreConnect, for example, turns something like `6.4.8-2020.06.19.06` into `6.4.8-2020.6.19.6`. This makes it difficult to figure out what the beta deploy tag is.

I've tried for a while to get this to work but the constant CI failures cause a lot of noise. So this PR "fixes the glitch" by not trying to target the commits anymore. The commit of the submission will point to the commit on which the promotion script was ran, which might include commits since the most recent beta. However, every promotion deploys the most recent beta, so we can find that pretty easily. And each deploy has its commit stamped into its `Info.plist` and accessible in the admin screen, so we can always be sure.

Prettier made some unrelated changes to the Fastfile, please forgive it 🙏 