### PR TITLE
[FX-2010] Add artworks to Artist Series

### DIFF
--- a/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
+++ b/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
@@ -139,7 +139,7 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
 - (ARCellData *)generateArtistSeries
 {
     return [self tappableCellDataWithTitle:@"Show Artist Series" selection:^{
-        AREigenArtistSeriesComponentViewController *viewController = [[AREigenArtistSeriesComponentViewController alloc] initWithArtistSeriesID:@"pumpkins"];
+        AREigenArtistSeriesComponentViewController *viewController = [[AREigenArtistSeriesComponentViewController alloc] initWithArtistSeriesID:@"yayoi-kusama-pumpkins"];
         [[ARTopMenuViewController sharedController] pushViewController:viewController animated:YES];
     }];
 }

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -37,6 +37,7 @@ upcoming:
     - Update bottom navigation tabs - david
     - Fixes small issue with the layout on LAI select-max-bid screens - ash
     - Fixes a problem where greyscale artwork images would be displayed as red in AR View in Room - ash
+    - Add Artist Series artworks - ashley
 
 releases:
   - version: 6.4.9

--- a/src/__generated__/ArtistSeriesArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,96 +1,39 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 6cdf139a8a823c99c4fa81c9c3d2fe61 */
+/* @relayHash f7a135f26df7f2ff55c37690f5964db0 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type ArtistSeriesTestsQueryVariables = {};
-export type ArtistSeriesTestsQueryResponse = {
+export type ArtistSeriesArtworksInfiniteScrollGridQueryVariables = {
+    id: string;
+    count: number;
+    cursor?: string | null;
+    sort?: string | null;
+};
+export type ArtistSeriesArtworksInfiniteScrollGridQueryResponse = {
     readonly artistSeries: {
-        readonly " $fragmentRefs": FragmentRefs<"ArtistSeries_artistSeries">;
+        readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesArtworks_artistSeries">;
     } | null;
 };
-export type ArtistSeriesTestsQueryRawResponse = {
-    readonly artistSeries: ({
-        readonly image: ({
-            readonly url: string | null;
-        }) | null;
-        readonly title: string;
-        readonly description: string | null;
-        readonly artists: ReadonlyArray<({
-            readonly id: string;
-            readonly internalID: string;
-            readonly name: string | null;
-            readonly slug: string;
-            readonly isFollowed: boolean | null;
-            readonly image: ({
-                readonly url: string | null;
-            }) | null;
-        }) | null> | null;
-        readonly artistSeriesArtworks: ({
-            readonly edges: ReadonlyArray<({
-                readonly node: ({
-                    readonly id: string;
-                    readonly slug: string;
-                    readonly image: ({
-                        readonly aspectRatio: number;
-                        readonly url: string | null;
-                    }) | null;
-                    readonly title: string | null;
-                    readonly date: string | null;
-                    readonly saleMessage: string | null;
-                    readonly artistNames: string | null;
-                    readonly href: string | null;
-                    readonly sale: ({
-                        readonly isAuction: boolean | null;
-                        readonly isClosed: boolean | null;
-                        readonly displayTimelyAt: string | null;
-                        readonly id: string | null;
-                    }) | null;
-                    readonly saleArtwork: ({
-                        readonly currentBid: ({
-                            readonly display: string | null;
-                        }) | null;
-                        readonly id: string | null;
-                    }) | null;
-                    readonly partner: ({
-                        readonly name: string | null;
-                        readonly id: string | null;
-                    }) | null;
-                    readonly __typename: "Artwork";
-                }) | null;
-                readonly cursor: string;
-                readonly id: string | null;
-            }) | null> | null;
-            readonly counts: ({
-                readonly total: number | null;
-            }) | null;
-            readonly pageInfo: {
-                readonly hasNextPage: boolean;
-                readonly startCursor: string | null;
-                readonly endCursor: string | null;
-            };
-            readonly id: string | null;
-        }) | null;
-    }) | null;
-};
-export type ArtistSeriesTestsQuery = {
-    readonly response: ArtistSeriesTestsQueryResponse;
-    readonly variables: ArtistSeriesTestsQueryVariables;
-    readonly rawResponse: ArtistSeriesTestsQueryRawResponse;
+export type ArtistSeriesArtworksInfiniteScrollGridQuery = {
+    readonly response: ArtistSeriesArtworksInfiniteScrollGridQueryResponse;
+    readonly variables: ArtistSeriesArtworksInfiniteScrollGridQueryVariables;
 };
 
 
 
 /*
-query ArtistSeriesTestsQuery {
-  artistSeries(id: "pumpkins") {
-    ...ArtistSeries_artistSeries
+query ArtistSeriesArtworksInfiniteScrollGridQuery(
+  $id: ID!
+  $sort: String
+) {
+  artistSeries(id: $id) {
+    ...ArtistSeriesArtworks_artistSeries_1RfMLO
   }
 }
 
-fragment ArtistSeriesArtworks_artistSeries on ArtistSeries {
-  artistSeriesArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch") {
+fragment ArtistSeriesArtworks_artistSeries_1RfMLO on ArtistSeries {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, sort: $sort) {
     edges {
       node {
         id
@@ -108,33 +51,6 @@ fragment ArtistSeriesArtworks_artistSeries on ArtistSeries {
     }
     id
   }
-}
-
-fragment ArtistSeriesHeader_artistSeries on ArtistSeries {
-  image {
-    url
-  }
-}
-
-fragment ArtistSeriesMeta_artistSeries on ArtistSeries {
-  title
-  description
-  artists(size: 1) {
-    id
-    internalID
-    name
-    slug
-    isFollowed
-    image {
-      url
-    }
-  }
-}
-
-fragment ArtistSeries_artistSeries on ArtistSeries {
-  ...ArtistSeriesHeader_artistSeries
-  ...ArtistSeriesMeta_artistSeries
-  ...ArtistSeriesArtworks_artistSeries
 }
 
 fragment ArtworkGridItem_artwork on Artwork {
@@ -192,91 +108,91 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
 const node: ConcreteRequest = (function(){
 var v0 = [
   {
-    "kind": "Literal",
+    "kind": "LocalArgument",
     "name": "id",
-    "value": "pumpkins"
+    "type": "ID!",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "count",
+    "type": "Int!",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "cursor",
+    "type": "String",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "sort",
+    "type": "String",
+    "defaultValue": null
   }
 ],
-v1 = {
-  "kind": "LinkedField",
-  "alias": null,
-  "name": "image",
-  "storageKey": null,
-  "args": null,
-  "concreteType": "Image",
-  "plural": false,
-  "selections": [
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "url",
-      "args": null,
-      "storageKey": null
-    }
-  ]
-},
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
 v2 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "title",
-  "args": null,
-  "storageKey": null
+  "kind": "Variable",
+  "name": "sort",
+  "variableName": "sort"
 },
-v3 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "id",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "name",
-  "args": null,
-  "storageKey": null
-},
-v5 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "slug",
-  "args": null,
-  "storageKey": null
-},
-v6 = [
+v3 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 20
   },
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "-decayed_merch"
-  }
-];
+  (v2/*: any*/)
+],
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+};
 return {
   "kind": "Request",
   "fragment": {
     "kind": "Fragment",
-    "name": "ArtistSeriesTestsQuery",
+    "name": "ArtistSeriesArtworksInfiniteScrollGridQuery",
     "type": "Query",
     "metadata": null,
-    "argumentDefinitions": [],
+    "argumentDefinitions": (v0/*: any*/),
     "selections": [
       {
         "kind": "LinkedField",
         "alias": null,
         "name": "artistSeries",
-        "storageKey": "artistSeries(id:\"pumpkins\")",
-        "args": (v0/*: any*/),
+        "storageKey": null,
+        "args": (v1/*: any*/),
         "concreteType": "ArtistSeries",
         "plural": false,
         "selections": [
           {
             "kind": "FragmentSpread",
-            "name": "ArtistSeries_artistSeries",
-            "args": null
+            "name": "ArtistSeriesArtworks_artistSeries",
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "count",
+                "variableName": "count"
+              },
+              {
+                "kind": "Variable",
+                "name": "cursor",
+                "variableName": "cursor"
+              },
+              (v2/*: any*/)
+            ]
           }
         ]
       }
@@ -284,68 +200,24 @@ return {
   },
   "operation": {
     "kind": "Operation",
-    "name": "ArtistSeriesTestsQuery",
-    "argumentDefinitions": [],
+    "name": "ArtistSeriesArtworksInfiniteScrollGridQuery",
+    "argumentDefinitions": (v0/*: any*/),
     "selections": [
       {
         "kind": "LinkedField",
         "alias": null,
         "name": "artistSeries",
-        "storageKey": "artistSeries(id:\"pumpkins\")",
-        "args": (v0/*: any*/),
+        "storageKey": null,
+        "args": (v1/*: any*/),
         "concreteType": "ArtistSeries",
         "plural": false,
         "selections": [
-          (v1/*: any*/),
-          (v2/*: any*/),
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "description",
-            "args": null,
-            "storageKey": null
-          },
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "artists",
-            "storageKey": "artists(size:1)",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "size",
-                "value": 1
-              }
-            ],
-            "concreteType": "Artist",
-            "plural": true,
-            "selections": [
-              (v3/*: any*/),
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "internalID",
-                "args": null,
-                "storageKey": null
-              },
-              (v4/*: any*/),
-              (v5/*: any*/),
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "isFollowed",
-                "args": null,
-                "storageKey": null
-              },
-              (v1/*: any*/)
-            ]
-          },
           {
             "kind": "LinkedField",
             "alias": "artistSeriesArtworks",
             "name": "filterArtworksConnection",
-            "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")",
-            "args": (v6/*: any*/),
+            "storageKey": null,
+            "args": (v3/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
@@ -367,8 +239,14 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
-                      (v5/*: any*/),
+                      (v4/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "slug",
+                        "args": null,
+                        "storageKey": null
+                      },
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -400,7 +278,13 @@ return {
                           }
                         ]
                       },
-                      (v2/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "title",
+                        "args": null,
+                        "storageKey": null
+                      },
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -459,7 +343,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v4/*: any*/)
                         ]
                       },
                       {
@@ -489,7 +373,7 @@ return {
                               }
                             ]
                           },
-                          (v3/*: any*/)
+                          (v4/*: any*/)
                         ]
                       },
                       {
@@ -501,8 +385,14 @@ return {
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
-                          (v3/*: any*/)
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "name",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v4/*: any*/)
                         ]
                       },
                       {
@@ -521,7 +411,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  (v3/*: any*/)
+                  (v4/*: any*/)
                 ]
               },
               {
@@ -574,14 +464,14 @@ return {
                   }
                 ]
               },
-              (v3/*: any*/)
+              (v4/*: any*/)
             ]
           },
           {
             "kind": "LinkedHandle",
             "alias": "artistSeriesArtworks",
             "name": "filterArtworksConnection",
-            "args": (v6/*: any*/),
+            "args": (v3/*: any*/),
             "handle": "connection",
             "key": "ArtistSeries_artistSeriesArtworks",
             "filters": [
@@ -594,12 +484,12 @@ return {
   },
   "params": {
     "operationKind": "query",
-    "name": "ArtistSeriesTestsQuery",
-    "id": "d91f183296f4dffcf29607d502c99e65",
+    "name": "ArtistSeriesArtworksInfiniteScrollGridQuery",
+    "id": "7f7d7b0171b00ea18bcffbb78460aff5",
     "text": null,
     "metadata": {}
   }
 };
 })();
-(node as any).hash = 'cb9b55b2d2788da2ecffb811cdebd6e3';
+(node as any).hash = '0c72212cf7d87ef79312e2984fe761f0';
 export default node;

--- a/src/__generated__/ArtistSeriesArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworksTestsQuery.graphql.ts
@@ -1,0 +1,498 @@
+/* tslint:disable */
+/* eslint-disable */
+/* @relayHash 4773c98e51eee428a953429902ba2e59 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistSeriesArtworksTestsQueryVariables = {};
+export type ArtistSeriesArtworksTestsQueryResponse = {
+    readonly artistSeries: {
+        readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesArtworks_artistSeries">;
+    } | null;
+};
+export type ArtistSeriesArtworksTestsQueryRawResponse = {
+    readonly artistSeries: ({
+        readonly artistSeriesArtworks: ({
+            readonly edges: ReadonlyArray<({
+                readonly node: ({
+                    readonly id: string;
+                    readonly slug: string;
+                    readonly image: ({
+                        readonly aspectRatio: number;
+                        readonly url: string | null;
+                    }) | null;
+                    readonly title: string | null;
+                    readonly date: string | null;
+                    readonly saleMessage: string | null;
+                    readonly artistNames: string | null;
+                    readonly href: string | null;
+                    readonly sale: ({
+                        readonly isAuction: boolean | null;
+                        readonly isClosed: boolean | null;
+                        readonly displayTimelyAt: string | null;
+                        readonly id: string | null;
+                    }) | null;
+                    readonly saleArtwork: ({
+                        readonly currentBid: ({
+                            readonly display: string | null;
+                        }) | null;
+                        readonly id: string | null;
+                    }) | null;
+                    readonly partner: ({
+                        readonly name: string | null;
+                        readonly id: string | null;
+                    }) | null;
+                    readonly __typename: "Artwork";
+                }) | null;
+                readonly cursor: string;
+                readonly id: string | null;
+            }) | null> | null;
+            readonly counts: ({
+                readonly total: number | null;
+            }) | null;
+            readonly pageInfo: {
+                readonly hasNextPage: boolean;
+                readonly startCursor: string | null;
+                readonly endCursor: string | null;
+            };
+            readonly id: string | null;
+        }) | null;
+    }) | null;
+};
+export type ArtistSeriesArtworksTestsQuery = {
+    readonly response: ArtistSeriesArtworksTestsQueryResponse;
+    readonly variables: ArtistSeriesArtworksTestsQueryVariables;
+    readonly rawResponse: ArtistSeriesArtworksTestsQueryRawResponse;
+};
+
+
+
+/*
+query ArtistSeriesArtworksTestsQuery {
+  artistSeries(id: "pumpkins") {
+    ...ArtistSeriesArtworks_artistSeries
+  }
+}
+
+fragment ArtistSeriesArtworks_artistSeries on ArtistSeries {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch") {
+    edges {
+      node {
+        id
+        __typename
+      }
+      cursor
+    }
+    counts {
+      total
+    }
+    ...InfiniteScrollArtworksGrid_connection
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    id
+  }
+}
+
+fragment ArtworkGridItem_artwork on Artwork {
+  title
+  date
+  saleMessage
+  slug
+  artistNames
+  href
+  sale {
+    isAuction
+    isClosed
+    displayTimelyAt
+    id
+  }
+  saleArtwork {
+    currentBid {
+      display
+    }
+    id
+  }
+  partner {
+    name
+    id
+  }
+  image {
+    url(version: "large")
+    aspectRatio
+  }
+}
+
+fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
+  pageInfo {
+    hasNextPage
+    startCursor
+    endCursor
+  }
+  edges {
+    __typename
+    node {
+      slug
+      id
+      image {
+        aspectRatio
+      }
+      ...ArtworkGridItem_artwork
+    }
+    ... on Node {
+      id
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "pumpkins"
+  }
+],
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 20
+  },
+  {
+    "kind": "Literal",
+    "name": "sort",
+    "value": "-decayed_merch"
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ArtistSeriesArtworksTestsQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artistSeries",
+        "storageKey": "artistSeries(id:\"pumpkins\")",
+        "args": (v0/*: any*/),
+        "concreteType": "ArtistSeries",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ArtistSeriesArtworks_artistSeries",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ArtistSeriesArtworksTestsQuery",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artistSeries",
+        "storageKey": "artistSeries(id:\"pumpkins\")",
+        "args": (v0/*: any*/),
+        "concreteType": "ArtistSeries",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": "artistSeriesArtworks",
+            "name": "filterArtworksConnection",
+            "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")",
+            "args": (v1/*: any*/),
+            "concreteType": "FilterArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "slug",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "image",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "aspectRatio",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "url",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "large"
+                              }
+                            ],
+                            "storageKey": "url(version:\"large\")"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "title",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "date",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "saleMessage",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "artistNames",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "href",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "sale",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "isAuction",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "isClosed",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayTimelyAt",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v2/*: any*/)
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "saleArtwork",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "currentBid",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCurrentBid",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "display",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
+                          },
+                          (v2/*: any*/)
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "partner",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Partner",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "name",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v2/*: any*/)
+                        ]
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "__typename",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "cursor",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  (v2/*: any*/)
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "counts",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "FilterArtworksCounts",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "total",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageInfo",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "hasNextPage",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "startCursor",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "endCursor",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              (v2/*: any*/)
+            ]
+          },
+          {
+            "kind": "LinkedHandle",
+            "alias": "artistSeriesArtworks",
+            "name": "filterArtworksConnection",
+            "args": (v1/*: any*/),
+            "handle": "connection",
+            "key": "ArtistSeries_artistSeriesArtworks",
+            "filters": [
+              "sort"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "ArtistSeriesArtworksTestsQuery",
+    "id": "f9984475749ea2dcfe170c7876d331fc",
+    "text": null,
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = 'dd616f7d9adf8f2d10c2990c09ac203d';
+export default node;

--- a/src/__generated__/ArtistSeriesArtworks_artistSeries.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworks_artistSeries.graphql.ts
@@ -1,0 +1,176 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistSeriesArtworks_artistSeries = {
+    readonly artistSeriesArtworks: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly id: string;
+            } | null;
+        } | null> | null;
+        readonly counts: {
+            readonly total: number | null;
+        } | null;
+        readonly " $fragmentRefs": FragmentRefs<"InfiniteScrollArtworksGrid_connection">;
+    } | null;
+    readonly " $refType": "ArtistSeriesArtworks_artistSeries";
+};
+export type ArtistSeriesArtworks_artistSeries$data = ArtistSeriesArtworks_artistSeries;
+export type ArtistSeriesArtworks_artistSeries$key = {
+    readonly " $data"?: ArtistSeriesArtworks_artistSeries$data;
+    readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesArtworks_artistSeries">;
+};
+
+
+
+const node: ReaderFragment = {
+  "kind": "Fragment",
+  "name": "ArtistSeriesArtworks_artistSeries",
+  "type": "ArtistSeries",
+  "metadata": {
+    "connection": [
+      {
+        "count": null,
+        "cursor": null,
+        "direction": "forward",
+        "path": [
+          "artistSeriesArtworks"
+        ]
+      }
+    ]
+  },
+  "argumentDefinitions": [
+    {
+      "kind": "LocalArgument",
+      "name": "count",
+      "type": "Int",
+      "defaultValue": 20
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "cursor",
+      "type": "String",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "sort",
+      "type": "String",
+      "defaultValue": "-decayed_merch"
+    }
+  ],
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": "artistSeriesArtworks",
+      "name": "__ArtistSeries_artistSeriesArtworks_connection",
+      "storageKey": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "sort",
+          "variableName": "sort"
+        }
+      ],
+      "concreteType": "FilterArtworksConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "FilterArtworksEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "Artwork",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "id",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "__typename",
+                  "args": null,
+                  "storageKey": null
+                }
+              ]
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "cursor",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        },
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "counts",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "FilterArtworksCounts",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "total",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        },
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "pageInfo",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "endCursor",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "hasNextPage",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        },
+        {
+          "kind": "FragmentSpread",
+          "name": "InfiniteScrollArtworksGrid_connection",
+          "args": null
+        }
+      ]
+    }
+  ]
+};
+(node as any).hash = '8b3036cc1240602c9a263679d82046cd';
+export default node;

--- a/src/__generated__/ArtistSeriesHeaderTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesHeaderTestsQuery.graphql.ts
@@ -1,0 +1,123 @@
+/* tslint:disable */
+/* eslint-disable */
+/* @relayHash 6e3d211b45cf8e314eff21570cb5c2cc */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistSeriesHeaderTestsQueryVariables = {};
+export type ArtistSeriesHeaderTestsQueryResponse = {
+    readonly artistSeries: {
+        readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesHeader_artistSeries">;
+    } | null;
+};
+export type ArtistSeriesHeaderTestsQueryRawResponse = {
+    readonly artistSeries: ({
+        readonly image: ({
+            readonly url: string | null;
+        }) | null;
+    }) | null;
+};
+export type ArtistSeriesHeaderTestsQuery = {
+    readonly response: ArtistSeriesHeaderTestsQueryResponse;
+    readonly variables: ArtistSeriesHeaderTestsQueryVariables;
+    readonly rawResponse: ArtistSeriesHeaderTestsQueryRawResponse;
+};
+
+
+
+/*
+query ArtistSeriesHeaderTestsQuery {
+  artistSeries(id: "pumpkins") {
+    ...ArtistSeriesHeader_artistSeries
+  }
+}
+
+fragment ArtistSeriesHeader_artistSeries on ArtistSeries {
+  image {
+    url
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "pumpkins"
+  }
+];
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ArtistSeriesHeaderTestsQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artistSeries",
+        "storageKey": "artistSeries(id:\"pumpkins\")",
+        "args": (v0/*: any*/),
+        "concreteType": "ArtistSeries",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ArtistSeriesHeader_artistSeries",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ArtistSeriesHeaderTestsQuery",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artistSeries",
+        "storageKey": "artistSeries(id:\"pumpkins\")",
+        "args": (v0/*: any*/),
+        "concreteType": "ArtistSeries",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "image",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Image",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "url",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "ArtistSeriesHeaderTestsQuery",
+    "id": "2453dc5a4829c2699e9627c3f450faaf",
+    "text": null,
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = '8195b41790b6eb2e0d25a9d32e318b3f';
+export default node;

--- a/src/__generated__/ArtistSeriesHeader_artistSeries.graphql.ts
+++ b/src/__generated__/ArtistSeriesHeader_artistSeries.graphql.ts
@@ -4,14 +4,8 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ArtistSeriesHeader_artistSeries = {
-    readonly imageURL: string | null;
-    readonly filterArtworksConnection: {
-        readonly edges: ReadonlyArray<{
-            readonly node: {
-                readonly title: string | null;
-                readonly imageUrl: string | null;
-            } | null;
-        } | null> | null;
+    readonly image: {
+        readonly url: string | null;
     } | null;
     readonly " $refType": "ArtistSeriesHeader_artistSeries";
 };
@@ -31,71 +25,24 @@ const node: ReaderFragment = {
   "argumentDefinitions": [],
   "selections": [
     {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "imageURL",
-      "args": null,
-      "storageKey": null
-    },
-    {
       "kind": "LinkedField",
       "alias": null,
-      "name": "filterArtworksConnection",
-      "storageKey": "filterArtworksConnection(first:1,sort:\"-merchandisability\")",
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "first",
-          "value": 1
-        },
-        {
-          "kind": "Literal",
-          "name": "sort",
-          "value": "-merchandisability"
-        }
-      ],
-      "concreteType": "FilterArtworksConnection",
+      "name": "image",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Image",
       "plural": false,
       "selections": [
         {
-          "kind": "LinkedField",
+          "kind": "ScalarField",
           "alias": null,
-          "name": "edges",
-          "storageKey": null,
+          "name": "url",
           "args": null,
-          "concreteType": "FilterArtworksEdge",
-          "plural": true,
-          "selections": [
-            {
-              "kind": "LinkedField",
-              "alias": null,
-              "name": "node",
-              "storageKey": null,
-              "args": null,
-              "concreteType": "Artwork",
-              "plural": false,
-              "selections": [
-                {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "title",
-                  "args": null,
-                  "storageKey": null
-                },
-                {
-                  "kind": "ScalarField",
-                  "alias": null,
-                  "name": "imageUrl",
-                  "args": null,
-                  "storageKey": null
-                }
-              ]
-            }
-          ]
+          "storageKey": null
         }
       ]
     }
   ]
 };
-(node as any).hash = '27c76f9a13ec3dd6700c77c66078f2ab';
+(node as any).hash = 'ae504c6f5001719cf6611e595d431138';
 export default node;

--- a/src/__generated__/ArtistSeriesHeader_artistSeries.graphql.ts
+++ b/src/__generated__/ArtistSeriesHeader_artistSeries.graphql.ts
@@ -1,0 +1,101 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistSeriesHeader_artistSeries = {
+    readonly imageURL: string | null;
+    readonly filterArtworksConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly title: string | null;
+                readonly imageUrl: string | null;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "ArtistSeriesHeader_artistSeries";
+};
+export type ArtistSeriesHeader_artistSeries$data = ArtistSeriesHeader_artistSeries;
+export type ArtistSeriesHeader_artistSeries$key = {
+    readonly " $data"?: ArtistSeriesHeader_artistSeries$data;
+    readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesHeader_artistSeries">;
+};
+
+
+
+const node: ReaderFragment = {
+  "kind": "Fragment",
+  "name": "ArtistSeriesHeader_artistSeries",
+  "type": "ArtistSeries",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "imageURL",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "filterArtworksConnection",
+      "storageKey": "filterArtworksConnection(first:1,sort:\"-merchandisability\")",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 1
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "-merchandisability"
+        }
+      ],
+      "concreteType": "FilterArtworksConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "FilterArtworksEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "Artwork",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "title",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "imageUrl",
+                  "args": null,
+                  "storageKey": null
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+(node as any).hash = '27c76f9a13ec3dd6700c77c66078f2ab';
+export default node;

--- a/src/__generated__/ArtistSeriesMetaFollowMutation.graphql.ts
+++ b/src/__generated__/ArtistSeriesMetaFollowMutation.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 53dbae3d92ddad6e39a94f74119ab673 */
+/* @relayHash afdc8c803d9fa9ef550b11dd0dd3ee50 */
 
 import { ConcreteRequest } from "relay-runtime";
 export type FollowArtistInput = {
@@ -8,25 +8,25 @@ export type FollowArtistInput = {
     clientMutationId?: string | null;
     unfollow?: boolean | null;
 };
-export type ArtistSeriesFollowMutationVariables = {
+export type ArtistSeriesMetaFollowMutationVariables = {
     input: FollowArtistInput;
 };
-export type ArtistSeriesFollowMutationResponse = {
+export type ArtistSeriesMetaFollowMutationResponse = {
     readonly followArtist: {
         readonly artist: {
             readonly isFollowed: boolean | null;
         } | null;
     } | null;
 };
-export type ArtistSeriesFollowMutation = {
-    readonly response: ArtistSeriesFollowMutationResponse;
-    readonly variables: ArtistSeriesFollowMutationVariables;
+export type ArtistSeriesMetaFollowMutation = {
+    readonly response: ArtistSeriesMetaFollowMutationResponse;
+    readonly variables: ArtistSeriesMetaFollowMutationVariables;
 };
 
 
 
 /*
-mutation ArtistSeriesFollowMutation(
+mutation ArtistSeriesMetaFollowMutation(
   $input: FollowArtistInput!
 ) {
   followArtist(input: $input) {
@@ -65,7 +65,7 @@ return {
   "kind": "Request",
   "fragment": {
     "kind": "Fragment",
-    "name": "ArtistSeriesFollowMutation",
+    "name": "ArtistSeriesMetaFollowMutation",
     "type": "Mutation",
     "metadata": null,
     "argumentDefinitions": (v0/*: any*/),
@@ -97,7 +97,7 @@ return {
   },
   "operation": {
     "kind": "Operation",
-    "name": "ArtistSeriesFollowMutation",
+    "name": "ArtistSeriesMetaFollowMutation",
     "argumentDefinitions": (v0/*: any*/),
     "selections": [
       {
@@ -134,12 +134,12 @@ return {
   },
   "params": {
     "operationKind": "mutation",
-    "name": "ArtistSeriesFollowMutation",
-    "id": "523157dd273912ab22e752fcb3ff4806",
+    "name": "ArtistSeriesMetaFollowMutation",
+    "id": "628973ab7893ef6c168d9a16152051e6",
     "text": null,
     "metadata": {}
   }
 };
 })();
-(node as any).hash = 'e848b22662bb6e1289fc8ab8dbd8b911';
+(node as any).hash = 'b3e0958b2c8727600b7c82ef0c74630f';
 export default node;

--- a/src/__generated__/ArtistSeriesMetaTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesMetaTestsQuery.graphql.ts
@@ -1,0 +1,207 @@
+/* tslint:disable */
+/* eslint-disable */
+/* @relayHash e0a5259ac54b7ff145dfb81f23ce138f */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistSeriesMetaTestsQueryVariables = {};
+export type ArtistSeriesMetaTestsQueryResponse = {
+    readonly artistSeries: {
+        readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesMeta_artistSeries">;
+    } | null;
+};
+export type ArtistSeriesMetaTestsQueryRawResponse = {
+    readonly artistSeries: ({
+        readonly title: string;
+        readonly description: string | null;
+        readonly artists: ReadonlyArray<({
+            readonly id: string;
+            readonly internalID: string;
+            readonly name: string | null;
+            readonly slug: string;
+            readonly isFollowed: boolean | null;
+            readonly image: ({
+                readonly url: string | null;
+            }) | null;
+        }) | null> | null;
+    }) | null;
+};
+export type ArtistSeriesMetaTestsQuery = {
+    readonly response: ArtistSeriesMetaTestsQueryResponse;
+    readonly variables: ArtistSeriesMetaTestsQueryVariables;
+    readonly rawResponse: ArtistSeriesMetaTestsQueryRawResponse;
+};
+
+
+
+/*
+query ArtistSeriesMetaTestsQuery {
+  artistSeries(id: "pumpkins") {
+    ...ArtistSeriesMeta_artistSeries
+  }
+}
+
+fragment ArtistSeriesMeta_artistSeries on ArtistSeries {
+  title
+  description
+  artists(size: 1) {
+    id
+    internalID
+    name
+    slug
+    isFollowed
+    image {
+      url
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "pumpkins"
+  }
+];
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ArtistSeriesMetaTestsQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artistSeries",
+        "storageKey": "artistSeries(id:\"pumpkins\")",
+        "args": (v0/*: any*/),
+        "concreteType": "ArtistSeries",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ArtistSeriesMeta_artistSeries",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ArtistSeriesMetaTestsQuery",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artistSeries",
+        "storageKey": "artistSeries(id:\"pumpkins\")",
+        "args": (v0/*: any*/),
+        "concreteType": "ArtistSeries",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "title",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "description",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "artists",
+            "storageKey": "artists(size:1)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 1
+              }
+            ],
+            "concreteType": "Artist",
+            "plural": true,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "id",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "internalID",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "name",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "slug",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "isFollowed",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "image",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Image",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "url",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "ArtistSeriesMetaTestsQuery",
+    "id": "96297eb198ba2a98c38275bd3e1ebce1",
+    "text": null,
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = '2cf5b0db7dfe478f822b91fb4ee2e201';
+export default node;

--- a/src/__generated__/ArtistSeriesMeta_artistSeries.graphql.ts
+++ b/src/__generated__/ArtistSeriesMeta_artistSeries.graphql.ts
@@ -1,0 +1,123 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistSeriesMeta_artistSeries = {
+    readonly title: string;
+    readonly description: string | null;
+    readonly artists: ReadonlyArray<{
+        readonly id: string;
+        readonly internalID: string;
+        readonly name: string | null;
+        readonly slug: string;
+        readonly isFollowed: boolean | null;
+        readonly image: {
+            readonly url: string | null;
+        } | null;
+    } | null> | null;
+    readonly " $refType": "ArtistSeriesMeta_artistSeries";
+};
+export type ArtistSeriesMeta_artistSeries$data = ArtistSeriesMeta_artistSeries;
+export type ArtistSeriesMeta_artistSeries$key = {
+    readonly " $data"?: ArtistSeriesMeta_artistSeries$data;
+    readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesMeta_artistSeries">;
+};
+
+
+
+const node: ReaderFragment = {
+  "kind": "Fragment",
+  "name": "ArtistSeriesMeta_artistSeries",
+  "type": "ArtistSeries",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "title",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "description",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "artists",
+      "storageKey": "artists(size:1)",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "size",
+          "value": 1
+        }
+      ],
+      "concreteType": "Artist",
+      "plural": true,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "id",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "internalID",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "name",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "slug",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "isFollowed",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "image",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "Image",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "url",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+(node as any).hash = 'abb8be191522eed818cbe29c578aab06';
+export default node;

--- a/src/__generated__/ArtistSeriesQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash bb2ab734b051cf2e25ba4f0556556117 */
+/* @relayHash 9902e19b56aec9ed5af1af98c8944ac0 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -28,17 +28,30 @@ query ArtistSeriesQuery(
   }
 }
 
-fragment ArtistSeriesHeader_artistSeries on ArtistSeries {
-  imageURL
-  filterArtworksConnection(first: 1, sort: "-merchandisability") {
+fragment ArtistSeriesArtworks_artistSeries on ArtistSeries {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch") {
     edges {
       node {
-        title
-        imageUrl
         id
+        __typename
       }
+      cursor
+    }
+    counts {
+      total
+    }
+    ...InfiniteScrollArtworksGrid_connection
+    pageInfo {
+      endCursor
+      hasNextPage
     }
     id
+  }
+}
+
+fragment ArtistSeriesHeader_artistSeries on ArtistSeries {
+  image {
+    url
   }
 }
 
@@ -58,8 +71,60 @@ fragment ArtistSeriesMeta_artistSeries on ArtistSeries {
 }
 
 fragment ArtistSeries_artistSeries on ArtistSeries {
-  ...ArtistSeriesMeta_artistSeries
   ...ArtistSeriesHeader_artistSeries
+  ...ArtistSeriesMeta_artistSeries
+  ...ArtistSeriesArtworks_artistSeries
+}
+
+fragment ArtworkGridItem_artwork on Artwork {
+  title
+  date
+  saleMessage
+  slug
+  artistNames
+  href
+  sale {
+    isAuction
+    isClosed
+    displayTimelyAt
+    id
+  }
+  saleArtwork {
+    currentBid {
+      display
+    }
+    id
+  }
+  partner {
+    name
+    id
+  }
+  image {
+    url(version: "large")
+    aspectRatio
+  }
+}
+
+fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
+  pageInfo {
+    hasNextPage
+    startCursor
+    endCursor
+  }
+  edges {
+    __typename
+    node {
+      slug
+      id
+      image {
+        aspectRatio
+      }
+      ...ArtworkGridItem_artwork
+    }
+    ... on Node {
+      id
+    }
+  }
 }
 */
 
@@ -80,19 +145,63 @@ v1 = [
   }
 ],
 v2 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "image",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Image",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "url",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+},
+v3 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "title",
   "args": null,
   "storageKey": null
 },
-v3 = {
+v4 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
-};
+},
+v5 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "slug",
+  "args": null,
+  "storageKey": null
+},
+v7 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 20
+  },
+  {
+    "kind": "Literal",
+    "name": "sort",
+    "value": "-decayed_merch"
+  }
+];
 return {
   "kind": "Request",
   "fragment": {
@@ -135,6 +244,7 @@ return {
         "plural": false,
         "selections": [
           (v2/*: any*/),
+          (v3/*: any*/),
           {
             "kind": "ScalarField",
             "alias": null,
@@ -157,7 +267,7 @@ return {
             "concreteType": "Artist",
             "plural": true,
             "selections": [
-              (v3/*: any*/),
+              (v4/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -165,20 +275,8 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "name",
-                "args": null,
-                "storageKey": null
-              },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "slug",
-                "args": null,
-                "storageKey": null
-              },
+              (v5/*: any*/),
+              (v6/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -186,50 +284,15 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "image",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "Image",
-                "plural": false,
-                "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "url",
-                    "args": null,
-                    "storageKey": null
-                  }
-                ]
-              }
+              (v2/*: any*/)
             ]
           },
           {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "imageURL",
-            "args": null,
-            "storageKey": null
-          },
-          {
             "kind": "LinkedField",
-            "alias": null,
+            "alias": "artistSeriesArtworks",
             "name": "filterArtworksConnection",
-            "storageKey": "filterArtworksConnection(first:1,sort:\"-merchandisability\")",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 1
-              },
-              {
-                "kind": "Literal",
-                "name": "sort",
-                "value": "-merchandisability"
-              }
-            ],
+            "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")",
+            "args": (v7/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
@@ -251,20 +314,225 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v2/*: any*/),
+                      (v4/*: any*/),
+                      (v6/*: any*/),
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "image",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "aspectRatio",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "url",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "large"
+                              }
+                            ],
+                            "storageKey": "url(version:\"large\")"
+                          }
+                        ]
+                      },
+                      (v3/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
-                        "name": "imageUrl",
+                        "name": "date",
                         "args": null,
                         "storageKey": null
                       },
-                      (v3/*: any*/)
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "saleMessage",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "artistNames",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "href",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "sale",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "isAuction",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "isClosed",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayTimelyAt",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v4/*: any*/)
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "saleArtwork",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "currentBid",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCurrentBid",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "display",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
+                          },
+                          (v4/*: any*/)
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "partner",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Partner",
+                        "plural": false,
+                        "selections": [
+                          (v5/*: any*/),
+                          (v4/*: any*/)
+                        ]
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "__typename",
+                        "args": null,
+                        "storageKey": null
+                      }
                     ]
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "cursor",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  (v4/*: any*/)
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "counts",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "FilterArtworksCounts",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "total",
+                    "args": null,
+                    "storageKey": null
                   }
                 ]
               },
-              (v3/*: any*/)
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageInfo",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "hasNextPage",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "startCursor",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "endCursor",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              (v4/*: any*/)
+            ]
+          },
+          {
+            "kind": "LinkedHandle",
+            "alias": "artistSeriesArtworks",
+            "name": "filterArtworksConnection",
+            "args": (v7/*: any*/),
+            "handle": "connection",
+            "key": "ArtistSeries_artistSeriesArtworks",
+            "filters": [
+              "sort"
             ]
           }
         ]
@@ -274,7 +542,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesQuery",
-    "id": "1c067eb1b2a9a3951e595d81a0334796",
+    "id": "f2bb83638b152ed27e1d4949d1c6f200",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeriesQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash ef4c138b735e5cf99ca458f332e78a6b */
+/* @relayHash bb2ab734b051cf2e25ba4f0556556117 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -28,6 +28,20 @@ query ArtistSeriesQuery(
   }
 }
 
+fragment ArtistSeriesHeader_artistSeries on ArtistSeries {
+  imageURL
+  filterArtworksConnection(first: 1, sort: "-merchandisability") {
+    edges {
+      node {
+        title
+        imageUrl
+        id
+      }
+    }
+    id
+  }
+}
+
 fragment ArtistSeriesMeta_artistSeries on ArtistSeries {
   title
   description
@@ -45,6 +59,7 @@ fragment ArtistSeriesMeta_artistSeries on ArtistSeries {
 
 fragment ArtistSeries_artistSeries on ArtistSeries {
   ...ArtistSeriesMeta_artistSeries
+  ...ArtistSeriesHeader_artistSeries
 }
 */
 
@@ -63,7 +78,21 @@ v1 = [
     "name": "id",
     "variableName": "artistSeriesID"
   }
-];
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "title",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+};
 return {
   "kind": "Request",
   "fragment": {
@@ -105,13 +134,7 @@ return {
         "concreteType": "ArtistSeries",
         "plural": false,
         "selections": [
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "title",
-            "args": null,
-            "storageKey": null
-          },
+          (v2/*: any*/),
           {
             "kind": "ScalarField",
             "alias": null,
@@ -134,13 +157,7 @@ return {
             "concreteType": "Artist",
             "plural": true,
             "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "id",
-                "args": null,
-                "storageKey": null
-              },
+              (v3/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -188,6 +205,67 @@ return {
                 ]
               }
             ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "imageURL",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "filterArtworksConnection",
+            "storageKey": "filterArtworksConnection(first:1,sort:\"-merchandisability\")",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 1
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "-merchandisability"
+              }
+            ],
+            "concreteType": "FilterArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "imageUrl",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      (v3/*: any*/)
+                    ]
+                  }
+                ]
+              },
+              (v3/*: any*/)
+            ]
           }
         ]
       }
@@ -196,7 +274,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesQuery",
-    "id": "5f8225dde15fb8dae26ea295f2210e95",
+    "id": "1c067eb1b2a9a3951e595d81a0334796",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeriesQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash f453ae8e50a326744e7c136c6402d6f5 */
+/* @relayHash ef4c138b735e5cf99ca458f332e78a6b */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -28,7 +28,7 @@ query ArtistSeriesQuery(
   }
 }
 
-fragment ArtistSeries_artistSeries on ArtistSeries {
+fragment ArtistSeriesMeta_artistSeries on ArtistSeries {
   title
   description
   artists(size: 1) {
@@ -41,6 +41,10 @@ fragment ArtistSeries_artistSeries on ArtistSeries {
       url
     }
   }
+}
+
+fragment ArtistSeries_artistSeries on ArtistSeries {
+  ...ArtistSeriesMeta_artistSeries
 }
 */
 
@@ -192,7 +196,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesQuery",
-    "id": "8b9cacebfc7a89f55e062e98dd9c9af4",
+    "id": "5f8225dde15fb8dae26ea295f2210e95",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash b897d699ccaae40eb73234fd3e8bc2c5 */
+/* @relayHash f89ca29654e2f6dac25c9ac81b15d924 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -41,7 +41,7 @@ query ArtistSeriesTestsQuery {
   }
 }
 
-fragment ArtistSeries_artistSeries on ArtistSeries {
+fragment ArtistSeriesMeta_artistSeries on ArtistSeries {
   title
   description
   artists(size: 1) {
@@ -54,6 +54,10 @@ fragment ArtistSeries_artistSeries on ArtistSeries {
       url
     }
   }
+}
+
+fragment ArtistSeries_artistSeries on ArtistSeries {
+  ...ArtistSeriesMeta_artistSeries
 }
 */
 
@@ -197,7 +201,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesTestsQuery",
-    "id": "45ea5ef1e176129e6a3264383a9b4a3e",
+    "id": "7e22f3fad50d4f34a863b53ef97cd537",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash f89ca29654e2f6dac25c9ac81b15d924 */
+/* @relayHash 218756445f0fbc0b8dedfb347b0d1d47 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -24,6 +24,17 @@ export type ArtistSeriesTestsQueryRawResponse = {
                 readonly url: string | null;
             }) | null;
         }) | null> | null;
+        readonly imageURL: string | null;
+        readonly filterArtworksConnection: ({
+            readonly edges: ReadonlyArray<({
+                readonly node: ({
+                    readonly title: string | null;
+                    readonly imageUrl: string | null;
+                    readonly id: string | null;
+                }) | null;
+            }) | null> | null;
+            readonly id: string | null;
+        }) | null;
     }) | null;
 };
 export type ArtistSeriesTestsQuery = {
@@ -38,6 +49,20 @@ export type ArtistSeriesTestsQuery = {
 query ArtistSeriesTestsQuery {
   artistSeries(id: "pumpkins") {
     ...ArtistSeries_artistSeries
+  }
+}
+
+fragment ArtistSeriesHeader_artistSeries on ArtistSeries {
+  imageURL
+  filterArtworksConnection(first: 1, sort: "-merchandisability") {
+    edges {
+      node {
+        title
+        imageUrl
+        id
+      }
+    }
+    id
   }
 }
 
@@ -58,6 +83,7 @@ fragment ArtistSeriesMeta_artistSeries on ArtistSeries {
 
 fragment ArtistSeries_artistSeries on ArtistSeries {
   ...ArtistSeriesMeta_artistSeries
+  ...ArtistSeriesHeader_artistSeries
 }
 */
 
@@ -68,7 +94,21 @@ var v0 = [
     "name": "id",
     "value": "pumpkins"
   }
-];
+],
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "title",
+  "args": null,
+  "storageKey": null
+},
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+};
 return {
   "kind": "Request",
   "fragment": {
@@ -110,13 +150,7 @@ return {
         "concreteType": "ArtistSeries",
         "plural": false,
         "selections": [
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "title",
-            "args": null,
-            "storageKey": null
-          },
+          (v1/*: any*/),
           {
             "kind": "ScalarField",
             "alias": null,
@@ -139,13 +173,7 @@ return {
             "concreteType": "Artist",
             "plural": true,
             "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "id",
-                "args": null,
-                "storageKey": null
-              },
+              (v2/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -193,6 +221,67 @@ return {
                 ]
               }
             ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "imageURL",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "filterArtworksConnection",
+            "storageKey": "filterArtworksConnection(first:1,sort:\"-merchandisability\")",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 1
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "-merchandisability"
+              }
+            ],
+            "concreteType": "FilterArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "plural": false,
+                    "selections": [
+                      (v1/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "imageUrl",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      (v2/*: any*/)
+                    ]
+                  }
+                ]
+              },
+              (v2/*: any*/)
+            ]
           }
         ]
       }
@@ -201,7 +290,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesTestsQuery",
-    "id": "7e22f3fad50d4f34a863b53ef97cd537",
+    "id": "3db326c243a77e56afbde3d197f3a470",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeries_artistSeries.graphql.ts
+++ b/src/__generated__/ArtistSeries_artistSeries.graphql.ts
@@ -4,7 +4,7 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ArtistSeries_artistSeries = {
-    readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesMeta_artistSeries" | "ArtistSeriesHeader_artistSeries">;
+    readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesHeader_artistSeries" | "ArtistSeriesMeta_artistSeries" | "ArtistSeriesArtworks_artistSeries">;
     readonly " $refType": "ArtistSeries_artistSeries";
 };
 export type ArtistSeries_artistSeries$data = ArtistSeries_artistSeries;
@@ -24,15 +24,20 @@ const node: ReaderFragment = {
   "selections": [
     {
       "kind": "FragmentSpread",
+      "name": "ArtistSeriesHeader_artistSeries",
+      "args": null
+    },
+    {
+      "kind": "FragmentSpread",
       "name": "ArtistSeriesMeta_artistSeries",
       "args": null
     },
     {
       "kind": "FragmentSpread",
-      "name": "ArtistSeriesHeader_artistSeries",
+      "name": "ArtistSeriesArtworks_artistSeries",
       "args": null
     }
   ]
 };
-(node as any).hash = '4002124279b6693393baf88109d83a95';
+(node as any).hash = '63c7c8120fcd0f25ac4fdedd7b23e8ce';
 export default node;

--- a/src/__generated__/ArtistSeries_artistSeries.graphql.ts
+++ b/src/__generated__/ArtistSeries_artistSeries.graphql.ts
@@ -4,18 +4,7 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ArtistSeries_artistSeries = {
-    readonly title: string;
-    readonly description: string | null;
-    readonly artists: ReadonlyArray<{
-        readonly id: string;
-        readonly internalID: string;
-        readonly name: string | null;
-        readonly slug: string;
-        readonly isFollowed: boolean | null;
-        readonly image: {
-            readonly url: string | null;
-        } | null;
-    } | null> | null;
+    readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesMeta_artistSeries">;
     readonly " $refType": "ArtistSeries_artistSeries";
 };
 export type ArtistSeries_artistSeries$data = ArtistSeries_artistSeries;
@@ -34,90 +23,11 @@ const node: ReaderFragment = {
   "argumentDefinitions": [],
   "selections": [
     {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "title",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "description",
-      "args": null,
-      "storageKey": null
-    },
-    {
-      "kind": "LinkedField",
-      "alias": null,
-      "name": "artists",
-      "storageKey": "artists(size:1)",
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "size",
-          "value": 1
-        }
-      ],
-      "concreteType": "Artist",
-      "plural": true,
-      "selections": [
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "id",
-          "args": null,
-          "storageKey": null
-        },
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "internalID",
-          "args": null,
-          "storageKey": null
-        },
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "name",
-          "args": null,
-          "storageKey": null
-        },
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "slug",
-          "args": null,
-          "storageKey": null
-        },
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "isFollowed",
-          "args": null,
-          "storageKey": null
-        },
-        {
-          "kind": "LinkedField",
-          "alias": null,
-          "name": "image",
-          "storageKey": null,
-          "args": null,
-          "concreteType": "Image",
-          "plural": false,
-          "selections": [
-            {
-              "kind": "ScalarField",
-              "alias": null,
-              "name": "url",
-              "args": null,
-              "storageKey": null
-            }
-          ]
-        }
-      ]
+      "kind": "FragmentSpread",
+      "name": "ArtistSeriesMeta_artistSeries",
+      "args": null
     }
   ]
 };
-(node as any).hash = 'e8f5745659042d101887387b164c3823';
+(node as any).hash = '2ac26cee63800c5dc6723900d081fe48';
 export default node;

--- a/src/__generated__/ArtistSeries_artistSeries.graphql.ts
+++ b/src/__generated__/ArtistSeries_artistSeries.graphql.ts
@@ -4,7 +4,7 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ArtistSeries_artistSeries = {
-    readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesMeta_artistSeries">;
+    readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesMeta_artistSeries" | "ArtistSeriesHeader_artistSeries">;
     readonly " $refType": "ArtistSeries_artistSeries";
 };
 export type ArtistSeries_artistSeries$data = ArtistSeries_artistSeries;
@@ -26,8 +26,13 @@ const node: ReaderFragment = {
       "kind": "FragmentSpread",
       "name": "ArtistSeriesMeta_artistSeries",
       "args": null
+    },
+    {
+      "kind": "FragmentSpread",
+      "name": "ArtistSeriesHeader_artistSeries",
+      "args": null
     }
   ]
 };
-(node as any).hash = '2ac26cee63800c5dc6723900d081fe48';
+(node as any).hash = '4002124279b6693393baf88109d83a95';
 export default node;

--- a/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
@@ -1,13 +1,12 @@
-import { Box, Flex, Spacer, Theme } from "@artsy/palette"
+import { Box, Spacer, Theme } from "@artsy/palette"
 import { ArtistSeries_artistSeries } from "__generated__/ArtistSeries_artistSeries.graphql"
 import { ArtistSeriesQuery } from "__generated__/ArtistSeriesQuery.graphql"
 import { AboveTheFoldFlatList } from "lib/Components/AboveTheFoldFlatList"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
-import { ArtistSeriesHeader } from "lib/Scenes/ArtistSeries/ArtistSeriesHeader"
+import { ArtistSeriesHeaderFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesHeader"
 import { ArtistSeriesMetaFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesMeta"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import React from "react"
-import { View } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 interface ArtistSeriesProps {
   artistSeries: ArtistSeries_artistSeries
@@ -22,7 +21,7 @@ export const ArtistSeries: React.FC<ArtistSeriesProps> = ({ artistSeries }) => {
           showsVerticalScrollIndicator={false}
           initialNumToRender={3}
           data={sections}
-          ListHeaderComponent={<ArtistSeriesHeader />}
+          ListHeaderComponent={<ArtistSeriesHeaderFragmentContainer artistSeries={artistSeries} />}
           ItemSeparatorComponent={() => <Spacer mb={2} />}
           keyExtractor={(_item, index) => String(index)}
           renderItem={({ item }): null | any => {
@@ -41,6 +40,7 @@ export const ArtistSeriesFragmentContainer = createFragmentContainer(ArtistSerie
   artistSeries: graphql`
     fragment ArtistSeries_artistSeries on ArtistSeries {
       ...ArtistSeriesMeta_artistSeries
+      ...ArtistSeriesHeader_artistSeries
     }
   `,
 })

--- a/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
@@ -3,17 +3,19 @@ import { ArtistSeries_artistSeries } from "__generated__/ArtistSeries_artistSeri
 import { ArtistSeriesQuery } from "__generated__/ArtistSeriesQuery.graphql"
 import { AboveTheFoldFlatList } from "lib/Components/AboveTheFoldFlatList"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
+import { ArtistSeriesArtworksFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesArtworks"
 import { ArtistSeriesHeaderFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesHeader"
 import { ArtistSeriesMetaFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesMeta"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import React from "react"
+
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 interface ArtistSeriesProps {
   artistSeries: ArtistSeries_artistSeries
 }
 
 export const ArtistSeries: React.FC<ArtistSeriesProps> = ({ artistSeries }) => {
-  const sections = ["artistSeriesMeta", "artistSeriesArtwork"]
+  const sections = ["artistSeriesMeta", "artistSeriesArtworks"]
   return (
     <Theme>
       <Box px={2}>
@@ -24,11 +26,14 @@ export const ArtistSeries: React.FC<ArtistSeriesProps> = ({ artistSeries }) => {
           ListHeaderComponent={<ArtistSeriesHeaderFragmentContainer artistSeries={artistSeries} />}
           ItemSeparatorComponent={() => <Spacer mb={2} />}
           keyExtractor={(_item, index) => String(index)}
-          renderItem={({ item }): null | any => {
+          renderItem={({ item }) => {
             switch (item) {
               case "artistSeriesMeta":
                 return <ArtistSeriesMetaFragmentContainer artistSeries={artistSeries} />
+              case "artistSeriesArtworks":
+                return <ArtistSeriesArtworksFragmentContainer artistSeries={artistSeries} />
             }
+            return null
           }}
         />
       </Box>
@@ -39,8 +44,9 @@ export const ArtistSeries: React.FC<ArtistSeriesProps> = ({ artistSeries }) => {
 export const ArtistSeriesFragmentContainer = createFragmentContainer(ArtistSeries, {
   artistSeries: graphql`
     fragment ArtistSeries_artistSeries on ArtistSeries {
-      ...ArtistSeriesMeta_artistSeries
       ...ArtistSeriesHeader_artistSeries
+      ...ArtistSeriesMeta_artistSeries
+      ...ArtistSeriesArtworks_artistSeries
     }
   `,
 })

--- a/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
@@ -1,117 +1,46 @@
-import { Box, EntityHeader, Flex, Sans } from "@artsy/palette"
+import { Box, Flex, Spacer, Theme } from "@artsy/palette"
 import { ArtistSeries_artistSeries } from "__generated__/ArtistSeries_artistSeries.graphql"
-import { ArtistSeriesFollowMutation } from "__generated__/ArtistSeriesFollowMutation.graphql"
 import { ArtistSeriesQuery } from "__generated__/ArtistSeriesQuery.graphql"
-import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
-import { ReadMore } from "lib/Components/ReadMore"
-import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { AboveTheFoldFlatList } from "lib/Components/AboveTheFoldFlatList"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
+import { ArtistSeriesHeader } from "lib/Scenes/ArtistSeries/ArtistSeriesHeader"
+import { ArtistSeriesMetaFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesMeta"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
-import { useScreenDimensions } from "lib/utils/useScreenDimensions"
-import React, { useRef } from "react"
-import { TouchableOpacity, TouchableWithoutFeedback, View } from "react-native"
-import { commitMutation, createFragmentContainer, graphql, QueryRenderer, RelayProp } from "react-relay"
-
+import React from "react"
+import { View } from "react-native"
+import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 interface ArtistSeriesProps {
   artistSeries: ArtistSeries_artistSeries
-  relay: RelayProp
 }
 
-type ArtistToFollowOrUnfollow = NonNullable<NonNullable<ArtistSeriesProps["artistSeries"]["artists"]>[0]>
-
-export const ArtistSeries: React.FC<ArtistSeriesProps> = ({ artistSeries, relay }) => {
-  const { width } = useScreenDimensions()
-  const isIPad = width > 700
-  const maxChars = isIPad ? 200 : 120
-  const ref = useRef<View | null>(null)
-
-  const followOrUnfollowArtist = (followArtist: ArtistToFollowOrUnfollow) => {
-    return new Promise<void>((resolve, reject) => {
-      commitMutation<ArtistSeriesFollowMutation>(relay.environment, {
-        mutation: graphql`
-          mutation ArtistSeriesFollowMutation($input: FollowArtistInput!) {
-            followArtist(input: $input) {
-              artist {
-                isFollowed
-              }
-            }
-          }
-        `,
-        variables: {
-          input: { artistID: followArtist.internalID, unfollow: followArtist.isFollowed },
-        },
-        onError: reject,
-        onCompleted: (_response, errors) => {
-          if (errors && errors.length > 0) {
-            reject(new Error(JSON.stringify(errors)))
-          } else {
-            resolve()
-          }
-        },
-      })
-    })
-  }
-
+export const ArtistSeries: React.FC<ArtistSeriesProps> = ({ artistSeries }) => {
+  const sections = ["artistSeriesMeta", "artistSeriesArtwork"]
   return (
-    <View ref={ref}>
-      <Box p={2}>
-        <Flex flexDirection="row" justifyContent="center">
-          {/* TODO: add image url */}
-          <OpaqueImageView width={180} height={180} />
-        </Flex>
-        <Sans size="8" mt={3} data-test-id="title">
-          {artistSeries.title}
-        </Sans>
-        {(artistSeries?.artists ?? []).length > 0 &&
-          artistSeries.artists?.map(
-            artist =>
-              !!artist?.name && (
-                <TouchableOpacity
-                  key={artist?.id as string}
-                  onPress={() => {
-                    SwitchBoard.presentNavigationViewController(ref.current!, `/artist/${artist.slug}`)
-                  }}
-                  style={{ marginVertical: 10 }}
-                >
-                  <EntityHeader
-                    smallVariant
-                    name={artist?.name}
-                    imageUrl={artist?.image?.url as string}
-                    FollowButton={
-                      <TouchableWithoutFeedback
-                        onPress={() => followOrUnfollowArtist(artist)}
-                        hitSlop={{ top: 20, left: 20, bottom: 20, right: 20 }}
-                      >
-                        <Sans style={{ textDecorationLine: "underline" }} size="3">
-                          {artist.isFollowed ? "Following" : "Follow"}
-                        </Sans>
-                      </TouchableWithoutFeedback>
-                    }
-                  />
-                </TouchableOpacity>
-              )
-          )}
-        <ReadMore data-test-id="description" sans content={artistSeries?.description ?? ""} maxChars={maxChars} />
+    <Theme>
+      <Box px={2}>
+        <AboveTheFoldFlatList
+          showsVerticalScrollIndicator={false}
+          initialNumToRender={3}
+          data={sections}
+          ListHeaderComponent={<ArtistSeriesHeader />}
+          ItemSeparatorComponent={() => <Spacer mb={2} />}
+          keyExtractor={(_item, index) => String(index)}
+          renderItem={({ item }): null | any => {
+            switch (item) {
+              case "artistSeriesMeta":
+                return <ArtistSeriesMetaFragmentContainer artistSeries={artistSeries} />
+            }
+          }}
+        />
       </Box>
-    </View>
+    </Theme>
   )
 }
 
 export const ArtistSeriesFragmentContainer = createFragmentContainer(ArtistSeries, {
   artistSeries: graphql`
     fragment ArtistSeries_artistSeries on ArtistSeries {
-      title
-      description
-      artists(size: 1) {
-        id
-        internalID
-        name
-        slug
-        isFollowed
-        image {
-          url
-        }
-      }
+      ...ArtistSeriesMeta_artistSeries
     }
   `,
 })

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
@@ -1,0 +1,83 @@
+import { Box, Separator } from "@artsy/palette"
+import { ArtistSeriesArtworks_artistSeries } from "__generated__/ArtistSeriesArtworks_artistSeries.graphql"
+import { InfiniteScrollArtworksGridContainer } from "lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
+import React from "react"
+import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
+
+interface ArtistSeriesArtworksProps {
+  artistSeries: ArtistSeriesArtworks_artistSeries
+  relay: RelayPaginationProp
+}
+export const ArtistSeriesArtworks: React.FC<ArtistSeriesArtworksProps> = ({ artistSeries, relay }) => {
+  const artworks = artistSeries?.artistSeriesArtworks!
+
+  if (artworks?.counts?.total === 0) {
+    return null
+  }
+
+  return (
+    <Box>
+      <Separator mb={3} mt={1} />
+      <InfiniteScrollArtworksGridContainer
+        connection={artworks}
+        loadMore={relay.loadMore}
+        hasMore={relay.hasMore}
+        isLoading={relay.isLoading}
+      />
+    </Box>
+  )
+}
+
+export const ArtistSeriesArtworksFragmentContainer = createPaginationContainer(
+  ArtistSeriesArtworks,
+  {
+    artistSeries: graphql`
+      fragment ArtistSeriesArtworks_artistSeries on ArtistSeries
+        @argumentDefinitions(
+          count: { type: "Int", defaultValue: 20 }
+          cursor: { type: "String" }
+          sort: { type: "String", defaultValue: "-decayed_merch" }
+        ) {
+        artistSeriesArtworks: filterArtworksConnection(first: 20, sort: $sort)
+          @connection(key: "ArtistSeries_artistSeriesArtworks") {
+          edges {
+            node {
+              id
+            }
+          }
+          counts {
+            total
+          }
+          ...InfiniteScrollArtworksGrid_connection
+        }
+      }
+    `,
+  },
+  {
+    direction: "forward",
+    getConnectionFromProps(props) {
+      return props?.artistSeries.artistSeriesArtworks
+    },
+    getFragmentVariables(previousVariables, totalCount) {
+      return {
+        ...previousVariables,
+        count: totalCount,
+      }
+    },
+    getVariables(props, { count, cursor }, fragmentVariables) {
+      return {
+        ...fragmentVariables,
+        props,
+        count,
+        cursor,
+      }
+    },
+    query: graphql`
+      query ArtistSeriesArtworksInfiniteScrollGridQuery($id: ID!, $count: Int!, $cursor: String, $sort: String) {
+        artistSeries(id: $id) {
+          ...ArtistSeriesArtworks_artistSeries @arguments(count: $count, cursor: $cursor, sort: $sort)
+        }
+      }
+    `,
+  }
+)

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesHeader.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesHeader.tsx
@@ -1,0 +1,12 @@
+import { Flex } from "@artsy/palette"
+import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
+import React from "react"
+
+export const ArtistSeriesHeader = () => {
+  return (
+    <Flex flexDirection="row" justifyContent="center">
+      {/* TODO: add image url */}
+      <OpaqueImageView width={180} height={180} />
+    </Flex>
+  )
+}

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesHeader.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesHeader.tsx
@@ -1,12 +1,36 @@
 import { Flex } from "@artsy/palette"
+import { ArtistSeriesHeader_artistSeries } from "__generated__/ArtistSeriesHeader_artistSeries.graphql"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
 
-export const ArtistSeriesHeader = () => {
+interface ArtistSeriesHeaderProps {
+  artistSeries: ArtistSeriesHeader_artistSeries
+}
+export const ArtistSeriesHeader: React.SFC<ArtistSeriesHeaderProps> = ({ artistSeries }) => {
+  const url = artistSeries.imageURL
+    ? artistSeries.imageURL
+    : artistSeries.filterArtworksConnection?.edges?.[0]?.node?.imageUrl
+
   return (
     <Flex flexDirection="row" justifyContent="center">
-      {/* TODO: add image url */}
-      <OpaqueImageView width={180} height={180} />
+      <OpaqueImageView width={180} height={180} imageURL={url} />
     </Flex>
   )
 }
+
+export const ArtistSeriesHeaderFragmentContainer = createFragmentContainer(ArtistSeriesHeader, {
+  artistSeries: graphql`
+    fragment ArtistSeriesHeader_artistSeries on ArtistSeries {
+      imageURL
+      filterArtworksConnection(first: 1, sort: "-merchandisability") {
+        edges {
+          node {
+            title
+            imageUrl
+          }
+        }
+      }
+    }
+  `,
+})

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesHeader.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesHeader.tsx
@@ -8,9 +8,7 @@ interface ArtistSeriesHeaderProps {
   artistSeries: ArtistSeriesHeader_artistSeries
 }
 export const ArtistSeriesHeader: React.SFC<ArtistSeriesHeaderProps> = ({ artistSeries }) => {
-  const url = artistSeries.imageURL
-    ? artistSeries.imageURL
-    : artistSeries.filterArtworksConnection?.edges?.[0]?.node?.imageUrl
+  const url = artistSeries.image?.url!
 
   return (
     <Flex flexDirection="row" justifyContent="center">
@@ -22,14 +20,8 @@ export const ArtistSeriesHeader: React.SFC<ArtistSeriesHeaderProps> = ({ artistS
 export const ArtistSeriesHeaderFragmentContainer = createFragmentContainer(ArtistSeriesHeader, {
   artistSeries: graphql`
     fragment ArtistSeriesHeader_artistSeries on ArtistSeries {
-      imageURL
-      filterArtworksConnection(first: 1, sort: "-merchandisability") {
-        edges {
-          node {
-            title
-            imageUrl
-          }
-        }
+      image {
+        url
       }
     }
   `,

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesMeta.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesMeta.tsx
@@ -1,4 +1,4 @@
-import { Box, EntityHeader, Sans } from "@artsy/palette"
+import { EntityHeader, Sans } from "@artsy/palette"
 import { ArtistSeriesMeta_artistSeries } from "__generated__/ArtistSeriesMeta_artistSeries.graphql"
 import { ArtistSeriesMetaFollowMutation } from "__generated__/ArtistSeriesMetaFollowMutation.graphql"
 import { ReadMore } from "lib/Components/ReadMore"
@@ -16,11 +16,12 @@ interface ArtistSeriesMetaProps {
 type ArtistToFollowOrUnfollow = NonNullable<NonNullable<ArtistSeriesMetaProps["artistSeries"]["artists"]>[0]>
 
 export const ArtistSeriesMeta: React.SFC<ArtistSeriesMetaProps> = ({ artistSeries, relay }) => {
-  const ref = useRef<View | null>(null)
+  const metaRef = useRef<View | null>(null)
 
   const { width } = useScreenDimensions()
   const isIPad = width > 700
   const maxChars = isIPad ? 200 : 120
+  const artist = artistSeries?.artists?.[0]
 
   const followOrUnfollowArtist = (followArtist: ArtistToFollowOrUnfollow) => {
     return new Promise<void>((resolve, reject) => {
@@ -50,41 +51,37 @@ export const ArtistSeriesMeta: React.SFC<ArtistSeriesMetaProps> = ({ artistSerie
   }
 
   return (
-    <Box ref={ref}>
+    <View ref={metaRef}>
       <Sans size="8" mt={3} data-test-id="title">
         {artistSeries.title}
       </Sans>
-      {(artistSeries?.artists ?? []).length > 0 &&
-        artistSeries.artists?.map(
-          artist =>
-            !!artist?.name && (
-              <TouchableOpacity
-                key={artist?.id as string}
-                onPress={() => {
-                  SwitchBoard.presentNavigationViewController(ref.current!, `/artist/${artist.slug}`)
-                }}
-                style={{ marginVertical: 10 }}
+      {!!artist && (
+        <TouchableOpacity
+          key={artist.id!}
+          onPress={() => {
+            SwitchBoard.presentNavigationViewController(metaRef.current!, `/artist/${artist.slug}`)
+          }}
+          style={{ marginVertical: 10 }}
+        >
+          <EntityHeader
+            smallVariant
+            name={artist.name!}
+            imageUrl={artist.image?.url!}
+            FollowButton={
+              <TouchableWithoutFeedback
+                onPress={() => followOrUnfollowArtist(artist)}
+                hitSlop={{ top: 20, left: 20, bottom: 20, right: 20 }}
               >
-                <EntityHeader
-                  smallVariant
-                  name={artist?.name}
-                  imageUrl={artist?.image?.url as string}
-                  FollowButton={
-                    <TouchableWithoutFeedback
-                      onPress={() => followOrUnfollowArtist(artist)}
-                      hitSlop={{ top: 20, left: 20, bottom: 20, right: 20 }}
-                    >
-                      <Sans style={{ textDecorationLine: "underline" }} size="3">
-                        {artist.isFollowed ? "Following" : "Follow"}
-                      </Sans>
-                    </TouchableWithoutFeedback>
-                  }
-                />
-              </TouchableOpacity>
-            )
-        )}
+                <Sans style={{ textDecorationLine: "underline" }} size="3">
+                  {artist.isFollowed ? "Following" : "Follow"}
+                </Sans>
+              </TouchableWithoutFeedback>
+            }
+          />
+        </TouchableOpacity>
+      )}
       <ReadMore data-test-id="description" sans content={artistSeries?.description ?? ""} maxChars={maxChars} />
-    </Box>
+    </View>
   )
 }
 

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesMeta.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesMeta.tsx
@@ -1,16 +1,12 @@
-import { Box, EntityHeader, Flex, Sans } from "@artsy/palette"
+import { Box, EntityHeader, Sans } from "@artsy/palette"
 import { ArtistSeriesMeta_artistSeries } from "__generated__/ArtistSeriesMeta_artistSeries.graphql"
 import { ArtistSeriesMetaFollowMutation } from "__generated__/ArtistSeriesMetaFollowMutation.graphql"
-import { ArtistSeriesQuery } from "__generated__/ArtistSeriesQuery.graphql"
-import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { ReadMore } from "lib/Components/ReadMore"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
-import { defaultEnvironment } from "lib/relay/createEnvironment"
-import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import React, { useRef } from "react"
 import { TouchableOpacity, TouchableWithoutFeedback, View } from "react-native"
-import { commitMutation, createFragmentContainer, graphql, QueryRenderer, RelayProp } from "react-relay"
+import { commitMutation, createFragmentContainer, graphql, RelayProp } from "react-relay"
 
 interface ArtistSeriesMetaProps {
   artistSeries: ArtistSeriesMeta_artistSeries

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesMeta.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesMeta.tsx
@@ -1,0 +1,112 @@
+import { Box, EntityHeader, Flex, Sans } from "@artsy/palette"
+import { ArtistSeriesMeta_artistSeries } from "__generated__/ArtistSeriesMeta_artistSeries.graphql"
+import { ArtistSeriesMetaFollowMutation } from "__generated__/ArtistSeriesMetaFollowMutation.graphql"
+import { ArtistSeriesQuery } from "__generated__/ArtistSeriesQuery.graphql"
+import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
+import { ReadMore } from "lib/Components/ReadMore"
+import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { defaultEnvironment } from "lib/relay/createEnvironment"
+import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
+import { useScreenDimensions } from "lib/utils/useScreenDimensions"
+import React, { useRef } from "react"
+import { TouchableOpacity, TouchableWithoutFeedback, View } from "react-native"
+import { commitMutation, createFragmentContainer, graphql, QueryRenderer, RelayProp } from "react-relay"
+
+interface ArtistSeriesMetaProps {
+  artistSeries: ArtistSeriesMeta_artistSeries
+  relay: RelayProp
+}
+
+type ArtistToFollowOrUnfollow = NonNullable<NonNullable<ArtistSeriesMetaProps["artistSeries"]["artists"]>[0]>
+
+export const ArtistSeriesMeta: React.SFC<ArtistSeriesMetaProps> = ({ artistSeries, relay }) => {
+  const ref = useRef<View | null>(null)
+
+  const { width } = useScreenDimensions()
+  const isIPad = width > 700
+  const maxChars = isIPad ? 200 : 120
+
+  const followOrUnfollowArtist = (followArtist: ArtistToFollowOrUnfollow) => {
+    return new Promise<void>((resolve, reject) => {
+      commitMutation<ArtistSeriesMetaFollowMutation>(relay.environment, {
+        mutation: graphql`
+          mutation ArtistSeriesMetaFollowMutation($input: FollowArtistInput!) {
+            followArtist(input: $input) {
+              artist {
+                isFollowed
+              }
+            }
+          }
+        `,
+        variables: {
+          input: { artistID: followArtist.internalID, unfollow: followArtist.isFollowed },
+        },
+        onError: reject,
+        onCompleted: (_response, errors) => {
+          if (errors && errors.length > 0) {
+            reject(new Error(JSON.stringify(errors)))
+          } else {
+            resolve()
+          }
+        },
+      })
+    })
+  }
+
+  return (
+    <Box ref={ref}>
+      <Sans size="8" mt={3} data-test-id="title">
+        {artistSeries.title}
+      </Sans>
+      {(artistSeries?.artists ?? []).length > 0 &&
+        artistSeries.artists?.map(
+          artist =>
+            !!artist?.name && (
+              <TouchableOpacity
+                key={artist?.id as string}
+                onPress={() => {
+                  SwitchBoard.presentNavigationViewController(ref.current!, `/artist/${artist.slug}`)
+                }}
+                style={{ marginVertical: 10 }}
+              >
+                <EntityHeader
+                  smallVariant
+                  name={artist?.name}
+                  imageUrl={artist?.image?.url as string}
+                  FollowButton={
+                    <TouchableWithoutFeedback
+                      onPress={() => followOrUnfollowArtist(artist)}
+                      hitSlop={{ top: 20, left: 20, bottom: 20, right: 20 }}
+                    >
+                      <Sans style={{ textDecorationLine: "underline" }} size="3">
+                        {artist.isFollowed ? "Following" : "Follow"}
+                      </Sans>
+                    </TouchableWithoutFeedback>
+                  }
+                />
+              </TouchableOpacity>
+            )
+        )}
+      <ReadMore data-test-id="description" sans content={artistSeries?.description ?? ""} maxChars={maxChars} />
+    </Box>
+  )
+}
+
+export const ArtistSeriesMetaFragmentContainer = createFragmentContainer(ArtistSeriesMeta, {
+  artistSeries: graphql`
+    fragment ArtistSeriesMeta_artistSeries on ArtistSeries {
+      title
+      description
+      artists(size: 1) {
+        id
+        internalID
+        name
+        slug
+        isFollowed
+        image {
+          url
+        }
+      }
+    }
+  `,
+})

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesArtworks-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesArtworks-tests.tsx
@@ -1,0 +1,185 @@
+import { Theme } from "@artsy/palette"
+import {
+  ArtistSeriesArtworksTestsQuery,
+  ArtistSeriesArtworksTestsQueryRawResponse,
+} from "__generated__/ArtistSeriesArtworksTestsQuery.graphql"
+import { InfiniteScrollArtworksGridContainer } from "lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
+import { ArtistSeriesArtworksFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesArtworks"
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import ReactTestRenderer, { act } from "react-test-renderer"
+import { createMockEnvironment } from "relay-test-utils"
+
+jest.unmock("react-relay")
+
+describe("Artist Series Artworks", () => {
+  let env: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => {
+    env = createMockEnvironment()
+  })
+
+  const TestRenderer = () => (
+    <QueryRenderer<ArtistSeriesArtworksTestsQuery>
+      environment={env}
+      query={graphql`
+        query ArtistSeriesArtworksTestsQuery @raw_response_type {
+          artistSeries(id: "pumpkins") {
+            ...ArtistSeriesArtworks_artistSeries
+          }
+        }
+      `}
+      variables={{ artistSeriesID: "pumpkins" }}
+      render={({ props, error }) => {
+        if (props?.artistSeries) {
+          return (
+            <Theme>
+              <ArtistSeriesArtworksFragmentContainer artistSeries={props.artistSeries} />
+            </Theme>
+          )
+        } else if (error) {
+          console.log(error)
+        }
+      }}
+    />
+  )
+
+  it("renders an artwork grid if artworks", () => {
+    const wrapper = () => {
+      const tree = ReactTestRenderer.create(<TestRenderer />)
+      act(() => {
+        env.mock.resolveMostRecentOperation({
+          errors: [],
+          data: {
+            ...ArtistSeriesArtworksFixture,
+          },
+        })
+      })
+      return tree
+    }
+
+    expect(wrapper().root.findAllByType(InfiniteScrollArtworksGridContainer)).toHaveLength(1)
+  })
+
+  it("renders a null component if no artworks", () => {
+    const wrapper = () => {
+      const tree = ReactTestRenderer.create(<TestRenderer />)
+      act(() => {
+        env.mock.resolveMostRecentOperation({
+          errors: [],
+          data: {
+            ...ArtistSeriesZeroArtworksFixture,
+          },
+        })
+      })
+      return tree
+    }
+
+    expect(wrapper().root.findAllByType(InfiniteScrollArtworksGridContainer)).toHaveLength(0)
+  })
+})
+
+const ArtistSeriesArtworksFixture: ArtistSeriesArtworksTestsQueryRawResponse = {
+  artistSeries: {
+    artistSeriesArtworks: {
+      pageInfo: {
+        hasNextPage: false,
+        startCursor: "ajdjabnz81",
+        endCursor: "aknqa9d81",
+      },
+      id: null,
+      counts: { total: 4 },
+      edges: [
+        {
+          node: {
+            id: "12345654321",
+            slug: "pumpkins-1",
+            image: null,
+            title: "Pumpkins 1.0",
+            date: null,
+            saleMessage: null,
+            artistNames: null,
+            href: null,
+            sale: null,
+            saleArtwork: null,
+            partner: null,
+            __typename: "Artwork",
+          },
+          cursor: "123456789",
+          id: "#8989141",
+        },
+        {
+          node: {
+            id: "9874491018",
+            slug: "pumpkins-2",
+            image: null,
+            title: "Pumpkins 2.0",
+            date: null,
+            saleMessage: null,
+            artistNames: null,
+            href: null,
+            sale: null,
+            saleArtwork: null,
+            partner: null,
+            __typename: "Artwork",
+          },
+          cursor: "98761511",
+          id: "faf91kjg8",
+        },
+        {
+          node: {
+            id: "128163456",
+            slug: "pumpkins-3",
+            image: null,
+            title: "Pumpkins 3.0",
+            date: null,
+            saleMessage: null,
+            artistNames: null,
+            href: null,
+            sale: null,
+            saleArtwork: null,
+            partner: null,
+            __typename: "Artwork",
+          },
+          cursor: "19017613",
+          id: "fja91k30v",
+        },
+        {
+          node: {
+            id: "123310456",
+            slug: "pumpkins-4",
+            image: null,
+            title: "Pumpkins 4.0",
+            date: null,
+            saleMessage: null,
+            artistNames: null,
+            href: null,
+            sale: null,
+            saleArtwork: null,
+            partner: null,
+            __typename: "Artwork",
+          },
+          cursor: "01827111",
+          id: "afd7a91m1",
+        },
+      ],
+    },
+  },
+}
+
+const ArtistSeriesZeroArtworksFixture: ArtistSeriesArtworksTestsQueryRawResponse = {
+  artistSeries: {
+    artistSeriesArtworks: {
+      pageInfo: {
+        hasNextPage: false,
+        startCursor: "ajdjabnz81",
+        endCursor: "aknqa9d81",
+      },
+      id: null,
+      counts: {
+        total: 0,
+      },
+      edges: [],
+    },
+  },
+}

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesHeader-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesHeader-tests.tsx
@@ -1,0 +1,73 @@
+import { Theme } from "@artsy/palette"
+import {
+  ArtistSeriesHeaderTestsQuery,
+  ArtistSeriesHeaderTestsQueryRawResponse,
+} from "__generated__/ArtistSeriesHeaderTestsQuery.graphql"
+import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
+import { ArtistSeriesHeaderFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesHeader"
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import ReactTestRenderer, { act } from "react-test-renderer"
+import { createMockEnvironment } from "relay-test-utils"
+
+jest.unmock("react-relay")
+
+describe("Artist Series Header", () => {
+  let env: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => {
+    env = createMockEnvironment()
+  })
+
+  const TestRenderer = () => (
+    <QueryRenderer<ArtistSeriesHeaderTestsQuery>
+      environment={env}
+      query={graphql`
+        query ArtistSeriesHeaderTestsQuery @raw_response_type {
+          artistSeries(id: "pumpkins") {
+            ...ArtistSeriesHeader_artistSeries
+          }
+        }
+      `}
+      variables={{ artistSeriesID: "pumpkins" }}
+      render={({ props, error }) => {
+        if (props?.artistSeries) {
+          return (
+            <Theme>
+              <ArtistSeriesHeaderFragmentContainer artistSeries={props.artistSeries} />
+            </Theme>
+          )
+        } else if (error) {
+          console.log(error)
+        }
+      }}
+    />
+  )
+
+  it("renders the Artist Series header", () => {
+    const wrapper = () => {
+      const tree = ReactTestRenderer.create(<TestRenderer />)
+      act(() => {
+        env.mock.resolveMostRecentOperation({
+          errors: [],
+          data: {
+            ...ArtistSeriesHeaderFixture,
+          },
+        })
+      })
+      return tree
+    }
+
+    expect(wrapper().root.findByType(OpaqueImageView).props.imageURL).toBe(
+      "https://www.imagesofpumpkins.cloudfront.net/primary/square.jpg"
+    )
+  })
+})
+
+const ArtistSeriesHeaderFixture: ArtistSeriesHeaderTestsQueryRawResponse = {
+  artistSeries: {
+    image: {
+      url: "https://www.imagesofpumpkins.cloudfront.net/primary/square.jpg",
+    },
+  },
+}

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesMeta-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesMeta-tests.tsx
@@ -1,19 +1,22 @@
 import { EntityHeader, Theme } from "@artsy/palette"
-import { ArtistSeriesTestsQuery, ArtistSeriesTestsQueryRawResponse } from "__generated__/ArtistSeriesTestsQuery.graphql"
+import {
+  ArtistSeriesMetaTestsQuery,
+  ArtistSeriesMetaTestsQueryRawResponse,
+} from "__generated__/ArtistSeriesMetaTestsQuery.graphql"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { ArtistSeriesMeta, ArtistSeriesMetaFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesMeta"
 import React from "react"
 import { TouchableOpacity } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
 import ReactTestRenderer, { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
-import { ArtistSeries, ArtistSeriesFragmentContainer } from "../ArtistSeries"
 
 jest.unmock("react-relay")
 jest.mock("lib/NativeModules/SwitchBoard", () => ({
   presentNavigationViewController: jest.fn(),
 }))
 
-describe("Artist Series Rail", () => {
+describe("Artist Series Meta", () => {
   let env: ReturnType<typeof createMockEnvironment>
 
   beforeEach(() => {
@@ -21,12 +24,12 @@ describe("Artist Series Rail", () => {
   })
 
   const TestRenderer = () => (
-    <QueryRenderer<ArtistSeriesTestsQuery>
+    <QueryRenderer<ArtistSeriesMetaTestsQuery>
       environment={env}
       query={graphql`
-        query ArtistSeriesTestsQuery @raw_response_type {
+        query ArtistSeriesMetaTestsQuery @raw_response_type {
           artistSeries(id: "pumpkins") {
-            ...ArtistSeries_artistSeries
+            ...ArtistSeriesMeta_artistSeries
           }
         }
       `}
@@ -35,7 +38,7 @@ describe("Artist Series Rail", () => {
         if (props?.artistSeries) {
           return (
             <Theme>
-              <ArtistSeriesFragmentContainer artistSeries={props.artistSeries} />
+              <ArtistSeriesMetaFragmentContainer artistSeries={props.artistSeries} />
             </Theme>
           )
         } else if (error) {
@@ -60,7 +63,7 @@ describe("Artist Series Rail", () => {
 
   it("renders without throwing an error", () => {
     const wrapper = getWrapper()
-    expect(wrapper.root.findAllByType(ArtistSeries)).toHaveLength(1)
+    expect(wrapper.root.findAllByType(ArtistSeriesMeta)).toHaveLength(1)
   })
 
   it("renders the Artist Series title", () => {
@@ -88,13 +91,10 @@ describe("Artist Series Rail", () => {
   })
 })
 
-const ArtistSeriesFixture: ArtistSeriesTestsQueryRawResponse = {
+const ArtistSeriesFixture: ArtistSeriesMetaTestsQueryRawResponse = {
   artistSeries: {
     title: "These are the Pumpkins",
     description: "A deliciously artistic variety of painted pumpkins.",
-    image: {
-      url: "https://www.imagesofthispumpkin.net/pgn",
-    },
     artists: [
       {
         id: "an-id",
@@ -107,34 +107,5 @@ const ArtistSeriesFixture: ArtistSeriesTestsQueryRawResponse = {
         },
       },
     ],
-    artistSeriesArtworks: {
-      pageInfo: {
-        hasNextPage: false,
-        startCursor: "ajdjabnz81",
-        endCursor: "aknqa9d81",
-      },
-      id: null,
-      counts: { total: 4 },
-      edges: [
-        {
-          node: {
-            id: "12345654321",
-            slug: "pumpkins-1",
-            image: null,
-            title: "Pumpkins 1.0",
-            date: null,
-            saleMessage: null,
-            artistNames: null,
-            href: null,
-            sale: null,
-            saleArtwork: null,
-            partner: null,
-            __typename: "Artwork",
-          },
-          cursor: "123456789",
-          id: "#8989141",
-        },
-      ],
-    },
   },
 }


### PR DESCRIPTION
The type of this PR is: Feature

<!-- Bugfix/Feature/Enhancement.. -->

This PR resolves: [FX-2010](https://artsyproduct.atlassian.net/browse/FX-2010) and [FX-2050](https://artsyproduct.atlassian.net/browse/FX-2050)

### Description

Implements an infinite scroll artwork grid on the Artist Series view.  In order to implement this feature I had to refactor the Artist Series "home page" to use a `Flatlist`.  This refactor involved breaking out the existing components into separate files (including test files). I also added a header image url to the Artist Series Header, which takes care of  [FX-2050](https://artsyproduct.atlassian.net/browse/FX-2050).

### Test Plan
 
@ashleyjelks  and @nicoleyeo will QA the new changes in a beta.

### Screenshots

![Kapture 2020-07-17 at 16 40 21](https://user-images.githubusercontent.com/10385964/87829369-f3b4bf00-c84c-11ea-8bdf-1658c9a7982d.gif)
