### PR TITLE
Remove horizon block check for now #trivial

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,13 +348,6 @@ workflows:
             branches:
               ignore:
                 - app_store_submission
-      - horizon/block:
-          context: horizon
-          project_id: 37
-          filters:
-            branches:
-              only:
-                - beta
       - build-test-app:
           filters:
             branches:
@@ -362,7 +355,6 @@ workflows:
                 - app_store_submission
           requires:
             - build-test-js
-            - horizon/block
       - update-metaphysics:
           filters:
             branches:


### PR DESCRIPTION
The type of this PR is: **Bugfix**

Our deploy block check is currently failing due to an issue with horizon:
https://artsy.slack.com/archives/CP9P4KR35/p1596570219288400

Removing for now to deploy a beta.
Will want to revert once this is resolved.
