### PR TITLE
Use standard page template on featured artist list

### DIFF
--- a/src/lib/Scenes/Collection/Components/FullFeaturedArtistList.tsx
+++ b/src/lib/Scenes/Collection/Components/FullFeaturedArtistList.tsx
@@ -1,13 +1,13 @@
-import { Box, color, Sans, Theme } from "@artsy/palette"
+import { Box } from "@artsy/palette"
 import { FullFeaturedArtistList_collection } from "__generated__/FullFeaturedArtistList_collection.graphql"
 import { FullFeaturedArtistListQuery } from "__generated__/FullFeaturedArtistListQuery.graphql"
 import { ArtistListItemContainer as ArtistListItem } from "lib/Components/ArtistListItem"
+import { PageWithSimpleHeader } from "lib/Components/PageWithSimpleHeader"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import React from "react"
 import { Dimensions, FlatList, ViewProperties } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
-import styled from "styled-components/native"
 
 interface Props extends ViewProperties {
   collection: FullFeaturedArtistList_collection
@@ -39,18 +39,11 @@ export class FullFeaturedArtistList extends React.Component<Props> {
     const allArtists = this.getFeaturedArtists()
 
     return (
-      <Theme>
+      <PageWithSimpleHeader title="Featured Artists">
         <FlatList
-          contentContainerStyle={{ marginLeft: 20, marginRight: 20 }}
+          contentContainerStyle={{ marginLeft: 20, marginRight: 20, paddingVertical: 20 }}
           data={allArtists}
           keyExtractor={(_item, index) => String(index)}
-          ListHeaderComponent={() => (
-            <HeaderContainer mb={2}>
-              <Sans size="4" textAlign="center" weight="medium">
-                Featured Artists
-              </Sans>
-            </HeaderContainer>
-          )}
           renderItem={({ item }) => {
             return (
               // @ts-ignore STRICTNESS_MIGRATION
@@ -63,7 +56,7 @@ export class FullFeaturedArtistList extends React.Component<Props> {
             )
           }}
         />
-      </Theme>
+      </PageWithSimpleHeader>
     )
   }
 }
@@ -85,15 +78,6 @@ export const CollectionFeaturedArtistsContainer = createFragmentContainer(FullFe
     }
   `,
 })
-
-const HeaderContainer = styled(Box)`
-  border-bottom-width: 1px;
-  border-color: ${color("black10")};
-  margin-left: -20px;
-  margin-right: -20px;
-  padding-top: 25px;
-  padding-bottom: 25px;
-`
 
 export const CollectionFullFeaturedArtistListQueryRenderer: React.SFC<{ collectionID: string }> = ({
   collectionID,


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves a QA item https://www.notion.so/artsy/header-in-Featured-Artists-list-in-collections-view-is-misaligned-05e969249d8e45ffbba5b68bcdc99f23

### Description

Use the standard `PageWithSimpleHeader` component

### Screenshots
before:
![image](https://user-images.githubusercontent.com/1242537/89309021-d4020100-d66a-11ea-9c21-2d56631a22d0.png)

after: 
![image](https://user-images.githubusercontent.com/1242537/89308972-c64c7b80-d66a-11ea-8a09-3d25277a8778.png)
