### PR TITLE
Adjust artwork separator horizontal margin

### DIFF
--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -252,7 +252,7 @@ export class Artwork extends React.Component<Props, State> {
       <FlatList<ArtworkPageSection>
         data={this.sections()}
         ItemSeparatorComponent={() => (
-          <Box px={2} mx={2} my={3}>
+          <Box mx={2} my={3}>
             <Separator />
           </Box>
         )}


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR resolves **[This](https://artsyproduct.atlassian.net/browse/MX-427?focusedCommentId=30419)**

### Description

<!-- Implementation description -->
Remove padding from the `ItemSeparatorComponent`

### Screenshots
<img width="298" alt="Screenshot 2020-08-04 at 18 11 34" src="https://user-images.githubusercontent.com/11945712/89317848-43352080-d67e-11ea-9f56-8e34c5ba78ef.png">
<img width="305" alt="Screenshot 2020-08-04 at 18 11 42" src="https://user-images.githubusercontent.com/11945712/89317856-44fee400-d67e-11ea-9d90-53cf6db73008.png">

#trivial