### PR TITLE
Requested tweaks #trivial

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -6,6 +6,7 @@ upcoming:
     - Track referrer in universal links - brian
   user_facing:
     - Adds pull-to-refresh control on empty states of Favourites view - ash
+    - Partner shows rail displays cover image, if available - ash
 
 releases:
   - version: 6.4.9

--- a/src/__generated__/PartnerQuery.graphql.ts
+++ b/src/__generated__/PartnerQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash ac33e1fbcc510406f4cd320dd94531e5 */
+/* @relayHash eb57364c19e620e3ceaad78eca39602e */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -183,6 +183,9 @@ fragment PartnerShowRailItem_show on Show {
   name
   exhibitionPeriod
   endAt
+  coverImage {
+    url
+  }
   images {
     url
   }
@@ -1100,6 +1103,16 @@ return {
                           }
                         ]
                       },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "coverImage",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": (v17/*: any*/)
+                      },
                       (v11/*: any*/)
                     ]
                   },
@@ -1124,7 +1137,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "PartnerQuery",
-    "id": "df36261979d59addf30cc66292b40c61",
+    "id": "a02eba61fb4278bd5c3692c5bd22720d",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/PartnerRefetchQuery.graphql.ts
+++ b/src/__generated__/PartnerRefetchQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash d527296265c9b56af7be8074f2ebc451 */
+/* @relayHash 59996ba0614706949a821264adf8c1f1 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -184,6 +184,9 @@ fragment PartnerShowRailItem_show on Show {
   name
   exhibitionPeriod
   endAt
+  coverImage {
+    url
+  }
   images {
     url
   }
@@ -1106,6 +1109,16 @@ return {
                               }
                             ]
                           },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "coverImage",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": (v17/*: any*/)
+                          },
                           (v2/*: any*/)
                         ]
                       },
@@ -1132,7 +1145,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "PartnerRefetchQuery",
-    "id": "0de52ece45e1497bf5ed1f634b44461f",
+    "id": "b180b22b802eef9003d2cef647ab3680",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/PartnerShowRailItem_show.graphql.ts
+++ b/src/__generated__/PartnerShowRailItem_show.graphql.ts
@@ -9,6 +9,9 @@ export type PartnerShowRailItem_show = {
     readonly name: string | null;
     readonly exhibitionPeriod: string | null;
     readonly endAt: string | null;
+    readonly coverImage: {
+        readonly url: string | null;
+    } | null;
     readonly images: ReadonlyArray<{
         readonly url: string | null;
     } | null> | null;
@@ -22,7 +25,17 @@ export type PartnerShowRailItem_show$key = {
 
 
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "url",
+    "args": null,
+    "storageKey": null
+  }
+];
+return {
   "kind": "Fragment",
   "name": "PartnerShowRailItem_show",
   "type": "Show",
@@ -67,22 +80,25 @@ const node: ReaderFragment = {
     {
       "kind": "LinkedField",
       "alias": null,
+      "name": "coverImage",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Image",
+      "plural": false,
+      "selections": (v0/*: any*/)
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
       "name": "images",
       "storageKey": null,
       "args": null,
       "concreteType": "Image",
       "plural": true,
-      "selections": [
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "url",
-          "args": null,
-          "storageKey": null
-        }
-      ]
+      "selections": (v0/*: any*/)
     }
   ]
 };
-(node as any).hash = 'f12d77e2781384f8498d622ce53b9266';
+})();
+(node as any).hash = '54b5a51d6b04d0248ff1995a6fb3e0b4';
 export default node;

--- a/src/__generated__/PartnerShowsInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/PartnerShowsInfiniteScrollGridQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 5f370576d040248254fe304d05c464bb */
+/* @relayHash 48cea724609c467c4c45d3590b767a6c */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -39,6 +39,9 @@ fragment PartnerShowRailItem_show on Show {
   name
   exhibitionPeriod
   endAt
+  coverImage {
+    url
+  }
   images {
     url
   }
@@ -286,6 +289,9 @@ v14 = [
     "value": "END_AT_ASC"
   },
   (v4/*: any*/)
+],
+v15 = [
+  (v10/*: any*/)
 ];
 return {
   "kind": "Request",
@@ -546,9 +552,7 @@ return {
                         "args": null,
                         "concreteType": "Image",
                         "plural": true,
-                        "selections": [
-                          (v10/*: any*/)
-                        ]
+                        "selections": (v15/*: any*/)
                       },
                       {
                         "kind": "LinkedField",
@@ -569,6 +573,16 @@ return {
                             ]
                           }
                         ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "coverImage",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": (v15/*: any*/)
                       },
                       (v11/*: any*/)
                     ]
@@ -595,7 +609,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "PartnerShowsInfiniteScrollGridQuery",
-    "id": "64338bb298400c3725175a87d4bed783",
+    "id": "5b9fd887367600efd3fb74e5a6c1dae2",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/PartnerShowsRailQuery.graphql.ts
+++ b/src/__generated__/PartnerShowsRailQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash b8723efe8a0d011790a8ab13a4baf1f8 */
+/* @relayHash e1dadc152671f34763e4185762ad017e */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -39,6 +39,9 @@ fragment PartnerShowRailItem_show on Show {
   name
   exhibitionPeriod
   endAt
+  coverImage {
+    url
+  }
   images {
     url
   }
@@ -155,7 +158,16 @@ v5 = {
   "args": null,
   "storageKey": null
 },
-v6 = {
+v6 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "url",
+    "args": null,
+    "storageKey": null
+  }
+],
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__typename",
@@ -306,15 +318,7 @@ return {
                         "args": null,
                         "concreteType": "Image",
                         "plural": true,
-                        "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "url",
-                            "args": null,
-                            "storageKey": null
-                          }
-                        ]
+                        "selections": (v6/*: any*/)
                       },
                       {
                         "kind": "LinkedField",
@@ -325,7 +329,7 @@ return {
                         "concreteType": null,
                         "plural": false,
                         "selections": [
-                          (v6/*: any*/),
+                          (v7/*: any*/),
                           (v4/*: any*/),
                           {
                             "kind": "InlineFragment",
@@ -336,7 +340,17 @@ return {
                           }
                         ]
                       },
-                      (v6/*: any*/)
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "coverImage",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": (v6/*: any*/)
+                      },
+                      (v7/*: any*/)
                     ]
                   },
                   {
@@ -370,7 +384,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "PartnerShowsRailQuery",
-    "id": "95b382e3b762d5c0207712abe8ae7b9d",
+    "id": "0db09b90675f21a22b86077c11299534",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/PartnerShowsTestsQuery.graphql.ts
+++ b/src/__generated__/PartnerShowsTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 36487596becf6bd28578f9d911dd8f11 */
+/* @relayHash e309ea3127da3bcbe28bb7a68148fb49 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -76,6 +76,9 @@ export type PartnerShowsTestsQueryRawResponse = {
                         readonly __typename: string | null;
                         readonly id: string | null;
                     }) | null;
+                    readonly coverImage: ({
+                        readonly url: string | null;
+                    }) | null;
                     readonly __typename: "Show";
                 }) | null;
                 readonly cursor: string;
@@ -106,6 +109,9 @@ fragment PartnerShowRailItem_show on Show {
   name
   exhibitionPeriod
   endAt
+  coverImage {
+    url
+  }
   images {
     url
   }
@@ -328,6 +334,9 @@ v13 = [
     "value": "END_AT_ASC"
   },
   (v3/*: any*/)
+],
+v14 = [
+  (v9/*: any*/)
 ];
 return {
   "kind": "Request",
@@ -577,9 +586,7 @@ return {
                         "args": null,
                         "concreteType": "Image",
                         "plural": true,
-                        "selections": [
-                          (v9/*: any*/)
-                        ]
+                        "selections": (v14/*: any*/)
                       },
                       {
                         "kind": "LinkedField",
@@ -600,6 +607,16 @@ return {
                             ]
                           }
                         ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "coverImage",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": (v14/*: any*/)
                       },
                       (v10/*: any*/)
                     ]
@@ -626,7 +643,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "PartnerShowsTestsQuery",
-    "id": "9ed2e053a23d9bcabbc739f257ded1cd",
+    "id": "a57e83f3faadb81f976ebad7d480029d",
     "text": null,
     "metadata": {}
   }

--- a/src/lib/Scenes/Partner/Components/PartnerShowRailItem.tsx
+++ b/src/lib/Scenes/Partner/Components/PartnerShowRailItem.tsx
@@ -3,8 +3,8 @@ import { PartnerShowRailItem_show } from "__generated__/PartnerShowRailItem_show
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { exhibitionDates } from "lib/Scenes/Map/exhibitionPeriodParser"
-import { get } from "lib/utils/get"
 import { Schema, track } from "lib/utils/track"
+import { first } from "lodash"
 import React from "react"
 import { Dimensions, TouchableWithoutFeedback } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -35,10 +35,8 @@ export class PartnerShowRailItem extends React.Component<Props> {
 
   render() {
     const { show } = this.props
-    const { name, exhibitionPeriod, endAt } = show
-
-    // @ts-ignore STRICTNESS_MIGRATION
-    const imageURL = get(show, s => s.images[0].url)
+    const { name, exhibitionPeriod, endAt, coverImage, images } = show
+    const imageURL = coverImage?.url || first(images)?.url
 
     return (
       <TouchableWithoutFeedback onPress={() => this.onPress()}>
@@ -69,6 +67,9 @@ export const PartnerShowRailItemContainer = createFragmentContainer(PartnerShowR
       name
       exhibitionPeriod
       endAt
+      coverImage {
+        url
+      }
       images {
         url
       }

--- a/src/lib/Scenes/Partner/Components/__tests__/PartnerShows-tests.tsx
+++ b/src/lib/Scenes/Partner/Components/__tests__/PartnerShows-tests.tsx
@@ -67,6 +67,7 @@ const PartnerShowsFixture: PartnerShowsTestsQueryRawResponse["partner"] = {
           exhibitionPeriod: "Sep 16 – Nov 2",
           endAt: "2019-11-02T12:00:00+00:00",
           images: [],
+          coverImage: null,
         },
       },
       {
@@ -85,6 +86,9 @@ const PartnerShowsFixture: PartnerShowsTestsQueryRawResponse["partner"] = {
               url: "https://d32dm0rphc51dk.cloudfront.net/zhjrZ8ys2AIjZK5e_kj9qw/tall.jpg",
             },
           ],
+          coverImage: {
+            url: "https://d32dm0rphc51dk.cloudfront.net/5pyq3gwxGzK6Owea_DIxmw/larger.jpg",
+          },
         },
       },
       {
@@ -103,6 +107,9 @@ const PartnerShowsFixture: PartnerShowsTestsQueryRawResponse["partner"] = {
               url: "https://d32dm0rphc51dk.cloudfront.net/5pyq3gwxGzK6Owea_DIxmw/larger.jpg",
             },
           ],
+          coverImage: {
+            url: "https://d32dm0rphc51dk.cloudfront.net/5pyq3gwxGzK6Owea_DIxmw/larger.jpg",
+          },
         },
       },
     ],

--- a/src/lib/Scenes/Sales/Components/ZeroState/index.tsx
+++ b/src/lib/Scenes/Sales/Components/ZeroState/index.tsx
@@ -13,7 +13,7 @@ export class ZeroState extends React.Component {
           <Separator />
           <Flex justifyContent="center" flexGrow={1}>
             <Sans size="3t" weight="medium" textAlign="center">
-              There’s no upcoming auctions scheduled
+              There are no upcoming auctions scheduled
             </Sans>
             <Sans size="3t" textAlign="center" color="black60">
               Check back soon for new auctions on Artsy.


### PR DESCRIPTION
Our colleagues have requested a few tweaks to the app. First, the empty state for the sales list should say "there are" instead of "there's no"; second, partner shows should show the cover image instead of using the first image of the show (if a cover image is specified). /cc @coolyoungdad 

![Screen Shot 2020-07-10 at 3 05 18 PM](https://user-images.githubusercontent.com/498212/87189740-2e53b000-c2bf-11ea-885d-4da1b75398e8.png)
