### PR TITLE
make `Read more` text use the new type styles #trivial

### DIFF
--- a/src/lib/Components/ReadMore.tsx
+++ b/src/lib/Components/ReadMore.tsx
@@ -146,9 +146,7 @@ function truncate({
             <>
               {"... "}
               <LinkText onPress={onExpand}>
-                <Sans size="3" weight="medium">
-                  Read&nbsp;more
-                </Sans>
+                <PaletteText variant="mediumText">Read&nbsp;more</PaletteText>
               </LinkText>
             </>
           )

--- a/src/lib/Components/__tests__/ReadMore-tests.tsx
+++ b/src/lib/Components/__tests__/ReadMore-tests.tsx
@@ -1,4 +1,4 @@
-import { Sans, Serif, Theme } from "@artsy/palette"
+import { Sans, Serif, Text, Theme } from "@artsy/palette"
 // @ts-ignore STRICTNESS_MIGRATION
 import { mount, shallow } from "enzyme"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
@@ -42,13 +42,23 @@ describe("ReadMore", () => {
   it("Shows the 'Read more' link when the length of the text is > the number of characters allowed", () => {
     const component = mount(
       <Theme>
-        <ReadMore maxChars={7} content={"This text is slightly longer than is allowed."} />
+        <ReadMore maxChars={7} textStyle="new" content={"This text is slightly longer than is allowed."} />
       </Theme>
     )
 
-    expect(component.find(Serif).length).toEqual(1)
-    expect(component.find(Serif).text()).toMatchInlineSnapshot(`"This te... Read more"`)
-    expect(component.find(Sans).length).toEqual(1)
+    expect(component.find(Text).length).toEqual(2)
+    expect(
+      component
+        .find(Text)
+        .at(0)
+        .text()
+    ).toMatchInlineSnapshot(`"This te... Read more"`)
+    expect(
+      component
+        .find(Text)
+        .at(1)
+        .text()
+    ).toMatchInlineSnapshot(`"Read more"`)
 
     // Clicking "Read more" expands the text
     component
@@ -58,8 +68,8 @@ describe("ReadMore", () => {
 
     component.update()
 
-    expect(component.find(Serif).text()).toEqual("This text is slightly longer than is allowed.")
-    expect(component.find(Sans).length).toEqual(0)
+    expect(component.find(Text).length).toEqual(1)
+    expect(component.find(Text).text()).toEqual("This text is slightly longer than is allowed.")
   })
 
   it("truncates correctly if there are links within the text", () => {
@@ -67,14 +77,25 @@ describe("ReadMore", () => {
       <Theme>
         <ReadMore
           maxChars={7}
+          textStyle="new"
           content={"This [text](/artist/text) is slightly longer than is [allowed](/gene/allowed)."}
         />
       </Theme>
     )
 
-    expect(component.find(Serif).length).toEqual(1)
-    expect(component.find(Serif).text()).toMatchInlineSnapshot(`"This te... Read more"`)
-    expect(component.find(Sans).length).toEqual(1)
+    expect(component.find(Text).length).toEqual(2)
+    expect(
+      component
+        .find(Text)
+        .at(0)
+        .text()
+    ).toMatchInlineSnapshot(`"This te... Read more"`)
+    expect(
+      component
+        .find(Text)
+        .at(1)
+        .text()
+    ).toMatchInlineSnapshot(`"Read more"`)
     expect(component.find(LinkText).length).toEqual(2) // One for the "text" link, one for "Read more"
 
     // Clicking "Read more" expands the text
@@ -86,8 +107,8 @@ describe("ReadMore", () => {
 
     component.update()
 
-    expect(component.find(Serif).text()).toEqual("This text is slightly longer than is allowed.")
-    expect(component.find(Sans).length).toEqual(0)
+    expect(component.find(Text).length).toEqual(1)
+    expect(component.find(Text).text()).toEqual("This text is slightly longer than is allowed.")
     expect(component.find(LinkText).length).toEqual(2) // We still have 2 links, since we expanded to view one
   })
 


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR is related to **[GALL-3073]**

### Description
The "Read more" button was using the old style of text, we moved it to the new.

<!-- Implementation description -->


### Screenshots

Before
<img width="387" alt="Screenshot 2020-08-10 at 19 04 50" src="https://user-images.githubusercontent.com/100233/89811049-57759380-db3e-11ea-8841-4465683ba1f9.png">

After
<img width="393" alt="Screenshot 2020-08-10 at 19 11 50" src="https://user-images.githubusercontent.com/100233/89811064-5c3a4780-db3e-11ea-8a07-5a8822311d51.png">

<!-- Add screenshots or simulator recordings if applicable -->


[GALL-3073]: https://artsyproduct.atlassian.net/browse/GALL-3073