### PR TITLE
[MX-467] Integrates Sailthru SDK

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -4386,10 +4386,14 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Artsy/Pods-Artsy-frameworks.sh",
+				"${PODS_ROOT}/SailthruMobile/SailthruMobile.framework",
+				"${PODS_ROOT}/SailthruMobile/SailthruMobileExtension.framework",
 				"${PODS_ROOT}/../node_modules/@mapbox/react-native-mapbox-gl/ios/Mapbox.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SailthruMobile.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SailthruMobileExtension.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mapbox.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4424,6 +4428,23 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/MARKRangeSlider/MARKRangeSlider.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/NPKeyboardLayoutGuide/NPKeyboardLayoutGuide.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/RNImageCropPicker/QBImagePicker.bundle",
+				"${PODS_ROOT}/SailthruMobile/SailthruMobile.framework/cp_close_button@2x.png",
+				"${PODS_ROOT}/SailthruMobile/SailthruMobile.framework/cp_close_button_white@2x.png",
+				"${PODS_ROOT}/SailthruMobile/SailthruMobile.framework/cp_message_close_button@2x.png",
+				"${PODS_ROOT}/SailthruMobile/SailthruMobile.framework/cp_refresh.png",
+				"${PODS_ROOT}/SailthruMobile/SailthruMobile.framework/cp_safari-7@2x~ipad.png",
+				"${PODS_ROOT}/SailthruMobile/SailthruMobile.framework/cp_safari-7@2x~iphone.png",
+				"${PODS_ROOT}/SailthruMobile/SailthruMobile.framework/cp_safari-7@3x~iphone.png",
+				"${PODS_ROOT}/SailthruMobile/SailthruMobile.framework/cp_safari-7~ipad.png",
+				"${PODS_ROOT}/SailthruMobile/SailthruMobile.framework/cp_safari-7~iphone.png",
+				"${PODS_ROOT}/SailthruMobile/SailthruMobile.framework/cp_safari@2x~ipad.png",
+				"${PODS_ROOT}/SailthruMobile/SailthruMobile.framework/cp_safari@2x~iphone.png",
+				"${PODS_ROOT}/SailthruMobile/SailthruMobile.framework/cp_safari@3x~iphone.png",
+				"${PODS_ROOT}/SailthruMobile/SailthruMobile.framework/cp_safari~ipad.png",
+				"${PODS_ROOT}/SailthruMobile/SailthruMobile.framework/cp_safari~iphone.png",
+				"${PODS_ROOT}/SailthruMobile/SailthruMobile.framework/cp_share_button_white@2x.png",
+				"${PODS_ROOT}/SailthruMobile/SailthruMobile.framework/cp_stream_back_button@2x.png",
+				"${PODS_ROOT}/SailthruMobile/SailthruMobile.framework/cp_stream_back_button_white@2x.png",
 				"${PODS_CONFIGURATION_BUILD_DIR}/Stripe/Stripe.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/TOCropViewController/TOCropViewControllerBundle.bundle",
 			);
@@ -4449,6 +4470,23 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MARKRangeSlider.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/NPKeyboardLayoutGuide.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/QBImagePicker.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/cp_close_button@2x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/cp_close_button_white@2x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/cp_message_close_button@2x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/cp_refresh.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/cp_safari-7@2x~ipad.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/cp_safari-7@2x~iphone.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/cp_safari-7@3x~iphone.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/cp_safari-7~ipad.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/cp_safari-7~iphone.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/cp_safari@2x~ipad.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/cp_safari@2x~iphone.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/cp_safari@3x~iphone.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/cp_safari~ipad.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/cp_safari~iphone.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/cp_share_button_white@2x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/cp_stream_back_button@2x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/cp_stream_back_button_white@2x.png",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Stripe.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/TOCropViewControllerBundle.bundle",
 			);

--- a/Artsy/App/ARAppDelegate.h
+++ b/Artsy/App/ARAppDelegate.h
@@ -1,7 +1,7 @@
 #import <JSDecoupledAppDelegate/JSDecoupledAppDelegate.h>
 #import "AROnboardingViewController.h"
 
-@class ARWindow;
+@class ARWindow, SailthruMobile;
 
 // This class, and infact the complete JSDecoupledAppDelegate class, is not used during testing.
 // The test app delegate class is ARTestHelper and is responsible for seting up the test env.
@@ -19,6 +19,9 @@
 
 @property (strong, nonatomic, readonly) NSString *referralURLRepresentation;
 @property (strong, nonatomic, readonly) NSString *landingURLRepresentation;
+
+/// Shared Sailthru instance.
+@property (strong, readonly) SailthruMobile *sailThru;
 
 - (void)showOnboarding;
 - (void)showOnboardingWithState:(enum ARInitialOnboardingState)state;

--- a/Artsy/App/ARAppDelegate.m
+++ b/Artsy/App/ARAppDelegate.m
@@ -4,6 +4,7 @@
 #import <AFOAuth1Client/AFOAuth1Client.h>
 #import <UICKeyChainStore/UICKeyChainStore.h>
 #import <Adjust/Adjust.h>
+#import <SailthruMobile/SailthruMobile.h>
 
 #import <ARAnalytics/ARAnalytics.h>
 #import "ARAnalyticsConstants.h"
@@ -57,6 +58,7 @@
 @property (strong, nonatomic, readwrite) NSString *referralURLRepresentation;
 @property (strong, nonatomic, readwrite) NSString *landingURLRepresentation;
 @property (strong, nonatomic, readwrite) NSDictionary *initialLaunchOptions;
+@property (strong, nonatomic, readwrite) SailthruMobile *sailThru;
 
 @end
 
@@ -123,6 +125,11 @@ static ARAppDelegate *_sharedInstance = nil;
     if (self.window) {
         return;
     }
+    
+    self.sailThru = [SailthruMobile new];
+    [self.sailThru setShouldClearBadgeOnLaunch:NO];
+    [self.sailThru startEngine:[[ArtsyKeys new] sailthruKey] withAuthorizationOption:STMPushAuthorizationOptionNoRequest];
+    
 
     // Temp Fix for: https://github.com/artsy/eigen/issues/602
     [self forceCacheCustomFonts];

--- a/Artsy/App/ARAppNotificationsDelegate.m
+++ b/Artsy/App/ARAppNotificationsDelegate.m
@@ -4,6 +4,7 @@
 #import "ArtsyAPI+DeviceTokens.h"
 #import "ArtsyAPI+CurrentUserFunctions.h"
 
+#import "ARAppDelegate.h"
 #import "ARAppConstants.h"
 #import "ARAnalyticsConstants.h"
 #import "UIApplicationStateEnum.h"
@@ -22,6 +23,7 @@
 #import <Emission/ARNotificationsManager.h>
 #import <ARAnalytics/ARAnalytics.h>
 #import <UserNotifications/UserNotifications.h>
+#import <SailthruMobile/SailthruMobile.h>
 
 @implementation ARAppNotificationsDelegate
 
@@ -164,6 +166,8 @@
 
     // Save device token purely for the admin settings view.
     [[NSUserDefaults standardUserDefaults] setValue:deviceToken forKey:ARAPNSDeviceTokenKey];
+    
+    [[[ARAppDelegate sharedInstance] sailThru] setDeviceTokenInBackground:deviceTokenData];
 
 // We only record device tokens on the Artsy service in case of Beta or App Store builds.
 #ifndef DEBUG

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -18,6 +18,7 @@ upcoming:
     - Fixes a bug when selecting home tab - ash
     - Artwork filter button animates into / out of view - ash & david & mounir & brian
     - Add pagination button to InfiniteScrollArtworksGrid component - ashley
+    - Integrates Sailthru SDK - ash
 
 releases:
   - version: 6.5.1

--- a/Podfile
+++ b/Podfile
@@ -41,7 +41,8 @@ plugin 'cocoapods-keys',
          'SentryProductionDSN',       # Crash Logging
          'SentryStagingDSN',          #
          'GoogleMapsAPIKey', # Consignment Location Lookup,
-         'MapBoxAPIClientKey' # Used in local discovery
+         'MapBoxAPIClientKey', # Used in local discovery
+         'SailthruKey'
        ]
 
 target 'Artsy' do
@@ -145,6 +146,7 @@ target 'Artsy' do
   # Analytics
   pod 'Analytics'
   pod 'ARAnalytics', subspecs: %w[Segmentio Adjust DSL]
+  pod 'SailthruMobile'
 
   # Developer Pods
   pod 'DHCShakeNotifier'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -445,6 +445,9 @@ PODS:
   - RNSVG (9.13.3):
     - React
   - RSSwizzle (0.1.0)
+  - SailthruMobile (11.0.0):
+    - SailthruMobile/Extension (= 11.0.0)
+  - SailthruMobile/Extension (11.0.0)
   - SDWebImage (3.7.3):
     - SDWebImage/Core (= 3.7.3)
   - SDWebImage/Core (3.7.3)
@@ -555,6 +558,7 @@ DEPENDENCIES:
   - RNReanimated (from `node_modules/react-native-reanimated`)
   - "RNSentry (from `node_modules/@sentry/react-native`)"
   - RNSVG (from `node_modules/react-native-svg`)
+  - SailthruMobile
   - SDWebImage (>= 3.7.2)
   - "Sentry (from `node_modules/@sentry/react-native/ios/Sentry`)"
   - Specta
@@ -606,6 +610,7 @@ SPEC REPOS:
     - Quick
     - ReactiveObjC
     - RSSwizzle
+    - SailthruMobile
     - SDWebImage
     - Specta
     - Starscream
@@ -858,6 +863,7 @@ SPEC CHECKSUMS:
   RNSentry: 2ec85f3e314c6a650b1c51b30ff764b6103ed7e2
   RNSVG: f6177f8d7c095fada7cfee2e4bb7388ba426064c
   RSSwizzle: d561958f595028bfcef98c7d55c318b3878a61c6
+  SailthruMobile: 52dd44daee69e05f2d60e789befba30c2aa00926
   SDWebImage: 1d2b1a1efda1ade1b00b6f8498865f8ddedc8a84
   Sentry: 26650184fe71eb7476dfd2737acb5ea6cc64b4b1
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
@@ -874,6 +880,6 @@ SPEC CHECKSUMS:
   "XCTest+OHHTTPStubSuiteCleanUp": 4469ec8863c6bc022c5089a9b94233eb3416c5ee
   Yoga: 50fb6eb13d2152e7363293ff603385db380815b1
 
-PODFILE CHECKSUM: cb9f398119b022733749a9e764c7c3f4010d176d
+PODFILE CHECKSUM: 598c02e8a6c7fdde0e21261447c8f4426e5c74d4
 
 COCOAPODS: 1.7.5


### PR DESCRIPTION
The type of this PR is: **dependency**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR resolves **[MX-467]**

### Description

This adds the Sailthru SDK. I looked through their headers to make sure we were using them correctly. Docs are fine but code talks. The new SDK key is in the usual place in 1P.

Fixes #3632. 

### Test Plan

See [MX-469].



[MX-467]: https://artsyproduct.atlassian.net/browse/MX-467
[MX-469]: https://artsyproduct.atlassian.net/browse/MX-469