### PR TITLE
[MX-492] - Disable sailthru swizzling to fix existing notifications

### DIFF
--- a/Artsy/App/ARAppDelegate.m
+++ b/Artsy/App/ARAppDelegate.m
@@ -124,11 +124,12 @@ static ARAppDelegate *_sharedInstance = nil;
     if (self.window) {
         return;
     }
-    
+
     self.sailThru = [SailthruMobile new];
+    [self.sailThru setAutoIntegrationEnabled:NO];
     [self.sailThru setShouldClearBadgeOnLaunch:NO];
     [self.sailThru startEngine:[[ArtsyKeys new] sailthruKey] withAuthorizationOption:STMPushAuthorizationOptionNoRequest];
-    
+
 
     // Temp Fix for: https://github.com/artsy/eigen/issues/602
     [self forceCacheCustomFonts];

--- a/Artsy/App/ARAppNotificationsDelegate.m
+++ b/Artsy/App/ARAppNotificationsDelegate.m
@@ -135,6 +135,7 @@
     UNAuthorizationOptions authOptions = (UNAuthorizationOptionBadge | UNAuthorizationOptionSound | UNAuthorizationOptionAlert);
     [[UNUserNotificationCenter currentNotificationCenter] requestAuthorizationWithOptions:authOptions completionHandler:^(BOOL granted, NSError * _Nullable error) {
         NSString *grantedString = granted ? @"YES" : @"NO";
+        [[[ARAppDelegate sharedInstance] sailThru] syncNotificationSettings];
         [ARAnalytics event:ARAnalyticsPushNotificationsRequested withProperties:@{@"granted" : grantedString}];
     }];
 
@@ -189,6 +190,7 @@
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))handler;
 {
     [self applicationDidReceiveRemoteNotification:userInfo inApplicationState:application.applicationState];
+    [[[ARAppDelegate sharedInstance] sailThru] handleNotificationPayload:userInfo];
     handler(UIBackgroundFetchResultNoData);
 }
 


### PR DESCRIPTION
The type of this PR is: **Bugfix**
This PR resolves **[MX-492]**

### Description

Disables 'auto-integration' from sailthru SDK which swizzles notification related methods that we use to handle deep linking. 

### Test Plan

- Send existing push notifications from staging and confirm deep links are followed 
- Send Sailthru notifications from console and confirm deep links are followed and pushes are generally handled correctly 



[MX-492]: https://artsyproduct.atlassian.net/browse/MX-492