### PR TITLE
[MX-289] - Artwork filters QA 

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -13,9 +13,10 @@ upcoming:
     - Add change name screen  - mounir
     - Add search functionality to Select component - david
     - Home promo QA fixes - david
+    - Color filter QA fixes - brian 
   user_facing:
     - Adds Notable Work rail to Artist pages - ashley
-    - Adds filters to artist pages, adds additional filter to collections
+    - Adds filters to artist pages, adds additional filter to collections - brian
     -
 
 releases:

--- a/src/lib/Components/ArtworkFilterOptions/ColorOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/ColorOptions.tsx
@@ -4,7 +4,12 @@ import {
   FilterDisplayName,
   FilterParamName,
 } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
-import { ArtworkFilterContext, FilterData, useSelectedOptionsDisplay } from "lib/utils/ArtworkFiltersStore"
+import {
+  ArtworkFilterContext,
+  FilterData,
+  ParamDefaultValues,
+  useSelectedOptionsDisplay,
+} from "lib/utils/ArtworkFiltersStore"
 import { isPad } from "lib/utils/hardware"
 import React, { useContext, useState } from "react"
 import { LayoutChangeEvent, NavigatorIOS, TouchableOpacity, View } from "react-native"
@@ -83,7 +88,7 @@ export const ColorOptionsScreen: React.SFC<ColorOptionsScreenProps> = ({ navigat
     }
   })
 
-  const allOption = { displayText: "All", paramName, paramValue: "All" }
+  const allOption = { displayText: "All", paramName, paramValue: ParamDefaultValues.color }
   const blackWhiteOption = {
     displayText: "black-and-white-2",
     paramName,

--- a/src/lib/Components/ArtworkFilterOptions/ColorOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/ColorOptions.tsx
@@ -11,6 +11,7 @@ import {
   useSelectedOptionsDisplay,
 } from "lib/utils/ArtworkFiltersStore"
 import { isPad } from "lib/utils/hardware"
+import { floor } from "lodash"
 import React, { useContext, useState } from "react"
 import { LayoutChangeEvent, NavigatorIOS, TouchableOpacity, View } from "react-native"
 import styled from "styled-components/native"
@@ -129,7 +130,7 @@ export const ColorOptionsScreen: React.SFC<ColorOptionsScreenProps> = ({ navigat
     const totalIterItemSpace = INTER_ITEM_SPACE * (itemsPerLine - 1)
     const sideMarginSpace = SIDE_MARGIN * 2
     const spaceForItems = width - (sideMarginSpace + totalIterItemSpace)
-    const size = spaceForItems / itemsPerLine
+    const size = floor(spaceForItems / itemsPerLine)
     setItemSize(size)
   }
 

--- a/src/lib/Components/ArtworkFilterOptions/ColorOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/ColorOptions.tsx
@@ -1,5 +1,9 @@
 import { Flex } from "@artsy/palette"
-import { AggregateOption, FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
+import {
+  AggregateOption,
+  FilterDisplayName,
+  FilterParamName,
+} from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import { ArtworkFilterContext, FilterData, useSelectedOptionsDisplay } from "lib/utils/ArtworkFiltersStore"
 import { isPad } from "lib/utils/hardware"
 import React, { useContext, useState } from "react"
@@ -127,7 +131,7 @@ export const ColorOptionsScreen: React.SFC<ColorOptionsScreenProps> = ({ navigat
   return (
     <View onLayout={handleLayout}>
       <Flex flexGrow={1}>
-        <ArtworkFilterHeader filterName={"Color"} handleBackNavigation={handleBackNavigation} />
+        <ArtworkFilterHeader filterName={FilterDisplayName.color} handleBackNavigation={handleBackNavigation} />
         <Flex
           ml={`${FLEX_MARGIN}px`}
           mr={`${FLEX_MARGIN}px`}

--- a/src/lib/Components/ArtworkFilterOptions/GalleryOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/GalleryOptions.tsx
@@ -3,7 +3,12 @@ import {
   FilterDisplayName,
   FilterParamName,
 } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
-import { ArtworkFilterContext, FilterData, useSelectedOptionsDisplay } from "lib/utils/ArtworkFiltersStore"
+import {
+  ArtworkFilterContext,
+  FilterData,
+  ParamDefaultValues,
+  useSelectedOptionsDisplay,
+} from "lib/utils/ArtworkFiltersStore"
 import React, { useContext } from "react"
 import { NavigatorIOS } from "react-native"
 import { aggregationForFilter } from "../FilterModal"
@@ -27,7 +32,7 @@ export const GalleryOptionsScreen: React.SFC<GalleryOptionsScreenProps> = ({ nav
       filterKey,
     }
   })
-  const allOption: FilterData = { displayText: "All", paramName, filterKey }
+  const allOption: FilterData = { displayText: "All", paramName, filterKey, paramValue: ParamDefaultValues.partnerID }
   const displayOptions = [allOption].concat(options ?? [])
 
   const selectedOptions = useSelectedOptionsDisplay()

--- a/src/lib/Components/ArtworkFilterOptions/GalleryOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/GalleryOptions.tsx
@@ -1,4 +1,8 @@
-import { AggregateOption, FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
+import {
+  AggregateOption,
+  FilterDisplayName,
+  FilterParamName,
+} from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import { ArtworkFilterContext, FilterData, useSelectedOptionsDisplay } from "lib/utils/ArtworkFiltersStore"
 import React, { useContext } from "react"
 import { NavigatorIOS } from "react-native"
@@ -44,7 +48,7 @@ export const GalleryOptionsScreen: React.SFC<GalleryOptionsScreenProps> = ({ nav
   return (
     <SingleSelectOptionScreen
       onSelect={selectOption}
-      filterHeaderText="Gallery"
+      filterHeaderText={FilterDisplayName.gallery}
       filterOptions={displayOptions}
       selectedOption={selectedOption}
       navigator={navigator}

--- a/src/lib/Components/ArtworkFilterOptions/InstitutionOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/InstitutionOptions.tsx
@@ -3,7 +3,12 @@ import {
   FilterDisplayName,
   FilterParamName,
 } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
-import { ArtworkFilterContext, FilterData, useSelectedOptionsDisplay } from "lib/utils/ArtworkFiltersStore"
+import {
+  ArtworkFilterContext,
+  FilterData,
+  ParamDefaultValues,
+  useSelectedOptionsDisplay,
+} from "lib/utils/ArtworkFiltersStore"
 import React, { useContext } from "react"
 import { NavigatorIOS } from "react-native"
 import { aggregationForFilter } from "../FilterModal"
@@ -27,7 +32,7 @@ export const InstitutionOptionsScreen: React.SFC<InstitutionOptionsScreenProps> 
       filterKey,
     }
   })
-  const allOption: FilterData = { displayText: "All", paramName, filterKey }
+  const allOption: FilterData = { displayText: "All", paramName, filterKey, paramValue: ParamDefaultValues.partnerID }
   const displayOptions = [allOption].concat(options ?? [])
   const selectedOptions = useSelectedOptionsDisplay()
   const selectedOption = selectedOptions.find(option => option.paramName === paramName)!

--- a/src/lib/Components/ArtworkFilterOptions/InstitutionOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/InstitutionOptions.tsx
@@ -26,7 +26,6 @@ export const InstitutionOptionsScreen: React.SFC<InstitutionOptionsScreenProps> 
   const allOption: FilterData = { displayText: "All", paramName, filterKey }
   const displayOptions = [allOption].concat(options ?? [])
   const selectedOptions = useSelectedOptionsDisplay()
-  console.log(selectedOptions)
   const selectedOption = selectedOptions.find(option => option.paramName === paramName)!
 
   const selectOption = (option: AggregateOption) => {

--- a/src/lib/Components/ArtworkFilterOptions/InstitutionOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/InstitutionOptions.tsx
@@ -1,4 +1,8 @@
-import { AggregateOption, FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
+import {
+  AggregateOption,
+  FilterDisplayName,
+  FilterParamName,
+} from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import { ArtworkFilterContext, FilterData, useSelectedOptionsDisplay } from "lib/utils/ArtworkFiltersStore"
 import React, { useContext } from "react"
 import { NavigatorIOS } from "react-native"
@@ -43,7 +47,7 @@ export const InstitutionOptionsScreen: React.SFC<InstitutionOptionsScreenProps> 
   return (
     <SingleSelectOptionScreen
       onSelect={selectOption}
-      filterHeaderText="Institution"
+      filterHeaderText={FilterDisplayName.institution}
       filterOptions={displayOptions}
       selectedOption={selectedOption}
       navigator={navigator}

--- a/src/lib/Components/ArtworkFilterOptions/MediumOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/MediumOptions.tsx
@@ -3,7 +3,12 @@ import {
   FilterDisplayName,
   FilterParamName,
 } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
-import { ArtworkFilterContext, FilterData, useSelectedOptionsDisplay } from "lib/utils/ArtworkFiltersStore"
+import {
+  ArtworkFilterContext,
+  FilterData,
+  ParamDefaultValues,
+  useSelectedOptionsDisplay,
+} from "lib/utils/ArtworkFiltersStore"
 import React, { useContext } from "react"
 import { NavigatorIOS } from "react-native"
 import { aggregationForFilter } from "../FilterModal"
@@ -26,7 +31,7 @@ export const MediumOptionsScreen: React.SFC<MediumOptionsScreenProps> = ({ navig
     }
   })
 
-  const allOption: FilterData = { displayText: "All", paramName, paramValue: "*" }
+  const allOption: FilterData = { displayText: "All", paramName, paramValue: ParamDefaultValues.medium }
   const displayOptions = [allOption].concat(options ?? [])
 
   const selectedOptions = useSelectedOptionsDisplay()

--- a/src/lib/Components/ArtworkFilterOptions/MediumOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/MediumOptions.tsx
@@ -1,4 +1,8 @@
-import { AggregateOption, FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
+import {
+  AggregateOption,
+  FilterDisplayName,
+  FilterParamName,
+} from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import { ArtworkFilterContext, FilterData, useSelectedOptionsDisplay } from "lib/utils/ArtworkFiltersStore"
 import React, { useContext } from "react"
 import { NavigatorIOS } from "react-native"
@@ -42,7 +46,7 @@ export const MediumOptionsScreen: React.SFC<MediumOptionsScreenProps> = ({ navig
   return (
     <SingleSelectOptionScreen
       onSelect={selectOption}
-      filterHeaderText="Medium"
+      filterHeaderText={FilterDisplayName.medium}
       filterOptions={displayOptions}
       selectedOption={selectedOption}
       navigator={navigator}

--- a/src/lib/Components/ArtworkFilterOptions/MultiSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/MultiSelectOption.tsx
@@ -10,7 +10,7 @@ import styled from "styled-components/native"
 interface MultiSelectOptionScreenProps {
   navigator: NavigatorIOS
   filterHeaderText: string
-  onSelect: (filterData: FilterData) => void
+  onSelect: (filterData: FilterData, updatedValue: boolean) => void
   filterOptions: FilterData[]
 }
 
@@ -45,8 +45,7 @@ export const MultiSelectOptionScreen: React.SFC<MultiSelectOptionScreenProps> = 
                     <FilterToggleButton
                       onChange={() => {
                         const currentParamValue = item.paramValue as boolean
-                        item.paramValue = !currentParamValue
-                        onSelect(item)
+                        onSelect(item, !currentParamValue)
                       }}
                       value={item.paramValue as boolean}
                     />

--- a/src/lib/Components/ArtworkFilterOptions/PriceRangeOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/PriceRangeOptions.tsx
@@ -1,4 +1,8 @@
-import { AggregateOption, FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
+import {
+  AggregateOption,
+  FilterDisplayName,
+  FilterParamName,
+} from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import { ArtworkFilterContext, FilterData, useSelectedOptionsDisplay } from "lib/utils/ArtworkFiltersStore"
 import React, { useContext } from "react"
 import { NavigatorIOS } from "react-native"
@@ -59,7 +63,7 @@ export const PriceRangeOptionsScreen: React.SFC<PriceRangeOptionsScreenProps> = 
   return (
     <SingleSelectOptionScreen
       onSelect={selectOption}
-      filterHeaderText="Price Range"
+      filterHeaderText={FilterDisplayName.priceRange}
       filterOptions={sortedOptions}
       selectedOption={selectedOption}
       navigator={navigator}

--- a/src/lib/Components/ArtworkFilterOptions/SizeOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/SizeOptions.tsx
@@ -3,7 +3,12 @@ import {
   FilterDisplayName,
   FilterParamName,
 } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
-import { ArtworkFilterContext, FilterData, useSelectedOptionsDisplay } from "lib/utils/ArtworkFiltersStore"
+import {
+  ArtworkFilterContext,
+  FilterData,
+  ParamDefaultValues,
+  useSelectedOptionsDisplay,
+} from "lib/utils/ArtworkFiltersStore"
 import React, { useContext } from "react"
 import { NavigatorIOS } from "react-native"
 import { aggregationForFilter } from "../FilterModal"
@@ -26,7 +31,7 @@ export const SizeOptionsScreen: React.SFC<SizeOptionsScreenProps> = ({ navigator
     }
   })
 
-  const allOption: FilterData = { displayText: "All", paramName }
+  const allOption: FilterData = { displayText: "All", paramName, paramValue: ParamDefaultValues.dimensionRange }
   const displayOptions = [allOption].concat(options ?? [])
   const selectedOptions = useSelectedOptionsDisplay()
   const selectedOption = selectedOptions.find(option => option.paramName === paramName)!

--- a/src/lib/Components/ArtworkFilterOptions/SizeOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/SizeOptions.tsx
@@ -1,4 +1,8 @@
-import { AggregateOption, FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
+import {
+  AggregateOption,
+  FilterDisplayName,
+  FilterParamName,
+} from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import { ArtworkFilterContext, FilterData, useSelectedOptionsDisplay } from "lib/utils/ArtworkFiltersStore"
 import React, { useContext } from "react"
 import { NavigatorIOS } from "react-native"
@@ -41,7 +45,7 @@ export const SizeOptionsScreen: React.SFC<SizeOptionsScreenProps> = ({ navigator
   return (
     <SingleSelectOptionScreen
       onSelect={selectOption}
-      filterHeaderText="Size"
+      filterHeaderText={FilterDisplayName.size}
       filterOptions={displayOptions}
       selectedOption={selectedOption}
       navigator={navigator}

--- a/src/lib/Components/ArtworkFilterOptions/SortOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/SortOptions.tsx
@@ -1,4 +1,4 @@
-import { FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
+import { FilterDisplayName, FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import { ArtworkFilterContext, FilterData, useSelectedOptionsDisplay } from "lib/utils/ArtworkFiltersStore"
 import React, { useContext } from "react"
 import { NavigatorIOS } from "react-native"
@@ -80,7 +80,7 @@ export const SortOptionsScreen: React.SFC<SortOptionsScreenProps> = ({ navigator
   return (
     <SingleSelectOptionScreen
       onSelect={selectOption}
-      filterHeaderText="Sort"
+      filterHeaderText={FilterDisplayName.sort}
       filterOptions={OrderedArtworkSorts}
       selectedOption={selectedOption}
       navigator={navigator}

--- a/src/lib/Components/ArtworkFilterOptions/TimePeriodOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/TimePeriodOptions.tsx
@@ -1,4 +1,4 @@
-import { FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
+import { FilterDisplayName, FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import { ArtworkFilterContext, FilterData, useSelectedOptionsDisplay } from "lib/utils/ArtworkFiltersStore"
 import _ from "lodash"
 import React, { useContext } from "react"
@@ -60,7 +60,7 @@ export const TimePeriodOptionsScreen: React.SFC<TimePeriodOptionsScreenProps> = 
   return (
     <SingleSelectOptionScreen
       onSelect={selectOption}
-      filterHeaderText="Time Period"
+      filterHeaderText={FilterDisplayName.timePeriod}
       filterOptions={filterOptions}
       selectedOption={selectedOption}
       navigator={navigator}

--- a/src/lib/Components/ArtworkFilterOptions/TimePeriodOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/TimePeriodOptions.tsx
@@ -1,5 +1,10 @@
 import { FilterDisplayName, FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
-import { ArtworkFilterContext, FilterData, useSelectedOptionsDisplay } from "lib/utils/ArtworkFiltersStore"
+import {
+  ArtworkFilterContext,
+  FilterData,
+  ParamDefaultValues,
+  useSelectedOptionsDisplay,
+} from "lib/utils/ArtworkFiltersStore"
 import _ from "lodash"
 import React, { useContext } from "react"
 import { NavigatorIOS } from "react-native"
@@ -47,7 +52,7 @@ export const TimePeriodOptionsScreen: React.SFC<TimePeriodOptionsScreenProps> = 
       }
     })
   )
-  const allOption: FilterData = { displayText: "All", paramName }
+  const allOption: FilterData = { displayText: "All", paramName, paramValue: ParamDefaultValues.majorPeriods }
   const filterOptions = [allOption].concat(aggFilterOptions)
 
   const selectedOptions = useSelectedOptionsDisplay()

--- a/src/lib/Components/ArtworkFilterOptions/WaysToBuyOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/WaysToBuyOptions.tsx
@@ -32,12 +32,12 @@ export const WaysToBuyOptionsScreen: React.SFC<WaysToBuyOptionsScreenProps> = ({
 
   const sortedOptions = waysToBuyOptions.sort(waysToBuySort)
 
-  const selectOption = (option: FilterData) => {
+  const selectOption = (option: FilterData, updatedValue: boolean) => {
     dispatch({
       type: "selectFilters",
       payload: {
         displayText: option.displayText,
-        paramValue: option.paramValue,
+        paramValue: updatedValue,
         paramName: option.paramName,
       },
     })

--- a/src/lib/Components/ArtworkFilterOptions/WaysToBuyOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/WaysToBuyOptions.tsx
@@ -1,4 +1,4 @@
-import { FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
+import { FilterDisplayName, FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import { ArtworkFilterContext, FilterData, useSelectedOptionsDisplay } from "lib/utils/ArtworkFiltersStore"
 import React, { useContext } from "react"
 import { NavigatorIOS } from "react-native"
@@ -46,7 +46,7 @@ export const WaysToBuyOptionsScreen: React.SFC<WaysToBuyOptionsScreenProps> = ({
   return (
     <MultiSelectOptionScreen
       onSelect={selectOption}
-      filterHeaderText="Ways to Buy"
+      filterHeaderText={FilterDisplayName.waysToBuy}
       filterOptions={sortedOptions}
       navigator={navigator}
     />

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -2,6 +2,7 @@ import { ArrowRightIcon, Box, Button, CloseIcon, color, Flex, Sans, Separator } 
 import {
   changedFiltersParams,
   filterArtworksParams,
+  FilterDisplayName,
   FilterParamName,
 } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import { Schema } from "lib/utils/track"
@@ -392,18 +393,6 @@ export const aggregationForFilter = (filterKey: string, aggregations: Aggregatio
   const aggregationName = aggregationNameFromFilter[filterKey]
   const aggregation = aggregations!.find(value => value.slice === aggregationName)
   return aggregation
-}
-
-enum FilterDisplayName {
-  sort = "Sort",
-  medium = "Medium",
-  priceRange = "Price range",
-  size = "Size",
-  color = "Color",
-  gallery = "Gallery",
-  institution = "Institution",
-  timePeriod = "Time period",
-  waysToBuy = "Ways to buy",
 }
 
 const filterOptionToDisplayConfigMap: Record<string, FilterDisplayConfig> = {

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -301,7 +301,6 @@ const OptionDetail: React.FC<{ currentOption: any; filterType: any }> = ({ curre
 const ColorSwatch: React.FC<{ colorOption: ColorOption }> = ({ colorOption }) => {
   return (
     <Box
-      mt={0.3}
       mr={0.3}
       style={{
         alignSelf: "center",

--- a/src/lib/Scenes/Collection/Helpers/FilterArtworksHelpers.ts
+++ b/src/lib/Scenes/Collection/Helpers/FilterArtworksHelpers.ts
@@ -32,6 +32,18 @@ interface FilterParams {
   offerable?: boolean
 }
 
+export enum FilterDisplayName {
+  sort = "Sort",
+  medium = "Medium",
+  priceRange = "Price range",
+  size = "Size",
+  color = "Color",
+  gallery = "Gallery",
+  institution = "Institution",
+  timePeriod = "Time period",
+  waysToBuy = "Ways to buy",
+}
+
 export interface InitialState {
   initialState: {
     selectedFilters: FilterArray

--- a/src/lib/utils/ArtworkFiltersStore.tsx
+++ b/src/lib/utils/ArtworkFiltersStore.tsx
@@ -120,18 +120,32 @@ export const reducer = (
   }
 }
 
-const defaultFilterOptions: Record<FilterParamName, string | boolean | null> = {
+export const ParamDefaultValues = {
   sort: "-decayed_merch",
   medium: "*",
   priceRange: "*-*",
   dimensionRange: "*-*",
-  color: null,
-  partnerID: null,
-  majorPeriods: null,
+  color: undefined,
+  partnerID: undefined,
+  majorPeriods: undefined,
   inquireableOnly: false,
   offerable: false,
   atAuction: false,
   acquireable: false,
+}
+
+const defaultFilterOptions: Record<FilterParamName, string | boolean | undefined> = {
+  sort: ParamDefaultValues.sort,
+  medium: ParamDefaultValues.medium,
+  priceRange: ParamDefaultValues.priceRange,
+  dimensionRange: ParamDefaultValues.dimensionRange,
+  color: ParamDefaultValues.color,
+  partnerID: ParamDefaultValues.partnerID,
+  majorPeriods: ParamDefaultValues.majorPeriods,
+  inquireableOnly: ParamDefaultValues.inquireableOnly,
+  offerable: ParamDefaultValues.offerable,
+  atAuction: ParamDefaultValues.atAuction,
+  acquireable: ParamDefaultValues.acquireable,
 }
 
 export const useSelectedOptionsDisplay = (): FilterArray => {


### PR DESCRIPTION
Fixes for a few bugs found in QA for artwork filters.

- Ways to buy filters were not allowing second selection because the filter object was being modified rather than passing new value, causing filter context to think nothing changed
-  "All" options in some filters didn't match default param values
- Layout and copy issue fixes