### PR TITLE
Starts tracking auction page load time

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -12,6 +12,7 @@ upcoming:
     - Add InputTitle component - chris
     - Clean up lab options - brian
     - Removes partner follow count, fixes partner page for partners without profiles - ash
+    - Starts tracking auction page load time - ash
   user_facing:
     - Enables lot condition report requests - ash
     - Add Artist Series artworks - ashley


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR resolves **[MX-475]**

### Description

This adds a Segment analytics event when the network calls necessary to render the current Auction view are completed. This is a good approximation of time-to-interactive.
### Test Plan

Get @mikehrom to look at the event and give a 👍 on the naming: `sale_screen_load_complete` with a property of `load_time_ms`.

Then I'll assign it to an engineer to review the code

### Screenshots

Original: 

![Screen Shot 2020-07-24 at 16 26 44](https://user-images.githubusercontent.com/498212/88432885-14d85b00-cdcb-11ea-9874-c0699a3b60c1.png)

Update: 

![Screen Shot 2020-07-27 at 17 08 48](https://user-images.githubusercontent.com/498212/88592352-e3aa9580-d02b-11ea-877d-cc12bf5337d1.png)


[MX-475]: https://artsyproduct.atlassian.net/browse/MX-475