### PR TITLE
Fix Artist Series header image border radius

### DIFF
--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesHeader.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesHeader.tsx
@@ -12,7 +12,7 @@ export const ArtistSeriesHeader: React.SFC<ArtistSeriesHeaderProps> = ({ artistS
 
   return (
     <Flex flexDirection="row" justifyContent="center" pt={1}>
-      <OpaqueImageView width={180} height={180} imageURL={url} style={{ borderRadius: 2 }} />
+      <OpaqueImageView width={180} height={180} imageURL={url} style={{ borderRadius: 2, overflow: "hidden" }} />
     </Flex>
   )
 }


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR resolves **[FX-2109]**

### Description

This is take 2 (after #3692 ) at setting the `borderRadius` for the Artist Series header image. Turns out that you need to set an overflow on the `OpaqueImageView` for the image to actually be constrained. 

Here is an exaggerated version, for demo purposes —

Without no `overflow` on the left -vs-  with `overflow: hidden` on the right.

<img height="200" alt="without" src="https://user-images.githubusercontent.com/140521/89823756-06ef3d80-db20-11ea-92ef-2fd4c18d1f50.png"> <img height="200" alt="with" src="https://user-images.githubusercontent.com/140521/89823758-0787d400-db20-11ea-9587-d317db1dd3f8.png">

### Screenshots

Here's the actual, final, very subtle 2px radius!

<img height="600" alt="final" src="https://user-images.githubusercontent.com/140521/89823901-3e5dea00-db20-11ea-9dc6-9e2aaa1d1d91.png">

#trivial

[FX-2109]: https://artsyproduct.atlassian.net/browse/FX-2109