### PR TITLE
[MX-437] Update type on Artwork Classifications

### DIFF
--- a/src/lib/Scenes/ArtworkAttributionClassFAQ/ArtworkAttributionClassFAQ.tsx
+++ b/src/lib/Scenes/ArtworkAttributionClassFAQ/ArtworkAttributionClassFAQ.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Sans, Serif, Spacer, Theme } from "@artsy/palette"
+import { Box, Button, Sans, Spacer, Theme } from "@artsy/palette"
 import { ArtworkAttributionClassFAQ_artworkAttributionClasses } from "__generated__/ArtworkAttributionClassFAQ_artworkAttributionClasses.graphql"
 import { ArtworkAttributionClassFAQQuery } from "__generated__/ArtworkAttributionClassFAQQuery.graphql"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
@@ -17,10 +17,10 @@ export const ArtworkAttributionClassFAQ: React.FC<Props> = ({ artworkAttribution
   const attributionClasses = artworkAttributionClasses.map((attributionClass, index) => {
     return (
       <React.Fragment key={index}>
-        <Serif size="3" weight="semibold">
+        <Sans size="3" weight="medium">
           {attributionClass.name}
-        </Serif>
-        <Serif size="3">{attributionClass.longDescription}</Serif>
+        </Sans>
+        <Sans size="3">{attributionClass.longDescription}</Sans>
         <Spacer m={1} />
       </React.Fragment>
     )
@@ -34,9 +34,9 @@ export const ArtworkAttributionClassFAQ: React.FC<Props> = ({ artworkAttribution
       <ScrollView ref={navRef}>
         <Box pt={safeAreaInsets.top + 3} pb={safeAreaInsets.top + 4} px={2}>
           <Spacer mt={3} />
-          <Serif mb={2} size="8">
+          <Sans mb={2} size="8">
             Artwork classifications
-          </Serif>
+          </Sans>
           {attributionClasses}
           <Sans color="black60" size="3" mb={3}>
             Our partners are responsible for providing accurate classification information for all works.

--- a/src/lib/Scenes/ArtworkAttributionClassFAQ/__tests__/ArtworkAttributionClassFAQ-tests.tsx
+++ b/src/lib/Scenes/ArtworkAttributionClassFAQ/__tests__/ArtworkAttributionClassFAQ-tests.tsx
@@ -1,4 +1,4 @@
-import { Button, Serif } from "@artsy/palette"
+import { Button, Sans } from "@artsy/palette"
 // @ts-ignore STRICTNESS_MIGRATION
 import { mount } from "enzyme"
 import React from "react"
@@ -22,7 +22,7 @@ describe("ArtworkAttributionClassFAQ", () => {
     )
     expect(
       component
-        .find(Serif)
+        .find(Sans)
         .at(0)
         .text()
     ).toEqual("Artwork classifications")
@@ -55,17 +55,17 @@ describe("ArtworkAttributionClassFAQ", () => {
     )
     expect(
       component
-        .find(Serif)
+        .find(Sans)
         .at(1)
         .text()
     ).toEqual("Unique")
     expect(
       component
-        .find(Serif)
+        .find(Sans)
         .at(2)
         .text()
     ).toEqual("One of a kind piece, created by the artist.")
-    expect(component.find(Serif)).toHaveLength(15)
+    expect(component.find(Sans)).toHaveLength(17)
   })
 
   it("returns to previous page when ok button is clicked", () => {


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR resolves **[MX-437]**

### Description

Update typography on Artwork Classification from Serif to Sans


### Screenshots
**Before**
<img width="295" alt="Screenshot 2020-08-03 at 12 41 18" src="https://user-images.githubusercontent.com/11945712/89176932-bb221e80-d58a-11ea-82f9-dbb5c1a28a2f.png">
**After**
<img width="300" alt="Screenshot 2020-08-03 at 13 10 45" src="https://user-images.githubusercontent.com/11945712/89176937-c07f6900-d58a-11ea-8eef-5b47d2f438b2.png">

<!-- Add screenshots or simulator recordings if applicable -->
#trivial

[MX-437]: https://artsyproduct.atlassian.net/browse/MX-437