### PR TITLE
[MX-452] - Prevent follow button going off screen partner/artist page

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,6 +5,7 @@ upcoming:
     -
   user_facing:
     - don't show password on wrong password entry - brian
+    - fix follow button going off screen, partner page - brian
 
 releases:
   - version: 6.6.0

--- a/src/lib/Components/ArtistListItem.tsx
+++ b/src/lib/Components/ArtistListItem.tsx
@@ -1,4 +1,4 @@
-import { Button, EntityHeader, Theme } from "@artsy/palette"
+import { Button, EntityHeader, Flex, Theme } from "@artsy/palette"
 import { ArtistListItem_artist } from "__generated__/ArtistListItem_artist.graphql"
 import { ArtistListItemFollowArtistMutation } from "__generated__/ArtistListItemFollowArtistMutation.graphql"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
@@ -18,7 +18,7 @@ interface State {
   isFollowedChanging: boolean
 }
 
-export const formatTombstoneText = (nationality: string, birthday: string, deathday: string) => {
+export const formatTombstoneText = (nationality: string | null, birthday: string | null, deathday: string | null) => {
   if (nationality && birthday && deathday) {
     return nationality.trim() + ", " + birthday + "-" + deathday
   } else if (nationality && birthday) {
@@ -76,8 +76,7 @@ export class ArtistListItem extends React.Component<Props, State> {
             },
           },
           updater: store => {
-            // @ts-ignore STRICTNESS_MIGRATION
-            store.get(id).setValue(!is_followed, "is_followed")
+            store.get(id)?.setValue(!is_followed, "is_followed")
           },
         })
       }
@@ -112,40 +111,36 @@ export class ArtistListItem extends React.Component<Props, State> {
     SwitchBoard.presentNavigationViewController(this, href)
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
-  getInitials = string => {
-    const names = string.split(" ")
-    let initials = names[0].substring(0, 1)
-    if (names.length > 1) {
-      initials += names[1].substring(0, 1)
-    }
-    return initials
-  }
-
   render() {
     const { isFollowedChanging } = this.state
     const { artist } = this.props
     const { is_followed, initials, image, href, name, nationality, birthday, deathday } = artist
     const imageURl = image && image.url
 
+    if (!name) {
+      return null
+    }
+
     return (
       <Theme>
         <TouchableWithoutFeedback
           onPress={() => {
-            // @ts-ignore STRICTNESS_MIGRATION
-            this.handleTap(href)
+            if (href) {
+              this.handleTap(href)
+            }
           }}
         >
-          <EntityHeader
-            // @ts-ignore STRICTNESS_MIGRATION
-            name={name}
-            // @ts-ignore STRICTNESS_MIGRATION
-            meta={formatTombstoneText(nationality, birthday, deathday)}
-            // @ts-ignore STRICTNESS_MIGRATION
-            imageUrl={imageURl}
-            // @ts-ignore STRICTNESS_MIGRATION
-            initials={initials}
-            FollowButton={
+          <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
+            <Flex flex={1}>
+              <EntityHeader
+                mr={1}
+                name={name}
+                meta={formatTombstoneText(nationality, birthday, deathday) ?? undefined}
+                imageUrl={imageURl ?? undefined}
+                initials={initials ?? undefined}
+              />
+            </Flex>
+            <Flex>
               <Button
                 variant={is_followed ? "secondaryOutline" : "primaryBlack"}
                 onPress={this.handleFollowArtist.bind(this)}
@@ -155,8 +150,8 @@ export class ArtistListItem extends React.Component<Props, State> {
               >
                 {is_followed ? "Following" : "Follow"}
               </Button>
-            }
-          />
+            </Flex>
+          </Flex>
         </TouchableWithoutFeedback>
       </Theme>
     )


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves **[MX-452]**

### Description

Moves follow button outside EntityHeader component adds a flex priority to EntityHeader. Fixes a few strictness migration comments. I wonder if this is something that can be fixed in palette EntityHeader component? FollowButton prop doesn't seem to respect flex bounds.

### Screenshots

#### Before

![beforeFlexChanges](https://user-images.githubusercontent.com/49686530/89584305-da7aaf00-d809-11ea-831c-2e979e91b63a.png)

#### After

![afterFlexChanges](https://user-images.githubusercontent.com/49686530/89584314-e0709000-d809-11ea-892b-7e595421b64f.png)



[MX-452]: https://artsyproduct.atlassian.net/browse/MX-452