### PR TITLE
[MX-493] - Push notification authorization not determined state 

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -168,7 +168,7 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
 
 #pragma mark - Native Module: Push Notification Permissions
 
-    emission.APIModule.notificationPermissionPrompter = ^(RCTResponseSenderBlock block) {
+    emission.APIModule.notificationPermissionPrompter = ^() {
         ARAppNotificationsDelegate *delegate = [[JSDecoupledAppDelegate sharedAppDelegate] remoteNotificationsDelegate];
         [delegate registerForDeviceNotificationsWithApple];
     };

--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -166,6 +166,13 @@ FollowRequestFailure(RCTResponseSenderBlock block, BOOL following, NSError *erro
 
     [AREmission setSharedInstance:emission];
 
+#pragma mark - Native Module: Push Notification Permissions
+
+    emission.APIModule.notificationPermissionPrompter = ^(RCTResponseSenderBlock block) {
+        ARAppNotificationsDelegate *delegate = [[JSDecoupledAppDelegate sharedAppDelegate] remoteNotificationsDelegate];
+        [delegate registerForDeviceNotificationsWithApple];
+    };
+
 #pragma mark - Native Module: Follow status
 
     emission.APIModule.notificationReadStatusAssigner = ^(RCTResponseSenderBlock block) {

--- a/Artsy/App/ARAppNotificationsDelegate.h
+++ b/Artsy/App/ARAppNotificationsDelegate.h
@@ -1,5 +1,7 @@
 #import <JSDecoupledAppDelegate/JSDecoupledAppDelegate.h>
 
+#import <React/RCTUtils.h>
+#import <React/RCTDevSettings.h>
 
 @interface ARAppNotificationsDelegate : NSObject <JSApplicationRemoteNotificationsDelegate>
 
@@ -15,6 +17,7 @@ typedef NS_ENUM(NSInteger, ARAppNotificationsRequestContext) {
 - (void)registerForDeviceNotificationsWithContext:(ARAppNotificationsRequestContext)requestContext;
 - (void)applicationDidReceiveRemoteNotification:(NSDictionary *)userInfo inApplicationState:(UIApplicationState)applicationState;
 
-/// Private API, used only in admin tools
+/// Used in admin tools and for react native to request permissions
 - (void)registerForDeviceNotificationsWithApple;
+
 @end

--- a/Artsy/App/ARAppNotificationsDelegate.m
+++ b/Artsy/App/ARAppNotificationsDelegate.m
@@ -39,7 +39,6 @@
         // if you've rejected Apple's push notification and you've not seen our prompt to send you to settings
         // lets show you a prompt to go to settings
         [self displayPushNotificationSettingsPrompt];
-
     } else if (![AROptions boolForOption:ARPushNotificationsAppleDialogueSeen] && [self shouldPresentPushNotificationAgain]) {
         // As long as you've not seen Apple's dialogue already, we will show you our pre-prompt.
         [self displayPushNotificationLocalRequestPrompt];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -27,6 +27,7 @@ upcoming:
     - Add pagination button to InfiniteScrollArtworksGrid component - ashley
     - Add My Bids (admin only for now) - yuki
     - Fix show/hide button overlap with clear button in password field - brian
+    - Adds push notifications notDetermined state to settings - david & mounir & brian
 
 releases:
   - version: 6.5.1

--- a/emission/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.h
+++ b/emission/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.h
@@ -3,12 +3,16 @@
 
 typedef void(^ARNotificationReadStatusAssigner)(RCTResponseSenderBlock block);
 
+typedef void(^ARNotificationPermissionsPrompter)(RCTResponseSenderBlock block);
+
 typedef void(^ARAugmentedRealityVIRPresenter)(NSString *imgUrl, CGFloat widthIn, CGFloat heightIn, NSString *artworkSlug, NSString *artworkId);
 
 /// While metaphysics is read-only, we need to rely on Eigen's
 /// v1 API access to get/set these bits of information.
 
 @interface ARTemporaryAPIModule : NSObject <RCTBridgeModule>
+
+@property (nonatomic, copy, readwrite) ARNotificationPermissionsPrompter notificationPermissionPrompter;
 
 @property (nonatomic, copy, readwrite) ARNotificationReadStatusAssigner notificationReadStatusAssigner;
 

--- a/emission/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.h
+++ b/emission/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.h
@@ -3,7 +3,7 @@
 
 typedef void(^ARNotificationReadStatusAssigner)(RCTResponseSenderBlock block);
 
-typedef void(^ARNotificationPermissionsPrompter)(RCTResponseSenderBlock block);
+typedef void(^ARNotificationPermissionsPrompter)();
 
 typedef void(^ARAugmentedRealityVIRPresenter)(NSString *imgUrl, CGFloat widthIn, CGFloat heightIn, NSString *artworkSlug, NSString *artworkId);
 

--- a/emission/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.m
+++ b/emission/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.m
@@ -10,11 +10,17 @@ RCT_EXPORT_METHOD(fetchNotificationPermissions:(RCTResponseSenderBlock)callback)
 {
     UNUserNotificationCenter *notifCenter = [UNUserNotificationCenter currentNotificationCenter];
     [notifCenter getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
-        UNAuthorizationStatus *status = [settings authorizationStatus];
-        if (status == UNAuthorizationStatusAuthorized) {
-            callback(@[[NSNull null], @YES]);
-        } else {
-            callback(@[[NSNull null], @NO]);
+        UNAuthorizationStatus status = [settings authorizationStatus];
+        switch (status) {
+            case UNAuthorizationStatusAuthorized:
+                callback(@[[NSNull null], @"authorized"]);
+                break;
+            case UNAuthorizationStatusDenied:
+                callback(@[[NSNull null], @"denied"]);
+                break;
+            case UNAuthorizationStatusNotDetermined:
+                callback(@[[NSNull null], @"notDetermined"]);
+                break;
         }
     }];
 }

--- a/emission/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.m
+++ b/emission/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.m
@@ -6,6 +6,12 @@
 RCT_EXPORT_MODULE();
 
 
+RCT_EXPORT_METHOD(requestNotificationPermissions:(RCTResponseSenderBlock)block)
+{
+    /* In eigen, this should request push notification permissions */
+    self.notificationPermissionPrompter(block);
+}
+
 RCT_EXPORT_METHOD(fetchNotificationPermissions:(RCTResponseSenderBlock)callback)
 {
     UNUserNotificationCenter *notifCenter = [UNUserNotificationCenter currentNotificationCenter];

--- a/emission/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.m
+++ b/emission/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.m
@@ -6,10 +6,10 @@
 RCT_EXPORT_MODULE();
 
 
-RCT_EXPORT_METHOD(requestNotificationPermissions:(RCTResponseSenderBlock)block)
+RCT_EXPORT_METHOD(requestNotificationPermissions)
 {
     /* In eigen, this should request push notification permissions */
-    self.notificationPermissionPrompter(block);
+    self.notificationPermissionPrompter();
 }
 
 RCT_EXPORT_METHOD(fetchNotificationPermissions:(RCTResponseSenderBlock)callback)

--- a/src/lib/Scenes/MyProfile/MyProfilePushNotifications.tsx
+++ b/src/lib/Scenes/MyProfile/MyProfilePushNotifications.tsx
@@ -65,7 +65,7 @@ export const OpenSettingsBanner = () => (
       <Sans size="4t" weight="medium" color="black">
         Turn on notifications
       </Sans>
-      <Sans size="3t" color="black60" marginTop="1" marginBottom="2">
+      <Sans size="3t" textAlign="center" color="black60" marginTop="1" marginBottom="2">
         To receive push notifications from Artsy, you'll need enable them in your iOS Settings. Tap Notifications, and
         then toggle "Allow Notifications" on.
       </Sans>
@@ -88,16 +88,16 @@ export const AllowPushNotificationsBanner = () => (
       <Sans size="4t" weight="medium" color="black">
         Turn on notifications
       </Sans>
-      <Sans size="3t" color="black60" marginTop="1" marginBottom="2">
+      <Sans size="3t" textAlign="center" color="black60" marginTop="1" marginBottom="2">
         Artsy needs your permission to send push notifications.
       </Sans>
       <Button
         size="large"
         onPress={() => {
-          // Linking.openURL("App-prefs:NOTIFICATIONS_ID")
+          NativeModules.ARTemporaryAPIModule.requestNotificationPermissions()
         }}
       >
-        Enable Notifications
+        Enable
       </Button>
     </Flex>
     <Separator />
@@ -140,12 +140,9 @@ export const MyProfilePushNotifications: React.FC<{
 
   useEffect(() => {
     NativeModules.ARTemporaryAPIModule.fetchNotificationPermissions((_, result: PushAuthorizationStatus) => {
-      console.log(result)
       setNotificationAuthorizationStatus(result)
     })
   }, [])
-
-  NativeModules.ARTemporaryAPIModule.requestNotificationPermissions()
 
   const onForeground = useCallback(() => {
     NativeModules.ARTemporaryAPIModule.fetchNotificationPermissions((_, result: PushAuthorizationStatus) => {

--- a/src/lib/Scenes/MyProfile/MyProfilePushNotifications.tsx
+++ b/src/lib/Scenes/MyProfile/MyProfilePushNotifications.tsx
@@ -29,7 +29,7 @@ interface SwitchMenuProps {
   disabled: boolean
 }
 
-export type PushNotificationPermissions =
+export type UserPushNotificationSettings =
   | "receiveLotOpeningSoonNotification"
   | "receiveNewSalesNotification"
   | "receiveNewWorksNotification"
@@ -66,8 +66,8 @@ export const AllowPushNotificationsBanner = () => (
         Turn on notifications
       </Sans>
       <Sans size="3t" color="black60" marginTop="1" marginBottom="2">
-        To receive push notifications from Artsy, you’ll need enable them in your iOS Settings. Tap Notifications, and
-        then toggle “Allow Notifications” on.
+        To receive push notifications from Artsy, you'll need enable them in your iOS Settings. Tap Notifications, and
+        then toggle "Allow Notifications" on.
       </Sans>
       <Button
         size="large"
@@ -99,22 +99,30 @@ const NotificationPermissionsBox = ({
   </Box>
 )
 
+export enum PushAuthorizationStatus {
+  NotDetermined = "notDetermined",
+  Authorized = "authorized",
+  Denied = "denied",
+}
+
 export const MyProfilePushNotifications: React.FC<{
   me: MyProfilePushNotifications_me
   relay: RelayRefetchProp
   isLoading: boolean
 }> = ({ me, relay, isLoading = false }) => {
-  const [hasPushNotificationsEnabled, setHasPushNotificationsEnabled] = useState<boolean>(true)
-  const [notificationPermissions, setNotificationPermissions] = useState<MyProfilePushNotifications_me>(me)
+  const [notificationAuthorizationStatus, setNotificationAuthorizationStatus] = useState<PushAuthorizationStatus>(
+    PushAuthorizationStatus.NotDetermined
+  )
+  const [userNotificationSettings, setUserNotificationSettings] = useState<MyProfilePushNotifications_me>(me)
   const [isRefreshing, setIsRefreshing] = useState<boolean>(false)
 
-  NativeModules.ARTemporaryAPIModule.fetchNotificationPermissions((_, result: boolean) => {
-    setHasPushNotificationsEnabled(result)
+  NativeModules.ARTemporaryAPIModule.fetchNotificationPermissions((_, result: PushAuthorizationStatus) => {
+    setNotificationAuthorizationStatus(result)
   })
 
   const onForeground = useCallback(() => {
-    NativeModules.ARTemporaryAPIModule.fetchNotificationPermissions((_, result: boolean) => {
-      setHasPushNotificationsEnabled(result)
+    NativeModules.ARTemporaryAPIModule.fetchNotificationPermissions((_, result: PushAuthorizationStatus) => {
+      setNotificationAuthorizationStatus(result)
     })
   }, [])
 
@@ -129,18 +137,18 @@ export const MyProfilePushNotifications: React.FC<{
     }
   }, [])
 
-  const handleUpdateNotificationPermissions = useCallback(
-    async (notificationType: PushNotificationPermissions, value: boolean) => {
+  const handleUpdateUserNotificationSettings = useCallback(
+    async (notificationType: UserPushNotificationSettings, value: boolean) => {
       try {
-        const updatedPermissions = { ...notificationPermissions, [notificationType]: value }
-        setNotificationPermissions(updatedPermissions)
-        await updateNotificationPermissions(updatedPermissions)
+        const updatedUserNotificationSettings = { ...userNotificationSettings, [notificationType]: value }
+        setUserNotificationSettings(updatedUserNotificationSettings)
+        await updateNotificationPermissions(updatedUserNotificationSettings)
       } catch (error) {
-        setNotificationPermissions(notificationPermissions)
+        setUserNotificationSettings(userNotificationSettings)
         Alert.alert(typeof error === "string" ? error : "Something went wrong.")
       }
     },
-    [notificationPermissions]
+    [userNotificationSettings]
   )
 
   const updateNotificationPermissions = useCallback(
@@ -153,27 +161,27 @@ export const MyProfilePushNotifications: React.FC<{
   // Render list of enabled push notification permissions
   const renderContent = () => (
     <View
-      style={{ opacity: hasPushNotificationsEnabled ? 1 : 0.5 }}
-      pointerEvents={hasPushNotificationsEnabled ? "auto" : "none"}
+      style={{ opacity: notificationAuthorizationStatus === "authorized" ? 1 : 0.5 }}
+      pointerEvents={notificationAuthorizationStatus === "authorized" ? "auto" : "none"}
     >
       <Join separator={<Separator my={1} />}>
         <NotificationPermissionsBox title="Purchase Updates" isLoading={isLoading}>
           <SwitchMenu
             title="Messages"
             description="Messages from sellers on your inquiries"
-            value={!!notificationPermissions.receivePurchaseNotification}
+            value={!!userNotificationSettings.receivePurchaseNotification}
             disabled={isLoading}
             onChange={value => {
-              handleUpdateNotificationPermissions("receivePurchaseNotification", value)
+              handleUpdateUserNotificationSettings("receivePurchaseNotification", value)
             }}
           />
           <SwitchMenu
             title="Outbid Alerts"
-            description="Alerts for when you’ve been outbid"
-            value={!!notificationPermissions.receiveOutbidNotification}
+            description="Alerts for when you've been outbid"
+            value={!!userNotificationSettings.receiveOutbidNotification}
             disabled={isLoading}
             onChange={value => {
-              handleUpdateNotificationPermissions("receiveOutbidNotification", value)
+              handleUpdateUserNotificationSettings("receiveOutbidNotification", value)
             }}
           />
         </NotificationPermissionsBox>
@@ -181,19 +189,19 @@ export const MyProfilePushNotifications: React.FC<{
           <SwitchMenu
             title="Lot Opening Soon"
             description="Your lots that are opening for live bidding soon"
-            value={!!notificationPermissions.receiveLotOpeningSoonNotification}
+            value={!!userNotificationSettings.receiveLotOpeningSoonNotification}
             disabled={isLoading}
             onChange={value => {
-              handleUpdateNotificationPermissions("receiveLotOpeningSoonNotification", value)
+              handleUpdateUserNotificationSettings("receiveLotOpeningSoonNotification", value)
             }}
           />
           <SwitchMenu
             title="Auctions Starting and Closing"
             description="Your registered auctions that are starting or closing soon"
-            value={!!notificationPermissions.receiveSaleOpeningClosingNotification}
+            value={!!userNotificationSettings.receiveSaleOpeningClosingNotification}
             disabled={isLoading}
             onChange={value => {
-              handleUpdateNotificationPermissions("receiveSaleOpeningClosingNotification", value)
+              handleUpdateUserNotificationSettings("receiveSaleOpeningClosingNotification", value)
             }}
           />
         </NotificationPermissionsBox>
@@ -201,28 +209,28 @@ export const MyProfilePushNotifications: React.FC<{
           <SwitchMenu
             title="New Works for You"
             description="New works added by artists you follow"
-            value={!!notificationPermissions.receiveNewWorksNotification}
+            value={!!userNotificationSettings.receiveNewWorksNotification}
             disabled={isLoading}
             onChange={value => {
-              handleUpdateNotificationPermissions("receiveNewWorksNotification", value)
+              handleUpdateUserNotificationSettings("receiveNewWorksNotification", value)
             }}
           />
           <SwitchMenu
             title="New Auctions for You"
             description="New auctions with artists you follow"
-            value={!!notificationPermissions.receiveNewSalesNotification}
+            value={!!userNotificationSettings.receiveNewSalesNotification}
             disabled={isLoading}
             onChange={value => {
-              handleUpdateNotificationPermissions("receiveNewSalesNotification", value)
+              handleUpdateUserNotificationSettings("receiveNewSalesNotification", value)
             }}
           />
           <SwitchMenu
             title="Promotions"
-            description="Updates on Artsy’s latest campaigns and special offers."
-            value={!!notificationPermissions.receivePromotionNotification}
+            description="Updates on Artsy's latest campaigns and special offers."
+            value={!!userNotificationSettings.receivePromotionNotification}
             disabled={isLoading}
             onChange={value => {
-              handleUpdateNotificationPermissions("receivePromotionNotification", value)
+              handleUpdateUserNotificationSettings("receivePromotionNotification", value)
             }}
           />
         </NotificationPermissionsBox>
@@ -236,7 +244,7 @@ export const MyProfilePushNotifications: React.FC<{
       right={isLoading ? <ActivityIndicator style={{ marginRight: 5 }} /> : null}
     >
       <ScrollView refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />}>
-        {!Boolean(hasPushNotificationsEnabled) && <AllowPushNotificationsBanner />}
+        {notificationAuthorizationStatus !== "authorized" && <AllowPushNotificationsBanner />}
         {renderContent()}
       </ScrollView>
     </PageWithSimpleHeader>

--- a/src/lib/Scenes/MyProfile/MyProfilePushNotifications.tsx
+++ b/src/lib/Scenes/MyProfile/MyProfilePushNotifications.tsx
@@ -120,6 +120,8 @@ export const MyProfilePushNotifications: React.FC<{
     setNotificationAuthorizationStatus(result)
   })
 
+  NativeModules.ARTemporaryAPIModule.requestNotificationPermissions()
+
   const onForeground = useCallback(() => {
     NativeModules.ARTemporaryAPIModule.fetchNotificationPermissions((_, result: PushAuthorizationStatus) => {
       setNotificationAuthorizationStatus(result)

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -149,6 +149,7 @@ NativeModules.ARNotificationsManager = {
 }
 
 NativeModules.ARTemporaryAPIModule = {
+  requestNotificationPermissions: jest.fn(),
   fetchNotificationPermissions: jest.fn(),
   markNotificationsRead: jest.fn(),
   setApplicationIconBadgeNumber: jest.fn(),

--- a/typings/emission.d.ts
+++ b/typings/emission.d.ts
@@ -17,6 +17,7 @@ declare module "react-native" {
 
   interface NativeModulesStatic {
     ARTemporaryAPIModule: {
+      requestNotificationPermissions(): void
       fetchNotificationPermissions(callback: (error: any, result: PushAuthorizationStatus) => void): void
       markNotificationsRead(): void
       setApplicationIconBadgeNumber(n: number): void

--- a/typings/emission.d.ts
+++ b/typings/emission.d.ts
@@ -1,3 +1,4 @@
+import { PushAuthorizationStatus } from "lib/Scenes/MyProfile/MyProfilePushNotifications"
 import { NativeState } from "lib/store/NativeModel"
 import { NativeModulesStatic } from "react-native"
 declare module "react-native" {
@@ -16,7 +17,7 @@ declare module "react-native" {
 
   interface NativeModulesStatic {
     ARTemporaryAPIModule: {
-      fetchNotificationPermissions(callback: (error: any, result: boolean) => void): void
+      fetchNotificationPermissions(callback: (error: any, result: PushAuthorizationStatus) => void): void
       markNotificationsRead(): void
       setApplicationIconBadgeNumber(n: number): void
       presentAugmentedRealityVIR(


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves **[MX-493]**

### Description

@MounirDhahri called out during knowledge share that this state was possible on this screen due to how we don't show system notification prompt in some cases. 

- Changes existing native method to access notifications permissions to return "notDetermined", "authorized" or "denied"
- Exposes a new native method to request notification permissions from react native
- Adjusts copy of banner and button for "notDetermined" state, prompts for permission on tap

### Screenshots

![Simulator Screen Shot - iPhone X (12 4) - 2020-08-04 at 13 55 41](https://user-images.githubusercontent.com/49686530/89327661-3f8fa280-d65a-11ea-8e89-e77749c4f445.png)

Co-authored by @ds300 @MounirDhahri 

[MX-493]: https://artsyproduct.atlassian.net/browse/MX-493