### PR TITLE
Qa fixes 3

### DIFF
--- a/src/__generated__/ViewingRoomArtworkQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomArtworkQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 4f87048717c1a28f4208313641fe1193 */
+/* @relayHash 055fecd300f1300eda1f1332701f704e */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -41,7 +41,7 @@ fragment ViewingRoomArtwork_selectedArtwork on Artwork {
   title
   artistNames
   date
-  description
+  additionalInformation
   saleMessage
   href
   slug
@@ -216,7 +216,7 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "description",
+            "name": "additionalInformation",
             "args": null,
             "storageKey": null
           },
@@ -491,7 +491,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomArtworkQuery",
-    "id": "f91fd0c8c5ca1f3ccb7d819ff4cfd200",
+    "id": "649ba90dbd127d2c0b189ba9d8ccc534",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomArtwork_selectedArtwork.graphql.ts
+++ b/src/__generated__/ViewingRoomArtwork_selectedArtwork.graphql.ts
@@ -7,7 +7,7 @@ export type ViewingRoomArtwork_selectedArtwork = {
     readonly title: string | null;
     readonly artistNames: string | null;
     readonly date: string | null;
-    readonly description: string | null;
+    readonly additionalInformation: string | null;
     readonly saleMessage: string | null;
     readonly href: string | null;
     readonly slug: string;
@@ -77,7 +77,7 @@ const node: ReaderFragment = {
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "description",
+      "name": "additionalInformation",
       "args": null,
       "storageKey": null
     },
@@ -270,5 +270,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = 'f01a199d8874c7e17bd5e86aede433fb';
+(node as any).hash = '5e7c59324112f12b35163453a71dab8f';
 export default node;

--- a/src/__generated__/ViewingRoomsHomeRailQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomsHomeRailQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 1dee6a4c45aabd5cc3d3d459667e4079 */
+/* @relayHash 46945eb879301ac211fbe3eac7267863 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -25,7 +25,6 @@ fragment ViewingRoomsHomeRail_regular on Query {
     edges {
       node {
         internalID
-        ...ViewingRoomsListItem_item
         title
         slug
         heroImage: image {
@@ -51,35 +50,6 @@ fragment ViewingRoomsHomeRail_regular on Query {
             }
           }
         }
-      }
-    }
-  }
-}
-
-fragment ViewingRoomsListItem_item on ViewingRoom {
-  internalID
-  title
-  slug
-  heroImage: image {
-    imageURLs {
-      normalized
-    }
-  }
-  status
-  distanceToOpen(short: true)
-  distanceToClose(short: true)
-  partner {
-    name
-    id
-  }
-  artworksConnection(first: 2) {
-    edges {
-      node {
-        image {
-          square: url(version: "square")
-          regular: url(version: "larger")
-        }
-        id
       }
     }
   }
@@ -333,7 +303,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomsHomeRailQuery",
-    "id": "564a78be609db60f2cf10193af32a0e2",
+    "id": "966d247f586be108308581eb410fda6d",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomsHomeRailQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomsHomeRailQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash d1bfa4dd5ff4e937c44333b1c476ed61 */
+/* @relayHash 1dee6a4c45aabd5cc3d3d459667e4079 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -21,10 +21,11 @@ query ViewingRoomsHomeRailQuery {
 }
 
 fragment ViewingRoomsHomeRail_regular on Query {
-  viewingRooms(first: 15) {
+  viewingRooms(first: 10) {
     edges {
       node {
         internalID
+        ...ViewingRoomsListItem_item
         title
         slug
         heroImage: image {
@@ -50,6 +51,35 @@ fragment ViewingRoomsHomeRail_regular on Query {
             }
           }
         }
+      }
+    }
+  }
+}
+
+fragment ViewingRoomsListItem_item on ViewingRoom {
+  internalID
+  title
+  slug
+  heroImage: image {
+    imageURLs {
+      normalized
+    }
+  }
+  status
+  distanceToOpen(short: true)
+  distanceToClose(short: true)
+  partner {
+    name
+    id
+  }
+  artworksConnection(first: 2) {
+    edges {
+      node {
+        image {
+          square: url(version: "square")
+          regular: url(version: "larger")
+        }
+        id
       }
     }
   }
@@ -96,12 +126,12 @@ return {
         "kind": "LinkedField",
         "alias": null,
         "name": "viewingRooms",
-        "storageKey": "viewingRooms(first:15)",
+        "storageKey": "viewingRooms(first:10)",
         "args": [
           {
             "kind": "Literal",
             "name": "first",
-            "value": 15
+            "value": 10
           }
         ],
         "concreteType": "ViewingRoomConnection",
@@ -303,7 +333,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomsHomeRailQuery",
-    "id": "acb5b86826aa683b644197a7f191300d",
+    "id": "564a78be609db60f2cf10193af32a0e2",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomsHomeRailQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomsHomeRailQuery.graphql.ts
@@ -1,0 +1,313 @@
+/* tslint:disable */
+/* eslint-disable */
+/* @relayHash d1bfa4dd5ff4e937c44333b1c476ed61 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ViewingRoomsHomeRailQueryVariables = {};
+export type ViewingRoomsHomeRailQueryResponse = {
+    readonly " $fragmentRefs": FragmentRefs<"ViewingRoomsHomeRail_regular">;
+};
+export type ViewingRoomsHomeRailQuery = {
+    readonly response: ViewingRoomsHomeRailQueryResponse;
+    readonly variables: ViewingRoomsHomeRailQueryVariables;
+};
+
+
+
+/*
+query ViewingRoomsHomeRailQuery {
+  ...ViewingRoomsHomeRail_regular
+}
+
+fragment ViewingRoomsHomeRail_regular on Query {
+  viewingRooms(first: 15) {
+    edges {
+      node {
+        internalID
+        title
+        slug
+        heroImage: image {
+          imageURLs {
+            normalized
+          }
+        }
+        status
+        distanceToOpen(short: true)
+        distanceToClose(short: true)
+        partner {
+          name
+          id
+        }
+        artworksConnection(first: 2) {
+          edges {
+            node {
+              image {
+                square: url(version: "square")
+                regular: url(version: "larger")
+              }
+              id
+            }
+          }
+        }
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "short",
+    "value": true
+  }
+],
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ViewingRoomsHomeRailQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "FragmentSpread",
+        "name": "ViewingRoomsHomeRail_regular",
+        "args": null
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ViewingRoomsHomeRailQuery",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "viewingRooms",
+        "storageKey": "viewingRooms(first:15)",
+        "args": [
+          {
+            "kind": "Literal",
+            "name": "first",
+            "value": 15
+          }
+        ],
+        "concreteType": "ViewingRoomConnection",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "edges",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "ViewingRoomEdge",
+            "plural": true,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "node",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ViewingRoom",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "internalID",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "title",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "slug",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": "heroImage",
+                    "name": "image",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ARImage",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "imageURLs",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "ImageURLs",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "normalized",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "status",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "distanceToOpen",
+                    "args": (v0/*: any*/),
+                    "storageKey": "distanceToOpen(short:true)"
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "distanceToClose",
+                    "args": (v0/*: any*/),
+                    "storageKey": "distanceToClose(short:true)"
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "partner",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Partner",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "name",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      (v1/*: any*/)
+                    ]
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "artworksConnection",
+                    "storageKey": "artworksConnection(first:2)",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "first",
+                        "value": 2
+                      }
+                    ],
+                    "concreteType": "ArtworkConnection",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "edges",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "ArtworkEdge",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "node",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "Artwork",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "image",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "Image",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": "square",
+                                    "name": "url",
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "version",
+                                        "value": "square"
+                                      }
+                                    ],
+                                    "storageKey": "url(version:\"square\")"
+                                  },
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": "regular",
+                                    "name": "url",
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "version",
+                                        "value": "larger"
+                                      }
+                                    ],
+                                    "storageKey": "url(version:\"larger\")"
+                                  }
+                                ]
+                              },
+                              (v1/*: any*/)
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "ViewingRoomsHomeRailQuery",
+    "id": "acb5b86826aa683b644197a7f191300d",
+    "text": null,
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = '0f49a7ead2d5f68b969c3bc9aba8fbc7';
+export default node;

--- a/src/__generated__/ViewingRoomsHomeRail_regular.graphql.ts
+++ b/src/__generated__/ViewingRoomsHomeRail_regular.graphql.ts
@@ -31,6 +31,7 @@ export type ViewingRoomsHomeRail_regular = {
                         } | null;
                     } | null> | null;
                 } | null;
+                readonly " $fragmentRefs": FragmentRefs<"ViewingRoomsListItem_item">;
             } | null;
         } | null> | null;
     } | null;
@@ -63,12 +64,12 @@ return {
       "kind": "LinkedField",
       "alias": null,
       "name": "viewingRooms",
-      "storageKey": "viewingRooms(first:15)",
+      "storageKey": "viewingRooms(first:10)",
       "args": [
         {
           "kind": "Literal",
           "name": "first",
-          "value": 15
+          "value": 10
         }
       ],
       "concreteType": "ViewingRoomConnection",
@@ -256,6 +257,11 @@ return {
                       ]
                     }
                   ]
+                },
+                {
+                  "kind": "FragmentSpread",
+                  "name": "ViewingRoomsListItem_item",
+                  "args": null
                 }
               ]
             }
@@ -266,5 +272,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'bdc4072331bb3fed2ac3cebbd17a1439';
+(node as any).hash = 'd93690fa81bba63db78285b3f3fd7d50';
 export default node;

--- a/src/__generated__/ViewingRoomsHomeRail_regular.graphql.ts
+++ b/src/__generated__/ViewingRoomsHomeRail_regular.graphql.ts
@@ -1,0 +1,270 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ViewingRoomsHomeRail_regular = {
+    readonly viewingRooms: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly internalID: string;
+                readonly title: string;
+                readonly slug: string;
+                readonly heroImage: {
+                    readonly imageURLs: {
+                        readonly normalized: string | null;
+                    } | null;
+                } | null;
+                readonly status: string;
+                readonly distanceToOpen: string | null;
+                readonly distanceToClose: string | null;
+                readonly partner: {
+                    readonly name: string | null;
+                } | null;
+                readonly artworksConnection: {
+                    readonly edges: ReadonlyArray<{
+                        readonly node: {
+                            readonly image: {
+                                readonly square: string | null;
+                                readonly regular: string | null;
+                            } | null;
+                        } | null;
+                    } | null> | null;
+                } | null;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "ViewingRoomsHomeRail_regular";
+};
+export type ViewingRoomsHomeRail_regular$data = ViewingRoomsHomeRail_regular;
+export type ViewingRoomsHomeRail_regular$key = {
+    readonly " $data"?: ViewingRoomsHomeRail_regular$data;
+    readonly " $fragmentRefs": FragmentRefs<"ViewingRoomsHomeRail_regular">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "short",
+    "value": true
+  }
+];
+return {
+  "kind": "Fragment",
+  "name": "ViewingRoomsHomeRail_regular",
+  "type": "Query",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "viewingRooms",
+      "storageKey": "viewingRooms(first:15)",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 15
+        }
+      ],
+      "concreteType": "ViewingRoomConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "ViewingRoomEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "ViewingRoom",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "internalID",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "title",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "slug",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "LinkedField",
+                  "alias": "heroImage",
+                  "name": "image",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "ARImage",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "LinkedField",
+                      "alias": null,
+                      "name": "imageURLs",
+                      "storageKey": null,
+                      "args": null,
+                      "concreteType": "ImageURLs",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "kind": "ScalarField",
+                          "alias": null,
+                          "name": "normalized",
+                          "args": null,
+                          "storageKey": null
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "status",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "distanceToOpen",
+                  "args": (v0/*: any*/),
+                  "storageKey": "distanceToOpen(short:true)"
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "distanceToClose",
+                  "args": (v0/*: any*/),
+                  "storageKey": "distanceToClose(short:true)"
+                },
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "partner",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "Partner",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "name",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
+                },
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "artworksConnection",
+                  "storageKey": "artworksConnection(first:2)",
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "first",
+                      "value": 2
+                    }
+                  ],
+                  "concreteType": "ArtworkConnection",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "LinkedField",
+                      "alias": null,
+                      "name": "edges",
+                      "storageKey": null,
+                      "args": null,
+                      "concreteType": "ArtworkEdge",
+                      "plural": true,
+                      "selections": [
+                        {
+                          "kind": "LinkedField",
+                          "alias": null,
+                          "name": "node",
+                          "storageKey": null,
+                          "args": null,
+                          "concreteType": "Artwork",
+                          "plural": false,
+                          "selections": [
+                            {
+                              "kind": "LinkedField",
+                              "alias": null,
+                              "name": "image",
+                              "storageKey": null,
+                              "args": null,
+                              "concreteType": "Image",
+                              "plural": false,
+                              "selections": [
+                                {
+                                  "kind": "ScalarField",
+                                  "alias": "square",
+                                  "name": "url",
+                                  "args": [
+                                    {
+                                      "kind": "Literal",
+                                      "name": "version",
+                                      "value": "square"
+                                    }
+                                  ],
+                                  "storageKey": "url(version:\"square\")"
+                                },
+                                {
+                                  "kind": "ScalarField",
+                                  "alias": "regular",
+                                  "name": "url",
+                                  "args": [
+                                    {
+                                      "kind": "Literal",
+                                      "name": "version",
+                                      "value": "larger"
+                                    }
+                                  ],
+                                  "storageKey": "url(version:\"larger\")"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+})();
+(node as any).hash = 'bdc4072331bb3fed2ac3cebbd17a1439';
+export default node;

--- a/src/__generated__/ViewingRoomsHomeRail_regular.graphql.ts
+++ b/src/__generated__/ViewingRoomsHomeRail_regular.graphql.ts
@@ -31,7 +31,6 @@ export type ViewingRoomsHomeRail_regular = {
                         } | null;
                     } | null> | null;
                 } | null;
-                readonly " $fragmentRefs": FragmentRefs<"ViewingRoomsListItem_item">;
             } | null;
         } | null> | null;
     } | null;
@@ -257,11 +256,6 @@ return {
                       ]
                     }
                   ]
-                },
-                {
-                  "kind": "FragmentSpread",
-                  "name": "ViewingRoomsListItem_item",
-                  "args": null
                 }
               ]
             }
@@ -272,5 +266,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'd93690fa81bba63db78285b3f3fd7d50';
+(node as any).hash = 'fcdb293ba50bd8b485b8aa45f96e8bb7';
 export default node;

--- a/src/lib/Components/Countdown/Ticker.tsx
+++ b/src/lib/Components/Countdown/Ticker.tsx
@@ -9,7 +9,7 @@ interface TimeSectionProps {
 }
 
 const padWithZero = (number: number) => (number.toString() as any).padStart(2, "0")
-const durationSections = (duration: Duration, labels: [string, string, string, string]) => [
+export const durationSections = (duration: Duration, labels: [string, string, string, string]) => [
   {
     time: padWithZero(Math.floor(duration.asDays())),
     label: labels[0],

--- a/src/lib/Components/Countdown/index.ts
+++ b/src/lib/Components/Countdown/index.ts
@@ -1,3 +1,3 @@
-export { SimpleTicker, LabeledTicker } from "./Ticker"
+export { SimpleTicker, LabeledTicker, durationSections } from "./Ticker"
 export { StateManager } from "./StateManager"
 export { DurationProvider } from "./DurationProvider"

--- a/src/lib/Scenes/Home/Home.tsx
+++ b/src/lib/Scenes/Home/Home.tsx
@@ -9,7 +9,7 @@ import { EmailConfirmationBannerFragmentContainer } from "lib/Scenes/Home/Compon
 import { FairsRailFragmentContainer } from "lib/Scenes/Home/Components/FairsRail"
 import { SalesRailFragmentContainer } from "lib/Scenes/Home/Components/SalesRail"
 
-import { ArtsyLogoIcon, Box, Flex, Join, Sans, Spacer, Theme } from "@artsy/palette"
+import { ArtsyLogoIcon, Box, Flex, Join, Spacer, Theme } from "@artsy/palette"
 import { Home_homePage } from "__generated__/Home_homePage.graphql"
 import { Home_me } from "__generated__/Home_me.graphql"
 import { HomeQuery } from "__generated__/HomeQuery.graphql"
@@ -158,12 +158,6 @@ const Home = (props: Props) => {
                   )
                 case "viewing-rooms":
                   return <ViewingRoomsHomeRail featured={featured} />
-                  return (
-                    <Button
-                      title="wowowow"
-                      onPress={() => SwitchBoard.presentNavigationViewController(navRef.current, "/viewing-rooms")}
-                    />
-                  )
               }
             }}
             ListHeaderComponent={

--- a/src/lib/Scenes/Home/Home.tsx
+++ b/src/lib/Scenes/Home/Home.tsx
@@ -1,5 +1,5 @@
 import React, { createRef, RefObject, useRef, useState } from "react"
-import { Button, RefreshControl, View, ViewProperties } from "react-native"
+import { RefreshControl, View, ViewProperties } from "react-native"
 import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
 
 import { ArtistRailFragmentContainer } from "lib/Components/Home/ArtistRails/ArtistRail"
@@ -18,16 +18,12 @@ import { compact, drop, flatten, take, times, zip } from "lodash"
 
 import { Home_featured } from "__generated__/Home_featured.graphql"
 import { AboveTheFoldFlatList } from "lib/Components/AboveTheFoldFlatList"
-import { SectionTitle } from "lib/Components/SectionTitle"
-import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { useEmissionOptions } from "lib/store/AppStore"
 import { isPad } from "lib/utils/hardware"
 import { PlaceholderBox, PlaceholderText } from "lib/utils/placeholders"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "lib/utils/track"
-import { useTracking } from "react-tracking"
 import { ViewingRoomsHomeRail } from "../ViewingRoom/Components/ViewingRoomsHomeRail"
-import { FeaturedRail } from "../ViewingRoom/Components/ViewingRoomsListFeatured"
 import { HomeHeroContainer, HomeHeroPlaceholder } from "./Components/HomeHero"
 import { RailScrollRef } from "./Components/types"
 
@@ -39,7 +35,6 @@ interface Props extends ViewProperties {
 }
 
 const Home = (props: Props) => {
-  const { trackEvent } = useTracking()
   const navRef = useRef<any>()
   const EmissionOptions = useEmissionOptions()
 

--- a/src/lib/Scenes/Home/Home.tsx
+++ b/src/lib/Scenes/Home/Home.tsx
@@ -1,5 +1,5 @@
 import React, { createRef, RefObject, useRef, useState } from "react"
-import { RefreshControl, View, ViewProperties } from "react-native"
+import { Button, RefreshControl, View, ViewProperties } from "react-native"
 import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
 
 import { ArtistRailFragmentContainer } from "lib/Components/Home/ArtistRails/ArtistRail"
@@ -26,6 +26,7 @@ import { PlaceholderBox, PlaceholderText } from "lib/utils/placeholders"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "lib/utils/track"
 import { useTracking } from "react-tracking"
+import { ViewingRoomsHomeRail } from "../ViewingRoom/Components/ViewingRoomsHomeRail"
 import { FeaturedRail } from "../ViewingRoom/Components/ViewingRoomsListFeatured"
 import { HomeHeroContainer, HomeHeroPlaceholder } from "./Components/HomeHero"
 import { RailScrollRef } from "./Components/types"
@@ -156,27 +157,12 @@ const Home = (props: Props) => {
                     />
                   )
                 case "viewing-rooms":
+                  return <ViewingRoomsHomeRail featured={featured} />
                   return (
-                    <>
-                      <Flex mx="2">
-                        <SectionTitle
-                          title="Viewing Rooms"
-                          onPress={() => {
-                            trackEvent(tracks.tappedViewingRoomsHeader())
-                            SwitchBoard.presentNavigationViewController(navRef.current, "/viewing-rooms")
-                          }}
-                          RightButtonContent={() => (
-                            <Sans size="3" color="black60">
-                              View all
-                            </Sans>
-                          )}
-                        />
-                      </Flex>
-                      <FeaturedRail
-                        featured={featured}
-                        trackInfo={{ screen: Schema.PageNames.Home, ownerType: Schema.OwnerEntityTypes.Home }}
-                      />
-                    </>
+                    <Button
+                      title="wowowow"
+                      onPress={() => SwitchBoard.presentNavigationViewController(navRef.current, "/viewing-rooms")}
+                    />
                   )
               }
             }}
@@ -199,17 +185,6 @@ const Home = (props: Props) => {
       </Theme>
     </ProvideScreenTracking>
   )
-}
-
-const tracks = {
-  tappedViewingRoomsHeader: () => ({
-    action: Schema.ActionNames.TappedViewingRoomGroup,
-    context_module: Schema.ContextModules.FeaturedViewingRoomsRail,
-    context_screen: Schema.PageNames.Home,
-    context_screen_owner_type: Schema.OwnerEntityTypes.Home,
-    destination_screen_owner_type: Schema.PageNames.ViewingRoomsList,
-    type: "header",
-  }),
 }
 
 export const HomeFragmentContainer = createRefetchContainer(

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex, space, Text } from "@artsy/palette"
 import { ViewingRoomHeader_viewingRoom } from "__generated__/ViewingRoomHeader_viewingRoom.graphql"
-import { durationSections, SimpleTicker } from "lib/Components/Countdown"
+import { durationSections } from "lib/Components/Countdown"
 import { CountdownProps, CountdownTimer } from "lib/Components/Countdown/CountdownTimer"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Sans, space } from "@artsy/palette"
+import { Box, Flex, Sans, space, Text } from "@artsy/palette"
 import { ViewingRoomHeader_viewingRoom } from "__generated__/ViewingRoomHeader_viewingRoom.graphql"
 import { SimpleTicker } from "lib/Components/Countdown"
 import { CountdownProps, CountdownTimer } from "lib/Components/Countdown/CountdownTimer"
@@ -100,9 +100,9 @@ export const ViewingRoomHeader: React.FC<ViewingRoomHeaderProps> = props => {
         <Overlay colors={["rgba(255, 255, 255, 0)", "rgba(0, 0, 0, 1)"]} />
         <Flex flexDirection="row" justifyContent="center" alignItems="flex-end" px={2} height={imageHeight - 60}>
           <Flex alignItems="center" flexDirection="column" flexGrow={1}>
-            <Sans data-test-id="title" size="6" textAlign="center" color="white100">
+            <Text data-test-id="title" variant="largeTitle" textAlign="center" color="white100">
               {title}
-            </Sans>
+            </Text>
           </Flex>
         </Flex>
         <PartnerContainer>

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
@@ -1,6 +1,6 @@
-import { Box, Flex, Sans, space, Text } from "@artsy/palette"
+import { Box, Flex, space, Text } from "@artsy/palette"
 import { ViewingRoomHeader_viewingRoom } from "__generated__/ViewingRoomHeader_viewingRoom.graphql"
-import { SimpleTicker } from "lib/Components/Countdown"
+import { durationSections, SimpleTicker } from "lib/Components/Countdown"
 import { CountdownProps, CountdownTimer } from "lib/Components/Countdown/CountdownTimer"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
@@ -47,9 +47,17 @@ const Overlay = styled(LinearGradient)`
   opacity: 0.15;
 `
 
-const CountdownText: React.SFC<CountdownProps> = ({ duration }) => (
-  <SimpleTicker duration={duration} separator="  " size="2" weight="medium" color="white100" />
-)
+const CountdownText: React.SFC<CountdownProps> = ({ duration }) => {
+  const separator = "  "
+  const sections = durationSections(duration, ["d", "h", "m", "s"])
+  return (
+    <Text variant="small" fontWeight={500} color="white100">
+      {sections
+        .map(({ time, label }, idx) => (idx < sections.length - 1 ? time + label + separator : time + label))
+        .join("")}
+    </Text>
+  )
+}
 
 const Countdown: React.FC<{ startAt: string; endAt: string; status: string }> = ({ startAt, endAt, status }) => {
   let finalText = ""
@@ -67,9 +75,9 @@ const Countdown: React.FC<{ startAt: string; endAt: string; status: string }> = 
 
   return (
     <>
-      <Sans size="2" weight="medium" color="white100">
+      <Text variant="small" fontWeight={500} color="white100">
         {finalText}
-      </Sans>
+      </Text>
       {status !== ViewingRoomStatus.CLOSED ? (
         <CountdownTimer startAt={startAt} endAt={endAt} countdownComponent={CountdownText} />
       ) : null}
@@ -118,9 +126,9 @@ export const ViewingRoomHeader: React.FC<ViewingRoomHeaderProps> = props => {
                   />
                 </Box>
               )}
-              <Sans size="2" weight="medium" numberOfLines={1} color="white100" data-test-id="partner-name">
+              <Text variant="small" fontWeight={500} color="white100" data-test-id="partner-name">
                 {partner!.name}
-              </Sans>
+              </Text>
             </Flex>
           </TouchableWithoutFeedback>
         </PartnerContainer>

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomSubsections.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomSubsections.tsx
@@ -1,4 +1,4 @@
-import { Box, Sans, Serif } from "@artsy/palette"
+import { Box, Flex, Text } from "@artsy/palette"
 import { ViewingRoomSubsections_viewingRoom } from "__generated__/ViewingRoomSubsections_viewingRoom.graphql"
 import ImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import React from "react"
@@ -15,22 +15,24 @@ export const ViewingRoomSubsections: React.FC<ViewingRoomSubsectionProps> = prop
       {subsections.map((subsection, index) => (
         <Box key={index} mt="3">
           {!!subsection.title && (
-            <Sans size="4" mb="1" mx="2">
-              {subsection.title}
-            </Sans>
+            <Flex mb="1" mx="2">
+              <Text variant="title">{subsection.title}</Text>
+            </Flex>
           )}
           {!!subsection.body && (
-            <Serif size="4" mb="2" mx="2">
-              {subsection.body}
-            </Serif>
+            <Flex mb="2" mx="2">
+              <Text variant="text">{subsection.body}</Text>
+            </Flex>
           )}
           {!!subsection.image?.imageURLs?.normalized && (
             <ImageView imageURL={subsection.image.imageURLs.normalized} aspectRatio={1} />
           )}
           {!!subsection.caption && (
-            <Sans size="2" color="black60" mt="1" mx="2">
-              {subsection.caption}
-            </Sans>
+            <Flex mt="1" mx="2">
+              <Text variant="caption" color="black60">
+                {subsection.caption}
+              </Text>
+            </Flex>
           )}
         </Box>
       ))}

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomsHomeRail.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomsHomeRail.tsx
@@ -1,16 +1,19 @@
-import { Flex, Sans } from "@artsy/palette"
+import { Box, Flex, Sans, Spacer } from "@artsy/palette"
 import { ViewingRoomsHomeRail_regular$key } from "__generated__/ViewingRoomsHomeRail_regular.graphql"
 import { ViewingRoomsHomeRailQuery } from "__generated__/ViewingRoomsHomeRailQuery.graphql"
 import { ViewingRoomsListFeatured_featured$key } from "__generated__/ViewingRoomsListFeatured_featured.graphql"
 import { SectionTitle } from "lib/Components/SectionTitle"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { extractNodes } from "lib/utils/extractNodes"
+import { PlaceholderBox, PlaceholderText, ProvidePlaceholderContext } from "lib/utils/placeholders"
 import { Schema } from "lib/utils/track"
+import _ from "lodash"
 import React, { useRef } from "react"
-import { View } from "react-native"
+import { FlatList, View } from "react-native"
 import { useTracking } from "react-tracking"
 import { graphql, useFragment, useQuery } from "relay-hooks"
 import { featuredFragment, FeaturedRail } from "./ViewingRoomsListFeatured"
+import { ViewingRoomsListItem } from "./ViewingRoomsListItem"
 
 interface ViewingRoomsHomeRailProps {
   featured: ViewingRoomsListFeatured_featured$key

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomsHomeRail.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomsHomeRail.tsx
@@ -1,0 +1,84 @@
+import { Flex, Sans } from "@artsy/palette"
+import { ViewingRoomsListFeatured_featured$key } from "__generated__/ViewingRoomsListFeatured_featured.graphql"
+import { SectionTitle } from "lib/Components/SectionTitle"
+import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { extractNodes } from "lib/utils/extractNodes"
+import { Schema } from "lib/utils/track"
+import React, { useRef } from "react"
+import { View } from "react-native"
+import { useTracking } from "react-tracking"
+import { graphql, useFragment } from "relay-hooks"
+import { featuredFragment, FeaturedRail } from "./ViewingRoomsListFeatured"
+
+interface ViewingRoomsHomeRailProps {
+  featured: ViewingRoomsListFeatured_featured$key
+}
+
+// const fragment = graphql`
+//   fragment ViewingRoomsListFeatured_regular on ViewingRoomConnection {
+//     edges {
+//       node {
+//         internalID
+//         title
+//         slug
+//         heroImage: image {
+//           imageURLs {
+//             normalized
+//           }
+//         }
+//         status
+//         distanceToOpen(short: true)
+//         distanceToClose(short: true)
+//         partner {
+//           name
+//         }
+//       }
+//     }
+//   }
+// `
+
+export const ViewingRoomsHomeRail: React.FC<ViewingRoomsHomeRailProps> = props => {
+  const { trackEvent } = useTracking()
+  const navRef = useRef<any>(null)
+
+  const featuredData = useFragment(featuredFragment, props.featured)
+  const featuredLength = extractNodes(featuredData).length
+
+  return (
+    <View ref={navRef}>
+      <Flex mx="2">
+        <SectionTitle
+          title="Viewing Rooms"
+          onPress={() => {
+            trackEvent(tracks.tappedViewingRoomsHeader())
+            SwitchBoard.presentNavigationViewController(navRef.current, "/viewing-rooms")
+          }}
+          RightButtonContent={() => (
+            <Sans size="3" color="black60">
+              View all
+            </Sans>
+          )}
+        />
+      </Flex>
+      {featuredLength > 0 ? (
+        <FeaturedRail
+          featured={props.featured}
+          trackInfo={{ screen: Schema.PageNames.Home, ownerType: Schema.OwnerEntityTypes.Home }}
+        />
+      ) : (
+        <Flex />
+      )}
+    </View>
+  )
+}
+
+const tracks = {
+  tappedViewingRoomsHeader: () => ({
+    action: Schema.ActionNames.TappedViewingRoomGroup,
+    context_module: Schema.ContextModules.FeaturedViewingRoomsRail,
+    context_screen: Schema.PageNames.Home,
+    context_screen_owner_type: Schema.OwnerEntityTypes.Home,
+    destination_screen_owner_type: Schema.PageNames.ViewingRoomsList,
+    type: "header",
+  }),
+}

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomsListFeatured.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomsListFeatured.tsx
@@ -101,7 +101,7 @@ export const FeaturedRail: React.FC<FeaturedRailProps & Partial<RailScrollProps>
   )
 }
 
-const tracks = {
+export const tracks = {
   tappedFeaturedViewingRoomRailItem: (vrId: string, vrSlug: string) => ({
     action: Schema.ActionNames.TappedViewingRoomGroup,
     context_module: Schema.ContextModules.FeaturedViewingRoomsRail,

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomsListItem.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomsListItem.tsx
@@ -23,7 +23,7 @@ export const tagForStatus = (
       }
       return {
         text: `${distanceToClose} left`,
-        textColor: "black100",
+        textColor: "black60",
         color: "white100",
         borderColor: "black5",
       }

--- a/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Sans, Serif, Spacer, Theme } from "@artsy/palette"
+import { Button, Flex, Sans, Spacer, Text, Theme } from "@artsy/palette"
 import { ViewingRoom_viewingRoom } from "__generated__/ViewingRoom_viewingRoom.graphql"
 import { ViewingRoomQuery } from "__generated__/ViewingRoomQuery.graphql"
 import LoadFailureView from "lib/Components/LoadFailureView"
@@ -87,9 +87,11 @@ export const ViewingRoom: React.FC<ViewingRoomProps> = props => {
       {
         key: "introStatement",
         content: (
-          <Serif data-test-id="intro-statement" mt="2" size="4" mx="2">
-            {viewingRoom.introStatement}
-          </Serif>
+          <Flex mt="2" mx="2">
+            <Text data-test-id="intro-statement" mt="2" variant="text" mx="2">
+              {viewingRoom.introStatement}
+            </Text>
+          </Flex>
         ),
       },
       {
@@ -101,9 +103,11 @@ export const ViewingRoom: React.FC<ViewingRoomProps> = props => {
         content: (
           <>
             {!!viewingRoom.pullQuote && (
-              <Sans data-test-id="pull-quote" size="8" textAlign="center" mx="2">
-                {viewingRoom.pullQuote}
-              </Sans>
+              <Flex mx="2">
+                <Text data-test-id="pull-quote" variant="largeTitle" textAlign="center">
+                  {viewingRoom.pullQuote}
+                </Text>
+              </Flex>
             )}
           </>
         ),
@@ -111,9 +115,11 @@ export const ViewingRoom: React.FC<ViewingRoomProps> = props => {
       {
         key: "body",
         content: (
-          <Serif data-test-id="body" size="4" mx="2">
-            {viewingRoom.body}
-          </Serif>
+          <Flex mx="2">
+            <Text data-test-id="body" variant="text">
+              {viewingRoom.body}
+            </Text>
+          </Flex>
         ),
       },
       {

--- a/src/lib/Scenes/ViewingRoom/ViewingRoomArtwork.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoomArtwork.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, color, EyeOpenedIcon, Flex, Sans, Separator, Serif, Spacer } from "@artsy/palette"
+import { Box, Button, color, EyeOpenedIcon, Flex, Sans, Separator, Spacer, Text } from "@artsy/palette"
 import { ViewingRoomArtwork_selectedArtwork$key } from "__generated__/ViewingRoomArtwork_selectedArtwork.graphql"
 import { ViewingRoomArtwork_viewingRoomInfo$key } from "__generated__/ViewingRoomArtwork_viewingRoomInfo.graphql"
 import { ViewingRoomArtworkQuery } from "__generated__/ViewingRoomArtworkQuery.graphql"
@@ -29,7 +29,7 @@ const selectedArtworkFragmentSpec = graphql`
     title
     artistNames
     date
-    description
+    additionalInformation
     saleMessage
     href
     slug
@@ -119,20 +119,20 @@ export const ViewingRoomArtworkContainer: React.FC<ViewingRoomArtworkProps> = pr
           )}
         </Flex>
         <Box mt="2" mx="2">
-          <Sans size="5t" color="black100" weight="medium">
+          <Text variant="title" color="black100">
             {selectedArtwork.artistNames}
-          </Sans>
-          <Sans size="4t" color="black60">
+          </Text>
+          <Text variant="text" color="black60">
             {selectedArtwork.title}, {selectedArtwork.date}
-          </Sans>
+          </Text>
           <Spacer mt="2" />
-          <Sans size="4t" color="black100">
+          <Text variant="text" color="black100">
             {selectedArtwork.saleMessage}
-          </Sans>
-          {!!selectedArtwork.description && (
+          </Text>
+          {!!selectedArtwork.additionalInformation && (
             <>
               <Spacer mt="2" />
-              <Serif size="4t">{selectedArtwork.description}</Serif>
+              <Text variant="text">{selectedArtwork.additionalInformation}</Text>
             </>
           )}
           <Spacer mt="4" />

--- a/src/lib/Scenes/ViewingRoom/ViewingRoomArtwork.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoomArtwork.tsx
@@ -155,9 +155,7 @@ export const ViewingRoomArtworkContainer: React.FC<ViewingRoomArtworkProps> = pr
               <Spacer mt="3" />
               <Separator />
               <Spacer mt="3" />
-              <Sans size="4" weight="medium">
-                More images
-              </Sans>
+              <Text variant="mediumText">More images</Text>
               <Spacer mt="2" />
             </Box>
             <FlatList
@@ -173,9 +171,7 @@ export const ViewingRoomArtworkContainer: React.FC<ViewingRoomArtworkProps> = pr
           <Spacer mt="3" />
           <Separator />
           <Spacer mt="3" />
-          <Sans size="4" weight="medium">
-            In viewing room
-          </Sans>
+          <Text variant="mediumText">In viewing room</Text>
           <Spacer mt="2" />
         </Box>
         <TouchableHighlight

--- a/src/lib/Scenes/ViewingRoom/ViewingRoomArtworks.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoomArtworks.tsx
@@ -1,4 +1,4 @@
-import { Box, color, Flex, Sans, Separator, Serif, space, Spinner, Theme } from "@artsy/palette"
+import { Box, color, Flex, Sans, Separator, Serif, space, Spinner, Text, Theme } from "@artsy/palette"
 import { ViewingRoomArtworks_viewingRoom } from "__generated__/ViewingRoomArtworks_viewingRoom.graphql"
 import { ViewingRoomArtworksQueryRendererQuery } from "__generated__/ViewingRoomArtworksQueryRendererQuery.graphql"
 import ImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
@@ -60,22 +60,22 @@ export const ViewingRoomArtworks: React.FC<ViewingRoomArtworksProps> = props => 
               <Box>
                 <ImageView imageURL={artwork.image?.url} aspectRatio={artwork.image!.aspectRatio} />
                 <Box mt="1" mx="2">
-                  <Sans size="3t" weight="medium">
-                    {artwork.artistNames}
-                  </Sans>
-                  <Sans size="3t" color="black60" key={index}>
+                  <Text variant="mediumText">{artwork.artistNames}</Text>
+                  <Text variant="text" color="black60" key={index}>
                     {artwork.title}
-                  </Sans>
-                  <Sans size="3t" color="black60">
+                  </Text>
+                  <Text variant="text" color="black60">
                     {artwork.saleMessage}
-                  </Sans>
+                  </Text>
                 </Box>
               </Box>
             </TouchableHighlight>
             {!!artwork.additionalInformation && (
-              <Serif size="4" mx="2" mt="1" data-test-id="artwork-additional-information">
-                {artwork.additionalInformation}
-              </Serif>
+              <Flex mx="2" mt="1">
+                <Text variant="text" data-test-id="artwork-additional-information">
+                  {artwork.additionalInformation}
+                </Text>
+              </Flex>
             )}
           </Box>
         ),

--- a/src/lib/Scenes/ViewingRoom/ViewingRoomArtworks.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoomArtworks.tsx
@@ -1,4 +1,4 @@
-import { Box, color, Flex, Sans, Separator, Serif, space, Spinner, Text, Theme } from "@artsy/palette"
+import { Box, color, Flex, Sans, Separator, space, Spinner, Text, Theme } from "@artsy/palette"
 import { ViewingRoomArtworks_viewingRoom } from "__generated__/ViewingRoomArtworks_viewingRoom.graphql"
 import { ViewingRoomArtworksQueryRendererQuery } from "__generated__/ViewingRoomArtworksQueryRendererQuery.graphql"
 import ImageView from "lib/Components/OpaqueImageView/OpaqueImageView"

--- a/src/lib/Scenes/ViewingRoom/ViewingRoomsList.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoomsList.tsx
@@ -12,9 +12,9 @@ import _ from "lodash"
 import React, { useRef, useState } from "react"
 import { FlatList, RefreshControl } from "react-native"
 import { ConnectionConfig } from "react-relay"
-import { graphql, usePagination, useQuery } from "relay-hooks"
+import { graphql, useFragment, usePagination, useQuery } from "relay-hooks"
 import { RailScrollRef } from "../Home/Components/types"
-import { FeaturedRail } from "./Components/ViewingRoomsListFeatured"
+import { featuredFragment, FeaturedRail } from "./Components/ViewingRoomsListFeatured"
 import { ViewingRoomsListItem } from "./Components/ViewingRoomsListItem"
 
 const fragmentSpec = graphql`
@@ -50,6 +50,9 @@ export const ViewingRoomsListContainer: React.FC<ViewingRoomsListProps> = props 
   const [queryData, { isLoading, hasMore, loadMore, refetchConnection }] = usePagination(fragmentSpec, props.query)
   const viewingRooms = extractNodes(queryData.viewingRooms)
 
+  const featuredData = useFragment(featuredFragment, props.featured)
+  const featuredLength = extractNodes(featuredData).length
+
   const handleLoadMore = () => {
     if (!hasMore() || isLoading()) {
       return
@@ -81,11 +84,15 @@ export const ViewingRoomsListContainer: React.FC<ViewingRoomsListProps> = props 
           ListHeaderComponent={() => (
             <>
               <Spacer mt="2" />
-              <Flex mx="2">
-                <SectionTitle title="Featured" />
-              </Flex>
-              <FeaturedRail featured={props.featured} scrollRef={scrollRef} />
-              <Spacer mt="4" />
+              {featuredLength > 0 && (
+                <>
+                  <Flex mx="2">
+                    <SectionTitle title="Featured" />
+                  </Flex>
+                  <FeaturedRail featured={props.featured} scrollRef={scrollRef} />
+                  <Spacer mt="4" />
+                </>
+              )}
               <Flex mx="2">
                 <SectionTitle title="Latest" />
               </Flex>


### PR DESCRIPTION
The type of this PR is: **Bugfix/Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->



### Description

A few things in here again:
- Copy changes, using the new font and removing the Serif one from VR related things.
- If there are no featured VRs, we hide that section in the VR landing page.
- If there are no featured VRs, we show the regular VRs in home.
- Fixed tag color.
- Show description in artwork page, it was hiding in `additionalInformation`.


I'll add #trivial and #skip_new_tests for the new component. It's a funky component that shows the featured rail or if its empty then does a new query to get the regular VRs.
https://f.p0l.co/file/dropshare-public-pavlos/Screen-Recording-2020-07-30-at-20.13.00.mov
I'm guessing we will always/usually have featured VRs so it would be fine to do another request? I felt it was too much to fetch these in the first place juuuust in case we don't have featured.
Also the promo placeholder is making things a bit ugly on wait, but eh. 🤷‍♂️ 
