### PR TITLE
[MX-356] - Move show/hide button outside text field to avoid clear overlap #trivial

### DIFF
--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/3_-_Sign_Up_+_Log_In/ARLoginFieldsView.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/3_-_Sign_Up_+_Log_In/ARLoginFieldsView.m
@@ -102,10 +102,10 @@
     [self.showPasswordButton setTitle:@"SHOW" forState:UIControlStateNormal];
     [self.showPasswordButton setTitleColor:[UIColor artsyGrayMedium] forState:UIControlStateNormal];
     self.showPasswordButton.titleLabel.font = [UIFont sansSerifFontWithSize:14.0];
-    self.showPasswordButton.titleLabel.textAlignment = NSTextAlignmentRight;
+    self.showPasswordButton.titleLabel.textAlignment = NSTextAlignmentCenter;
     [self.showPasswordButton addTarget:self action:@selector(toggleShowPassword:) forControlEvents:UIControlEventTouchUpInside];
+
     [self addSubview:self.showPasswordButton];
-    
     [self.showPasswordButton alignTopEdgeWithView:self predicate:@"30"];
     [self.showPasswordButton constrainWidth:@"80" height:@"54"];
     [self.showPasswordButton alignTrailingEdgeWithView:self predicate:@"-1"];
@@ -130,7 +130,7 @@
     [self.emailField alignTrailingEdgeWithView:self predicate:@"-20"];
     
     [self.passwordField alignLeadingEdgeWithView:self predicate:@"20"];
-    [self.passwordField alignTrailingEdgeWithView:self predicate:@"-20"];
+    [self.passwordField alignTrailingEdgeWithView:self.showPasswordButton predicate:@"-80"];
     
     self.emailField.baseline.backgroundColor = [UIColor blackColor].CGColor;
     self.passwordField.baseline.backgroundColor = [UIColor blackColor].CGColor;
@@ -152,7 +152,6 @@
     self.passwordField.secureTextEntry = !self.passwordField.secureTextEntry;
     NSString *titleText = self.passwordField.secureTextEntry ? @"SHOW" : @"HIDE";
     [self.showPasswordButton setTitle:titleText forState:UIControlStateNormal];
-    
 }
 
 - (void)enableErrorState

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -24,6 +24,7 @@ upcoming:
     - Artwork filter button animates into / out of view - ash & david & mounir & brian
     - Add pagination button to InfiniteScrollArtworksGrid component - ashley
     - Add My Bids (admin only for now) - yuki
+    - Fix show/hide button overlap with clear button in password field - brian
 
 releases:
   - version: 6.5.1


### PR DESCRIPTION
The type of this PR is: **Bugfix**
This PR resolves **[MX-356]**

### Description

Moves the show/hide button outside the password textfield on login and create password screens to avoid overlap with the clear button.
### Screenshots

#### Before
![before](https://user-images.githubusercontent.com/49686530/89049841-da694380-d31f-11ea-9d68-b63649f49695.png)



#### After

![after](https://user-images.githubusercontent.com/49686530/89049107-bf4a0400-d31e-11ea-9d2c-9954d3c616ee.png)



[MX-356]: https://artsyproduct.atlassian.net/browse/MX-356