### PR TITLE
[CSGN-268] Drive collection artwork detail with data

### DIFF
--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -340,8 +340,8 @@ static ARSwitchBoard *sharedInstance = nil;
         return [[ARMyCollectionAddArtworkComponentViewController alloc] init];
     }];
 
-    [self.routes addRoute:@"/my-collection/artwork-detail" handler:JLRouteParams {
-        return [[ARMyCollectionArtworkDetailComponentViewController alloc] init];
+    [self.routes addRoute:@"/my-collection/artwork-detail/:id" handler:JLRouteParams {
+        return [[ARMyCollectionArtworkDetailComponentViewController alloc] initWithArtworkID:parameters[@"id"]];
     }];
 
     [self.routes addRoute:@"/my-collection/artwork-list" handler:JLRouteParams {

--- a/emission/Pod/Classes/ViewControllers/ARMyCollectionArtworkDetailComponentViewController.h
+++ b/emission/Pod/Classes/ViewControllers/ARMyCollectionArtworkDetailComponentViewController.h
@@ -4,11 +4,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ARMyCollectionArtworkDetailComponentViewController : ARComponentViewController
 
-- (instancetype)init NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithArtworkID:(NSString *)artworkID;
+- (instancetype)initWithArtworkID:(NSString *)artworkID
+                         emission:(nullable AREmission *)emission NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)initWithEmission:(nullable AREmission *)emission
                       moduleName:(NSString *)moduleName
                initialProperties:(nullable NSDictionary *)initialProperties NS_UNAVAILABLE;
+
+@property (nonatomic, readonly) NSString *artworkID;
 
 @end
 

--- a/emission/Pod/Classes/ViewControllers/ARMyCollectionArtworkDetailComponentViewController.m
+++ b/emission/Pod/Classes/ViewControllers/ARMyCollectionArtworkDetailComponentViewController.m
@@ -2,9 +2,20 @@
 
 @implementation ARMyCollectionArtworkDetailComponentViewController
 
-- (instancetype)init
+- (instancetype)initWithArtworkID:(NSString *)artworkID;
 {
-    return [super initWithEmission:nil moduleName:@"MyCollectionArtworkDetail" initialProperties:nil];
+    return [self initWithArtworkID:artworkID emission:nil];
+}
+
+- (instancetype)initWithArtworkID:(NSString *)artworkID
+                         emission:(nullable AREmission *)emission;
+{
+    if ((self = [super initWithEmission:emission
+                        moduleName:@"MyCollectionArtworkDetail"
+                      initialProperties:@{ @"artworkID": artworkID }])) {
+        _artworkID = artworkID;
+    }
+    return self;
 }
 
 @end

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -28,7 +28,7 @@ import { CollectionFullFeaturedArtistListQueryRenderer } from "./Scenes/Collecti
 import { Consignments } from "./Scenes/Consignments"
 import { setupMyCollectionScreen } from "./Scenes/Consignments/v2/Boot"
 import { MyCollectionAddArtwork } from "./Scenes/Consignments/v2/Screens/MyCollectionAddArtwork/MyCollectionAddArtwork"
-import { MyCollectionArtworkDetail } from "./Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/MyCollectionArtworkDetail"
+import { MyCollectionArtworkDetailContainer as MyCollectionArtworkDetail } from "./Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/MyCollectionArtworkDetail"
 import { MyCollectionArtworkList } from "./Scenes/Consignments/v2/Screens/MyCollectionArtworkList/MyCollectionArtworkList"
 import { MyCollectionHome } from "./Scenes/Consignments/v2/Screens/MyCollectionHome/MyCollectionHome"
 import { MyCollectionMarketingHome } from "./Scenes/Consignments/v2/Screens/MyCollectionHome/MyCollectionMarketingHome"

--- a/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/ArtworkMeta.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/ArtworkMeta.tsx
@@ -1,0 +1,24 @@
+import React from "react"
+import { Field } from "./Field"
+
+export const ArtworkMeta: React.FC<{ artwork: ArtworkMetaArtwork }> = ({ artwork }) => {
+  const titleField = !!artwork.title && <Field label="Title" value={artwork.title} />
+  const yearField = !!artwork.date && <Field label="Year created" value={artwork.date} />
+  const mediumField = !!artwork.medium && <Field label="Medium" value={artwork?.medium} />
+
+  return (
+    <>
+      <Field label="Artist" value={artwork.artistNames} />
+      {titleField}
+      {yearField}
+      {mediumField}
+    </>
+  )
+}
+
+export interface ArtworkMetaArtwork {
+  artistNames: string
+  date?: string
+  medium?: string
+  title?: string
+}

--- a/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/ArtworkMeta.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/ArtworkMeta.tsx
@@ -16,6 +16,7 @@ export const ArtworkMeta: React.FC<{ artwork: ArtworkMetaArtwork }> = ({ artwork
   )
 }
 
+// FIXME: Everything below here will be replaced when we're connected to real data
 export interface ArtworkMetaArtwork {
   artistNames: string
   date?: string

--- a/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/AuctionResults.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/AuctionResults.tsx
@@ -1,0 +1,52 @@
+import { Box, Button, Flex, InfoCircleIcon, Join, Sans, Spacer } from "@artsy/palette"
+import { useStoreActions } from "lib/Scenes/Consignments/v2/State/hooks"
+import React from "react"
+
+export const AuctionResults: React.FC = () => {
+  const navActions = useStoreActions(actions => actions.navigation)
+  return (
+    <Join separator={<Spacer my={1} />}>
+      <Flex flexDirection="row">
+        <Sans size="4" weight="medium">
+          Auction Results
+        </Sans>
+        <Box ml={1} position="relative" top="4px">
+          <InfoCircleIcon />
+        </Box>
+      </Flex>
+
+      <AuctionWork />
+      <AuctionWork />
+
+      <Button variant="secondaryGray" onPress={navActions.navigateToArtist}>
+        Browse all auction works
+      </Button>
+    </Join>
+  )
+}
+
+const AuctionWork: React.FC = () => {
+  return (
+    <Box>
+      <Sans size="3">Last work sold</Sans>
+      <Flex flexDirection="row" justifyContent="space-between">
+        <Box>
+          <Flex flexDirection="row">
+            <Box width={45} height={45} bg="black30" mr={1} />
+            <Box>
+              <Sans size="3" color="black60">
+                The Ground, 1953
+              </Sans>
+              <Sans size="3" color="black60">
+                Sold Nov 24, 2019
+              </Sans>
+            </Box>
+          </Flex>
+        </Box>
+        <Box>
+          <Sans size="3">€87,500</Sans>
+        </Box>
+      </Flex>
+    </Box>
+  )
+}

--- a/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/ConsignCTA.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/ConsignCTA.tsx
@@ -1,0 +1,26 @@
+import { BorderBox, Box, Button, Flex, Sans } from "@artsy/palette"
+import { useStoreActions } from "lib/Scenes/Consignments/v2/State/hooks"
+import React from "react"
+
+export const ConsignCTA: React.FC = () => {
+  const navActions = useStoreActions(actions => actions.navigation)
+  return (
+    <BorderBox>
+      <Flex flexDirection="row" justifyContent="space-between">
+        <Box>
+          <Sans size="4" weight="medium">
+            Strong demand
+          </Sans>
+          <Sans size="4" color="black60">
+            Est: $2,500 - $435,000
+          </Sans>
+        </Box>
+        <Box>
+          <Button size="large" onPress={navActions.navigateToConsign}>
+            Consign
+          </Button>
+        </Box>
+      </Flex>
+    </BorderBox>
+  )
+}

--- a/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/Field.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/Field.tsx
@@ -1,0 +1,13 @@
+import { Flex, Sans } from "@artsy/palette"
+import React from "react"
+
+export const Field: React.FC<{ label: string; value: string }> = ({ label, value }) => {
+  return (
+    <Flex flexDirection="row" justifyContent="space-between" my={0.5}>
+      <Sans size="4" color="black60">
+        {label}
+      </Sans>
+      <Sans size="4">{value}</Sans>
+    </Flex>
+  )
+}

--- a/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/Insights.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/Insights.tsx
@@ -1,0 +1,30 @@
+import { BorderBox, Box, Join, Sans, Spacer } from "@artsy/palette"
+import React from "react"
+import { Text } from "react-native"
+import { Field } from "./Field"
+
+export const Insights: React.FC = () => {
+  return (
+    <Join separator={<Spacer my={1} />}>
+      <BorderBox height={100} bg="#ccc">
+        <Text>Price / Demand graphs / charts</Text>
+      </BorderBox>
+
+      <BorderBox>
+        <Sans size="3">Strong demand</Sans>
+        <Sans size="3" color="black60">
+          Demand is much higher than the supply available in the market and sale price exceeds estimates.
+        </Sans>
+      </BorderBox>
+
+      <Box>
+        <Field label="Avg. Annual Value Sold" value="$5,346,000" />
+        <Field label="Avg. Annual Lots Sold" value="25 - 50" />
+        <Field label="Sell-through Rate" value="94.5%" />
+        <Field label="Median Sale Price to Estimate" value="1.70x" />
+        <Field label="Liquidity" value="Very high" />
+        <Field label="1-Year Trend" value="Flat" />
+      </Box>
+    </Join>
+  )
+}

--- a/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/MyCollectionArtworkDetail.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/MyCollectionArtworkDetail.tsx
@@ -13,7 +13,7 @@ import { ScrollView, Text } from "react-native"
  * communicating back with this container that sits under the edit modal.
  */
 
-export const MyCollectionArtworkDetail = () => {
+export const MyCollectionArtworkDetail: React.FC<{ artworkID: string }> = ({ artworkID }) => {
   const navActions = useStoreActions(actions => actions.navigation)
 
   return (

--- a/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/MyCollectionArtworkDetail.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/MyCollectionArtworkDetail.tsx
@@ -1,4 +1,5 @@
 import { BorderBox, Box, Button, Flex, InfoCircleIcon, Join, Sans, Separator, Spacer } from "@artsy/palette"
+import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { ScreenMargin } from "lib/Scenes/Consignments/v2/Components/ScreenMargin"
 import { useStoreActions } from "lib/Scenes/Consignments/v2/State/hooks"
 import React from "react"
@@ -21,12 +22,52 @@ export const MyCollectionArtworkDetailContainer: React.FC<{ artworkID: string }>
 
 interface MyCollectionArtworkDetailArtwork {
   id: string
-}
-function getArtworkByID(artworkID: string) {
-  return {
-    id: artworkID,
+  artistNames: string
+  date: string
+  demand: string
+  estimate: string
+  image: {
+    url: string
+  }
+  medium: string
+  title: string
+  insights: {
+    averageAnnualValueSold: string
+    averageAnnualLotsSold: string
+    sellThroughRate: string
+    medianSalePriceToEstimate: string
+    liquidity: string
+    oneYearTrend: string
   }
 }
+
+function getArtworkByID(artworkID: string): MyCollectionArtworkDetailArtwork {
+  return {
+    id: artworkID,
+    artistNames: "Andy Warhol",
+    date: "1992",
+    demand: "Strong demand",
+    estimate: "$2,500 - $435,000",
+    image: {
+      url: "https://d32dm0rphc51dk.cloudfront.net/DkpNiCKRYoqa7BXEtsZSpQ/:version.jpg",
+    },
+    medium: "Dry Erase markers",
+    title: "Stone Temple Pilots, they're elegant bachelors",
+    insights: {
+      averageAnnualValueSold: "$5,346,000",
+      averageAnnualLotsSold: "25 - 50",
+      sellThroughRate: "94.5%",
+      medianSalePriceToEstimate: "1.70x",
+      liquidity: "Very high",
+      oneYearTrend: "Flat",
+    },
+  }
+}
+
+// TODO:
+//   * Finish making data "dynamic"
+//   * render sections as a FlatList
+//   * Deal with optional fields
 
 export const MyCollectionArtworkDetail: React.FC<{ artwork: MyCollectionArtworkDetailArtwork }> = ({ artwork }) => {
   const navActions = useStoreActions(actions => actions.navigation)
@@ -43,25 +84,29 @@ export const MyCollectionArtworkDetail: React.FC<{ artwork: MyCollectionArtworkD
           </Flex>
         </ScreenMargin>
 
-        <BorderBox height={200} bg="#ccc">
-          <Text>Uploaded image placeholder</Text>
-        </BorderBox>
+        <OpaqueImageView
+          // TODO: figure out if "normalized" is the correct version
+          imageURL={artwork.image.url.replace(":version", "normalized")}
+          height={200}
+          // TODO: see https://github.com/artsy/eigen/blob/master/src/lib/Containers/WorksForYou.tsx#L92 for getting the actual screen width
+          width={420}
+        />
 
         <ScreenMargin>
-          <Field label="Artist" value="Cindy Sherman" />
-          <Field label="Title" value="Untitled Film Still #3" />
-          <Field label="Year created" value="1977" />
-          <Field label="Medium" value="Photography" />
+          <Field label="Artist" value={artwork.artistNames} />
+          <Field label="Title" value={artwork.title} />
+          <Field label="Year created" value={artwork.date} />
+          <Field label="Medium" value={artwork.medium} />
         </ScreenMargin>
 
         <BorderBox>
           <Flex flexDirection="row" justifyContent="space-between">
             <Box>
               <Sans size="4" weight="medium">
-                Strong demand
+                {artwork.demand}
               </Sans>
               <Sans size="4" color="black60">
-                Est: $2,500 - $435,000
+                Est: {artwork.estimate}
               </Sans>
             </Box>
             <Box>
@@ -86,12 +131,12 @@ export const MyCollectionArtworkDetail: React.FC<{ artwork: MyCollectionArtworkD
             </BorderBox>
 
             <Box>
-              <Field label="Avg. Annual Value Sold" value="$5,346,000" />
-              <Field label="Avg. Annual Lots Sold" value="25 - 50" />
-              <Field label="Sell-through Rate" value="94.5%" />
-              <Field label="Median Sale Price to Estimate" value="1.70x" />
-              <Field label="Liquidity" value="Very high" />
-              <Field label="1-Year Trend" value="Flat" />
+              <Field label="Avg. Annual Value Sold" value={artwork.insights.averageAnnualValueSold} />
+              <Field label="Avg. Annual Lots Sold" value={artwork.insights.averageAnnualLotsSold} />
+              <Field label="Sell-through Rate" value={artwork.insights.sellThroughRate} />
+              <Field label="Median Sale Price to Estimate" value={artwork.insights.medianSalePriceToEstimate} />
+              <Field label="Liquidity" value={artwork.insights.liquidity} />
+              <Field label="1-Year Trend" value={artwork.insights.oneYearTrend} />
             </Box>
           </Join>
         </ScreenMargin>
@@ -123,9 +168,21 @@ export const MyCollectionArtworkDetail: React.FC<{ artwork: MyCollectionArtworkD
         <ScreenMargin>
           <Join separator={<Spacer my={1} />}>
             <Sans size="6">Why sell with Artsy?</Sans>
-            <WhySellStep />
-            <WhySellStep />
-            <WhySellStep />
+            <WhySellStep
+              step={1}
+              title="Simple Steps"
+              description="Submit your work once, pick the best offer, and ship the work when it sells."
+            />
+            <WhySellStep
+              step={2}
+              title="Industry Expertise"
+              description="Receive virtual valuation and expert guidance on the best sales strategies."
+            />
+            <WhySellStep
+              step={3}
+              title="Global Reach"
+              description="Your work will reach the world's collectors, galleries, and auction houses."
+            />
           </Join>
         </ScreenMargin>
 
@@ -184,16 +241,16 @@ const AuctionWork: React.FC = () => {
   )
 }
 
-const WhySellStep: React.FC = () => {
+const WhySellStep: React.FC<{ step: number; title: string; description: string }> = ({ step, title, description }) => {
   return (
     <Flex flexDirection="row">
       <Box mr={2}>
-        <Sans size="3">1</Sans>
+        <Sans size="3">{step}</Sans>
       </Box>
       <Box>
-        <Sans size="3">Simple Steps</Sans>
+        <Sans size="3">{title}</Sans>
         <Sans size="3" color="black60">
-          Submit your work once, pick the best offer, and ship the work when it sells.{" "}
+          {description}
         </Sans>
       </Box>
     </Flex>

--- a/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/MyCollectionArtworkDetail.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/MyCollectionArtworkDetail.tsx
@@ -154,7 +154,7 @@ const WhySellStep: React.FC<{ step: number; title: string; description: string }
   )
 }
 
-// Everything below here will be replaced when we're connected to real data
+// FIXME: Everything below here will be replaced when we're connected to real data
 
 interface MyCollectionArtworkDetailArtwork extends ArtworkMetaArtwork {
   id: string

--- a/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/MyCollectionArtworkDetail.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/MyCollectionArtworkDetail.tsx
@@ -13,7 +13,22 @@ import { ScrollView, Text } from "react-native"
  * communicating back with this container that sits under the edit modal.
  */
 
-export const MyCollectionArtworkDetail: React.FC<{ artworkID: string }> = ({ artworkID }) => {
+export const MyCollectionArtworkDetailContainer: React.FC<{ artworkID: string }> = ({ artworkID }) => {
+  // Eventually this is happening via relay
+  const artwork = getArtworkByID(artworkID)
+  return <MyCollectionArtworkDetail artwork={artwork} />
+}
+
+interface MyCollectionArtworkDetailArtwork {
+  id: string
+}
+function getArtworkByID(artworkID: string) {
+  return {
+    id: artworkID,
+  }
+}
+
+export const MyCollectionArtworkDetail: React.FC<{ artwork: MyCollectionArtworkDetailArtwork }> = ({ artwork }) => {
   const navActions = useStoreActions(actions => actions.navigation)
 
   return (

--- a/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/MyCollectionArtworkDetail.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkDetail/MyCollectionArtworkDetail.tsx
@@ -1,9 +1,13 @@
-import { BorderBox, Box, Button, Flex, InfoCircleIcon, Join, Sans, Separator, Spacer } from "@artsy/palette"
+import { Box, Button, Flex, Join, Sans, Separator, Spacer } from "@artsy/palette"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { ScreenMargin } from "lib/Scenes/Consignments/v2/Components/ScreenMargin"
 import { useStoreActions } from "lib/Scenes/Consignments/v2/State/hooks"
 import React from "react"
-import { ScrollView, Text } from "react-native"
+import { ScrollView } from "react-native"
+import { ArtworkMeta, ArtworkMetaArtwork } from "./ArtworkMeta"
+import { AuctionResults } from "./AuctionResults"
+import { ConsignCTA } from "./ConsignCTA"
+import { Insights } from "./Insights"
 
 /**
  * TODO: This will need to be a relay refetch container, because if the edit
@@ -20,55 +24,6 @@ export const MyCollectionArtworkDetailContainer: React.FC<{ artworkID: string }>
   return <MyCollectionArtworkDetail artwork={artwork} />
 }
 
-interface MyCollectionArtworkDetailArtwork {
-  id: string
-  artistNames: string
-  date: string
-  demand: string
-  estimate: string
-  image: {
-    url: string
-  }
-  medium: string
-  title: string
-  insights: {
-    averageAnnualValueSold: string
-    averageAnnualLotsSold: string
-    sellThroughRate: string
-    medianSalePriceToEstimate: string
-    liquidity: string
-    oneYearTrend: string
-  }
-}
-
-function getArtworkByID(artworkID: string): MyCollectionArtworkDetailArtwork {
-  return {
-    id: artworkID,
-    artistNames: "Andy Warhol",
-    date: "1992",
-    demand: "Strong demand",
-    estimate: "$2,500 - $435,000",
-    image: {
-      url: "https://d32dm0rphc51dk.cloudfront.net/DkpNiCKRYoqa7BXEtsZSpQ/:version.jpg",
-    },
-    medium: "Dry Erase markers",
-    title: "Stone Temple Pilots, they're elegant bachelors",
-    insights: {
-      averageAnnualValueSold: "$5,346,000",
-      averageAnnualLotsSold: "25 - 50",
-      sellThroughRate: "94.5%",
-      medianSalePriceToEstimate: "1.70x",
-      liquidity: "Very high",
-      oneYearTrend: "Flat",
-    },
-  }
-}
-
-// TODO:
-//   * Finish making data "dynamic"
-//   * render sections as a FlatList
-//   * Deal with optional fields
-
 export const MyCollectionArtworkDetail: React.FC<{ artwork: MyCollectionArtworkDetailArtwork }> = ({ artwork }) => {
   const navActions = useStoreActions(actions => actions.navigation)
 
@@ -84,86 +39,17 @@ export const MyCollectionArtworkDetail: React.FC<{ artwork: MyCollectionArtworkD
           </Flex>
         </ScreenMargin>
 
-        <OpaqueImageView
-          // TODO: figure out if "normalized" is the correct version
-          imageURL={artwork.image.url.replace(":version", "normalized")}
-          height={200}
-          // TODO: see https://github.com/artsy/eigen/blob/master/src/lib/Containers/WorksForYou.tsx#L92 for getting the actual screen width
-          width={420}
-        />
+        <ArtworkImage artwork={artwork} />
 
         <ScreenMargin>
-          <Field label="Artist" value={artwork.artistNames} />
-          <Field label="Title" value={artwork.title} />
-          <Field label="Year created" value={artwork.date} />
-          <Field label="Medium" value={artwork.medium} />
+          <ArtworkMeta artwork={artwork} />
         </ScreenMargin>
 
-        <BorderBox>
-          <Flex flexDirection="row" justifyContent="space-between">
-            <Box>
-              <Sans size="4" weight="medium">
-                {artwork.demand}
-              </Sans>
-              <Sans size="4" color="black60">
-                Est: {artwork.estimate}
-              </Sans>
-            </Box>
-            <Box>
-              <Button size="large" onPress={navActions.navigateToConsign}>
-                Consign
-              </Button>
-            </Box>
-          </Flex>
-        </BorderBox>
+        <ConsignCTA />
 
-        <ScreenMargin>
-          <Join separator={<Spacer my={1} />}>
-            <BorderBox height={100} bg="#ccc">
-              <Text>Price / Demand graphs / charts</Text>
-            </BorderBox>
+        <InsightWrapper artwork={artwork} />
 
-            <BorderBox>
-              <Sans size="3">Very Strong Demand</Sans>
-              <Sans size="3" color="black60">
-                Demand is much higher than the supply available in the market and sale price exceeds estimates.
-              </Sans>
-            </BorderBox>
-
-            <Box>
-              <Field label="Avg. Annual Value Sold" value={artwork.insights.averageAnnualValueSold} />
-              <Field label="Avg. Annual Lots Sold" value={artwork.insights.averageAnnualLotsSold} />
-              <Field label="Sell-through Rate" value={artwork.insights.sellThroughRate} />
-              <Field label="Median Sale Price to Estimate" value={artwork.insights.medianSalePriceToEstimate} />
-              <Field label="Liquidity" value={artwork.insights.liquidity} />
-              <Field label="1-Year Trend" value={artwork.insights.oneYearTrend} />
-            </Box>
-          </Join>
-        </ScreenMargin>
-
-        <Separator />
-
-        <ScreenMargin>
-          <Join separator={<Spacer my={1} />}>
-            <Flex flexDirection="row">
-              <Sans size="4" weight="medium">
-                Auction Results
-              </Sans>
-              <Box ml={1} position="relative" top="4px">
-                <InfoCircleIcon />
-              </Box>
-            </Flex>
-
-            <AuctionWork />
-            <AuctionWork />
-
-            <Button variant="secondaryGray" onPress={navActions.navigateToArtist}>
-              Browse all auction works
-            </Button>
-          </Join>
-        </ScreenMargin>
-
-        <Separator />
+        <AuctionResultsWrapper artwork={artwork} />
 
         <ScreenMargin>
           <Join separator={<Spacer my={1} />}>
@@ -204,40 +90,51 @@ export const MyCollectionArtworkDetail: React.FC<{ artwork: MyCollectionArtworkD
   )
 }
 
-const Field: React.FC<{ label: string; value: string }> = ({ label, value }) => {
+const ArtworkImage: React.FC<{ artwork: MyCollectionArtworkDetailArtwork }> = ({ artwork }) => {
+  if (!artwork.image?.url) {
+    return null
+  }
+
   return (
-    <Flex flexDirection="row" justifyContent="space-between" my={0.5}>
-      <Sans size="4" color="black60">
-        {label}
-      </Sans>
-      <Sans size="4">{value}</Sans>
-    </Flex>
+    <OpaqueImageView
+      // TODO: figure out if "normalized" is the correct version
+      imageURL={artwork.image.url.replace(":version", "normalized")}
+      height={200}
+      // TODO: see https://github.com/artsy/eigen/blob/master/src/lib/Containers/WorksForYou.tsx#L92 for getting the actual screen width
+      width={420}
+    />
   )
 }
 
-const AuctionWork: React.FC = () => {
+const InsightWrapper: React.FC<{ artwork: MyCollectionArtworkDetailArtwork }> = ({ artwork }) => {
+  if (!artwork.hasInsights) {
+    return null
+  }
+
   return (
-    <Box>
-      <Sans size="3">Last work sold</Sans>
-      <Flex flexDirection="row" justifyContent="space-between">
-        <Box>
-          <Flex flexDirection="row">
-            <Box width={45} height={45} bg="black30" mr={1} />
-            <Box>
-              <Sans size="3" color="black60">
-                The Ground, 1953
-              </Sans>
-              <Sans size="3" color="black60">
-                Sold Nov 24, 2019
-              </Sans>
-            </Box>
-          </Flex>
-        </Box>
-        <Box>
-          <Sans size="3">€87,500</Sans>
-        </Box>
-      </Flex>
-    </Box>
+    <>
+      <ScreenMargin>
+        <Insights />
+      </ScreenMargin>
+
+      <Separator />
+    </>
+  )
+}
+
+const AuctionResultsWrapper: React.FC<{ artwork: MyCollectionArtworkDetailArtwork }> = ({ artwork }) => {
+  if (!artwork.hasAuctionResults) {
+    return null
+  }
+
+  return (
+    <>
+      <ScreenMargin>
+        <AuctionResults />
+      </ScreenMargin>
+
+      <Separator />
+    </>
   )
 }
 
@@ -255,4 +152,79 @@ const WhySellStep: React.FC<{ step: number; title: string; description: string }
       </Box>
     </Flex>
   )
+}
+
+// Everything below here will be replaced when we're connected to real data
+
+interface MyCollectionArtworkDetailArtwork extends ArtworkMetaArtwork {
+  id: string
+  artistNames: string
+  date?: string
+  demand: string
+  estimate: string
+  image?: {
+    url: string
+  }
+  hasInsights: boolean
+  hasAuctionResults: boolean
+}
+
+function getArtworkByID(artworkID: string): MyCollectionArtworkDetailArtwork {
+  return data[artworkID]
+}
+
+const data: { [artworkId: string]: MyCollectionArtworkDetailArtwork } = {
+  "1": {
+    id: "1",
+    artistNames: "Andy Goldsworthy",
+    date: "1991",
+    demand: "Strong demand",
+    estimate: "$1,500 - $115,000",
+    image: {
+      url: "https://d32dm0rphc51dk.cloudfront.net/XfpWAbjogvTja0baxOk2eg/square.jpg",
+    },
+    medium: "Photography",
+    title: "Mint Avalanche",
+    hasInsights: false,
+    hasAuctionResults: false,
+  },
+  "2": {
+    id: "2",
+    artistNames: "Andy Warhol",
+    date: "1992",
+    demand: "Strong demand",
+    estimate: "$2,500 - $225,000",
+    image: {
+      url: "https://d32dm0rphc51dk.cloudfront.net/DkpNiCKRYoqa7BXEtsZSpQ/square.jpg",
+    },
+    medium: "Dry Erase markers",
+    title: "Butter Pecan",
+    hasInsights: true,
+    hasAuctionResults: false,
+  },
+  "3": {
+    id: "3",
+    artistNames: "James Rosenquist",
+    date: "1993",
+    demand: "Strong demand",
+    estimate: "$3,500 - $335,000",
+    medium: "Cat hair",
+    title: "Rocky Road",
+    hasInsights: false,
+    hasAuctionResults: true,
+  },
+  "4": {
+    id: "4",
+    artistNames: "Banksy",
+    date: "1994",
+    demand: "Strong demand",
+    estimate: "$4,500 - $445,000",
+    image: {
+      url: "https://d32dm0rphc51dk.cloudfront.net/ng_LZVBhBb2805HMUIl6UQ/:version.jpg",
+    },
+    medium: "Pastels",
+    title: "Turtle",
+    hasInsights: true,
+    hasAuctionResults: true,
+  },
 }

--- a/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkList/MyCollectionArtworkList.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkList/MyCollectionArtworkList.tsx
@@ -33,7 +33,7 @@ const TouchElement = styled.TouchableHighlight.attrs({ underlayColor: color("whi
 
 interface MyCollectionArtworkListItemProps {
   item: MyCollectionArtwork
-  onPress: ((event: GestureResponderEvent) => void) | undefined
+  onPress: (event: GestureResponderEvent) => void
 }
 const MyCollectionArtworkListItem: React.FC<MyCollectionArtworkListItemProps> = ({ item, onPress }) => {
   const imageURL = item.image?.url

--- a/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkList/MyCollectionArtworkList.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/MyCollectionArtworkList/MyCollectionArtworkList.tsx
@@ -23,7 +23,7 @@ export const MyCollectionArtworkList = () => {
       ItemSeparatorComponent={() => <Separator />}
       keyExtractor={item => item.id}
       renderItem={({ item }) => (
-        <MyCollectionArtworkListItem item={item} onPress={() => navActions.navigateToArtworkDetail()} />
+        <MyCollectionArtworkListItem item={item} onPress={() => navActions.navigateToArtworkDetail(item.id)} />
       )}
     />
   )

--- a/src/lib/Scenes/Consignments/v2/Screens/MyCollectionHome/MyCollectionHome.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/MyCollectionHome/MyCollectionHome.tsx
@@ -17,7 +17,7 @@ export const MyCollectionHome = () => {
         <Button block onPress={() => navActions.navigateToAddArtwork()}>
           Add a work
         </Button>
-        <Button block onPress={() => navActions.navigateToArtworkDetail()}>
+        <Button block onPress={() => navActions.navigateToArtworkDetail("1")}>
           Artwork Detail
         </Button>
         <Button block onPress={() => navActions.navigateToArtworkList()}>

--- a/src/lib/Scenes/Consignments/v2/State/navigationModel.tsx
+++ b/src/lib/Scenes/Consignments/v2/State/navigationModel.tsx
@@ -30,7 +30,7 @@ export interface NavigationModel {
   navigateToAddArtwork: Action<NavigationModel>
   navigateToAddArtworkPhotos: Action<NavigationModel>
   navigateToAddTitleAndYear: Action<NavigationModel>
-  navigateToArtworkDetail: Action<NavigationModel>
+  navigateToArtworkDetail: Action<NavigationModel, string>
   navigateToArtworkList: Action<NavigationModel>
   navigateToHome: Action<NavigationModel>
   navigateToMarketingHome: Action<NavigationModel>
@@ -67,7 +67,8 @@ export const navigationModel: NavigationModel = {
   onAddArtworkComplete: thunkOn(
     (_, storeActions) => storeActions.artwork.addArtworkComplete,
     actions => {
-      actions.navigateToArtworkDetail()
+      // TODO - fill in the actual artwork id ("1")
+      actions.navigateToArtworkDetail("1")
 
       setTimeout(() => {
         actions.dismissModal()
@@ -104,8 +105,8 @@ export const navigationModel: NavigationModel = {
     })
   }),
 
-  navigateToArtworkDetail: action(state => {
-    SwitchBoard.presentNavigationViewController(state.navViewRef.current, "/my-collection/artwork-detail")
+  navigateToArtworkDetail: action((state, payload) => {
+    SwitchBoard.presentNavigationViewController(state.navViewRef.current, `/my-collection/artwork-detail/${payload}`)
   }),
 
   navigateToArtworkList: action(state => {

--- a/src/lib/Scenes/Consignments/v2/State/navigationModel.tsx
+++ b/src/lib/Scenes/Consignments/v2/State/navigationModel.tsx
@@ -105,8 +105,8 @@ export const navigationModel: NavigationModel = {
     })
   }),
 
-  navigateToArtworkDetail: action((state, payload) => {
-    SwitchBoard.presentNavigationViewController(state.navViewRef.current, `/my-collection/artwork-detail/${payload}`)
+  navigateToArtworkDetail: action((state, artworkID) => {
+    SwitchBoard.presentNavigationViewController(state.navViewRef.current, `/my-collection/artwork-detail/${artworkID}`)
   }),
 
   navigateToArtworkList: action(state => {


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/CSGN-268

This PR adds some fake "real" data to drive the artwork detail page of My Collection. 

Some components are extracted where it seems easy to predict fragment container boundaries, but at this point that's a lot of guessing. In some cases I didn't bother to drive the components from "real" data because it seems unlikely we'll have real data for them soon. This gets us _closer_ to a place where we just need to hook up metaphysics, but not all the way there.

#trivial #skip_new_tests (but really this is work in progress that is hidden behind a lab flag)
