### PR TITLE
[MX-458] - Update copy, spacing in partner header #trivial

### DIFF
--- a/src/lib/Scenes/Partner/Components/PartnerHeader.tsx
+++ b/src/lib/Scenes/Partner/Components/PartnerHeader.tsx
@@ -13,15 +13,13 @@ const PartnerHeader: React.FC<{
 
   return (
     <Box px={2} pb={1} pt={6}>
-      <Sans mb={2} size="8">
+      <Sans mb={1} size="8">
         {partner.name}
       </Sans>
       <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
         <Stack spacing={0.5}>
           {!!eligibleArtworks && (
-            <Sans size="3t">
-              {!!eligibleArtworks && formatText(eligibleArtworks, "Work for sale", "Works for sale")}
-            </Sans>
+            <Sans size="3t">{!!eligibleArtworks && formatText(eligibleArtworks, "work", "works")}</Sans>
           )}
         </Stack>
         {!!partner.profile && (

--- a/src/lib/Scenes/Partner/Components/__tests__/PartnerHeader-tests.tsx
+++ b/src/lib/Scenes/Partner/Components/__tests__/PartnerHeader-tests.tsx
@@ -47,7 +47,7 @@ describe("PartnerHeader", () => {
       })
     })
 
-    expect(extractText(tree.root)).toContain("1.2k Works for sale")
+    expect(extractText(tree.root)).toContain("1.2k works")
   })
 
   it("renders the partner name", async () => {


### PR DESCRIPTION
The type of this PR is: **Design Upkeep**

This PR resolves **[MX-458]**

### Description

Follow-up from feedback on https://github.com/artsy/eigen/pull/3660:
- Reduces spacing in below partner name to 10px
- Updates 'Works for sale' copy to 'works' to align with other pages

### Screenshots

#### Before

![partner-before](https://user-images.githubusercontent.com/49686530/89796732-fcb94900-daf7-11ea-921c-c6f1dd0fb3bf.png)

#### After

![partner-after](https://user-images.githubusercontent.com/49686530/89796738-fe830c80-daf7-11ea-9d59-2f0cb7f74d0e.png)




[MX-458]: https://artsyproduct.atlassian.net/browse/MX-458