### PR TITLE
[MX-451] - Prevent follow button going off screen #trivial

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,7 +4,7 @@ upcoming:
   dev:
     -
   user_facing:
-    -
+    - Prevent follow button going off screen in artist page - brian
 
 releases:
   - version: 6.6.0

--- a/src/lib/Components/Artist/ArtistHeader.tsx
+++ b/src/lib/Components/Artist/ArtistHeader.tsx
@@ -40,15 +40,19 @@ class Header extends React.Component<Props, State> {
         <Spacer mb={1} />
         {Boolean(followersCount || bylineRequired) && (
           <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
-            <Flex>
-              {!!bylineRequired && <Sans size="3t">{this.descriptiveString()}</Sans>}
+            <Flex flex={1}>
+              {!!bylineRequired && (
+                <Sans mr={1} size="3t">
+                  {this.descriptiveString()}
+                </Sans>
+              )}
               <Sans size="3t">
                 {formatText(artist.counts?.artworks ?? 0, "work")}
                 {"  "}•{"  "}
                 {formatText(artist.counts?.follows ?? 0, "follower")}
               </Sans>
             </Flex>
-            <Flex flexGrow={0} flexShrink={0}>
+            <Flex>
               <Button
                 variant={this.props.artist.isFollowed ? "secondaryOutline" : "primaryBlack"}
                 loading={this.state.isFollowedChanging}


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves **[MX-451]**

### Description

Adds a flex priority to artist metadata flex container.  Adds a right margin to artist metadata.

### Screenshots

#### Before

![beforeFlexPriority](https://user-images.githubusercontent.com/49686530/89575173-6507e200-d7fb-11ea-9dcf-f33c6fa84256.png)

#### After

![afterFlexPriority](https://user-images.githubusercontent.com/49686530/89575506-e0699380-d7fb-11ea-9e18-7b30591c55e6.png)





[MX-451]: https://artsyproduct.atlassian.net/browse/MX-451