### PR TITLE
[MX-434] - Filter button visibility

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -23,6 +23,7 @@ upcoming:
     - Track referrer in universal links - brian
     - Fix a bunch of warnings in native code - brian
     - Migrates native code to Metaphysics v2 - ash
+    - Hide artwork filter button until artworks are visible - brian
   user_facing:
     - Adds pull-to-refresh control on empty states of Favourites view - ash
     - Partner shows rail displays cover image, if available - ash

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -62,17 +62,10 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) 
   }
 
   const onViewRef = React.useRef(({ viewableItems }: ViewableItems) => {
-    console.log(viewableItems)
-    ;(viewableItems! ?? []).map((viewableItem: ViewToken) => {
-      const artworksRenderItem = viewableItem?.item ?? ""
-      const artworksRenderItemViewable = viewableItem?.isViewable || false
-
-      if (artworksRenderItem === "filteredArtworks" && artworksRenderItemViewable) {
-        return setArtworksGridVisible(true)
-      }
-
-      return setArtworksGridVisible(false)
+    const artworksItem = (viewableItems! ?? []).find((viewableItem: ViewToken) => {
+      return viewableItem?.item === "filteredArtworks"
     })
+    setArtworksGridVisible(artworksItem?.isViewable ?? false)
   })
 
   const viewConfigRef = React.useRef({ viewAreaCoveragePercentThreshold: 25 })

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -1,4 +1,4 @@
-import { Box, FilterIcon, Sans, Separator, Spacer } from "@artsy/palette"
+import { Box, FilterIcon, Sans, Separator } from "@artsy/palette"
 import { ArtistArtworks_artist } from "__generated__/ArtistArtworks_artist.graphql"
 import { ArtistNotableWorksRailFragmentContainer } from "lib/Components/Artist/ArtistArtworks/ArtistNotableWorksRail"
 import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
@@ -206,7 +206,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ViewableItemRefs> = 
     } else {
       return (
         <>
-          <Box mx={"-20px"} mb={3} mt={1}>
+          <Box mx={"-20px"} mb={3}>
             <Separator />
           </Box>
           <InfiniteScrollArtworksGrid
@@ -225,31 +225,28 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ViewableItemRefs> = 
   const sections = ["notableWorks", "collections", "filteredArtworks"]
 
   return artist.artworks ? (
-    <>
-      <Spacer mb={2} />
-      <FlatList
-        data={sections}
-        onViewableItemsChanged={viewableItemsRef.current}
-        viewabilityConfig={viewConfigRef.current}
-        keyExtractor={(_item, index) => String(index)}
-        renderItem={({ item }): null | any => {
-          switch (item) {
-            case "notableWorks":
-              return <ArtistNotableWorksRailFragmentContainer artist={artist} {...props} />
-            case "collections":
-              return (
-                <ArtistCollectionsRailFragmentContainer
-                  collections={artist.iconicCollections}
-                  artist={artist}
-                  {...props}
-                />
-              )
-            case "filteredArtworks":
-              return filteredArtworks()
-          }
-        }}
-      />
-    </>
+    <FlatList
+      data={sections}
+      onViewableItemsChanged={viewableItemsRef.current}
+      viewabilityConfig={viewConfigRef.current}
+      keyExtractor={(_item, index) => String(index)}
+      renderItem={({ item }): null | any => {
+        switch (item) {
+          case "notableWorks":
+            return <ArtistNotableWorksRailFragmentContainer artist={artist} {...props} />
+          case "collections":
+            return (
+              <ArtistCollectionsRailFragmentContainer
+                collections={artist.iconicCollections}
+                artist={artist}
+                {...props}
+              />
+            )
+          case "filteredArtworks":
+            return filteredArtworks()
+        }
+      }}
+    />
   ) : null
 }
 

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistCollectionsRail.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistCollectionsRail.tsx
@@ -19,7 +19,7 @@ export const ArtistCollectionsRail: React.FC<ArtistCollectionsRailProps> = props
   if (collections && collections.length > 1) {
     return (
       <Box>
-        <Box mb={1}>
+        <Box mt={1} mb={1}>
           <SectionTitle title="Iconic Collections" />
         </Box>
         <ArtistSeriesRailWrapper>

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistNotableWorksRail.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistNotableWorksRail.tsx
@@ -50,7 +50,7 @@ const ArtistNotableWorksRail: React.FC<ArtistNotableWorksRailProps> = ({ artist 
 
   return (
     <Box>
-      <Box mb={1}>
+      <Box mt={2} mb={1}>
         <SectionTitle title="Notable Works" />
       </Box>
       <ArtistNotableWorksRailWrapper>

--- a/src/lib/Scenes/Collection/Collection.tsx
+++ b/src/lib/Scenes/Collection/Collection.tsx
@@ -111,7 +111,7 @@ export class Collection extends Component<CollectionProps, CollectionState> {
     const { collection } = this.props
     const { linkedCollections, isDepartment } = collection
 
-    const sections = ["collectionFeaturedArtists", "collectionHubsRails", "collectionArtworks"] as const
+    const sections = ["collectionFeaturedArtists", "collectionHubsRails", "collectionArtworks"]
 
     return (
       <ArtworkFilterGlobalStateProvider>

--- a/src/lib/Scenes/Collection/Collection.tsx
+++ b/src/lib/Scenes/Collection/Collection.tsx
@@ -57,16 +57,10 @@ export class Collection extends Component<CollectionProps, CollectionState> {
   private flatList = createRef<FlatList<any>>()
 
   onViewableItemsChanged = ({ viewableItems }: ViewableItems) => {
-    ;(viewableItems! ?? []).map((viewableItem: ViewToken) => {
-      const artworksRenderItem = viewableItem?.item ?? ""
-      const artworksRenderItemViewable = viewableItem?.isViewable || false
-
-      if (artworksRenderItem === "collectionArtworks" && artworksRenderItemViewable) {
-        return this.setState(_prevState => ({ isArtworkGridVisible: true }))
-      }
-
-      return this.setState(_prevState => ({ isArtworkGridVisible: false }))
+    const artworksItem = (viewableItems! ?? []).find((viewableItem: ViewToken) => {
+      return viewableItem?.item === "collectionArtworks"
     })
+    this.setState(_prevState => ({ isArtworkGridVisible: artworksItem?.isViewable ?? false }))
   }
 
   handleFilterArtworksModal() {


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/MX-434

This hides the filter button on the artist artworks page until the artist artwork are visible, it is pretty close to the implementation in the collections component: https://github.com/artsy/eigen/blob/master/src/lib/Scenes/Collection/Collection.tsx#L59

- Adds a flatlist to contain the artist artworks and rails in section
- Adds callbacks for viewableItems changed and displays filter button when filtered artworks section is visible
 