### PR TITLE
Users can see related artworks from an artist series on the artwork page

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -9,6 +9,7 @@ upcoming:
     - fix follow button going off screen, partner page - brian
     - Add Full Artist Series route and view - ashley
     - Add Artist Series to Artist page - ashley
+    - Add ability to see related artist series artworks on the artwork page - will
 
 releases:
   - version: 6.6.0

--- a/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash defd30de14b3e30852f3a043f82c99cd */
+/* @relayHash 27373a9e289ce45cd59fa07e837add33 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -137,6 +137,7 @@ fragment ArtistNotableWorksRail_artist on Artist {
         id
         image {
           imageURL
+          aspectRatio
         }
         saleMessage
         saleArtwork {
@@ -351,32 +352,39 @@ v13 = [
 v14 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "title",
+  "name": "aspectRatio",
   "args": null,
   "storageKey": null
 },
 v15 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "saleMessage",
+  "name": "title",
   "args": null,
   "storageKey": null
 },
 v16 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "isAuction",
+  "name": "saleMessage",
   "args": null,
   "storageKey": null
 },
 v17 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "isAuction",
+  "args": null,
+  "storageKey": null
+},
+v18 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "isClosed",
   "args": null,
   "storageKey": null
 },
-v18 = [
+v19 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -385,12 +393,12 @@ v18 = [
     "storageKey": null
   }
 ],
-v19 = {
+v20 = {
   "kind": "Literal",
   "name": "first",
   "value": 3
 },
-v20 = {
+v21 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "image",
@@ -408,7 +416,7 @@ v20 = {
     }
   ]
 },
-v21 = {
+v22 = {
   "kind": "Literal",
   "name": "sort",
   "value": "-weighted_iconicity"
@@ -607,13 +615,7 @@ return {
                         "concreteType": "Image",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "aspectRatio",
-                            "args": null,
-                            "storageKey": null
-                          },
+                          (v14/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -629,7 +631,7 @@ return {
                           }
                         ]
                       },
-                      (v14/*: any*/),
+                      (v15/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -637,7 +639,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v15/*: any*/),
+                      (v16/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -661,8 +663,8 @@ return {
                         "concreteType": "Sale",
                         "plural": false,
                         "selections": [
-                          (v16/*: any*/),
                           (v17/*: any*/),
+                          (v18/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -690,7 +692,7 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkCurrentBid",
                             "plural": false,
-                            "selections": (v18/*: any*/)
+                            "selections": (v19/*: any*/)
                           },
                           (v9/*: any*/)
                         ]
@@ -806,7 +808,7 @@ return {
             "selections": [
               (v3/*: any*/),
               (v9/*: any*/),
-              (v14/*: any*/),
+              (v15/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -827,7 +829,7 @@ return {
                       "TOTAL"
                     ]
                   },
-                  (v19/*: any*/),
+                  (v20/*: any*/),
                   (v12/*: any*/)
                 ],
                 "concreteType": "FilterArtworksConnection",
@@ -851,8 +853,8 @@ return {
                         "concreteType": "Artwork",
                         "plural": false,
                         "selections": [
-                          (v14/*: any*/),
-                          (v20/*: any*/),
+                          (v15/*: any*/),
+                          (v21/*: any*/),
                           (v9/*: any*/)
                         ]
                       }
@@ -870,7 +872,7 @@ return {
             "storageKey": "filterArtworksConnection(first:10,sort:\"-weighted_iconicity\")",
             "args": [
               (v11/*: any*/),
-              (v21/*: any*/)
+              (v22/*: any*/)
             ],
             "concreteType": "FilterArtworksConnection",
             "plural": false,
@@ -909,10 +911,11 @@ return {
                             "name": "imageURL",
                             "args": null,
                             "storageKey": null
-                          }
+                          },
+                          (v14/*: any*/)
                         ]
                       },
-                      (v15/*: any*/),
+                      (v16/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -930,7 +933,7 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkOpeningBid",
                             "plural": false,
-                            "selections": (v18/*: any*/)
+                            "selections": (v19/*: any*/)
                           },
                           {
                             "kind": "LinkedField",
@@ -940,7 +943,7 @@ return {
                             "args": null,
                             "concreteType": "SaleArtworkHighestBid",
                             "plural": false,
-                            "selections": (v18/*: any*/)
+                            "selections": (v19/*: any*/)
                           },
                           (v9/*: any*/)
                         ]
@@ -954,12 +957,12 @@ return {
                         "concreteType": "Sale",
                         "plural": false,
                         "selections": [
+                          (v18/*: any*/),
                           (v17/*: any*/),
-                          (v16/*: any*/),
                           (v9/*: any*/)
                         ]
                       },
-                      (v14/*: any*/),
+                      (v15/*: any*/),
                       (v2/*: any*/),
                       (v3/*: any*/)
                     ]
@@ -1011,7 +1014,7 @@ return {
                     "selections": [
                       (v3/*: any*/),
                       (v2/*: any*/),
-                      (v14/*: any*/),
+                      (v15/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -1019,7 +1022,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v20/*: any*/)
+                      (v21/*: any*/)
                     ]
                   }
                 ]
@@ -1032,8 +1035,8 @@ return {
             "name": "filterArtworksConnection",
             "storageKey": "filterArtworksConnection(first:3,sort:\"-weighted_iconicity\")",
             "args": [
-              (v19/*: any*/),
-              (v21/*: any*/)
+              (v20/*: any*/),
+              (v22/*: any*/)
             ],
             "concreteType": "FilterArtworksConnection",
             "plural": false,
@@ -1071,7 +1074,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistAboveTheFoldQuery",
-    "id": "0ba0a6d30d1c6f6a7231200d5038d7a2",
+    "id": "ac2fc59a72d148930030e19cbdba9ba9",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistArtworksQuery.graphql.ts
+++ b/src/__generated__/ArtistArtworksQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 9be3c96ca622ffd244eb514c39fc847e */
+/* @relayHash bee61df95776f8c1376c83623be5e2aa */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -133,6 +133,7 @@ fragment ArtistNotableWorksRail_artist on Artist {
         id
         image {
           imageURL
+          aspectRatio
         }
         saleMessage
         saleArtwork {
@@ -451,32 +452,39 @@ v18 = {
 v19 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "title",
+  "name": "aspectRatio",
   "args": null,
   "storageKey": null
 },
 v20 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "saleMessage",
+  "name": "title",
   "args": null,
   "storageKey": null
 },
 v21 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "isAuction",
+  "name": "saleMessage",
   "args": null,
   "storageKey": null
 },
 v22 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "isAuction",
+  "args": null,
+  "storageKey": null
+},
+v23 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "isClosed",
   "args": null,
   "storageKey": null
 },
-v23 = [
+v24 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -485,12 +493,12 @@ v23 = [
     "storageKey": null
   }
 ],
-v24 = {
+v25 = {
   "kind": "Literal",
   "name": "first",
   "value": 3
 },
-v25 = {
+v26 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "image",
@@ -508,7 +516,7 @@ v25 = {
     }
   ]
 },
-v26 = {
+v27 = {
   "kind": "Literal",
   "name": "sort",
   "value": "-weighted_iconicity"
@@ -672,13 +680,7 @@ return {
                             "concreteType": "Image",
                             "plural": false,
                             "selections": [
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspectRatio",
-                                "args": null,
-                                "storageKey": null
-                              },
+                              (v19/*: any*/),
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -694,7 +696,7 @@ return {
                               }
                             ]
                           },
-                          (v19/*: any*/),
+                          (v20/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -702,7 +704,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v20/*: any*/),
+                          (v21/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -726,8 +728,8 @@ return {
                             "concreteType": "Sale",
                             "plural": false,
                             "selections": [
-                              (v21/*: any*/),
                               (v22/*: any*/),
+                              (v23/*: any*/),
                               {
                                 "kind": "ScalarField",
                                 "alias": null,
@@ -755,7 +757,7 @@ return {
                                 "args": null,
                                 "concreteType": "SaleArtworkCurrentBid",
                                 "plural": false,
-                                "selections": (v23/*: any*/)
+                                "selections": (v24/*: any*/)
                               },
                               (v14/*: any*/)
                             ]
@@ -865,7 +867,7 @@ return {
                 "selections": [
                   (v15/*: any*/),
                   (v14/*: any*/),
-                  (v19/*: any*/),
+                  (v20/*: any*/),
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -886,7 +888,7 @@ return {
                           "TOTAL"
                         ]
                       },
-                      (v24/*: any*/),
+                      (v25/*: any*/),
                       {
                         "kind": "Literal",
                         "name": "sort",
@@ -914,8 +916,8 @@ return {
                             "concreteType": "Artwork",
                             "plural": false,
                             "selections": [
-                              (v19/*: any*/),
-                              (v25/*: any*/),
+                              (v20/*: any*/),
+                              (v26/*: any*/),
                               (v14/*: any*/)
                             ]
                           }
@@ -937,7 +939,7 @@ return {
                     "name": "first",
                     "value": 10
                   },
-                  (v26/*: any*/)
+                  (v27/*: any*/)
                 ],
                 "concreteType": "FilterArtworksConnection",
                 "plural": false,
@@ -976,10 +978,11 @@ return {
                                 "name": "imageURL",
                                 "args": null,
                                 "storageKey": null
-                              }
+                              },
+                              (v19/*: any*/)
                             ]
                           },
-                          (v20/*: any*/),
+                          (v21/*: any*/),
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -997,7 +1000,7 @@ return {
                                 "args": null,
                                 "concreteType": "SaleArtworkOpeningBid",
                                 "plural": false,
-                                "selections": (v23/*: any*/)
+                                "selections": (v24/*: any*/)
                               },
                               {
                                 "kind": "LinkedField",
@@ -1007,7 +1010,7 @@ return {
                                 "args": null,
                                 "concreteType": "SaleArtworkHighestBid",
                                 "plural": false,
-                                "selections": (v23/*: any*/)
+                                "selections": (v24/*: any*/)
                               },
                               (v14/*: any*/)
                             ]
@@ -1021,12 +1024,12 @@ return {
                             "concreteType": "Sale",
                             "plural": false,
                             "selections": [
+                              (v23/*: any*/),
                               (v22/*: any*/),
-                              (v21/*: any*/),
                               (v14/*: any*/)
                             ]
                           },
-                          (v19/*: any*/),
+                          (v20/*: any*/),
                           (v16/*: any*/),
                           (v15/*: any*/)
                         ]
@@ -1078,7 +1081,7 @@ return {
                         "selections": [
                           (v15/*: any*/),
                           (v16/*: any*/),
-                          (v19/*: any*/),
+                          (v20/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1086,7 +1089,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v25/*: any*/)
+                          (v26/*: any*/)
                         ]
                       }
                     ]
@@ -1099,8 +1102,8 @@ return {
                 "name": "filterArtworksConnection",
                 "storageKey": "filterArtworksConnection(first:3,sort:\"-weighted_iconicity\")",
                 "args": [
-                  (v24/*: any*/),
-                  (v26/*: any*/)
+                  (v25/*: any*/),
+                  (v27/*: any*/)
                 ],
                 "concreteType": "FilterArtworksConnection",
                 "plural": false,
@@ -1140,7 +1143,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistArtworksQuery",
-    "id": "9655b3fae42648aa5e1db812dc957d8d",
+    "id": "bfec3003174c351ce356b56c5f0d4501",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistNotableWorksRailTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistNotableWorksRailTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 27295d2ac0c6a6600d805d9d43371144 */
+/* @relayHash 9850041053a96091b26a6fd103dfe44f */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -18,6 +18,7 @@ export type ArtistNotableWorksRailTestsQueryRawResponse = {
                     readonly id: string;
                     readonly image: ({
                         readonly imageURL: string | null;
+                        readonly aspectRatio: number;
                     }) | null;
                     readonly saleMessage: string | null;
                     readonly saleArtwork: ({
@@ -67,6 +68,7 @@ fragment ArtistNotableWorksRail_artist on Artist {
         id
         image {
           imageURL
+          aspectRatio
         }
         saleMessage
         saleArtwork {
@@ -212,6 +214,13 @@ return {
                             "name": "imageURL",
                             "args": null,
                             "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "aspectRatio",
+                            "args": null,
+                            "storageKey": null
                           }
                         ]
                       },
@@ -316,7 +325,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistNotableWorksRailTestsQuery",
-    "id": "92c8775b1f3ecc0656b0ab08f57d5f51",
+    "id": "d538509ee0be92f3cd476a762808e6f3",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistNotableWorksRail_artist.graphql.ts
+++ b/src/__generated__/ArtistNotableWorksRail_artist.graphql.ts
@@ -10,6 +10,7 @@ export type ArtistNotableWorksRail_artist = {
                 readonly id: string;
                 readonly image: {
                     readonly imageURL: string | null;
+                    readonly aspectRatio: number;
                 } | null;
                 readonly saleMessage: string | null;
                 readonly saleArtwork: {
@@ -117,6 +118,13 @@ return {
                       "name": "imageURL",
                       "args": null,
                       "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "aspectRatio",
+                      "args": null,
+                      "storageKey": null
                     }
                   ]
                 },
@@ -213,5 +221,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '218526857d14fe615707af5b55bb09ac';
+(node as any).hash = '169c295998c2442d10e5762e5c40b0c6';
 export default node;

--- a/src/__generated__/ArtworkBelowTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtworkBelowTheFoldQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash b1a1c800de7b6bd2587df4d346499142 */
+/* @relayHash e433b86f2981fae48d734c91b2359fb4 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -206,6 +206,18 @@ fragment ArtworksInSeriesRail_artwork on Artwork {
               image {
                 imageURL
                 aspectRatio
+              }
+              sale {
+                isAuction
+                isClosed
+                displayTimelyAt
+                id
+              }
+              saleArtwork {
+                currentBid {
+                  display
+                }
+                id
               }
               saleMessage
               title
@@ -502,6 +514,63 @@ v21 = {
   "storageKey": null
 },
 v22 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "sale",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Sale",
+  "plural": false,
+  "selections": [
+    (v12/*: any*/),
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "isClosed",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "displayTimelyAt",
+      "args": null,
+      "storageKey": null
+    },
+    (v2/*: any*/)
+  ]
+},
+v23 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "saleArtwork",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "SaleArtwork",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "currentBid",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "SaleArtworkCurrentBid",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "display",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    },
+    (v2/*: any*/)
+  ]
+},
+v24 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "partner",
@@ -940,64 +1009,9 @@ return {
                           (v4/*: any*/),
                           (v21/*: any*/),
                           (v5/*: any*/),
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "sale",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "Sale",
-                            "plural": false,
-                            "selections": [
-                              (v12/*: any*/),
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "isClosed",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "displayTimelyAt",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              (v2/*: any*/)
-                            ]
-                          },
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "saleArtwork",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "SaleArtwork",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "kind": "LinkedField",
-                                "alias": null,
-                                "name": "currentBid",
-                                "storageKey": null,
-                                "args": null,
-                                "concreteType": "SaleArtworkCurrentBid",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "kind": "ScalarField",
-                                    "alias": null,
-                                    "name": "display",
-                                    "args": null,
-                                    "storageKey": null
-                                  }
-                                ]
-                              },
-                              (v2/*: any*/)
-                            ]
-                          },
-                          (v22/*: any*/)
+                          (v22/*: any*/),
+                          (v23/*: any*/),
+                          (v24/*: any*/)
                         ]
                       }
                     ]
@@ -1162,10 +1176,12 @@ return {
                                       (v17/*: any*/)
                                     ]
                                   },
+                                  (v22/*: any*/),
+                                  (v23/*: any*/),
                                   (v20/*: any*/),
                                   (v18/*: any*/),
                                   (v19/*: any*/),
-                                  (v22/*: any*/),
+                                  (v24/*: any*/),
                                   (v2/*: any*/)
                                 ]
                               }
@@ -1186,7 +1202,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtworkBelowTheFoldQuery",
-    "id": "894c89a1ac0e73fef8dd51596390760d",
+    "id": "57d8278584f542e850b72f864aca027e",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtworkBelowTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtworkBelowTheFoldQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash ebae587dc6fc9954990fb5669d8bcd7a */
+/* @relayHash b1a1c800de7b6bd2587df4d346499142 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -188,6 +188,39 @@ fragment Artwork_artworkBelowTheFold on Artwork {
   ...ArtworkDetails_artwork
   ...ContextCard_artwork
   ...ArtworkHistory_artwork
+  ...ArtworksInSeriesRail_artwork
+}
+
+fragment ArtworksInSeriesRail_artwork on Artwork {
+  artistSeriesConnection(first: 1) {
+    edges {
+      node {
+        slug
+        artworksConnection(first: 20) {
+          edges {
+            node {
+              slug
+              internalID
+              href
+              artistNames
+              image {
+                imageURL
+                aspectRatio
+              }
+              saleMessage
+              title
+              date
+              partner {
+                name
+                id
+              }
+              id
+            }
+          }
+        }
+      }
+    }
+  }
 }
 
 fragment ContextCard_artwork on Artwork {
@@ -436,9 +469,50 @@ v16 = {
 v17 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "aspectRatio",
+  "args": null,
+  "storageKey": null
+},
+v18 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "title",
   "args": null,
   "storageKey": null
+},
+v19 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "date",
+  "args": null,
+  "storageKey": null
+},
+v20 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "saleMessage",
+  "args": null,
+  "storageKey": null
+},
+v21 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "artistNames",
+  "args": null,
+  "storageKey": null
+},
+v22 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "partner",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Partner",
+  "plural": false,
+  "selections": [
+    (v3/*: any*/),
+    (v2/*: any*/)
+  ]
 };
 return {
   "kind": "Request",
@@ -857,38 +931,14 @@ return {
                                 ],
                                 "storageKey": "url(version:\"large\")"
                               },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspectRatio",
-                                "args": null,
-                                "storageKey": null
-                              }
+                              (v17/*: any*/)
                             ]
                           },
-                          (v17/*: any*/),
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "date",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "saleMessage",
-                            "args": null,
-                            "storageKey": null
-                          },
+                          (v18/*: any*/),
+                          (v19/*: any*/),
+                          (v20/*: any*/),
                           (v4/*: any*/),
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "artistNames",
-                            "args": null,
-                            "storageKey": null
-                          },
+                          (v21/*: any*/),
                           (v5/*: any*/),
                           {
                             "kind": "LinkedField",
@@ -947,19 +997,7 @@ return {
                               (v2/*: any*/)
                             ]
                           },
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "partner",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "Partner",
-                            "plural": false,
-                            "selections": [
-                              (v3/*: any*/),
-                              (v2/*: any*/)
-                            ]
-                          }
+                          (v22/*: any*/)
                         ]
                       }
                     ]
@@ -967,7 +1005,7 @@ return {
                 ]
               },
               (v11/*: any*/),
-              (v17/*: any*/),
+              (v18/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -1033,7 +1071,114 @@ return {
             ]
           },
           (v4/*: any*/),
-          (v2/*: any*/)
+          (v2/*: any*/),
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "artistSeriesConnection",
+            "storageKey": "artistSeriesConnection(first:1)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 1
+              }
+            ],
+            "concreteType": "ArtistSeriesConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtistSeriesEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ArtistSeries",
+                    "plural": false,
+                    "selections": [
+                      (v4/*: any*/),
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "artworksConnection",
+                        "storageKey": "artworksConnection(first:20)",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "first",
+                            "value": 20
+                          }
+                        ],
+                        "concreteType": "ArtworkConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "edges",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "ArtworkEdge",
+                            "plural": true,
+                            "selections": [
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "node",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "Artwork",
+                                "plural": false,
+                                "selections": [
+                                  (v4/*: any*/),
+                                  (v7/*: any*/),
+                                  (v5/*: any*/),
+                                  (v21/*: any*/),
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "image",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "imageURL",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      (v17/*: any*/)
+                                    ]
+                                  },
+                                  (v20/*: any*/),
+                                  (v18/*: any*/),
+                                  (v19/*: any*/),
+                                  (v22/*: any*/),
+                                  (v2/*: any*/)
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
         ]
       }
     ]
@@ -1041,7 +1186,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtworkBelowTheFoldQuery",
-    "id": "ccd50881e3857d29f735b0d49885fe9f",
+    "id": "894c89a1ac0e73fef8dd51596390760d",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtworkBelowTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtworkBelowTheFoldQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash e433b86f2981fae48d734c91b2359fb4 */
+/* @relayHash e66483a1d5f21cdc4c38b2a62d2aa8cc */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -177,6 +177,19 @@ fragment Artwork_artworkBelowTheFold on Artwork {
       edges {
         node {
           id
+        }
+      }
+    }
+  }
+  artistSeriesConnection(first: 1) {
+    edges {
+      node {
+        artworksConnection(first: 20) {
+          edges {
+            node {
+              id
+            }
+          }
         }
       }
     }
@@ -1037,6 +1050,115 @@ return {
             ]
           },
           {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "artistSeriesConnection",
+            "storageKey": "artistSeriesConnection(first:1)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 1
+              }
+            ],
+            "concreteType": "ArtistSeriesConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtistSeriesEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ArtistSeries",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "artworksConnection",
+                        "storageKey": "artworksConnection(first:20)",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "first",
+                            "value": 20
+                          }
+                        ],
+                        "concreteType": "ArtworkConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "edges",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "ArtworkEdge",
+                            "plural": true,
+                            "selections": [
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "node",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "Artwork",
+                                "plural": false,
+                                "selections": [
+                                  (v2/*: any*/),
+                                  (v4/*: any*/),
+                                  (v7/*: any*/),
+                                  (v5/*: any*/),
+                                  (v21/*: any*/),
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "image",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "imageURL",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      (v17/*: any*/)
+                                    ]
+                                  },
+                                  (v22/*: any*/),
+                                  (v23/*: any*/),
+                                  (v20/*: any*/),
+                                  (v18/*: any*/),
+                                  (v19/*: any*/),
+                                  (v24/*: any*/)
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      (v4/*: any*/)
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
             "kind": "ScalarField",
             "alias": null,
             "name": "isInAuction",
@@ -1085,116 +1207,7 @@ return {
             ]
           },
           (v4/*: any*/),
-          (v2/*: any*/),
-          {
-            "kind": "LinkedField",
-            "alias": null,
-            "name": "artistSeriesConnection",
-            "storageKey": "artistSeriesConnection(first:1)",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 1
-              }
-            ],
-            "concreteType": "ArtistSeriesConnection",
-            "plural": false,
-            "selections": [
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "edges",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "ArtistSeriesEdge",
-                "plural": true,
-                "selections": [
-                  {
-                    "kind": "LinkedField",
-                    "alias": null,
-                    "name": "node",
-                    "storageKey": null,
-                    "args": null,
-                    "concreteType": "ArtistSeries",
-                    "plural": false,
-                    "selections": [
-                      (v4/*: any*/),
-                      {
-                        "kind": "LinkedField",
-                        "alias": null,
-                        "name": "artworksConnection",
-                        "storageKey": "artworksConnection(first:20)",
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "first",
-                            "value": 20
-                          }
-                        ],
-                        "concreteType": "ArtworkConnection",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "edges",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "ArtworkEdge",
-                            "plural": true,
-                            "selections": [
-                              {
-                                "kind": "LinkedField",
-                                "alias": null,
-                                "name": "node",
-                                "storageKey": null,
-                                "args": null,
-                                "concreteType": "Artwork",
-                                "plural": false,
-                                "selections": [
-                                  (v4/*: any*/),
-                                  (v7/*: any*/),
-                                  (v5/*: any*/),
-                                  (v21/*: any*/),
-                                  {
-                                    "kind": "LinkedField",
-                                    "alias": null,
-                                    "name": "image",
-                                    "storageKey": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "kind": "ScalarField",
-                                        "alias": null,
-                                        "name": "imageURL",
-                                        "args": null,
-                                        "storageKey": null
-                                      },
-                                      (v17/*: any*/)
-                                    ]
-                                  },
-                                  (v22/*: any*/),
-                                  (v23/*: any*/),
-                                  (v20/*: any*/),
-                                  (v18/*: any*/),
-                                  (v19/*: any*/),
-                                  (v24/*: any*/),
-                                  (v2/*: any*/)
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
+          (v2/*: any*/)
         ]
       }
     ]
@@ -1202,7 +1215,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtworkBelowTheFoldQuery",
-    "id": "57d8278584f542e850b72f864aca027e",
+    "id": "340377d6fd6ff0afcf48332f11314ca4",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtworkRefetchQuery.graphql.ts
+++ b/src/__generated__/ArtworkRefetchQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash b1b58190556a9100e2c2fbfc34dcf3b9 */
+/* @relayHash ae622f228f5e6a6640b3e2528653b738 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -314,6 +314,18 @@ fragment ArtworksInSeriesRail_artwork on Artwork {
               image {
                 imageURL
                 aspectRatio
+              }
+              sale {
+                isAuction
+                isClosed
+                displayTimelyAt
+                id
+              }
+              saleArtwork {
+                currentBid {
+                  display
+                }
+                id
               }
               saleMessage
               title
@@ -867,6 +879,40 @@ v28 = {
   "name": "artistNames",
   "args": null,
   "storageKey": null
+},
+v29 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "sale",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Sale",
+  "plural": false,
+  "selections": [
+    (v13/*: any*/),
+    (v14/*: any*/),
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "displayTimelyAt",
+      "args": null,
+      "storageKey": null
+    },
+    (v2/*: any*/)
+  ]
+},
+v30 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "saleArtwork",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "SaleArtwork",
+  "plural": false,
+  "selections": [
+    (v20/*: any*/),
+    (v2/*: any*/)
+  ]
 };
 return {
   "kind": "Request",
@@ -1845,40 +1891,8 @@ return {
                           (v4/*: any*/),
                           (v28/*: any*/),
                           (v6/*: any*/),
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "sale",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "Sale",
-                            "plural": false,
-                            "selections": [
-                              (v13/*: any*/),
-                              (v14/*: any*/),
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "displayTimelyAt",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              (v2/*: any*/)
-                            ]
-                          },
-                          {
-                            "kind": "LinkedField",
-                            "alias": null,
-                            "name": "saleArtwork",
-                            "storageKey": null,
-                            "args": null,
-                            "concreteType": "SaleArtwork",
-                            "plural": false,
-                            "selections": [
-                              (v20/*: any*/),
-                              (v2/*: any*/)
-                            ]
-                          },
+                          (v29/*: any*/),
+                          (v30/*: any*/),
                           (v16/*: any*/)
                         ]
                       }
@@ -1994,6 +2008,8 @@ return {
                                       (v27/*: any*/)
                                     ]
                                   },
+                                  (v29/*: any*/),
+                                  (v30/*: any*/),
                                   (v22/*: any*/),
                                   (v5/*: any*/),
                                   (v17/*: any*/),
@@ -2018,7 +2034,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtworkRefetchQuery",
-    "id": "139282a5ce23748a027843ec87b76d45",
+    "id": "83c3a746fb8636f63b4b9a102de1cf85",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtworkRefetchQuery.graphql.ts
+++ b/src/__generated__/ArtworkRefetchQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash ae622f228f5e6a6640b3e2528653b738 */
+/* @relayHash 42b9a79eb1c0454ab676defc73576cc5 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -285,6 +285,19 @@ fragment Artwork_artworkBelowTheFold on Artwork {
       edges {
         node {
           id
+        }
+      }
+    }
+  }
+  artistSeriesConnection(first: 1) {
+    edges {
+      node {
+        artworksConnection(first: 20) {
+          edges {
+            node {
+              id
+            }
+          }
         }
       }
     }
@@ -1951,7 +1964,6 @@ return {
                     "concreteType": "ArtistSeries",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -1985,6 +1997,7 @@ return {
                                 "concreteType": "Artwork",
                                 "plural": false,
                                 "selections": [
+                                  (v2/*: any*/),
                                   (v4/*: any*/),
                                   (v3/*: any*/),
                                   (v6/*: any*/),
@@ -2013,14 +2026,14 @@ return {
                                   (v22/*: any*/),
                                   (v5/*: any*/),
                                   (v17/*: any*/),
-                                  (v16/*: any*/),
-                                  (v2/*: any*/)
+                                  (v16/*: any*/)
                                 ]
                               }
                             ]
                           }
                         ]
-                      }
+                      },
+                      (v4/*: any*/)
                     ]
                   }
                 ]
@@ -2034,7 +2047,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtworkRefetchQuery",
-    "id": "83c3a746fb8636f63b4b9a102de1cf85",
+    "id": "0aa70f3e1dffbdfb80e91900f514f0c9",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtworkRefetchQuery.graphql.ts
+++ b/src/__generated__/ArtworkRefetchQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 8ec7c4832b4d3d84a462fad9a6a7d0fc */
+/* @relayHash b1b58190556a9100e2c2fbfc34dcf3b9 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -296,6 +296,39 @@ fragment Artwork_artworkBelowTheFold on Artwork {
   ...ArtworkDetails_artwork
   ...ContextCard_artwork
   ...ArtworkHistory_artwork
+  ...ArtworksInSeriesRail_artwork
+}
+
+fragment ArtworksInSeriesRail_artwork on Artwork {
+  artistSeriesConnection(first: 1) {
+    edges {
+      node {
+        slug
+        artworksConnection(first: 20) {
+          edges {
+            node {
+              slug
+              internalID
+              href
+              artistNames
+              image {
+                imageURL
+                aspectRatio
+              }
+              saleMessage
+              title
+              date
+              partner {
+                name
+                id
+              }
+              id
+            }
+          }
+        }
+      }
+    }
+  }
 }
 
 fragment AuctionPrice_artwork on Artwork {
@@ -818,6 +851,20 @@ v26 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "exhibitionPeriod",
+  "args": null,
+  "storageKey": null
+},
+v27 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "aspectRatio",
+  "args": null,
+  "storageKey": null
+},
+v28 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "artistNames",
   "args": null,
   "storageKey": null
 };
@@ -1789,26 +1836,14 @@ return {
                                 ],
                                 "storageKey": "url(version:\"large\")"
                               },
-                              {
-                                "kind": "ScalarField",
-                                "alias": null,
-                                "name": "aspectRatio",
-                                "args": null,
-                                "storageKey": null
-                              }
+                              (v27/*: any*/)
                             ]
                           },
                           (v5/*: any*/),
                           (v17/*: any*/),
                           (v22/*: any*/),
                           (v4/*: any*/),
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "artistNames",
-                            "args": null,
-                            "storageKey": null
-                          },
+                          (v28/*: any*/),
                           (v6/*: any*/),
                           {
                             "kind": "LinkedField",
@@ -1868,6 +1903,113 @@ return {
                 "storageKey": null
               }
             ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "artistSeriesConnection",
+            "storageKey": "artistSeriesConnection(first:1)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 1
+              }
+            ],
+            "concreteType": "ArtistSeriesConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtistSeriesEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ArtistSeries",
+                    "plural": false,
+                    "selections": [
+                      (v4/*: any*/),
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "artworksConnection",
+                        "storageKey": "artworksConnection(first:20)",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "first",
+                            "value": 20
+                          }
+                        ],
+                        "concreteType": "ArtworkConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "edges",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "ArtworkEdge",
+                            "plural": true,
+                            "selections": [
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "node",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "Artwork",
+                                "plural": false,
+                                "selections": [
+                                  (v4/*: any*/),
+                                  (v3/*: any*/),
+                                  (v6/*: any*/),
+                                  (v28/*: any*/),
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "image",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "imageURL",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      (v27/*: any*/)
+                                    ]
+                                  },
+                                  (v22/*: any*/),
+                                  (v5/*: any*/),
+                                  (v17/*: any*/),
+                                  (v16/*: any*/),
+                                  (v2/*: any*/)
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
         ]
       }
@@ -1876,7 +2018,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtworkRefetchQuery",
-    "id": "ced320519de162049027a9cec469f6b9",
+    "id": "139282a5ce23748a027843ec87b76d45",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/Artwork_artworkBelowTheFold.graphql.ts
+++ b/src/__generated__/Artwork_artworkBelowTheFold.graphql.ts
@@ -59,7 +59,7 @@ export type Artwork_artworkBelowTheFold = {
             } | null> | null;
         } | null;
     } | null> | null;
-    readonly " $fragmentRefs": FragmentRefs<"PartnerCard_artwork" | "AboutWork_artwork" | "OtherWorks_artwork" | "AboutArtist_artwork" | "ArtworkDetails_artwork" | "ContextCard_artwork" | "ArtworkHistory_artwork">;
+    readonly " $fragmentRefs": FragmentRefs<"PartnerCard_artwork" | "AboutWork_artwork" | "OtherWorks_artwork" | "AboutArtist_artwork" | "ArtworkDetails_artwork" | "ContextCard_artwork" | "ArtworkHistory_artwork" | "ArtworksInSeriesRail_artwork">;
     readonly " $refType": "Artwork_artworkBelowTheFold";
 };
 export type Artwork_artworkBelowTheFold$data = Artwork_artworkBelowTheFold;
@@ -408,9 +408,14 @@ return {
       "kind": "FragmentSpread",
       "name": "ArtworkHistory_artwork",
       "args": null
+    },
+    {
+      "kind": "FragmentSpread",
+      "name": "ArtworksInSeriesRail_artwork",
+      "args": null
     }
   ]
 };
 })();
-(node as any).hash = '0c4b1bba8fe4cd5ae1caca3eea781409';
+(node as any).hash = '495ed0731944eafdcaca2caadc2db6cd';
 export default node;

--- a/src/__generated__/Artwork_artworkBelowTheFold.graphql.ts
+++ b/src/__generated__/Artwork_artworkBelowTheFold.graphql.ts
@@ -59,6 +59,19 @@ export type Artwork_artworkBelowTheFold = {
             } | null> | null;
         } | null;
     } | null> | null;
+    readonly artistSeriesConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly artworksConnection: {
+                    readonly edges: ReadonlyArray<{
+                        readonly node: {
+                            readonly id: string;
+                        } | null;
+                    } | null> | null;
+                } | null;
+            } | null;
+        } | null> | null;
+    } | null;
     readonly " $fragmentRefs": FragmentRefs<"PartnerCard_artwork" | "AboutWork_artwork" | "OtherWorks_artwork" | "AboutArtist_artwork" | "ArtworkDetails_artwork" | "ContextCard_artwork" | "ArtworkHistory_artwork" | "ArtworksInSeriesRail_artwork">;
     readonly " $refType": "Artwork_artworkBelowTheFold";
 };
@@ -85,6 +98,31 @@ v1 = [
     "name": "details",
     "args": null,
     "storageKey": null
+  }
+],
+v2 = [
+  {
+    "kind": "LinkedField",
+    "alias": null,
+    "name": "edges",
+    "storageKey": null,
+    "args": null,
+    "concreteType": "ArtworkEdge",
+    "plural": true,
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "node",
+        "storageKey": null,
+        "args": null,
+        "concreteType": "Artwork",
+        "plural": false,
+        "selections": [
+          (v0/*: any*/)
+        ]
+      }
+    ]
   }
 ];
 return {
@@ -346,27 +384,58 @@ return {
           ],
           "concreteType": "ArtworkConnection",
           "plural": false,
+          "selections": (v2/*: any*/)
+        }
+      ]
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "artistSeriesConnection",
+      "storageKey": "artistSeriesConnection(first:1)",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 1
+        }
+      ],
+      "concreteType": "ArtistSeriesConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "ArtistSeriesEdge",
+          "plural": true,
           "selections": [
             {
               "kind": "LinkedField",
               "alias": null,
-              "name": "edges",
+              "name": "node",
               "storageKey": null,
               "args": null,
-              "concreteType": "ArtworkEdge",
-              "plural": true,
+              "concreteType": "ArtistSeries",
+              "plural": false,
               "selections": [
                 {
                   "kind": "LinkedField",
                   "alias": null,
-                  "name": "node",
-                  "storageKey": null,
-                  "args": null,
-                  "concreteType": "Artwork",
+                  "name": "artworksConnection",
+                  "storageKey": "artworksConnection(first:20)",
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "first",
+                      "value": 20
+                    }
+                  ],
+                  "concreteType": "ArtworkConnection",
                   "plural": false,
-                  "selections": [
-                    (v0/*: any*/)
-                  ]
+                  "selections": (v2/*: any*/)
                 }
               ]
             }
@@ -417,5 +486,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '495ed0731944eafdcaca2caadc2db6cd';
+(node as any).hash = '3a6548470cdd6c57bfac174808f9803d';
 export default node;

--- a/src/__generated__/ArtworksInSeriesRailTestsQuery.graphql.ts
+++ b/src/__generated__/ArtworksInSeriesRailTestsQuery.graphql.ts
@@ -1,0 +1,428 @@
+/* tslint:disable */
+/* eslint-disable */
+/* @relayHash 6fe0c052f6b9c9f3f3a3e18dffbc9be7 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtworksInSeriesRailTestsQueryVariables = {};
+export type ArtworksInSeriesRailTestsQueryResponse = {
+    readonly artwork: {
+        readonly " $fragmentRefs": FragmentRefs<"ArtworksInSeriesRail_artwork">;
+    } | null;
+};
+export type ArtworksInSeriesRailTestsQueryRawResponse = {
+    readonly artwork: ({
+        readonly artistSeriesConnection: ({
+            readonly edges: ReadonlyArray<({
+                readonly node: ({
+                    readonly slug: string;
+                    readonly artworksConnection: ({
+                        readonly edges: ReadonlyArray<({
+                            readonly node: ({
+                                readonly slug: string;
+                                readonly internalID: string;
+                                readonly href: string | null;
+                                readonly artistNames: string | null;
+                                readonly image: ({
+                                    readonly imageURL: string | null;
+                                    readonly aspectRatio: number;
+                                }) | null;
+                                readonly sale: ({
+                                    readonly isAuction: boolean | null;
+                                    readonly isClosed: boolean | null;
+                                    readonly displayTimelyAt: string | null;
+                                    readonly id: string | null;
+                                }) | null;
+                                readonly saleArtwork: ({
+                                    readonly currentBid: ({
+                                        readonly display: string | null;
+                                    }) | null;
+                                    readonly id: string | null;
+                                }) | null;
+                                readonly saleMessage: string | null;
+                                readonly title: string | null;
+                                readonly date: string | null;
+                                readonly partner: ({
+                                    readonly name: string | null;
+                                    readonly id: string | null;
+                                }) | null;
+                                readonly id: string | null;
+                            }) | null;
+                        }) | null> | null;
+                    }) | null;
+                }) | null;
+            }) | null> | null;
+        }) | null;
+        readonly id: string | null;
+    }) | null;
+};
+export type ArtworksInSeriesRailTestsQuery = {
+    readonly response: ArtworksInSeriesRailTestsQueryResponse;
+    readonly variables: ArtworksInSeriesRailTestsQueryVariables;
+    readonly rawResponse: ArtworksInSeriesRailTestsQueryRawResponse;
+};
+
+
+
+/*
+query ArtworksInSeriesRailTestsQuery {
+  artwork(id: "some-artwork") {
+    ...ArtworksInSeriesRail_artwork
+    id
+  }
+}
+
+fragment ArtworksInSeriesRail_artwork on Artwork {
+  artistSeriesConnection(first: 1) {
+    edges {
+      node {
+        slug
+        artworksConnection(first: 20) {
+          edges {
+            node {
+              slug
+              internalID
+              href
+              artistNames
+              image {
+                imageURL
+                aspectRatio
+              }
+              sale {
+                isAuction
+                isClosed
+                displayTimelyAt
+                id
+              }
+              saleArtwork {
+                currentBid {
+                  display
+                }
+                id
+              }
+              saleMessage
+              title
+              date
+              partner {
+                name
+                id
+              }
+              id
+            }
+          }
+        }
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "some-artwork"
+  }
+],
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "slug",
+  "args": null,
+  "storageKey": null
+},
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "ArtworksInSeriesRailTestsQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artwork",
+        "storageKey": "artwork(id:\"some-artwork\")",
+        "args": (v0/*: any*/),
+        "concreteType": "Artwork",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "ArtworksInSeriesRail_artwork",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "ArtworksInSeriesRailTestsQuery",
+    "argumentDefinitions": [],
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "artwork",
+        "storageKey": "artwork(id:\"some-artwork\")",
+        "args": (v0/*: any*/),
+        "concreteType": "Artwork",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "artistSeriesConnection",
+            "storageKey": "artistSeriesConnection(first:1)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 1
+              }
+            ],
+            "concreteType": "ArtistSeriesConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtistSeriesEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ArtistSeries",
+                    "plural": false,
+                    "selections": [
+                      (v1/*: any*/),
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "artworksConnection",
+                        "storageKey": "artworksConnection(first:20)",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "first",
+                            "value": 20
+                          }
+                        ],
+                        "concreteType": "ArtworkConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "edges",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "ArtworkEdge",
+                            "plural": true,
+                            "selections": [
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "node",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "Artwork",
+                                "plural": false,
+                                "selections": [
+                                  (v1/*: any*/),
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "internalID",
+                                    "args": null,
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "href",
+                                    "args": null,
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "artistNames",
+                                    "args": null,
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "image",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "imageURL",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "aspectRatio",
+                                        "args": null,
+                                        "storageKey": null
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "sale",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "Sale",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "isAuction",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "isClosed",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "displayTimelyAt",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      (v2/*: any*/)
+                                    ]
+                                  },
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "saleArtwork",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "SaleArtwork",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "kind": "LinkedField",
+                                        "alias": null,
+                                        "name": "currentBid",
+                                        "storageKey": null,
+                                        "args": null,
+                                        "concreteType": "SaleArtworkCurrentBid",
+                                        "plural": false,
+                                        "selections": [
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "display",
+                                            "args": null,
+                                            "storageKey": null
+                                          }
+                                        ]
+                                      },
+                                      (v2/*: any*/)
+                                    ]
+                                  },
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "saleMessage",
+                                    "args": null,
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "title",
+                                    "args": null,
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "date",
+                                    "args": null,
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "partner",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "Partner",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "name",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      (v2/*: any*/)
+                                    ]
+                                  },
+                                  (v2/*: any*/)
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          (v2/*: any*/)
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "ArtworksInSeriesRailTestsQuery",
+    "id": "bfebd0f476ac12eb7a0282ae511cf20a",
+    "text": null,
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = 'b3301f7c86dc8f69c41558912cff2603';
+export default node;

--- a/src/__generated__/ArtworksInSeriesRail_artwork.graphql.ts
+++ b/src/__generated__/ArtworksInSeriesRail_artwork.graphql.ts
@@ -19,6 +19,16 @@ export type ArtworksInSeriesRail_artwork = {
                                 readonly imageURL: string | null;
                                 readonly aspectRatio: number;
                             } | null;
+                            readonly sale: {
+                                readonly isAuction: boolean | null;
+                                readonly isClosed: boolean | null;
+                                readonly displayTimelyAt: string | null;
+                            } | null;
+                            readonly saleArtwork: {
+                                readonly currentBid: {
+                                    readonly display: string | null;
+                                } | null;
+                            } | null;
                             readonly saleMessage: string | null;
                             readonly title: string | null;
                             readonly date: string | null;
@@ -171,6 +181,67 @@ return {
                               ]
                             },
                             {
+                              "kind": "LinkedField",
+                              "alias": null,
+                              "name": "sale",
+                              "storageKey": null,
+                              "args": null,
+                              "concreteType": "Sale",
+                              "plural": false,
+                              "selections": [
+                                {
+                                  "kind": "ScalarField",
+                                  "alias": null,
+                                  "name": "isAuction",
+                                  "args": null,
+                                  "storageKey": null
+                                },
+                                {
+                                  "kind": "ScalarField",
+                                  "alias": null,
+                                  "name": "isClosed",
+                                  "args": null,
+                                  "storageKey": null
+                                },
+                                {
+                                  "kind": "ScalarField",
+                                  "alias": null,
+                                  "name": "displayTimelyAt",
+                                  "args": null,
+                                  "storageKey": null
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "LinkedField",
+                              "alias": null,
+                              "name": "saleArtwork",
+                              "storageKey": null,
+                              "args": null,
+                              "concreteType": "SaleArtwork",
+                              "plural": false,
+                              "selections": [
+                                {
+                                  "kind": "LinkedField",
+                                  "alias": null,
+                                  "name": "currentBid",
+                                  "storageKey": null,
+                                  "args": null,
+                                  "concreteType": "SaleArtworkCurrentBid",
+                                  "plural": false,
+                                  "selections": [
+                                    {
+                                      "kind": "ScalarField",
+                                      "alias": null,
+                                      "name": "display",
+                                      "args": null,
+                                      "storageKey": null
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
                               "kind": "ScalarField",
                               "alias": null,
                               "name": "saleMessage",
@@ -224,5 +295,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'ec9c70a0a16971280525c46f787ea7ea';
+(node as any).hash = '4b6f793963f3ff2acfe89aca814448b1';
 export default node;

--- a/src/__generated__/ArtworksInSeriesRail_artwork.graphql.ts
+++ b/src/__generated__/ArtworksInSeriesRail_artwork.graphql.ts
@@ -1,0 +1,228 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtworksInSeriesRail_artwork = {
+    readonly artistSeriesConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly slug: string;
+                readonly artworksConnection: {
+                    readonly edges: ReadonlyArray<{
+                        readonly node: {
+                            readonly slug: string;
+                            readonly internalID: string;
+                            readonly href: string | null;
+                            readonly artistNames: string | null;
+                            readonly image: {
+                                readonly imageURL: string | null;
+                                readonly aspectRatio: number;
+                            } | null;
+                            readonly saleMessage: string | null;
+                            readonly title: string | null;
+                            readonly date: string | null;
+                            readonly partner: {
+                                readonly name: string | null;
+                            } | null;
+                        } | null;
+                    } | null> | null;
+                } | null;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "ArtworksInSeriesRail_artwork";
+};
+export type ArtworksInSeriesRail_artwork$data = ArtworksInSeriesRail_artwork;
+export type ArtworksInSeriesRail_artwork$key = {
+    readonly " $data"?: ArtworksInSeriesRail_artwork$data;
+    readonly " $fragmentRefs": FragmentRefs<"ArtworksInSeriesRail_artwork">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "slug",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Fragment",
+  "name": "ArtworksInSeriesRail_artwork",
+  "type": "Artwork",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "artistSeriesConnection",
+      "storageKey": "artistSeriesConnection(first:1)",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 1
+        }
+      ],
+      "concreteType": "ArtistSeriesConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "ArtistSeriesEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "ArtistSeries",
+              "plural": false,
+              "selections": [
+                (v0/*: any*/),
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "artworksConnection",
+                  "storageKey": "artworksConnection(first:20)",
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "first",
+                      "value": 20
+                    }
+                  ],
+                  "concreteType": "ArtworkConnection",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "LinkedField",
+                      "alias": null,
+                      "name": "edges",
+                      "storageKey": null,
+                      "args": null,
+                      "concreteType": "ArtworkEdge",
+                      "plural": true,
+                      "selections": [
+                        {
+                          "kind": "LinkedField",
+                          "alias": null,
+                          "name": "node",
+                          "storageKey": null,
+                          "args": null,
+                          "concreteType": "Artwork",
+                          "plural": false,
+                          "selections": [
+                            (v0/*: any*/),
+                            {
+                              "kind": "ScalarField",
+                              "alias": null,
+                              "name": "internalID",
+                              "args": null,
+                              "storageKey": null
+                            },
+                            {
+                              "kind": "ScalarField",
+                              "alias": null,
+                              "name": "href",
+                              "args": null,
+                              "storageKey": null
+                            },
+                            {
+                              "kind": "ScalarField",
+                              "alias": null,
+                              "name": "artistNames",
+                              "args": null,
+                              "storageKey": null
+                            },
+                            {
+                              "kind": "LinkedField",
+                              "alias": null,
+                              "name": "image",
+                              "storageKey": null,
+                              "args": null,
+                              "concreteType": "Image",
+                              "plural": false,
+                              "selections": [
+                                {
+                                  "kind": "ScalarField",
+                                  "alias": null,
+                                  "name": "imageURL",
+                                  "args": null,
+                                  "storageKey": null
+                                },
+                                {
+                                  "kind": "ScalarField",
+                                  "alias": null,
+                                  "name": "aspectRatio",
+                                  "args": null,
+                                  "storageKey": null
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "ScalarField",
+                              "alias": null,
+                              "name": "saleMessage",
+                              "args": null,
+                              "storageKey": null
+                            },
+                            {
+                              "kind": "ScalarField",
+                              "alias": null,
+                              "name": "title",
+                              "args": null,
+                              "storageKey": null
+                            },
+                            {
+                              "kind": "ScalarField",
+                              "alias": null,
+                              "name": "date",
+                              "args": null,
+                              "storageKey": null
+                            },
+                            {
+                              "kind": "LinkedField",
+                              "alias": null,
+                              "name": "partner",
+                              "storageKey": null,
+                              "args": null,
+                              "concreteType": "Partner",
+                              "plural": false,
+                              "selections": [
+                                {
+                                  "kind": "ScalarField",
+                                  "alias": null,
+                                  "name": "name",
+                                  "args": null,
+                                  "storageKey": null
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+})();
+(node as any).hash = 'ec9c70a0a16971280525c46f787ea7ea';
+export default node;

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistNotableWorksRail.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistNotableWorksRail.tsx
@@ -73,8 +73,6 @@ const ArtistNotableWorksRail: React.FC<ArtistNotableWorksRailProps> = ({ artist 
                 title={item?.node?.title}
                 saleMessage={saleMessage(item)}
                 key={item?.node?.internalID}
-                useNormalFontWeight
-                useLighterFont
                 onPress={() => {
                   handleNavigation(item?.node?.slug)
                 }}

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistNotableWorksRail.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistNotableWorksRail.tsx
@@ -68,10 +68,11 @@ const ArtistNotableWorksRail: React.FC<ArtistNotableWorksRailProps> = ({ artist 
             return (
               <ArtworkTileRailCard
                 imageURL={item?.node?.image?.imageURL}
-                artistNames={item?.node?.title}
+                imageAspectRatio={item?.node?.image?.aspectRatio}
+                imageSize="large"
+                title={item?.node?.title}
                 saleMessage={saleMessage(item)}
                 key={item?.node?.internalID}
-                useLargeImageSize
                 useNormalFontWeight
                 useLighterFont
                 onPress={() => {
@@ -101,6 +102,7 @@ export const ArtistNotableWorksRailFragmentContainer = createFragmentContainer(A
             id
             image {
               imageURL
+              aspectRatio
             }
             saleMessage
             saleArtwork {

--- a/src/lib/Components/Artist/ArtistArtworks/__tests__/ArtistNotableWorksRail-tests.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/__tests__/ArtistNotableWorksRail-tests.tsx
@@ -46,7 +46,7 @@ describe("Notable Works Rail", () => {
         wrapper
           .find(ArtworkTileRailCard)
           .first()
-          .props().artistNames
+          .props().title
       ).toBe("My Second Greatest Art")
 
       expect(
@@ -70,7 +70,7 @@ describe("Notable Works Rail", () => {
         wrapper
           .find(ArtworkTileRailCard)
           .at(1)
-          .props().artistNames
+          .props().title
       ).toBe("My Greatest Art")
     })
 
@@ -81,7 +81,7 @@ describe("Notable Works Rail", () => {
         wrapper
           .find(ArtworkTileRailCard)
           .at(2)
-          .props().artistNames
+          .props().title
       ).toBe("My Third Greatest Art")
 
       expect(
@@ -104,6 +104,7 @@ const artistMockData: ArtistNotableWorksRailTestsQueryRawResponse["artist"] = {
           id: "another-another-id-2",
           image: {
             imageURL: "https://www.testimages.net/test2.jpg",
+            aspectRatio: 0.5,
           },
           saleMessage: "€2,500 - 5,000",
           saleArtwork: null,
@@ -118,6 +119,7 @@ const artistMockData: ArtistNotableWorksRailTestsQueryRawResponse["artist"] = {
           id: "another-another-id",
           image: {
             imageURL: "https://www.testimages.net/test.jpg",
+            aspectRatio: 0.8,
           },
           saleMessage: null,
           saleArtwork: null,
@@ -136,6 +138,7 @@ const artistMockData: ArtistNotableWorksRailTestsQueryRawResponse["artist"] = {
           id: "another-another-id-3",
           image: {
             imageURL: "https://www.testimages.net/test3.jpg",
+            aspectRatio: 0.9,
           },
           saleMessage: null,
           saleArtwork: {

--- a/src/lib/Components/ArtworkTileRail/ArtworkTileRail.tsx
+++ b/src/lib/Components/ArtworkTileRail/ArtworkTileRail.tsx
@@ -59,6 +59,8 @@ export const ArtworkTileRailContainer: React.FC<ArtworkTileRailContainerProps> =
             imageURL={item.image?.imageURL}
             artistNames={item.artistNames}
             saleMessage={item.saleMessage}
+            useSquareAspectRatio
+            imageSize="small"
           />
         )}
         keyExtractor={(item, index) => String(item.image?.imageURL || index)}

--- a/src/lib/Components/ArtworkTileRail/ArtworkTileRailCard.tsx
+++ b/src/lib/Components/ArtworkTileRail/ArtworkTileRailCard.tsx
@@ -12,7 +12,7 @@ const IMAGE_SIZES = {
 
 const ArtworkCard = styled.TouchableHighlight.attrs({ underlayColor: color("white100"), activeOpacity: 0.8 })``
 
-interface ArtworkTileRailCardProps {
+export interface ArtworkTileRailCardProps {
   onPress: ((event: GestureResponderEvent) => void) | null | undefined
   imageURL: string | null | undefined
   imageSize: "small" | "medium" | "large"
@@ -23,7 +23,6 @@ interface ArtworkTileRailCardProps {
   title?: string | null | undefined
   imageAspectRatio?: number | null | undefined
   useSquareAspectRatio?: boolean | null
-  useLighterFont?: boolean | null
 }
 
 export const ArtworkTileRailCard: React.FC<ArtworkTileRailCardProps> = ({
@@ -38,6 +37,10 @@ export const ArtworkTileRailCard: React.FC<ArtworkTileRailCardProps> = ({
   imageSize,
   useSquareAspectRatio = false,
 }) => {
+  if (!!imageURL && !imageAspectRatio && !useSquareAspectRatio) {
+    throw new Error("imageAspectRatio is required for non-square images")
+  }
+
   const size = IMAGE_SIZES[imageSize]
   const imageHeight = size
   const imageWidth = useSquareAspectRatio ? size : (imageAspectRatio ?? 1) * size

--- a/src/lib/Components/ArtworkTileRail/ArtworkTileRailCard.tsx
+++ b/src/lib/Components/ArtworkTileRail/ArtworkTileRailCard.tsx
@@ -15,16 +15,14 @@ const ArtworkCard = styled.TouchableHighlight.attrs({ underlayColor: color("whit
 interface ArtworkTileRailCardProps {
   onPress: ((event: GestureResponderEvent) => void) | null | undefined
   imageURL: string | null | undefined
-  artistNames?: string | null | undefined
+  imageSize: "small" | "medium" | "large"
   saleMessage: string | null | undefined
+  artistNames?: string | null | undefined
   date?: string | null | undefined
   partner?: { name: string | null } | null | undefined
   title?: string | null | undefined
-  // todo: default to "small"
-  imageSize?: string
   imageAspectRatio?: number | null | undefined
   useSquareAspectRatio?: boolean | null
-  useNormalFontWeight?: boolean | null
   useLighterFont?: boolean | null
 }
 
@@ -38,29 +36,26 @@ export const ArtworkTileRailCard: React.FC<ArtworkTileRailCardProps> = ({
   title,
   imageAspectRatio,
   imageSize,
-  useSquareAspectRatio,
-  useNormalFontWeight,
-  useLighterFont,
+  useSquareAspectRatio = false,
 }) => {
   const size = IMAGE_SIZES[imageSize]
-  const height = size
-  const width = useSquareAspectRatio ? size : (imageAspectRatio ?? 1) * size
+  const imageHeight = size
+  const imageWidth = useSquareAspectRatio ? size : (imageAspectRatio ?? 1) * size
   const desiredVersion = useSquareAspectRatio ? "square" : "large"
-  const url = imageURL.replace(":version", desiredVersion)
 
   const imageDisplay = imageURL ? (
-    <OpaqueImageView imageURL={url} width={width} height={height} style={{ borderRadius: 2, overflow: "hidden" }} />
+    <OpaqueImageView
+      imageURL={imageURL.replace(":version", desiredVersion)}
+      width={imageWidth}
+      height={imageHeight}
+      style={{ borderRadius: 2, overflow: "hidden" }}
+    />
   ) : (
-    <Box bg={color("black30")} width={width} height={height} style={{ borderRadius: 2 }} />
+    <Box bg={color("black30")} width={imageWidth} height={imageHeight} style={{ borderRadius: 2 }} />
   )
 
   const artistNamesDisplay = artistNames ? (
-    <Sans
-      size="3t"
-      weight={useNormalFontWeight ? "regular" : "medium"}
-      color={useLighterFont ? "black60" : "black100"}
-      numberOfLines={1}
-    >
+    <Sans size="3t" weight="medium" color="black100" numberOfLines={1}>
       {artistNames}
     </Sans>
   ) : null
@@ -88,7 +83,7 @@ export const ArtworkTileRailCard: React.FC<ArtworkTileRailCardProps> = ({
     <ArtworkCard onPress={onPress || undefined}>
       <Flex>
         {imageDisplay}
-        <Box mt={1} width={width}>
+        <Box mt={1} width={imageWidth}>
           {artistNamesDisplay}
           {titleAndDateDisplay}
           {partnerDisplay}

--- a/src/lib/Components/ArtworkTileRail/ArtworkTileRailCard.tsx
+++ b/src/lib/Components/ArtworkTileRail/ArtworkTileRailCard.tsx
@@ -68,13 +68,13 @@ export const ArtworkTileRailCard: React.FC<ArtworkTileRailCardProps> = ({
 
   const titleAndDateDisplay =
     title || date ? (
-      <Sans size="3t" color="black60">
+      <Sans size="3t" color="black60" numberOfLines={1}>
         {[title, date].filter(Boolean).join(", ")}
       </Sans>
     ) : null
 
   const partnerDisplay = partner?.name ? (
-    <Sans size="3t" color="black60">
+    <Sans size="3t" color="black60" numberOfLines={1}>
       {partner.name}
     </Sans>
   ) : null

--- a/src/lib/Components/ArtworkTileRail/ArtworkTileRailCard.tsx
+++ b/src/lib/Components/ArtworkTileRail/ArtworkTileRailCard.tsx
@@ -4,8 +4,11 @@ import { GestureResponderEvent } from "react-native"
 import styled from "styled-components/native"
 import OpaqueImageView from "../OpaqueImageView/OpaqueImageView"
 
-const SMALL_TILE_IMAGE_SIZE = 120
-const LARGE_TILE_IMAGE_SIZE = 240
+const IMAGE_SIZES = {
+  small: 120,
+  medium: 160,
+  large: 240,
+}
 
 const ArtworkCard = styled.TouchableHighlight.attrs({ underlayColor: color("white100"), activeOpacity: 0.8 })``
 
@@ -14,7 +17,13 @@ interface ArtworkTileRailCardProps {
   imageURL: string | null | undefined
   artistNames: string | null | undefined
   saleMessage: string | null | undefined
-  useLargeImageSize?: boolean | null
+  date: string | null | undefined
+  partner: { name: string | null } | null | undefined
+  title: string | null | undefined
+  // todo: default to "small"
+  imageSize?: string
+  imageAspectRatio?: number | null | undefined
+  useSquareAspectRatio?: boolean | null
   useNormalFontWeight?: boolean | null
   useLighterFont?: boolean | null
 }
@@ -24,24 +33,25 @@ export const ArtworkTileRailCard: React.FC<ArtworkTileRailCardProps> = ({
   imageURL,
   artistNames,
   saleMessage,
-  useLargeImageSize,
+  date,
+  partner,
+  title,
+  imageAspectRatio,
+  imageSize,
+  useSquareAspectRatio,
   useNormalFontWeight,
   useLighterFont,
 }) => {
+  const size = IMAGE_SIZES[imageSize]
+  const height = size
+  const width = useSquareAspectRatio ? size : (imageAspectRatio ?? 1) * size
+  const desiredVersion = useSquareAspectRatio ? "square" : "large"
+  const url = imageURL.replace(":version", desiredVersion)
+
   const imageDisplay = imageURL ? (
-    <OpaqueImageView
-      imageURL={imageURL.replace(":version", useLargeImageSize ? "large" : "square")}
-      width={useLargeImageSize ? LARGE_TILE_IMAGE_SIZE : SMALL_TILE_IMAGE_SIZE}
-      height={useLargeImageSize ? LARGE_TILE_IMAGE_SIZE : SMALL_TILE_IMAGE_SIZE}
-      style={{ borderRadius: 2, overflow: "hidden" }}
-    />
+    <OpaqueImageView imageURL={url} width={width} height={height} style={{ borderRadius: 2, overflow: "hidden" }} />
   ) : (
-    <Box
-      bg={color("black30")}
-      width={useLargeImageSize ? LARGE_TILE_IMAGE_SIZE : SMALL_TILE_IMAGE_SIZE}
-      height={useLargeImageSize ? LARGE_TILE_IMAGE_SIZE : SMALL_TILE_IMAGE_SIZE}
-      style={{ borderRadius: 2 }}
-    />
+    <Box bg={color("black30")} width={width} height={height} style={{ borderRadius: 2 }} />
   )
 
   const artistNamesDisplay = artistNames ? (
@@ -61,12 +71,27 @@ export const ArtworkTileRailCard: React.FC<ArtworkTileRailCardProps> = ({
     </Sans>
   ) : null
 
+  const titleAndDateDisplay =
+    title || date ? (
+      <Sans size="3t" color="black60">
+        {[title, date].filter(Boolean).join(", ")}
+      </Sans>
+    ) : null
+
+  const partnerDisplay = partner?.name ? (
+    <Sans size="3t" color="black60">
+      {partner.name}
+    </Sans>
+  ) : null
+
   return (
     <ArtworkCard onPress={onPress || undefined}>
       <Flex>
         {imageDisplay}
-        <Box mt={1} width={useLargeImageSize ? LARGE_TILE_IMAGE_SIZE : SMALL_TILE_IMAGE_SIZE}>
+        <Box mt={1} width={width}>
           {artistNamesDisplay}
+          {titleAndDateDisplay}
+          {partnerDisplay}
           {saleMessageDisplay}
         </Box>
       </Flex>

--- a/src/lib/Components/ArtworkTileRail/ArtworkTileRailCard.tsx
+++ b/src/lib/Components/ArtworkTileRail/ArtworkTileRailCard.tsx
@@ -15,11 +15,11 @@ const ArtworkCard = styled.TouchableHighlight.attrs({ underlayColor: color("whit
 interface ArtworkTileRailCardProps {
   onPress: ((event: GestureResponderEvent) => void) | null | undefined
   imageURL: string | null | undefined
-  artistNames: string | null | undefined
+  artistNames?: string | null | undefined
   saleMessage: string | null | undefined
-  date: string | null | undefined
-  partner: { name: string | null } | null | undefined
-  title: string | null | undefined
+  date?: string | null | undefined
+  partner?: { name: string | null } | null | undefined
+  title?: string | null | undefined
   // todo: default to "small"
   imageSize?: string
   imageAspectRatio?: number | null | undefined

--- a/src/lib/Components/ArtworkTileRail/__tests__/ArtworkTileRailCard-tests.tsx
+++ b/src/lib/Components/ArtworkTileRail/__tests__/ArtworkTileRailCard-tests.tsx
@@ -2,17 +2,22 @@ import { Theme } from "@artsy/palette"
 // @ts-ignore STRICTNESS_MIGRATION
 import { mount } from "enzyme"
 import React from "react"
-import { ArtworkTileRailCard } from "../ArtworkTileRailCard"
+import { ArtworkTileRailCard, ArtworkTileRailCardProps } from "../ArtworkTileRailCard"
 
 describe("ArtworkTileRailCard", () => {
-  const defaultProps = {
+  const defaultProps: ArtworkTileRailCardProps = {
     onPress: jest.fn(),
     imageURL: "http://placekitten.com/200/200",
     artistNames: "Andy Goldsworthy",
     saleMessage: "Sold for $1,200",
+    title: "CoronaCats",
+    date: "2020",
+    partner: { name: "Big Cats Unlimited" },
+    imageSize: "large",
+    imageAspectRatio: 0.9,
   }
 
-  it("renders an image with an imageURL", () => {
+  it("renders an image with an imageURL and maintains the aspect ratio", () => {
     const props = defaultProps
 
     const result = mount(
@@ -21,7 +26,39 @@ describe("ArtworkTileRailCard", () => {
       </Theme>
     )
 
-    expect(result.find("AROpaqueImageView").length).toBe(1)
+    const image = result.find("AROpaqueImageView")
+    expect(image.length).toBe(1)
+    expect(image.prop("height")).toBe(240)
+    expect(image.prop("width")).toBe(216)
+  })
+
+  it("renders the title and date together when both are given", () => {
+    const props = defaultProps
+
+    const result = mount(
+      <Theme>
+        <ArtworkTileRailCard {...props} />
+      </Theme>
+    )
+
+    const sans = result.find("Sans")
+    expect(sans.at(1).prop("children")).toMatch("CoronaCats, 2020")
+  })
+
+  it("renders the title when no date is given", () => {
+    const props = {
+      ...defaultProps,
+      date: undefined,
+    }
+
+    const result = mount(
+      <Theme>
+        <ArtworkTileRailCard {...props} />
+      </Theme>
+    )
+
+    const sans = result.find("Sans")
+    expect(sans.at(1).prop("children")).toMatch("CoronaCats")
   })
 
   it("renders no image without imageURL", () => {
@@ -63,5 +100,77 @@ describe("ArtworkTileRailCard", () => {
         <ArtworkTileRailCard {...props} />
       </Theme>
     )
+  })
+
+  it("renders without an artwork date", () => {
+    const props = {
+      ...defaultProps,
+      date: undefined,
+    }
+
+    mount(
+      <Theme>
+        <ArtworkTileRailCard {...props} />
+      </Theme>
+    )
+  })
+
+  it("renders without a partner", () => {
+    const props = {
+      ...defaultProps,
+      partner: undefined,
+    }
+
+    mount(
+      <Theme>
+        <ArtworkTileRailCard {...props} />
+      </Theme>
+    )
+  })
+
+  it("renders without a title", () => {
+    const props = {
+      ...defaultProps,
+      title: undefined,
+    }
+
+    mount(
+      <Theme>
+        <ArtworkTileRailCard {...props} />
+      </Theme>
+    )
+  })
+
+  it("throws an error when trying to render a non-square image without an aspect ratio", () => {
+    const props = {
+      ...defaultProps,
+      imageAspectRatio: undefined,
+    }
+    const error = new Error("imageAspectRatio is required for non-square images")
+
+    expect(() =>
+      mount(
+        <Theme>
+          <ArtworkTileRailCard {...props} />
+        </Theme>
+      )
+    ).toThrowError(error)
+  })
+
+  it("renders a square image when useSquareAspectRatio is true", () => {
+    const props = {
+      ...defaultProps,
+      useSquareAspectRatio: true,
+    }
+
+    const result = mount(
+      <Theme>
+        <ArtworkTileRailCard {...props} />
+      </Theme>
+    )
+
+    const image = result.find("AROpaqueImageView")
+    expect(image.prop("height")).toBe(240)
+    expect(image.prop("width")).toBe(240)
   })
 })

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -27,6 +27,7 @@ import { AboutWorkFragmentContainer as AboutWork } from "./Components/AboutWork"
 import { ArtworkDetailsFragmentContainer as ArtworkDetails } from "./Components/ArtworkDetails"
 import { ArtworkHeaderFragmentContainer as ArtworkHeader } from "./Components/ArtworkHeader"
 import { ArtworkHistoryFragmentContainer as ArtworkHistory } from "./Components/ArtworkHistory"
+import { ArtworksInSeriesRailFragmentContainer as ArtworksInSeriesRail } from "./Components/ArtworksInSeriesRail"
 import { CommercialInformationFragmentContainer as CommercialInformation } from "./Components/CommercialInformation"
 import { ContextCardFragmentContainer as ContextCard } from "./Components/ContextCard"
 import { OtherWorksFragmentContainer as OtherWorks, populatedGrids } from "./Components/OtherWorks/OtherWorks"
@@ -237,6 +238,11 @@ export class Artwork extends React.Component<Props, State> {
       })
     }
 
+    sections.push({
+      key: "artworksInSeriesRail",
+      element: <ArtworksInSeriesRail artwork={artworkBelowTheFold} />,
+    })
+
     if (this.shouldRenderOtherWorks()) {
       sections.push({
         key: "otherWorks",
@@ -349,6 +355,7 @@ export const ArtworkContainer = createRefetchContainer(
         ...ArtworkDetails_artwork
         ...ContextCard_artwork
         ...ArtworkHistory_artwork
+        ...ArtworksInSeriesRail_artwork
       }
     `,
     me: graphql`

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -17,7 +17,7 @@ import {
 import { Schema, screenTrack } from "lib/utils/track"
 import { ProvideScreenDimensions, useScreenDimensions } from "lib/utils/useScreenDimensions"
 import React from "react"
-import { ActivityIndicator, FlatList, View } from "react-native"
+import { ActivityIndicator, FlatList, NativeModules, View } from "react-native"
 import { RefreshControl } from "react-native"
 import { commitMutation, createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { TrackingProp } from "react-tracking"
@@ -135,10 +135,11 @@ export class Artwork extends React.Component<Props, State> {
   }
 
   shouldRenderArtworksInArtistSeries = () => {
+    const featureFlagEnabled = NativeModules.Emission.options.AROptionsArtistSeries
     const { artistSeriesConnection } = this.props.artworkBelowTheFold
     const artistSeries = artistSeriesConnection?.edges?.[0]
-    const numArtworks = artistSeries?.node?.artworksConnection?.edges?.length ?? 0
-    return artistSeries && numArtworks > 0
+    const numArtistSeriesArtworks = artistSeries?.node?.artworksConnection?.edges?.length ?? 0
+    return featureFlagEnabled && numArtistSeriesArtworks > 0
   }
 
   onRefresh = (cb?: () => any) => {

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -134,6 +134,13 @@ export class Artwork extends React.Component<Props, State> {
     }
   }
 
+  shouldRenderArtworksInArtistSeries = () => {
+    const { artistSeriesConnection } = this.props.artworkBelowTheFold
+    const artistSeries = artistSeriesConnection?.edges?.[0]
+    const numArtworks = artistSeries?.node?.artworksConnection?.edges?.length ?? 0
+    return artistSeries && numArtworks > 0
+  }
+
   onRefresh = (cb?: () => any) => {
     if (this.state.refreshing) {
       return
@@ -238,10 +245,12 @@ export class Artwork extends React.Component<Props, State> {
       })
     }
 
-    sections.push({
-      key: "artworksInSeriesRail",
-      element: <ArtworksInSeriesRail artwork={artworkBelowTheFold} />,
-    })
+    if (this.shouldRenderArtworksInArtistSeries()) {
+      sections.push({
+        key: "artworksInSeriesRail",
+        element: <ArtworksInSeriesRail artwork={artworkBelowTheFold} />,
+      })
+    }
 
     if (this.shouldRenderOtherWorks()) {
       sections.push({
@@ -344,6 +353,19 @@ export const ArtworkContainer = createRefetchContainer(
             edges {
               node {
                 id
+              }
+            }
+          }
+        }
+        artistSeriesConnection(first: 1) {
+          edges {
+            node {
+              artworksConnection(first: 20) {
+                edges {
+                  node {
+                    id
+                  }
+                }
               }
             }
           }

--- a/src/lib/Scenes/Artwork/Components/ArtworksInSeriesRail.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworksInSeriesRail.tsx
@@ -31,16 +31,14 @@ export const ArtworksInSeriesRail: React.FC<ArtworksInSeriesRailProps> = ({ artw
           SwitchBoard.presentNavigationViewController(navRef.current!, `/artist-series/${artistSeriesSlug}`)
         }}
       >
-        <Flex py={1} flexDirection="row" justifyContent="space-between">
+        <Flex pb={1} flexDirection="row" justifyContent="space-between">
           <Sans size="4">More from this series</Sans>
           <ArrowRightIcon mr="-5px" />
         </Flex>
       </TouchableOpacity>
       <FlatList
         horizontal
-        ListHeaderComponent={() => <Spacer mr={2}></Spacer>}
-        ListFooterComponent={() => <Spacer mr={2}></Spacer>}
-        ItemSeparatorComponent={() => <Spacer width={15}></Spacer>}
+        ItemSeparatorComponent={() => <Spacer width={10}></Spacer>}
         showsHorizontalScrollIndicator={false}
         data={artworks}
         initialNumToRender={5}

--- a/src/lib/Scenes/Artwork/Components/ArtworksInSeriesRail.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworksInSeriesRail.tsx
@@ -1,0 +1,93 @@
+import { ArrowRightIcon, Flex, Sans, Spacer } from "@artsy/palette"
+import { ArtworksInSeriesRail_artwork } from "__generated__/ArtworksInSeriesRail_artwork.graphql"
+import { ArtworkTileRailCard } from "lib/Components/ArtworkTileRail"
+import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { extractNodes } from "lib/utils/extractNodes"
+import React, { useRef } from "react"
+import { FlatList } from "react-native"
+import { createFragmentContainer, graphql } from "react-relay"
+
+interface ArtworksInSeriesRailProps {
+  artwork: ArtworksInSeriesRail_artwork
+}
+
+export const ArtworksInSeriesRail: React.FC<ArtworksInSeriesRailProps> = ({ artwork }) => {
+  const navRef = useRef(null)
+
+  const artworksConnection = artwork?.artistSeriesConnection?.edges?.[0]?.node?.artworksConnection
+
+  if (!artworksConnection) {
+    return null
+  }
+
+  const artworks = extractNodes(artworksConnection)
+
+  return (
+    <Flex ref={navRef}>
+      <Flex py={1} flexDirection="row" justifyContent="space-between">
+        <Sans size="4">More from this series</Sans>
+        <ArrowRightIcon mr="-5px" />
+      </Flex>
+      <FlatList
+        horizontal
+        ListHeaderComponent={() => <Spacer mr={2}></Spacer>}
+        ListFooterComponent={() => <Spacer mr={2}></Spacer>}
+        ItemSeparatorComponent={() => <Spacer width={15}></Spacer>}
+        showsHorizontalScrollIndicator={false}
+        data={artworks}
+        initialNumToRender={5}
+        windowSize={3}
+        renderItem={({ item }) => (
+          <ArtworkTileRailCard
+            onPress={() => {
+              SwitchBoard.presentNavigationViewController(navRef.current!, item.href!)
+            }}
+            imageURL={item.image?.imageURL}
+            imageAspectRatio={item.image?.aspectRatio}
+            imageSize="medium"
+            artistNames={item.artistNames}
+            title={item.title}
+            partner={item.partner}
+            date={item.date}
+            saleMessage={item.saleMessage}
+          />
+        )}
+        keyExtractor={(item, index) => String(item.image?.imageURL || index)}
+      />
+    </Flex>
+  )
+}
+
+export const ArtworksInSeriesRailFragmentContainer = createFragmentContainer(ArtworksInSeriesRail, {
+  artwork: graphql`
+    fragment ArtworksInSeriesRail_artwork on Artwork {
+      artistSeriesConnection(first: 1) {
+        edges {
+          node {
+            slug
+            artworksConnection(first: 20) {
+              edges {
+                node {
+                  slug
+                  internalID
+                  href
+                  artistNames
+                  image {
+                    imageURL
+                    aspectRatio
+                  }
+                  saleMessage
+                  title
+                  date
+                  partner {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `,
+})

--- a/src/lib/Scenes/Artwork/Components/ArtworksInSeriesRail.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworksInSeriesRail.tsx
@@ -1,5 +1,6 @@
 import { ArrowRightIcon, Flex, Sans, Spacer } from "@artsy/palette"
 import { ArtworksInSeriesRail_artwork } from "__generated__/ArtworksInSeriesRail_artwork.graphql"
+import { saleMessageOrBidInfo } from "lib/Components/ArtworkGrids/ArtworkGridItem"
 import { ArtworkTileRailCard } from "lib/Components/ArtworkTileRail"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { extractNodes } from "lib/utils/extractNodes"
@@ -56,7 +57,7 @@ export const ArtworksInSeriesRail: React.FC<ArtworksInSeriesRailProps> = ({ artw
             title={item.title}
             partner={item.partner}
             date={item.date}
-            saleMessage={item.saleMessage}
+            saleMessage={saleMessageOrBidInfo(item)}
             key={item.internalID}
           />
         )}
@@ -83,6 +84,16 @@ export const ArtworksInSeriesRailFragmentContainer = createFragmentContainer(Art
                   image {
                     imageURL
                     aspectRatio
+                  }
+                  sale {
+                    isAuction
+                    isClosed
+                    displayTimelyAt
+                  }
+                  saleArtwork {
+                    currentBid {
+                      display
+                    }
                   }
                   saleMessage
                   title

--- a/src/lib/Scenes/Artwork/Components/ArtworksInSeriesRail.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworksInSeriesRail.tsx
@@ -3,8 +3,8 @@ import { ArtworksInSeriesRail_artwork } from "__generated__/ArtworksInSeriesRail
 import { ArtworkTileRailCard } from "lib/Components/ArtworkTileRail"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { extractNodes } from "lib/utils/extractNodes"
-import React, { useRef } from "react"
-import { FlatList } from "react-native"
+import React, { Component, useRef } from "react"
+import { FlatList, TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 
 interface ArtworksInSeriesRailProps {
@@ -12,8 +12,9 @@ interface ArtworksInSeriesRailProps {
 }
 
 export const ArtworksInSeriesRail: React.FC<ArtworksInSeriesRailProps> = ({ artwork }) => {
-  const navRef = useRef(null)
+  const navRef = useRef<Component>(null)
 
+  const artistSeriesSlug = artwork?.artistSeriesConnection?.edges?.[0]?.node?.slug
   const artworksConnection = artwork?.artistSeriesConnection?.edges?.[0]?.node?.artworksConnection
 
   if (!artworksConnection) {
@@ -24,10 +25,16 @@ export const ArtworksInSeriesRail: React.FC<ArtworksInSeriesRailProps> = ({ artw
 
   return (
     <Flex ref={navRef}>
-      <Flex py={1} flexDirection="row" justifyContent="space-between">
-        <Sans size="4">More from this series</Sans>
-        <ArrowRightIcon mr="-5px" />
-      </Flex>
+      <TouchableOpacity
+        onPress={() => {
+          SwitchBoard.presentNavigationViewController(navRef.current!, `/artist-series/${artistSeriesSlug}`)
+        }}
+      >
+        <Flex py={1} flexDirection="row" justifyContent="space-between">
+          <Sans size="4">More from this series</Sans>
+          <ArrowRightIcon mr="-5px" />
+        </Flex>
+      </TouchableOpacity>
       <FlatList
         horizontal
         ListHeaderComponent={() => <Spacer mr={2}></Spacer>}
@@ -50,6 +57,7 @@ export const ArtworksInSeriesRail: React.FC<ArtworksInSeriesRailProps> = ({ artw
             partner={item.partner}
             date={item.date}
             saleMessage={item.saleMessage}
+            key={item.internalID}
           />
         )}
         keyExtractor={(item, index) => String(item.image?.imageURL || index)}

--- a/src/lib/Scenes/Artwork/Components/__tests__/ArtworksInSeriesRail-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/ArtworksInSeriesRail-tests.tsx
@@ -1,0 +1,212 @@
+import { Theme } from "@artsy/palette"
+import {
+  ArtworksInSeriesRailTestsQuery,
+  ArtworksInSeriesRailTestsQueryRawResponse,
+} from "__generated__/ArtworksInSeriesRailTestsQuery.graphql"
+import { ArtworkTileRailCard } from "lib/Components/ArtworkTileRail/ArtworkTileRailCard"
+import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import React from "react"
+import { TouchableOpacity } from "react-native"
+import { graphql, QueryRenderer } from "react-relay"
+import ReactTestRenderer, { act } from "react-test-renderer"
+import { createMockEnvironment } from "relay-test-utils"
+import { ArtworksInSeriesRail, ArtworksInSeriesRailFragmentContainer } from "../ArtworksInSeriesRail"
+
+jest.mock("lib/NativeModules/SwitchBoard", () => ({
+  presentNavigationViewController: jest.fn(),
+}))
+
+jest.unmock("react-relay")
+
+describe("ArtworksInSeriesRail", () => {
+  let env: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => {
+    env = createMockEnvironment()
+  })
+
+  const TestRenderer = () => (
+    <QueryRenderer<ArtworksInSeriesRailTestsQuery>
+      environment={env}
+      query={graphql`
+        query ArtworksInSeriesRailTestsQuery @raw_response_type {
+          artwork(id: "some-artwork") {
+            ...ArtworksInSeriesRail_artwork
+          }
+        }
+      `}
+      variables={{}}
+      render={({ props, error }) => {
+        if (props?.artwork) {
+          return (
+            <Theme>
+              <ArtworksInSeriesRailFragmentContainer artwork={props.artwork} />
+            </Theme>
+          )
+        } else if (error) {
+          console.log(error)
+        }
+      }}
+    />
+  )
+
+  const getWrapper = () => {
+    const tree = ReactTestRenderer.create(<TestRenderer />)
+    act(() => {
+      env.mock.resolveMostRecentOperation({
+        errors: [],
+        data: {
+          ...ArtworksInSeriesRailFixture,
+        },
+      })
+    })
+    return tree
+  }
+
+  it("renders without throwing an error", () => {
+    const wrapper = getWrapper()
+    expect(wrapper.root.findAllByType(ArtworksInSeriesRail)).toHaveLength(1)
+  })
+
+  it("renders each artwork in the artist series", () => {
+    const wrapper = getWrapper()
+    expect(wrapper.root.findAllByType(ArtworkTileRailCard)).toHaveLength(5)
+  })
+
+  it("navigates to the artist series when the header is tapped", () => {
+    const wrapper = getWrapper()
+    const header = wrapper.root.findAllByType(TouchableOpacity)[0]
+    header.props.onPress()
+    expect(SwitchBoard.presentNavigationViewController).toHaveBeenCalledWith(
+      expect.anything(),
+      "/artist-series/alex-katz-departure"
+    )
+  })
+
+  const ArtworksInSeriesRailFixture: ArtworksInSeriesRailTestsQueryRawResponse = {
+    artwork: {
+      artistSeriesConnection: {
+        edges: [
+          {
+            node: {
+              slug: "alex-katz-departure",
+              artworksConnection: {
+                edges: [
+                  {
+                    node: {
+                      id: "abc123",
+                      slug: "alex-katz-departure-28",
+                      internalID: "5a20271ccd530e50722ae2df",
+                      href: "/artwork/alex-katz-departure-28",
+                      artistNames: "Alex Katz",
+                      image: {
+                        imageURL: "https://d32dm0rphc51dk.cloudfront.net/FCwTE6IvudGFVmnR9106xg/:version.jpg",
+                        aspectRatio: 0.67,
+                      },
+                      sale: null,
+                      saleArtwork: null,
+                      saleMessage: "$20,000",
+                      title: "Departure",
+                      date: "2017",
+                      partner: {
+                        id: "abc123",
+                        name: "Haw Contemporary",
+                      },
+                    },
+                  },
+                  {
+                    node: {
+                      id: "abc456",
+                      slug: "alex-katz-departure-56",
+                      internalID: "594c3b40b202a34d4f9810fe",
+                      href: "/artwork/alex-katz-departure-56",
+                      artistNames: "Alex Katz",
+                      image: {
+                        imageURL: "https://d32dm0rphc51dk.cloudfront.net/PPclmZKx-vXZTSJdAEHUzw/:version.jpg",
+                        aspectRatio: 0.67,
+                      },
+                      sale: null,
+                      saleArtwork: null,
+                      saleMessage: "$21,000",
+                      title: "Departure",
+                      date: "2017",
+                      partner: {
+                        id: "abc123",
+                        name: "Newzones",
+                      },
+                    },
+                  },
+                  {
+                    node: {
+                      id: "abc789",
+                      slug: "alex-katz-departure-2-ada",
+                      internalID: "5daa29db5f3f9d000e059e00",
+                      href: "/artwork/alex-katz-departure-2-ada",
+                      artistNames: "Alex Katz",
+                      image: {
+                        imageURL: "https://d32dm0rphc51dk.cloudfront.net/l9MiP2_A-_CoWimV4ZnNRA/:version.jpg",
+                        aspectRatio: 0.5,
+                      },
+                      sale: null,
+                      saleArtwork: null,
+                      saleMessage: "Contact For Price",
+                      title: "Departure 2 (Ada)",
+                      date: "2017",
+                      partner: {
+                        id: "abc123",
+                        name: "Kasmin",
+                      },
+                    },
+                  },
+                  {
+                    node: {
+                      slug: "alex-katz-park-avenue-departure",
+                      internalID: "5e7123b39d099c0011959efd",
+                      href: "/artwork/alex-katz-park-avenue-departure",
+                      artistNames: "Alex Katz",
+                      image: {
+                        imageURL: "https://d32dm0rphc51dk.cloudfront.net/fz_V0Mj3GPFnKhMwujWB3g/:version.jpg",
+                        aspectRatio: 0.67,
+                      },
+                      sale: null,
+                      saleArtwork: null,
+                      saleMessage: "Contact For Price",
+                      title: "Park Avenue Departure",
+                      date: "2019",
+                      partner: {
+                        id: "abc123",
+                        name: "Kasmin",
+                      },
+                    },
+                  },
+                  {
+                    node: {
+                      id: "abc012",
+                      slug: "alex-katz-departure-cut-out-2",
+                      internalID: "5959da15c9dc2404d231179f",
+                      href: "/artwork/alex-katz-departure-cut-out-2",
+                      artistNames: "Alex Katz",
+                      image: {
+                        imageURL: "https://d32dm0rphc51dk.cloudfront.net/IQp10TeWJi6CHJu-Nm6yrQ/:version.jpg",
+                        aspectRatio: 0.7,
+                      },
+                      sale: null,
+                      saleArtwork: null,
+                      saleMessage: "Contact For Price",
+                      title: "Departure (Cut-Out)",
+                      date: "2017",
+                      partner: {
+                        id: "abc123",
+                        name: "Meyerovich Gallery",
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    },
+  }
+})

--- a/src/lib/Scenes/Artwork/Components/__tests__/ArtworksInSeriesRail-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/ArtworksInSeriesRail-tests.tsx
@@ -85,6 +85,7 @@ describe("ArtworksInSeriesRail", () => {
 
   const ArtworksInSeriesRailFixture: ArtworksInSeriesRailTestsQueryRawResponse = {
     artwork: {
+      id: "asdf123",
       artistSeriesConnection: {
         edges: [
           {
@@ -160,6 +161,7 @@ describe("ArtworksInSeriesRail", () => {
                   },
                   {
                     node: {
+                      id: "xyz123",
                       slug: "alex-katz-park-avenue-departure",
                       internalID: "5e7123b39d099c0011959efd",
                       href: "/artwork/alex-katz-park-avenue-departure",

--- a/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/Components/RecentlySold.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/Components/RecentlySold.tsx
@@ -63,6 +63,8 @@ export const RecentlySold: React.FC<RecentlySoldProps> = ({ targetSupply, isLoad
                     imageURL={item?.image?.imageURL}
                     artistNames={item?.artistNames}
                     saleMessage={saleMessage}
+                    useSquareAspectRatio
+                    imageSize="small"
                     key={item?.internalID}
                     data-test-id="recently-sold-item"
                     onPress={() => {

--- a/src/lib/Scenes/Home/Components/SmallTileRail.tsx
+++ b/src/lib/Scenes/Home/Components/SmallTileRail.tsx
@@ -43,6 +43,8 @@ const SmallTileRail: React.FC<{
               : undefined
           }
           imageURL={item.image?.imageURL ?? ""}
+          imageSize="small"
+          useSquareAspectRatio
           artistNames={item.artistNames}
           saleMessage={saleMessageOrBidInfo(item)}
         />


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR resolves **[FX-2019](https://artsyproduct.atlassian.net/browse/FX-2019)**

### Description

- Creates `ArtworksInSeriesRail` component that, for an artwork in an artist series, displays other artworks from the series on the artwork page
- Updates `ArtworkTileRailCard`:
  - Displays artwork title, date and partner (if given) 
  - Supports true aspect ratio images
- `ArtistNotableWorksRail` to use true aspect ratio images instead of square aspect ratio images
- Updates other artwork rails as needed to use new `ArtworkTileRailCard` props

### Test Plan

* @williardx to test in beta

### Screenshots

**`ArtworksInSeriesRail`**

![fx-2019](https://user-images.githubusercontent.com/4432348/89676553-dad28300-d8b9-11ea-8e79-543629120bb5.gif)

**`ArtistNotableWorksRail`**

![Screen Shot 2020-08-06 at 11 49 46 AM](https://user-images.githubusercontent.com/4432348/89676991-985d7600-d8ba-11ea-959b-d70cb047b57e.png)

