### PR TITLE
FX-2107: Artwork grid tap

### DIFF
--- a/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 27373a9e289ce45cd59fa07e837add33 */
+/* @relayHash 4f46990041cce50c1f039c018a9cd969 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -186,6 +186,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -640,6 +641,7 @@ return {
                         "storageKey": null
                       },
                       (v16/*: any*/),
+                      (v2/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -1074,7 +1076,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistAboveTheFoldQuery",
-    "id": "ac2fc59a72d148930030e19cbdba9ba9",
+    "id": "315ade00ee4427d3d2879e7e125b92f3",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistArtworksQuery.graphql.ts
+++ b/src/__generated__/ArtistArtworksQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash bee61df95776f8c1376c83623be5e2aa */
+/* @relayHash 3df346b8fc64acf4069681c95cb3073a */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -182,6 +182,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -705,6 +706,7 @@ return {
                             "storageKey": null
                           },
                           (v21/*: any*/),
+                          (v16/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1143,7 +1145,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistArtworksQuery",
-    "id": "bfec3003174c351ce356b56c5f0d4501",
+    "id": "4e4e408e5dcdc50a1ce1b12b70639e45",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeriesArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 43429a1921aa9f6eaf10500ff9c8e1f4 */
+/* @relayHash adefe08aa99495543af1f1df3c2f90c0 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -35,6 +35,7 @@ query ArtistSeriesArtworksInfiniteScrollGridQuery(
 
 fragment ArtistSeriesArtworks_artistSeries_1RfMLO on ArtistSeries {
   slug
+  internalID
   artistSeriesArtworks: filterArtworksConnection(first: 20, sort: $sort, after: $cursor) {
     edges {
       node {
@@ -60,6 +61,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -153,7 +155,14 @@ v3 = {
   "args": null,
   "storageKey": null
 },
-v4 = [
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "internalID",
+  "args": null,
+  "storageKey": null
+},
+v5 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -166,7 +175,7 @@ v4 = [
   },
   (v2/*: any*/)
 ],
-v5 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
@@ -227,12 +236,13 @@ return {
         "plural": false,
         "selections": [
           (v3/*: any*/),
+          (v4/*: any*/),
           {
             "kind": "LinkedField",
             "alias": "artistSeriesArtworks",
             "name": "filterArtworksConnection",
             "storageKey": null,
-            "args": (v4/*: any*/),
+            "args": (v5/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
@@ -254,7 +264,7 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/),
+                      (v6/*: any*/),
                       (v3/*: any*/),
                       {
                         "kind": "LinkedField",
@@ -308,6 +318,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
+                      (v4/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -352,7 +363,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v5/*: any*/)
+                          (v6/*: any*/)
                         ]
                       },
                       {
@@ -382,7 +393,7 @@ return {
                               }
                             ]
                           },
-                          (v5/*: any*/)
+                          (v6/*: any*/)
                         ]
                       },
                       {
@@ -401,7 +412,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v5/*: any*/)
+                          (v6/*: any*/)
                         ]
                       },
                       {
@@ -420,7 +431,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  (v5/*: any*/)
+                  (v6/*: any*/)
                 ]
               },
               {
@@ -473,14 +484,14 @@ return {
                   }
                 ]
               },
-              (v5/*: any*/)
+              (v6/*: any*/)
             ]
           },
           {
             "kind": "LinkedHandle",
             "alias": "artistSeriesArtworks",
             "name": "filterArtworksConnection",
-            "args": (v4/*: any*/),
+            "args": (v5/*: any*/),
             "handle": "connection",
             "key": "ArtistSeries_artistSeriesArtworks",
             "filters": [
@@ -494,7 +505,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesArtworksInfiniteScrollGridQuery",
-    "id": "a7d0a4531a7ce14aced916946330f717",
+    "id": "c418c3392d0c70796d2791ea2de4d84e",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeriesArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworksTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash f582a1be8c83968560e72152bde6ebc6 */
+/* @relayHash a8cdb3187ab2443583db25e90c853fdc */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -13,6 +13,7 @@ export type ArtistSeriesArtworksTestsQueryResponse = {
 export type ArtistSeriesArtworksTestsQueryRawResponse = {
     readonly artistSeries: ({
         readonly slug: string;
+        readonly internalID: string;
         readonly artistSeriesArtworks: ({
             readonly edges: ReadonlyArray<({
                 readonly node: ({
@@ -25,6 +26,7 @@ export type ArtistSeriesArtworksTestsQueryRawResponse = {
                     readonly title: string | null;
                     readonly date: string | null;
                     readonly saleMessage: string | null;
+                    readonly internalID: string;
                     readonly artistNames: string | null;
                     readonly href: string | null;
                     readonly sale: ({
@@ -77,6 +79,7 @@ query ArtistSeriesArtworksTestsQuery {
 
 fragment ArtistSeriesArtworks_artistSeries on ArtistSeries {
   slug
+  internalID
   artistSeriesArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch") {
     edges {
       node {
@@ -102,6 +105,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -164,7 +168,14 @@ v1 = {
   "args": null,
   "storageKey": null
 },
-v2 = [
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "internalID",
+  "args": null,
+  "storageKey": null
+},
+v3 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -176,7 +187,7 @@ v2 = [
     "value": "-decayed_merch"
   }
 ],
-v3 = {
+v4 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
@@ -225,12 +236,13 @@ return {
         "plural": false,
         "selections": [
           (v1/*: any*/),
+          (v2/*: any*/),
           {
             "kind": "LinkedField",
             "alias": "artistSeriesArtworks",
             "name": "filterArtworksConnection",
             "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")",
-            "args": (v2/*: any*/),
+            "args": (v3/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
@@ -252,7 +264,7 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
+                      (v4/*: any*/),
                       (v1/*: any*/),
                       {
                         "kind": "LinkedField",
@@ -306,6 +318,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
+                      (v2/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -350,7 +363,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v4/*: any*/)
                         ]
                       },
                       {
@@ -380,7 +393,7 @@ return {
                               }
                             ]
                           },
-                          (v3/*: any*/)
+                          (v4/*: any*/)
                         ]
                       },
                       {
@@ -399,7 +412,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v4/*: any*/)
                         ]
                       },
                       {
@@ -418,7 +431,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  (v3/*: any*/)
+                  (v4/*: any*/)
                 ]
               },
               {
@@ -471,14 +484,14 @@ return {
                   }
                 ]
               },
-              (v3/*: any*/)
+              (v4/*: any*/)
             ]
           },
           {
             "kind": "LinkedHandle",
             "alias": "artistSeriesArtworks",
             "name": "filterArtworksConnection",
-            "args": (v2/*: any*/),
+            "args": (v3/*: any*/),
             "handle": "connection",
             "key": "ArtistSeries_artistSeriesArtworks",
             "filters": [
@@ -492,7 +505,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesArtworksTestsQuery",
-    "id": "c7a7c2462a6659378f5c158b12b6f3f2",
+    "id": "cd4270fc2a86a6afdbad3bfac72d19b7",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeriesArtworks_artistSeries.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworks_artistSeries.graphql.ts
@@ -5,6 +5,7 @@ import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ArtistSeriesArtworks_artistSeries = {
     readonly slug: string;
+    readonly internalID: string;
     readonly artistSeriesArtworks: {
         readonly edges: ReadonlyArray<{
             readonly node: {
@@ -67,6 +68,13 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "alias": null,
       "name": "slug",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "internalID",
       "args": null,
       "storageKey": null
     },
@@ -180,5 +188,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = '0d5c28fda4444b413f6ea6d444f69b39';
+(node as any).hash = '12fed3cf8c36f39cfea138b47924c910';
 export default node;

--- a/src/__generated__/ArtistSeriesQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 2318ae8b36d95c11f9d3f456f06f687c */
+/* @relayHash b67013c752e061c40ed885b95cb2141c */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -30,6 +30,7 @@ query ArtistSeriesQuery(
 
 fragment ArtistSeriesArtworks_artistSeries on ArtistSeries {
   slug
+  internalID
   artistSeriesArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch") {
     edges {
       node {
@@ -105,6 +106,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -321,6 +323,7 @@ return {
             ]
           },
           (v8/*: any*/),
+          (v6/*: any*/),
           {
             "kind": "LinkedField",
             "alias": "artistSeriesArtworks",
@@ -396,6 +399,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
+                      (v6/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -646,7 +650,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesQuery",
-    "id": "496f6031254e44e96591e95f7d339dc3",
+    "id": "ce9708a46b863d987e976150cce86701",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 06448f15169936a72291d394ce9571db */
+/* @relayHash 9947a3ede638183a41ac67d10f0f4acc */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -29,6 +29,7 @@ export type ArtistSeriesTestsQueryRawResponse = {
             }) | null;
         }) | null> | null;
         readonly slug: string;
+        readonly internalID: string;
         readonly artistSeriesArtworks: ({
             readonly edges: ReadonlyArray<({
                 readonly node: ({
@@ -41,6 +42,7 @@ export type ArtistSeriesTestsQueryRawResponse = {
                     readonly title: string | null;
                     readonly date: string | null;
                     readonly saleMessage: string | null;
+                    readonly internalID: string;
                     readonly artistNames: string | null;
                     readonly href: string | null;
                     readonly sale: ({
@@ -111,6 +113,7 @@ query ArtistSeriesTestsQuery {
 
 fragment ArtistSeriesArtworks_artistSeries on ArtistSeries {
   slug
+  internalID
   artistSeriesArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch") {
     edges {
       node {
@@ -186,6 +189,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -394,6 +398,7 @@ return {
             ]
           },
           (v7/*: any*/),
+          (v5/*: any*/),
           {
             "kind": "LinkedField",
             "alias": "artistSeriesArtworks",
@@ -469,6 +474,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
+                      (v5/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -719,7 +725,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesTestsQuery",
-    "id": "8aab827e10ae23c29a44a8f50a56f3f2",
+    "id": "9604369cf57cba77d528c6f4deef395a",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtworkBelowTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtworkBelowTheFoldQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash e66483a1d5f21cdc4c38b2a62d2aa8cc */
+/* @relayHash 9b3d056007d54201a3af42a70cf9e518 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -92,6 +92,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -1020,6 +1021,7 @@ return {
                           (v19/*: any*/),
                           (v20/*: any*/),
                           (v4/*: any*/),
+                          (v7/*: any*/),
                           (v21/*: any*/),
                           (v5/*: any*/),
                           (v22/*: any*/),
@@ -1215,7 +1217,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtworkBelowTheFoldQuery",
-    "id": "340377d6fd6ff0afcf48332f11314ca4",
+    "id": "595e90c87bd069e28149c01c56b87976",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtworkGridItem_artwork.graphql.ts
+++ b/src/__generated__/ArtworkGridItem_artwork.graphql.ts
@@ -8,6 +8,7 @@ export type ArtworkGridItem_artwork = {
     readonly date: string | null;
     readonly saleMessage: string | null;
     readonly slug: string;
+    readonly internalID: string;
     readonly artistNames: string | null;
     readonly href: string | null;
     readonly sale: {
@@ -69,6 +70,13 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "alias": null,
       "name": "slug",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "internalID",
       "args": null,
       "storageKey": null
     },
@@ -198,5 +206,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = '7bd5287864a230b68d4fcf6830fba6b9';
+(node as any).hash = '4ba49da4fd8772ee73096b3c98f95ed5';
 export default node;

--- a/src/__generated__/ArtworkRefetchQuery.graphql.ts
+++ b/src/__generated__/ArtworkRefetchQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 42b9a79eb1c0454ab676defc73576cc5 */
+/* @relayHash 141e453f7bfab18a518e497d2ff414e2 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -143,6 +143,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -1902,6 +1903,7 @@ return {
                           (v17/*: any*/),
                           (v22/*: any*/),
                           (v4/*: any*/),
+                          (v3/*: any*/),
                           (v28/*: any*/),
                           (v6/*: any*/),
                           (v29/*: any*/),
@@ -2047,7 +2049,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtworkRefetchQuery",
-    "id": "0aa70f3e1dffbdfb80e91900f514f0c9",
+    "id": "8f3ffd7a174c65cfe8c959aaa8208451",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/CollectionArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/CollectionArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash bb96bfa4113cc23f4a8e3e8555cfda0c */
+/* @relayHash 0a12bace4b00e126cef8ad31b96b9353 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -60,6 +60,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -563,6 +564,13 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
+                        "name": "internalID",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
                         "name": "artistNames",
                         "args": null,
                         "storageKey": null
@@ -733,7 +741,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "CollectionArtworksInfiniteScrollGridQuery",
-    "id": "1beb29fc6d39715e1902c3275bd43582",
+    "id": "9e33ad233b6e0d21dca400a3d2ff2d3a",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/CollectionArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/CollectionArtworksTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 519c71ea379097f0f84acf09653296a0 */
+/* @relayHash 1f8f031fd108ea6977d3fc77f7cbf78e */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -39,6 +39,7 @@ export type CollectionArtworksTestsQueryRawResponse = {
                     readonly title: string | null;
                     readonly date: string | null;
                     readonly saleMessage: string | null;
+                    readonly internalID: string;
                     readonly artistNames: string | null;
                     readonly href: string | null;
                     readonly sale: ({
@@ -92,6 +93,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -431,6 +433,13 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
+                        "name": "internalID",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
                         "name": "artistNames",
                         "args": null,
                         "storageKey": null
@@ -601,7 +610,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "CollectionArtworksTestsQuery",
-    "id": "44227b14636b5c10f0ce30ab1d909973",
+    "id": "b44b27b8e019ff592ab7967ad78093bb",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/CollectionQuery.graphql.ts
+++ b/src/__generated__/CollectionQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 784fcf7209f976f3fa97c1c5bdf7410f */
+/* @relayHash 000e397a15f46770419c565e58e820d0 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -51,6 +51,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -354,11 +355,18 @@ v9 = {
 v10 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "href",
+  "name": "internalID",
   "args": null,
   "storageKey": null
 },
 v11 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
+  "args": null,
+  "storageKey": null
+},
+v12 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "image",
@@ -376,7 +384,7 @@ v11 = {
     }
   ]
 },
-v12 = {
+v13 = {
   "kind": "Literal",
   "name": "aggregations",
   "value": [
@@ -647,6 +655,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
+                      (v10/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -654,7 +663,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v10/*: any*/),
+                      (v11/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -845,13 +854,7 @@ return {
                 "concreteType": "Artist",
                 "plural": true,
                 "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "internalID",
-                    "args": null,
-                    "storageKey": null
-                  },
+                  (v10/*: any*/),
                   (v2/*: any*/),
                   (v3/*: any*/),
                   (v9/*: any*/),
@@ -862,7 +865,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  (v10/*: any*/),
+                  (v11/*: any*/),
                   {
                     "kind": "ScalarField",
                     "alias": "is_followed",
@@ -891,7 +894,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  (v11/*: any*/)
+                  (v12/*: any*/)
                 ]
               },
               (v2/*: any*/)
@@ -965,7 +968,7 @@ return {
                     "name": "artworksConnection",
                     "storageKey": "artworksConnection(aggregations:[\"TOTAL\"],first:3,sort:\"-decayed_merch\")",
                     "args": [
-                      (v12/*: any*/),
+                      (v13/*: any*/),
                       {
                         "kind": "Literal",
                         "name": "first",
@@ -995,7 +998,7 @@ return {
                             "plural": false,
                             "selections": [
                               (v4/*: any*/),
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               (v2/*: any*/)
                             ]
                           }
@@ -1011,7 +1014,7 @@ return {
                     "name": "artworksConnection",
                     "storageKey": "artworksConnection(aggregations:[\"TOTAL\"],first:1,sort:\"-decayed_merch\")",
                     "args": [
-                      (v12/*: any*/),
+                      (v13/*: any*/),
                       (v6/*: any*/),
                       (v7/*: any*/)
                     ],
@@ -1036,7 +1039,7 @@ return {
                             "concreteType": "Artwork",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               (v2/*: any*/)
                             ]
                           }
@@ -1056,7 +1059,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "CollectionQuery",
-    "id": "f8096b0bc5a25421701aabf0f1d9f7b7",
+    "id": "fb7882cb52a6795f85c4cf3f4e2757a4",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/CollectionTestsQuery.graphql.ts
+++ b/src/__generated__/CollectionTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 39f7ccd4d9bb891b0962231200b4101f */
+/* @relayHash 5a962e6f39e5f93c40ad8edb970ca9af */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -46,6 +46,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -335,11 +336,18 @@ v8 = {
 v9 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "href",
+  "name": "internalID",
   "args": null,
   "storageKey": null
 },
 v10 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
+  "args": null,
+  "storageKey": null
+},
+v11 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "image",
@@ -357,74 +365,74 @@ v10 = {
     }
   ]
 },
-v11 = {
+v12 = {
   "kind": "Literal",
   "name": "aggregations",
   "value": [
     "TOTAL"
   ]
 },
-v12 = {
-  "type": "ID",
-  "enumValues": null,
-  "plural": false,
-  "nullable": false
-},
 v13 = {
-  "type": "String",
+  "type": "ID",
   "enumValues": null,
   "plural": false,
   "nullable": false
 },
 v14 = {
-  "type": "Boolean",
+  "type": "String",
   "enumValues": null,
   "plural": false,
   "nullable": false
 },
 v15 = {
-  "type": "String",
+  "type": "Boolean",
   "enumValues": null,
   "plural": false,
-  "nullable": true
+  "nullable": false
 },
 v16 = {
-  "type": "FilterArtworksConnection",
+  "type": "String",
   "enumValues": null,
   "plural": false,
   "nullable": true
 },
 v17 = {
+  "type": "FilterArtworksConnection",
+  "enumValues": null,
+  "plural": false,
+  "nullable": true
+},
+v18 = {
   "type": "String",
   "enumValues": null,
   "plural": true,
   "nullable": true
 },
-v18 = {
+v19 = {
   "type": "FilterArtworksEdge",
   "enumValues": null,
   "plural": true,
   "nullable": true
 },
-v19 = {
+v20 = {
   "type": "ID",
   "enumValues": null,
   "plural": false,
   "nullable": true
 },
-v20 = {
+v21 = {
   "type": "Artwork",
   "enumValues": null,
   "plural": false,
   "nullable": true
 },
-v21 = {
+v22 = {
   "type": "Image",
   "enumValues": null,
   "plural": false,
   "nullable": true
 },
-v22 = {
+v23 = {
   "type": "Boolean",
   "enumValues": null,
   "plural": false,
@@ -688,6 +696,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
+                      (v9/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -695,7 +704,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v9/*: any*/),
+                      (v10/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -886,13 +895,7 @@ return {
                 "concreteType": "Artist",
                 "plural": true,
                 "selections": [
-                  {
-                    "kind": "ScalarField",
-                    "alias": null,
-                    "name": "internalID",
-                    "args": null,
-                    "storageKey": null
-                  },
+                  (v9/*: any*/),
                   (v1/*: any*/),
                   (v2/*: any*/),
                   (v8/*: any*/),
@@ -903,7 +906,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  (v9/*: any*/),
+                  (v10/*: any*/),
                   {
                     "kind": "ScalarField",
                     "alias": "is_followed",
@@ -932,7 +935,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  (v10/*: any*/)
+                  (v11/*: any*/)
                 ]
               },
               (v1/*: any*/)
@@ -1006,7 +1009,7 @@ return {
                     "name": "artworksConnection",
                     "storageKey": "artworksConnection(aggregations:[\"TOTAL\"],first:3,sort:\"-decayed_merch\")",
                     "args": [
-                      (v11/*: any*/),
+                      (v12/*: any*/),
                       {
                         "kind": "Literal",
                         "name": "first",
@@ -1036,7 +1039,7 @@ return {
                             "plural": false,
                             "selections": [
                               (v3/*: any*/),
-                              (v10/*: any*/),
+                              (v11/*: any*/),
                               (v1/*: any*/)
                             ]
                           }
@@ -1052,7 +1055,7 @@ return {
                     "name": "artworksConnection",
                     "storageKey": "artworksConnection(aggregations:[\"TOTAL\"],first:1,sort:\"-decayed_merch\")",
                     "args": [
-                      (v11/*: any*/),
+                      (v12/*: any*/),
                       (v5/*: any*/),
                       (v6/*: any*/)
                     ],
@@ -1077,7 +1080,7 @@ return {
                             "concreteType": "Artwork",
                             "plural": false,
                             "selections": [
-                              (v10/*: any*/),
+                              (v11/*: any*/),
                               (v1/*: any*/)
                             ]
                           }
@@ -1097,7 +1100,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "CollectionTestsQuery",
-    "id": "2dfc512625e29282d815be8dc11096af",
+    "id": "fbb05f86a347b9e116d0e1badbbea1d9",
     "text": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -1107,30 +1110,30 @@ return {
           "plural": false,
           "nullable": true
         },
-        "marketingCollection.id": (v12/*: any*/),
-        "marketingCollection.slug": (v13/*: any*/),
-        "marketingCollection.isDepartment": (v14/*: any*/),
+        "marketingCollection.id": (v13/*: any*/),
+        "marketingCollection.slug": (v14/*: any*/),
+        "marketingCollection.isDepartment": (v15/*: any*/),
         "marketingCollection.linkedCollections": {
           "type": "MarketingCollectionGroup",
           "enumValues": null,
           "plural": true,
           "nullable": false
         },
-        "marketingCollection.title": (v13/*: any*/),
-        "marketingCollection.headerImage": (v15/*: any*/),
-        "marketingCollection.descriptionMarkdown": (v15/*: any*/),
-        "marketingCollection.image": (v16/*: any*/),
-        "marketingCollection.collectionArtworks": (v16/*: any*/),
-        "marketingCollection.artworksConnection": (v16/*: any*/),
+        "marketingCollection.title": (v14/*: any*/),
+        "marketingCollection.headerImage": (v16/*: any*/),
+        "marketingCollection.descriptionMarkdown": (v16/*: any*/),
+        "marketingCollection.image": (v17/*: any*/),
+        "marketingCollection.collectionArtworks": (v17/*: any*/),
+        "marketingCollection.artworksConnection": (v17/*: any*/),
         "marketingCollection.query": {
           "type": "MarketingCollectionQuery",
           "enumValues": null,
           "plural": false,
           "nullable": false
         },
-        "marketingCollection.featuredArtistExclusionIds": (v17/*: any*/),
-        "marketingCollection.image.edges": (v18/*: any*/),
-        "marketingCollection.image.id": (v19/*: any*/),
+        "marketingCollection.featuredArtistExclusionIds": (v18/*: any*/),
+        "marketingCollection.image.edges": (v19/*: any*/),
+        "marketingCollection.image.id": (v20/*: any*/),
         "marketingCollection.collectionArtworks.aggregations": {
           "type": "ArtworksAggregationResults",
           "enumValues": null,
@@ -1155,16 +1158,16 @@ return {
           "plural": false,
           "nullable": false
         },
-        "marketingCollection.collectionArtworks.id": (v19/*: any*/),
+        "marketingCollection.collectionArtworks.id": (v20/*: any*/),
         "marketingCollection.artworksConnection.merchandisableArtists": {
           "type": "Artist",
           "enumValues": null,
           "plural": true,
           "nullable": true
         },
-        "marketingCollection.artworksConnection.id": (v19/*: any*/),
-        "marketingCollection.query.artistIDs": (v17/*: any*/),
-        "marketingCollection.query.id": (v19/*: any*/),
+        "marketingCollection.artworksConnection.id": (v20/*: any*/),
+        "marketingCollection.query.artistIDs": (v18/*: any*/),
+        "marketingCollection.query.id": (v20/*: any*/),
         "marketingCollection.linkedCollections.groupType": {
           "type": "MarketingGroupTypes",
           "enumValues": [
@@ -1175,7 +1178,7 @@ return {
           "plural": false,
           "nullable": false
         },
-        "marketingCollection.image.edges.node": (v20/*: any*/),
+        "marketingCollection.image.edges.node": (v21/*: any*/),
         "marketingCollection.collectionArtworks.aggregations.slice": {
           "type": "ArtworkAggregation",
           "enumValues": [
@@ -1207,73 +1210,74 @@ return {
           "plural": false,
           "nullable": true
         },
-        "marketingCollection.collectionArtworks.edges.node": (v20/*: any*/),
-        "marketingCollection.artworksConnection.merchandisableArtists.internalID": (v12/*: any*/),
-        "marketingCollection.artworksConnection.merchandisableArtists.id": (v12/*: any*/),
-        "marketingCollection.linkedCollections.name": (v13/*: any*/),
+        "marketingCollection.collectionArtworks.edges.node": (v21/*: any*/),
+        "marketingCollection.artworksConnection.merchandisableArtists.internalID": (v13/*: any*/),
+        "marketingCollection.artworksConnection.merchandisableArtists.id": (v13/*: any*/),
+        "marketingCollection.linkedCollections.name": (v14/*: any*/),
         "marketingCollection.linkedCollections.members": {
           "type": "MarketingCollection",
           "enumValues": null,
           "plural": true,
           "nullable": false
         },
-        "marketingCollection.image.edges.node.image": (v21/*: any*/),
-        "marketingCollection.image.edges.node.id": (v19/*: any*/),
-        "marketingCollection.collectionArtworks.aggregations.counts.value": (v13/*: any*/),
-        "marketingCollection.collectionArtworks.aggregations.counts.name": (v13/*: any*/),
+        "marketingCollection.image.edges.node.image": (v22/*: any*/),
+        "marketingCollection.image.edges.node.id": (v20/*: any*/),
+        "marketingCollection.collectionArtworks.aggregations.counts.value": (v14/*: any*/),
+        "marketingCollection.collectionArtworks.aggregations.counts.name": (v14/*: any*/),
         "marketingCollection.collectionArtworks.aggregations.counts.count": {
           "type": "Int",
           "enumValues": null,
           "plural": false,
           "nullable": false
         },
-        "marketingCollection.collectionArtworks.edges.node.id": (v12/*: any*/),
-        "marketingCollection.collectionArtworks.edges.cursor": (v13/*: any*/),
-        "marketingCollection.collectionArtworks.pageInfo.hasNextPage": (v14/*: any*/),
-        "marketingCollection.collectionArtworks.pageInfo.startCursor": (v15/*: any*/),
-        "marketingCollection.collectionArtworks.pageInfo.endCursor": (v15/*: any*/),
-        "marketingCollection.artworksConnection.merchandisableArtists.slug": (v12/*: any*/),
-        "marketingCollection.artworksConnection.merchandisableArtists.name": (v15/*: any*/),
-        "marketingCollection.artworksConnection.merchandisableArtists.initials": (v15/*: any*/),
-        "marketingCollection.artworksConnection.merchandisableArtists.href": (v15/*: any*/),
-        "marketingCollection.artworksConnection.merchandisableArtists.is_followed": (v22/*: any*/),
-        "marketingCollection.artworksConnection.merchandisableArtists.nationality": (v15/*: any*/),
-        "marketingCollection.artworksConnection.merchandisableArtists.birthday": (v15/*: any*/),
-        "marketingCollection.artworksConnection.merchandisableArtists.deathday": (v15/*: any*/),
-        "marketingCollection.artworksConnection.merchandisableArtists.image": (v21/*: any*/),
-        "marketingCollection.linkedCollections.members.slug": (v13/*: any*/),
-        "marketingCollection.linkedCollections.members.id": (v12/*: any*/),
-        "marketingCollection.linkedCollections.members.title": (v13/*: any*/),
+        "marketingCollection.collectionArtworks.edges.node.id": (v13/*: any*/),
+        "marketingCollection.collectionArtworks.edges.cursor": (v14/*: any*/),
+        "marketingCollection.collectionArtworks.pageInfo.hasNextPage": (v15/*: any*/),
+        "marketingCollection.collectionArtworks.pageInfo.startCursor": (v16/*: any*/),
+        "marketingCollection.collectionArtworks.pageInfo.endCursor": (v16/*: any*/),
+        "marketingCollection.artworksConnection.merchandisableArtists.slug": (v13/*: any*/),
+        "marketingCollection.artworksConnection.merchandisableArtists.name": (v16/*: any*/),
+        "marketingCollection.artworksConnection.merchandisableArtists.initials": (v16/*: any*/),
+        "marketingCollection.artworksConnection.merchandisableArtists.href": (v16/*: any*/),
+        "marketingCollection.artworksConnection.merchandisableArtists.is_followed": (v23/*: any*/),
+        "marketingCollection.artworksConnection.merchandisableArtists.nationality": (v16/*: any*/),
+        "marketingCollection.artworksConnection.merchandisableArtists.birthday": (v16/*: any*/),
+        "marketingCollection.artworksConnection.merchandisableArtists.deathday": (v16/*: any*/),
+        "marketingCollection.artworksConnection.merchandisableArtists.image": (v22/*: any*/),
+        "marketingCollection.linkedCollections.members.slug": (v14/*: any*/),
+        "marketingCollection.linkedCollections.members.id": (v13/*: any*/),
+        "marketingCollection.linkedCollections.members.title": (v14/*: any*/),
         "marketingCollection.linkedCollections.members.priceGuidance": {
           "type": "Float",
           "enumValues": null,
           "plural": false,
           "nullable": true
         },
-        "marketingCollection.linkedCollections.members.artworksConnection": (v16/*: any*/),
-        "marketingCollection.linkedCollections.members.descriptionMarkdown": (v15/*: any*/),
-        "marketingCollection.linkedCollections.members.featuredCollectionArtworks": (v16/*: any*/),
-        "marketingCollection.image.edges.node.image.url": (v15/*: any*/),
-        "marketingCollection.collectionArtworks.edges.node.__typename": (v13/*: any*/),
-        "marketingCollection.collectionArtworks.edges.node.slug": (v12/*: any*/),
-        "marketingCollection.collectionArtworks.edges.node.image": (v21/*: any*/),
-        "marketingCollection.collectionArtworks.edges.id": (v19/*: any*/),
-        "marketingCollection.artworksConnection.merchandisableArtists.image.url": (v15/*: any*/),
-        "marketingCollection.linkedCollections.members.artworksConnection.edges": (v18/*: any*/),
-        "marketingCollection.linkedCollections.members.artworksConnection.id": (v19/*: any*/),
-        "marketingCollection.linkedCollections.members.featuredCollectionArtworks.edges": (v18/*: any*/),
-        "marketingCollection.linkedCollections.members.featuredCollectionArtworks.id": (v19/*: any*/),
+        "marketingCollection.linkedCollections.members.artworksConnection": (v17/*: any*/),
+        "marketingCollection.linkedCollections.members.descriptionMarkdown": (v16/*: any*/),
+        "marketingCollection.linkedCollections.members.featuredCollectionArtworks": (v17/*: any*/),
+        "marketingCollection.image.edges.node.image.url": (v16/*: any*/),
+        "marketingCollection.collectionArtworks.edges.node.__typename": (v14/*: any*/),
+        "marketingCollection.collectionArtworks.edges.node.slug": (v13/*: any*/),
+        "marketingCollection.collectionArtworks.edges.node.image": (v22/*: any*/),
+        "marketingCollection.collectionArtworks.edges.id": (v20/*: any*/),
+        "marketingCollection.artworksConnection.merchandisableArtists.image.url": (v16/*: any*/),
+        "marketingCollection.linkedCollections.members.artworksConnection.edges": (v19/*: any*/),
+        "marketingCollection.linkedCollections.members.artworksConnection.id": (v20/*: any*/),
+        "marketingCollection.linkedCollections.members.featuredCollectionArtworks.edges": (v19/*: any*/),
+        "marketingCollection.linkedCollections.members.featuredCollectionArtworks.id": (v20/*: any*/),
         "marketingCollection.collectionArtworks.edges.node.image.aspectRatio": {
           "type": "Float",
           "enumValues": null,
           "plural": false,
           "nullable": false
         },
-        "marketingCollection.collectionArtworks.edges.node.title": (v15/*: any*/),
-        "marketingCollection.collectionArtworks.edges.node.date": (v15/*: any*/),
-        "marketingCollection.collectionArtworks.edges.node.saleMessage": (v15/*: any*/),
-        "marketingCollection.collectionArtworks.edges.node.artistNames": (v15/*: any*/),
-        "marketingCollection.collectionArtworks.edges.node.href": (v15/*: any*/),
+        "marketingCollection.collectionArtworks.edges.node.title": (v16/*: any*/),
+        "marketingCollection.collectionArtworks.edges.node.date": (v16/*: any*/),
+        "marketingCollection.collectionArtworks.edges.node.saleMessage": (v16/*: any*/),
+        "marketingCollection.collectionArtworks.edges.node.internalID": (v13/*: any*/),
+        "marketingCollection.collectionArtworks.edges.node.artistNames": (v16/*: any*/),
+        "marketingCollection.collectionArtworks.edges.node.href": (v16/*: any*/),
         "marketingCollection.collectionArtworks.edges.node.sale": {
           "type": "Sale",
           "enumValues": null,
@@ -1292,30 +1296,30 @@ return {
           "plural": false,
           "nullable": true
         },
-        "marketingCollection.linkedCollections.members.artworksConnection.edges.node": (v20/*: any*/),
-        "marketingCollection.linkedCollections.members.featuredCollectionArtworks.edges.node": (v20/*: any*/),
-        "marketingCollection.collectionArtworks.edges.node.sale.isAuction": (v22/*: any*/),
-        "marketingCollection.collectionArtworks.edges.node.sale.isClosed": (v22/*: any*/),
-        "marketingCollection.collectionArtworks.edges.node.sale.displayTimelyAt": (v15/*: any*/),
-        "marketingCollection.collectionArtworks.edges.node.sale.id": (v19/*: any*/),
+        "marketingCollection.linkedCollections.members.artworksConnection.edges.node": (v21/*: any*/),
+        "marketingCollection.linkedCollections.members.featuredCollectionArtworks.edges.node": (v21/*: any*/),
+        "marketingCollection.collectionArtworks.edges.node.sale.isAuction": (v23/*: any*/),
+        "marketingCollection.collectionArtworks.edges.node.sale.isClosed": (v23/*: any*/),
+        "marketingCollection.collectionArtworks.edges.node.sale.displayTimelyAt": (v16/*: any*/),
+        "marketingCollection.collectionArtworks.edges.node.sale.id": (v20/*: any*/),
         "marketingCollection.collectionArtworks.edges.node.saleArtwork.currentBid": {
           "type": "SaleArtworkCurrentBid",
           "enumValues": null,
           "plural": false,
           "nullable": true
         },
-        "marketingCollection.collectionArtworks.edges.node.saleArtwork.id": (v19/*: any*/),
-        "marketingCollection.collectionArtworks.edges.node.partner.name": (v15/*: any*/),
-        "marketingCollection.collectionArtworks.edges.node.partner.id": (v19/*: any*/),
-        "marketingCollection.collectionArtworks.edges.node.image.url": (v15/*: any*/),
-        "marketingCollection.linkedCollections.members.artworksConnection.edges.node.title": (v15/*: any*/),
-        "marketingCollection.linkedCollections.members.artworksConnection.edges.node.image": (v21/*: any*/),
-        "marketingCollection.linkedCollections.members.artworksConnection.edges.node.id": (v19/*: any*/),
-        "marketingCollection.linkedCollections.members.featuredCollectionArtworks.edges.node.image": (v21/*: any*/),
-        "marketingCollection.linkedCollections.members.featuredCollectionArtworks.edges.node.id": (v19/*: any*/),
-        "marketingCollection.collectionArtworks.edges.node.saleArtwork.currentBid.display": (v15/*: any*/),
-        "marketingCollection.linkedCollections.members.artworksConnection.edges.node.image.url": (v15/*: any*/),
-        "marketingCollection.linkedCollections.members.featuredCollectionArtworks.edges.node.image.url": (v15/*: any*/)
+        "marketingCollection.collectionArtworks.edges.node.saleArtwork.id": (v20/*: any*/),
+        "marketingCollection.collectionArtworks.edges.node.partner.name": (v16/*: any*/),
+        "marketingCollection.collectionArtworks.edges.node.partner.id": (v20/*: any*/),
+        "marketingCollection.collectionArtworks.edges.node.image.url": (v16/*: any*/),
+        "marketingCollection.linkedCollections.members.artworksConnection.edges.node.title": (v16/*: any*/),
+        "marketingCollection.linkedCollections.members.artworksConnection.edges.node.image": (v22/*: any*/),
+        "marketingCollection.linkedCollections.members.artworksConnection.edges.node.id": (v20/*: any*/),
+        "marketingCollection.linkedCollections.members.featuredCollectionArtworks.edges.node.image": (v22/*: any*/),
+        "marketingCollection.linkedCollections.members.featuredCollectionArtworks.edges.node.id": (v20/*: any*/),
+        "marketingCollection.collectionArtworks.edges.node.saleArtwork.currentBid.display": (v16/*: any*/),
+        "marketingCollection.linkedCollections.members.artworksConnection.edges.node.image.url": (v16/*: any*/),
+        "marketingCollection.linkedCollections.members.featuredCollectionArtworks.edges.node.image.url": (v16/*: any*/)
       }
     }
   }

--- a/src/__generated__/DetailTestsQuery.graphql.ts
+++ b/src/__generated__/DetailTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 24362599f9d4778d5d37bc5255e73e0e */
+/* @relayHash 803bc35cf6f246eb8401017a473b4e3c */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -85,6 +85,7 @@ export type DetailTestsQueryRawResponse = {
                     readonly date: string | null;
                     readonly saleMessage: string | null;
                     readonly slug: string;
+                    readonly internalID: string;
                     readonly artistNames: string | null;
                     readonly href: string | null;
                     readonly sale: ({
@@ -217,6 +218,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -881,6 +883,7 @@ return {
                         "storageKey": null
                       },
                       (v2/*: any*/),
+                      (v1/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -1249,7 +1252,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "DetailTestsQuery",
-    "id": "95f99a406b32d919eede300148358695",
+    "id": "67ce9977bb536af62bde12b7788e091d",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/FairArtworksQuery.graphql.ts
+++ b/src/__generated__/FairArtworksQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash bb3aead49879a3d2e06b16872cc58a78 */
+/* @relayHash 1e7fe6a18a1ef40dfa37185baf862bba */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -34,6 +34,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -144,11 +145,18 @@ v2 = {
 v3 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "internalID",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "slug",
   "args": null,
   "storageKey": null
 },
-v4 = [
+v5 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -174,7 +182,7 @@ v4 = [
     "value": "*-*"
   }
 ],
-v5 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
@@ -223,20 +231,14 @@ return {
         "plural": false,
         "selections": [
           (v2/*: any*/),
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "internalID",
-            "args": null,
-            "storageKey": null
-          },
           (v3/*: any*/),
+          (v4/*: any*/),
           {
             "kind": "LinkedField",
             "alias": null,
             "name": "filterArtworksConnection",
             "storageKey": "filterArtworksConnection(aggregations:[\"MEDIUM\",\"PRICE_RANGE\",\"TOTAL\"],first:10,medium:\"*\",priceRange:\"*-*\")",
-            "args": (v4/*: any*/),
+            "args": (v5/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
@@ -259,7 +261,7 @@ return {
                     "plural": false,
                     "selections": [
                       (v2/*: any*/),
-                      (v3/*: any*/),
+                      (v4/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -312,6 +314,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
+                      (v3/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -398,7 +401,7 @@ return {
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v6/*: any*/),
                           (v2/*: any*/)
                         ]
                       },
@@ -446,7 +449,7 @@ return {
                     "concreteType": "AggregationCount",
                     "plural": true,
                     "selections": [
-                      (v5/*: any*/),
+                      (v6/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -497,7 +500,7 @@ return {
             "kind": "LinkedHandle",
             "alias": null,
             "name": "filterArtworksConnection",
-            "args": (v4/*: any*/),
+            "args": (v5/*: any*/),
             "handle": "connection",
             "key": "FilteredInfiniteScrollGridContainer_filterArtworksConnection",
             "filters": [
@@ -513,7 +516,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "FairArtworksQuery",
-    "id": "27ce2e47999679bd2eeb19cba09b4571",
+    "id": "26a316f9d1fa96cd6ab699727af3cea2",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/FairBoothQuery.graphql.ts
+++ b/src/__generated__/FairBoothQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash edce5fcf9894fb06aeda15dc54a59e04 */
+/* @relayHash e7602e047de3c7ebad0e3061f1fe221a */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -50,6 +50,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -515,6 +516,7 @@ return {
                         "storageKey": null
                       },
                       (v2/*: any*/),
+                      (v3/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -623,7 +625,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "FairBoothQuery",
-    "id": "ccca0b2860b9a87d62b3e95e90488411",
+    "id": "3932b2cde9f9a803a0b461444585886a",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/FairDetailShowsQuery.graphql.ts
+++ b/src/__generated__/FairDetailShowsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 37a30f08c1fa6836378717c1b692ed39 */
+/* @relayHash 321117ddef1154d412c72aa71f4458b4 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -38,6 +38,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -926,6 +927,7 @@ return {
                                     "args": null,
                                     "storageKey": null
                                   },
+                                  (v6/*: any*/),
                                   {
                                     "kind": "ScalarField",
                                     "alias": null,
@@ -1122,7 +1124,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "FairDetailShowsQuery",
-    "id": "76dab86cf1d663b5b49588783777cc5e",
+    "id": "d73b958e6fa827b406bd3e646de0f164",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/FairQuery.graphql.ts
+++ b/src/__generated__/FairQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 7af1a4c0e5cf12f4781c00c33effd1c1 */
+/* @relayHash c5f229e6d6330d49b8deb76606f6dbfe */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -34,6 +34,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -900,6 +901,7 @@ return {
                                     "args": null,
                                     "storageKey": null
                                   },
+                                  (v7/*: any*/),
                                   {
                                     "kind": "ScalarField",
                                     "alias": null,
@@ -1095,7 +1097,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "FairQuery",
-    "id": "83a50c5f2db0a6729c8b1fde1df1d1eb",
+    "id": "36a300c586eaef955d0c8a9677873d82",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/FavoriteArtworksPaginationQuery.graphql.ts
+++ b/src/__generated__/FavoriteArtworksPaginationQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash ab9312746a8bf3969d893ceaef69d91a */
+/* @relayHash f15d36394b4f3ecd61364a142b9880d5 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -36,6 +36,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -326,6 +327,13 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
+                            "name": "internalID",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
                             "name": "artistNames",
                             "args": null,
                             "storageKey": null
@@ -460,7 +468,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "FavoriteArtworksPaginationQuery",
-    "id": "f32fe4d0b429106f5b61db3ac3ffcbee",
+    "id": "39e0c40a24e9e2260603d6de3ec3a8ad",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/FavoriteArtworksQuery.graphql.ts
+++ b/src/__generated__/FavoriteArtworksQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash bd5063c4cde39d85e8edc6290177af1d */
+/* @relayHash 0fe2b908e3aec09a60af7b25351d05f6 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -30,6 +30,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -295,6 +296,13 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
+                            "name": "internalID",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
                             "name": "artistNames",
                             "args": null,
                             "storageKey": null
@@ -429,7 +437,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "FavoriteArtworksQuery",
-    "id": "402ba69d530dae7b081a798831ba6131",
+    "id": "78ec093f4882facf839775fd52e58e5b",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/FeatureQuery.graphql.ts
+++ b/src/__generated__/FeatureQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 21ba1c62782968008bbccef250648b3e */
+/* @relayHash cf21e675294eac733ae2fd21888ce345 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -34,6 +34,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -442,6 +443,13 @@ return {
                                       {
                                         "kind": "ScalarField",
                                         "alias": null,
+                                        "name": "internalID",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
                                         "name": "artistNames",
                                         "args": null,
                                         "storageKey": null
@@ -545,7 +553,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "FeatureQuery",
-    "id": "ed927a1b72f07ff1739da8d16a7555bb",
+    "id": "c15c99374feae48f40abc7ea6bd0d95b",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/FilterModalTestsQuery.graphql.ts
+++ b/src/__generated__/FilterModalTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 43be7275d6d58f45cffee7f64e16a605 */
+/* @relayHash 06fd81b0e9f195ce899df82476739d7e */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -39,6 +39,7 @@ export type FilterModalTestsQueryRawResponse = {
                     readonly title: string | null;
                     readonly date: string | null;
                     readonly saleMessage: string | null;
+                    readonly internalID: string;
                     readonly artistNames: string | null;
                     readonly href: string | null;
                     readonly sale: ({
@@ -92,6 +93,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -431,6 +433,13 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
+                        "name": "internalID",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
                         "name": "artistNames",
                         "args": null,
                         "storageKey": null
@@ -601,7 +610,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "FilterModalTestsQuery",
-    "id": "5db0fd04ab35ddbb9b48f5042f1fa3ab",
+    "id": "fe585f9293f57734a8d351bafa4e7041",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/FilteredInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/FilteredInfiniteScrollGridQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 35e4ca7bfb62eda0ce14cc76e978a3ee */
+/* @relayHash 6b39acc42f8ce24b1b4a8a9d6ff4a63f */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -45,6 +45,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -362,6 +363,13 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
+                        "name": "internalID",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
                         "name": "artistNames",
                         "args": null,
                         "storageKey": null
@@ -554,7 +562,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "FilteredInfiniteScrollGridQuery",
-    "id": "06da22dde1bb01959afebe4b1bebd345",
+    "id": "1eada0aec414cc5f03bacec423da4e54",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/GenePaginationQuery.graphql.ts
+++ b/src/__generated__/GenePaginationQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash a7feba946c4a0b73c6485f0264458390 */
+/* @relayHash ca2d39b79e69439c78f0ddab2b69ce19 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -55,6 +55,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -242,25 +243,32 @@ v6 = {
 v7 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "slug",
+  "name": "internalID",
   "args": null,
   "storageKey": null
 },
 v8 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "slug",
   "args": null,
   "storageKey": null
 },
 v9 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "href",
+  "name": "name",
   "args": null,
   "storageKey": null
 },
 v10 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
+  "args": null,
+  "storageKey": null
+},
+v11 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "url",
@@ -273,7 +281,7 @@ v10 = {
   ],
   "storageKey": "url(version:\"large\")"
 },
-v11 = [
+v12 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -369,14 +377,8 @@ return {
             "kind": "InlineFragment",
             "type": "Gene",
             "selections": [
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "internalID",
-                "args": null,
-                "storageKey": null
-              },
               (v7/*: any*/),
+              (v8/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -384,7 +386,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              (v8/*: any*/),
+              (v9/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -402,8 +404,8 @@ return {
                 "plural": true,
                 "selections": [
                   (v6/*: any*/),
+                  (v10/*: any*/),
                   (v9/*: any*/),
-                  (v8/*: any*/),
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -438,7 +440,7 @@ return {
                     "concreteType": "Image",
                     "plural": false,
                     "selections": [
-                      (v10/*: any*/)
+                      (v11/*: any*/)
                     ]
                   }
                 ]
@@ -448,7 +450,7 @@ return {
                 "alias": "artworks",
                 "name": "filterArtworksConnection",
                 "storageKey": null,
-                "args": (v11/*: any*/),
+                "args": (v12/*: any*/),
                 "concreteType": "FilterArtworksConnection",
                 "plural": false,
                 "selections": [
@@ -502,7 +504,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v8/*: any*/),
+                          (v9/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -533,7 +535,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v6/*: any*/),
-                          (v7/*: any*/),
+                          (v8/*: any*/),
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -550,7 +552,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              (v10/*: any*/)
+                              (v11/*: any*/)
                             ]
                           },
                           {
@@ -574,6 +576,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
+                          (v7/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -581,7 +584,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v9/*: any*/),
+                          (v10/*: any*/),
                           {
                             "kind": "LinkedField",
                             "alias": null,
@@ -654,7 +657,7 @@ return {
                             "concreteType": "Partner",
                             "plural": false,
                             "selections": [
-                              (v8/*: any*/),
+                              (v9/*: any*/),
                               (v6/*: any*/)
                             ]
                           },
@@ -710,7 +713,7 @@ return {
                 "kind": "LinkedHandle",
                 "alias": "artworks",
                 "name": "filterArtworksConnection",
-                "args": (v11/*: any*/),
+                "args": (v12/*: any*/),
                 "handle": "connection",
                 "key": "Gene_artworks",
                 "filters": [
@@ -730,7 +733,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "GenePaginationQuery",
-    "id": "a860cb1f32ce2b56f0bc742984afa400",
+    "id": "2a382ebdbba7397e8240ca62c0f94b92",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/GeneQuery.graphql.ts
+++ b/src/__generated__/GeneQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 2dbfd60f82b36529e4cc1c2aada8b929 */
+/* @relayHash 4de40f2faf486e6f30f3375839f4b768 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -46,6 +46,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -203,25 +204,32 @@ v4 = {
 v5 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "slug",
+  "name": "internalID",
   "args": null,
   "storageKey": null
 },
 v6 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "slug",
   "args": null,
   "storageKey": null
 },
 v7 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "href",
+  "name": "name",
   "args": null,
   "storageKey": null
 },
 v8 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
+  "args": null,
+  "storageKey": null
+},
+v9 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "url",
@@ -234,7 +242,7 @@ v8 = {
   ],
   "storageKey": "url(version:\"large\")"
 },
-v9 = [
+v10 = [
   {
     "kind": "Literal",
     "name": "after",
@@ -312,14 +320,8 @@ return {
         "plural": false,
         "selections": [
           (v4/*: any*/),
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "internalID",
-            "args": null,
-            "storageKey": null
-          },
           (v5/*: any*/),
+          (v6/*: any*/),
           {
             "kind": "ScalarField",
             "alias": null,
@@ -327,7 +329,7 @@ return {
             "args": null,
             "storageKey": null
           },
-          (v6/*: any*/),
+          (v7/*: any*/),
           {
             "kind": "ScalarField",
             "alias": null,
@@ -345,8 +347,8 @@ return {
             "plural": true,
             "selections": [
               (v4/*: any*/),
+              (v8/*: any*/),
               (v7/*: any*/),
-              (v6/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -381,7 +383,7 @@ return {
                 "concreteType": "Image",
                 "plural": false,
                 "selections": [
-                  (v8/*: any*/)
+                  (v9/*: any*/)
                 ]
               }
             ]
@@ -391,7 +393,7 @@ return {
             "alias": "artworks",
             "name": "filterArtworksConnection",
             "storageKey": null,
-            "args": (v9/*: any*/),
+            "args": (v10/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
@@ -445,7 +447,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v6/*: any*/),
+                      (v7/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -476,7 +478,7 @@ return {
                     "plural": false,
                     "selections": [
                       (v4/*: any*/),
-                      (v5/*: any*/),
+                      (v6/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -493,7 +495,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v8/*: any*/)
+                          (v9/*: any*/)
                         ]
                       },
                       {
@@ -517,6 +519,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
+                      (v5/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -524,7 +527,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v7/*: any*/),
+                      (v8/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -597,7 +600,7 @@ return {
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          (v6/*: any*/),
+                          (v7/*: any*/),
                           (v4/*: any*/)
                         ]
                       },
@@ -659,7 +662,7 @@ return {
             "kind": "LinkedHandle",
             "alias": "artworks",
             "name": "filterArtworksConnection",
-            "args": (v9/*: any*/),
+            "args": (v10/*: any*/),
             "handle": "connection",
             "key": "Gene_artworks",
             "filters": [
@@ -677,7 +680,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "GeneQuery",
-    "id": "126a1900cbee90691e5ff17e7b5eecd8",
+    "id": "c9e392ce78970bee20bece6dead0a881",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/HomeQuery.graphql.ts
+++ b/src/__generated__/HomeQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash ea1b20f6743a7ea4d7046c6a99b8dc8e */
+/* @relayHash ee957c5483ff148e0ae3455e411d06c2 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -78,6 +78,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -1346,7 +1347,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "HomeQuery",
-    "id": "17885d49b65557bb0cb5471712d60184",
+    "id": "dd3181e7922e16a56e8569200d64d7b7",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/HomeRefetchQuery.graphql.ts
+++ b/src/__generated__/HomeRefetchQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash c0fba7d35b00d5daa933d7e28512621d */
+/* @relayHash fda5bb6a4e3ee7c8893fd8f92f55d74f */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -78,6 +78,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -1346,7 +1347,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "HomeRefetchQuery",
-    "id": "9c4e06821bddb3777a68e3d61708fb21",
+    "id": "d7373b26da4d5231c389d6a869c97e98",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/InfiniteScrollArtworksGridTestsQuery.graphql.ts
+++ b/src/__generated__/InfiniteScrollArtworksGridTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash f0692a391f96ccbbd4117d4c614e3d4f */
+/* @relayHash b5d0b4076ba7b64a2cdaf1e9ef5b4623 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -42,6 +42,7 @@ export type InfiniteScrollArtworksGridTestsQueryRawResponse = {
                 readonly title: string | null;
                 readonly date: string | null;
                 readonly saleMessage: string | null;
+                readonly internalID: string;
                 readonly artistNames: string | null;
                 readonly href: string | null;
                 readonly sale: ({
@@ -100,6 +101,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -334,6 +336,13 @@ return {
                   {
                     "kind": "ScalarField",
                     "alias": null,
+                    "name": "internalID",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
                     "name": "artistNames",
                     "args": null,
                     "storageKey": null
@@ -439,7 +448,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "InfiniteScrollArtworksGridTestsQuery",
-    "id": "f69533b9c6b8aeed2cd637919bf1ccb3",
+    "id": "fd842256b4241fcce9e2d9948610520d",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/LotsByFollowedArtistsQuery.graphql.ts
+++ b/src/__generated__/LotsByFollowedArtistsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash b5a71f733c8c0580061a7e220ce67550 */
+/* @relayHash c832570e7576e05ed43e67818f140762 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -36,6 +36,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -301,6 +302,13 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
+                        "name": "internalID",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
                         "name": "artistNames",
                         "args": null,
                         "storageKey": null
@@ -453,7 +461,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "LotsByFollowedArtistsQuery",
-    "id": "ef0c275f7a0b66553cd8ed019de4dfe1",
+    "id": "885a70b1181e981b3ed5401fd1f8ad28",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/PartnerArtworkInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/PartnerArtworkInfiniteScrollGridQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 80ba63e467e43a097cff7fa78b95f006 */
+/* @relayHash c3a79868efb9f45fa40640c4e2611148 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -38,6 +38,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -131,7 +132,14 @@ v1 = [
     "variableName": "id"
   }
 ],
-v2 = [
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "internalID",
+  "args": null,
+  "storageKey": null
+},
+v3 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -148,7 +156,7 @@ v2 = [
     "value": "PARTNER_UPDATED_AT_DESC"
   }
 ],
-v3 = {
+v4 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
@@ -207,19 +215,13 @@ return {
         "concreteType": "Partner",
         "plural": false,
         "selections": [
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "internalID",
-            "args": null,
-            "storageKey": null
-          },
+          (v2/*: any*/),
           {
             "kind": "LinkedField",
             "alias": "artworks",
             "name": "artworksConnection",
             "storageKey": null,
-            "args": (v2/*: any*/),
+            "args": (v3/*: any*/),
             "concreteType": "ArtworkConnection",
             "plural": false,
             "selections": [
@@ -241,7 +243,7 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
+                      (v4/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -301,6 +303,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
+                      (v2/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -345,7 +348,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v4/*: any*/)
                         ]
                       },
                       {
@@ -375,7 +378,7 @@ return {
                               }
                             ]
                           },
-                          (v3/*: any*/)
+                          (v4/*: any*/)
                         ]
                       },
                       {
@@ -394,7 +397,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v4/*: any*/)
                         ]
                       },
                       {
@@ -413,7 +416,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  (v3/*: any*/)
+                  (v4/*: any*/)
                 ]
               },
               {
@@ -454,14 +457,14 @@ return {
             "kind": "LinkedHandle",
             "alias": "artworks",
             "name": "artworksConnection",
-            "args": (v2/*: any*/),
+            "args": (v3/*: any*/),
             "handle": "connection",
             "key": "Partner_artworks",
             "filters": [
               "sort"
             ]
           },
-          (v3/*: any*/)
+          (v4/*: any*/)
         ]
       }
     ]
@@ -469,7 +472,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "PartnerArtworkInfiniteScrollGridQuery",
-    "id": "c1a5edecb1da0baff3f6d2a0c4f1f425",
+    "id": "3ade55c4436397924a187694ee0ef398",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/PartnerArtworkTestsQuery.graphql.ts
+++ b/src/__generated__/PartnerArtworkTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash f143f2f04b8a1dd0e15e6b57de02b888 */
+/* @relayHash c8309369cbffe7721521790e1b2aacb1 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -25,6 +25,7 @@ export type PartnerArtworkTestsQueryRawResponse = {
                     readonly title: string | null;
                     readonly date: string | null;
                     readonly saleMessage: string | null;
+                    readonly internalID: string;
                     readonly artistNames: string | null;
                     readonly href: string | null;
                     readonly sale: ({
@@ -78,6 +79,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -151,7 +153,14 @@ var v0 = [
     "value": "anderson-fine-art-gallery-flickinger-collection"
   }
 ],
-v1 = [
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "internalID",
+  "args": null,
+  "storageKey": null
+},
+v2 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -163,7 +172,7 @@ v1 = [
     "value": "PARTNER_UPDATED_AT_DESC"
   }
 ],
-v2 = {
+v3 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
@@ -211,19 +220,13 @@ return {
         "concreteType": "Partner",
         "plural": false,
         "selections": [
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "internalID",
-            "args": null,
-            "storageKey": null
-          },
+          (v1/*: any*/),
           {
             "kind": "LinkedField",
             "alias": "artworks",
             "name": "artworksConnection",
             "storageKey": "artworksConnection(first:10,sort:\"PARTNER_UPDATED_AT_DESC\")",
-            "args": (v1/*: any*/),
+            "args": (v2/*: any*/),
             "concreteType": "ArtworkConnection",
             "plural": false,
             "selections": [
@@ -245,7 +248,7 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v2/*: any*/),
+                      (v3/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -305,6 +308,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
+                      (v1/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -349,7 +353,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v2/*: any*/)
+                          (v3/*: any*/)
                         ]
                       },
                       {
@@ -379,7 +383,7 @@ return {
                               }
                             ]
                           },
-                          (v2/*: any*/)
+                          (v3/*: any*/)
                         ]
                       },
                       {
@@ -398,7 +402,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v2/*: any*/)
+                          (v3/*: any*/)
                         ]
                       },
                       {
@@ -417,7 +421,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  (v2/*: any*/)
+                  (v3/*: any*/)
                 ]
               },
               {
@@ -458,14 +462,14 @@ return {
             "kind": "LinkedHandle",
             "alias": "artworks",
             "name": "artworksConnection",
-            "args": (v1/*: any*/),
+            "args": (v2/*: any*/),
             "handle": "connection",
             "key": "Partner_artworks",
             "filters": [
               "sort"
             ]
           },
-          (v2/*: any*/)
+          (v3/*: any*/)
         ]
       }
     ]
@@ -473,7 +477,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "PartnerArtworkTestsQuery",
-    "id": "ec9afa084202ae4a42169a66ab940f8f",
+    "id": "d873aa2109490eb34a6592da72c42026",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/PartnerQuery.graphql.ts
+++ b/src/__generated__/PartnerQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 95d640a6bc8618cf0024d70edaedb3ac */
+/* @relayHash c884d56c10d3fa607079b3c9b2951fe2 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -50,6 +50,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -610,6 +611,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
+                      (v3/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -1074,7 +1076,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "PartnerQuery",
-    "id": "ac77bedbb41b24c681068e8a96da0d07",
+    "id": "89656f585617920ccc696c0357db6b62",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/PartnerRefetchQuery.graphql.ts
+++ b/src/__generated__/PartnerRefetchQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 149925e9dd27824e4b9cfa6f7b7d6d0c */
+/* @relayHash ac350a537a8b352191945a14f3e26e89 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -51,6 +51,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -616,6 +617,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
+                          (v4/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1082,7 +1084,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "PartnerRefetchQuery",
-    "id": "f18b497c4e517fb341fcac4046c4d915",
+    "id": "6923772c0a0a0616d3e3b7e1d7221eae",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/SalesQuery.graphql.ts
+++ b/src/__generated__/SalesQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash cfade88f44dfecf68e95163c8e3e1482 */
+/* @relayHash e8ccb3e9f4b2d1d14e33ce7ff838d226 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -36,6 +36,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -424,6 +425,13 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
+                        "name": "internalID",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
                         "name": "artistNames",
                         "args": null,
                         "storageKey": null
@@ -565,7 +573,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "SalesQuery",
-    "id": "da3c402301dead8e8ac2e4878ceb0012",
+    "id": "36e67c57fccf47b7152799612b8952e4",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/SalesQueryRendererQuery.graphql.ts
+++ b/src/__generated__/SalesQueryRendererQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 3968a50d1f2df4c30c381fdf4c6bdd10 */
+/* @relayHash 589571f4bcf077a15efb2d6fd35fc81a */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -36,6 +36,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -424,6 +425,13 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
+                        "name": "internalID",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
                         "name": "artistNames",
                         "args": null,
                         "storageKey": null
@@ -565,7 +573,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "SalesQueryRendererQuery",
-    "id": "34d76c518b145cebf30db78060672a65",
+    "id": "f051330e04cd6a9d836f70c20f3baaac",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ShowArtworksPreviewTestsQuery.graphql.ts
+++ b/src/__generated__/ShowArtworksPreviewTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 99cc475b8e215f0eb784906d9d7311b7 */
+/* @relayHash 70eccaf8c4d8aa1a80ff2276dac0cf1d */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -29,6 +29,7 @@ export type ShowArtworksPreviewTestsQueryRawResponse = {
                     readonly date: string | null;
                     readonly saleMessage: string | null;
                     readonly slug: string;
+                    readonly internalID: string;
                     readonly artistNames: string | null;
                     readonly href: string | null;
                     readonly sale: ({
@@ -73,6 +74,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -299,6 +301,13 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
+                        "name": "internalID",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
                         "name": "artistNames",
                         "args": null,
                         "storageKey": null
@@ -405,7 +414,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ShowArtworksPreviewTestsQuery",
-    "id": "54ecfd2e1954aeaa0c5ce1966cafb570",
+    "id": "cd5df0c37e2be99afd1f3171ee84ff33",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ShowArtworksQuery.graphql.ts
+++ b/src/__generated__/ShowArtworksQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 2ee7978d140786db5590b4b12c9b9624 */
+/* @relayHash 5943f12a84e842320e2f7b0049cc3bf6 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -34,6 +34,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -148,7 +149,14 @@ v3 = {
   "args": null,
   "storageKey": null
 },
-v4 = [
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "internalID",
+  "args": null,
+  "storageKey": null
+},
+v5 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -174,7 +182,7 @@ v4 = [
     "value": "*-*"
   }
 ],
-v5 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
@@ -224,19 +232,13 @@ return {
         "selections": [
           (v2/*: any*/),
           (v3/*: any*/),
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "internalID",
-            "args": null,
-            "storageKey": null
-          },
+          (v4/*: any*/),
           {
             "kind": "LinkedField",
             "alias": null,
             "name": "filterArtworksConnection",
             "storageKey": "filterArtworksConnection(aggregations:[\"MEDIUM\",\"PRICE_RANGE\",\"TOTAL\"],first:10,medium:\"*\",priceRange:\"*-*\")",
-            "args": (v4/*: any*/),
+            "args": (v5/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
@@ -312,6 +314,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
+                      (v4/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -398,7 +401,7 @@ return {
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v6/*: any*/),
                           (v2/*: any*/)
                         ]
                       },
@@ -446,7 +449,7 @@ return {
                     "concreteType": "AggregationCount",
                     "plural": true,
                     "selections": [
-                      (v5/*: any*/),
+                      (v6/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -497,7 +500,7 @@ return {
             "kind": "LinkedHandle",
             "alias": null,
             "name": "filterArtworksConnection",
-            "args": (v4/*: any*/),
+            "args": (v5/*: any*/),
             "handle": "connection",
             "key": "FilteredInfiniteScrollGridContainer_filterArtworksConnection",
             "filters": [
@@ -513,7 +516,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ShowArtworksQuery",
-    "id": "c55dd5fd88ef5d67c9ab7e918843c301",
+    "id": "de0d5d86b0a5d113db7aaf094f18c690",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ShowArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/ShowArtworksTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash b6164a7da1b0979d9de64bad35808027 */
+/* @relayHash 8c16207eb3c6ce32fd5846dd492b6361 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -28,6 +28,7 @@ export type ShowArtworksTestsQueryRawResponse = {
                     readonly title: string | null;
                     readonly date: string | null;
                     readonly saleMessage: string | null;
+                    readonly internalID: string;
                     readonly artistNames: string | null;
                     readonly href: string | null;
                     readonly sale: ({
@@ -88,6 +89,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -194,7 +196,14 @@ v2 = {
   "args": null,
   "storageKey": null
 },
-v3 = [
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "internalID",
+  "args": null,
+  "storageKey": null
+},
+v4 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -220,7 +229,7 @@ v3 = [
     "value": "*-*"
   }
 ],
-v4 = {
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
@@ -270,19 +279,13 @@ return {
         "selections": [
           (v1/*: any*/),
           (v2/*: any*/),
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "internalID",
-            "args": null,
-            "storageKey": null
-          },
+          (v3/*: any*/),
           {
             "kind": "LinkedField",
             "alias": null,
             "name": "filterArtworksConnection",
             "storageKey": "filterArtworksConnection(aggregations:[\"MEDIUM\",\"PRICE_RANGE\",\"TOTAL\"],first:10,medium:\"*\",priceRange:\"*-*\")",
-            "args": (v3/*: any*/),
+            "args": (v4/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
@@ -358,6 +361,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
+                      (v3/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -444,7 +448,7 @@ return {
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
+                          (v5/*: any*/),
                           (v1/*: any*/)
                         ]
                       },
@@ -492,7 +496,7 @@ return {
                     "concreteType": "AggregationCount",
                     "plural": true,
                     "selections": [
-                      (v4/*: any*/),
+                      (v5/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -543,7 +547,7 @@ return {
             "kind": "LinkedHandle",
             "alias": null,
             "name": "filterArtworksConnection",
-            "args": (v3/*: any*/),
+            "args": (v4/*: any*/),
             "handle": "connection",
             "key": "FilteredInfiniteScrollGridContainer_filterArtworksConnection",
             "filters": [
@@ -559,7 +563,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ShowArtworksTestsQuery",
-    "id": "1a3f7a40121c448874c7d591cc088060",
+    "id": "ed5ef3913660fcb4326548008df9ea13",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ShowQuery.graphql.ts
+++ b/src/__generated__/ShowQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 32b6c0cb695142509ace9c7c2ae4f572 */
+/* @relayHash 5387f614416d5708e055f75d541e46fd */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -50,6 +50,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -726,6 +727,7 @@ return {
                         "storageKey": null
                       },
                       (v3/*: any*/),
+                      (v2/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -1094,7 +1096,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ShowQuery",
-    "id": "31e47e32bf908f95bd646b49d2b826f5",
+    "id": "d357e72ef0ac8f804f0f466f42c6414f",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ShowTestsQuery.graphql.ts
+++ b/src/__generated__/ShowTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash c3e4a3e461529b15b891b551e50d0bef */
+/* @relayHash 11bf312050e43a41a2466ba4ca3b2772 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -85,6 +85,7 @@ export type ShowTestsQueryRawResponse = {
                     readonly date: string | null;
                     readonly saleMessage: string | null;
                     readonly slug: string;
+                    readonly internalID: string;
                     readonly artistNames: string | null;
                     readonly href: string | null;
                     readonly sale: ({
@@ -217,6 +218,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -885,6 +887,7 @@ return {
                         "storageKey": null
                       },
                       (v2/*: any*/),
+                      (v1/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -1253,7 +1256,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ShowTestsQuery",
-    "id": "4e518f721780c9e5cc08167ad928f0f4",
+    "id": "e6bf742286d3f284cc4677dd855e2aad",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/WorksForYouPaginationQuery.graphql.ts
+++ b/src/__generated__/WorksForYouPaginationQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 2abcc6173fd2a6b1ad99bd818ea89488 */
+/* @relayHash aa8a884682c6cd81aaae93c4a98f75b2 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -36,6 +36,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -406,6 +407,13 @@ return {
                                       {
                                         "kind": "ScalarField",
                                         "alias": null,
+                                        "name": "internalID",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
                                         "name": "artistNames",
                                         "args": null,
                                         "storageKey": null
@@ -580,7 +588,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "WorksForYouPaginationQuery",
-    "id": "3a2b99d40807e2cff9247ea6da3e43e0",
+    "id": "545024e271e2ea9be5c8df725f75e6a4",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/WorksForYouQuery.graphql.ts
+++ b/src/__generated__/WorksForYouQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash ae73ebdf4499832498f5d7a43f10569f */
+/* @relayHash 4442f9fe1e26d190b2dd38f2f34a3551 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -30,6 +30,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -367,6 +368,13 @@ return {
                                       {
                                         "kind": "ScalarField",
                                         "alias": null,
+                                        "name": "internalID",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
                                         "name": "artistNames",
                                         "args": null,
                                         "storageKey": null
@@ -541,7 +549,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "WorksForYouQuery",
-    "id": "79bf98dd959b0f63fa82185d6c5b0163",
+    "id": "5dd9dec9c3940e407860109145dd970c",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/indexTestsQuery.graphql.ts
+++ b/src/__generated__/indexTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 2be628b86ec504014642274afa105c88 */
+/* @relayHash 2211559e57b0f025bb1d82246e8203c8 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -85,6 +85,7 @@ export type indexTestsQueryRawResponse = {
                     readonly date: string | null;
                     readonly saleMessage: string | null;
                     readonly slug: string;
+                    readonly internalID: string;
                     readonly artistNames: string | null;
                     readonly href: string | null;
                     readonly sale: ({
@@ -217,6 +218,7 @@ fragment ArtworkGridItem_artwork on Artwork {
   date
   saleMessage
   slug
+  internalID
   artistNames
   href
   sale {
@@ -885,6 +887,7 @@ return {
                         "storageKey": null
                       },
                       (v2/*: any*/),
+                      (v1/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -1253,7 +1256,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "indexTestsQuery",
-    "id": "693cde1ec4465973097197fee6e6302f",
+    "id": "fb009a79c521112211a54c363505f39e",
     "text": null,
     "metadata": {}
   }

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -1,3 +1,4 @@
+import { OwnerType } from "@artsy/cohesion"
 import { Box, Separator, Spacer } from "@artsy/palette"
 import { ArtistArtworks_artist } from "__generated__/ArtistArtworks_artist.graphql"
 import { ArtistNotableWorksRailFragmentContainer } from "lib/Components/Artist/ArtistArtworks/ArtistNotableWorksRail"
@@ -187,6 +188,9 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ViewableItemRefs> = 
             hasMore={relay.hasMore}
             isLoading={relay.isLoading}
             {...props}
+            contextScreenOwnerType={OwnerType.artist}
+            contextScreenOwnerId={artist.internalID}
+            contextScreenOwnerSlug={artist.slug}
           />
         </>
       )

--- a/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -17,6 +17,7 @@ import { isCloseToBottom } from "lib/utils/isCloseToBottom"
 
 import { PAGE_SIZE } from "lib/data/constants"
 
+import { ScreenOwnerType } from "@artsy/cohesion"
 import { Box, Button, space, Theme } from "@artsy/palette"
 import { InfiniteScrollArtworksGrid_connection } from "__generated__/InfiniteScrollArtworksGrid_connection.graphql"
 import { extractNodes } from "lib/utils/extractNodes"
@@ -55,6 +56,15 @@ export interface Props {
 
   /** Number of items to fetch in pagination request. Default is 10 */
   pageSize?: number
+
+  /** Parent screen where the grid is located. For analytics purposes. */
+  contextScreenOwnerType?: ScreenOwnerType
+
+  /** Id of the parent screen's entity where the grid is located. For analytics purposes. */
+  contextScreenOwnerId?: string
+
+  /** Slug of the parent screen's entity where the grid is located. For analytics purposes. */
+  contextScreenOwnerSlug?: string
 }
 
 interface PrivateProps {
@@ -183,7 +193,15 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
       const artworkComponents: JSX.Element[] = []
       for (let j = 0; j < sectionedArtworks[i].length; j++) {
         const artwork = sectionedArtworks[i][j]
-        artworkComponents.push(<Artwork artwork={artwork} key={"artwork-" + j + "-" + artwork.id} />)
+        artworkComponents.push(
+          <Artwork
+            contextScreenOwnerType={this.props.contextScreenOwnerType}
+            contextScreenOwnerId={this.props.contextScreenOwnerId}
+            contextScreenOwnerSlug={this.props.contextScreenOwnerSlug}
+            artwork={artwork}
+            key={"artwork-" + j + "-" + artwork.id}
+          />
+        )
         // Setting a marginBottom on the artwork component didn’t work, so using a spacer view instead.
         if (j < artworks.length - 1) {
           artworkComponents.push(

--- a/src/lib/Components/ArtworkGrids/__tests__/ArtworkGridItem-tests.tsx
+++ b/src/lib/Components/ArtworkGrids/__tests__/ArtworkGridItem-tests.tsx
@@ -5,7 +5,11 @@ import * as renderer from "react-test-renderer"
 
 import Artwork from "../ArtworkGridItem"
 
+import { OwnerType } from "@artsy/cohesion"
 import { Theme } from "@artsy/palette"
+import { Touchable } from "palette"
+import { act } from "react-test-renderer"
+import { useTracking } from "react-tracking"
 
 it("renders without throwing an error", () => {
   renderer.create(
@@ -13,6 +17,62 @@ it("renders without throwing an error", () => {
       <Artwork artwork={artworkProps() as any} />
     </Theme>
   )
+})
+
+describe("tracking", () => {
+  const trackEvent = jest.fn()
+
+  beforeEach(() => {
+    ;(useTracking as any).mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("sends an event when trackTap is passed", () => {
+    const trackTap = jest.fn()
+    const rendered = renderer.create(
+      <Theme>
+        <Artwork trackTap={trackTap} artwork={artworkProps() as any} itemIndex={1} />
+      </Theme>
+    )
+
+    const touchableArtwork = rendered.root.findByType(Touchable)
+    act(() => touchableArtwork.props.onPress())
+    expect(trackTap).toBeCalledWith("cool-artwork", 1)
+  })
+
+  it("sends a tracking event when contextScreenOwnerType is included", () => {
+    const rendered = renderer.create(
+      <Theme>
+        <Artwork
+          artwork={artworkProps() as any}
+          contextScreenOwnerType={OwnerType.artist}
+          contextScreenOwnerId="abc124"
+          contextScreenOwnerSlug="andy-warhol"
+        />
+      </Theme>
+    )
+
+    const touchableArtwork = rendered.root.findByType(Touchable)
+    act(() => touchableArtwork.props.onPress())
+    expect(trackEvent).toBeCalledWith({
+      action: "tappedMainArtworkGrid",
+      context_module: "artworkGrid",
+      context_screen_owner_id: "abc124",
+      context_screen_owner_slug: "andy-warhol",
+      context_screen_owner_type: "artist",
+      destination_screen_owner_id: "abc1234",
+      destination_screen_owner_slug: "cool-artwork",
+      destination_screen_owner_type: "artwork",
+      type: "thumbnail",
+    })
+  })
 })
 
 describe("in an open sale", () => {
@@ -111,5 +171,7 @@ const artworkProps = (saleArtwork = null) => {
     artistsNames: "Mikael Olson",
     id: "mikael-olson-some-kind-of-dinosaur",
     href: "/artwork/mikael-olson-some-kind-of-dinosaur",
+    slug: "cool-artwork",
+    internalID: "abc1234",
   }
 }

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
@@ -1,3 +1,4 @@
+import { OwnerType } from "@artsy/cohesion"
 import { Box, Separator } from "@artsy/palette"
 import { ArtistSeriesArtworks_artistSeries } from "__generated__/ArtistSeriesArtworks_artistSeries.graphql"
 import { InfiniteScrollArtworksGridContainer } from "lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
@@ -26,6 +27,9 @@ export const ArtistSeriesArtworks: React.FC<ArtistSeriesArtworksProps> = ({ arti
         isLoading={relay.isLoading}
         autoFetch={false}
         pageSize={ARTIST_SERIES_PAGE_SIZE}
+        contextScreenOwnerType={OwnerType.artistSeries}
+        contextScreenOwnerId={artistSeries.internalID}
+        contextScreenOwnerSlug={artistSeries.slug}
       />
     </Box>
   )
@@ -42,6 +46,7 @@ export const ArtistSeriesArtworksFragmentContainer = createPaginationContainer(
           sort: { type: "String", defaultValue: "-decayed_merch" }
         ) {
         slug
+        internalID
         artistSeriesArtworks: filterArtworksConnection(first: 20, sort: $sort, after: $cursor)
           @connection(key: "ArtistSeries_artistSeriesArtworks") {
           edges {

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeries-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeries-tests.tsx
@@ -85,6 +85,7 @@ const ArtistSeriesFixture: ArtistSeriesTestsQueryRawResponse = {
   artistSeries: {
     title: "These are the Pumpkins",
     slug: "more-pumpkins",
+    internalID: "abc",
     description: "A deliciously artistic variety of painted pumpkins.",
     image: {
       url: "https://www.imagesofthispumpkin.net/pgn",
@@ -136,6 +137,7 @@ const ArtistSeriesFixture: ArtistSeriesTestsQueryRawResponse = {
         {
           node: {
             id: "12345654321",
+            internalID: "abc",
             slug: "pumpkins-1",
             image: null,
             title: "Pumpkins 1.0",
@@ -159,6 +161,7 @@ const ArtistSeriesFixture: ArtistSeriesTestsQueryRawResponse = {
 const ArtistSeriesNoArtistFixture: ArtistSeriesTestsQueryRawResponse = {
   artistSeries: {
     title: "These are the Pumpkins",
+    internalID: "abc",
     slug: "more-pumpkins",
     description: "A deliciously artistic variety of painted pumpkins.",
     image: {
@@ -179,6 +182,7 @@ const ArtistSeriesNoArtistFixture: ArtistSeriesTestsQueryRawResponse = {
         {
           node: {
             id: "12345654321",
+            internalID: "abc",
             slug: "pumpkins-1",
             image: null,
             title: "Pumpkins 1.0",

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesArtworks-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesArtworks-tests.tsx
@@ -82,6 +82,7 @@ describe("Artist Series Artworks", () => {
 const ArtistSeriesArtworksFixture: ArtistSeriesArtworksTestsQueryRawResponse = {
   artistSeries: {
     slug: "a-slug",
+    internalID: "abc",
     artistSeriesArtworks: {
       pageInfo: {
         hasNextPage: false,
@@ -94,6 +95,7 @@ const ArtistSeriesArtworksFixture: ArtistSeriesArtworksTestsQueryRawResponse = {
         {
           node: {
             id: "12345654321",
+            internalID: "abc",
             slug: "pumpkins-1",
             image: null,
             title: "Pumpkins 1.0",
@@ -112,6 +114,7 @@ const ArtistSeriesArtworksFixture: ArtistSeriesArtworksTestsQueryRawResponse = {
         {
           node: {
             id: "9874491018",
+            internalID: "abc",
             slug: "pumpkins-2",
             image: null,
             title: "Pumpkins 2.0",
@@ -130,6 +133,7 @@ const ArtistSeriesArtworksFixture: ArtistSeriesArtworksTestsQueryRawResponse = {
         {
           node: {
             id: "128163456",
+            internalID: "abc",
             slug: "pumpkins-3",
             image: null,
             title: "Pumpkins 3.0",
@@ -148,6 +152,7 @@ const ArtistSeriesArtworksFixture: ArtistSeriesArtworksTestsQueryRawResponse = {
         {
           node: {
             id: "123310456",
+            internalID: "abc",
             slug: "pumpkins-4",
             image: null,
             title: "Pumpkins 4.0",
@@ -171,6 +176,7 @@ const ArtistSeriesArtworksFixture: ArtistSeriesArtworksTestsQueryRawResponse = {
 const ArtistSeriesZeroArtworksFixture: ArtistSeriesArtworksTestsQueryRawResponse = {
   artistSeries: {
     slug: "a-slug",
+    internalID: "abc",
     artistSeriesArtworks: {
       pageInfo: {
         hasNextPage: false,

--- a/src/lib/Scenes/Artwork/Components/ArtworkDetails.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkDetails.tsx
@@ -2,7 +2,7 @@ import { Box, Join, Sans, Spacer } from "@artsy/palette"
 import { ArtworkDetails_artwork } from "__generated__/ArtworkDetails_artwork.graphql"
 import { ReadMore } from "lib/Components/ReadMore"
 import { truncatedTextLimit } from "lib/utils/hardware"
-import { Schema, track } from "lib/utils/track"
+import { Schema } from "lib/utils/track"
 import React from "react"
 import { NativeModules } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -12,14 +12,7 @@ interface ArtworkDetailsProps {
   artwork: ArtworkDetails_artwork
 }
 
-@track()
 export class ArtworkDetails extends React.Component<ArtworkDetailsProps> {
-  @track(() => ({
-    action_name: Schema.ActionNames.ShowMoreArtworksDetails,
-    action_type: Schema.ActionTypes.Tap,
-    flow: Schema.Flow.ArtworkDetails,
-    context_module: Schema.ContextModules.ArtworkDetails,
-  }))
   render() {
     const { artwork } = this.props
 

--- a/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -1,3 +1,4 @@
+import { OwnerType } from "@artsy/cohesion"
 import { Box, Separator } from "@artsy/palette"
 import { CollectionArtworks_collection } from "__generated__/CollectionArtworks_collection.graphql"
 import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
@@ -80,6 +81,9 @@ export const CollectionArtworks: React.SFC<CollectionArtworksProps> = ({ collect
         loadMore={relay.loadMore}
         hasMore={relay.hasMore}
         isLoading={relay.isLoading}
+        contextScreenOwnerType={OwnerType.collection}
+        contextScreenOwnerId={collection.id}
+        contextScreenOwnerSlug={collection.slug}
       />
     </ArtworkGridWrapper>
   ) : null


### PR DESCRIPTION
The type of this PR is: **Enhancement**

This PR resolves [FX-2107](https://artsyproduct.atlassian.net/browse/FX-2107)

### Description

We want to track taps from our "Main" artwork grids: Collection, Artist, and Artist Series. Eventually, the FX team will use this data to determine how effective changes to our ranking algorithm are.

While there is a generic tracking event already on the `ArtworkGridItem`, it did not appear to be working. As part of this change, I updated the component to be a functional one to take advantage of our hooks-based tracking.

Minor: I also removed the `ShowArtworkDetails` event as it fired on render (thus on every artwork view) and the analytics team confirmed it was unnecessary.

### Test Plan

Sarah will verify in a beta that everything works!

### Screenshots

**From artist page grid**
<img width="702" alt="Screen Shot 2020-08-10 at 6 17 13 PM" src="https://user-images.githubusercontent.com/2081340/89838155-84bf4300-db38-11ea-9bb6-979209d0b437.png">

**From artist series page**
<img width="708" alt="Screen Shot 2020-08-10 at 6 16 44 PM" src="https://user-images.githubusercontent.com/2081340/89838181-94d72280-db38-11ea-90c8-b2f98b08734b.png">

**From collection page**
<img width="718" alt="Screen Shot 2020-08-10 at 6 17 43 PM" src="https://user-images.githubusercontent.com/2081340/89838186-9acd0380-db38-11ea-903d-02a1ce03e9e6.png">

