### PR TITLE
Adds react-native-image-crop-picker

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -4423,7 +4423,9 @@
 				"${PODS_ROOT}/FBSDKCoreKit/FacebookSDKStrings.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/MARKRangeSlider/MARKRangeSlider.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/NPKeyboardLayoutGuide/NPKeyboardLayoutGuide.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/RNImageCropPicker/QBImagePicker.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/Stripe/Stripe.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/TOCropViewController/TOCropViewControllerBundle.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -4446,7 +4448,9 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/FacebookSDKStrings.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MARKRangeSlider.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/NPKeyboardLayoutGuide.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/QBImagePicker.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Stripe.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/TOCropViewControllerBundle.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Podfile
+++ b/Podfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 using_bundler = defined? Bundler
 unless using_bundler
   puts "\nPlease re-run using:".red
@@ -20,10 +22,7 @@ require 'fileutils'
 # fetching a key from CocoaPods-Keys). Not pretty, but it works!
 installing_pods = ARGV.include?('install') || ARGV.include?('update')
 
-if installing_pods
-  system 'yarn install --ignore-engines'
-end
-
+system 'yarn install --ignore-engines' if installing_pods
 
 # Note: These should be reflected _accurately_ in the environment of
 #       the continuous build server.
@@ -134,9 +133,10 @@ target 'Artsy' do
   pod 'RNCAsyncStorage', path: 'node_modules/@react-native-community/async-storage'
   pod 'RNCPicker', path: 'node_modules/@react-native-community/picker'
   pod 'BVLinearGradient', path: './node_modules/react-native-linear-gradient'
+  pod 'RNImageCropPicker', path: './node_modules/react-native-image-crop-picker/RNImageCropPicker.podspec'
 
   # For Stripe integration with Emission. Using Ash's fork for this issue: https://github.com/tipsi/tipsi-stripe/issues/408
-  pod 'Pulley', :git => 'https://github.com/l2succes/Pulley.git', :branch => 'master'
+  pod 'Pulley', git: 'https://github.com/l2succes/Pulley.git', branch: 'master'
 
   # Facebook
   pod 'FBSDKCoreKit', '~> 4.33'
@@ -182,13 +182,13 @@ end
 post_install do |installer|
   # So we can show some of this stuff in the Admin panel
   emission_podspec_json = installer.pod_targets.find { |f| f.name == 'Emission' }.specs[0].to_json
-  File.write("Pods/Local Podspecs/Emission.podspec.json", emission_podspec_json)
+  File.write('Pods/Local Podspecs/Emission.podspec.json', emission_podspec_json)
 
   # Note: we don't want Echo.json checked in, so Artsy staff download it at pod install time. We
   # use a stubbed copy for OSS developers.
   echo_key = `bundle exec pod keys get ArtsyEchoProductionToken Artsy`
   if echo_key.length > 1 # OSS contributors have "-" as their key
-    puts "Updating Echo..."
+    puts 'Updating Echo...'
     `make update_echo &> /dev/null`
   end
 
@@ -223,9 +223,7 @@ post_install do |installer|
   swift4 = ['Nimble-Snapshots']
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
-      if swift4.include?(target.name)
-        config.build_settings['SWIFT_VERSION'] = '4.0'
-      end
+      config.build_settings['SWIFT_VERSION'] = '4.0' if swift4.include?(target.name)
     end
   end
 
@@ -263,7 +261,7 @@ post_install do |installer|
     Pods/Quick/Sources/QuickObjectiveC
   ].flat_map { |x| Dir.glob(File.join(x, '**/*.{h,m}')) }.each do |header|
     contents = File.read(header)
-    patched = contents.sub(/["<]\w+\/(\w+-Swift\.h)[">]/, '"\1"')
+    patched = contents.sub(%r{["<]\w+/(\w+-Swift\.h)[">]}, '"\1"')
     File.write(header, patched) if Regexp.last_match
   end
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -428,6 +428,15 @@ PODS:
     - React
   - RNCPicker (1.3.0):
     - React
+  - RNImageCropPicker (0.32.2):
+    - React-Core
+    - React-RCTImage
+    - RNImageCropPicker/QBImagePickerController (= 0.32.2)
+    - TOCropViewController
+  - RNImageCropPicker/QBImagePickerController (0.32.2):
+    - React-Core
+    - React-RCTImage
+    - TOCropViewController
   - RNReanimated (1.4.0):
     - React
   - RNSentry (1.3.2):
@@ -451,6 +460,7 @@ PODS:
   - tipsi-stripe (7.5.0):
     - React
     - Stripe (~> 14.0.0)
+  - TOCropViewController (2.5.4)
   - UICKeyChainStore (1.0.5)
   - "UIView+BooleanAnimations (1.0.2)"
   - VCRURLConnection (0.2.0)
@@ -541,6 +551,7 @@ DEPENDENCIES:
   - ReactiveObjC
   - "RNCAsyncStorage (from `node_modules/@react-native-community/async-storage`)"
   - "RNCPicker (from `node_modules/@react-native-community/picker`)"
+  - RNImageCropPicker (from `./node_modules/react-native-image-crop-picker/RNImageCropPicker.podspec`)
   - RNReanimated (from `node_modules/react-native-reanimated`)
   - "RNSentry (from `node_modules/@sentry/react-native`)"
   - RNSVG (from `node_modules/react-native-svg`)
@@ -601,6 +612,7 @@ SPEC REPOS:
     - Stripe
     - SwiftyJSON
     - Then
+    - TOCropViewController
     - UICKeyChainStore
     - "UIView+BooleanAnimations"
     - VCRURLConnection
@@ -704,6 +716,8 @@ EXTERNAL SOURCES:
     :path: "node_modules/@react-native-community/async-storage"
   RNCPicker:
     :path: "node_modules/@react-native-community/picker"
+  RNImageCropPicker:
+    :path: "./node_modules/react-native-image-crop-picker/RNImageCropPicker.podspec"
   RNReanimated:
     :path: node_modules/react-native-reanimated
   RNSentry:
@@ -839,6 +853,7 @@ SPEC CHECKSUMS:
   ReactiveObjC: 7b6782ae39f9ac0f57205c3b0c0b69b9dd7048c0
   RNCAsyncStorage: 3c304d1adfaea02ec732ac218801cb13897aa8c0
   RNCPicker: 7d06ee91dff65b0bcd400ca00039051d5ddcb938
+  RNImageCropPicker: f0557a908758c4a3f83978894ec7227651529b45
   RNReanimated: b2ab0b693dddd2339bd2f300e770f6302d2e960c
   RNSentry: 2ec85f3e314c6a650b1c51b30ff764b6103ed7e2
   RNSVG: f6177f8d7c095fada7cfee2e4bb7388ba426064c
@@ -852,12 +867,13 @@ SPEC CHECKSUMS:
   SwiftyJSON: 070dabdcb1beb81b247c65ffa3a79dbbfb3b48aa
   Then: ee21c97b85ff6062b9b0080c9abb1eea46743345
   tipsi-stripe: 8aaaa6f5e4cfea5c35be3affbb616c4e6cfafa5f
+  TOCropViewController: 2a1ae1242600b1f2d996fd91a5268b2309a33b5c
   UICKeyChainStore: e81dc3b58d56ffaed61ab6669eb97071e53fc377
   "UIView+BooleanAnimations": a760be9a066036e55f298b7b7350a6cb14cfcd97
   VCRURLConnection: accd771ebd4be11183a3e4d5a4403f180a9a235e
   "XCTest+OHHTTPStubSuiteCleanUp": 4469ec8863c6bc022c5089a9b94233eb3416c5ee
   Yoga: 50fb6eb13d2152e7363293ff603385db380815b1
 
-PODFILE CHECKSUM: 10ee386ebcc379d68dee1be0029251f224951889
+PODFILE CHECKSUM: cb9f398119b022733749a9e764c7c3f4010d176d
 
 COCOAPODS: 1.7.5

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "react": "16.11.0",
     "react-native": "0.62.1",
     "react-native-hyperlink": "0.0.11",
+    "react-native-image-crop-picker": "^0.32.2",
     "react-native-linear-gradient": "2.5.6",
     "react-native-navigator-ios": "https://github.com/ashfurrow/react-native-navigator-ios#license_podspec",
     "react-native-parallax-scroll-view": "orta/react-native-parallax-scroll-view",

--- a/patches/react-native-image-crop-picker+0.32.2.patch
+++ b/patches/react-native-image-crop-picker+0.32.2.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/react-native-image-crop-picker/ios/.DS_Store b/node_modules/react-native-image-crop-picker/ios/.DS_Store
+new file mode 100644
+index 0000000..5172429
+Binary files /dev/null and b/node_modules/react-native-image-crop-picker/ios/.DS_Store differ
+diff --git a/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m b/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m
+index 25ead1a..3b431c8 100644
+--- a/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m
++++ b/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m
+@@ -124,7 +124,7 @@ - (void) setConfiguration:(NSDictionary *)options
+ }
+ 
+ - (UIViewController*) getRootVC {
+-    UIViewController *root = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
++    UIViewController *root = [[[[UIApplication sharedApplication] windows] lastObject] rootViewController];
+     while (root.presentedViewController != nil) {
+         root = root.presentedViewController;
+     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10697,6 +10697,11 @@ react-native-hyperlink@0.0.11:
   dependencies:
     linkify-it "^1.2.0"
 
+react-native-image-crop-picker@^0.32.2:
+  version "0.32.2"
+  resolved "https://registry.yarnpkg.com/react-native-image-crop-picker/-/react-native-image-crop-picker-0.32.2.tgz#862bddc99f7a8e17b7f584846a0c46bfad233917"
+  integrity sha512-x1rwdpVKL6v1AY38rLNYUkLEJIxOK/3C8ipmNbcYFUKunVcmsEvhGLX2ll9kMjp/q+vGOmx4YO38eGp0axYoxg==
+
 react-native-linear-gradient@2.5.6:
   version "2.5.6"
   resolved "https://registry.yarnpkg.com/react-native-linear-gradient/-/react-native-linear-gradient-2.5.6.tgz#96215cbc5ec7a01247a20890888aa75b834d44a0"


### PR DESCRIPTION
The type of this PR is: **dependency**

See: https://github.com/artsy/eigen/issues/3473

### Description

The Objective-C code had a bug specific to our app setup, so I had to patch it. I've [submitted a PR](https://github.com/ivpusic/react-native-image-crop-picker/pull/1354) to address it for others, too. Prettier mangled the Podfile, too 😭 



### Screenshots

<details>
  <summary>GIF proof of concept</summary>



![2020-07-24 10-37-05 2020-07-24 10_50_09](https://user-images.githubusercontent.com/498212/88404132-75e83a80-cd9b-11ea-943a-6e427718f098.gif)



</details> 