### PR TITLE
Add basic and static My Bids screen

### DIFF
--- a/Artsy/App/AROptions.h
+++ b/Artsy/App/AROptions.h
@@ -2,6 +2,7 @@
 
 
 // All the options as consts
+extern NSString *const AROptionsBidManagement;
 extern NSString *const AROptionsDebugARVIR;
 extern NSString *const AROptionsDevReactEnv;
 extern NSString *const AROptionsDisableNativeLiveAuctions;

--- a/Artsy/App/AROptions.m
+++ b/Artsy/App/AROptions.m
@@ -5,6 +5,7 @@ static NSDictionary *options = nil;
 // Up here is the NSUserDefault set, and sent into Emission
 
 // UI Tweaks
+NSString *const AROptionsBidManagement = @"AROptionsBidManagement";
 NSString *const AROptionsEnableMyCollection = @"AROptionsEnableMyCollection";
 NSString *const AROptionsLoadingScreenAlpha = @"AROptionsLoadingScreenAlpha";
 NSString *const AROptionsShowAnalyticsOnScreen = @"AROptionsShowAnalyticsOnScreen";
@@ -38,6 +39,7 @@ NSString *const AROptionsPriceTransparency = @"AROptionsPriceTransparency";
          AROptionsViewingRooms: @"Enable Viewing Rooms",
          AROptionsPriceTransparency: @"Price Transparency",
          AROptionsLoadingScreenAlpha: @"Loading screens are transparent",
+         AROptionsBidManagement: @"Enable Bid Management (a.k.a My Bids)",
         };
     });
 }

--- a/Artsy/App/ARSwitchBoard.m
+++ b/Artsy/App/ARSwitchBoard.m
@@ -328,6 +328,10 @@ static ARSwitchBoard *sharedInstance = nil;
         return [[ARComponentViewController alloc] initWithEmission:nil moduleName:@"MyAccountEditPhone" initialProperties:parameters hidesBackButton:YES];
     }];
 
+    [self.routes addRoute:@"/my-bids" handler:JLRouteParams {
+        return [[ARComponentViewController alloc] initWithEmission:nil moduleName:@"MyBids" initialProperties:parameters ];
+    }];
+
     [self.routes addRoute:@"/my-profile/payment" handler:JLRouteParams {
         return [[ARComponentViewController alloc] initWithEmission:nil moduleName:@"MyProfilePayment" initialProperties:parameters ];
     }];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -23,6 +23,7 @@ upcoming:
     - Fixes a bug when selecting home tab - ash
     - Artwork filter button animates into / out of view - ash & david & mounir & brian
     - Add pagination button to InfiniteScrollArtworksGrid component - ashley
+    - Add My Bids (admin only for now) - yuki
 
 releases:
   - version: 6.5.1

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -55,6 +55,7 @@ import { MyAccountEditEmailQueryRenderer } from "./Scenes/MyAccount/MyAccountEdi
 import { MyAccountEditNameQueryRenderer } from "./Scenes/MyAccount/MyAccountEditName"
 import { MyAccountEditPassword } from "./Scenes/MyAccount/MyAccountEditPassword"
 import { MyAccountEditPhoneQueryRenderer } from "./Scenes/MyAccount/MyAccountEditPhone"
+import { MyBids } from "./Scenes/MyBids"
 import { NewSubmissionForm } from "./Scenes/MyCollection/NewSubmissionForm"
 import { MyProfileQueryRenderer } from "./Scenes/MyProfile/MyProfile"
 import { MyProfilePaymentQueryRenderer } from "./Scenes/MyProfile/MyProfilePayment"
@@ -343,6 +344,9 @@ register("MyAccountEditName", MyAccountEditNameQueryRenderer)
 register("MyAccountEditPassword", MyAccountEditPassword)
 register("MyAccountEditEmail", MyAccountEditEmailQueryRenderer)
 register("MyAccountEditPhone", MyAccountEditPhoneQueryRenderer)
+
+// My Bids
+register("MyBids", MyBids)
 
 // My Collection
 register("Sales", setupMyCollectionScreen(Consignments)) // Placeholder for sales tab!

--- a/src/lib/Scenes/MyBids/index.tsx
+++ b/src/lib/Scenes/MyBids/index.tsx
@@ -1,0 +1,57 @@
+import { Text, View } from "react-native"
+import React from "react"
+import { Flex, Message, Sans, Theme } from "@artsy/palette"
+import ScrollableTabView from "react-native-scrollable-tab-view"
+
+import ScrollableTabBar, { ScrollableTab } from "../../Components/ScrollableTabBar"
+import { ProvideScreenDimensions } from "../../utils/useScreenDimensions"
+import { StickyTabPage } from "../../Components/StickyTabPage/StickyTabPage"
+import ArtistHeader from "../../Components/Artist/ArtistHeader"
+import { ProvideScreenTracking } from "../../utils/track"
+import { StickyTabPageScrollView } from "../../Components/StickyTabPage/StickyTabPageScrollView"
+
+export const MyBids = () => (
+  <Theme>
+    <ProvideScreenDimensions>
+      <Flex style={{ flex: 1 }}>
+        <StickyTabPage
+          staticHeaderContent={
+            <View style={{ marginTop: 20 }}>
+              <Sans size="4" weight="medium" textAlign="center">
+                My Bids
+              </Sans>
+            </View>
+          }
+          tabs={[
+            {
+              title: "Upcoming",
+              content: (
+                <StickyTabPageScrollView>
+                  <View>
+                    <Text>
+                      There aren’t any works available by the artist at this time. Follow to receive notifications when
+                      new works are added.
+                    </Text>
+                  </View>
+                </StickyTabPageScrollView>
+              ),
+            },
+            {
+              title: "Recently Closed",
+              content: (
+                <StickyTabPageScrollView>
+                  <View>
+                    <Text>
+                      There aren’t any works available by the artist at this time. Follow to receive notifications when
+                      new works are added.
+                    </Text>
+                  </View>
+                </StickyTabPageScrollView>
+              ),
+            },
+          ]}
+        />
+      </Flex>
+    </ProvideScreenDimensions>
+  </Theme>
+)

--- a/src/lib/Scenes/MyBids/index.tsx
+++ b/src/lib/Scenes/MyBids/index.tsx
@@ -1,57 +1,366 @@
-import { Text, View } from "react-native"
+import {
+  CheckCircleFillIcon,
+  ChevronIcon,
+  Flex,
+  Join,
+  Sans,
+  Separator,
+  Spacer,
+  Text,
+  TimerIcon,
+  XCircleIcon,
+} from "@artsy/palette"
 import React from "react"
-import { Flex, Message, Sans, Theme } from "@artsy/palette"
-import ScrollableTabView from "react-native-scrollable-tab-view"
+import { FlatList, View } from "react-native"
+import styled from "styled-components/native"
 
-import ScrollableTabBar, { ScrollableTab } from "../../Components/ScrollableTabBar"
-import { ProvideScreenDimensions } from "../../utils/useScreenDimensions"
-import { StickyTabPage } from "../../Components/StickyTabPage/StickyTabPage"
-import ArtistHeader from "../../Components/Artist/ArtistHeader"
-import { ProvideScreenTracking } from "../../utils/track"
-import { StickyTabPageScrollView } from "../../Components/StickyTabPage/StickyTabPageScrollView"
+import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
+import { StickyTabPage } from "lib/Components/StickyTabPage/StickyTabPage"
+import { StickyTabPageScrollView } from "lib/Components/StickyTabPage/StickyTabPageScrollView"
+
+const LOT_STANDINGS = [
+  {
+    isHighestBidder: true,
+    isLeadingBidder: true,
+    sale: {
+      liveStartAt: "2020-07-27T14:55:00+00:00",
+      endAt: "2020-07-27T14:55:54+00:00",
+    },
+    saleArtwork: {
+      id: "U2FsZUFydHdvcms6NWYxZWVhMThlZTBmZDkwMDA2MTRiMjIw",
+      lotLabel: "3",
+      counts: {
+        bidderPositions: 1,
+      },
+      currentBid: {
+        display: "CHF 950",
+      },
+      artwork: {
+        slug: "leo-jansen-untitled",
+        artistNames: "Leo Jansen",
+        image: {
+          url: "https://d2v80f5yrouhh2.cloudfront.net/GEShb3U9PruEueZ732WYlw/medium.jpg",
+        },
+      },
+    },
+  },
+  {
+    isHighestBidder: false,
+    isLeadingBidder: false,
+    sale: {
+      liveStartAt: "2020-07-27T14:55:00+00:00",
+      endAt: "2020-07-27T14:55:54+00:00",
+    },
+    saleArtwork: {
+      id: "U2FsZUFydHdvcms6NWYxZWVhMTdlZTBmZDkwMDA2MTRiMjE4",
+      lotLabel: "2",
+      counts: {
+        bidderPositions: 2,
+      },
+      currentBid: {
+        display: "CHF 18,000",
+      },
+      artwork: {
+        slug: "blazo-kovacevic-painting",
+        artistNames: "Blazo Kovacevic",
+        image: {
+          url: "https://d2v80f5yrouhh2.cloudfront.net/NyWl4Lhcj88ImL8vUMWTLw/medium.jpg",
+        },
+      },
+    },
+  },
+  {
+    isHighestBidder: true,
+    isLeadingBidder: true,
+    sale: {
+      liveStartAt: "2020-07-27T14:55:00+00:00",
+      endAt: "2020-07-27T14:55:54+00:00",
+    },
+    saleArtwork: {
+      id: "U2FsZUFydHdvcms6NWYxZWVhMTVlZTBmZDkwMDA2MTRiMjEw",
+      lotLabel: "1",
+      counts: {
+        bidderPositions: 1,
+      },
+      currentBid: {
+        display: "CHF 450",
+      },
+      artwork: {
+        slug: "rodrigo-zamora-painting",
+        artistNames: "Rodrigo Zamora",
+        image: {
+          url: "https://d2v80f5yrouhh2.cloudfront.net/bih3YROhPBXPHecFApJ4Jw/medium.jpg",
+        },
+      },
+    },
+  },
+]
+
+const REGISTERED_SALES = [
+  {
+    node: {
+      endAt: "2020-07-28T17:00:00+00:00",
+      liveStartAt: null,
+      timeZone: "America/New_York",
+      name: "RoGallery: A Curated Summer Sale",
+      slug: "rogallery-a-curated-summer-sale",
+      coverImage: {
+        url: "https://d32dm0rphc51dk.cloudfront.net/gNH3Jqo7shTMj2fPuoHBRg/square.jpg",
+      },
+      partner: {
+        name: "RoGallery Auctions",
+      },
+    },
+  },
+  {
+    node: {
+      endAt: null,
+      liveStartAt: "2020-07-30T16:00:00+00:00",
+      timeZone: "America/Chicago",
+      name: "Wright: Art + Design",
+      slug: "wright-art-plus-design-13",
+      coverImage: {
+        url: "https://d32dm0rphc51dk.cloudfront.net/oatfVx6L7sj2DSEPBtt8PQ/large_rectangle.jpg",
+      },
+      partner: {
+        name: "Rago/Wright",
+      },
+    },
+  },
+  {
+    node: {
+      endAt: "2020-07-29T16:00:00+00:00",
+      liveStartAt: null,
+      timeZone: "America/New_York",
+      name: "Artsy x Capsule Auctions: Collection Refresh III",
+      slug: "artsy-x-capsule-auctions-collection-refresh-iii",
+      coverImage: {
+        url: "https://d32dm0rphc51dk.cloudfront.net/XPuUTGDL_z7mypji_tv39Q/wide.jpg",
+      },
+      partner: {
+        name: "Artsy x Capsule Auctions",
+      },
+    },
+  },
+  {
+    node: {
+      endAt: null,
+      liveStartAt: "2020-08-05T15:00:00+00:00",
+      timeZone: "America/Chicago",
+      name: "Heritage: Urban Art Summer Skate",
+      slug: "heritage-urban-art-summer-skate",
+      coverImage: {
+        url: "https://d32dm0rphc51dk.cloudfront.net/JOeiPjbfKixGJbQjQHubXA/source.jpg",
+      },
+      partner: {
+        name: "Heritage Auctions",
+      },
+    },
+  },
+  {
+    node: {
+      endAt: "2020-07-30T21:00:00+00:00",
+      liveStartAt: null,
+      timeZone: "America/New_York",
+      name: "LongHouse Shares: Benefit Auction 2020",
+      slug: "longhouse-shares-benefit-auction-2020",
+      coverImage: {
+        url: "https://d32dm0rphc51dk.cloudfront.net/TiJguopz8SwkypYEBH1TJw/source.jpg",
+      },
+      partner: {
+        name: "LongHouse Reserve Benefit Auction",
+      },
+    },
+  },
+]
+
+const CARD_WIDTH = 330
+const CARD_HEIGHT = 140
+
+const CardRailCard = styled.TouchableHighlight.attrs({ underlayColor: "transparent" })`
+  width: ${CARD_WIDTH}px;
+  border: 1px solid #e5e5e5;
+  border-radius: 4px;
+  overflow: hidden;
+`
+
+const CardRailArtworkImageContainer = styled.View`
+  width: 100%;
+  height: ${CARD_HEIGHT}px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  overflow: hidden;
+`
+
+const LotRow = ({ lot }: { lot: typeof LOT_STANDINGS[0] }) => {
+  return (
+    <View>
+      <Flex my="1" flexDirection="row">
+        <Flex mr="1">
+          <OpaqueImageView width={60} height={60} imageURL={lot.saleArtwork.artwork.image.url} />
+        </Flex>
+
+        <Flex flexGrow={1}>
+          <Text variant="caption">{lot.saleArtwork.artwork.artistNames}</Text>
+          <Text variant="caption">Lot {lot.saleArtwork.lotLabel}</Text>
+          <Text variant="caption" color="black60">
+            Opens in 22 minutes
+          </Text>
+        </Flex>
+
+        <Flex flexGrow={1} alignItems="flex-end">
+          <Flex flexDirection="row">
+            <Text variant="caption">{lot.saleArtwork.currentBid.display}</Text>
+            <Text variant="caption" color="black60">
+              {" "}
+              ({lot.saleArtwork.counts.bidderPositions} {lot.saleArtwork.counts.bidderPositions === 1 ? "bid" : "bids"})
+            </Text>
+          </Flex>
+          <Flex flexDirection="row" alignItems="center">
+            {lot.isHighestBidder ? (
+              <>
+                <CheckCircleFillIcon fill="green100" />
+                <Text variant="caption"> Highest Bid</Text>
+              </>
+            ) : (
+              <>
+                <XCircleIcon fill="red100" />
+                <Text variant="caption"> Outbid</Text>
+              </>
+            )}
+          </Flex>
+        </Flex>
+      </Flex>
+
+      <Separator my="1" />
+    </View>
+  )
+}
 
 export const MyBids = () => (
-  <Theme>
-    <ProvideScreenDimensions>
-      <Flex style={{ flex: 1 }}>
-        <StickyTabPage
-          staticHeaderContent={
-            <View style={{ marginTop: 20 }}>
-              <Sans size="4" weight="medium" textAlign="center">
-                My Bids
-              </Sans>
-            </View>
-          }
-          tabs={[
-            {
-              title: "Upcoming",
-              content: (
-                <StickyTabPageScrollView>
-                  <View>
-                    <Text>
-                      There aren’t any works available by the artist at this time. Follow to receive notifications when
-                      new works are added.
+  <Flex flex={1}>
+    <StickyTabPage
+      staticHeaderContent={
+        <Flex mt={2}>
+          <Sans size="4" weight="medium" textAlign="center">
+            My Bids
+          </Sans>
+        </Flex>
+      }
+      tabs={[
+        {
+          title: "Upcoming",
+          content: (
+            <StickyTabPageScrollView style={{ paddingHorizontal: 0 }}>
+              <View>
+                <Flex mt="2" mb="1" mx="2">
+                  <Text variant="subtitle">Registered Sales</Text>
+                </Flex>
+
+                <Flex flexDirection="row">
+                  <Join separator={<Spacer mr={0.5} />}>
+                    <FlatList
+                      horizontal
+                      ListHeaderComponent={() => <Spacer mr={2} />}
+                      ListFooterComponent={() => <Spacer mr={2} />}
+                      ItemSeparatorComponent={() => <Spacer width={15} />}
+                      showsHorizontalScrollIndicator={false}
+                      initialNumToRender={5}
+                      windowSize={3}
+                      data={REGISTERED_SALES}
+                      keyExtractor={({ node }) => node.slug}
+                      renderItem={({ item }) => {
+                        return (
+                          <CardRailCard key={item.node.slug}>
+                            <View>
+                              <CardRailArtworkImageContainer>
+                                <OpaqueImageView
+                                  width={CARD_WIDTH}
+                                  height={CARD_HEIGHT}
+                                  imageURL={item.node.coverImage.url}
+                                />
+                              </CardRailArtworkImageContainer>
+
+                              <Flex style={{ margin: 15 }}>
+                                {!!item.node.partner?.name && (
+                                  <Text variant="small" color="black60">
+                                    {item.node.partner.name}
+                                  </Text>
+                                )}
+                                <Text variant="title">{item.node.name}</Text>
+
+                                <Flex style={{ marginTop: 15 }} flexDirection="row">
+                                  <TimerIcon fill="black60" />
+
+                                  <Flex style={{ marginLeft: 5 }}>
+                                    <Text variant="caption">Live sale opens today at 5:00pm</Text>
+                                    <Text variant="caption" color="black60">
+                                      Starting in 44 minutes
+                                    </Text>
+                                  </Flex>
+                                </Flex>
+                              </Flex>
+                            </View>
+                          </CardRailCard>
+                        )
+                      }}
+                    />
+                  </Join>
+                </Flex>
+
+                <Flex m="2">
+                  <Text variant="subtitle">Your lots</Text>
+
+                  {LOT_STANDINGS.map((lot, index) => (
+                    <LotRow lot={lot} key={index} />
+                  ))}
+
+                  <Flex pt="1" pb="2" flexDirection="row" alignItems="center">
+                    <Flex flexGrow={1}>
+                      <Text variant="caption">View past bids</Text>
+                    </Flex>
+
+                    <Text variant="caption" color="black60">
+                      30
                     </Text>
-                  </View>
-                </StickyTabPageScrollView>
-              ),
-            },
-            {
-              title: "Recently Closed",
-              content: (
-                <StickyTabPageScrollView>
-                  <View>
-                    <Text>
-                      There aren’t any works available by the artist at this time. Follow to receive notifications when
-                      new works are added.
-                    </Text>
-                  </View>
-                </StickyTabPageScrollView>
-              ),
-            },
-          ]}
-        />
-      </Flex>
-    </ProvideScreenDimensions>
-  </Theme>
+
+                    <ChevronIcon direction="right" fill="black60" />
+                  </Flex>
+
+                  <Separator mb="2" />
+                </Flex>
+              </View>
+            </StickyTabPageScrollView>
+          ),
+        },
+        {
+          title: "Recently Closed",
+          content: (
+            <StickyTabPageScrollView>
+              <Flex mt={1}>
+                {LOT_STANDINGS.map((lot, index) => (
+                  <LotRow lot={lot} key={index} />
+                ))}
+
+                <Flex pt="1" pb="2" flexDirection="row" alignItems="center">
+                  <Flex flexGrow={1}>
+                    <Text variant="caption">View full history</Text>
+                  </Flex>
+
+                  <Text variant="caption" color="black60">
+                    30
+                  </Text>
+
+                  <ChevronIcon direction="right" fill="black60" />
+                </Flex>
+
+                <Separator mb="2" />
+              </Flex>
+            </StickyTabPageScrollView>
+          ),
+        },
+      ]}
+    />
+  </Flex>
 )

--- a/src/lib/Scenes/MyProfile/MyProfile.tsx
+++ b/src/lib/Scenes/MyProfile/MyProfile.tsx
@@ -17,6 +17,7 @@ const MyProfile: React.FC<{ me: MyProfile_me; relay: RelayRefetchProp }> = ({ me
   const navRef = useRef(null)
   const listRef = useRef<FlatList<any>>()
   const recentlySavedArtworks = extractNodes(me.followsAndSaves?.artworksConnection)
+  const shouldDisplayMyBids = NativeModules?.Emission?.options?.AROptionsBidManagement
   const [isRefreshing, setIsRefreshing] = useState(false)
   const onRefresh = useCallback(() => {
     setIsRefreshing(true)
@@ -25,6 +26,7 @@ const MyProfile: React.FC<{ me: MyProfile_me; relay: RelayRefetchProp }> = ({ me
       listRef.current?.scrollToOffset({ offset: 0, animated: false })
     })
   }, [])
+
   return (
     <ScrollView ref={navRef} refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />}>
       <Sans size="8" mx="2" mt="3">
@@ -32,6 +34,12 @@ const MyProfile: React.FC<{ me: MyProfile_me; relay: RelayRefetchProp }> = ({ me
       </Sans>
       <Separator my={2} />
       <SectionHeading title="Favorites" />
+      {!!shouldDisplayMyBids && (
+        <MyProfileMenuItem
+          title="My Bids"
+          onPress={() => SwitchBoard.presentNavigationViewController(navRef.current!, "my-bids")}
+        />
+      )}
       <MyProfileMenuItem
         title="Saves and Follows"
         onPress={() => SwitchBoard.presentNavigationViewController(navRef.current!, "favorites")}

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -133,6 +133,7 @@ NativeModules.ARNotificationsManager = {
   nativeState: {
     selectedTab: "home",
     emissionOptions: {
+      AROptionsBidManagement: false,
       AROptionsEnableMyCollection: false,
       AROptionsLotConditionReport: false,
       AROptionsPriceTransparency: false,
@@ -171,6 +172,7 @@ function setupEmissionModule() {
     metaphysicsURL: "metaphysicsURL",
     deviceId: "testDevice",
     options: {
+      AROptionsBidManagement: false,
       AROptionsEnableMyCollection: false,
       AROptionsLotConditionReport: false,
       AROptionsPriceTransparency: false,

--- a/typings/emission.d.ts
+++ b/typings/emission.d.ts
@@ -2,8 +2,9 @@ import { NativeState } from "lib/store/NativeModel"
 import { NativeModulesStatic } from "react-native"
 declare module "react-native" {
   interface EmissionOptions {
-    AROptionsLotConditionReport: boolean
+    AROptionsBidManagement: boolean
     AROptionsEnableMyCollection: boolean
+    AROptionsLotConditionReport: boolean
     AROptionsPriceTransparency: boolean
     AROptionsViewingRooms: boolean
     AREnableViewingRooms: boolean


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/AUCT-1158

This is the first basic implementation of the new My Bids screen. The data shown is all static as we are still working on the backend to expose the necessary GraphQL queries/fields, but you should be able to see what it looks like and it should allow us to iterate on the frontend without having to wait until the backend work is done.

#skip_new_tests

## Screenshots

The "Enable Bid Management" feature flag needs to be on to have the My Bids row show up on the My Profile screen:

<img width="559" alt="Screen Shot 2020-07-30 at 4 29 47 PM" src="https://user-images.githubusercontent.com/386234/88972749-08994580-d284-11ea-89c1-c019b45e4b47.png">

And the actual UX:

![AUCT-1158-resized](https://user-images.githubusercontent.com/386234/88973134-a725a680-d284-11ea-9044-368e0af7164f.gif)
