### PR TITLE
Makes promo space link 60% max width on iPad #trivial

### DIFF
--- a/src/lib/Scenes/Home/Components/HomeHero.tsx
+++ b/src/lib/Scenes/Home/Components/HomeHero.tsx
@@ -55,7 +55,7 @@ const HomeHero: React.FC<{ homePage: HomeHero_homePage }> = ({ homePage }) => {
           </Sans>
         ) : null}
         {unit.linkText ? (
-          <Sans size="3t" color="white" weight="medium" mt={0.5}>
+          <Sans size="3t" color="white" weight="medium" mt={0.5} maxWidth={isPad() ? "60%" : undefined}>
             {unit.linkText}
           </Sans>
         ) : null}


### PR DESCRIPTION
The type of this PR is: Enhancement

<!-- Bugfix/Feature/Enhancement.. -->

This PR resolves: **MX-405**

### Description

#3530 made the title 60% max width on iPad. The subtitle is already capped, so I added the same max width to the link text too. Open to feedback, maybe we want to use the same cap as the subtitle, but I'm not as familiar with the designs.

### Test Plan

n/a

### Screenshots

| Before | After |
|---|---|
|  ![Screen Shot 2020-07-15 at 2 43 38 PM](https://user-images.githubusercontent.com/498212/87583804-7c472a00-c6aa-11ea-9317-32c02d1621ba.png) |  ![Screen Shot 2020-07-15 at 2 45 00 PM](https://user-images.githubusercontent.com/498212/87583826-8701bf00-c6aa-11ea-8179-b6acf8e1a634.png) |
|  ![Screen Shot 2020-07-15 at 2 43 40 PM](https://user-images.githubusercontent.com/498212/87583928-b284a980-c6aa-11ea-9900-7eaf26689011.png) |  ![Screen Shot 2020-07-15 at 2 44 55 PM](https://user-images.githubusercontent.com/498212/87583944-b9132100-c6aa-11ea-8888-61a6ed11fb8d.png) |
