### PR TITLE
[MX-439] - Don't show secure text on editing ended #trivial

### DIFF
--- a/Artsy/View_Controllers/Util/ARSecureTextFieldWithPlaceholder.m
+++ b/Artsy/View_Controllers/Util/ARSecureTextFieldWithPlaceholder.m
@@ -28,7 +28,6 @@
 {
     [self addTarget:self action:@selector(editingDidBegin) forControlEvents:UIControlEventEditingDidBegin];
     [self addTarget:self action:@selector(editingDidChange) forControlEvents:UIControlEventEditingChanged];
-    [self addTarget:self action:@selector(editingDidFinish) forControlEvents:UIControlEventEditingDidEnd];
 }
 
 - (void)editingDidBegin
@@ -39,11 +38,6 @@
 - (void)editingDidChange
 {
     self.actualText = self.text;
-}
-
-- (void)editingDidFinish
-{
-    self.secureTextEntry = NO;
 }
 
 - (void)setSecureTextEntry:(BOOL)secureTextEntry


### PR DESCRIPTION
The type of this PR is: **Bugfix**
This PR resolves **[MX-439]**

### Description

Removes editingDidFinish event disabling secure text. 

### Screenshots

#### Before
![showPwd](https://user-images.githubusercontent.com/49686530/89558253-fc603b80-d7e1-11ea-99e8-95a74039d726.png)
#### After
![hidePwd](https://user-images.githubusercontent.com/49686530/89558148-dcc91300-d7e1-11ea-8b92-4c13c14a2333.png)



