### PR TITLE
Partner view on ipad

### DIFF
--- a/Artsy/View_Controllers/Fair/ARProfileViewController.m
+++ b/Artsy/View_Controllers/Fair/ARProfileViewController.m
@@ -62,37 +62,37 @@
 
 - (void)loadProfile
 {
-        // We need to figure out if it's a fair URL or not
-        //
-        // So let's load the martsy view now, and at the same time
-        // make a request to find whether the vanity URL represents a
-        // fair, so that we can show the native VCs on iPhone
-        [self loadMartsyView];
-        [self ar_presentIndeterminateLoadingIndicatorAnimated:YES];
+    // We need to figure out if it's a fair URL or not
+    //
+    // So let's load the martsy view now, and at the same time
+    // make a request to find whether the vanity URL represents a
+    // fair, so that we can show the native VCs on iPhone
+    [self loadMartsyView];
+    [self ar_presentIndeterminateLoadingIndicatorAnimated:YES];
 
-        [ArtsyAPI getProfileForProfileID:self.profileID success:^(Profile *profile) {
-            // It's a fair
-            if ([profile.profileOwner isKindOfClass:[Fair class]]) {
-                // Remove the loading martsy view, and replace it with the ARFairVC
-                [self ar_removeChildViewController: self.childViewControllers.firstObject];
+    [ArtsyAPI getProfileForProfileID:self.profileID success:^(Profile *profile) {
+        // It's a fair
+        if ([profile.profileOwner isKindOfClass:[Fair class]]) {
+            // Remove the loading martsy view, and replace it with the ARFairVC
+            [self ar_removeChildViewController: self.childViewControllers.firstObject];
 
-                NSString * fairID = ((Fair *) profile.profileOwner).fairID;
-                ARFairComponentViewController *viewController = [[ARFairComponentViewController alloc] initWithFairID:fairID];
-                [self showViewController:viewController];
-            } else if ([profile.profileOwner isKindOfClass:[Partner class]] && ARSwitchBoard.sharedInstance.echo.features[@"AREnableNewPartnerView"].state) {
-              [self ar_removeChildViewController: self.childViewControllers.firstObject];
-              
-              NSString *partnerID = ((Partner *) profile.profileOwner).partnerID;
-              ARPartnerComponentViewController *viewController =
-              [[ARPartnerComponentViewController alloc] initWithPartnerID:partnerID];
-              [self showViewController:viewController];
-            }
+            NSString * fairID = ((Fair *) profile.profileOwner).fairID;
+            ARFairComponentViewController *viewController = [[ARFairComponentViewController alloc] initWithFairID:fairID];
+            [self showViewController:viewController];
+        } else if ([profile.profileOwner isKindOfClass:[Partner class]] && ARSwitchBoard.sharedInstance.echo.features[@"AREnableNewPartnerView"].state) {
+            [self ar_removeChildViewController: self.childViewControllers.firstObject];
 
-            [self ar_removeIndeterminateLoadingIndicatorAnimated:YES];
-        } failure:^(NSError *error) {
-            ARErrorLog(@"Error getting Profile %@, falling back to Martsy.", self.profileID);
-            [self ar_removeIndeterminateLoadingIndicatorAnimated:YES];
-        }];
+            NSString *partnerID = ((Partner *) profile.profileOwner).partnerID;
+            ARPartnerComponentViewController *viewController =
+            [[ARPartnerComponentViewController alloc] initWithPartnerID:partnerID];
+            [self showViewController:viewController];
+        }
+
+        [self ar_removeIndeterminateLoadingIndicatorAnimated:YES];
+    } failure:^(NSError *error) {
+        ARErrorLog(@"Error getting Profile %@, falling back to Martsy.", self.profileID);
+        [self ar_removeIndeterminateLoadingIndicatorAnimated:YES];
+    }];
 }
 
 - (void)loadMartsyView

--- a/Artsy/View_Controllers/Fair/ARProfileViewController.m
+++ b/Artsy/View_Controllers/Fair/ARProfileViewController.m
@@ -62,10 +62,6 @@
 
 - (void)loadProfile
 {
-    // We have no unique vanity URLs for iPad, so always load the martsy view
-    if ([UIDevice isPad]) {
-        [self loadMartsyView];
-    } else {
         // We need to figure out if it's a fair URL or not
         //
         // So let's load the martsy view now, and at the same time
@@ -97,7 +93,6 @@
             ARErrorLog(@"Error getting Profile %@, falling back to Martsy.", self.profileID);
             [self ar_removeIndeterminateLoadingIndicatorAnimated:YES];
         }];
-    }
 }
 
 - (void)loadMartsyView

--- a/Artsy_Tests/View_Controller_Tests/Fair/ARProfileViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Fair/ARProfileViewControllerTests.m
@@ -92,7 +92,6 @@ describe(@"loadProfile", ^{
         });
 
         it(@"loads a fairvc on iphone with a fair organizer", ^{
-            [ARTestContext stubDevice:ARDeviceTypePhone5];
             [[viewControllerMock reject] showViewController:[OCMArg checkForClass:[ARFairComponentViewController class]]];
             [[viewControllerMock expect] loadMartsyView];
             [[apiMock expect] getProfileForProfileID:profileID success:[OCMArg checkWithBlock:^BOOL(void (^obj)(Profile *profile)) {
@@ -120,7 +119,6 @@ describe(@"loadProfile", ^{
         });
 
         it(@"loads a fairvc on iphone with a fair", ^{
-            [ARTestContext stubDevice:ARDeviceTypePhone5];
             // Shows the web view
             [[viewControllerMock expect] loadMartsyView];
             // Removes the web view
@@ -142,20 +140,6 @@ describe(@"loadProfile", ^{
                 }
                 return YES;
             }] failure:OCMOCK_ANY];
-            
-            [viewController loadProfile];
-            [viewControllerMock verify];
-            
-            [apiMock verify];
-            [apiMock stopMocking];
-            [ARTestContext stopStubbing];
-        });
-
-        it(@"always loads martsy on ipad", ^{
-            [ARTestContext stubDevice:ARDeviceTypePad];
-            [[viewControllerMock reject] showViewController:[OCMArg checkForClass:[ARFairComponentViewController class]]];
-            [[viewControllerMock expect] loadMartsyView];
-            [[apiMock reject] getProfileForProfileID:profileID success:OCMOCK_ANY failure:OCMOCK_ANY];
             
             [viewController loadProfile];
             [viewControllerMock verify];


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->



### Description

Enable the ipad app to go to partners natively, not in a webview.

<!-- Implementation description -->

### Test Plan

I guess try to go to one, or maybe try to see if there is a case where this might be/look broken?
<!-- If necessary -->

### Screenshots

<!-- Add screenshots or simulator recordings if applicable -->

These are a bit slow on my network and device, but you see the diff.

#### before
https://f.p0l.co/file/dropshare-public-pavlos/RPReplay_Final1596450747.MP4

#### after
https://f.p0l.co/file/dropshare-public-pavlos/RPReplay_Final1596450608.MP4