### PR TITLE
Fixes Sailthru SDK crash #trivial

### DIFF
--- a/Artsy/App/ARSailthruIntegration.m
+++ b/Artsy/App/ARSailthruIntegration.m
@@ -41,7 +41,7 @@
         @try {
             [self.sailThru logEvent:event withVars:filteredDictionary];
         } @catch (NSException *exception) {
-            NSLog(@"Failed to send event to Sailthr: %@", exception);
+            NSLog(@"Failed to send event to Sailthru: %@", exception);
         }
     }
 }


### PR DESCRIPTION
The type of this PR is: **bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->



### Description

Sailthru's SDK crashes in some circumstances. This PR guards against them.

Here is the stack trace of the crash, in case someone finds this through Google:

<details>
  <summary>Crash stacktrace</summary>

```
2020-07-29 16:11:17.485 [fatal][tid:com.facebook.react.AREventsModuleQueue] Exception 'Attempt to insert non-property list object (
        {
        date = 1596053477;
        name = "Screen view";
        origin = session;
        vars =         {
            "context_screen_owner_type" = "<null>";
            screen = Home;
        };
    }
) for key com.corepush.customevents' was thrown while invoking postEvent on target AREventsModule with params (
        {
        "context_screen" = Home;
        "context_screen_owner_type" = "<null>";
    }
)
callstack: (
	0   CoreFoundation                      0x00000001150868db __exceptionPreprocess + 331
	1   libobjc.A.dylib                     0x00000001134a2ac5 objc_exception_throw + 48
	2   CoreFoundation                      0x0000000115086735 +[NSException raise:format:] + 197
	3   CoreFoundation                      0x0000000114fa19fb _CFPrefsValidateValueForKey + 283
	4   CoreFoundation                      0x0000000114fa1e65 -[CFPrefsSource setValues:forKeys:count:copyValues:removeValuesForKeys:count:from:] + 373
	5   CoreFoundation                      0x0000000114fa218c -[CFPrefsSource setValues:forKeys:count:copyValues:from:] + 28
	6   CoreFoundation                      0x0000000114fa21e3 -[CFPrefsSource setValue:forKey:from:] + 67
	7   CoreFoundation                      0x000000011507d77e __108-[_CFXPreferences(SearchListAdditions) withSearchListForIdentifier:container:cloudConfigurationURL:perform:]_block_invoke + 318
	8   CoreFoundation                      0x000000011507cfea normalizeQuintuplet + 314
	9   CoreFoundation                      0x000000011507d634 -[_CFXPreferences(SearchListAdditions) withSearchListForIdentifier:container:cloudConfigurationURL:perform:] + 100
	10  CoreFoundation                      0x000000011505a5db -[_CFXPreferences setValue:forKey:appIdentifier:container:configurationURL:] + 91
	11  CoreFoundation                      0x000000011505e245 _CFPreferencesSetAppValueWithContainer + 117
	12  Foundation                          0x000000010fb274a7 -[NSUserDefaults(NSUserDefaults) setObject:forKey:] + 55
	13  SailthruMobile                      0x00000001121b01c3 +[CPEventsController setEvents:forKey:] + 106
	14  SailthruMobile                      0x00000001121af896 +[CPEventsController saveCustomEvent:] + 243
	15  SailthruMobile                      0x00000001121cd94e -[SailthruMobile logEvent:withVars:] + 91
	16  Artsy                               0x000000010bf707c0 -[ARSailthruIntegration event:withProperties:] + 128
	17  Artsy                               0x000000010c11d68e -[ARAnalyticalProvider didShowNewPageView:withProperties:] + 382
	18  Artsy                               0x000000010c122dfb __39+[ARAnalytics pageView:withProperties:]_block_invoke + 91
	19  Artsy                               0x000000010c123819 -[ARAnalytics iterateThroughProviders:] + 361
	20  Artsy                               0x000000010c122d11 +[ARAnalytics pageView:withProperties:] + 449
	21  Artsy                               0x000000010be47c7a __62-[ARAppDelegate(Emission) setupSharedEmissionWithPackagerURL:]_block_invoke_5 + 698
	22  Artsy                               0x000000010c1b233f -[AREventsModule postEvent:] + 95
	23  CoreFoundation                      0x000000011508d6ac __invoking___ + 140
	24  CoreFoundation                      0x000000011508ac25 -[NSInvocation invoke] + 325
	25  CoreFoundation                      0x000000011508b076 -[NSInvocation invokeWithTarget:] + 54
	26  Artsy                               0x000000010c4f8ff2 -[RCTModuleMethod invokeWithBridge:module:arguments:] + 2658
	27  Artsy                               0x000000010c4fd127 _ZN8facebook5reactL11invokeInnerEP9RCTBridgeP13RCTModuleDatajRKN5folly7dynamicE + 791
	28  Artsy                               0x000000010c4fcc33 _ZZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEiENK3$_0clEv + 131
	29  Artsy                               0x000000010c4fcba9 ___ZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEi_block_invoke + 25
	30  libdispatch.dylib                   0x000000011739cd7f _dispatch_call_block_and_release + 12
	31  libdispatch.dylib                   0x000000011739ddb5 _dispatch_client_callout + 8
	32  libdispatch.dylib                   0x00000001173a5225 _dispatch_lane_serial_drain + 778
	33  libdispatch.dylib                   0x00000001173a5e9c _dispatch_lane_invoke + 425
	34  libdispatch.dylib                   0x00000001173afea3 _dispatch_workloop_worker_thread + 733
	35  libsystem_pthread.dylib             0x000000011778fa3d _pthread_wqthread + 290
	36  libsystem_pthread.dylib             0x000000011778eb77 start_wqthread + 15
)
```

</details> 