### PR TITLE
generalize and use in vr #trivial

### DIFF
--- a/src/lib/Components/AnimatedBottomButton.tsx
+++ b/src/lib/Components/AnimatedBottomButton.tsx
@@ -1,0 +1,38 @@
+import _ from "lodash"
+import React, { useEffect, useMemo } from "react"
+import { Animated, TouchableWithoutFeedback } from "react-native"
+import styled from "styled-components/native"
+
+export const BottomButtonContainer = styled(Animated.View)`
+  position: absolute;
+  bottom: 20;
+  flex: 1;
+  justify-content: center;
+  width: 100%;
+  flex-direction: row;
+`
+
+export const AnimatedBottomButton: React.FC<{ isVisible: boolean; onPress: () => void }> = ({
+  isVisible,
+  onPress,
+  children,
+}) => {
+  const topOffset = useMemo(() => {
+    return new Animated.Value(100)
+  }, [])
+
+  useEffect(() => {
+    Animated.spring(topOffset, {
+      toValue: isVisible ? 0 : 100,
+      useNativeDriver: true,
+      bounciness: -7,
+      speed: 13,
+    }).start()
+  }, [isVisible])
+
+  return (
+    <BottomButtonContainer style={{ transform: [{ translateY: topOffset }] }}>
+      <TouchableWithoutFeedback onPress={onPress}>{children}</TouchableWithoutFeedback>
+    </BottomButtonContainer>
+  )
+}

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -9,8 +9,8 @@ import {
 import { Schema } from "lib/utils/track"
 import { OwnerEntityTypes, PageNames } from "lib/utils/track/schema"
 import _ from "lodash"
-import React, { useContext, useEffect, useMemo } from "react"
-import { Animated, FlatList, TouchableOpacity, TouchableWithoutFeedback, View, ViewProperties } from "react-native"
+import React, { useContext } from "react"
+import { FlatList, TouchableOpacity, View, ViewProperties } from "react-native"
 import NavigatorIOS from "react-native-navigator-ios"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
@@ -21,6 +21,7 @@ import {
   FilterData,
   useSelectedOptionsDisplay,
 } from "../utils/ArtworkFiltersStore"
+import { AnimatedBottomButton } from "./AnimatedBottomButton"
 import { ColorOption, ColorOptionsScreen } from "./ArtworkFilterOptions/ColorOptions"
 import { colorHexMap } from "./ArtworkFilterOptions/ColorSwatch"
 import { GalleryOptionsScreen } from "./ArtworkFilterOptions/GalleryOptions"
@@ -369,15 +370,6 @@ export const FilterHeader = styled(Sans)`
   padding-left: 35px;
 `
 
-export const FilterArtworkButtonContainer = styled(Animated.View)`
-  position: absolute;
-  bottom: 20;
-  flex: 1;
-  justify-content: center;
-  width: 100%;
-  flex-direction: row;
-`
-
 export const FilterArtworkButton = styled(Flex)`
   border-radius: 20;
   background-color: ${color("black100")};
@@ -391,43 +383,26 @@ export const AnimatedArtworkFilterButton: React.FC<{ count: number; isVisible: b
   count,
   isVisible,
   onPress,
-}) => {
-  const topOffset = useMemo(() => {
-    return new Animated.Value(100)
-  }, [])
-
-  useEffect(() => {
-    Animated.spring(topOffset, {
-      toValue: isVisible ? 0 : 100,
-      useNativeDriver: true,
-      bounciness: -7,
-      speed: 13,
-    }).start()
-  }, [isVisible])
-
-  return (
-    <FilterArtworkButtonContainer style={{ transform: [{ translateY: topOffset }] }}>
-      <TouchableWithoutFeedback onPress={onPress}>
-        <FilterArtworkButton px="2">
-          <FilterIcon fill="white100" />
-          <Sans size="3t" pl="1" py="1" color="white100" weight="medium">
-            Filter
+}) => (
+  <AnimatedBottomButton isVisible={isVisible} onPress={onPress}>
+    <FilterArtworkButton px="2">
+      <FilterIcon fill="white100" />
+      <Sans size="3t" pl="1" py="1" color="white100" weight="medium">
+        Filter
+      </Sans>
+      {count > 0 && (
+        <>
+          <Sans size="3t" pl={0.5} py="1" color="white100" weight="medium">
+            {"\u2022"}
           </Sans>
-          {count > 0 && (
-            <>
-              <Sans size="3t" pl={0.5} py="1" color="white100" weight="medium">
-                {"\u2022"}
-              </Sans>
-              <Sans size="3t" pl={0.5} py="1" color="white100" weight="medium">
-                {count}
-              </Sans>
-            </>
-          )}
-        </FilterArtworkButton>
-      </TouchableWithoutFeedback>
-    </FilterArtworkButtonContainer>
-  )
-}
+          <Sans size="3t" pl={0.5} py="1" color="white100" weight="medium">
+            {count}
+          </Sans>
+        </>
+      )}
+    </FilterArtworkButton>
+  </AnimatedBottomButton>
+)
 
 export const TouchableOptionListItemRow = styled(TouchableOpacity)``
 

--- a/src/lib/Scenes/Collection/__tests__/Collection-tests.tsx
+++ b/src/lib/Scenes/Collection/__tests__/Collection-tests.tsx
@@ -1,5 +1,6 @@
 import { CollectionTestsQuery } from "__generated__/CollectionTestsQuery.graphql"
-import { FilterArtworkButton, FilterArtworkButtonContainer } from "lib/Components/FilterModal"
+import { AnimatedBottomButton } from "lib/Components/AnimatedBottomButton"
+import { FilterArtworkButton } from "lib/Components/FilterModal"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import ReactTestRenderer from "react-test-renderer"
@@ -43,7 +44,7 @@ describe("Collection", () => {
   it("does not display a filter artworks button by default", () => {
     const root = ReactTestRenderer.create(<TestRenderer />).root
 
-    expect(root.findAllByType(FilterArtworkButtonContainer)).toHaveLength(0)
+    expect(root.findAllByType(AnimatedBottomButton)).toHaveLength(0)
     expect(root.findAllByType(FilterArtworkButton)).toHaveLength(0)
   })
 
@@ -52,7 +53,7 @@ describe("Collection", () => {
    * get these components to render
    */
   xit("does display a filter artworks button when artworks grid when artworks grid is in view", () => {
-    // expect(root.findAllByType(FilterArtworkButtonContainer)).toHaveLength(1)
+    // expect(root.findAllByType(AnimatedBottomButton)).toHaveLength(1)
     // expect(root.findAllByType(FilterArtworkButton)).toHaveLength(1)
   })
 })

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomViewWorksButton.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomViewWorksButton.tsx
@@ -1,27 +1,30 @@
 import { color, Flex, Sans } from "@artsy/palette"
 import { ViewingRoomViewWorksButton_viewingRoom } from "__generated__/ViewingRoomViewWorksButton_viewingRoom.graphql"
+import { AnimatedBottomButton } from "lib/Components/AnimatedBottomButton"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { Schema } from "lib/utils/track"
 import React, { useRef } from "react"
-import { TouchableWithoutFeedback } from "react-native"
+import { View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
 
 interface ViewingRoomViewWorksButtonProps {
   viewingRoom: ViewingRoomViewWorksButton_viewingRoom
+  isVisible: boolean
 }
 
 export const ViewingRoomViewWorksButton: React.FC<ViewingRoomViewWorksButtonProps> = props => {
   const { viewingRoom } = props
   const tracking = useTracking()
-  const navRef = useRef()
+  const navRef = useRef(null)
   const artworksCount = viewingRoom.artworksForCount?.totalCount
   const pluralizedArtworksCount = artworksCount === 1 ? "work" : "works"
 
   return (
-    <ViewWorksButtonContainer ref={navRef as any /* STRICTNESS_MIGRATION */}>
-      <TouchableWithoutFeedback
+    <View ref={navRef}>
+      <AnimatedBottomButton
+        isVisible={props.isVisible}
         onPress={() => {
           tracking.trackEvent(tracks.tappedViewWorksButton(viewingRoom.internalID, viewingRoom.slug))
           SwitchBoard.presentNavigationViewController(navRef.current!, `/viewing-room/${viewingRoom.slug}/artworks`)
@@ -32,19 +35,10 @@ export const ViewingRoomViewWorksButton: React.FC<ViewingRoomViewWorksButtonProp
             View {pluralizedArtworksCount} ({artworksCount})
           </Sans>
         </ViewWorksButton>
-      </TouchableWithoutFeedback>
-    </ViewWorksButtonContainer>
+      </AnimatedBottomButton>
+    </View>
   )
 }
-
-const ViewWorksButtonContainer = styled(Flex)`
-  position: absolute;
-  bottom: 20;
-  flex: 1;
-  justify-content: center;
-  width: 100%;
-  flex-direction: row;
-`
 
 const ViewWorksButton = styled(Flex)`
   border-radius: 20;

--- a/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
@@ -144,7 +144,7 @@ export const ViewingRoom: React.FC<ViewingRoomProps> = props => {
               return item.content
             }}
           />
-          {!!displayViewWorksButton && <ViewingRoomViewWorksButtonContainer {...props} />}
+          <ViewingRoomViewWorksButtonContainer isVisible={displayViewWorksButton} {...props} />
         </View>
       </Theme>
     </ProvideScreenTracking>

--- a/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoom-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoom-tests.tsx
@@ -1,4 +1,5 @@
 import { ViewingRoomTestsQuery } from "__generated__/ViewingRoomTestsQuery.graphql"
+import { AnimatedBottomButton } from "lib/Components/AnimatedBottomButton"
 import { extractText } from "lib/tests/extractText"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import { Schema } from "lib/utils/track"
@@ -10,7 +11,6 @@ import { useTracking } from "react-tracking"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { ViewingRoomArtworkRailContainer } from "../Components/ViewingRoomArtworkRail"
 import { ViewingRoomSubsections } from "../Components/ViewingRoomSubsections"
-import { ViewingRoomViewWorksButtonContainer } from "../Components/ViewingRoomViewWorksButton"
 import { ClosedNotice, tracks, ViewingRoomFragmentContainer } from "../ViewingRoom"
 
 jest.unmock("react-relay")
@@ -134,13 +134,14 @@ describe("ViewingRoom", () => {
         return result
       })
 
-      expect(tree.root.findAllByType(ViewingRoomViewWorksButtonContainer)).toHaveLength(0)
+      expect(tree.root.findAllByType(AnimatedBottomButton)).toHaveLength(1)
+      expect(tree.root.findAllByType(AnimatedBottomButton)[0].props.isVisible).toBe(false)
 
       act(() => {
         tree.root.findByType(FlatList).props.onViewableItemsChanged({ viewableItems: [{ item: { key: "body" } }] })
       })
 
-      expect(tree.root.findAllByType(ViewingRoomViewWorksButtonContainer)).toHaveLength(1)
+      expect(tree.root.findAllByType(AnimatedBottomButton)[0].props.isVisible).toBe(true)
       expect(useTracking().trackEvent).toHaveBeenCalledWith({
         action_name: Schema.ActionNames.BodyImpression,
         action_type: Schema.ActionTypes.Impression,


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->


### Description

I extracted the animated part of `AnimatedArtworkFilterButton` into `AnimatedBottomButton`. This way we can reuse it easily. In the PR I also am adding it in the VR page, so we are consistent. :)

<!-- Implementation description -->

#skip_new_tests

### Screenshots

<!-- Add screenshots or simulator recordings if applicable -->

#### before
![Screen Recording 2020-07-24 at 20 24 21](https://user-images.githubusercontent.com/100233/88423302-de5f0800-cdeb-11ea-9775-1ef0d910c29d.gif)

#### after

![Screen Recording 2020-07-24 at 20 23 50](https://user-images.githubusercontent.com/100233/88423441-123a2d80-cdec-11ea-81f4-0721bf0820c5.gif)
