### PR TITLE
dont crash if no image. just show an empty one. #trivial

### DIFF
--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomsListItem.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomsListItem.tsx
@@ -80,7 +80,7 @@ export const ViewingRoomsListItem: React.FC<ViewingRoomsListItemProps> = props =
   } else if (extractedArtworks.length > 1) {
     artworks = extractedArtworks.map(a => a.image!.square!)
   }
-  const images = [heroImageURL!, ...artworks]
+  const images = [heroImageURL ?? "", ...artworks]
 
   return (
     <View>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->



### Description

Tiny change, but in VR list, when there is no hero image, the app would crash. now its just showing an empty square, as it should. Normally we wouldn't allow no hero image on cms and we would not return it from MP, but for now since we are still building the verifications, ill just add this here.

<!-- Implementation description -->

### Test Plan

<!-- If necessary -->

- Go to VR list page.
- Your app didn't crash.

### Screenshots

<!-- Add screenshots or simulator recordings if applicable -->
