### PR TITLE
Add ArtistSeriesMoreSeries component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ Artsy.xcodeproj/project.xcworkspace/xcshareddata/
 Artsy.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
 vendor/
 compiler_commands.json
+.swiftpm
 
 # Artsy Development APN certificate
 net.artsy.artsy.dev.pem

--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -29,6 +29,7 @@
 #import <Emission/AREmission.h>
 #import "ARNotificationsManager.h"
 
+#import <Emission/ARArtistSeriesComponentViewController.h>
 #import <Emission/ARArtworkAttributionClassFAQViewController.h>
 #import <Emission/ARAuctionsComponentViewController.h>
 #import <Emission/ARCityBMWListComponentViewController.h>
@@ -284,6 +285,10 @@ static ARSwitchBoard *sharedInstance = nil;
 
     [self.routes addRoute:@"/feature/:slug" handler:JLRouteParams {
         return [[ARComponentViewController alloc] initWithEmission:nil moduleName:@"Feature" initialProperties:parameters];
+    }];
+
+    [self.routes addRoute:@"/artist-series/:slug" handler:JLRouteParams {
+        return [[ARArtistSeriesComponentViewController alloc] initWithArtistSeriesID:parameters[@"slug"]];
     }];
 
     [self.routes addRoute:@"/collection/:id" handler:JLRouteParams {

--- a/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
+++ b/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
@@ -139,7 +139,7 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
 - (ARCellData *)generateArtistSeries
 {
     return [self tappableCellDataWithTitle:@"→ Artist Series" selection:^{
-        AREigenArtistSeriesComponentViewController *viewController = [[AREigenArtistSeriesComponentViewController alloc] initWithArtistSeriesID:@"yayoi-kusama-pumpkins"];
+        AREigenArtistSeriesComponentViewController *viewController = [[AREigenArtistSeriesComponentViewController alloc] initWithArtistSeriesID:@"alex-katz-departure"];
         [[ARTopMenuViewController sharedController] pushViewController:viewController animated:YES];
     }];
 }

--- a/src/__generated__/ArtistSeriesMoreSeriesTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesMoreSeriesTestsQuery.graphql.ts
@@ -1,0 +1,254 @@
+/* tslint:disable */
+/* eslint-disable */
+/* @relayHash 6e8b91fcb335a078df286ee87d25c1c0 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistSeriesMoreSeriesTestsQueryVariables = {};
+export type ArtistSeriesMoreSeriesTestsQueryResponse = {
+    readonly artistSeries: {
+        readonly artist: ReadonlyArray<{
+            readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesMoreSeries_artist">;
+        } | null> | null;
+    } | null;
+};
+export type ArtistSeriesMoreSeriesTestsQueryRawResponse = {
+    readonly artistSeries: ({
+        readonly artist: ReadonlyArray<({
+            readonly artistSeriesConnection: ({
+                readonly edges: ReadonlyArray<({
+                    readonly node: ({
+                        readonly slug: string;
+                        readonly internalID: string;
+                        readonly title: string;
+                        readonly forSaleArtworksCount: number;
+                        readonly image: ({
+                            readonly url: string | null;
+                        }) | null;
+                    }) | null;
+                }) | null> | null;
+            }) | null;
+            readonly id: string | null;
+        }) | null> | null;
+    }) | null;
+};
+export type ArtistSeriesMoreSeriesTestsQuery = {
+    readonly response: ArtistSeriesMoreSeriesTestsQueryResponse;
+    readonly variables: ArtistSeriesMoreSeriesTestsQueryVariables;
+    readonly rawResponse: ArtistSeriesMoreSeriesTestsQueryRawResponse;
+};
+
+
+
+/*
+query ArtistSeriesMoreSeriesTestsQuery {
+  artistSeries(id: "pumpkins") {
+    artist: artists(size: 1) {
+      ...ArtistSeriesMoreSeries_artist
+      id
+    }
+  }
+}
+
+fragment ArtistSeriesMoreSeries_artist on Artist {
+  artistSeriesConnection(first: 4) {
+    edges {
+      node {
+        slug
+        internalID
+        title
+        forSaleArtworksCount
+        image {
+          url
+        }
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "pumpkins"
+  }
+],
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "size",
+    "value": 1
+  }
+];
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ArtistSeriesMoreSeriesTestsQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artistSeries",
+        "storageKey": "artistSeries(id:\"pumpkins\")",
+        "args": (v0/*: any*/),
+        "concreteType": "ArtistSeries",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": "artist",
+            "name": "artists",
+            "storageKey": "artists(size:1)",
+            "args": (v1/*: any*/),
+            "concreteType": "Artist",
+            "plural": true,
+            "selections": [
+              {
+                "kind": "FragmentSpread",
+                "name": "ArtistSeriesMoreSeries_artist",
+                "args": null
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ArtistSeriesMoreSeriesTestsQuery",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artistSeries",
+        "storageKey": "artistSeries(id:\"pumpkins\")",
+        "args": (v0/*: any*/),
+        "concreteType": "ArtistSeries",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": "artist",
+            "name": "artists",
+            "storageKey": "artists(size:1)",
+            "args": (v1/*: any*/),
+            "concreteType": "Artist",
+            "plural": true,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "artistSeriesConnection",
+                "storageKey": "artistSeriesConnection(first:4)",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 4
+                  }
+                ],
+                "concreteType": "ArtistSeriesConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "edges",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ArtistSeriesEdge",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "node",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "ArtistSeries",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "slug",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "internalID",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "title",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "forSaleArtworksCount",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "image",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "url",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "id",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "ArtistSeriesMoreSeriesTestsQuery",
+    "id": "c7f7ec015ad3874bffbb2d988acabd0b",
+    "text": null,
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = '5bf5ba76c7fb3490b2d0d102614bc680';
+export default node;

--- a/src/__generated__/ArtistSeriesMoreSeries_artist.graphql.ts
+++ b/src/__generated__/ArtistSeriesMoreSeries_artist.graphql.ts
@@ -1,0 +1,125 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistSeriesMoreSeries_artist = {
+    readonly artistSeriesConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly slug: string;
+                readonly internalID: string;
+                readonly title: string;
+                readonly forSaleArtworksCount: number;
+                readonly image: {
+                    readonly url: string | null;
+                } | null;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "ArtistSeriesMoreSeries_artist";
+};
+export type ArtistSeriesMoreSeries_artist$data = ArtistSeriesMoreSeries_artist;
+export type ArtistSeriesMoreSeries_artist$key = {
+    readonly " $data"?: ArtistSeriesMoreSeries_artist$data;
+    readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesMoreSeries_artist">;
+};
+
+
+
+const node: ReaderFragment = {
+  "kind": "Fragment",
+  "name": "ArtistSeriesMoreSeries_artist",
+  "type": "Artist",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "artistSeriesConnection",
+      "storageKey": "artistSeriesConnection(first:4)",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 4
+        }
+      ],
+      "concreteType": "ArtistSeriesConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "ArtistSeriesEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "ArtistSeries",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "slug",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "internalID",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "title",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "forSaleArtworksCount",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "image",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "Image",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "url",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+(node as any).hash = '29acb14e3525d98a4dc967891b4d01ef';
+export default node;

--- a/src/__generated__/ArtistSeriesQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash d65e25f5a608097c55f3ef7b20f3f01a */
+/* @relayHash 9198cdb1111fd054b2da929e64485a1e */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -71,10 +71,31 @@ fragment ArtistSeriesMeta_artistSeries on ArtistSeries {
   }
 }
 
+fragment ArtistSeriesMoreSeries_artist on Artist {
+  artistSeriesConnection(first: 4) {
+    edges {
+      node {
+        slug
+        internalID
+        title
+        forSaleArtworksCount
+        image {
+          url
+        }
+      }
+    }
+  }
+}
+
 fragment ArtistSeries_artistSeries on ArtistSeries {
+  artistIDs
   ...ArtistSeriesHeader_artistSeries
   ...ArtistSeriesMeta_artistSeries
   ...ArtistSeriesArtworks_artistSeries
+  artist: artists(size: 1) {
+    ...ArtistSeriesMoreSeries_artist
+    id
+  }
 }
 
 fragment ArtworkGridItem_artwork on Artwork {
@@ -170,28 +191,42 @@ v3 = {
   "args": null,
   "storageKey": null
 },
-v4 = {
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "size",
+    "value": 1
+  }
+],
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v5 = {
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "internalID",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v6 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "slug",
   "args": null,
   "storageKey": null
 },
-v7 = [
+v9 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -244,6 +279,13 @@ return {
         "concreteType": "ArtistSeries",
         "plural": false,
         "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "artistIDs",
+            "args": null,
+            "storageKey": null
+          },
           (v2/*: any*/),
           (v3/*: any*/),
           {
@@ -258,26 +300,14 @@ return {
             "alias": null,
             "name": "artists",
             "storageKey": "artists(size:1)",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "size",
-                "value": 1
-              }
-            ],
+            "args": (v4/*: any*/),
             "concreteType": "Artist",
             "plural": true,
             "selections": [
-              (v4/*: any*/),
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "internalID",
-                "args": null,
-                "storageKey": null
-              },
               (v5/*: any*/),
               (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -288,13 +318,13 @@ return {
               (v2/*: any*/)
             ]
           },
-          (v6/*: any*/),
+          (v8/*: any*/),
           {
             "kind": "LinkedField",
             "alias": "artistSeriesArtworks",
             "name": "filterArtworksConnection",
             "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")",
-            "args": (v7/*: any*/),
+            "args": (v9/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
@@ -316,8 +346,8 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
-                      (v6/*: any*/),
+                      (v5/*: any*/),
+                      (v8/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -408,7 +438,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v4/*: any*/)
+                          (v5/*: any*/)
                         ]
                       },
                       {
@@ -438,7 +468,7 @@ return {
                               }
                             ]
                           },
-                          (v4/*: any*/)
+                          (v5/*: any*/)
                         ]
                       },
                       {
@@ -450,8 +480,8 @@ return {
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
-                          (v4/*: any*/)
+                          (v7/*: any*/),
+                          (v5/*: any*/)
                         ]
                       },
                       {
@@ -470,7 +500,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  (v4/*: any*/)
+                  (v5/*: any*/)
                 ]
               },
               {
@@ -523,18 +553,80 @@ return {
                   }
                 ]
               },
-              (v4/*: any*/)
+              (v5/*: any*/)
             ]
           },
           {
             "kind": "LinkedHandle",
             "alias": "artistSeriesArtworks",
             "name": "filterArtworksConnection",
-            "args": (v7/*: any*/),
+            "args": (v9/*: any*/),
             "handle": "connection",
             "key": "ArtistSeries_artistSeriesArtworks",
             "filters": [
               "sort"
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": "artist",
+            "name": "artists",
+            "storageKey": "artists(size:1)",
+            "args": (v4/*: any*/),
+            "concreteType": "Artist",
+            "plural": true,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "artistSeriesConnection",
+                "storageKey": "artistSeriesConnection(first:4)",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 4
+                  }
+                ],
+                "concreteType": "ArtistSeriesConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "edges",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ArtistSeriesEdge",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "node",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "ArtistSeries",
+                        "plural": false,
+                        "selections": [
+                          (v8/*: any*/),
+                          (v6/*: any*/),
+                          (v3/*: any*/),
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "forSaleArtworksCount",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v2/*: any*/)
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              (v5/*: any*/)
             ]
           }
         ]
@@ -544,7 +636,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesQuery",
-    "id": "d17edae5030628e1c05f43a027b600e7",
+    "id": "32d99d661c25a424861a629da5b65a74",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash d56e4d8efc4d9be55c524d72a4f94da4 */
+/* @relayHash b8d9e9e4c0848dc7fe78e05ae96919ad */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -12,6 +12,7 @@ export type ArtistSeriesTestsQueryResponse = {
 };
 export type ArtistSeriesTestsQueryRawResponse = {
     readonly artistSeries: ({
+        readonly artistIDs: ReadonlyArray<string>;
         readonly image: ({
             readonly url: string | null;
         }) | null;
@@ -73,6 +74,22 @@ export type ArtistSeriesTestsQueryRawResponse = {
             };
             readonly id: string | null;
         }) | null;
+        readonly artist: ReadonlyArray<({
+            readonly artistSeriesConnection: ({
+                readonly edges: ReadonlyArray<({
+                    readonly node: ({
+                        readonly slug: string;
+                        readonly internalID: string;
+                        readonly title: string;
+                        readonly forSaleArtworksCount: number;
+                        readonly image: ({
+                            readonly url: string | null;
+                        }) | null;
+                    }) | null;
+                }) | null> | null;
+            }) | null;
+            readonly id: string | null;
+        }) | null> | null;
     }) | null;
 };
 export type ArtistSeriesTestsQuery = {
@@ -133,10 +150,31 @@ fragment ArtistSeriesMeta_artistSeries on ArtistSeries {
   }
 }
 
+fragment ArtistSeriesMoreSeries_artist on Artist {
+  artistSeriesConnection(first: 4) {
+    edges {
+      node {
+        slug
+        internalID
+        title
+        forSaleArtworksCount
+        image {
+          url
+        }
+      }
+    }
+  }
+}
+
 fragment ArtistSeries_artistSeries on ArtistSeries {
+  artistIDs
   ...ArtistSeriesHeader_artistSeries
   ...ArtistSeriesMeta_artistSeries
   ...ArtistSeriesArtworks_artistSeries
+  artist: artists(size: 1) {
+    ...ArtistSeriesMoreSeries_artist
+    id
+  }
 }
 
 fragment ArtworkGridItem_artwork on Artwork {
@@ -224,28 +262,42 @@ v2 = {
   "args": null,
   "storageKey": null
 },
-v3 = {
+v3 = [
+  {
+    "kind": "Literal",
+    "name": "size",
+    "value": 1
+  }
+],
+v4 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v4 = {
+v5 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "internalID",
+  "args": null,
+  "storageKey": null
+},
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v5 = {
+v7 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "slug",
   "args": null,
   "storageKey": null
 },
-v6 = [
+v8 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -298,6 +350,13 @@ return {
         "concreteType": "ArtistSeries",
         "plural": false,
         "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "artistIDs",
+            "args": null,
+            "storageKey": null
+          },
           (v1/*: any*/),
           (v2/*: any*/),
           {
@@ -312,26 +371,14 @@ return {
             "alias": null,
             "name": "artists",
             "storageKey": "artists(size:1)",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "size",
-                "value": 1
-              }
-            ],
+            "args": (v3/*: any*/),
             "concreteType": "Artist",
             "plural": true,
             "selections": [
-              (v3/*: any*/),
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "internalID",
-                "args": null,
-                "storageKey": null
-              },
               (v4/*: any*/),
               (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -342,13 +389,13 @@ return {
               (v1/*: any*/)
             ]
           },
-          (v5/*: any*/),
+          (v7/*: any*/),
           {
             "kind": "LinkedField",
             "alias": "artistSeriesArtworks",
             "name": "filterArtworksConnection",
             "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")",
-            "args": (v6/*: any*/),
+            "args": (v8/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
@@ -370,8 +417,8 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
-                      (v5/*: any*/),
+                      (v4/*: any*/),
+                      (v7/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -462,7 +509,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v4/*: any*/)
                         ]
                       },
                       {
@@ -492,7 +539,7 @@ return {
                               }
                             ]
                           },
-                          (v3/*: any*/)
+                          (v4/*: any*/)
                         ]
                       },
                       {
@@ -504,8 +551,8 @@ return {
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
-                          (v3/*: any*/)
+                          (v6/*: any*/),
+                          (v4/*: any*/)
                         ]
                       },
                       {
@@ -524,7 +571,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  (v3/*: any*/)
+                  (v4/*: any*/)
                 ]
               },
               {
@@ -577,18 +624,80 @@ return {
                   }
                 ]
               },
-              (v3/*: any*/)
+              (v4/*: any*/)
             ]
           },
           {
             "kind": "LinkedHandle",
             "alias": "artistSeriesArtworks",
             "name": "filterArtworksConnection",
-            "args": (v6/*: any*/),
+            "args": (v8/*: any*/),
             "handle": "connection",
             "key": "ArtistSeries_artistSeriesArtworks",
             "filters": [
               "sort"
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": "artist",
+            "name": "artists",
+            "storageKey": "artists(size:1)",
+            "args": (v3/*: any*/),
+            "concreteType": "Artist",
+            "plural": true,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "artistSeriesConnection",
+                "storageKey": "artistSeriesConnection(first:4)",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 4
+                  }
+                ],
+                "concreteType": "ArtistSeriesConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "edges",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ArtistSeriesEdge",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "node",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "ArtistSeries",
+                        "plural": false,
+                        "selections": [
+                          (v7/*: any*/),
+                          (v5/*: any*/),
+                          (v2/*: any*/),
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "forSaleArtworksCount",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v1/*: any*/)
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              (v4/*: any*/)
             ]
           }
         ]
@@ -598,7 +707,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesTestsQuery",
-    "id": "81504efbed1b3b04ea3cd6272dbd2cd5",
+    "id": "ad1838444b496805877ecac5738f3e08",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeries_artistSeries.graphql.ts
+++ b/src/__generated__/ArtistSeries_artistSeries.graphql.ts
@@ -4,6 +4,10 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ArtistSeries_artistSeries = {
+    readonly artistIDs: ReadonlyArray<string>;
+    readonly artist: ReadonlyArray<{
+        readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesMoreSeries_artist">;
+    } | null> | null;
     readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesHeader_artistSeries" | "ArtistSeriesMeta_artistSeries" | "ArtistSeriesArtworks_artistSeries">;
     readonly " $refType": "ArtistSeries_artistSeries";
 };
@@ -23,6 +27,35 @@ const node: ReaderFragment = {
   "argumentDefinitions": [],
   "selections": [
     {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "artistIDs",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "LinkedField",
+      "alias": "artist",
+      "name": "artists",
+      "storageKey": "artists(size:1)",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "size",
+          "value": 1
+        }
+      ],
+      "concreteType": "Artist",
+      "plural": true,
+      "selections": [
+        {
+          "kind": "FragmentSpread",
+          "name": "ArtistSeriesMoreSeries_artist",
+          "args": null
+        }
+      ]
+    },
+    {
       "kind": "FragmentSpread",
       "name": "ArtistSeriesHeader_artistSeries",
       "args": null
@@ -39,5 +72,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = '63c7c8120fcd0f25ac4fdedd7b23e8ce';
+(node as any).hash = '8f47e869e6f738f0c34e13460067c4c0';
 export default node;

--- a/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
@@ -1,10 +1,11 @@
-import { Box, Theme } from "@artsy/palette"
+import { Box, Separator, Theme } from "@artsy/palette"
 import { ArtistSeries_artistSeries } from "__generated__/ArtistSeries_artistSeries.graphql"
 import { ArtistSeriesQuery } from "__generated__/ArtistSeriesQuery.graphql"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { ArtistSeriesArtworksFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesArtworks"
 import { ArtistSeriesHeaderFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesHeader"
 import { ArtistSeriesMetaFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesMeta"
+import { ArtistSeriesMoreSeriesFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import React from "react"
 
@@ -15,6 +16,8 @@ interface ArtistSeriesProps {
 }
 
 export const ArtistSeries: React.FC<ArtistSeriesProps> = ({ artistSeries }) => {
+  const artist = artistSeries.artist?.[0]
+
   return (
     <Theme>
       <Box px={2}>
@@ -22,6 +25,8 @@ export const ArtistSeries: React.FC<ArtistSeriesProps> = ({ artistSeries }) => {
           <ArtistSeriesHeaderFragmentContainer artistSeries={artistSeries} />
           <ArtistSeriesMetaFragmentContainer artistSeries={artistSeries} />
           <ArtistSeriesArtworksFragmentContainer artistSeries={artistSeries} />
+          <Separator />
+          <ArtistSeriesMoreSeriesFragmentContainer artist={artist} />
         </ScrollView>
       </Box>
     </Theme>
@@ -31,9 +36,15 @@ export const ArtistSeries: React.FC<ArtistSeriesProps> = ({ artistSeries }) => {
 export const ArtistSeriesFragmentContainer = createFragmentContainer(ArtistSeries, {
   artistSeries: graphql`
     fragment ArtistSeries_artistSeries on ArtistSeries {
+      artistIDs
+
       ...ArtistSeriesHeader_artistSeries
       ...ArtistSeriesMeta_artistSeries
       ...ArtistSeriesArtworks_artistSeries
+
+      artist: artists(size: 1) {
+        ...ArtistSeriesMoreSeries_artist
+      }
     }
   `,
 })

--- a/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
@@ -20,21 +20,25 @@ export const ArtistSeries: React.FC<ArtistSeriesProps> = ({ artistSeries }) => {
 
   return (
     <Theme>
-      <Box px={2}>
-        <ScrollView showsVerticalScrollIndicator={false}>
+      <ScrollView showsVerticalScrollIndicator={false}>
+        <Box px={2}>
           <ArtistSeriesHeaderFragmentContainer artistSeries={artistSeries} />
           <ArtistSeriesMetaFragmentContainer artistSeries={artistSeries} />
           <ArtistSeriesArtworksFragmentContainer artistSeries={artistSeries} />
-          {!!artist && (
-            <ArtistSeriesMoreSeriesFragmentContainer
-              artist={artist}
-              borderTopWidth="1px"
-              borderTopColor="black10"
-              mt={1}
-            />
-          )}
-        </ScrollView>
-      </Box>
+        </Box>
+        {/* We don't want to see ArtistSeriesMoreSeries or the Separator when there are no related artist series.
+            However, this component doesn't have access to the count of related artist series. So, we implement the
+            Separator using a border instead, which won't show when there are no children in ArtistSeriesMoreSeries.
+          */
+        !!artist && (
+          <ArtistSeriesMoreSeriesFragmentContainer
+            artist={artist}
+            borderTopWidth="1px"
+            borderTopColor="black10"
+            mt={1}
+          />
+        )}
+      </ScrollView>
     </Theme>
   )
 }

--- a/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
@@ -25,7 +25,14 @@ export const ArtistSeries: React.FC<ArtistSeriesProps> = ({ artistSeries }) => {
           <ArtistSeriesHeaderFragmentContainer artistSeries={artistSeries} />
           <ArtistSeriesMetaFragmentContainer artistSeries={artistSeries} />
           <ArtistSeriesArtworksFragmentContainer artistSeries={artistSeries} />
-          {!!artist && <ArtistSeriesMoreSeriesFragmentContainer artist={artist} />}
+          {!!artist && (
+            <ArtistSeriesMoreSeriesFragmentContainer
+              artist={artist}
+              borderTopWidth="1px"
+              borderTopColor="black10"
+              mt={1}
+            />
+          )}
         </ScrollView>
       </Box>
     </Theme>

--- a/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
@@ -1,4 +1,4 @@
-import { Box, Separator, Theme } from "@artsy/palette"
+import { Box, Theme } from "@artsy/palette"
 import { ArtistSeries_artistSeries } from "__generated__/ArtistSeries_artistSeries.graphql"
 import { ArtistSeriesQuery } from "__generated__/ArtistSeriesQuery.graphql"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
@@ -25,12 +25,7 @@ export const ArtistSeries: React.FC<ArtistSeriesProps> = ({ artistSeries }) => {
           <ArtistSeriesHeaderFragmentContainer artistSeries={artistSeries} />
           <ArtistSeriesMetaFragmentContainer artistSeries={artistSeries} />
           <ArtistSeriesArtworksFragmentContainer artistSeries={artistSeries} />
-          {!!artist && (
-            <>
-              <Separator />
-              <ArtistSeriesMoreSeriesFragmentContainer artist={artist} />
-            </>
-          )}
+          {!!artist && <ArtistSeriesMoreSeriesFragmentContainer artist={artist} />}
         </ScrollView>
       </Box>
     </Theme>

--- a/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
@@ -25,8 +25,12 @@ export const ArtistSeries: React.FC<ArtistSeriesProps> = ({ artistSeries }) => {
           <ArtistSeriesHeaderFragmentContainer artistSeries={artistSeries} />
           <ArtistSeriesMetaFragmentContainer artistSeries={artistSeries} />
           <ArtistSeriesArtworksFragmentContainer artistSeries={artistSeries} />
-          <Separator />
-          <ArtistSeriesMoreSeriesFragmentContainer artist={artist} />
+          {!!artist && (
+            <>
+              <Separator />
+              <ArtistSeriesMoreSeriesFragmentContainer artist={artist} />
+            </>
+          )}
         </ScrollView>
       </Box>
     </Theme>

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightIcon, Flex, Sans } from "@artsy/palette"
+import { ArrowRightIcon, Flex, Sans, Separator } from "@artsy/palette"
 import { ArtistSeriesMoreSeries_artist } from "__generated__/ArtistSeriesMoreSeries_artist.graphql"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
@@ -69,19 +69,24 @@ export const ArtistSeriesMoreSeries: React.FC<ArtistSeriesMoreSeriesProps> = ({ 
     })
 
   return (
-    <Flex ref={navRef}>
-      <Sans my={2} size="4t">
-        More series by this artist
-      </Sans>
-      {sortedSeries.map(item => {
-        const artistSeriesItem = item?.node
-        if (!!artistSeriesItem) {
-          return <ArtistSeriesMoreSeriesItem artistSeriesItem={artistSeriesItem} handleNavigation={handleNavigation} />
-        } else {
-          return null
-        }
-      })}
-    </Flex>
+    <>
+      <Separator />
+      <Flex ref={navRef}>
+        <Sans my={2} size="4t">
+          More series by this artist
+        </Sans>
+        {sortedSeries.map(item => {
+          const artistSeriesItem = item?.node
+          if (!!artistSeriesItem) {
+            return (
+              <ArtistSeriesMoreSeriesItem artistSeriesItem={artistSeriesItem} handleNavigation={handleNavigation} />
+            )
+          } else {
+            return null
+          }
+        })}
+      </Flex>
+    </>
   )
 }
 

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries.tsx
@@ -1,9 +1,9 @@
-import { ArrowRightIcon, Flex, FlexProps, Sans } from "@artsy/palette"
+import { ArrowRightIcon, color, Flex, FlexProps, Sans } from "@artsy/palette"
 import { ArtistSeriesMoreSeries_artist } from "__generated__/ArtistSeriesMoreSeries_artist.graphql"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import React, { Component, useRef } from "react"
-import { TouchableWithoutFeedback } from "react-native"
+import { TouchableHighlight } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 
 type ArtistSeriesConnectionEdge = NonNullable<
@@ -24,8 +24,8 @@ export const ArtistSeriesMoreSeriesItem: React.FC<ArtistSeriesMoreSeriesItemProp
   handleNavigation,
 }) => {
   return (
-    <TouchableWithoutFeedback onPress={() => handleNavigation(artistSeriesItem.slug)}>
-      <Flex key={artistSeriesItem.internalID} flexDirection="row" justifyContent="space-between" mb={1}>
+    <TouchableHighlight underlayColor={color("black5")} onPress={() => handleNavigation(artistSeriesItem.slug)}>
+      <Flex px={2} py={5} key={artistSeriesItem.internalID} flexDirection="row" justifyContent="space-between">
         <Flex flexDirection="row">
           <OpaqueImageView
             imageURL={artistSeriesItem.image?.url}
@@ -33,7 +33,7 @@ export const ArtistSeriesMoreSeriesItem: React.FC<ArtistSeriesMoreSeriesItemProp
             width={70}
             style={{ borderRadius: 2, overflow: "hidden" }}
           />
-          <Flex ml={1} justifyContent="center" flexDirection="column">
+          <Flex ml={1} justifyContent="center">
             <Sans size="3t">{artistSeriesItem.title}</Sans>
             <Sans size="3" color="black60">
               {artistSeriesItem.forSaleArtworksCount} available
@@ -41,10 +41,10 @@ export const ArtistSeriesMoreSeriesItem: React.FC<ArtistSeriesMoreSeriesItemProp
           </Flex>
         </Flex>
         <Flex justifyContent="center">
-          <ArrowRightIcon />
+          <ArrowRightIcon mr="-5px" />
         </Flex>
       </Flex>
-    </TouchableWithoutFeedback>
+    </TouchableHighlight>
   )
 }
 
@@ -66,7 +66,7 @@ export const ArtistSeriesMoreSeries: React.FC<ArtistSeriesMoreSeriesProps> = ({ 
 
   return (
     <Flex {...rest} ref={navRef}>
-      <Sans my={2} size="4t">
+      <Sans px={2} mt={2} mb="15px" size="4t">
         More series by this artist
       </Sans>
       {series.map(item => {

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries.tsx
@@ -1,0 +1,94 @@
+import { ArrowRightIcon, Flex, Sans } from "@artsy/palette"
+import { ArtistSeriesMoreSeries_artist } from "__generated__/ArtistSeriesMoreSeries_artist.graphql"
+import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
+import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import React, { useRef } from "react"
+import { TouchableWithoutFeedback } from "react-native"
+import { createFragmentContainer, graphql } from "react-relay"
+
+interface ArtistSeriesMoreSeriesProps {
+  artist: ArtistSeriesMoreSeries_artist | null | undefined
+}
+
+type Mutable<T> = { -readonly [P in keyof T]: T[P] }
+type MutableArtistSeriesList = Mutable<NonNullable<ArtistSeriesMoreSeries_artist["artistSeriesConnection"]>["edges"]>
+
+type ArtistSeriesListItem = NonNullable<
+  NonNullable<ArtistSeriesMoreSeries_artist["artistSeriesConnection"]>["edges"]
+>[0]
+
+export const ArtistSeriesMoreSeries: React.FC<ArtistSeriesMoreSeriesProps> = ({ artist }) => {
+  const navRef = useRef<any>()
+  const handleNavigation = (slug: string) => {
+    return SwitchBoard.presentNavigationViewController(navRef.current, `/artist-series/${slug}`)
+  }
+
+  const artistSeriesComparator = (a: ArtistSeriesListItem, b: ArtistSeriesListItem) => {
+    return Math.sign((b?.node?.forSaleArtworksCount ?? 0) - (a?.node?.forSaleArtworksCount ?? 0))
+  }
+
+  const series = artist?.artistSeriesConnection?.edges ?? []
+  if (!artist || series?.length <= 1) {
+    return null
+  }
+
+  const sortedSeries: MutableArtistSeriesList = series.concat().sort(artistSeriesComparator)
+
+  return (
+    <Flex ref={navRef}>
+      <Sans my={2} size="4t">
+        More series by this artist
+      </Sans>
+      {sortedSeries.map(item => {
+        const artistSeriesItem = item?.node
+        if (!!artistSeriesItem) {
+          return (
+            <TouchableWithoutFeedback onPress={() => handleNavigation(artistSeriesItem!.slug)}>
+              <Flex key={artistSeriesItem!.internalID} flexDirection="row" justifyContent="space-between" mb={1}>
+                <Flex flexDirection="row">
+                  <OpaqueImageView
+                    imageURL={artistSeriesItem!.image?.url}
+                    height={70}
+                    width={70}
+                    style={{ borderRadius: 2, overflow: "hidden" }}
+                  />
+                  <Flex ml={1} justifyContent="center" flexDirection="column">
+                    <Sans size="3t">{item?.node?.title}</Sans>
+                    <Sans size="3" color="black60">
+                      {`${artistSeriesItem!.forSaleArtworksCount} available`}
+                    </Sans>
+                  </Flex>
+                </Flex>
+                <Flex justifyContent="center">
+                  <ArrowRightIcon />
+                </Flex>
+              </Flex>
+            </TouchableWithoutFeedback>
+          )
+        } else {
+          return null
+        }
+      })}
+    </Flex>
+  )
+}
+
+export const ArtistSeriesMoreSeriesFragmentContainer = createFragmentContainer(ArtistSeriesMoreSeries, {
+  artist: graphql`
+    fragment ArtistSeriesMoreSeries_artist on Artist {
+      artistSeriesConnection(first: 4) {
+        edges {
+          node {
+            slug
+            internalID
+            title
+            forSaleArtworksCount
+            image {
+              url
+            }
+          }
+        }
+      }
+    }
+  `,
+})

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesMoreSeries-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesMoreSeries-tests.tsx
@@ -11,7 +11,7 @@ import {
   ArtistSeriesMoreSeriesItem,
 } from "lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
 import React from "react"
-import { TouchableWithoutFeedback } from "react-native"
+import { TouchableHighlight } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
 import ReactTestRenderer, { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
@@ -93,7 +93,7 @@ describe("ArtistSeriesMoreSeries", () => {
     it("navigates to the artist series when tapped", () => {
       const wrapper = getWrapper(ArtistSeriesMoreSeriesFixture)
       const item = wrapper.root.findAllByType(ArtistSeriesMoreSeriesItem)[0]
-      item.findByType(TouchableWithoutFeedback).props.onPress()
+      item.findByType(TouchableHighlight).props.onPress()
       expect(SwitchBoard.presentNavigationViewController).toHaveBeenCalledWith(
         expect.anything(),
         "/artist-series/yayoi-kusama-plums"

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesMoreSeries-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesMoreSeries-tests.tsx
@@ -80,13 +80,6 @@ describe("ArtistSeriesMoreSeries", () => {
       const wrapper = getWrapper(ArtistSeriesMoreSeriesFixture)
       expect(wrapper.root.findAllByType(ArtistSeriesMoreSeriesItem).length).toBe(4)
     })
-
-    it("sorts the artist series by the for sale artwork counts", () => {
-      const wrapper = getWrapper(ArtistSeriesMoreSeriesFixture)
-      const items = wrapper.root.findAllByType(ArtistSeriesMoreSeriesItem)
-      const forSaleArtworkCounts = items.map(item => item.props.artistSeriesItem.forSaleArtworksCount)
-      expect(forSaleArtworkCounts).toEqual([40, 35, 25, 4])
-    })
   })
 
   describe("with no other series related to the artist to show", () => {
@@ -114,7 +107,7 @@ describe("ArtistSeriesMoreSeries", () => {
         "https://d32dm0rphc51dk.cloudfront.net/bLKO-OQg8UOzKuKcKxXeWQ/main.jpg"
       )
       expect(item.findAllByType(Sans)[0].props.children).toEqual("plums")
-      expect(item.findAllByType(Sans)[1].props.children).toEqual("40 available")
+      expect(item.findAllByType(Sans)[1].props.children.join("")).toEqual("40 available")
     })
   })
 })
@@ -141,12 +134,12 @@ const ArtistSeriesMoreSeriesFixture: ArtistSeriesMoreSeriesTestsQueryRawResponse
           edges: [
             {
               node: {
-                slug: "yayoi-kusama-pumpkins",
-                internalID: "58597ef5-3390-406b-b6d2-d4e308125d0d",
-                title: "Pumpkins",
-                forSaleArtworksCount: 25,
+                slug: "yayoi-kusama-plums",
+                internalID: "da821a13-92fc-49c2-bbd5-bebb790f7020",
+                title: "plums",
+                forSaleArtworksCount: 40,
                 image: {
-                  url: "https://d32dm0rphc51dk.cloudfront.net/dL3hz4h6f_tMHQjVHsdO4w/medium.jpg",
+                  url: "https://d32dm0rphc51dk.cloudfront.net/bLKO-OQg8UOzKuKcKxXeWQ/main.jpg",
                 },
               },
             },
@@ -163,12 +156,12 @@ const ArtistSeriesMoreSeriesFixture: ArtistSeriesMoreSeriesTestsQueryRawResponse
             },
             {
               node: {
-                slug: "yayoi-kusama-plums",
-                internalID: "da821a13-92fc-49c2-bbd5-bebb790f7020",
-                title: "plums",
-                forSaleArtworksCount: 40,
+                slug: "yayoi-kusama-pumpkins",
+                internalID: "58597ef5-3390-406b-b6d2-d4e308125d0d",
+                title: "Pumpkins",
+                forSaleArtworksCount: 25,
                 image: {
-                  url: "https://d32dm0rphc51dk.cloudfront.net/bLKO-OQg8UOzKuKcKxXeWQ/main.jpg",
+                  url: "https://d32dm0rphc51dk.cloudfront.net/dL3hz4h6f_tMHQjVHsdO4w/medium.jpg",
                 },
               },
             },

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesMoreSeries-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesMoreSeries-tests.tsx
@@ -1,0 +1,153 @@
+import { Theme } from "@artsy/palette"
+import {
+  ArtistSeriesMoreSeriesTestsQuery,
+  ArtistSeriesMoreSeriesTestsQueryRawResponse,
+} from "__generated__/ArtistSeriesMoreSeriesTestsQuery.graphql"
+import { ArtistSeriesMoreSeriesFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import ReactTestRenderer, { act } from "react-test-renderer"
+import { createMockEnvironment } from "relay-test-utils"
+
+jest.unmock("react-relay")
+
+describe("ArtistSeriesMoreSeries", () => {
+  let env: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => {
+    env = createMockEnvironment()
+  })
+
+  const TestRenderer = () => (
+    <QueryRenderer<ArtistSeriesMoreSeriesTestsQuery>
+      environment={env}
+      query={graphql`
+        query ArtistSeriesMoreSeriesTestsQuery @raw_response_type {
+          artistSeries(id: $artistSeriesID) {
+            artist: artists(size: 1) {
+              ...ArtistSeriesMoreSeries_artist
+            }
+          }
+        }
+      `}
+      variables={{ artistSeriesID: "pumpkins" }}
+      render={({ props, error }) => {
+        if (props?.artistSeries) {
+          const artist = props.artistSeries.artist[0]
+          return (
+            <Theme>
+              <ArtistSeriesMoreSeriesFragmentContainer artist={artist} />
+            </Theme>
+          )
+        } else if (error) {
+          console.log(error)
+        } else {
+          console.log("should not reach this")
+        }
+      }}
+    />
+  )
+
+  const getWrapper = (testFixture: any) => {
+    const tree = ReactTestRenderer.create(<TestRenderer />)
+    act(() => {
+      env.mock.resolveMostRecentOperation({
+        errors: [],
+        data: {
+          ...testFixture,
+        },
+      })
+    })
+    return tree
+  }
+
+  describe("with at least one other series related to the artist to show", () => {
+    it("renders the related artist series", () => {
+      const wrapper = getWrapper(ArtistSeriesMoreSeriesFixture)
+      expect(wrapper.root.findAllByType(ArtistSeriesMoreSeries))
+    })
+  })
+
+  describe("with no other series related to the artist to show", () => {
+    it("does not render", () => {
+
+    })
+  })
+})
+
+const ArtistSeriesMoreSeriesNoArtistFixture: ArtistSeriesMoreSeriesTestsQueryRawResponse = {
+  artistSeries: {
+    artist: [],
+  },
+}
+
+const ArtistSeriesMoreSeriesNoSeriesFixture: ArtistSeriesMoreSeriesTestsQueryRawResponse = {
+  artistSeries: {
+    artist: [
+      {
+        id: "abc123",
+        artistSeriesConnection: {
+          edges: [],
+        },
+      },
+    ],
+  },
+}
+
+const ArtistSeriesMoreSeriesFixture: ArtistSeriesMoreSeriesTestsQueryRawResponse = {
+  artistSeries: {
+    artist: [
+      {
+        id: "abc123",
+        artistSeriesConnection: {
+          edges: [
+            {
+              node: {
+                slug: "yayoi-kusama-pumpkins",
+                internalID: "58597ef5-3390-406b-b6d2-d4e308125d0d",
+                title: "Pumpkins",
+                forSaleArtworksCount: 25,
+                image: {
+                  url: "https://d32dm0rphc51dk.cloudfront.net/dL3hz4h6f_tMHQjVHsdO4w/medium.jpg",
+                },
+              },
+            },
+            {
+              node: {
+                slug: "yayoi-kusama-apricots",
+                internalID: "ecfa5731-9d64-4bc2-9f9f-c427a9126064",
+                title: "apricots",
+                forSaleArtworksCount: 35,
+                image: {
+                  url: "https://d32dm0rphc51dk.cloudfront.net/Oymspr9llGzRC-lTZA8htA/main.jpg",
+                },
+              },
+            },
+            {
+              node: {
+                slug: "yayoi-kusama-plums",
+                internalID: "da821a13-92fc-49c2-bbd5-bebb790f7020",
+                title: "plums",
+                forSaleArtworksCount: 40,
+                image: {
+                  url: "https://d32dm0rphc51dk.cloudfront.net/bLKO-OQg8UOzKuKcKxXeWQ/main.jpg",
+                },
+              },
+            },
+            {
+              node: {
+                slug: "yayoi-kusama-apples",
+                internalID: "5856ee51-35eb-4b75-bb12-15a1cd7e012e",
+                title: "apples",
+                forSaleArtworksCount: 4,
+                image: {
+                  url: "https://d32dm0rphc51dk.cloudfront.net/Nv63KiPQo91g2-W2V3lgAw/main.jpg",
+                },
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+}


### PR DESCRIPTION
The type of this PR is: **feature**

This PR resolves [**[FX-2015]**](https://artsyproduct.atlassian.net/browse/FX-2015)

### Description

- Adds `ArtistSeriesMoreSeries` component that shows additional artist series by the artist on the artist series view. This also involves updating the view controller to be able to navigate to a different artist series.
- Lightly refactors tests for `ArtistSeries` to remove duplicated tests and account for a new case
- Adds `.swiftpm` to `.gitignore`

**Edge cases**
- If there is no artist associated with the artist series, `ArtistSeriesMoreArtist` is not rendered.
- If there are no other artist series the child components of `ArtistSeriesMoreSeries` are not rendered.

**Followup work**
- [User does not see the current artist series when looking at a list of related artist series](https://artsyproduct.atlassian.net/browse/FX-2119)

### Test Plan

- Unit tests
- Visual QA

### Screenshots

![Screen Shot 2020-07-28 at 2 56 28 PM](https://user-images.githubusercontent.com/4432348/88945573-26eb4b00-d25c-11ea-9cf2-9b7602b84754.png)



[FX-2015]: https://artsyproduct.atlassian.net/browse/FX-2015