### PR TITLE
Enable noFallThroughCasesInSwitch typescript check #trivial

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "strict": true,
     "strictBindCallApply": true,
     "noImplicitThis": true,
+    "noFallthroughCasesInSwitch": true,
     "strictFunctionTypes": true,
     "target": "es6",
     "types": ["jest", "react", "react-native"],


### PR DESCRIPTION
Enables typescript check to return errors when non-empty switch cases fallthrough: 
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-1-8.html#case-clause-fall-throughs

#trivial