### PR TITLE
[MX-251] Adds pull-to-refresh control on empty states of Favourites view

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,7 +5,7 @@ upcoming:
     - Remove noisy sentry errors - brian
     - Track referrer in universal links - brian
   user_facing:
-    -
+    - Adds pull-to-refresh control on empty states of Favourites view - ash
 
 releases:
   - version: 6.4.9

--- a/src/lib/Scenes/Favorites/Components/Artists/index.tsx
+++ b/src/lib/Scenes/Favorites/Components/Artists/index.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { FlatList, RefreshControl } from "react-native"
+import { FlatList, RefreshControl, ScrollView } from "react-native"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 
 import SavedItemRow from "lib/Components/Lists/SavedItemRow"
@@ -59,10 +59,15 @@ class Artists extends React.Component<Props, State> {
 
     if (rows.length === 0) {
       return (
-        <ZeroState
-          title="You haven’t followed any artists yet"
-          subtitle="When you’ve found an artist you like, follow them to get updates on new works that become available."
-        />
+        <ScrollView
+          contentContainerStyle={{ flexGrow: 1 }}
+          refreshControl={<RefreshControl refreshing={this.state.refreshingFromPull} onRefresh={this.handleRefresh} />}
+        >
+          <ZeroState
+            title="You haven’t followed any artists yet"
+            subtitle="When you’ve found an artist you like, follow them to get updates on new works that become available."
+          />
+        </ScrollView>
       )
     }
 

--- a/src/lib/Scenes/Favorites/Components/Artworks/index.tsx
+++ b/src/lib/Scenes/Favorites/Components/Artworks/index.tsx
@@ -68,21 +68,26 @@ export class SavedWorks extends Component<Props, State> {
 
     if (artworks.length === 0) {
       return (
-        <ZeroState
-          title="You haven’t saved any works yet"
-          subtitle="Tap the heart on an artwork to save for later."
-          callToAction={
-            <Button
-              variant="secondaryOutline"
-              size="large"
-              onPress={() => {
-                SwitchBoard.presentNavigationViewController(this, "/")
-              }}
-            >
-              Browse works for you
-            </Button>
-          }
-        />
+        <ScrollView
+          contentContainerStyle={{ flexGrow: 1 }}
+          refreshControl={<RefreshControl refreshing={this.state.refreshingFromPull} onRefresh={this.handleRefresh} />}
+        >
+          <ZeroState
+            title="You haven’t saved any works yet"
+            subtitle="Tap the heart on an artwork to save for later."
+            callToAction={
+              <Button
+                variant="secondaryOutline"
+                size="large"
+                onPress={() => {
+                  SwitchBoard.presentNavigationViewController(this, "/")
+                }}
+              >
+                Browse works for you
+              </Button>
+            }
+          />
+        </ScrollView>
       )
     }
 

--- a/src/lib/Scenes/Favorites/Components/Categories/index.tsx
+++ b/src/lib/Scenes/Favorites/Components/Categories/index.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { FlatList, RefreshControl } from "react-native"
+import { FlatList, RefreshControl, ScrollView } from "react-native"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 
 import SavedItemRow from "lib/Components/Lists/SavedItemRow"
@@ -58,10 +58,15 @@ export class Categories extends React.Component<Props, State> {
 
     if (rows.length === 0) {
       return (
-        <ZeroState
-          title="You’re not following any categories yet"
-          subtitle="Find a few categories to help improve your artwork recommendations."
-        />
+        <ScrollView
+          contentContainerStyle={{ flexGrow: 1 }}
+          refreshControl={<RefreshControl refreshing={this.state.refreshingFromPull} onRefresh={this.handleRefresh} />}
+        >
+          <ZeroState
+            title="You’re not following any categories yet"
+            subtitle="Find a few categories to help improve your artwork recommendations."
+          />
+        </ScrollView>
       )
     }
 

--- a/src/lib/Scenes/Favorites/Components/Fairs/index.tsx
+++ b/src/lib/Scenes/Favorites/Components/Fairs/index.tsx
@@ -3,7 +3,7 @@ import Spinner from "lib/Components/Spinner"
 import { ZeroState } from "lib/Components/States/ZeroState"
 import { PAGE_SIZE } from "lib/data/constants"
 import React, { Component } from "react"
-import { FlatList, RefreshControl } from "react-native"
+import { FlatList, RefreshControl, ScrollView } from "react-native"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 
 import { Fairs_me } from "__generated__/Fairs_me.graphql"
@@ -58,10 +58,15 @@ export class SavedFairs extends Component<Props, State> {
 
     if (fairs.length === 0 || !fairs) {
       return (
-        <ZeroState
-          title="You haven’t followed any fairs yet"
-          subtitle="Follow fairs to get notified about new fairs that have been added to Artsy."
-        />
+        <ScrollView
+          contentContainerStyle={{ flexGrow: 1 }}
+          refreshControl={<RefreshControl refreshing={this.state.refreshingFromPull} onRefresh={this.handleRefresh} />}
+        >
+          <ZeroState
+            title="You haven’t followed any fairs yet"
+            subtitle="Follow fairs to get notified about new fairs that have been added to Artsy."
+          />
+        </ScrollView>
       )
     }
 

--- a/src/lib/Scenes/Favorites/Components/Shows/index.tsx
+++ b/src/lib/Scenes/Favorites/Components/Shows/index.tsx
@@ -3,7 +3,7 @@ import Spinner from "lib/Components/Spinner"
 import { ZeroState } from "lib/Components/States/ZeroState"
 import { PAGE_SIZE } from "lib/data/constants"
 import React, { Component } from "react"
-import { FlatList, RefreshControl } from "react-native"
+import { FlatList, RefreshControl, ScrollView } from "react-native"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 
 import { Box, Separator, Theme } from "@artsy/palette"
@@ -55,15 +55,19 @@ export class Shows extends Component<Props, State> {
 
   // @TODO: Implement test on this component https://artsyproduct.atlassian.net/browse/LD-563
   render() {
-    console.warn(this.props.me)
     const shows = extractNodes(this.props.me.followsAndSaves?.shows)
 
     if (!shows.length) {
       return (
-        <ZeroState
-          title="You haven’t saved any shows yet"
-          subtitle="When you save shows, they will show up here for future use."
-        />
+        <ScrollView
+          contentContainerStyle={{ flexGrow: 1 }}
+          refreshControl={<RefreshControl refreshing={this.state.refreshingFromPull} onRefresh={this.handleRefresh} />}
+        >
+          <ZeroState
+            title="You haven’t saved any shows yet"
+            subtitle="When you save shows, they will show up here for future use."
+          />
+        </ScrollView>
       )
     }
 


### PR DESCRIPTION
This was done by wrapping the `ZeroState` component in a scrollview, modifying the scroll view's content to stretch full screen, and adding the same refresh control.

![2020-07-10 11-06-37 2020-07-10 11_09_15](https://user-images.githubusercontent.com/498212/87169491-1455a580-c29e-11ea-857a-14bf51960fae.gif)
