### PR TITLE
Fixes problem selecting home tab initially

### DIFF
--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.m
@@ -118,7 +118,8 @@ static ARTopMenuViewController *_sharedManager = nil;
     self.buttonController = [[ARComponentViewController alloc] initWithEmission:nil
                                                                      moduleName:@"BottomTabs"
                                                               initialProperties:@{}];
-
+    
+    self.currentTab = [ARTabType home];
     [self.tabContentView forceSetCurrentTab:[ARTabType home] animated:NO];
     [tabContainer addSubview:self.buttonController.view];
     [self.buttonController.view alignToView:tabContainer];
@@ -343,7 +344,7 @@ static ARTopMenuViewController *_sharedManager = nil;
 
 - (void)presentRootViewControllerInTab:(NSString *)tabType animated:(BOOL)animated;
 {
-    BOOL alreadySelectedTab = self.currentTab == tabType;
+    BOOL alreadySelectedTab = [self.currentTab isEqual:tabType];
     ARNavigationController *controller = [self rootNavigationControllerAtTab:tabType];
 
     if (!alreadySelectedTab) {

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,6 +5,7 @@ upcoming:
     -
   user_facing:
     - Add Artist Series artworks - ashley
+    - Fixes a bug when selecting home tab - ash
 
 releases:
   - version: 6.5.0


### PR DESCRIPTION
The type of this PR is: **bugfix**

### Description

Here's the bug:

- Open the app. It shows the home tab.
- Without tapping into another tab, tap the home tab icon.

What happens is we see a blank screen, and the other tabs are unresponsive. 

The cause of the bug is that the `currentTab` property isn't initially set to anything, leading the comparison to check if the user has selected the  current tab to fail (comparison to `nil`). If the user selects another tab, then the bug doesn't appear (the `currentTab` property has been set).

I also fixed a stylistic Objective-C issue with a `==` versus `isEqual:`. `==` is a pointer comparison, but happens to succeed because Objective-C string literals are hoisted into static memory, so every Objective-C `@"home"` string literal _is_ the identical `NSString` instance. 

We should probably release a hot fix with this tomorrow; it probably won't affect many users, but the app becomes unresponsive until it's restarted.

### Test Plan

Let's test on device, too.

