### PR TITLE
[MX-447] - Add method to create wrapped components in tests, lint rule to enforce usage #skip_new_tests

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
   dev:
     - Add Artist Series feature flag - ashley
     - Cleans up uses of createPaginationContainer - ash
+    - Add method for rendering wrapped components - brian
   user_facing:
     - Prevent follow button going off screen in artist page - brian
     - don't show password on wrong password entry - brian

--- a/src/lib/Components/Artist/Articles/__tests__/Article-tests.tsx
+++ b/src/lib/Components/Artist/Articles/__tests__/Article-tests.tsx
@@ -1,7 +1,7 @@
 import "react-native"
 
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
 
 import Article from "../Article"
 
@@ -18,7 +18,7 @@ it("renders without throwing an error", () => {
       url: "artsy.net/image-url",
     },
   }
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <Article article={article as any} />
     </Theme>

--- a/src/lib/Components/Artist/Articles/__tests__/Article-tests.tsx
+++ b/src/lib/Components/Artist/Articles/__tests__/Article-tests.tsx
@@ -5,8 +5,6 @@ import React from "react"
 
 import Article from "../Article"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing an error", () => {
   const article = {
     thumbnail_title: "Something Happened",
@@ -18,9 +16,5 @@ it("renders without throwing an error", () => {
       url: "artsy.net/image-url",
     },
   }
-  renderWithWrappers(
-    <Theme>
-      <Article article={article as any} />
-    </Theme>
-  )
+  renderWithWrappers(<Article article={article as any} />)
 })

--- a/src/lib/Components/Artist/ArtistShows/__tests__/ArtistShow-tests.tsx
+++ b/src/lib/Components/Artist/ArtistShows/__tests__/ArtistShow-tests.tsx
@@ -1,7 +1,7 @@
 import "react-native"
 
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
 
 import ArtistShow from "../ArtistShow"
 
@@ -38,7 +38,7 @@ const showStyles = {
 }
 
 it("renders without throwing an error with all props", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <ArtistShow show={showProps as any} styles={showStyles} />
     </Theme>
@@ -51,7 +51,7 @@ it("renders without throwing an error with null show kind", () => {
     kind: null,
   }
 
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <ArtistShow show={showPropsNullKind as any} styles={showStyles} />
     </Theme>

--- a/src/lib/Components/Artist/ArtistShows/__tests__/ArtistShow-tests.tsx
+++ b/src/lib/Components/Artist/ArtistShows/__tests__/ArtistShow-tests.tsx
@@ -5,8 +5,6 @@ import React from "react"
 
 import ArtistShow from "../ArtistShow"
 
-import { Theme } from "@artsy/palette"
-
 const showProps = {
   href: "artsy.net/show",
   cover_image: {
@@ -38,11 +36,7 @@ const showStyles = {
 }
 
 it("renders without throwing an error with all props", () => {
-  renderWithWrappers(
-    <Theme>
-      <ArtistShow show={showProps as any} styles={showStyles} />
-    </Theme>
-  )
+  renderWithWrappers(<ArtistShow show={showProps as any} styles={showStyles} />)
 })
 
 it("renders without throwing an error with null show kind", () => {
@@ -51,9 +45,5 @@ it("renders without throwing an error with null show kind", () => {
     kind: null,
   }
 
-  renderWithWrappers(
-    <Theme>
-      <ArtistShow show={showPropsNullKind as any} styles={showStyles} />
-    </Theme>
-  )
+  renderWithWrappers(<ArtistShow show={showPropsNullKind as any} styles={showStyles} />)
 })

--- a/src/lib/Components/Artist/ArtistShows/__tests__/Metadata-tests.tsx
+++ b/src/lib/Components/Artist/ArtistShows/__tests__/Metadata-tests.tsx
@@ -5,8 +5,6 @@ import React from "react"
 
 import Metadata from "../Metadata"
 
-import { Theme } from "@artsy/palette"
-
 it("renders properly", () => {
   const show = {
     kind: "solo",
@@ -21,9 +19,5 @@ it("renders properly", () => {
       city: "Berlin",
     },
   }
-  renderWithWrappers(
-    <Theme>
-      <Metadata show={show as any} />
-    </Theme>
-  )
+  renderWithWrappers(<Metadata show={show as any} />)
 })

--- a/src/lib/Components/Artist/ArtistShows/__tests__/Metadata-tests.tsx
+++ b/src/lib/Components/Artist/ArtistShows/__tests__/Metadata-tests.tsx
@@ -1,7 +1,7 @@
 import "react-native"
 
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
 
 import Metadata from "../Metadata"
 
@@ -21,7 +21,7 @@ it("renders properly", () => {
       city: "Berlin",
     },
   }
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <Metadata show={show as any} />
     </Theme>

--- a/src/lib/Components/Artist/ArtistShows/__tests__/SmallList-tests.tsx
+++ b/src/lib/Components/Artist/ArtistShows/__tests__/SmallList-tests.tsx
@@ -5,8 +5,6 @@ import React from "react"
 
 import SmallList from "../SmallList"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing an error", () => {
   const show1 = showProps()
   const show2 = showProps()
@@ -15,11 +13,7 @@ it("renders without throwing an error", () => {
 
   const shows = [show1, show2]
 
-  renderWithWrappers(
-    <Theme>
-      <SmallList shows={shows as any} />
-    </Theme>
-  )
+  renderWithWrappers(<SmallList shows={shows as any} />)
 })
 
 const showProps = () => {

--- a/src/lib/Components/Artist/ArtistShows/__tests__/SmallList-tests.tsx
+++ b/src/lib/Components/Artist/ArtistShows/__tests__/SmallList-tests.tsx
@@ -1,7 +1,7 @@
 import "react-native"
 
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
 
 import SmallList from "../SmallList"
 
@@ -15,7 +15,7 @@ it("renders without throwing an error", () => {
 
   const shows = [show1, show2]
 
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <SmallList shows={shows as any} />
     </Theme>

--- a/src/lib/Components/Artist/ArtistShows/__tests__/VariableSizeShowsList-tests.tsx
+++ b/src/lib/Components/Artist/ArtistShows/__tests__/VariableSizeShowsList-tests.tsx
@@ -1,6 +1,6 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import ShowsList from "../VariableSizeShowsList"
 
@@ -13,7 +13,7 @@ it("renders without throwing an error", () => {
   show2.location.city = "London"
 
   const shows = [show1, show2]
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <ShowsList shows={shows as any} showSize={"medium"} />
     </Theme>

--- a/src/lib/Components/Artist/ArtistShows/__tests__/VariableSizeShowsList-tests.tsx
+++ b/src/lib/Components/Artist/ArtistShows/__tests__/VariableSizeShowsList-tests.tsx
@@ -4,8 +4,6 @@ import "react-native"
 
 import ShowsList from "../VariableSizeShowsList"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing an error", () => {
   const show1 = showProps(1)
   const show2 = showProps(2)
@@ -13,11 +11,7 @@ it("renders without throwing an error", () => {
   show2.location.city = "London"
 
   const shows = [show1, show2]
-  renderWithWrappers(
-    <Theme>
-      <ShowsList shows={shows as any} showSize={"medium"} />
-    </Theme>
-  )
+  renderWithWrappers(<ShowsList shows={shows as any} showSize={"medium"} />)
 })
 
 // @ts-ignore STRICTNESS_MIGRATION

--- a/src/lib/Components/Artist/__tests__/ArtistConsignButton-tests.tsx
+++ b/src/lib/Components/Artist/__tests__/ArtistConsignButton-tests.tsx
@@ -1,13 +1,13 @@
-import { Theme } from "@artsy/palette"
 import { ArtistConsignButtonTestsQuery } from "__generated__/ArtistConsignButtonTestsQuery.graphql"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { __appStoreTestUtils__, AppStoreProvider } from "lib/store/AppStore"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { cloneDeep } from "lodash"
 import React from "react"
 import { TouchableOpacity } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { useTracking } from "react-tracking"
 import { createMockEnvironment } from "relay-test-utils"
 import { ArtistConsignButtonFragmentContainer, tests } from "../ArtistConsignButton"
@@ -36,9 +36,7 @@ describe("ArtistConsignButton", () => {
         if (props) {
           return (
             <AppStoreProvider>
-              <Theme>
-                <ArtistConsignButtonFragmentContainer artist={props.artist as any} />
-              </Theme>
+              <ArtistConsignButtonFragmentContainer artist={props.artist as any} />
             </AppStoreProvider>
           )
         } else if (error) {
@@ -84,7 +82,7 @@ describe("ArtistConsignButton", () => {
     }
 
     it("renders microfunnel correctly", () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       expect(env.mock.getMostRecentOperation().request.node.operation.name).toBe("ArtistConsignButtonTestsQuery")
       act(() => {
         env.mock.resolveMostRecentOperation({
@@ -97,7 +95,7 @@ describe("ArtistConsignButton", () => {
     })
 
     it("renders target supply correctly", () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       expect(env.mock.getMostRecentOperation().request.node.operation.name).toBe("ArtistConsignButtonTestsQuery")
       act(() => {
         const targetSupplyResponse = cloneDeep(response)
@@ -113,7 +111,7 @@ describe("ArtistConsignButton", () => {
     })
 
     it("guards against missing imageURL", async () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       act(() => {
         const responseWithoutImage = cloneDeep(response)
         // @ts-ignore STRICTNESS_MIGRATION
@@ -128,7 +126,7 @@ describe("ArtistConsignButton", () => {
     })
 
     it("tracks clicks on outer container", async () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       act(() => {
         env.mock.resolveMostRecentOperation({
           errors: [],
@@ -164,7 +162,7 @@ describe("ArtistConsignButton", () => {
     }
 
     it("renders with data", () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       act(() => {
         env.mock.resolveMostRecentOperation({
           errors: [],
@@ -177,7 +175,7 @@ describe("ArtistConsignButton", () => {
     })
 
     it("tracks clicks on outer container", async () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       act(() => {
         env.mock.resolveMostRecentOperation({
           errors: [],
@@ -215,7 +213,7 @@ describe("ArtistConsignButton", () => {
     it("sends user to sales tab if not already there", () => {
       __appStoreTestUtils__?.injectInitialState.mockReturnValueOnce({ native: { selectedTab: "home" } })
 
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       act(() => {
         env.mock.resolveMostRecentOperation({
           errors: [],
@@ -230,7 +228,7 @@ describe("ArtistConsignButton", () => {
     it("sends user to a new instance of landing page if user is already in sales tab", () => {
       __appStoreTestUtils__?.injectInitialState.mockReturnValueOnce({ native: { selectedTab: "sell" } })
 
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       act(() => {
         env.mock.resolveMostRecentOperation({
           errors: [],

--- a/src/lib/Components/Artist/__tests__/Header-tests.tsx
+++ b/src/lib/Components/Artist/__tests__/Header-tests.tsx
@@ -3,8 +3,6 @@ import React from "react"
 
 import Header from "../ArtistHeader"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing an error", () => {
   const artist = {
     internalID: "some-id",
@@ -16,9 +14,5 @@ it("renders without throwing an error", () => {
       follows: 22,
     },
   }
-  renderWithWrappers(
-    <Theme>
-      <Header artist={artist as any} />
-    </Theme>
-  )
+  renderWithWrappers(<Header artist={artist as any} />)
 })

--- a/src/lib/Components/Artist/__tests__/Header-tests.tsx
+++ b/src/lib/Components/Artist/__tests__/Header-tests.tsx
@@ -1,5 +1,5 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
 
 import Header from "../ArtistHeader"
 
@@ -16,7 +16,7 @@ it("renders without throwing an error", () => {
       follows: 22,
     },
   }
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <Header artist={artist as any} />
     </Theme>

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/AggregationOptionCommonValidation.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/AggregationOptionCommonValidation.tsx
@@ -1,9 +1,10 @@
 import { CheckIcon } from "@artsy/palette"
 import { FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { Aggregations, ArtworkFilterContextState } from "lib/utils/ArtworkFiltersStore"
 import React from "react"
-import { act, create, ReactTestRenderer } from "react-test-renderer"
+import { act, ReactTestRenderer } from "react-test-renderer"
 import { ReactElement } from "simple-markdown"
 import { FakeNavigator as MockNavigator } from "../../../../lib/Components/Bidding/__tests__/Helpers/FakeNavigator"
 import { aggregationForFilter, OptionListItem } from "../../../../lib/Components/FilterModal"
@@ -44,20 +45,20 @@ export const sharedAggregateFilterValidation = (params: ValidationParams) => {
     const aggregation = aggregationForFilter(params.filterKey, params.aggregations!)
 
     it("renders the correct number of " + params.name + " options", () => {
-      const tree = create(<params.Screen initialState={state} navigator={mockNavigator} />)
+      const tree = renderWithWrappers(<params.Screen initialState={state} navigator={mockNavigator} />)
       // Counts returned + all option
       expect(tree.root.findAllByType(OptionListItem)).toHaveLength(aggregation!.counts.length + 1)
     })
 
     it("adds an all option", () => {
-      const tree = create(<params.Screen initialState={state} navigator={mockNavigator} />)
+      const tree = renderWithWrappers(<params.Screen initialState={state} navigator={mockNavigator} />)
       const firstRow = tree.root.findAllByType(SingleSelectOptionListItemRow)[0]
       expect(extractText(firstRow)).toContain("All")
     })
 
     describe("selecting a " + params.name + " filter", () => {
       it("displays the default " + params.name + " if no selected filters", () => {
-        const component = create(<params.Screen initialState={state} navigator={mockNavigator} />)
+        const component = renderWithWrappers(<params.Screen initialState={state} navigator={mockNavigator} />)
         const selectedOption = selectedFilterOption(component)
         expect(extractText(selectedOption)).toContain("All")
       })
@@ -77,7 +78,7 @@ export const sharedAggregateFilterValidation = (params: ValidationParams) => {
           aggregations: params.aggregations,
         }
 
-        const component = create(<params.Screen initialState={state} navigator={mockNavigator} />)
+        const component = renderWithWrappers(<params.Screen initialState={state} navigator={mockNavigator} />)
         const selectedOption = selectedFilterOption(component)
         expect(extractText(selectedOption)).toContain(aggregation!.counts[0].name)
       })
@@ -89,7 +90,7 @@ export const sharedAggregateFilterValidation = (params: ValidationParams) => {
           params.name +
           " options are tapped",
         () => {
-          const tree = create(<params.Screen initialState={state} navigator={mockNavigator} />)
+          const tree = renderWithWrappers(<params.Screen initialState={state} navigator={mockNavigator} />)
 
           const [firstOptionInstance, secondOptionInstance, thirdOptionInstance] = tree.root.findAllByType(
             SingleSelectOptionListItemRow

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/ColorOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/ColorOptions-tests.tsx
@@ -1,9 +1,9 @@
-import { Theme } from "@artsy/palette"
 import { aggregationForFilter } from "lib/Components/FilterModal"
 import { FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { Aggregations, ArtworkFilterContext, ArtworkFilterContextState, reducer } from "lib/utils/ArtworkFiltersStore"
 import React from "react"
-import { act, create, ReactTestRenderer } from "react-test-renderer"
+import { act, ReactTestRenderer } from "react-test-renderer"
 import { FakeNavigator as MockNavigator } from "../../../../lib/Components/Bidding/__tests__/Helpers/FakeNavigator"
 import { ColorContainer, ColorOptionsScreen } from "../ColorOptions"
 import { ColorSwatch } from "../ColorSwatch"
@@ -55,16 +55,14 @@ describe("Color options screen", () => {
     const [filterState, dispatch] = React.useReducer(reducer, initialState)
 
     return (
-      <Theme>
-        <ArtworkFilterContext.Provider
-          value={{
-            state: filterState,
-            dispatch,
-          }}
-        >
-          <ColorOptionsScreen navigator={navigator} />
-        </ArtworkFilterContext.Provider>
-      </Theme>
+      <ArtworkFilterContext.Provider
+        value={{
+          state: filterState,
+          dispatch,
+        }}
+      >
+        <ColorOptionsScreen navigator={navigator} />
+      </ArtworkFilterContext.Provider>
     )
   }
 
@@ -82,7 +80,7 @@ describe("Color options screen", () => {
   const aggregation = aggregationForFilter(FilterParamName.color, mockAggregations)
 
   it("shows the correct number of color options", () => {
-    const tree = create(
+    const tree = renderWithWrappers(
       <MockColorScreen initialState={state} aggregations={mockAggregations} navigator={mockNavigator} />
     )
     // Counts returned + extra black and white option
@@ -105,7 +103,7 @@ describe("Color options screen", () => {
         aggregations: mockAggregations,
       }
 
-      const component = create(<MockColorScreen initialState={state} navigator={mockNavigator} />)
+      const component = renderWithWrappers(<MockColorScreen initialState={state} navigator={mockNavigator} />)
       const selectedOption = selectedColorOptions(component)[0]
       expect(selectedOption.props.colorOption).toMatch(aggregation!.counts[0].name)
     })
@@ -125,7 +123,7 @@ describe("Color options screen", () => {
         aggregations: mockAggregations,
       }
 
-      const tree = create(<MockColorScreen initialState={state} navigator={mockNavigator} />)
+      const tree = renderWithWrappers(<MockColorScreen initialState={state} navigator={mockNavigator} />)
 
       const firstOptionInstance = tree.root.findAllByType(ColorContainer)[0]
       const secondOptionInstance = tree.root.findAllByType(ColorContainer)[1]
@@ -149,7 +147,7 @@ describe("Color options screen", () => {
         aggregations: mockAggregations,
       }
 
-      const tree = create(<MockColorScreen initialState={state} navigator={mockNavigator} />)
+      const tree = renderWithWrappers(<MockColorScreen initialState={state} navigator={mockNavigator} />)
 
       const secondOptionInstance = tree.root.findAllByType(ColorContainer)[1]
 

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/ColorSwatch-tests.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/ColorSwatch-tests.tsx
@@ -1,30 +1,30 @@
 import { color, Flex } from "@artsy/palette"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { View } from "react-native"
-import { create } from "react-test-renderer"
 import { ColorSwatch } from "../ColorSwatch"
 
 describe("Color swatch", () => {
   it("adds a border when selected", () => {
-    const selectedTree = create(<ColorSwatch size={30} colorOption="darkblue" selected={true} />)
+    const selectedTree = renderWithWrappers(<ColorSwatch size={30} colorOption="darkblue" selected={true} />)
     const selectedFlex = selectedTree.root.findByType(Flex)
     expect(selectedFlex.props.style).toMatchObject({ borderColor: color("black100"), borderWidth: 1 })
 
-    const unselectedTree = create(<ColorSwatch size={30} colorOption="darkblue" selected={false} />)
+    const unselectedTree = renderWithWrappers(<ColorSwatch size={30} colorOption="darkblue" selected={false} />)
     const unselectedFlex = unselectedTree.root.findByType(Flex)
     expect(unselectedFlex.props.style).toMatchObject({ borderColor: color("black10"), borderWidth: 1 })
   })
 
   it("has correct background color for passed in color", () => {
-    const darkblue = create(<ColorSwatch size={30} colorOption="darkblue" selected={true} />)
+    const darkblue = renderWithWrappers(<ColorSwatch size={30} colorOption="darkblue" selected={true} />)
     const darkBlueView = darkblue.root.findAllByType(View)[1]
     expect(darkBlueView.props.style.backgroundColor).toMatch("#435EA9")
 
-    const blackAndWhite = create(<ColorSwatch size={30} colorOption="black-and-white" selected={false} />)
+    const blackAndWhite = renderWithWrappers(<ColorSwatch size={30} colorOption="black-and-white" selected={false} />)
     const blackAndWhiteView = blackAndWhite.root.findAllByType(View)[1]
     expect(blackAndWhiteView.props.style.backgroundColor).toMatch("#595A5B")
 
-    const orange = create(<ColorSwatch size={30} colorOption="darkorange" selected={false} />)
+    const orange = renderWithWrappers(<ColorSwatch size={30} colorOption="darkorange" selected={false} />)
     const orangeView = orange.root.findAllByType(View)[1]
     expect(orangeView.props.style.backgroundColor).toMatch("#F1572C")
   })

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/GalleryOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/GalleryOptions-tests.tsx
@@ -1,4 +1,3 @@
-import { Theme } from "@artsy/palette"
 import { FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import React from "react"
 import { Aggregations, ArtworkFilterContext, reducer } from "../../../utils/ArtworkFiltersStore"
@@ -48,16 +47,14 @@ describe("Gallery Options Screen", () => {
     const [filterState, dispatch] = React.useReducer(reducer, initialState)
 
     return (
-      <Theme>
-        <ArtworkFilterContext.Provider
-          value={{
-            state: filterState,
-            dispatch,
-          }}
-        >
-          <GalleryOptionsScreen navigator={navigator} />
-        </ArtworkFilterContext.Provider>
-      </Theme>
+      <ArtworkFilterContext.Provider
+        value={{
+          state: filterState,
+          dispatch,
+        }}
+      >
+        <GalleryOptionsScreen navigator={navigator} />
+      </ArtworkFilterContext.Provider>
     )
   }
 

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/InstitutionOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/InstitutionOptions-tests.tsx
@@ -1,4 +1,3 @@
-import { Theme } from "@artsy/palette"
 import { FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import React from "react"
 import { Aggregations, ArtworkFilterContext, reducer } from "../../../utils/ArtworkFiltersStore"
@@ -33,16 +32,14 @@ describe("Institution Options Screen", () => {
     const [filterState, dispatch] = React.useReducer(reducer, initialState)
 
     return (
-      <Theme>
-        <ArtworkFilterContext.Provider
-          value={{
-            state: filterState,
-            dispatch,
-          }}
-        >
-          <InstitutionOptionsScreen navigator={navigator} />
-        </ArtworkFilterContext.Provider>
-      </Theme>
+      <ArtworkFilterContext.Provider
+        value={{
+          state: filterState,
+          dispatch,
+        }}
+      >
+        <InstitutionOptionsScreen navigator={navigator} />
+      </ArtworkFilterContext.Provider>
     )
   }
 

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/MediumOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/MediumOptions-tests.tsx
@@ -1,4 +1,3 @@
-import { Theme } from "@artsy/palette"
 import { FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import React from "react"
 import { Aggregations, ArtworkFilterContext, reducer } from "../../../utils/ArtworkFiltersStore"
@@ -58,16 +57,14 @@ describe("Medium Options Screen", () => {
     const [filterState, dispatch] = React.useReducer(reducer, initialState)
 
     return (
-      <Theme>
-        <ArtworkFilterContext.Provider
-          value={{
-            state: filterState,
-            dispatch,
-          }}
-        >
-          <MediumOptionsScreen navigator={navigator} />
-        </ArtworkFilterContext.Provider>
-      </Theme>
+      <ArtworkFilterContext.Provider
+        value={{
+          state: filterState,
+          dispatch,
+        }}
+      >
+        <MediumOptionsScreen navigator={navigator} />
+      </ArtworkFilterContext.Provider>
     )
   }
 

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/PriceRangeOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/PriceRangeOptions-tests.tsx
@@ -1,8 +1,9 @@
 import { Box, Theme } from "@artsy/palette"
 import { FilterParamName, InitialState } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import { create, ReactTestRenderer } from "react-test-renderer"
+import { ReactTestRenderer } from "react-test-renderer"
 import { FakeNavigator as MockNavigator } from "../../../../lib/Components/Bidding/__tests__/Helpers/FakeNavigator"
 import { OptionListItem } from "../../../../lib/Components/FilterModal"
 import { Aggregations, ArtworkFilterContext, ArtworkFilterContextState } from "../../../utils/ArtworkFiltersStore"
@@ -84,19 +85,19 @@ describe("Price Range Options Screen", () => {
   }
 
   it("renders the correct number of price range options", () => {
-    const tree = create(<MockPriceRangeScreen initialState={state} />)
+    const tree = renderWithWrappers(<MockPriceRangeScreen initialState={state} />)
     expect(tree.root.findAllByType(OptionListItem)).toHaveLength(6)
   })
 
   it("has an all option", () => {
-    const tree = create(<MockPriceRangeScreen initialState={state} />)
+    const tree = renderWithWrappers(<MockPriceRangeScreen initialState={state} />)
     const firstOption = tree.root.findAllByType(OptionListItem)[0]
     expect(extractText(firstOption)).toContain("All")
   })
 
   describe("selectedPriceRangeOption", () => {
     it("returns the default option if there are no selected or applied filters", () => {
-      const tree = create(<MockPriceRangeScreen initialState={state} />)
+      const tree = renderWithWrappers(<MockPriceRangeScreen initialState={state} />)
       const selectedOption = selectedPriceRangeOption(tree)
       expect(extractText(selectedOption)).toContain("All")
     })
@@ -124,7 +125,7 @@ describe("Price Range Options Screen", () => {
         aggregations,
       }
 
-      const tree = create(<MockPriceRangeScreen initialState={state} />)
+      const tree = renderWithWrappers(<MockPriceRangeScreen initialState={state} />)
       const selectedOption = selectedPriceRangeOption(tree)
       expect(extractText(selectedOption)).toContain("$5,000-10,000")
     })
@@ -145,7 +146,7 @@ describe("Price Range Options Screen", () => {
         aggregations,
       }
 
-      const component = create(<MockPriceRangeScreen initialState={state} />)
+      const component = renderWithWrappers(<MockPriceRangeScreen initialState={state} />)
       const selectedOption = selectedPriceRangeOption(component)
       expect(extractText(selectedOption)).toContain("$5,000-10,000")
     })
@@ -180,7 +181,7 @@ describe("Price Range Options Screen", () => {
         aggregations,
       }
 
-      const tree = create(<MockPriceRangeScreen initialState={state} />)
+      const tree = renderWithWrappers(<MockPriceRangeScreen initialState={state} />)
       const selectedOption = selectedPriceRangeOption(tree)
       expect(extractText(selectedOption)).toContain("$5,000-10,000")
     })

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/SizeOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/SizeOptions-tests.tsx
@@ -1,4 +1,3 @@
-import { Theme } from "@artsy/palette"
 import { FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import React from "react"
 import { Aggregations, ArtworkFilterContext, reducer } from "../../../utils/ArtworkFiltersStore"
@@ -38,16 +37,14 @@ describe("Size Options Screen", () => {
     const [filterState, dispatch] = React.useReducer(reducer, initialState)
 
     return (
-      <Theme>
-        <ArtworkFilterContext.Provider
-          value={{
-            state: filterState,
-            dispatch,
-          }}
-        >
-          <SizeOptionsScreen navigator={navigator} />
-        </ArtworkFilterContext.Provider>
-      </Theme>
+      <ArtworkFilterContext.Provider
+        value={{
+          state: filterState,
+          dispatch,
+        }}
+      >
+        <SizeOptionsScreen navigator={navigator} />
+      </ArtworkFilterContext.Provider>
     )
   }
 

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/SortOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/SortOptions-tests.tsx
@@ -1,8 +1,9 @@
 import { Box, CheckIcon, Theme } from "@artsy/palette"
 import { FilterParamName, InitialState } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import { create, ReactTestRenderer } from "react-test-renderer"
+import { ReactTestRenderer } from "react-test-renderer"
 import { FakeNavigator as MockNavigator } from "../../../../lib/Components/Bidding/__tests__/Helpers/FakeNavigator"
 import { OptionListItem } from "../../../../lib/Components/FilterModal"
 import { ArtworkFilterContext, ArtworkFilterContextState } from "../../../utils/ArtworkFiltersStore"
@@ -47,13 +48,13 @@ describe("Sort Options Screen", () => {
   }
 
   it("renders the correct number of sort options", () => {
-    const tree = create(<MockSortScreen initialState={state} />)
+    const tree = renderWithWrappers(<MockSortScreen initialState={state} />)
     expect(tree.root.findAllByType(OptionListItem)).toHaveLength(7)
   })
 
   describe("selectedSortOption", () => {
     it("returns the default option if there are no selected or applied filters", () => {
-      const tree = create(<MockSortScreen initialState={state} />)
+      const tree = renderWithWrappers(<MockSortScreen initialState={state} />)
       const selectedOption = selectedSortOption(tree)
       expect(extractText(selectedOption)).toContain("Default")
     })
@@ -81,7 +82,7 @@ describe("Sort Options Screen", () => {
         aggregations: [],
       }
 
-      const tree = create(<MockSortScreen initialState={state} />)
+      const tree = renderWithWrappers(<MockSortScreen initialState={state} />)
       const selectedOption = selectedSortOption(tree)
       expect(extractText(selectedOption)).toContain("Recently added")
     })
@@ -102,7 +103,7 @@ describe("Sort Options Screen", () => {
         aggregations: [],
       }
 
-      const tree = create(<MockSortScreen initialState={state} />)
+      const tree = renderWithWrappers(<MockSortScreen initialState={state} />)
       const selectedOption = selectedSortOption(tree)
       expect(extractText(selectedOption)).toContain("Recently added")
     })
@@ -137,7 +138,7 @@ describe("Sort Options Screen", () => {
         aggregations: [],
       }
 
-      const tree = create(<MockSortScreen initialState={state} />)
+      const tree = renderWithWrappers(<MockSortScreen initialState={state} />)
       const selectedOption = selectedSortOption(tree)
       expect(extractText(selectedOption)).toContain("Recently added")
     })
@@ -164,7 +165,7 @@ describe("Sort Options Screen", () => {
       applyFilters: false,
       aggregations: [],
     }
-    const tree = create(<MockSortScreen initialState={state} />)
+    const tree = renderWithWrappers(<MockSortScreen initialState={state} />)
     const selectedRow = selectedSortOption(tree)
     expect(extractText(selectedRow)).toEqual("Price (high to low)")
     expect(selectedRow.findAllByType(CheckIcon)).toHaveLength(1)

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/TimePeriodOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/TimePeriodOptions-tests.tsx
@@ -1,4 +1,3 @@
-import { Theme } from "@artsy/palette"
 import { FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import React from "react"
 import { Aggregations, ArtworkFilterContext, reducer } from "../../../utils/ArtworkFiltersStore"
@@ -48,16 +47,14 @@ describe("Time Period Options Screen", () => {
     const [filterState, dispatch] = React.useReducer(reducer, initialState)
 
     return (
-      <Theme>
-        <ArtworkFilterContext.Provider
-          value={{
-            state: filterState,
-            dispatch,
-          }}
-        >
-          <TimePeriodOptionsScreen navigator={navigator} />
-        </ArtworkFilterContext.Provider>
-      </Theme>
+      <ArtworkFilterContext.Provider
+        value={{
+          state: filterState,
+          dispatch,
+        }}
+      >
+        <TimePeriodOptionsScreen navigator={navigator} />
+      </ArtworkFilterContext.Provider>
     )
   }
 

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/WaysToBuyOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/WaysToBuyOptions-tests.tsx
@@ -1,10 +1,9 @@
-import { Theme } from "@artsy/palette"
 import { MockFilterScreen } from "lib/Components/__tests__/FilterTestHelper"
 import { FilterParamName, InitialState } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { Switch } from "react-native"
-import { create } from "react-test-renderer"
 import { FakeNavigator as MockNavigator } from "../../../../lib/Components/Bidding/__tests__/Helpers/FakeNavigator"
 import { OptionListItem as FilterModalOptionListItem } from "../../../../lib/Components/FilterModal"
 import { ArtworkFilterContext, ArtworkFilterContextState, reducer } from "../../../utils/ArtworkFiltersStore"
@@ -30,21 +29,19 @@ describe("Ways to Buy Options Screen", () => {
     const [filterState, dispatch] = React.useReducer(reducer, initialState)
 
     return (
-      <Theme>
-        <ArtworkFilterContext.Provider
-          value={{
-            state: filterState,
-            dispatch,
-          }}
-        >
-          <WaysToBuyOptionsScreen navigator={mockNavigator as any} />
-        </ArtworkFilterContext.Provider>
-      </Theme>
+      <ArtworkFilterContext.Provider
+        value={{
+          state: filterState,
+          dispatch,
+        }}
+      >
+        <WaysToBuyOptionsScreen navigator={mockNavigator as any} />
+      </ArtworkFilterContext.Provider>
     )
   }
 
   it("renders the correct ways to buy options", () => {
-    const tree = create(<MockWaysToBuyScreen initialState={state} />)
+    const tree = renderWithWrappers(<MockWaysToBuyScreen initialState={state} />)
 
     expect(tree.root.findAllByType(OptionListItem)).toHaveLength(4)
 
@@ -71,7 +68,7 @@ describe("Ways to Buy Options Screen", () => {
       aggregations: [],
     }
 
-    const tree = create(<MockFilterScreen initialState={state} />)
+    const tree = renderWithWrappers(<MockFilterScreen initialState={state} />)
     const waysToBuyListItem = tree.root.findAllByType(FilterModalOptionListItem)[1]
 
     expect(extractText(waysToBuyListItem)).toContain("All")
@@ -102,7 +99,7 @@ describe("Ways to Buy Options Screen", () => {
       aggregations: [],
     }
 
-    const tree = create(<MockFilterScreen initialState={state} />)
+    const tree = renderWithWrappers(<MockFilterScreen initialState={state} />)
     const waysToBuyListItem = tree.root.findAllByType(FilterModalOptionListItem)[1]
 
     expect(extractText(waysToBuyListItem)).toContain("Buy now, Inquire, Bid")
@@ -123,7 +120,7 @@ describe("Ways to Buy Options Screen", () => {
       aggregations: [],
     }
 
-    const tree = create(<MockWaysToBuyScreen initialState={initialState} />)
+    const tree = renderWithWrappers(<MockWaysToBuyScreen initialState={initialState} />)
     const switches = tree.root.findAllByType(Switch)
 
     expect(switches[0].props.value).toBe(true)
@@ -156,7 +153,7 @@ describe("Ways to Buy Options Screen", () => {
       aggregations: [],
     }
 
-    const tree = create(<MockWaysToBuyScreen initialState={initialState} />)
+    const tree = renderWithWrappers(<MockWaysToBuyScreen initialState={initialState} />)
     const switches = tree.root.findAllByType(Switch)
 
     expect(switches[0].props.value).toBe(false)

--- a/src/lib/Components/ArtworkGrids/__tests__/ArtworkGridItem-tests.tsx
+++ b/src/lib/Components/ArtworkGrids/__tests__/ArtworkGridItem-tests.tsx
@@ -31,9 +31,7 @@ describe("tracking", () => {
 
   it("sends an event when trackTap is passed", () => {
     const trackTap = jest.fn()
-    const rendered = renderWithWrappers(
-      <Artwork trackTap={trackTap} artwork={artworkProps() as any} itemIndex={1} />
-    )
+    const rendered = renderWithWrappers(<Artwork trackTap={trackTap} artwork={artworkProps() as any} itemIndex={1} />)
 
     const touchableArtwork = rendered.root.findByType(Touchable)
     act(() => touchableArtwork.props.onPress())
@@ -41,15 +39,13 @@ describe("tracking", () => {
   })
 
   it("sends a tracking event when contextScreenOwnerType is included", () => {
-    const rendered = renderer.create(
-      <Theme>
-        <Artwork
-          artwork={artworkProps() as any}
-          contextScreenOwnerType={OwnerType.artist}
-          contextScreenOwnerId="abc124"
-          contextScreenOwnerSlug="andy-warhol"
-        />
-      </Theme>
+    const rendered = renderWithWrappers(
+      <Artwork
+        artwork={artworkProps() as any}
+        contextScreenOwnerType={OwnerType.artist}
+        contextScreenOwnerId="abc124"
+        contextScreenOwnerSlug="andy-warhol"
+      />
     )
 
     const touchableArtwork = rendered.root.findByType(Touchable)

--- a/src/lib/Components/ArtworkGrids/__tests__/ArtworkGridItem-tests.tsx
+++ b/src/lib/Components/ArtworkGrids/__tests__/ArtworkGridItem-tests.tsx
@@ -1,14 +1,14 @@
 import "react-native"
 
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
 
 import Artwork from "../ArtworkGridItem"
 
 import { Theme } from "@artsy/palette"
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <Artwork artwork={artworkProps() as any} />
     </Theme>
@@ -23,7 +23,7 @@ describe("in an open sale", () => {
         isClosed: false,
       },
     }
-    renderer.create(
+    renderWithWrappers(
       <Theme>
         <Artwork
           artwork={
@@ -41,7 +41,7 @@ describe("in an open sale", () => {
     // @ts-ignore STRICTNESS_MIGRATION
     const props = artworkProps({}) // Passing in empty sale_artwork prop to trigger "sale is live" code in artworkProps()
     props.saleArtwork = null
-    renderer.create(
+    renderWithWrappers(
       <Theme>
         <Artwork artwork={props as any} />
       </Theme>
@@ -56,7 +56,7 @@ describe("in a closed sale", () => {
         isClosed: true,
       },
     }
-    renderer.create(
+    renderWithWrappers(
       <Theme>
         <Artwork
           artwork={
@@ -78,7 +78,7 @@ describe("in a closed sale", () => {
         // is_open: false (this would be returned from Metaphysics, though we don't fetch this field)
       },
     }
-    renderer.create(
+    renderWithWrappers(
       <Theme>
         <Artwork
           artwork={

--- a/src/lib/Components/ArtworkGrids/__tests__/ArtworkGridItem-tests.tsx
+++ b/src/lib/Components/ArtworkGrids/__tests__/ArtworkGridItem-tests.tsx
@@ -5,14 +5,8 @@ import React from "react"
 
 import Artwork from "../ArtworkGridItem"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <Artwork artwork={artworkProps() as any} />
-    </Theme>
-  )
+  renderWithWrappers(<Artwork artwork={artworkProps() as any} />)
 })
 
 describe("in an open sale", () => {
@@ -24,16 +18,14 @@ describe("in an open sale", () => {
       },
     }
     renderWithWrappers(
-      <Theme>
-        <Artwork
-          artwork={
-            artworkProps(
-              // @ts-ignore STRICTNESS_MIGRATION
-              saleArtwork
-            ) as any
-          }
-        />
-      </Theme>
+      <Artwork
+        artwork={
+          artworkProps(
+            // @ts-ignore STRICTNESS_MIGRATION
+            saleArtwork
+          ) as any
+        }
+      />
     )
   })
 
@@ -41,11 +33,7 @@ describe("in an open sale", () => {
     // @ts-ignore STRICTNESS_MIGRATION
     const props = artworkProps({}) // Passing in empty sale_artwork prop to trigger "sale is live" code in artworkProps()
     props.saleArtwork = null
-    renderWithWrappers(
-      <Theme>
-        <Artwork artwork={props as any} />
-      </Theme>
-    )
+    renderWithWrappers(<Artwork artwork={props as any} />)
   })
 })
 
@@ -57,16 +45,14 @@ describe("in a closed sale", () => {
       },
     }
     renderWithWrappers(
-      <Theme>
-        <Artwork
-          artwork={
-            artworkProps(
-              // @ts-ignore STRICTNESS_MIGRATION
-              saleArtwork
-            ) as any
-          }
-        />
-      </Theme>
+      <Artwork
+        artwork={
+          artworkProps(
+            // @ts-ignore STRICTNESS_MIGRATION
+            saleArtwork
+          ) as any
+        }
+      />
     )
   })
 
@@ -79,16 +65,14 @@ describe("in a closed sale", () => {
       },
     }
     renderWithWrappers(
-      <Theme>
-        <Artwork
-          artwork={
-            artworkProps(
-              // @ts-ignore STRICTNESS_MIGRATION
-              saleArtwork
-            ) as any
-          }
-        />
-      </Theme>
+      <Artwork
+        artwork={
+          artworkProps(
+            // @ts-ignore STRICTNESS_MIGRATION
+            saleArtwork
+          ) as any
+        }
+      />
     )
   })
 })

--- a/src/lib/Components/ArtworkGrids/__tests__/InfiniteScrollArtworksGrid-tests.tsx
+++ b/src/lib/Components/ArtworkGrids/__tests__/InfiniteScrollArtworksGrid-tests.tsx
@@ -1,13 +1,14 @@
-import { Button, Theme } from "@artsy/palette"
+import { Button } from "@artsy/palette"
 import {
   InfiniteScrollArtworksGridTestsQuery,
   InfiniteScrollArtworksGridTestsQueryResponse,
 } from "__generated__/InfiniteScrollArtworksGridTestsQuery.graphql"
 import { InfiniteScrollArtworksGridContainer } from "lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 jest.unmock("react-relay")
@@ -53,15 +54,13 @@ describe("Artist Series Artworks", () => {
       render={({ props, error }) => {
         if (props?.artworksConnection) {
           return (
-            <Theme>
-              <InfiniteScrollArtworksGridContainer
-                // @ts-ignore
-                connection={artworksConnection}
-                loadMore={relayMock.loadMore}
-                hasMore={relayMock.hasMore}
-                isLoading={relayMock.isLoading}
-              />
-            </Theme>
+            <InfiniteScrollArtworksGridContainer
+              // @ts-ignore
+              connection={artworksConnection}
+              loadMore={relayMock.loadMore}
+              hasMore={relayMock.hasMore}
+              isLoading={relayMock.isLoading}
+            />
           )
         } else if (error) {
           console.log(error)
@@ -72,7 +71,7 @@ describe("Artist Series Artworks", () => {
 
   it("renders component with default props", () => {
     const wrapper = () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       act(() => {
         env.mock.resolveMostRecentOperation({
           errors: [],

--- a/src/lib/Components/ArtworkTileRail/__tests__/ArtworkTileRail-tests.tsx
+++ b/src/lib/Components/ArtworkTileRail/__tests__/ArtworkTileRail-tests.tsx
@@ -1,10 +1,10 @@
 import { Theme } from "@artsy/palette"
 import { ArtworkTileRailTestsQuery } from "__generated__/ArtworkTileRailTestsQuery.graphql"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { Schema } from "lib/utils/track"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer from "react-test-renderer"
 import { useTracking } from "react-tracking"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { ArtworkTileRail, tappedArtworkGroupThumbnail } from "../ArtworkTileRail"
@@ -53,7 +53,7 @@ describe("ArtworkTileRail", () => {
   })
 
   it("navigates to an artwork + calls tracking when a card is tapped", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation => {
       const result = MockPayloadGenerator.generate(operation, {
         ViewingRoom: () => ({

--- a/src/lib/Components/ArtworkTileRail/__tests__/ArtworkTileRail-tests.tsx
+++ b/src/lib/Components/ArtworkTileRail/__tests__/ArtworkTileRail-tests.tsx
@@ -1,4 +1,3 @@
-import { Theme } from "@artsy/palette"
 import { ArtworkTileRailTestsQuery } from "__generated__/ArtworkTileRailTestsQuery.graphql"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
@@ -18,35 +17,31 @@ jest.mock("lib/NativeModules/SwitchBoard", () => ({
 describe("ArtworkTileRail", () => {
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
   const TestRenderer = () => (
-    <Theme>
-      <QueryRenderer<ArtworkTileRailTestsQuery>
-        environment={mockEnvironment}
-        query={graphql`
-          query ArtworkTileRailTestsQuery {
-            viewingRoom(id: "whatever") {
-              artworksConnection {
-                ...ArtworkTileRail_artworksConnection
-              }
+    <QueryRenderer<ArtworkTileRailTestsQuery>
+      environment={mockEnvironment}
+      query={graphql`
+        query ArtworkTileRailTestsQuery {
+          viewingRoom(id: "whatever") {
+            artworksConnection {
+              ...ArtworkTileRail_artworksConnection
             }
           }
-        `}
-        render={({ props, error }) => {
-          if (props?.viewingRoom) {
-            return (
-              <Theme>
-                <ArtworkTileRail
-                  artworksConnection={props.viewingRoom.artworksConnection! /* STRICTNESS_MIGRATION */}
-                  contextModule={Schema.ContextModules.ViewingRoomArtworkRail}
-                />
-              </Theme>
-            )
-          } else if (error) {
-            console.log(error)
-          }
-        }}
-        variables={{}}
-      />
-    </Theme>
+        }
+      `}
+      render={({ props, error }) => {
+        if (props?.viewingRoom) {
+          return (
+            <ArtworkTileRail
+              artworksConnection={props.viewingRoom.artworksConnection! /* STRICTNESS_MIGRATION */}
+              contextModule={Schema.ContextModules.ViewingRoomArtworkRail}
+            />
+          )
+        } else if (error) {
+          console.log(error)
+        }
+      }}
+      variables={{}}
+    />
   )
   beforeEach(() => {
     mockEnvironment = createMockEnvironment()

--- a/src/lib/Components/Bidding/Components/__tests__/Checkbox-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/Checkbox-tests.tsx
@@ -1,6 +1,6 @@
 import { Serif } from "@artsy/palette"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
 
 import { TouchableWithoutFeedback } from "react-native"
 import { theme } from "../../Elements/Theme"
@@ -9,7 +9,7 @@ import { BiddingThemeProvider } from "../BiddingThemeProvider"
 import { Checkbox, CheckMark, DisabledMark } from "../Checkbox"
 
 it("shows children within the checkbox", () => {
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <Checkbox>
         <Serif size="2">Remember me</Serif>
@@ -24,7 +24,7 @@ it("calls onPress when tapped", done => {
   let clicked: boolean
   const onPress = () => (clicked = true)
 
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <Checkbox onPress={onPress} />
     </BiddingThemeProvider>
@@ -40,7 +40,7 @@ it("calls onPress when tapped", done => {
 })
 
 it("shows a gray border and white background by default", () => {
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <Checkbox />
     </BiddingThemeProvider>
@@ -53,7 +53,7 @@ it("shows a gray border and white background by default", () => {
 })
 
 it("shows a black border and black background if checked is true", () => {
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <Checkbox error checked />
     </BiddingThemeProvider>
@@ -66,7 +66,7 @@ it("shows a black border and black background if checked is true", () => {
 })
 
 it("shows a purple border and white background if error is true", () => {
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <Checkbox error />
     </BiddingThemeProvider>
@@ -79,7 +79,7 @@ it("shows a purple border and white background if error is true", () => {
 })
 
 it("shows a black border and black background if both error and checked are true", () => {
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <Checkbox error checked />
     </BiddingThemeProvider>
@@ -92,7 +92,7 @@ it("shows a black border and black background if both error and checked are true
 })
 
 it("shows a gray border and background if it is disabled", () => {
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <Checkbox disabled />
     </BiddingThemeProvider>
@@ -107,7 +107,7 @@ it("shows a gray border and background if it is disabled", () => {
 })
 
 it("shows a black border and black background if it is disabled but checked", () => {
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <Checkbox disabled checked />
     </BiddingThemeProvider>

--- a/src/lib/Components/Bidding/Components/__tests__/Input-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/Input-tests.tsx
@@ -1,26 +1,24 @@
 import React from "react"
 import { TextInput } from "react-native"
-import ReactTestRenderer from "react-test-renderer"
 
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { theme } from "../../Elements/Theme"
 import { BiddingThemeProvider } from "../BiddingThemeProvider"
 import { Input } from "../Input"
 
-/* tslint:disable use-wrapped-components */
-
 it("shows a gray border by default", () => {
-  const component = ReactTestRenderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <Input />
     </BiddingThemeProvider>
   )
 
-  // @ts-ignore STRICTNESS_MIGRATION
-  expect(component.toJSON().props.style[0].borderColor).toEqual(theme.colors.black10)
+  expect(component.toJSON()).toBeTruthy()
+  expect(component.toJSON()?.props.style[0].borderColor).toEqual(theme.colors.black10)
 })
 
 it("shows a purple border on focus", () => {
-  const component = ReactTestRenderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <Input />
     </BiddingThemeProvider>
@@ -30,12 +28,12 @@ it("shows a purple border on focus", () => {
 
   inputComponent.onFocus()
 
-  // @ts-ignore STRICTNESS_MIGRATION
-  expect(component.toJSON().props.style[0].borderColor).toEqual(theme.colors.purple100)
+  expect(component.toJSON()).toBeTruthy()
+  expect(component.toJSON()?.props.style[0].borderColor).toEqual(theme.colors.purple100)
 })
 
 it("changes the border color back to gray on blur", () => {
-  const component = ReactTestRenderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <Input />
     </BiddingThemeProvider>
@@ -46,19 +44,19 @@ it("changes the border color back to gray on blur", () => {
   inputComponent.onFocus()
   inputComponent.onBlur()
 
-  // @ts-ignore STRICTNESS_MIGRATION
-  expect(component.toJSON().props.style[0].borderColor).toEqual(theme.colors.black10)
+  expect(component.toJSON()).toBeTruthy()
+  expect(component.toJSON()?.props.style[0].borderColor).toEqual(theme.colors.black10)
 })
 
 it("shows a red border if error is true", () => {
-  const component = ReactTestRenderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <Input error />
     </BiddingThemeProvider>
   )
 
-  // @ts-ignore STRICTNESS_MIGRATION
-  expect(component.toJSON().props.style[0].borderColor).toEqual(theme.colors.red100)
+  expect(component.toJSON()).toBeTruthy()
+  expect(component.toJSON()?.props.style[0].borderColor).toEqual(theme.colors.red100)
 })
 
 it("updates the border color when the parent component updates the error prop", () => {
@@ -74,28 +72,29 @@ it("updates the border color when the parent component updates the error prop", 
     }
   }
 
-  const component = ReactTestRenderer.create(<TestFormForInput />)
+  const component = renderWithWrappers(<TestFormForInput />)
 
-  // @ts-ignore STRICTNESS_MIGRATION
-  expect(component.toJSON().props.style[0].borderColor).toEqual(theme.colors.black10)
+  expect(component.toJSON()).toBeTruthy()
+  expect(component.toJSON()?.props.style[0].borderColor).toEqual(theme.colors.black10)
 
   // Explicitly calling setState to force-render the Input component
-  component.root.instance.setState({ error: true })
+  const parentComponent = component.root.findByType(TestFormForInput).instance
+  parentComponent.setState({ error: true })
 
-  // @ts-ignore STRICTNESS_MIGRATION
-  expect(component.toJSON().props.style[0].borderColor).toEqual(theme.colors.red100)
+  expect(component.toJSON()).toBeTruthy()
+  expect(component.toJSON()?.props.style[0].borderColor).toEqual(theme.colors.red100)
 
-  component.root.instance.setState({ error: false })
+  parentComponent.setState({ error: false })
 
-  // @ts-ignore STRICTNESS_MIGRATION
-  expect(component.toJSON().props.style[0].borderColor).toEqual(theme.colors.black10)
+  expect(component.toJSON()).toBeTruthy()
+  expect(component.toJSON()?.props.style[0].borderColor).toEqual(theme.colors.black10)
 })
 
 it("allows for capturing the ref to the actual text input", () => {
   // FXIME: This is a StyledNativeComponent instance. Find the appropriate type and replace any with it.
   let inputRef: any
 
-  const component = ReactTestRenderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <Input inputRef={element => (inputRef = element)} />
     </BiddingThemeProvider>

--- a/src/lib/Components/Bidding/Components/__tests__/Input-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/Input-tests.tsx
@@ -1,13 +1,15 @@
 import React from "react"
 import { TextInput } from "react-native"
-import * as renderer from "react-test-renderer"
+import ReactTestRenderer from "react-test-renderer"
 
 import { theme } from "../../Elements/Theme"
 import { BiddingThemeProvider } from "../BiddingThemeProvider"
 import { Input } from "../Input"
 
+/* tslint:disable use-wrapped-components */
+
 it("shows a gray border by default", () => {
-  const component = renderer.create(
+  const component = ReactTestRenderer.create(
     <BiddingThemeProvider>
       <Input />
     </BiddingThemeProvider>
@@ -18,7 +20,7 @@ it("shows a gray border by default", () => {
 })
 
 it("shows a purple border on focus", () => {
-  const component = renderer.create(
+  const component = ReactTestRenderer.create(
     <BiddingThemeProvider>
       <Input />
     </BiddingThemeProvider>
@@ -33,7 +35,7 @@ it("shows a purple border on focus", () => {
 })
 
 it("changes the border color back to gray on blur", () => {
-  const component = renderer.create(
+  const component = ReactTestRenderer.create(
     <BiddingThemeProvider>
       <Input />
     </BiddingThemeProvider>
@@ -49,7 +51,7 @@ it("changes the border color back to gray on blur", () => {
 })
 
 it("shows a red border if error is true", () => {
-  const component = renderer.create(
+  const component = ReactTestRenderer.create(
     <BiddingThemeProvider>
       <Input error />
     </BiddingThemeProvider>
@@ -72,7 +74,7 @@ it("updates the border color when the parent component updates the error prop", 
     }
   }
 
-  const component = renderer.create(<TestFormForInput />)
+  const component = ReactTestRenderer.create(<TestFormForInput />)
 
   // @ts-ignore STRICTNESS_MIGRATION
   expect(component.toJSON().props.style[0].borderColor).toEqual(theme.colors.black10)
@@ -93,7 +95,7 @@ it("allows for capturing the ref to the actual text input", () => {
   // FXIME: This is a StyledNativeComponent instance. Find the appropriate type and replace any with it.
   let inputRef: any
 
-  const component = renderer.create(
+  const component = ReactTestRenderer.create(
     <BiddingThemeProvider>
       <Input inputRef={element => (inputRef = element)} />
     </BiddingThemeProvider>

--- a/src/lib/Components/Bidding/Components/__tests__/MaxBidPicker-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/MaxBidPicker-tests.tsx
@@ -1,6 +1,6 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import { MaxBidPicker } from "../MaxBidPicker"
 
@@ -18,7 +18,7 @@ const Bids = [
 ]
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <BiddingThemeProvider>
       <MaxBidPicker bids={Bids} selectedValue={0} onValueChange={jest.fn()} />
     </BiddingThemeProvider>

--- a/src/lib/Components/Bidding/Components/__tests__/PaymentInfo-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/PaymentInfo-tests.tsx
@@ -1,6 +1,6 @@
 import { Serif } from "@artsy/palette"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
 
 import { BillingAddress } from "../../Screens/BillingAddress"
 import { CreditCardForm } from "../../Screens/CreditCardForm"
@@ -23,7 +23,7 @@ const mockNavigator = { push: route => (nextStep = route), pop: () => null }
 jest.useFakeTimers()
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <BiddingThemeProvider>
       <PaymentInfo {...initialProps} />
     </BiddingThemeProvider>
@@ -31,13 +31,11 @@ it("renders without throwing an error", () => {
 })
 
 it("shows the billing address that the user typed in the billing address form", () => {
-  const billingAddressRow = renderer
-    .create(
-      <BiddingThemeProvider>
-        <PaymentInfo {...initialProps} />
-      </BiddingThemeProvider>
-    )
-    .root.findAllByType(BidInfoRow)[1]
+  const billingAddressRow = renderWithWrappers(
+    <BiddingThemeProvider>
+      <PaymentInfo {...initialProps} />
+    </BiddingThemeProvider>
+  ).root.findAllByType(BidInfoRow)[1]
   billingAddressRow.instance.props.onPress()
   // @ts-ignore STRICTNESS_MIGRATION
   expect(nextStep.component).toEqual(BillingAddress)
@@ -46,13 +44,11 @@ it("shows the billing address that the user typed in the billing address form", 
 })
 
 it("shows the cc info that the user had typed into the form", () => {
-  const creditCardRow = renderer
-    .create(
-      <BiddingThemeProvider>
-        <PaymentInfo {...initialProps} />
-      </BiddingThemeProvider>
-    )
-    .root.findAllByType(BidInfoRow)[0]
+  const creditCardRow = renderWithWrappers(
+    <BiddingThemeProvider>
+      <PaymentInfo {...initialProps} />
+    </BiddingThemeProvider>
+  ).root.findAllByType(BidInfoRow)[0]
   creditCardRow.instance.props.onPress()
   // @ts-ignore STRICTNESS_MIGRATION
   expect(nextStep.component).toEqual(CreditCardForm)

--- a/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
@@ -1,10 +1,10 @@
 import { Sans } from "@artsy/palette"
 // @ts-ignore STRICTNESS_MIGRATION
 import { mount } from "enzyme"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import moment from "moment"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import { mockTimezone } from "lib/tests/mockTimezone"
 import { Timer } from "../Timer"
@@ -65,7 +65,7 @@ it("formats the remaining time in '00d  00h  00m  00s'", () => {
   let timer
 
   // Thursday, May 14, 2018 10:24:31.000 AM UTC
-  timer = renderer.create(
+  timer = renderWithWrappers(
     <BiddingThemeProvider>
       <Timer endsAt="2018-05-14T10:24:31+00:00" />
     </BiddingThemeProvider>
@@ -74,7 +74,7 @@ it("formats the remaining time in '00d  00h  00m  00s'", () => {
   expect(getTimerText(timer)).toEqual("03d  14h  01m  59s")
 
   // Thursday, May 10, 2018 8:42:32.000 PM UTC
-  timer = renderer.create(
+  timer = renderWithWrappers(
     <BiddingThemeProvider>
       <Timer endsAt="2018-05-10T20:42:32+00:00" />
     </BiddingThemeProvider>
@@ -83,7 +83,7 @@ it("formats the remaining time in '00d  00h  00m  00s'", () => {
   expect(getTimerText(timer)).toEqual("00d  00h  20m  00s")
 
   // Thursday, May 10, 2018 8:22:42.000 PM UTC
-  timer = renderer.create(
+  timer = renderWithWrappers(
     <BiddingThemeProvider>
       <Timer endsAt="2018-05-10T20:22:42+00:00" />
     </BiddingThemeProvider>
@@ -93,7 +93,7 @@ it("formats the remaining time in '00d  00h  00m  00s'", () => {
 })
 
 it("shows 'Ends' when it's an online-only sale with an ending time", () => {
-  const timer = renderer.create(
+  const timer = renderWithWrappers(
     <BiddingThemeProvider>
       <Timer endsAt="2018-05-14T20:00:00+00:00" />
     </BiddingThemeProvider>
@@ -103,7 +103,7 @@ it("shows 'Ends' when it's an online-only sale with an ending time", () => {
 })
 
 it("shows 'Live' when the liveStartsAt prop is given", () => {
-  const timer = renderer.create(
+  const timer = renderWithWrappers(
     <BiddingThemeProvider>
       <Timer liveStartsAt="2018-05-14T20:00:00+00:00" />
     </BiddingThemeProvider>
@@ -113,7 +113,7 @@ it("shows 'Live' when the liveStartsAt prop is given", () => {
 })
 
 it("shows 'Starts' the sale has not started yet", () => {
-  const timer = renderer.create(
+  const timer = renderWithWrappers(
     <BiddingThemeProvider>
       <Timer startsAt="2018-04-14T20:00:00+00:00" isPreview={true} liveStartsAt="2018-05-14T20:00:00+00:00" />
     </BiddingThemeProvider>
@@ -123,7 +123,7 @@ it("shows 'Starts' the sale has not started yet", () => {
 })
 
 it("shows 'Bidding closed' when the auction is closed", () => {
-  const timer = renderer.create(
+  const timer = renderWithWrappers(
     <BiddingThemeProvider>
       <Timer
         startsAt="2018-04-14T20:00:00+00:00"
@@ -138,7 +138,7 @@ it("shows 'Bidding closed' when the auction is closed", () => {
 })
 
 it("shows 'In progress' when the auction is in live auction integration mode", () => {
-  const timer = renderer.create(
+  const timer = renderWithWrappers(
     <BiddingThemeProvider>
       <Timer
         startsAt="2018-04-14T20:00:00+00:00"
@@ -156,7 +156,7 @@ it("shows 'In progress' when the auction is in live auction integration mode", (
 })
 
 it("counts down to zero", () => {
-  const timer = renderer.create(
+  const timer = renderWithWrappers(
     <BiddingThemeProvider>
       <Timer endsAt="2018-05-14T10:23:10+00:00" />
     </BiddingThemeProvider>
@@ -178,7 +178,7 @@ it("shows month, date, and hour adjusted for the timezone where the user is", ()
 
   // Thursday, May 14, 2018 8:00:00.000 PM UTC
   // Thursday, May 14, 2018 1:00:00.000 PM PDT in LA
-  const timer = renderer.create(
+  const timer = renderWithWrappers(
     <BiddingThemeProvider>
       <Timer endsAt="2018-05-14T20:00:00+00:00" />
     </BiddingThemeProvider>
@@ -190,7 +190,7 @@ it("shows month, date, and hour adjusted for the timezone where the user is", ()
 it("displays the minutes when the sale does not end on the hour", () => {
   mockTimezone("America/New_York")
 
-  let timer = renderer.create(
+  let timer = renderWithWrappers(
     <BiddingThemeProvider>
       <Timer endsAt="2018-05-14T20:01:00+00:00" />
     </BiddingThemeProvider>
@@ -198,7 +198,7 @@ it("displays the minutes when the sale does not end on the hour", () => {
 
   expect(getTimerLabel(timer)).toEqual("Ends May 14, 4:01 PM EDT")
 
-  timer = renderer.create(
+  timer = renderWithWrappers(
     <BiddingThemeProvider>
       <Timer endsAt="2018-05-14T20:30:00+00:00" />
     </BiddingThemeProvider>
@@ -210,7 +210,7 @@ it("displays the minutes when the sale does not end on the hour", () => {
 it("omits the minutes when the sale ends on the hour", () => {
   mockTimezone("America/New_York")
 
-  const timer = renderer.create(
+  const timer = renderWithWrappers(
     <BiddingThemeProvider>
       <Timer endsAt="2018-05-14T20:00:00+00:00" />
     </BiddingThemeProvider>

--- a/src/lib/Components/Bidding/Components/__tests__/Title-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/Title-tests.tsx
@@ -1,13 +1,13 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import { Title } from "../Title"
 
 import { BiddingThemeProvider } from "../BiddingThemeProvider"
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <BiddingThemeProvider>
       <Title>Confirm your bid</Title>
     </BiddingThemeProvider>

--- a/src/lib/Components/Bidding/Screens/__tests__/BidResult-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/BidResult-tests.tsx
@@ -3,9 +3,9 @@ import { BidResult_sale_artwork } from "__generated__/BidResult_sale_artwork.gra
 // @ts-ignore STRICTNESS_MIGRATION
 import { shallow } from "enzyme"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { NativeModules } from "react-native"
-import * as renderer from "react-test-renderer"
 import { BiddingThemeProvider } from "../../Components/BiddingThemeProvider"
 import { BidderPositionResult } from "../../types"
 import { BidResult } from "../BidResult"
@@ -63,7 +63,7 @@ describe("BidResult component", () => {
   describe("high bidder", () => {
     // marking this as pending since this component depends on the Timer component that depends on local timezone
     xit("renders winning screen properly", () => {
-      renderer.create(
+      renderWithWrappers(
         <BiddingThemeProvider>
           <BidResult
             refreshBidderInfo={refreshBidderInfoMock}
@@ -91,7 +91,7 @@ describe("BidResult component", () => {
     })
 
     it("dismisses the controller when the continue button is pressed", () => {
-      const bidResult = renderer.create(
+      const bidResult = renderWithWrappers(
         <BiddingThemeProvider>
           <BidResult
             refreshBidderInfo={refreshBidderInfoMock}
@@ -116,7 +116,7 @@ describe("BidResult component", () => {
   describe("low bidder", () => {
     // marking this as pending since this component depends on the Timer component that depends on local timezone
     xit("renders without throwing an error", () => {
-      renderer.create(
+      renderWithWrappers(
         <BiddingThemeProvider>
           <BidResult
             refreshBidderInfo={refreshBidderInfoMock}
@@ -144,7 +144,7 @@ describe("BidResult component", () => {
     })
 
     it("pops to root when bid-again button is pressed", () => {
-      const bidResult = renderer.create(
+      const bidResult = renderWithWrappers(
         <BiddingThemeProvider>
           <BidResult
             refreshBidderInfo={refreshBidderInfoMock}
@@ -167,7 +167,7 @@ describe("BidResult component", () => {
   describe("live bidding has started", () => {
     // marking this as pending since this component depends on the Timer component that depends on local timezone
     xit("renders without throwing an error", () => {
-      renderer.create(
+      renderWithWrappers(
         <BiddingThemeProvider>
           <BidResult
             refreshBidderInfo={refreshBidderInfoMock}
@@ -196,7 +196,7 @@ describe("BidResult component", () => {
 
     it("dismisses controller and presents live interface when continue button is pressed", () => {
       NativeModules.Emission.predictionURL = "https://live-staging.artsy.net"
-      const bidResult = renderer.create(
+      const bidResult = renderWithWrappers(
         <BiddingThemeProvider>
           <BidResult
             refreshBidderInfo={refreshBidderInfoMock}

--- a/src/lib/Components/Bidding/Screens/__tests__/BillingAddress-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/BillingAddress-tests.tsx
@@ -1,7 +1,7 @@
 import { Sans, Serif } from "@artsy/palette"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { TextInput, TouchableWithoutFeedback } from "react-native"
-import * as renderer from "react-test-renderer"
 
 import { Button } from "@artsy/palette"
 import { FakeNavigator } from "../../__tests__/Helpers/FakeNavigator"
@@ -20,7 +20,7 @@ const selectCountry = (component, navigator, country) => {
 }
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <BiddingThemeProvider>
       <BillingAddress />
     </BiddingThemeProvider>
@@ -28,7 +28,7 @@ it("renders without throwing an error", () => {
 })
 
 it("shows an error message for each field", () => {
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <BillingAddress />
     </BiddingThemeProvider>
@@ -47,7 +47,7 @@ it("calls the onSubmit() callback with billing address when ADD BILLING ADDRESS 
   const fakeNavigator = new FakeNavigator()
   const onSubmitMock = jest.fn()
 
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <BillingAddress onSubmit={onSubmitMock} navigator={fakeNavigator as any} />
     </BiddingThemeProvider>
@@ -70,7 +70,7 @@ it("calls the onSubmit() callback with billing address when ADD BILLING ADDRESS 
 it("updates the validation for country when coming back from the select country screen", () => {
   const fakeNavigator = new FakeNavigator()
 
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <BillingAddress onSubmit={() => null} navigator={fakeNavigator as any} />
     </BiddingThemeProvider>
@@ -95,7 +95,7 @@ it("updates the validation for country when coming back from the select country 
 })
 
 it("pre-fills the fields if initial billing address is provided", () => {
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <BillingAddress billingAddress={billingAddress} />
     </BiddingThemeProvider>

--- a/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
@@ -3,11 +3,11 @@ jest.mock("lib/relay/createEnvironment", () => ({
 }))
 
 import { Button, Sans, Serif } from "@artsy/palette"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { merge } from "lodash"
 import React from "react"
 import { NativeModules, Text, TouchableWithoutFeedback } from "react-native"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import { LinkText } from "../../../Text/LinkText"
 import { BidInfoRow } from "../../Components/BidInfoRow"
@@ -68,7 +68,7 @@ const findPlaceBidButton = component => {
 
 // @ts-ignore STRICTNESS_MIGRATION
 const mountConfirmBidComponent = props => {
-  return renderer.create(
+  return renderWithWrappers(
     <BiddingThemeProvider>
       <ConfirmBid {...props} />
     </BiddingThemeProvider>
@@ -111,7 +111,7 @@ it("displays the artwork title correctly with date", () => {
 
 it("displays the artwork title correctly without date", () => {
   const datelessProps = merge({}, initialProps, { sale_artwork: { artwork: { date: null } } })
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <ConfirmBid {...datelessProps} />
     </BiddingThemeProvider>

--- a/src/lib/Components/Bidding/Screens/__tests__/CreditCardForm-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/CreditCardForm-tests.tsx
@@ -1,10 +1,8 @@
 import { Button, Sans } from "@artsy/palette"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import ReactTestRenderer from "react-test-renderer"
 
 import { CreditCardForm } from "../CreditCardForm"
-
-/* tslint:disable use-wrapped-components */
 
 jest.mock("tipsi-stripe", () => ({
   setOptions: jest.fn(),
@@ -23,13 +21,13 @@ afterEach(() => {
 })
 
 it("renders without throwing an error", () => {
-  ReactTestRenderer.create(<CreditCardForm onSubmit={onSubmitMock} />)
+  renderWithWrappers(<CreditCardForm onSubmit={onSubmitMock} />)
 })
 
 it("calls the onSubmit() callback with valid credit card when ADD CREDIT CARD is tapped", () => {
   stripe.createTokenWithCard.mockReturnValueOnce(stripeToken)
   jest.useFakeTimers()
-  const component = ReactTestRenderer.create(
+  const wrappedComponent = renderWithWrappers(
     <CreditCardForm
       onSubmit={onSubmitMock}
       navigator={
@@ -40,8 +38,9 @@ it("calls the onSubmit() callback with valid credit card when ADD CREDIT CARD is
     />
   )
 
-  component.root.instance.setState({ valid: true, params: creditCard })
-  component.root.findByType(Button).instance.props.onPress()
+  const component = wrappedComponent.root.findByType(CreditCardForm)
+  component.instance.setState({ valid: true, params: creditCard })
+  component.findByType(Button).instance.props.onPress()
 
   jest.runAllTicks()
 
@@ -51,7 +50,7 @@ it("calls the onSubmit() callback with valid credit card when ADD CREDIT CARD is
 it("is disabled while the form is invalid", () => {
   stripe.createTokenWithCard.mockReturnValueOnce(stripeToken)
   jest.useFakeTimers()
-  const component = ReactTestRenderer.create(
+  const wrappedComponent = renderWithWrappers(
     <CreditCardForm
       onSubmit={onSubmitMock}
       navigator={
@@ -62,14 +61,15 @@ it("is disabled while the form is invalid", () => {
     />
   )
 
-  component.root.instance.setState({ valid: false, params: creditCard })
-  expect(component.root.findByType(Button).props.disabled).toEqual(true)
+  const component = wrappedComponent.root.findByType(CreditCardForm)
+  component.instance.setState({ valid: false, params: creditCard })
+  expect(component.findByType(Button).props.disabled).toEqual(true)
 })
 
 it("is enabled while the form is valid", () => {
   stripe.createTokenWithCard.mockReturnValueOnce(stripeToken)
   jest.useFakeTimers()
-  const component = ReactTestRenderer.create(
+  const wrappedComponent = renderWithWrappers(
     <CreditCardForm
       onSubmit={onSubmitMock}
       navigator={
@@ -80,8 +80,9 @@ it("is enabled while the form is valid", () => {
     />
   )
 
-  component.root.instance.setState({ valid: true, params: creditCard })
-  expect(component.root.findByType(Button).props.disabled).toEqual(false)
+  const component = wrappedComponent.root.findByType(CreditCardForm)
+  component.instance.setState({ valid: true, params: creditCard })
+  expect(component.findByType(Button).props.disabled).toEqual(false)
 })
 
 it("shows an error when stripe's API returns an error", () => {
@@ -92,7 +93,7 @@ it("shows an error when stripe's API returns an error", () => {
     throw new Error("Error tokenizing card")
   })
   jest.useFakeTimers()
-  const component = ReactTestRenderer.create(
+  const wrappedComponent = renderWithWrappers(
     <CreditCardForm
       onSubmit={onSubmitMock}
       navigator={
@@ -103,11 +104,12 @@ it("shows an error when stripe's API returns an error", () => {
     />
   )
 
-  component.root.instance.setState({ valid: true, params: creditCard })
-  component.root.findByType(Button).instance.props.onPress()
+  const component = wrappedComponent.root.findByType(CreditCardForm)
+  component.instance.setState({ valid: true, params: creditCard })
+  component.findByType(Button).instance.props.onPress()
 
   jest.runAllTicks()
-  expect(component.root.findAllByType(Sans)[0].props.children).toEqual("There was an error. Please try again.")
+  expect(component.findAllByType(Sans)[0].props.children).toEqual("There was an error. Please try again.")
 })
 
 const creditCard = {

--- a/src/lib/Components/Bidding/Screens/__tests__/CreditCardForm-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/CreditCardForm-tests.tsx
@@ -1,8 +1,10 @@
 import { Button, Sans } from "@artsy/palette"
 import React from "react"
-import * as renderer from "react-test-renderer"
+import ReactTestRenderer from "react-test-renderer"
 
 import { CreditCardForm } from "../CreditCardForm"
+
+/* tslint:disable use-wrapped-components */
 
 jest.mock("tipsi-stripe", () => ({
   setOptions: jest.fn(),
@@ -21,13 +23,13 @@ afterEach(() => {
 })
 
 it("renders without throwing an error", () => {
-  renderer.create(<CreditCardForm onSubmit={onSubmitMock} />)
+  ReactTestRenderer.create(<CreditCardForm onSubmit={onSubmitMock} />)
 })
 
 it("calls the onSubmit() callback with valid credit card when ADD CREDIT CARD is tapped", () => {
   stripe.createTokenWithCard.mockReturnValueOnce(stripeToken)
   jest.useFakeTimers()
-  const component = renderer.create(
+  const component = ReactTestRenderer.create(
     <CreditCardForm
       onSubmit={onSubmitMock}
       navigator={
@@ -49,7 +51,7 @@ it("calls the onSubmit() callback with valid credit card when ADD CREDIT CARD is
 it("is disabled while the form is invalid", () => {
   stripe.createTokenWithCard.mockReturnValueOnce(stripeToken)
   jest.useFakeTimers()
-  const component = renderer.create(
+  const component = ReactTestRenderer.create(
     <CreditCardForm
       onSubmit={onSubmitMock}
       navigator={
@@ -67,7 +69,7 @@ it("is disabled while the form is invalid", () => {
 it("is enabled while the form is valid", () => {
   stripe.createTokenWithCard.mockReturnValueOnce(stripeToken)
   jest.useFakeTimers()
-  const component = renderer.create(
+  const component = ReactTestRenderer.create(
     <CreditCardForm
       onSubmit={onSubmitMock}
       navigator={
@@ -90,7 +92,7 @@ it("shows an error when stripe's API returns an error", () => {
     throw new Error("Error tokenizing card")
   })
   jest.useFakeTimers()
-  const component = renderer.create(
+  const component = ReactTestRenderer.create(
     <CreditCardForm
       onSubmit={onSubmitMock}
       navigator={

--- a/src/lib/Components/Bidding/Screens/__tests__/Registration-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/Registration-tests.tsx
@@ -1,9 +1,9 @@
 import { Button, Sans, Serif } from "@artsy/palette"
 import { Registration_me } from "__generated__/Registration_me.graphql"
 import { Registration_sale } from "__generated__/Registration_sale.graphql"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { NativeModules, Text, TouchableWithoutFeedback } from "react-native"
-import * as renderer from "react-test-renderer"
 import { BidInfoRow } from "../../Components/BidInfoRow"
 import { Checkbox } from "../../Components/Checkbox"
 import { BillingAddress } from "../BillingAddress"
@@ -48,7 +48,7 @@ beforeEach(() => {
 })
 
 it("renders properly for a user without a credit card", () => {
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <Registration {...initialPropsForUserWithoutCreditCard} />
     </BiddingThemeProvider>
@@ -58,7 +58,7 @@ it("renders properly for a user without a credit card", () => {
 })
 
 it("renders properly for a user with a credit card", () => {
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <Registration {...initialPropsForUserWithCreditCard} />
     </BiddingThemeProvider>
@@ -70,7 +70,7 @@ it("renders properly for a user with a credit card", () => {
 })
 
 it("renders properly for a verified user with a credit card", () => {
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <Registration
         {...initialProps}
@@ -89,13 +89,11 @@ it("renders properly for a verified user with a credit card", () => {
 })
 
 it("shows the billing address that the user typed in the billing address form", () => {
-  const billingAddressRow = renderer
-    .create(
-      <BiddingThemeProvider>
-        <Registration {...initialPropsForUserWithoutCreditCard} />
-      </BiddingThemeProvider>
-    )
-    .root.findAllByType(BidInfoRow)[1]
+  const billingAddressRow = renderWithWrappers(
+    <BiddingThemeProvider>
+      <Registration {...initialPropsForUserWithoutCreditCard} />
+    </BiddingThemeProvider>
+  ).root.findAllByType(BidInfoRow)[1]
   billingAddressRow.instance.props.onPress()
   // @ts-ignore STRICTNESS_MIGRATION
   expect(nextStep.component).toEqual(BillingAddress)
@@ -107,13 +105,11 @@ it("shows the billing address that the user typed in the billing address form", 
 })
 
 it("shows the credit card form when the user tap the edit text in the credit card row", () => {
-  const creditcardRow = renderer
-    .create(
-      <BiddingThemeProvider>
-        <Registration {...initialPropsForUserWithoutCreditCard} />
-      </BiddingThemeProvider>
-    )
-    .root.findAllByType(BidInfoRow)[0]
+  const creditcardRow = renderWithWrappers(
+    <BiddingThemeProvider>
+      <Registration {...initialPropsForUserWithoutCreditCard} />
+    </BiddingThemeProvider>
+  ).root.findAllByType(BidInfoRow)[0]
 
   creditcardRow.instance.props.onPress()
 
@@ -122,7 +118,7 @@ it("shows the credit card form when the user tap the edit text in the credit car
 })
 
 it("shows the option for entering payment information if the user does not have a credit card on file", () => {
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <Registration {...initialPropsForUserWithoutCreditCard} />
     </BiddingThemeProvider>
@@ -133,7 +129,7 @@ it("shows the option for entering payment information if the user does not have 
 })
 
 it("shows no option for entering payment information if the user has a credit card on file", () => {
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <Registration {...initialPropsForUserWithCreditCard} />
     </BiddingThemeProvider>
@@ -153,7 +149,7 @@ describe("when the sale requires identity verification", () => {
   }
 
   it("displays information about IDV if the user is not verified", () => {
-    const component = renderer.create(
+    const component = renderWithWrappers(
       <BiddingThemeProvider>
         <Registration {...propsWithIDVSale} me={{ ...me, identityVerified: false } as any} />
       </BiddingThemeProvider>
@@ -165,7 +161,7 @@ describe("when the sale requires identity verification", () => {
   })
 
   it("does not display information about IDV if the user is verified", () => {
-    const component = renderer.create(
+    const component = renderWithWrappers(
       <BiddingThemeProvider>
         <Registration {...propsWithIDVSale} me={{ ...me, identityVerified: true } as any} />
       </BiddingThemeProvider>
@@ -199,7 +195,7 @@ describe("when pressing register button", () => {
 
     stripe.createTokenWithCard.mockReturnValueOnce(stripeToken)
 
-    const component = renderer.create(
+    const component = renderWithWrappers(
       <BiddingThemeProvider>
         <Registration {...initialPropsForUserWithoutCreditCard} />
       </BiddingThemeProvider>
@@ -244,7 +240,7 @@ describe("when pressing register button", () => {
   })
 
   it("when there is a credit card on file, it commits mutation", () => {
-    const component = renderer.create(
+    const component = renderWithWrappers(
       <BiddingThemeProvider>
         <Registration {...initialPropsForUserWithCreditCard} />
       </BiddingThemeProvider>
@@ -261,7 +257,7 @@ describe("when pressing register button", () => {
     const navigator = { push: jest.fn() } as any
     relay.commitMutation = jest.fn()
 
-    const component = renderer.create(
+    const component = renderWithWrappers(
       <BiddingThemeProvider>
         <Registration {...initialPropsForUserWithoutCreditCard} navigator={navigator} />
       </BiddingThemeProvider>
@@ -306,7 +302,7 @@ describe("when pressing register button", () => {
       throw new Error("Error tokenizing card")
     })
     console.error = jest.fn() // Silences component logging.
-    const component = renderer.create(
+    const component = renderWithWrappers(
       <BiddingThemeProvider>
         <Registration {...initialPropsForUserWithoutCreditCard} />
       </BiddingThemeProvider>
@@ -339,7 +335,7 @@ describe("when pressing register button", () => {
       return null
     }) as any
 
-    const component = renderer.create(
+    const component = renderWithWrappers(
       <BiddingThemeProvider>
         <Registration {...initialPropsForUserWithoutCreditCard} />
       </BiddingThemeProvider>
@@ -376,7 +372,7 @@ describe("when pressing register button", () => {
       return null
     }) as any
 
-    const component = renderer.create(
+    const component = renderWithWrappers(
       <BiddingThemeProvider>
         <Registration {...initialPropsForUserWithoutCreditCard} />
       </BiddingThemeProvider>
@@ -405,7 +401,7 @@ describe("when pressing register button", () => {
       .fn()
       .mockImplementationOnce((_, { onError }) => onError(new TypeError("Network request failed")))
 
-    const component = renderer.create(
+    const component = renderWithWrappers(
       <BiddingThemeProvider>
         <Registration {...initialPropsForUserWithoutCreditCard} />
       </BiddingThemeProvider>
@@ -444,7 +440,7 @@ describe("when pressing register button", () => {
         return null
       }) as any
 
-    const component = renderer.create(
+    const component = renderWithWrappers(
       <BiddingThemeProvider>
         <Registration {...initialPropsForUserWithoutCreditCard} />
       </BiddingThemeProvider>
@@ -486,7 +482,7 @@ describe("when pressing register button", () => {
         return null
       }) as any
 
-    const component = renderer.create(
+    const component = renderWithWrappers(
       <BiddingThemeProvider>
         <Registration {...initialPropsForUserWithoutCreditCard} />
       </BiddingThemeProvider>
@@ -528,7 +524,7 @@ describe("when pressing register button", () => {
         return null
       }) as any
 
-    const component = renderer.create(
+    const component = renderWithWrappers(
       <BiddingThemeProvider>
         <Registration {...initialPropsForUserWithoutCreditCard} />
       </BiddingThemeProvider>
@@ -558,7 +554,7 @@ describe("when pressing register button", () => {
     console.error = jest.fn() // Silences component logging.
     relay.commitMutation = jest.fn().mockImplementation((_, { onCompleted }) => onCompleted({}, [error]))
 
-    const component = renderer.create(
+    const component = renderWithWrappers(
       <BiddingThemeProvider>
         <Registration {...initialPropsForUserWithCreditCard} />
       </BiddingThemeProvider>
@@ -588,7 +584,7 @@ describe("when pressing register button", () => {
       return null
     }) as any
 
-    const component = renderer.create(
+    const component = renderWithWrappers(
       <BiddingThemeProvider>
         <Registration {...initialPropsForUserWithCreditCard} />
       </BiddingThemeProvider>
@@ -616,7 +612,7 @@ describe("when pressing register button", () => {
       return null
     }) as any
 
-    const component = renderer.create(
+    const component = renderWithWrappers(
       <BiddingThemeProvider>
         <Registration {...initialPropsForUserWithCreditCard} />
       </BiddingThemeProvider>
@@ -655,7 +651,7 @@ describe("when pressing register button", () => {
       return null
     }) as any
 
-    const component = renderer.create(
+    const component = renderWithWrappers(
       <BiddingThemeProvider>
         <Registration {...propsWithIDVSale} />
       </BiddingThemeProvider>
@@ -682,7 +678,7 @@ describe("when pressing register button", () => {
       return null
     }) as any
 
-    const component = renderer.create(
+    const component = renderWithWrappers(
       <BiddingThemeProvider>
         <Registration {...initialPropsForUserWithCreditCard} />
       </BiddingThemeProvider>
@@ -722,7 +718,7 @@ describe("when pressing register button", () => {
       return null
     }) as any
 
-    const component = renderer.create(
+    const component = renderWithWrappers(
       <BiddingThemeProvider>
         <Registration {...propsWithIDVSale} />
       </BiddingThemeProvider>

--- a/src/lib/Components/Bidding/Screens/__tests__/RegistrationResult-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/RegistrationResult-tests.tsx
@@ -1,5 +1,5 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
 
 import { Button } from "@artsy/palette"
 import { RegistrationResult, RegistrationStatus } from "../RegistrationResult"
@@ -19,7 +19,7 @@ import { Icon20 } from "../../Components/Icon"
 
 describe("Registration result component", () => {
   it("renders registration pending properly", () => {
-    const tree = renderer.create(
+    const tree = renderWithWrappers(
       <BiddingThemeProvider>
         <RegistrationResult status={RegistrationStatus.RegistrationStatusPending} needsIdentityVerification={false} />
       </BiddingThemeProvider>
@@ -32,7 +32,7 @@ describe("Registration result component", () => {
   })
 
   it("renders registration pending with an explanation about IDV", () => {
-    const tree = renderer.create(
+    const tree = renderWithWrappers(
       <BiddingThemeProvider>
         <RegistrationResult status={RegistrationStatus.RegistrationStatusPending} needsIdentityVerification />
       </BiddingThemeProvider>
@@ -46,7 +46,7 @@ describe("Registration result component", () => {
   })
 
   it("does not render the icon when the registration status is pending", () => {
-    const component = renderer.create(
+    const component = renderWithWrappers(
       <BiddingThemeProvider>
         <RegistrationResult status={RegistrationStatus.RegistrationStatusPending} />
       </BiddingThemeProvider>
@@ -56,7 +56,7 @@ describe("Registration result component", () => {
   })
 
   it("renders registration complete properly", () => {
-    const tree = renderer.create(
+    const tree = renderWithWrappers(
       <BiddingThemeProvider>
         <RegistrationResult status={RegistrationStatus.RegistrationStatusComplete} />
       </BiddingThemeProvider>
@@ -65,7 +65,7 @@ describe("Registration result component", () => {
   })
 
   it("renders registration error properly", () => {
-    const tree = renderer.create(
+    const tree = renderWithWrappers(
       <BiddingThemeProvider>
         <RegistrationResult status={RegistrationStatus.RegistrationStatusError} />
       </BiddingThemeProvider>
@@ -77,7 +77,7 @@ describe("Registration result component", () => {
   })
 
   it("renders an error screen when the status is a network error", () => {
-    const tree = renderer.create(
+    const tree = renderWithWrappers(
       <BiddingThemeProvider>
         <RegistrationResult status={RegistrationStatus.RegistrationStatusNetworkError} />
       </BiddingThemeProvider>
@@ -91,7 +91,7 @@ describe("Registration result component", () => {
     Linking.canOpenURL = jest.fn().mockReturnValue(Promise.resolve(true))
     Linking.openURL = jest.fn()
 
-    const component = renderer.create(
+    const component = renderWithWrappers(
       <BiddingThemeProvider>
         <RegistrationResult status={RegistrationStatus.RegistrationStatusError} />
       </BiddingThemeProvider>
@@ -102,7 +102,7 @@ describe("Registration result component", () => {
 
   it("dismisses the controller when the continue button is pressed", () => {
     jest.useFakeTimers()
-    const component = renderer.create(
+    const component = renderWithWrappers(
       <BiddingThemeProvider>
         <RegistrationResult status={RegistrationStatus.RegistrationStatusComplete} />
       </BiddingThemeProvider>

--- a/src/lib/Components/Bidding/Screens/__tests__/SelectCountry-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/SelectCountry-tests.tsx
@@ -1,12 +1,12 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { TextInput } from "react-native"
-import * as renderer from "react-test-renderer"
 import { SelectCountry } from "../SelectCountry"
 
 import { BiddingThemeProvider } from "../../Components/BiddingThemeProvider"
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <BiddingThemeProvider>
       <SelectCountry navigator={{} as any} />
     </BiddingThemeProvider>
@@ -14,7 +14,7 @@ it("renders without throwing an error", () => {
 })
 
 it("pre-populates the country field if initial country is provided", () => {
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <SelectCountry
         country={{

--- a/src/lib/Components/Bidding/Screens/__tests__/SelectMaxBid-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/SelectMaxBid-tests.tsx
@@ -2,9 +2,9 @@ jest.mock("lib/Components/Bidding/Screens/ConfirmBid/PriceSummary", () => ({
   PriceSummary: () => null,
 }))
 
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 import { FakeNavigator } from "../../__tests__/Helpers/FakeNavigator"
 
 import { Button } from "@artsy/palette"
@@ -75,7 +75,7 @@ beforeEach(() => {
 })
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <BiddingThemeProvider>
       <SelectMaxBid me={Me} sale_artwork={SaleArtwork} navigator={fakeNavigator as any} relay={fakeRelay as any} />
     </BiddingThemeProvider>
@@ -83,17 +83,18 @@ it("renders without throwing an error", () => {
 })
 
 it("shows a spinner while fetching new bid increments", () => {
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <SelectMaxBid me={Me} sale_artwork={SaleArtwork} navigator={fakeNavigator as any} relay={fakeRelay as any} />
   )
 
-  component.root.instance.setState({ isRefreshingSaleArtwork: true })
+  const selectBidComponent = component.root.findByType(SelectMaxBid)
+  selectBidComponent.instance.setState({ isRefreshingSaleArtwork: true })
 
   expect(component.root.findByType(Spinner)).toBeDefined()
 })
 
 it("refetches in next component's refreshSaleArtwork", () => {
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <SelectMaxBid me={Me} sale_artwork={SaleArtwork} navigator={fakeNavigator as any} relay={fakeRelay as any} />
     </BiddingThemeProvider>
@@ -110,7 +111,7 @@ it("refetches in next component's refreshSaleArtwork", () => {
 })
 
 it("removes the spinner once the refetch is complete", () => {
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <SelectMaxBid me={Me} sale_artwork={SaleArtwork} navigator={fakeNavigator as any} relay={fakeRelay as any} />
     </BiddingThemeProvider>

--- a/src/lib/Components/Bidding/Screens/__tests__/SelectMaxBidEdit-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/SelectMaxBidEdit-tests.tsx
@@ -1,6 +1,6 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 import { FakeNavigator } from "../../__tests__/Helpers/FakeNavigator"
 
 import { MaxBidPicker } from "../../Components/MaxBidPicker"
@@ -40,7 +40,7 @@ beforeEach(() => {
 })
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <BiddingThemeProvider>
       <SelectMaxBidEdit {...initialProps} />
     </BiddingThemeProvider>
@@ -48,7 +48,7 @@ it("renders without throwing an error", () => {
 })
 
 it("passes the correct selection", () => {
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <BiddingThemeProvider>
       <SelectMaxBidEdit {...initialProps} selectedBidIndex={3} />
     </BiddingThemeProvider>

--- a/src/lib/Components/Bidding/__tests__/BidFlow-tests.tsx
+++ b/src/lib/Components/Bidding/__tests__/BidFlow-tests.tsx
@@ -27,7 +27,6 @@ jest.mock("tipsi-stripe", () => ({
 // @ts-ignore STRICTNESS_MIGRATION
 import stripe from "tipsi-stripe"
 
-import { Theme } from "@artsy/palette"
 import { BidderPositionQueryResponse } from "__generated__/BidderPositionQuery.graphql"
 import { waitUntil } from "lib/tests/waitUntil"
 
@@ -53,15 +52,13 @@ beforeEach(() => {
 
 it("allows bidders with a qualified credit card to bid", async () => {
   let screen = renderWithWrappers(
-    <Theme>
-      <SelectMaxBid
-        me={Me.qualifiedUser as any}
-        sale_artwork={SaleArtwork as any}
-        navigator={fakeNavigator as any}
-        // @ts-ignore STRICTNESS_MIGRATION
-        relay={fakeRelay as any}
-      />
-    </Theme>
+    <SelectMaxBid
+      me={Me.qualifiedUser as any}
+      sale_artwork={SaleArtwork as any}
+      navigator={fakeNavigator as any}
+      // @ts-ignore STRICTNESS_MIGRATION
+      relay={fakeRelay as any}
+    />
   )
 
   screen.root.findByType(MaxBidPicker).instance.props.onValueChange(null, 2)
@@ -89,15 +86,13 @@ it("allows bidders with a qualified credit card to bid", async () => {
 
 it("allows bidders without a qualified credit card to register a card and bid", async () => {
   let screen = renderWithWrappers(
-    <Theme>
-      <SelectMaxBid
-        me={Me.unqualifiedUser as any}
-        sale_artwork={SaleArtwork as any}
-        navigator={fakeNavigator as any}
-        // @ts-ignore STRICTNESS_MIGRATION
-        relay={fakeRelay as any}
-      />
-    </Theme>
+    <SelectMaxBid
+      me={Me.unqualifiedUser as any}
+      sale_artwork={SaleArtwork as any}
+      navigator={fakeNavigator as any}
+      // @ts-ignore STRICTNESS_MIGRATION
+      relay={fakeRelay as any}
+    />
   )
 
   screen.root.findByType(MaxBidPicker).instance.props.onValueChange(null, 2)

--- a/src/lib/Components/Bidding/__tests__/BidFlow-tests.tsx
+++ b/src/lib/Components/Bidding/__tests__/BidFlow-tests.tsx
@@ -2,9 +2,9 @@ jest.mock("lib/Components/Bidding/Screens/ConfirmBid/PriceSummary", () => ({
   PriceSummary: () => null,
 }))
 
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import { Button } from "@artsy/palette"
 import relay from "react-relay"
@@ -52,7 +52,7 @@ beforeEach(() => {
 })
 
 it("allows bidders with a qualified credit card to bid", async () => {
-  let screen = renderer.create(
+  let screen = renderWithWrappers(
     <Theme>
       <SelectMaxBid
         me={Me.qualifiedUser as any}
@@ -88,7 +88,7 @@ it("allows bidders with a qualified credit card to bid", async () => {
 })
 
 it("allows bidders without a qualified credit card to register a card and bid", async () => {
-  let screen = renderer.create(
+  let screen = renderWithWrappers(
     <Theme>
       <SelectMaxBid
         me={Me.unqualifiedUser as any}

--- a/src/lib/Components/Bidding/__tests__/Helpers/FakeNavigator.tsx
+++ b/src/lib/Components/Bidding/__tests__/Helpers/FakeNavigator.tsx
@@ -1,7 +1,7 @@
 import { Theme } from "@artsy/palette"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { Route } from "react-native"
-import * as renderer from "react-test-renderer"
 
 export class FakeNavigator {
   private stack: Route[] = []
@@ -35,7 +35,7 @@ export class FakeNavigator {
   nextStep() {
     const currentRoute = this.stack[this.stack.length - 1]
 
-    return renderer.create(
+    return renderWithWrappers(
       <Theme>
         {React.createElement(currentRoute.component as any /* STRICTNESS_MIGRATION */, {
           ...currentRoute.passProps,

--- a/src/lib/Components/Bidding/__tests__/Helpers/FakeNavigator.tsx
+++ b/src/lib/Components/Bidding/__tests__/Helpers/FakeNavigator.tsx
@@ -1,4 +1,3 @@
-import { Theme } from "@artsy/palette"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { Route } from "react-native"
@@ -36,7 +35,7 @@ export class FakeNavigator {
     const currentRoute = this.stack[this.stack.length - 1]
 
     return renderWithWrappers(
-      <Theme>
+      <>
         {React.createElement(currentRoute.component as any /* STRICTNESS_MIGRATION */, {
           ...currentRoute.passProps,
           nextScreen: true,
@@ -45,7 +44,7 @@ export class FakeNavigator {
             environment: null,
           },
         })}
-      </Theme>
+      </>
     )
   }
 }

--- a/src/lib/Components/Buttons/__tests__/CaretButton-tests.tsx
+++ b/src/lib/Components/Buttons/__tests__/CaretButton-tests.tsx
@@ -3,16 +3,11 @@ import React from "react"
 
 import { CaretButton } from "../CaretButton"
 
-import { Theme } from "@artsy/palette"
 import { extractText } from "lib/tests/extractText"
 
 describe("CaretButton", () => {
   it("renders properly", () => {
-    const button = renderWithWrappers(
-      <Theme>
-        <CaretButton text="I am a caret button" />
-      </Theme>
-    )
+    const button = renderWithWrappers(<CaretButton text="I am a caret button" />)
     expect(extractText(button.root)).toContain("I am a caret button")
   })
 })

--- a/src/lib/Components/Buttons/__tests__/CaretButton-tests.tsx
+++ b/src/lib/Components/Buttons/__tests__/CaretButton-tests.tsx
@@ -1,5 +1,5 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
 
 import { CaretButton } from "../CaretButton"
 
@@ -8,7 +8,7 @@ import { extractText } from "lib/tests/extractText"
 
 describe("CaretButton", () => {
   it("renders properly", () => {
-    const button = renderer.create(
+    const button = renderWithWrappers(
       <Theme>
         <CaretButton text="I am a caret button" />
       </Theme>

--- a/src/lib/Components/Buttons/__tests__/DarkNavigationButton-tests.tsx
+++ b/src/lib/Components/Buttons/__tests__/DarkNavigationButton-tests.tsx
@@ -10,14 +10,8 @@ jest.mock("lib/NativeModules/SwitchBoard", () => ({
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import DarkNavigationButton from "../DarkNavigationButton"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <DarkNavigationButton title={"uI am a navigation button"} href="/some/path" />
-    </Theme>
-  )
+  renderWithWrappers(<DarkNavigationButton title={"uI am a navigation button"} href="/some/path" />)
 })
 
 describe("routing", () => {

--- a/src/lib/Components/Buttons/__tests__/DarkNavigationButton-tests.tsx
+++ b/src/lib/Components/Buttons/__tests__/DarkNavigationButton-tests.tsx
@@ -1,7 +1,7 @@
 import "react-native"
 
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
 
 jest.mock("lib/NativeModules/SwitchBoard", () => ({
   presentNavigationViewController: jest.fn(),
@@ -13,7 +13,7 @@ import DarkNavigationButton from "../DarkNavigationButton"
 import { Theme } from "@artsy/palette"
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <DarkNavigationButton title={"uI am a navigation button"} href="/some/path" />
     </Theme>

--- a/src/lib/Components/Gene/__tests__/About-tests.tsx
+++ b/src/lib/Components/Gene/__tests__/About-tests.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import "react-native"
 
 // Note: test renderer must be required after react-native.
-import * as renderer from "react-test-renderer"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 
 import About from "../About"
 
@@ -44,7 +44,7 @@ it("renders without throwing a error", () => {
     ],
   }
 
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <About gene={gene as any} />
     </Theme>

--- a/src/lib/Components/Gene/__tests__/About-tests.tsx
+++ b/src/lib/Components/Gene/__tests__/About-tests.tsx
@@ -6,8 +6,6 @@ import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 
 import About from "../About"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing a error", () => {
   const gene = {
     description: `Deep time refers to the concept of an expansive time that stretches far beyond human history to
@@ -44,9 +42,5 @@ it("renders without throwing a error", () => {
     ],
   }
 
-  renderWithWrappers(
-    <Theme>
-      <About gene={gene as any} />
-    </Theme>
-  )
+  renderWithWrappers(<About gene={gene as any} />)
 })

--- a/src/lib/Components/Gene/__tests__/Biography-tests.tsx
+++ b/src/lib/Components/Gene/__tests__/Biography-tests.tsx
@@ -5,15 +5,9 @@ import React from "react"
 
 import Biography from "../Biography"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing a error", () => {
   const gene = {
     description: "Watercolor painting is very nice",
   }
-  renderWithWrappers(
-    <Theme>
-      <Biography gene={gene as any} />
-    </Theme>
-  )
+  renderWithWrappers(<Biography gene={gene as any} />)
 })

--- a/src/lib/Components/Gene/__tests__/Biography-tests.tsx
+++ b/src/lib/Components/Gene/__tests__/Biography-tests.tsx
@@ -1,7 +1,7 @@
 import "react-native"
 
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
 
 import Biography from "../Biography"
 
@@ -11,7 +11,7 @@ it("renders without throwing a error", () => {
   const gene = {
     description: "Watercolor painting is very nice",
   }
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <Biography gene={gene as any} />
     </Theme>

--- a/src/lib/Components/Gene/__tests__/Header-tests.tsx
+++ b/src/lib/Components/Gene/__tests__/Header-tests.tsx
@@ -3,8 +3,6 @@ import React from "react"
 
 import Header from "../Header"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing a error", () => {
   const gene = {
     id: "gene-deep-time",
@@ -13,9 +11,5 @@ it("renders without throwing a error", () => {
     name: "Deep Time",
   }
 
-  renderWithWrappers(
-    <Theme>
-      <Header gene={gene as any} shortForm={false} />
-    </Theme>
-  )
+  renderWithWrappers(<Header gene={gene as any} shortForm={false} />)
 })

--- a/src/lib/Components/Gene/__tests__/Header-tests.tsx
+++ b/src/lib/Components/Gene/__tests__/Header-tests.tsx
@@ -1,5 +1,5 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
 
 import Header from "../Header"
 
@@ -13,7 +13,7 @@ it("renders without throwing a error", () => {
     name: "Deep Time",
   }
 
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <Header gene={gene as any} shortForm={false} />
     </Theme>

--- a/src/lib/Components/Home/ArtistRails/__tests__/ArtistCard-tests.tsx
+++ b/src/lib/Components/Home/ArtistRails/__tests__/ArtistCard-tests.tsx
@@ -4,14 +4,8 @@ import "react-native"
 
 import { ArtistCard } from "../ArtistCard"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing a error", () => {
-  renderWithWrappers(
-    <Theme>
-      <ArtistCard artist={artistProps().artist as any} />
-    </Theme>
-  )
+  renderWithWrappers(<ArtistCard artist={artistProps().artist as any} />)
 })
 
 const artistProps = () => {

--- a/src/lib/Components/Home/ArtistRails/__tests__/ArtistCard-tests.tsx
+++ b/src/lib/Components/Home/ArtistRails/__tests__/ArtistCard-tests.tsx
@@ -1,13 +1,13 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import { ArtistCard } from "../ArtistCard"
 
 import { Theme } from "@artsy/palette"
 
 it("renders without throwing a error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <ArtistCard artist={artistProps().artist as any} />
     </Theme>

--- a/src/lib/Components/Inbox/ActiveBids/__tests__/ActiveBid-tests.tsx
+++ b/src/lib/Components/Inbox/ActiveBids/__tests__/ActiveBid-tests.tsx
@@ -3,23 +3,14 @@ import React from "react"
 
 import ActiveBid from "../ActiveBid"
 
-import { Theme } from "@artsy/palette"
 import { extractText } from "lib/tests/extractText"
 
 it("renders without throwing a error", () => {
-  renderWithWrappers(
-    <Theme>
-      <ActiveBid bid={bid()} />
-    </Theme>
-  )
+  renderWithWrappers(<ActiveBid bid={bid()} />)
 })
 
 it("looks right for bids in live open auctions", () => {
-  const tree = renderWithWrappers(
-    <Theme>
-      <ActiveBid bid={bid(true)} />
-    </Theme>
-  )
+  const tree = renderWithWrappers(<ActiveBid bid={bid(true)} />)
   expect(extractText(tree.root)).toMatch("Live bidding now open")
 })
 

--- a/src/lib/Components/Inbox/ActiveBids/__tests__/ActiveBid-tests.tsx
+++ b/src/lib/Components/Inbox/ActiveBids/__tests__/ActiveBid-tests.tsx
@@ -1,5 +1,5 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
 
 import ActiveBid from "../ActiveBid"
 
@@ -7,7 +7,7 @@ import { Theme } from "@artsy/palette"
 import { extractText } from "lib/tests/extractText"
 
 it("renders without throwing a error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <ActiveBid bid={bid()} />
     </Theme>
@@ -15,7 +15,7 @@ it("renders without throwing a error", () => {
 })
 
 it("looks right for bids in live open auctions", () => {
-  const tree = renderer.create(
+  const tree = renderWithWrappers(
     <Theme>
       <ActiveBid bid={bid(true)} />
     </Theme>

--- a/src/lib/Components/Inbox/Conversations/Preview/Attachment/__tests__/ImagePreview-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/Attachment/__tests__/ImagePreview-tests.tsx
@@ -1,13 +1,13 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import { ImagePreview } from "../ImagePreview"
 
 import { Theme } from "@artsy/palette"
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <ImagePreview attachment={attachment as any} />
     </Theme>

--- a/src/lib/Components/Inbox/Conversations/Preview/Attachment/__tests__/ImagePreview-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/Attachment/__tests__/ImagePreview-tests.tsx
@@ -4,14 +4,8 @@ import "react-native"
 
 import { ImagePreview } from "../ImagePreview"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <ImagePreview attachment={attachment as any} />
-    </Theme>
-  )
+  renderWithWrappers(<ImagePreview attachment={attachment as any} />)
 })
 
 const attachment = {

--- a/src/lib/Components/Inbox/Conversations/Preview/Attachment/__tests__/PDFPreview-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/Attachment/__tests__/PDFPreview-tests.tsx
@@ -1,13 +1,13 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import PDFPreview from "../PDFPreview"
 
 import { Theme } from "@artsy/palette"
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <PDFPreview attachment={attachment as any} />
     </Theme>

--- a/src/lib/Components/Inbox/Conversations/Preview/Attachment/__tests__/PDFPreview-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/Attachment/__tests__/PDFPreview-tests.tsx
@@ -4,14 +4,8 @@ import "react-native"
 
 import PDFPreview from "../PDFPreview"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <PDFPreview attachment={attachment as any} />
-    </Theme>
-  )
+  renderWithWrappers(<PDFPreview attachment={attachment as any} />)
 })
 
 const attachment = {

--- a/src/lib/Components/Inbox/Conversations/Preview/__tests__/ArtworkPreview-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/__tests__/ArtworkPreview-tests.tsx
@@ -1,6 +1,6 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import ArtworkPreview from "../ArtworkPreview"
 
@@ -8,12 +8,12 @@ import { TouchableHighlight } from "react-native"
 
 describe("concerning selection handling", () => {
   it("passes a onPress handler to the touchable component if an onSelected handler is given", () => {
-    const tree = renderer.create(<ArtworkPreview artwork={artwork as any} onSelected={() => null} />)
+    const tree = renderWithWrappers(<ArtworkPreview artwork={artwork as any} onSelected={() => null} />)
     expect(tree.root.findByType(TouchableHighlight).props.onPress).toBeTruthy()
   })
 
   it("does not pass a onPress handler to the touchable component if no onSelected handler is given", () => {
-    const tree = renderer.create(<ArtworkPreview artwork={artwork as any} />)
+    const tree = renderWithWrappers(<ArtworkPreview artwork={artwork as any} />)
     expect(tree.root.findByType(TouchableHighlight).props.onPress).toBeFalsy()
   })
 })

--- a/src/lib/Components/Inbox/Conversations/Preview/__tests__/ShowPreview-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/__tests__/ShowPreview-tests.tsx
@@ -1,13 +1,13 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import ShowPreview from "../ShowPreview"
 
 import { Theme } from "@artsy/palette"
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <ShowPreview show={show as any} />
     </Theme>

--- a/src/lib/Components/Inbox/Conversations/Preview/__tests__/ShowPreview-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/__tests__/ShowPreview-tests.tsx
@@ -4,14 +4,8 @@ import "react-native"
 
 import ShowPreview from "../ShowPreview"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <ShowPreview show={show as any} />
-    </Theme>
-  )
+  renderWithWrappers(<ShowPreview show={show as any} />)
 })
 
 const show = {

--- a/src/lib/Components/Inbox/Conversations/__tests__/Avatar-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/Avatar-tests.tsx
@@ -1,13 +1,13 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import Avatar from "../Avatar"
 
 import { Theme } from "@artsy/palette"
 
 it("renders without throwing a error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <Avatar isUser={true} initials={"MC"} />
     </Theme>

--- a/src/lib/Components/Inbox/Conversations/__tests__/Avatar-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/Avatar-tests.tsx
@@ -4,12 +4,6 @@ import "react-native"
 
 import Avatar from "../Avatar"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing a error", () => {
-  renderWithWrappers(
-    <Theme>
-      <Avatar isUser={true} initials={"MC"} />
-    </Theme>
-  )
+  renderWithWrappers(<Avatar isUser={true} initials={"MC"} />)
 })

--- a/src/lib/Components/Inbox/Conversations/__tests__/Composer-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/Composer-tests.tsx
@@ -7,14 +7,8 @@ jest.unmock("react-tracking")
 
 import Composer, { SendButton } from "../Composer"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing a error", () => {
-  renderWithWrappers(
-    <Theme>
-      <Composer />
-    </Theme>
-  )
+  renderWithWrappers(<Composer />)
 })
 
 describe("regarding the send button", () => {

--- a/src/lib/Components/Inbox/Conversations/__tests__/Composer-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/Composer-tests.tsx
@@ -1,7 +1,7 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { TextInput } from "react-native"
 import { TouchableWithoutFeedback } from "react-native"
-import * as renderer from "react-test-renderer"
 
 jest.unmock("react-tracking")
 
@@ -10,7 +10,7 @@ import Composer, { SendButton } from "../Composer"
 import { Theme } from "@artsy/palette"
 
 it("renders without throwing a error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <Composer />
     </Theme>
@@ -22,7 +22,7 @@ describe("regarding the send button", () => {
     const overrideText = "History repeats itself, first as tragedy, second as farce."
     // We're using 'dive' here to only fetch the component we want to test
     // This is because the component is wrapped by react-tracking, which changes the tree structure
-    const tree = renderer.create(<Composer value={overrideText} disabled={true} />)
+    const tree = renderWithWrappers(<Composer value={overrideText} disabled={true} />)
 
     expect(tree.root.findByType(SendButton).props.disabled).toBeTruthy()
   })
@@ -31,7 +31,7 @@ describe("regarding the send button", () => {
     const onSubmit = jest.fn()
     // We're using 'dive' here to only fetch the component we want to test
     // This is because the component is wrapped by react-tracking, which changes the tree structure
-    const tree = renderer.create(<Composer onSubmit={onSubmit} />)
+    const tree = renderWithWrappers(<Composer onSubmit={onSubmit} />)
     const text = "Don't trust everything you see, even salt looks like sugar"
     tree.root.findByType(TextInput).props.onChangeText(text)
     tree.root.findByType(TouchableWithoutFeedback).props.onPress()

--- a/src/lib/Components/Inbox/Conversations/__tests__/ConversationSnippet-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/ConversationSnippet-tests.tsx
@@ -5,22 +5,12 @@ import "react-native"
 
 import ConversationSnippet from "../ConversationSnippet"
 
-import { Theme } from "@artsy/palette"
-
 it("renders with an artwork without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <ConversationSnippet conversation={artworkConversation as any} onSelected={undefined} />
-    </Theme>
-  )
+  renderWithWrappers(<ConversationSnippet conversation={artworkConversation as any} onSelected={undefined} />)
 })
 
 it("renders with a show without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <ConversationSnippet conversation={showConversation as any} onSelected={undefined} />
-    </Theme>
-  )
+  renderWithWrappers(<ConversationSnippet conversation={showConversation as any} onSelected={undefined} />)
 })
 
 const artwork = {

--- a/src/lib/Components/Inbox/Conversations/__tests__/ConversationSnippet-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/ConversationSnippet-tests.tsx
@@ -1,14 +1,14 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import moment from "moment"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import ConversationSnippet from "../ConversationSnippet"
 
 import { Theme } from "@artsy/palette"
 
 it("renders with an artwork without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <ConversationSnippet conversation={artworkConversation as any} onSelected={undefined} />
     </Theme>
@@ -16,7 +16,7 @@ it("renders with an artwork without throwing an error", () => {
 })
 
 it("renders with a show without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <ConversationSnippet conversation={showConversation as any} onSelected={undefined} />
     </Theme>

--- a/src/lib/Components/Inbox/Conversations/__tests__/Conversations-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/Conversations-tests.tsx
@@ -1,17 +1,13 @@
-import React from "react"
-import "react-native"
-import * as renderer from "react-test-renderer"
-
-import { getTextTree } from "lib/utils/getTestWrapper"
-
-import { Conversations_me } from "__generated__/Conversations_me.graphql"
-import { Conversations } from "../Conversations"
-
 import { Theme } from "@artsy/palette"
+import { Conversations_me } from "__generated__/Conversations_me.graphql"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { getTextTree } from "lib/utils/getTestWrapper"
+import React from "react"
+import { Conversations } from "../Conversations"
 
 describe("messaging inbox", () => {
   it("renders without throwing a error", () => {
-    renderer.create(
+    renderWithWrappers(
       <Theme>
         <Conversations
           me={meProps}

--- a/src/lib/Components/Inbox/Conversations/__tests__/Conversations-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/Conversations-tests.tsx
@@ -1,4 +1,3 @@
-import { Theme } from "@artsy/palette"
 import { Conversations_me } from "__generated__/Conversations_me.graphql"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { getTextTree } from "lib/utils/getTestWrapper"
@@ -8,16 +7,14 @@ import { Conversations } from "../Conversations"
 describe("messaging inbox", () => {
   it("renders without throwing a error", () => {
     renderWithWrappers(
-      <Theme>
-        <Conversations
-          me={meProps}
-          relay={
-            {
-              hasMore: jest.fn(),
-            } as any
-          }
-        />
-      </Theme>
+      <Conversations
+        me={meProps}
+        relay={
+          {
+            hasMore: jest.fn(),
+          } as any
+        }
+      />
     )
   })
 

--- a/src/lib/Components/Inbox/Conversations/__tests__/Message-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/Message-tests.tsx
@@ -1,7 +1,7 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import moment from "moment"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import Message from "../Message"
 
@@ -30,7 +30,7 @@ it("renders without throwing an error", () => {
       payment_url: "https://www.adopt-cats.org/pay-here",
     },
   }
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <Message
         conversationId={"420"}

--- a/src/lib/Components/Inbox/Conversations/__tests__/Message-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/Message-tests.tsx
@@ -5,8 +5,6 @@ import "react-native"
 
 import Message from "../Message"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing an error", () => {
   // tslint:disable-next-line:max-line-length
   const messageBody =
@@ -31,15 +29,13 @@ it("renders without throwing an error", () => {
     },
   }
   renderWithWrappers(
-    <Theme>
-      <Message
-        conversationId={"420"}
-        initialText=""
-        firstMessage={false}
-        index={0}
-        senderName={senderName}
-        message={props as any}
-      />
-    </Theme>
+    <Message
+      conversationId={"420"}
+      initialText=""
+      firstMessage={false}
+      index={0}
+      senderName={senderName}
+      message={props as any}
+    />
   )
 })

--- a/src/lib/Components/Inbox/Conversations/__tests__/Messages-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/Messages-tests.tsx
@@ -1,13 +1,13 @@
 import React from "react"
 
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import "react-native"
-import * as renderer from "react-test-renderer"
 import Messages from "../Messages"
 
 import { Theme } from "@artsy/palette"
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <Messages conversation={props as any} />
     </Theme>

--- a/src/lib/Components/Inbox/Conversations/__tests__/Messages-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/Messages-tests.tsx
@@ -4,14 +4,8 @@ import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import "react-native"
 import Messages from "../Messages"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <Messages conversation={props as any} />
-    </Theme>
-  )
+  renderWithWrappers(<Messages conversation={props as any} />)
 })
 
 const props = {

--- a/src/lib/Components/Lists/__tests__/SavedItemRow-tests.tsx
+++ b/src/lib/Components/Lists/__tests__/SavedItemRow-tests.tsx
@@ -1,7 +1,6 @@
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 
-import { Theme } from "@artsy/palette"
 import { SavedItemRow } from "../SavedItemRow"
 
 const props = {
@@ -11,9 +10,5 @@ const props = {
 }
 
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <SavedItemRow {...props} />
-    </Theme>
-  )
+  renderWithWrappers(<SavedItemRow {...props} />)
 })

--- a/src/lib/Components/Lists/__tests__/SavedItemRow-tests.tsx
+++ b/src/lib/Components/Lists/__tests__/SavedItemRow-tests.tsx
@@ -1,5 +1,5 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
 
 import { Theme } from "@artsy/palette"
 import { SavedItemRow } from "../SavedItemRow"
@@ -11,7 +11,7 @@ const props = {
 }
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <SavedItemRow {...props} />
     </Theme>

--- a/src/lib/Components/LocationMap/__tests__/index-tests.tsx
+++ b/src/lib/Components/LocationMap/__tests__/index-tests.tsx
@@ -1,11 +1,11 @@
 import { Theme } from "@artsy/palette"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 import { LocationMap } from "../index"
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <LocationMap {...(data as any)} />
     </Theme>

--- a/src/lib/Components/LocationMap/__tests__/index-tests.tsx
+++ b/src/lib/Components/LocationMap/__tests__/index-tests.tsx
@@ -1,15 +1,10 @@
-import { Theme } from "@artsy/palette"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
 import { LocationMap } from "../index"
 
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <LocationMap {...(data as any)} />
-    </Theme>
-  )
+  renderWithWrappers(<LocationMap {...(data as any)} />)
 })
 
 const data = {

--- a/src/lib/Components/Modals/__tests__/LoadingModal-tests.tsx
+++ b/src/lib/Components/Modals/__tests__/LoadingModal-tests.tsx
@@ -1,4 +1,3 @@
-import { Theme } from "@artsy/palette"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
@@ -6,18 +5,10 @@ import LoadingModal from "../LoadingModal"
 
 describe("LoadingModal", () => {
   it("renders without throwing when invisible", () => {
-    renderWithWrappers(
-      <Theme>
-        <LoadingModal isVisible={false} />
-      </Theme>
-    )
+    renderWithWrappers(<LoadingModal isVisible={false} />)
   })
 
   it("renders without throwing when visible", () => {
-    renderWithWrappers(
-      <Theme>
-        <LoadingModal isVisible={false} />
-      </Theme>
-    )
+    renderWithWrappers(<LoadingModal isVisible={false} />)
   })
 })

--- a/src/lib/Components/Modals/__tests__/LoadingModal-tests.tsx
+++ b/src/lib/Components/Modals/__tests__/LoadingModal-tests.tsx
@@ -1,12 +1,12 @@
 import { Theme } from "@artsy/palette"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 import LoadingModal from "../LoadingModal"
 
 describe("LoadingModal", () => {
   it("renders without throwing when invisible", () => {
-    renderer.create(
+    renderWithWrappers(
       <Theme>
         <LoadingModal isVisible={false} />
       </Theme>
@@ -14,7 +14,7 @@ describe("LoadingModal", () => {
   })
 
   it("renders without throwing when visible", () => {
-    renderer.create(
+    renderWithWrappers(
       <Theme>
         <LoadingModal isVisible={false} />
       </Theme>

--- a/src/lib/Components/Show/__tests__/ShowArtistsPreview-tests.tsx
+++ b/src/lib/Components/Show/__tests__/ShowArtistsPreview-tests.tsx
@@ -1,11 +1,12 @@
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 import { Button } from "@artsy/palette"
 import { ShowArtistsPreviewTestsQuery } from "__generated__/ShowArtistsPreviewTestsQuery.graphql"
 import { ArtistListItem } from "lib/Components/ArtistListItem"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { ShowArtistsPreviewContainer as ShowArtistsPreview } from "../ShowArtistsPreview"
 
@@ -40,7 +41,7 @@ describe("ArtistsContainer", () => {
   })
 
   it("Renders the show artists", async () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],
@@ -62,7 +63,7 @@ describe("ArtistsContainer", () => {
   })
 
   it("commits a follow mutation", async () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],

--- a/src/lib/Components/Show/__tests__/ShowArtworksPreview-tests.tsx
+++ b/src/lib/Components/Show/__tests__/ShowArtworksPreview-tests.tsx
@@ -1,9 +1,10 @@
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 import { ShowArtworksPreviewTestsQuery } from "__generated__/ShowArtworksPreviewTestsQuery.graphql"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { ShowArtworksPreviewContainer as ShowArtworksPreview } from "../ShowArtworksPreview"
 
 jest.unmock("react-relay")
@@ -31,7 +32,7 @@ it("renders without throwing an error", async () => {
     />
   )
 
-  ReactTestRenderer.create(<TestRenderer />)
+  renderWithWrappers(<TestRenderer />)
   act(() => {
     env.mock.resolveMostRecentOperation({
       errors: [],

--- a/src/lib/Components/__tests__/ConnectivityBanner-tests.tsx
+++ b/src/lib/Components/__tests__/ConnectivityBanner-tests.tsx
@@ -1,12 +1,12 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 import ConnectivityBanner from "../ConnectivityBanner"
 
 import { Theme } from "@artsy/palette"
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <ConnectivityBanner />
     </Theme>

--- a/src/lib/Components/__tests__/ConnectivityBanner-tests.tsx
+++ b/src/lib/Components/__tests__/ConnectivityBanner-tests.tsx
@@ -3,12 +3,6 @@ import React from "react"
 import "react-native"
 import ConnectivityBanner from "../ConnectivityBanner"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <ConnectivityBanner />
-    </Theme>
-  )
+  renderWithWrappers(<ConnectivityBanner />)
 })

--- a/src/lib/Components/__tests__/Disappearable-tests.tsx
+++ b/src/lib/Components/__tests__/Disappearable-tests.tsx
@@ -1,13 +1,13 @@
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { Text } from "react-native"
-import { create } from "react-test-renderer"
 import { Disappearable } from "../Disappearable"
 
 describe("Disappearable", () => {
   const ref = { current: null as null | Disappearable }
   it(`disappears`, async () => {
-    const tree = create(
+    const tree = renderWithWrappers(
       <Disappearable ref={ref}>
         <Text>this is the content</Text>
       </Disappearable>

--- a/src/lib/Components/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/__tests__/FilterModal-tests.tsx
@@ -178,23 +178,21 @@ const MockFilterModalNavigator = ({ initialState }: InitialState) => {
 describe("Filter modal navigation flow", () => {
   it("allows users to navigate forward to sort screen from filter screen", () => {
     const filterScreen = renderWithWrappers(
-      <Theme>
-        <ArtworkFilterContext.Provider
-          value={{
-            state,
-            // @ts-ignore STRICTNESS_MIGRATION
-            dispatch: null,
-          }}
-        >
-          <FilterOptions
-            id="id"
-            slug="slug"
-            mode={FilterModalMode.Collection}
-            closeModal={jest.fn()}
-            navigator={mockNavigator as any}
-          />
-        </ArtworkFilterContext.Provider>
-      </Theme>
+      <ArtworkFilterContext.Provider
+        value={{
+          state,
+          // @ts-ignore STRICTNESS_MIGRATION
+          dispatch: null,
+        }}
+      >
+        <FilterOptions
+          id="id"
+          slug="slug"
+          mode={FilterModalMode.Collection}
+          closeModal={jest.fn()}
+          navigator={mockNavigator as any}
+        />
+      </ArtworkFilterContext.Provider>
     )
 
     // the first row item takes users to the Medium navigation route
@@ -205,28 +203,26 @@ describe("Filter modal navigation flow", () => {
     const nextRoute = mockNavigator.nextRoute()
 
     const nextScreen = renderWithWrappers(
-      <Theme>
-        <ArtworkFilterContext.Provider
-          value={{
-            state,
-            // @ts-ignore STRICTNESS_MIGRATION
-            dispatch: null,
-          }}
-        >
-          {React.createElement(
-            // @ts-ignore STRICTNESS_MIGRATION
-            nextRoute.component,
-            {
-              ...nextRoute.passProps,
-              nextScreen: true,
-              navigator: MockNavigator,
-              relay: {
-                environment: null,
-              },
-            }
-          )}
-        </ArtworkFilterContext.Provider>
-      </Theme>
+      <ArtworkFilterContext.Provider
+        value={{
+          state,
+          // @ts-ignore STRICTNESS_MIGRATION
+          dispatch: null,
+        }}
+      >
+        {React.createElement(
+          // @ts-ignore STRICTNESS_MIGRATION
+          nextRoute.component,
+          {
+            ...nextRoute.passProps,
+            nextScreen: true,
+            navigator: MockNavigator,
+            relay: {
+              environment: null,
+            },
+          }
+        )}
+      </ArtworkFilterContext.Provider>
     )
 
     // @ts-ignore STRICTNESS_MIGRATION
@@ -237,24 +233,22 @@ describe("Filter modal navigation flow", () => {
 
   it("allows users to navigate forward to medium screen from filter screen", () => {
     const filterScreen = renderWithWrappers(
-      <Theme>
-        <ArtworkFilterContext.Provider
-          value={{
-            state,
-            aggregations: mockAggregations,
-            // @ts-ignore STRICTNESS_MIGRATION
-            dispatch: null,
-          }}
-        >
-          <FilterOptions
-            id="id"
-            slug="slug"
-            mode={FilterModalMode.Collection}
-            closeModal={jest.fn()}
-            navigator={mockNavigator as any}
-          />
-        </ArtworkFilterContext.Provider>
-      </Theme>
+      <ArtworkFilterContext.Provider
+        value={{
+          state,
+          aggregations: mockAggregations,
+          // @ts-ignore STRICTNESS_MIGRATION
+          dispatch: null,
+        }}
+      >
+        <FilterOptions
+          id="id"
+          slug="slug"
+          mode={FilterModalMode.Collection}
+          closeModal={jest.fn()}
+          navigator={mockNavigator as any}
+        />
+      </ArtworkFilterContext.Provider>
     )
 
     // the second row item takes users to the Medium navigation route
@@ -265,29 +259,27 @@ describe("Filter modal navigation flow", () => {
     const nextRoute = mockNavigator.nextRoute()
 
     const nextScreen = renderWithWrappers(
-      <Theme>
-        <ArtworkFilterContext.Provider
-          value={{
-            state,
-            aggregations: mockAggregations,
-            // @ts-ignore STRICTNESS_MIGRATION
-            dispatch: null,
-          }}
-        >
-          {React.createElement(
-            // @ts-ignore STRICTNESS_MIGRATION
-            nextRoute.component,
-            {
-              ...nextRoute.passProps,
-              nextScreen: true,
-              navigator: MockNavigator,
-              relay: {
-                environment: null,
-              },
-            }
-          )}
-        </ArtworkFilterContext.Provider>
-      </Theme>
+      <ArtworkFilterContext.Provider
+        value={{
+          state,
+          aggregations: mockAggregations,
+          // @ts-ignore STRICTNESS_MIGRATION
+          dispatch: null,
+        }}
+      >
+        {React.createElement(
+          // @ts-ignore STRICTNESS_MIGRATION
+          nextRoute.component,
+          {
+            ...nextRoute.passProps,
+            nextScreen: true,
+            navigator: MockNavigator,
+            relay: {
+              environment: null,
+            },
+          }
+        )}
+      </ArtworkFilterContext.Provider>
     )
 
     // @ts-ignore STRICTNESS_MIGRATION

--- a/src/lib/Components/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/__tests__/FilterModal-tests.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 import { Sans, Theme } from "@artsy/palette"
@@ -10,6 +10,7 @@ import { mount } from "enzyme"
 import { CollectionFixture } from "lib/Scenes/Collection/Components/__fixtures__/CollectionFixture"
 import { FilterParamName, InitialState } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import { CollectionArtworksFragmentContainer } from "lib/Scenes/Collection/Screens/CollectionArtworks"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { useTracking } from "react-tracking"
 import { FakeNavigator as MockNavigator } from "../../../lib/Components/Bidding/__tests__/Helpers/FakeNavigator"
 import {
@@ -176,7 +177,7 @@ const MockFilterModalNavigator = ({ initialState }: InitialState) => {
 
 describe("Filter modal navigation flow", () => {
   it("allows users to navigate forward to sort screen from filter screen", () => {
-    const filterScreen = ReactTestRenderer.create(
+    const filterScreen = renderWithWrappers(
       <Theme>
         <ArtworkFilterContext.Provider
           value={{
@@ -203,7 +204,7 @@ describe("Filter modal navigation flow", () => {
 
     const nextRoute = mockNavigator.nextRoute()
 
-    const nextScreen = ReactTestRenderer.create(
+    const nextScreen = renderWithWrappers(
       <Theme>
         <ArtworkFilterContext.Provider
           value={{
@@ -235,7 +236,7 @@ describe("Filter modal navigation flow", () => {
   })
 
   it("allows users to navigate forward to medium screen from filter screen", () => {
-    const filterScreen = ReactTestRenderer.create(
+    const filterScreen = renderWithWrappers(
       <Theme>
         <ArtworkFilterContext.Provider
           value={{
@@ -263,7 +264,7 @@ describe("Filter modal navigation flow", () => {
 
     const nextRoute = mockNavigator.nextRoute()
 
-    const nextScreen = ReactTestRenderer.create(
+    const nextScreen = renderWithWrappers(
       <Theme>
         <ArtworkFilterContext.Provider
           value={{
@@ -663,7 +664,7 @@ describe("Applying filters", () => {
         }}
       />
     )
-    ReactTestRenderer.create(<TestRenderer />)
+    renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],

--- a/src/lib/Components/__tests__/Markdown-tests.tsx
+++ b/src/lib/Components/__tests__/Markdown-tests.tsx
@@ -1,6 +1,6 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { Linking, Text } from "react-native"
-import * as renderer from "react-test-renderer"
 
 import { Theme } from "@artsy/palette"
 import { Markdown } from "../Markdown"
@@ -19,7 +19,7 @@ beforeEach(() => {
 
 describe("Markdown", () => {
   it("renders multiple paragraphs as Text elements", () => {
-    const markdown = renderer.create(
+    const markdown = renderWithWrappers(
       <Theme>
         <Markdown>
           paragraph 1 has some text.
@@ -36,7 +36,7 @@ describe("Markdown", () => {
   })
 
   it("renders links as LinkText", () => {
-    const markdown = renderer.create(
+    const markdown = renderWithWrappers(
       <Theme>
         <Markdown>
           Sorry, your bid wasn’t received before
@@ -60,7 +60,7 @@ describe("Markdown", () => {
     Linking.canOpenURL = jest.fn().mockReturnValue(Promise.resolve(true))
     Linking.openURL = jest.fn()
 
-    const markdown = renderer.create(
+    const markdown = renderWithWrappers(
       <Theme>
         <Markdown>
           Your bid can’t be placed at this time.
@@ -89,7 +89,7 @@ describe("Markdown", () => {
         react: (node, output, state) => <Text testID="foobar">{output(node.content, state)}</Text>,
       },
     }
-    const markdown = renderer.create(
+    const markdown = renderWithWrappers(
       <Theme>
         <Markdown rules={rules}>Paragraph 1 has some text</Markdown>
       </Theme>

--- a/src/lib/Components/__tests__/Markdown-tests.tsx
+++ b/src/lib/Components/__tests__/Markdown-tests.tsx
@@ -2,7 +2,6 @@ import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { Linking, Text } from "react-native"
 
-import { Theme } from "@artsy/palette"
 import { Markdown } from "../Markdown"
 import { LinkText } from "../Text/LinkText"
 
@@ -20,14 +19,12 @@ beforeEach(() => {
 describe("Markdown", () => {
   it("renders multiple paragraphs as Text elements", () => {
     const markdown = renderWithWrappers(
-      <Theme>
-        <Markdown>
-          paragraph 1 has some text.
-          {"\n"}
-          {"\n"}
-          paragraph 2 also has text.
-        </Markdown>
-      </Theme>
+      <Markdown>
+        paragraph 1 has some text.
+        {"\n"}
+        {"\n"}
+        paragraph 2 also has text.
+      </Markdown>
     )
 
     expect(markdown.root.findAllByType(Text).length).toEqual(4)
@@ -37,15 +34,13 @@ describe("Markdown", () => {
 
   it("renders links as LinkText", () => {
     const markdown = renderWithWrappers(
-      <Theme>
-        <Markdown>
-          Sorry, your bid wasn’t received before
-          {"\n"}
-          live bidding started. To continue
-          {"\n"}
-          bidding, please [join the live auction](http://www.artsy.net).
-        </Markdown>
-      </Theme>
+      <Markdown>
+        Sorry, your bid wasn’t received before
+        {"\n"}
+        live bidding started. To continue
+        {"\n"}
+        bidding, please [join the live auction](http://www.artsy.net).
+      </Markdown>
     )
 
     expect(markdown.root.findAllByType(LinkText).length).toEqual(1)
@@ -61,15 +56,13 @@ describe("Markdown", () => {
     Linking.openURL = jest.fn()
 
     const markdown = renderWithWrappers(
-      <Theme>
-        <Markdown>
-          Your bid can’t be placed at this time.
-          {"\n"}
-          Please contact [support@artsy.net](mailto:support@artsy.net) for
-          {"\n"}
-          more information.
-        </Markdown>
-      </Theme>
+      <Markdown>
+        Your bid can’t be placed at this time.
+        {"\n"}
+        Please contact [support@artsy.net](mailto:support@artsy.net) for
+        {"\n"}
+        more information.
+      </Markdown>
     )
 
     expect(markdown.root.findAllByType(LinkText).length).toEqual(1)
@@ -89,11 +82,7 @@ describe("Markdown", () => {
         react: (node, output, state) => <Text testID="foobar">{output(node.content, state)}</Text>,
       },
     }
-    const markdown = renderWithWrappers(
-      <Theme>
-        <Markdown rules={rules}>Paragraph 1 has some text</Markdown>
-      </Theme>
-    )
+    const markdown = renderWithWrappers(<Markdown rules={rules}>Paragraph 1 has some text</Markdown>)
 
     expect(markdown.root.findAllByType(Text)[0].props.testID).toBe("foobar")
   })

--- a/src/lib/Components/__tests__/Modal-tests.tsx
+++ b/src/lib/Components/__tests__/Modal-tests.tsx
@@ -1,13 +1,13 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import { Modal } from "../Modal"
 
 import { Theme } from "@artsy/palette"
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <Modal headerText="An error occurred" detailText="This is an error moop." />
     </Theme>

--- a/src/lib/Components/__tests__/Modal-tests.tsx
+++ b/src/lib/Components/__tests__/Modal-tests.tsx
@@ -4,12 +4,6 @@ import "react-native"
 
 import { Modal } from "../Modal"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <Modal headerText="An error occurred" detailText="This is an error moop." />
-    </Theme>
-  )
+  renderWithWrappers(<Modal headerText="An error occurred" detailText="This is an error moop." />)
 })

--- a/src/lib/Components/__tests__/RetryErrorBoundary-tests.tsx
+++ b/src/lib/Components/__tests__/RetryErrorBoundary-tests.tsx
@@ -1,6 +1,6 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import LoadFailureView from "../LoadFailureView"
 import { RetryErrorBoundary } from "../RetryErrorBoundary"
@@ -14,13 +14,13 @@ afterEach(() => {
 })
 
 it("Renders the fallback view when the rendered component crashes", () => {
-  const tree = renderer.create(<RetryErrorBoundary render={() => <CrashingComponent shouldCrash={true} />} />)
+  const tree = renderWithWrappers(<RetryErrorBoundary render={() => <CrashingComponent shouldCrash={true} />} />)
   expect(tree.root.findAllByType(LoadFailureView)).toHaveLength(1)
 })
 
 it("passes false for isRetry to render prop on first pass", () => {
   let receivedIsRetry = true
-  renderer.create(
+  renderWithWrappers(
     <RetryErrorBoundary
       render={({ isRetry }) => {
         receivedIsRetry = isRetry
@@ -33,7 +33,7 @@ it("passes false for isRetry to render prop on first pass", () => {
 
 it("passes true for isRetry to render prop on retry", () => {
   let receivedIsRetry = false
-  const tree = renderer.create(
+  const tree = renderWithWrappers(
     <RetryErrorBoundary
       render={({ isRetry }) => {
         receivedIsRetry = isRetry

--- a/src/lib/Components/__tests__/SectionTitle-tests.tsx
+++ b/src/lib/Components/__tests__/SectionTitle-tests.tsx
@@ -1,14 +1,12 @@
-import { ArrowRightIcon, Theme } from "@artsy/palette"
+import { ArrowRightIcon } from "@artsy/palette"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import { create } from "react-test-renderer"
 import { SectionTitle } from "../SectionTitle"
-
-const render = (jsx: JSX.Element) => create(<Theme>{jsx}</Theme>)
 
 describe("SectionTitle", () => {
   it(`renders a title alone`, async () => {
-    const tree = render(<SectionTitle title="hello" />)
+    const tree = renderWithWrappers(<SectionTitle title="hello" />)
 
     expect(extractText(tree.root)).toContain("hello")
     expect(tree.root.findAllByType(ArrowRightIcon)).toHaveLength(0)
@@ -16,7 +14,7 @@ describe("SectionTitle", () => {
   })
 
   it(`renders a subtitle when specified`, async () => {
-    const tree = render(<SectionTitle title="hello" subtitle="welcome to test" />)
+    const tree = renderWithWrappers(<SectionTitle title="hello" subtitle="welcome to test" />)
 
     expect(extractText(tree.root.findByProps({ "data-test-id": "title" }))).toContain("hello")
     expect(extractText(tree.root.findByProps({ "data-test-id": "subtitle" }))).toBe("welcome to test")
@@ -25,7 +23,7 @@ describe("SectionTitle", () => {
 
   it(`renders a right arrow when given an 'onPress' prop`, async () => {
     const onPress = jest.fn()
-    const tree = render(<SectionTitle title="hello" subtitle="welcome to test" onPress={onPress} />)
+    const tree = renderWithWrappers(<SectionTitle title="hello" subtitle="welcome to test" onPress={onPress} />)
 
     expect(extractText(tree.root.findByProps({ "data-test-id": "title" }))).toContain("hello")
     expect(extractText(tree.root.findByProps({ "data-test-id": "subtitle" }))).toBe("welcome to test")

--- a/src/lib/Components/__tests__/Separator-tests.tsx
+++ b/src/lib/Components/__tests__/Separator-tests.tsx
@@ -3,12 +3,6 @@ import React from "react"
 import "react-native"
 import Separator from "../Separator"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <Separator />
-    </Theme>
-  )
+  renderWithWrappers(<Separator />)
 })

--- a/src/lib/Components/__tests__/Separator-tests.tsx
+++ b/src/lib/Components/__tests__/Separator-tests.tsx
@@ -1,12 +1,12 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 import Separator from "../Separator"
 
 import { Theme } from "@artsy/palette"
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <Separator />
     </Theme>

--- a/src/lib/Containers/__tests__/Artist-tests.tsx
+++ b/src/lib/Containers/__tests__/Artist-tests.tsx
@@ -4,10 +4,10 @@ import ArtistHeader from "lib/Components/Artist/ArtistHeader"
 import ArtistShows from "lib/Components/Artist/ArtistShows/ArtistShows"
 import { StickyTab } from "lib/Components/StickyTabPage/StickyTabPageTabBar"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import _ from "lodash"
 import React from "react"
 import "react-native"
-import { create } from "react-test-renderer"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { MockResolvers } from "relay-test-utils/lib/RelayMockPayloadGenerator"
 import { ArtistQueryRenderer } from "../Artist"
@@ -50,7 +50,7 @@ describe("availableTabs", () => {
   }
 
   it("returns an empty state if artist has no metadata, shows, or works", async () => {
-    const tree = create(<TestWrapper />)
+    const tree = renderWithWrappers(<TestWrapper />)
     mockMostRecentOperation("ArtistAboveTheFoldQuery", {
       Artist() {
         return {
@@ -67,7 +67,7 @@ describe("availableTabs", () => {
   })
 
   it("returns About tab if artist has metadata", async () => {
-    const tree = create(<TestWrapper />)
+    const tree = renderWithWrappers(<TestWrapper />)
     mockMostRecentOperation("ArtistAboveTheFoldQuery", {
       Artist() {
         return {
@@ -85,7 +85,7 @@ describe("availableTabs", () => {
   })
 
   it("returns About tab if artist has articles", async () => {
-    const tree = create(<TestWrapper />)
+    const tree = renderWithWrappers(<TestWrapper />)
     mockMostRecentOperation("ArtistAboveTheFoldQuery", {
       Artist() {
         return {
@@ -99,7 +99,7 @@ describe("availableTabs", () => {
   })
 
   it("returns Shows tab if artist has shows", async () => {
-    const tree = create(<TestWrapper />)
+    const tree = renderWithWrappers(<TestWrapper />)
     mockMostRecentOperation("ArtistAboveTheFoldQuery", {
       Artist() {
         return {
@@ -113,7 +113,7 @@ describe("availableTabs", () => {
   })
 
   it("returns all three tabs if artist has metadata, works, and shows", async () => {
-    const tree = create(<TestWrapper />)
+    const tree = renderWithWrappers(<TestWrapper />)
     mockMostRecentOperation("ArtistAboveTheFoldQuery", {
       Artist() {
         return {
@@ -129,7 +129,7 @@ describe("availableTabs", () => {
   })
 
   it("tracks a page view", () => {
-    create(<TestWrapper />)
+    renderWithWrappers(<TestWrapper />)
     mockMostRecentOperation("ArtistAboveTheFoldQuery")
     expect(postEvent).toHaveBeenCalledTimes(1)
     expect(postEvent.mock.calls[0][0]).toMatchInlineSnapshot(`

--- a/src/lib/Containers/__tests__/BidFlow-tests.tsx
+++ b/src/lib/Containers/__tests__/BidFlow-tests.tsx
@@ -2,7 +2,6 @@ import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
 
-import { Theme } from "@artsy/palette"
 import { BidFlowFragmentContainer } from "../BidFlow"
 
 jest.mock("tipsi-stripe", () => ({ setOptions: jest.fn() }))
@@ -42,9 +41,5 @@ const SaleArtwork = {
 }
 
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <BidFlowFragmentContainer me={Me as any} sale_artwork={SaleArtwork as any} />
-    </Theme>
-  )
+  renderWithWrappers(<BidFlowFragmentContainer me={Me as any} sale_artwork={SaleArtwork as any} />)
 })

--- a/src/lib/Containers/__tests__/BidFlow-tests.tsx
+++ b/src/lib/Containers/__tests__/BidFlow-tests.tsx
@@ -1,6 +1,6 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import { Theme } from "@artsy/palette"
 import { BidFlowFragmentContainer } from "../BidFlow"
@@ -42,7 +42,7 @@ const SaleArtwork = {
 }
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <BidFlowFragmentContainer me={Me as any} sale_artwork={SaleArtwork as any} />
     </Theme>

--- a/src/lib/Containers/__tests__/Conversation-tests.tsx
+++ b/src/lib/Containers/__tests__/Conversation-tests.tsx
@@ -1,8 +1,8 @@
 import ConnectivityBanner from "lib/Components/ConnectivityBanner"
 import Composer from "lib/Components/Inbox/Conversations/Composer"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import { create } from "react-test-renderer"
 import { Conversation, ConversationFragmentContainer } from "../Conversation"
 
 jest.unmock("react-tracking")
@@ -22,7 +22,7 @@ jest.mock("@react-native-community/netinfo", () => {
 })
 
 it("looks correct when rendered", () => {
-  const conversation = create(<ConversationFragmentContainer me={props as any} />)
+  const conversation = renderWithWrappers(<ConversationFragmentContainer me={props as any} />)
   // @ts-ignore
   conversation.root.findByType(Conversation).children[0].instance.handleConnectivityChange(true)
   expect(conversation.root.findByType(Composer).props.disabled).toBeFalsy()
@@ -30,7 +30,7 @@ it("looks correct when rendered", () => {
 })
 
 it("displays a connectivity banner when network is down", () => {
-  const conversation = create(<ConversationFragmentContainer me={props as any} />)
+  const conversation = renderWithWrappers(<ConversationFragmentContainer me={props as any} />)
   // @ts-ignore
   conversation.root.findByType(Conversation).children[0].instance.handleConnectivityChange(false)
   expect(conversation.root.findByType(Composer).props.disabled).toBeTruthy()

--- a/src/lib/Containers/__tests__/Inbox-tests.tsx
+++ b/src/lib/Containers/__tests__/Inbox-tests.tsx
@@ -7,8 +7,6 @@ import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 
 import { Inbox as ActualInbox, InboxContainer } from "../Inbox"
 
-import { Theme } from "@artsy/palette"
-
 jest.mock("../../Components/Inbox/Conversations/Conversations", () => ({
   ConversationsContainer: () => "Conversations",
 }))
@@ -19,11 +17,7 @@ const emptyMeProps = {
 }
 
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <InboxContainer me={meProps() as any} isVisible={true} />
-    </Theme>
-  )
+  renderWithWrappers(<InboxContainer me={meProps() as any} isVisible={true} />)
 })
 
 it("Shows a zero state when there are no bids/conversations", () => {

--- a/src/lib/Containers/__tests__/Inbox-tests.tsx
+++ b/src/lib/Containers/__tests__/Inbox-tests.tsx
@@ -3,7 +3,7 @@ import "react-native"
 import { Environment } from "relay-runtime"
 
 import { renderWithLayout } from "lib/tests/renderWithLayout"
-import * as renderer from "react-test-renderer"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 
 import { Inbox as ActualInbox, InboxContainer } from "../Inbox"
 
@@ -19,7 +19,7 @@ const emptyMeProps = {
 }
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <InboxContainer me={meProps() as any} isVisible={true} />
     </Theme>

--- a/src/lib/Containers/__tests__/Inquiry-tests.tsx
+++ b/src/lib/Containers/__tests__/Inquiry-tests.tsx
@@ -1,12 +1,12 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import { Theme } from "@artsy/palette"
 import { InquiryFragmentContainer } from "../Inquiry"
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <InquiryFragmentContainer artwork={inquiryProps as any} />
     </Theme>

--- a/src/lib/Containers/__tests__/Inquiry-tests.tsx
+++ b/src/lib/Containers/__tests__/Inquiry-tests.tsx
@@ -2,15 +2,10 @@ import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
 
-import { Theme } from "@artsy/palette"
 import { InquiryFragmentContainer } from "../Inquiry"
 
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <InquiryFragmentContainer artwork={inquiryProps as any} />
-    </Theme>
-  )
+  renderWithWrappers(<InquiryFragmentContainer artwork={inquiryProps as any} />)
 })
 
 const inquiryProps = {

--- a/src/lib/Containers/__tests__/RegistrationFlow-tests.tsx
+++ b/src/lib/Containers/__tests__/RegistrationFlow-tests.tsx
@@ -1,6 +1,6 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import { mockTimezone } from "lib/tests/mockTimezone"
 
@@ -29,7 +29,7 @@ beforeEach(() => {
 it("renders without throwing an error", () => {
   console.error = jest.fn() // Silences component logging.
 
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <RegistrationFlowFragmentContainer
         me={

--- a/src/lib/Containers/__tests__/RegistrationFlow-tests.tsx
+++ b/src/lib/Containers/__tests__/RegistrationFlow-tests.tsx
@@ -4,7 +4,6 @@ import "react-native"
 
 import { mockTimezone } from "lib/tests/mockTimezone"
 
-import { Theme } from "@artsy/palette"
 import { RegistrationFlowFragmentContainer } from "../RegistrationFlow"
 
 jest.mock("tipsi-stripe", () => ({ setOptions: jest.fn() }))
@@ -30,15 +29,13 @@ it("renders without throwing an error", () => {
   console.error = jest.fn() // Silences component logging.
 
   renderWithWrappers(
-    <Theme>
-      <RegistrationFlowFragmentContainer
-        me={
-          {
-            has_credit_cards: true,
-          } as any
-        }
-        sale={Sale as any}
-      />
-    </Theme>
+    <RegistrationFlowFragmentContainer
+      me={
+        {
+          has_credit_cards: true,
+        } as any
+      }
+      sale={Sale as any}
+    />
   )
 })

--- a/src/lib/Containers/__tests__/WorksForYou-tests.tsx
+++ b/src/lib/Containers/__tests__/WorksForYou-tests.tsx
@@ -1,6 +1,6 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { NativeModules } from "react-native"
-import * as renderer from "react-test-renderer"
 
 import { WorksForYou } from "../WorksForYou"
 
@@ -15,7 +15,7 @@ beforeAll(() => {
 describe("with notifications", () => {
   it("updates the notification count", () => {
     const me = notificationsResponse().query.me
-    renderer.create(
+    renderWithWrappers(
       <Theme>
         <WorksForYou
           me={me as any}
@@ -30,7 +30,7 @@ describe("with notifications", () => {
   it("renders without throwing an error", () => {
     const me = notificationsResponse().query.me
     // @ts-ignore STRICTNESS_MIGRATION
-    renderer.create(<WorksForYou me={me as any} relay={null} />)
+    renderWithWrappers(<WorksForYou me={me as any} relay={null} />)
   })
 })
 
@@ -38,7 +38,7 @@ describe("without notifications", () => {
   it("renders without throwing an error", () => {
     const me = emptyStateResponse().query.me
     // @ts-ignore STRICTNESS_MIGRATION
-    renderer.create(<WorksForYou me={me as any} relay={null} />)
+    renderWithWrappers(<WorksForYou me={me as any} relay={null} />)
   })
 })
 

--- a/src/lib/Containers/__tests__/WorksForYou-tests.tsx
+++ b/src/lib/Containers/__tests__/WorksForYou-tests.tsx
@@ -4,8 +4,6 @@ import { NativeModules } from "react-native"
 
 import { WorksForYou } from "../WorksForYou"
 
-import { Theme } from "@artsy/palette"
-
 beforeAll(() => {
   WorksForYou.prototype.componentDidUpdate = () => {
     return null
@@ -16,13 +14,11 @@ describe("with notifications", () => {
   it("updates the notification count", () => {
     const me = notificationsResponse().query.me
     renderWithWrappers(
-      <Theme>
-        <WorksForYou
-          me={me as any}
-          // @ts-ignore STRICTNESS_MIGRATION
-          relay={null}
-        />
-      </Theme>
+      <WorksForYou
+        me={me as any}
+        // @ts-ignore STRICTNESS_MIGRATION
+        relay={null}
+      />
     )
     expect(NativeModules.ARTemporaryAPIModule.markNotificationsRead).toBeCalled()
   })

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeries-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeries-tests.tsx
@@ -1,13 +1,13 @@
-import { Theme } from "@artsy/palette"
 import { ArtistSeriesTestsQuery, ArtistSeriesTestsQueryRawResponse } from "__generated__/ArtistSeriesTestsQuery.graphql"
 import { ArtistSeries, ArtistSeriesFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeries"
 import { ArtistSeriesArtworks } from "lib/Scenes/ArtistSeries/ArtistSeriesArtworks"
 import { ArtistSeriesHeader } from "lib/Scenes/ArtistSeries/ArtistSeriesHeader"
 import { ArtistSeriesMeta } from "lib/Scenes/ArtistSeries/ArtistSeriesMeta"
 import { ArtistSeriesMoreSeries } from "lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 jest.unmock("react-relay")
@@ -35,11 +35,7 @@ describe("Artist Series Rail", () => {
       variables={{ artistSeriesID: "pumpkins" }}
       render={({ props, error }) => {
         if (props?.artistSeries) {
-          return (
-            <Theme>
-              <ArtistSeriesFragmentContainer artistSeries={props.artistSeries} />
-            </Theme>
-          )
+          return <ArtistSeriesFragmentContainer artistSeries={props.artistSeries} />
         } else if (error) {
           console.log(error)
         }
@@ -48,7 +44,7 @@ describe("Artist Series Rail", () => {
   )
 
   const getWrapper = (testFixture: ArtistSeriesTestsQueryRawResponse) => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesArtworks-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesArtworks-tests.tsx
@@ -1,13 +1,13 @@
-import { Theme } from "@artsy/palette"
 import {
   ArtistSeriesArtworksTestsQuery,
   ArtistSeriesArtworksTestsQueryRawResponse,
 } from "__generated__/ArtistSeriesArtworksTestsQuery.graphql"
 import { InfiniteScrollArtworksGridContainer } from "lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
 import { ArtistSeriesArtworksFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesArtworks"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 jest.unmock("react-relay")
@@ -32,11 +32,7 @@ describe("Artist Series Artworks", () => {
       variables={{ artistSeriesID: "pumpkins" }}
       render={({ props, error }) => {
         if (props?.artistSeries) {
-          return (
-            <Theme>
-              <ArtistSeriesArtworksFragmentContainer artistSeries={props.artistSeries} />
-            </Theme>
-          )
+          return <ArtistSeriesArtworksFragmentContainer artistSeries={props.artistSeries} />
         } else if (error) {
           console.log(error)
         }
@@ -46,7 +42,7 @@ describe("Artist Series Artworks", () => {
 
   it("renders an artwork grid if artworks", () => {
     const wrapper = () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       act(() => {
         env.mock.resolveMostRecentOperation({
           errors: [],
@@ -63,7 +59,7 @@ describe("Artist Series Artworks", () => {
 
   it("renders a null component if no artworks", () => {
     const wrapper = () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       act(() => {
         env.mock.resolveMostRecentOperation({
           errors: [],

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesFullArtistSeriesList-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesFullArtistSeriesList-tests.tsx
@@ -1,4 +1,3 @@
-import { Theme } from "@artsy/palette"
 import {
   ArtistSeriesFullArtistSeriesListTestsQuery,
   ArtistSeriesFullArtistSeriesListTestsQueryRawResponse,
@@ -6,9 +5,10 @@ import {
 import { PageWithSimpleHeader } from "lib/Components/PageWithSimpleHeader"
 import { ArtistSeriesFullArtistSeriesListFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesFullArtistSeriesList"
 import { ArtistSeriesListItem } from "lib/Scenes/ArtistSeries/ArtistSeriesListItem"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 jest.unmock("react-relay")
@@ -33,11 +33,7 @@ describe("Full Artist Series List", () => {
       variables={{ artistID: "a-great-artist" }}
       render={({ props, error }) => {
         if (props?.artist) {
-          return (
-            <Theme>
-              <ArtistSeriesFullArtistSeriesListFragmentContainer artist={props.artist} />
-            </Theme>
-          )
+          return <ArtistSeriesFullArtistSeriesListFragmentContainer artist={props.artist} />
         } else if (error) {
           console.log(error)
         }
@@ -47,7 +43,7 @@ describe("Full Artist Series List", () => {
 
   it("renders the Full Artist Series Page Header", () => {
     const wrapper = () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       act(() => {
         env.mock.resolveMostRecentOperation({
           errors: [],
@@ -64,7 +60,7 @@ describe("Full Artist Series List", () => {
 
   it("renders the all of an artist's associated Artist Series", () => {
     const wrapper = () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       act(() => {
         env.mock.resolveMostRecentOperation({
           errors: [],

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesHeader-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesHeader-tests.tsx
@@ -1,13 +1,13 @@
-import { Theme } from "@artsy/palette"
 import {
   ArtistSeriesHeaderTestsQuery,
   ArtistSeriesHeaderTestsQueryRawResponse,
 } from "__generated__/ArtistSeriesHeaderTestsQuery.graphql"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { ArtistSeriesHeaderFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesHeader"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 jest.unmock("react-relay")
@@ -32,11 +32,7 @@ describe("Artist Series Header", () => {
       variables={{ artistSeriesID: "pumpkins" }}
       render={({ props, error }) => {
         if (props?.artistSeries) {
-          return (
-            <Theme>
-              <ArtistSeriesHeaderFragmentContainer artistSeries={props.artistSeries} />
-            </Theme>
-          )
+          return <ArtistSeriesHeaderFragmentContainer artistSeries={props.artistSeries} />
         } else if (error) {
           console.log(error)
         }
@@ -46,7 +42,7 @@ describe("Artist Series Header", () => {
 
   it("renders the Artist Series header", () => {
     const wrapper = () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       act(() => {
         env.mock.resolveMostRecentOperation({
           errors: [],

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesListItem-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesListItem-tests.tsx
@@ -1,11 +1,11 @@
-import { Theme } from "@artsy/palette"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { ArtistSeriesListItem } from "lib/Scenes/ArtistSeries/ArtistSeriesListItem"
 import { ArtistSeriesConnectionEdge } from "lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { TouchableOpacity } from "react-native"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 
 jest.mock("lib/NativeModules/SwitchBoard", () => ({
   presentNavigationViewController: jest.fn(),
@@ -15,11 +15,7 @@ jest.unmock("react-relay")
 
 describe("ArtistSeriesListItem", () => {
   it("navigates to the artist series when tapped", () => {
-    const artistSeriesListItem = ReactTestRenderer.create(
-      <Theme>
-        <ArtistSeriesListItem listItem={ArtistSeriesListItemFixture} />
-      </Theme>
-    )
+    const artistSeriesListItem = renderWithWrappers(<ArtistSeriesListItem listItem={ArtistSeriesListItemFixture} />)
 
     const instance = artistSeriesListItem.root.findAllByType(TouchableOpacity)[0]
 
@@ -32,11 +28,7 @@ describe("ArtistSeriesListItem", () => {
   })
 
   it("shows the artist series title, image and for sale artwork counts", () => {
-    const artistSeriesListItem = ReactTestRenderer.create(
-      <Theme>
-        <ArtistSeriesListItem listItem={ArtistSeriesListItemFixture} />
-      </Theme>
-    )
+    const artistSeriesListItem = renderWithWrappers(<ArtistSeriesListItem listItem={ArtistSeriesListItemFixture} />)
 
     const instance = artistSeriesListItem.root.findAllByType(TouchableOpacity)[0]
 

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesMeta-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesMeta-tests.tsx
@@ -1,14 +1,15 @@
-import { EntityHeader, Theme } from "@artsy/palette"
+import { EntityHeader } from "@artsy/palette"
 import {
   ArtistSeriesMetaTestsQuery,
   ArtistSeriesMetaTestsQueryRawResponse,
 } from "__generated__/ArtistSeriesMetaTestsQuery.graphql"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { ArtistSeriesMeta, ArtistSeriesMetaFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesMeta"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { TouchableOpacity } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 jest.unmock("react-relay")
@@ -36,11 +37,7 @@ describe("Artist Series Meta", () => {
       variables={{ artistSeriesID: "pumpkins" }}
       render={({ props, error }) => {
         if (props?.artistSeries) {
-          return (
-            <Theme>
-              <ArtistSeriesMetaFragmentContainer artistSeries={props.artistSeries} />
-            </Theme>
-          )
+          return <ArtistSeriesMetaFragmentContainer artistSeries={props.artistSeries} />
         } else if (error) {
           console.log(error)
         }
@@ -49,7 +46,7 @@ describe("Artist Series Meta", () => {
   )
 
   const getWrapper = () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesMoreSeries-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesMoreSeries-tests.tsx
@@ -1,4 +1,3 @@
-import { Theme } from "@artsy/palette"
 import {
   ArtistSeriesMoreSeriesTestsQuery,
   ArtistSeriesMoreSeriesTestsQueryRawResponse,
@@ -44,13 +43,11 @@ describe("ArtistSeriesMoreSeries", () => {
         if (props?.artistSeries) {
           const artist = props.artistSeries.artist?.[0]
           return (
-            <Theme>
-              <ArtistSeriesMoreSeriesFragmentContainer
-                artist={artist}
-                artistSeriesHeader="This is a header"
-                currentArtistSeriesExcluded
-              />
-            </Theme>
+            <ArtistSeriesMoreSeriesFragmentContainer
+              artist={artist}
+              artistSeriesHeader="This is a header"
+              currentArtistSeriesExcluded
+            />
           )
         } else if (error) {
           console.log(error)

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesMoreSeries-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesMoreSeries-tests.tsx
@@ -8,9 +8,10 @@ import {
   ArtistSeriesMoreSeries,
   ArtistSeriesMoreSeriesFragmentContainer,
 } from "lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 jest.mock("lib/NativeModules/SwitchBoard", () => ({
@@ -59,7 +60,7 @@ describe("ArtistSeriesMoreSeries", () => {
   )
 
   const getWrapper = (testFixture: any) => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],

--- a/src/lib/Scenes/Artwork/Components/__tests__/ArtworksInSeriesRail-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/ArtworksInSeriesRail-tests.tsx
@@ -1,14 +1,14 @@
-import { Theme } from "@artsy/palette"
 import {
   ArtworksInSeriesRailTestsQuery,
   ArtworksInSeriesRailTestsQueryRawResponse,
 } from "__generated__/ArtworksInSeriesRailTestsQuery.graphql"
 import { ArtworkTileRailCard } from "lib/Components/ArtworkTileRail/ArtworkTileRailCard"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { TouchableOpacity } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 import { ArtworksInSeriesRail, ArtworksInSeriesRailFragmentContainer } from "../ArtworksInSeriesRail"
 
@@ -38,11 +38,7 @@ describe("ArtworksInSeriesRail", () => {
       variables={{}}
       render={({ props, error }) => {
         if (props?.artwork) {
-          return (
-            <Theme>
-              <ArtworksInSeriesRailFragmentContainer artwork={props.artwork} />
-            </Theme>
-          )
+          return <ArtworksInSeriesRailFragmentContainer artwork={props.artwork} />
         } else if (error) {
           console.log(error)
         }
@@ -51,7 +47,7 @@ describe("ArtworksInSeriesRail", () => {
   )
 
   const getWrapper = () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],

--- a/src/lib/Scenes/Artwork/__tests__/Artwork-tests.tsx
+++ b/src/lib/Scenes/Artwork/__tests__/Artwork-tests.tsx
@@ -108,33 +108,30 @@ describe("Artwork", () => {
   })
 
   it("renders above the fold content before the full query has been resolved", async () => {
-    const wrappedComponent = renderWithWrappers(<TestRenderer />)
-    const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockMostRecentOperation("ArtworkAboveTheFoldQuery")
-    expect(component.findAllByType(ImageCarousel)).toHaveLength(1)
-    expect(component.findAllByType(CommercialInformation)).toHaveLength(1)
-    expect(component.findAllByType(ActivityIndicator)).toHaveLength(1)
-    expect(component.findAllByType(ArtworkDetails)).toHaveLength(0)
+    expect(tree.root.findAllByType(ImageCarousel)).toHaveLength(1)
+    expect(tree.root.findAllByType(CommercialInformation)).toHaveLength(1)
+    expect(tree.root.findAllByType(ActivityIndicator)).toHaveLength(1)
+    expect(tree.root.findAllByType(ArtworkDetails)).toHaveLength(0)
   })
 
   it("renders all content after the full query has been resolved", async () => {
-    const wrappedComponent = renderWithWrappers(<TestRenderer />)
-    const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockMostRecentOperation("ArtworkAboveTheFoldQuery")
     mockMostRecentOperation("ArtworkMarkAsRecentlyViewedQuery")
     mockMostRecentOperation("ArtworkBelowTheFoldQuery")
     await flushPromiseQueue()
-    expect(component.findAllByType(ImageCarousel)).toHaveLength(1)
-    expect(component.findAllByType(CommercialInformation)).toHaveLength(1)
-    expect(component.findAllByType(ActivityIndicator)).toHaveLength(0)
-    expect(component.findAllByType(ArtworkDetails)).toHaveLength(1)
+    expect(tree.root.findAllByType(ImageCarousel)).toHaveLength(1)
+    expect(tree.root.findAllByType(CommercialInformation)).toHaveLength(1)
+    expect(tree.root.findAllByType(ActivityIndicator)).toHaveLength(0)
+    expect(tree.root.findAllByType(ArtworkDetails)).toHaveLength(1)
   })
 
   describe("artist series components", () => {
     it("renders with the feature flag enabled and artist series to show", async () => {
       NativeModules.Emission.options.AROptionsArtistSeries = true
-      const wrappedComponent = renderWithWrappers(<TestRenderer />)
-      const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
+      const tree = renderWithWrappers(<TestRenderer />)
       mockMostRecentOperation("ArtworkAboveTheFoldQuery")
       mockMostRecentOperation("ArtworkMarkAsRecentlyViewedQuery")
       mockMostRecentOperation("ArtworkBelowTheFoldQuery", {
@@ -149,14 +146,13 @@ describe("Artwork", () => {
         },
       })
       await flushPromiseQueue()
-      expect(component.findAllByType(ArtistSeriesMoreSeries)).toHaveLength(1)
-      expect(component.findAllByType(ArtworksInSeriesRail)).toHaveLength(1)
+      expect(tree.root.findAllByType(ArtistSeriesMoreSeries)).toHaveLength(1)
+      expect(tree.root.findAllByType(ArtworksInSeriesRail)).toHaveLength(1)
     })
 
     it("does not render with the feature flag disabled", async () => {
       NativeModules.Emission.options.AROptionsArtistSeries = false
-      const wrappedComponent = renderWithWrappers(<TestRenderer />)
-      const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
+      const tree = renderWithWrappers(<TestRenderer />)
       mockMostRecentOperation("ArtworkAboveTheFoldQuery")
       mockMostRecentOperation("ArtworkMarkAsRecentlyViewedQuery")
       mockMostRecentOperation("ArtworkBelowTheFoldQuery", {
@@ -171,14 +167,13 @@ describe("Artwork", () => {
         },
       })
       await flushPromiseQueue()
-      expect(component.findAllByType(ArtistSeriesMoreSeries)).toHaveLength(0)
-      expect(component.findAllByType(ArtworksInSeriesRail)).toHaveLength(0)
+      expect(tree.root.findAllByType(ArtistSeriesMoreSeries)).toHaveLength(0)
+      expect(tree.root.findAllByType(ArtworksInSeriesRail)).toHaveLength(0)
     })
 
     it("does not render when there are no artist series to show", async () => {
       NativeModules.Emission.options.AROptionsArtistSeries = true
-      const wrappedComponent = renderWithWrappers(<TestRenderer />)
-      const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
+      const tree = renderWithWrappers(<TestRenderer />)
       mockMostRecentOperation("ArtworkAboveTheFoldQuery")
       mockMostRecentOperation("ArtworkMarkAsRecentlyViewedQuery")
       mockMostRecentOperation("ArtworkBelowTheFoldQuery", {
@@ -196,14 +191,13 @@ describe("Artwork", () => {
         },
       })
       await flushPromiseQueue()
-      expect(component.findAllByType(ArtistSeriesMoreSeries)).toHaveLength(0)
-      expect(component.findAllByType(ArtworksInSeriesRail)).toHaveLength(0)
+      expect(tree.root.findAllByType(ArtistSeriesMoreSeries)).toHaveLength(0)
+      expect(tree.root.findAllByType(ArtworksInSeriesRail)).toHaveLength(0)
     })
   })
 
   it("renders the ArtworkDetails component when conditionDescription is null but canRequestLotConditionsReport is true", async () => {
-    const wrappedComponent = renderWithWrappers(<TestRenderer />)
-    const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockMostRecentOperation("ArtworkAboveTheFoldQuery")
     mockMostRecentOperation("ArtworkMarkAsRecentlyViewedQuery")
     mockMostRecentOperation("ArtworkBelowTheFoldQuery", {
@@ -224,7 +218,7 @@ describe("Artwork", () => {
       },
     })
     await flushPromiseQueue()
-    expect(component.findAllByType(ArtworkDetails)).toHaveLength(1)
+    expect(tree.root.findAllByType(ArtworkDetails)).toHaveLength(1)
   })
 
   it("marks the artwork as viewed", () => {
@@ -313,8 +307,7 @@ describe("Artwork", () => {
   })
 
   it("does not show a contextCard if the work is in a non-auction sale", async () => {
-    const wrappedComponent = renderWithWrappers(<TestRenderer />)
-    const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
+    const tree = renderWithWrappers(<TestRenderer />)
 
     mockMostRecentOperation("ArtworkAboveTheFoldQuery")
     mockMostRecentOperation("ArtworkMarkAsRecentlyViewedQuery")
@@ -327,13 +320,12 @@ describe("Artwork", () => {
     })
     await flushPromiseQueue()
 
-    expect(component.findAllByType(ContextCard)).toHaveLength(0)
-    expect(component.findAllByType(OtherWorksFragmentContainer)).toHaveLength(1)
+    expect(tree.root.findAllByType(ContextCard)).toHaveLength(0)
+    expect(tree.root.findAllByType(OtherWorksFragmentContainer)).toHaveLength(1)
   })
 
   it("does show a contextCard if the work is in an auction", async () => {
-    const wrappedComponent = renderWithWrappers(<TestRenderer />)
-    const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
+    const tree = renderWithWrappers(<TestRenderer />)
 
     mockMostRecentOperation("ArtworkAboveTheFoldQuery")
     mockMostRecentOperation("ArtworkMarkAsRecentlyViewedQuery")
@@ -347,14 +339,13 @@ describe("Artwork", () => {
 
     await flushPromiseQueue()
 
-    expect(component.findAllByType(ContextCard)).toHaveLength(1)
+    expect(tree.root.findAllByType(ContextCard)).toHaveLength(1)
   })
 
   describe("Live Auction States", () => {
     describe("has the correct state for a work that is in an auction that is currently live", () => {
       it("for which I am registered", () => {
-        const wrappedComponent = renderWithWrappers(<TestRenderer />)
-        const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
+        const tree = renderWithWrappers(<TestRenderer />)
 
         mockMostRecentOperation("ArtworkAboveTheFoldQuery", {
           Artwork() {
@@ -362,15 +353,14 @@ describe("Artwork", () => {
           },
         })
 
-        expect(component.findAllByType(CommercialPartnerInformation)).toHaveLength(0)
-        expect(component.findAllByType(Countdown)).toHaveLength(1)
-        expect(component.findByType(Countdown).props.label).toBe("In progress")
-        expect(extractText(component.findByType(BidButton))).toContain("Enter live bidding")
+        expect(tree.root.findAllByType(CommercialPartnerInformation)).toHaveLength(0)
+        expect(tree.root.findAllByType(Countdown)).toHaveLength(1)
+        expect(tree.root.findByType(Countdown).props.label).toBe("In progress")
+        expect(extractText(tree.root.findByType(BidButton))).toContain("Enter live bidding")
       })
 
       it("for which I am not registered and registration is open", () => {
-        const wrappedComponent = renderWithWrappers(<TestRenderer />)
-        const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
+        const tree = renderWithWrappers(<TestRenderer />)
 
         mockMostRecentOperation("ArtworkAboveTheFoldQuery", {
           Artwork() {
@@ -378,16 +368,15 @@ describe("Artwork", () => {
           },
         })
 
-        expect(component.findAllByType(CommercialPartnerInformation)).toHaveLength(0)
-        expect(component.findAllByType(Countdown)).toHaveLength(1)
-        expect(component.findByType(Countdown).props.label).toBe("In progress")
-        expect(extractText(component.findByType(BidButton))).toContain("Registration closed")
-        expect(extractText(component.findByType(BidButton))).toContain("Watch live bidding")
+        expect(tree.root.findAllByType(CommercialPartnerInformation)).toHaveLength(0)
+        expect(tree.root.findAllByType(Countdown)).toHaveLength(1)
+        expect(tree.root.findByType(Countdown).props.label).toBe("In progress")
+        expect(extractText(tree.root.findByType(BidButton))).toContain("Registration closed")
+        expect(extractText(tree.root.findByType(BidButton))).toContain("Watch live bidding")
       })
 
       it("for which I am not registered and registration is closed", () => {
-        const wrappedComponent = renderWithWrappers(<TestRenderer />)
-        const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
+        const tree = renderWithWrappers(<TestRenderer />)
 
         mockMostRecentOperation("ArtworkAboveTheFoldQuery", {
           Artwork() {
@@ -395,11 +384,11 @@ describe("Artwork", () => {
           },
         })
 
-        expect(component.findAllByType(CommercialPartnerInformation)).toHaveLength(0)
-        expect(component.findAllByType(Countdown)).toHaveLength(1)
-        expect(component.findByType(Countdown).props.label).toBe("In progress")
-        expect(extractText(component.findByType(Countdown))).toContain("00d  00h  00m  00s")
-        expect(extractText(component.findByType(BidButton))).toContain("Enter live bidding")
+        expect(tree.root.findAllByType(CommercialPartnerInformation)).toHaveLength(0)
+        expect(tree.root.findAllByType(Countdown)).toHaveLength(1)
+        expect(tree.root.findByType(Countdown).props.label).toBe("In progress")
+        expect(extractText(tree.root.findByType(Countdown))).toContain("00d  00h  00m  00s")
+        expect(extractText(tree.root.findByType(BidButton))).toContain("Enter live bidding")
       })
     })
   })

--- a/src/lib/Scenes/Artwork/__tests__/Artwork-tests.tsx
+++ b/src/lib/Scenes/Artwork/__tests__/Artwork-tests.tsx
@@ -9,6 +9,7 @@ import { Countdown } from "lib/Components/Bidding/Components/Timer"
 import { ArtistSeriesMoreSeries } from "lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
 import { extractText } from "lib/tests/extractText"
 import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { merge } from "lodash"
 import _ from "lodash"
 import React, { Suspense } from "react"
@@ -110,30 +111,33 @@ describe("Artwork", () => {
   })
 
   it("renders above the fold content before the full query has been resolved", async () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const wrappedComponent = renderWithWrappers(<TestRenderer />)
+    const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
     mockMostRecentOperation("ArtworkAboveTheFoldQuery")
-    expect(tree.root.findAllByType(ImageCarousel)).toHaveLength(1)
-    expect(tree.root.findAllByType(CommercialInformation)).toHaveLength(1)
-    expect(tree.root.findAllByType(ActivityIndicator)).toHaveLength(1)
-    expect(tree.root.findAllByType(ArtworkDetails)).toHaveLength(0)
+    expect(component.findAllByType(ImageCarousel)).toHaveLength(1)
+    expect(component.findAllByType(CommercialInformation)).toHaveLength(1)
+    expect(component.findAllByType(ActivityIndicator)).toHaveLength(1)
+    expect(component.findAllByType(ArtworkDetails)).toHaveLength(0)
   })
 
   it("renders all content after the full query has been resolved", async () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const wrappedComponent = renderWithWrappers(<TestRenderer />)
+    const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
     mockMostRecentOperation("ArtworkAboveTheFoldQuery")
     mockMostRecentOperation("ArtworkMarkAsRecentlyViewedQuery")
     mockMostRecentOperation("ArtworkBelowTheFoldQuery")
     await flushPromiseQueue()
-    expect(tree.root.findAllByType(ImageCarousel)).toHaveLength(1)
-    expect(tree.root.findAllByType(CommercialInformation)).toHaveLength(1)
-    expect(tree.root.findAllByType(ActivityIndicator)).toHaveLength(0)
-    expect(tree.root.findAllByType(ArtworkDetails)).toHaveLength(1)
+    expect(component.findAllByType(ImageCarousel)).toHaveLength(1)
+    expect(component.findAllByType(CommercialInformation)).toHaveLength(1)
+    expect(component.findAllByType(ActivityIndicator)).toHaveLength(0)
+    expect(component.findAllByType(ArtworkDetails)).toHaveLength(1)
   })
 
   describe("artist series components", () => {
     it("renders with the feature flag enabled and artist series to show", async () => {
       NativeModules.Emission.options.AROptionsArtistSeries = true
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const wrappedComponent = renderWithWrappers(<TestRenderer />)
+      const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
       mockMostRecentOperation("ArtworkAboveTheFoldQuery")
       mockMostRecentOperation("ArtworkMarkAsRecentlyViewedQuery")
       mockMostRecentOperation("ArtworkBelowTheFoldQuery", {
@@ -148,13 +152,14 @@ describe("Artwork", () => {
         },
       })
       await flushPromiseQueue()
-      expect(tree.root.findAllByType(ArtistSeriesMoreSeries)).toHaveLength(1)
-      expect(tree.root.findAllByType(ArtworksInSeriesRail)).toHaveLength(1)
+      expect(component.findAllByType(ArtistSeriesMoreSeries)).toHaveLength(1)
+      expect(component.findAllByType(ArtworksInSeriesRail)).toHaveLength(1)
     })
 
     it("does not render with the feature flag disabled", async () => {
       NativeModules.Emission.options.AROptionsArtistSeries = false
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const wrappedComponent = renderWithWrappers(<TestRenderer />)
+      const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
       mockMostRecentOperation("ArtworkAboveTheFoldQuery")
       mockMostRecentOperation("ArtworkMarkAsRecentlyViewedQuery")
       mockMostRecentOperation("ArtworkBelowTheFoldQuery", {
@@ -169,13 +174,14 @@ describe("Artwork", () => {
         },
       })
       await flushPromiseQueue()
-      expect(tree.root.findAllByType(ArtistSeriesMoreSeries)).toHaveLength(0)
-      expect(tree.root.findAllByType(ArtworksInSeriesRail)).toHaveLength(0)
+      expect(component.findAllByType(ArtistSeriesMoreSeries)).toHaveLength(0)
+      expect(component.findAllByType(ArtworksInSeriesRail)).toHaveLength(0)
     })
 
     it("does not render when there are no artist series to show", async () => {
       NativeModules.Emission.options.AROptionsArtistSeries = true
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const wrappedComponent = renderWithWrappers(<TestRenderer />)
+      const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
       mockMostRecentOperation("ArtworkAboveTheFoldQuery")
       mockMostRecentOperation("ArtworkMarkAsRecentlyViewedQuery")
       mockMostRecentOperation("ArtworkBelowTheFoldQuery", {
@@ -193,13 +199,14 @@ describe("Artwork", () => {
         },
       })
       await flushPromiseQueue()
-      expect(tree.root.findAllByType(ArtistSeriesMoreSeries)).toHaveLength(0)
-      expect(tree.root.findAllByType(ArtworksInSeriesRail)).toHaveLength(0)
+      expect(component.findAllByType(ArtistSeriesMoreSeries)).toHaveLength(0)
+      expect(component.findAllByType(ArtworksInSeriesRail)).toHaveLength(0)
     })
   })
 
   it("renders the ArtworkDetails component when conditionDescription is null but canRequestLotConditionsReport is true", async () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const wrappedComponent = renderWithWrappers(<TestRenderer />)
+    const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
     mockMostRecentOperation("ArtworkAboveTheFoldQuery")
     mockMostRecentOperation("ArtworkMarkAsRecentlyViewedQuery")
     mockMostRecentOperation("ArtworkBelowTheFoldQuery", {
@@ -220,11 +227,11 @@ describe("Artwork", () => {
       },
     })
     await flushPromiseQueue()
-    expect(tree.root.findAllByType(ArtworkDetails)).toHaveLength(1)
+    expect(component.findAllByType(ArtworkDetails)).toHaveLength(1)
   })
 
   it("marks the artwork as viewed", () => {
-    ReactTestRenderer.create(<TestRenderer />)
+    renderWithWrappers(<TestRenderer />)
     const slug = "test artwork id"
 
     mockMostRecentOperation("ArtworkAboveTheFoldQuery", {
@@ -309,7 +316,8 @@ describe("Artwork", () => {
   })
 
   it("does not show a contextCard if the work is in a non-auction sale", async () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const wrappedComponent = renderWithWrappers(<TestRenderer />)
+    const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
 
     mockMostRecentOperation("ArtworkAboveTheFoldQuery")
     mockMostRecentOperation("ArtworkMarkAsRecentlyViewedQuery")
@@ -322,12 +330,13 @@ describe("Artwork", () => {
     })
     await flushPromiseQueue()
 
-    expect(tree.root.findAllByType(ContextCard)).toHaveLength(0)
-    expect(tree.root.findAllByType(OtherWorksFragmentContainer)).toHaveLength(1)
+    expect(component.findAllByType(ContextCard)).toHaveLength(0)
+    expect(component.findAllByType(OtherWorksFragmentContainer)).toHaveLength(1)
   })
 
   it("does show a contextCard if the work is in an auction", async () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const wrappedComponent = renderWithWrappers(<TestRenderer />)
+    const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
 
     mockMostRecentOperation("ArtworkAboveTheFoldQuery")
     mockMostRecentOperation("ArtworkMarkAsRecentlyViewedQuery")
@@ -341,13 +350,14 @@ describe("Artwork", () => {
 
     await flushPromiseQueue()
 
-    expect(tree.root.findAllByType(ContextCard)).toHaveLength(1)
+    expect(component.findAllByType(ContextCard)).toHaveLength(1)
   })
 
   describe("Live Auction States", () => {
     describe("has the correct state for a work that is in an auction that is currently live", () => {
       it("for which I am registered", () => {
-        const tree = ReactTestRenderer.create(<TestRenderer />)
+        const wrappedComponent = renderWithWrappers(<TestRenderer />)
+        const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
 
         mockMostRecentOperation("ArtworkAboveTheFoldQuery", {
           Artwork() {
@@ -355,14 +365,15 @@ describe("Artwork", () => {
           },
         })
 
-        expect(tree.root.findAllByType(CommercialPartnerInformation)).toHaveLength(0)
-        expect(tree.root.findAllByType(Countdown)).toHaveLength(1)
-        expect(tree.root.findByType(Countdown).props.label).toBe("In progress")
-        expect(extractText(tree.root.findByType(BidButton))).toContain("Enter live bidding")
+        expect(component.findAllByType(CommercialPartnerInformation)).toHaveLength(0)
+        expect(component.findAllByType(Countdown)).toHaveLength(1)
+        expect(component.findByType(Countdown).props.label).toBe("In progress")
+        expect(extractText(component.findByType(BidButton))).toContain("Enter live bidding")
       })
 
       it("for which I am not registered and registration is open", () => {
-        const tree = ReactTestRenderer.create(<TestRenderer />)
+        const wrappedComponent = renderWithWrappers(<TestRenderer />)
+        const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
 
         mockMostRecentOperation("ArtworkAboveTheFoldQuery", {
           Artwork() {
@@ -370,15 +381,16 @@ describe("Artwork", () => {
           },
         })
 
-        expect(tree.root.findAllByType(CommercialPartnerInformation)).toHaveLength(0)
-        expect(tree.root.findAllByType(Countdown)).toHaveLength(1)
-        expect(tree.root.findByType(Countdown).props.label).toBe("In progress")
-        expect(extractText(tree.root.findByType(BidButton))).toContain("Registration closed")
-        expect(extractText(tree.root.findByType(BidButton))).toContain("Watch live bidding")
+        expect(component.findAllByType(CommercialPartnerInformation)).toHaveLength(0)
+        expect(component.findAllByType(Countdown)).toHaveLength(1)
+        expect(component.findByType(Countdown).props.label).toBe("In progress")
+        expect(extractText(component.findByType(BidButton))).toContain("Registration closed")
+        expect(extractText(component.findByType(BidButton))).toContain("Watch live bidding")
       })
 
       it("for which I am not registered and registration is closed", () => {
-        const tree = ReactTestRenderer.create(<TestRenderer />)
+        const wrappedComponent = renderWithWrappers(<TestRenderer />)
+        const component = wrappedComponent.root.findByType(ArtworkQueryRenderer)
 
         mockMostRecentOperation("ArtworkAboveTheFoldQuery", {
           Artwork() {
@@ -386,11 +398,11 @@ describe("Artwork", () => {
           },
         })
 
-        expect(tree.root.findAllByType(CommercialPartnerInformation)).toHaveLength(0)
-        expect(tree.root.findAllByType(Countdown)).toHaveLength(1)
-        expect(tree.root.findByType(Countdown).props.label).toBe("In progress")
-        expect(extractText(tree.root.findByType(Countdown))).toContain("00d  00h  00m  00s")
-        expect(extractText(tree.root.findByType(BidButton))).toContain("Enter live bidding")
+        expect(component.findAllByType(CommercialPartnerInformation)).toHaveLength(0)
+        expect(component.findAllByType(Countdown)).toHaveLength(1)
+        expect(component.findByType(Countdown).props.label).toBe("In progress")
+        expect(extractText(component.findByType(Countdown))).toContain("00d  00h  00m  00s")
+        expect(extractText(component.findByType(BidButton))).toContain("Enter live bidding")
       })
     })
   })

--- a/src/lib/Scenes/Artwork/__tests__/Artwork-tests.tsx
+++ b/src/lib/Scenes/Artwork/__tests__/Artwork-tests.tsx
@@ -25,6 +25,8 @@ import { ContextCard } from "../Components/ContextCard"
 import { ImageCarousel } from "../Components/ImageCarousel/ImageCarousel"
 import { OtherWorksFragmentContainer } from "../Components/OtherWorks/OtherWorks"
 
+/* tslint:disable use-wrapped-components */
+
 type ArtworkQueries =
   | "ArtworkAboveTheFoldQuery"
   | "ArtworkBelowTheFoldQuery"

--- a/src/lib/Scenes/Artwork/__tests__/Artwork-tests.tsx
+++ b/src/lib/Scenes/Artwork/__tests__/Artwork-tests.tsx
@@ -9,7 +9,7 @@ import { Countdown } from "lib/Components/Bidding/Components/Timer"
 import { ArtistSeriesMoreSeries } from "lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
 import { extractText } from "lib/tests/extractText"
 import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
-import { componentWithWrappers, renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { merge } from "lodash"
 import _ from "lodash"
 import React, { Suspense } from "react"
@@ -251,8 +251,8 @@ describe("Artwork", () => {
 
     expect(environment.mock.getAllOperations()).toHaveLength(0)
 
-    tree.update(componentWithWrappers(<TestRenderer isVisible={false} />))
-    tree.update(componentWithWrappers(<TestRenderer isVisible={true} />))
+    tree.update(<TestRenderer isVisible={false} />)
+    tree.update(<TestRenderer isVisible={true} />)
 
     mockMostRecentOperation("ArtworkRefetchQuery")
     await flushPromiseQueue()
@@ -276,8 +276,8 @@ describe("Artwork", () => {
       },
     })
 
-    tree.update(componentWithWrappers(<TestRenderer isVisible={false} />))
-    tree.update(componentWithWrappers(<TestRenderer isVisible={true} />))
+    tree.update(<TestRenderer isVisible={false} />)
+    tree.update(<TestRenderer isVisible={true} />)
 
     mockMostRecentOperation("ArtworkRefetchQuery", {
       Artwork() {

--- a/src/lib/Scenes/Artwork/__tests__/Artwork-tests.tsx
+++ b/src/lib/Scenes/Artwork/__tests__/Artwork-tests.tsx
@@ -9,12 +9,11 @@ import { Countdown } from "lib/Components/Bidding/Components/Timer"
 import { ArtistSeriesMoreSeries } from "lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
 import { extractText } from "lib/tests/extractText"
 import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { componentWithWrappers, renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { merge } from "lodash"
 import _ from "lodash"
 import React, { Suspense } from "react"
 import { ActivityIndicator, NativeModules } from "react-native"
-import ReactTestRenderer from "react-test-renderer"
 import { useTracking } from "react-tracking"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { MockResolvers } from "relay-test-utils/lib/RelayMockPayloadGenerator"
@@ -27,8 +26,6 @@ import { CommercialPartnerInformation } from "../Components/CommercialPartnerInf
 import { ContextCard } from "../Components/ContextCard"
 import { ImageCarousel } from "../Components/ImageCarousel/ImageCarousel"
 import { OtherWorksFragmentContainer } from "../Components/OtherWorks/OtherWorks"
-
-/* tslint:disable use-wrapped-components */
 
 type ArtworkQueries =
   | "ArtworkAboveTheFoldQuery"
@@ -252,7 +249,7 @@ describe("Artwork", () => {
   })
 
   it("refetches on re-appear", async () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
 
     mockMostRecentOperation("ArtworkAboveTheFoldQuery")
     mockMostRecentOperation("ArtworkMarkAsRecentlyViewedQuery")
@@ -260,8 +257,8 @@ describe("Artwork", () => {
 
     expect(environment.mock.getAllOperations()).toHaveLength(0)
 
-    tree.update(<TestRenderer isVisible={false} />)
-    tree.update(<TestRenderer isVisible={true} />)
+    tree.update(componentWithWrappers(<TestRenderer isVisible={false} />))
+    tree.update(componentWithWrappers(<TestRenderer isVisible={true} />))
 
     mockMostRecentOperation("ArtworkRefetchQuery")
     await flushPromiseQueue()
@@ -269,7 +266,7 @@ describe("Artwork", () => {
   })
 
   it("updates the above-the-fold content on re-appear", async () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
 
     mockMostRecentOperation("ArtworkAboveTheFoldQuery", {
       Artwork() {
@@ -285,8 +282,8 @@ describe("Artwork", () => {
       },
     })
 
-    tree.update(<TestRenderer isVisible={false} />)
-    tree.update(<TestRenderer isVisible={true} />)
+    tree.update(componentWithWrappers(<TestRenderer isVisible={false} />))
+    tree.update(componentWithWrappers(<TestRenderer isVisible={true} />))
 
     mockMostRecentOperation("ArtworkRefetchQuery", {
       Artwork() {

--- a/src/lib/Scenes/BottomTabs/__tests__/BottomTabs-tests.tsx
+++ b/src/lib/Scenes/BottomTabs/__tests__/BottomTabs-tests.tsx
@@ -1,11 +1,10 @@
-import { Theme } from "@artsy/palette"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { __appStoreTestUtils__, AppStoreProvider } from "lib/store/AppStore"
 import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { useInterval } from "lib/utils/useInterval"
 import React from "react"
 import { NativeModules } from "react-native"
-import { create } from "react-test-renderer"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { BottomTabs } from "../BottomTabs"
 import { BottomTabsButton } from "../BottomTabsButton"
@@ -38,9 +37,7 @@ function resolveUnreadConversationCountQuery(unreadConversationCount: number) {
 const TestWrapper: React.FC<{}> = ({}) => {
   return (
     <AppStoreProvider>
-      <Theme>
-        <BottomTabs />
-      </Theme>
+      <BottomTabs />
     </AppStoreProvider>
   )
 }
@@ -50,7 +47,7 @@ type ButtonProps = React.ComponentProps<typeof BottomTabsButton>
 describe(BottomTabs, () => {
   it(`displays the current unread notifications count`, async () => {
     __appStoreTestUtils__?.injectInitialState.mockReturnValueOnce({ bottomTabs: { unreadConversationCount: 4 } })
-    const tree = create(<TestWrapper />)
+    const tree = renderWithWrappers(<TestWrapper />)
 
     const inboxButton = tree.root
       .findAllByType(BottomTabsButton)
@@ -62,7 +59,7 @@ describe(BottomTabs, () => {
   })
 
   it(`fetches the current unread conversation count on mount`, async () => {
-    const tree = create(<TestWrapper />)
+    const tree = renderWithWrappers(<TestWrapper />)
 
     await flushPromiseQueue()
 
@@ -79,7 +76,7 @@ describe(BottomTabs, () => {
   })
 
   it(`sets the application icon badge count`, async () => {
-    create(<TestWrapper />)
+    renderWithWrappers(<TestWrapper />)
 
     await flushPromiseQueue()
 
@@ -92,7 +89,7 @@ describe(BottomTabs, () => {
   })
 
   it(`fetches the current unread conversation count once in a while`, async () => {
-    const tree = create(<TestWrapper />)
+    const tree = renderWithWrappers(<TestWrapper />)
     expect(useInterval).toHaveBeenCalledWith(expect.any(Function), expect.any(Number))
     await flushPromiseQueue()
 

--- a/src/lib/Scenes/BottomTabs/__tests__/BottomTabsButton-tests.tsx
+++ b/src/lib/Scenes/BottomTabs/__tests__/BottomTabsButton-tests.tsx
@@ -1,11 +1,10 @@
-import { Theme } from "@artsy/palette"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { __appStoreTestUtils__, AppStoreProvider } from "lib/store/AppStore"
 import { extractText } from "lib/tests/extractText"
 import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { TouchableWithoutFeedback } from "react-native"
-import { create } from "react-test-renderer"
 import { useTracking } from "react-tracking"
 import { BottomTabsButton } from "../BottomTabsButton"
 
@@ -16,16 +15,14 @@ const trackEvent = useTracking().trackEvent
 const TestWrapper: React.FC<React.ComponentProps<typeof BottomTabsButton>> = props => {
   return (
     <AppStoreProvider>
-      <Theme>
-        <BottomTabsButton {...props} />
-      </Theme>
+      <BottomTabsButton {...props} />
     </AppStoreProvider>
   )
 }
 
 describe(BottomTabsButton, () => {
   it(`navigates on press`, async () => {
-    const tree = create(<TestWrapper tab="search" />)
+    const tree = renderWithWrappers(<TestWrapper tab="search" />)
 
     expect(SwitchBoard.presentNavigationViewController).not.toHaveBeenCalled()
     tree.root.findByType(TouchableWithoutFeedback).props.onPress()
@@ -33,7 +30,7 @@ describe(BottomTabsButton, () => {
   })
 
   it(`updates the selected tab state on press`, async () => {
-    const tree = create(<TestWrapper tab="search" />)
+    const tree = renderWithWrappers(<TestWrapper tab="search" />)
     expect(__appStoreTestUtils__?.getCurrentState().bottomTabs.selectedTab).toBe("home")
     tree.root.findByType(TouchableWithoutFeedback).props.onPress()
     await flushPromiseQueue()
@@ -41,7 +38,7 @@ describe(BottomTabsButton, () => {
   })
 
   it(`dispatches an analytics action on press`, async () => {
-    const tree = create(<TestWrapper tab="sell" />)
+    const tree = renderWithWrappers(<TestWrapper tab="sell" />)
     expect(trackEvent).not.toHaveBeenCalled()
     tree.root.findByType(TouchableWithoutFeedback).props.onPress()
     await flushPromiseQueue()
@@ -57,13 +54,13 @@ describe(BottomTabsButton, () => {
 
   describe(`badge`, () => {
     it(`doesn't show anything when the number is 0`, async () => {
-      const tree = create(<TestWrapper tab="sell" />)
+      const tree = renderWithWrappers(<TestWrapper tab="sell" />)
       expect(extractText(tree.root)).toBe("")
       tree.update(<TestWrapper tab="sell" badgeCount={0} />)
       expect(extractText(tree.root)).toBe("")
     })
     it(`shows the number when the number is bigger than 0`, async () => {
-      const tree = create(<TestWrapper tab="sell" badgeCount={1} />)
+      const tree = renderWithWrappers(<TestWrapper tab="sell" badgeCount={1} />)
       expect(extractText(tree.root)).toBe("1")
       tree.update(<TestWrapper tab="sell" badgeCount={5} />)
       expect(extractText(tree.root)).toBe("5")
@@ -71,7 +68,7 @@ describe(BottomTabsButton, () => {
       expect(extractText(tree.root)).toBe("52")
     })
     it(`tops out at 99`, async () => {
-      const tree = create(<TestWrapper tab="sell" badgeCount={1} />)
+      const tree = renderWithWrappers(<TestWrapper tab="sell" badgeCount={1} />)
       expect(extractText(tree.root)).toBe("1")
       tree.update(<TestWrapper tab="sell" badgeCount={99} />)
       expect(extractText(tree.root)).toBe("99")

--- a/src/lib/Scenes/Collection/Components/CollectionHubsRails/ArtistSeries/__tests__/CollectionArtistSeriesRail-tests.tsx
+++ b/src/lib/Scenes/Collection/Components/CollectionHubsRails/ArtistSeries/__tests__/CollectionArtistSeriesRail-tests.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 import { Sans, Theme } from "@artsy/palette"
@@ -22,6 +22,7 @@ import {
   CollectionArtistSeriesRail,
   CollectionArtistSeriesRailContainer,
 } from "lib/Scenes/Collection/Components/CollectionHubsRails/ArtistSeries/CollectionArtistSeriesRail"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { useTracking } from "react-tracking"
 
 jest.unmock("react-relay")
@@ -52,12 +53,10 @@ describe("Artist Series Rail", () => {
       render={({ props, error }) => {
         if (props?.marketingCollection) {
           return (
-            <Theme>
-              <CollectionArtistSeriesRailContainer
-                collection={props.marketingCollection}
-                collectionGroup={props.marketingCollection.linkedCollections[0]}
-              />
-            </Theme>
+            <CollectionArtistSeriesRailContainer
+              collection={props.marketingCollection}
+              collectionGroup={props.marketingCollection.linkedCollections[0]}
+            />
           )
         } else if (error) {
           console.log(error)
@@ -67,7 +66,7 @@ describe("Artist Series Rail", () => {
   )
 
   const getWrapper = () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],

--- a/src/lib/Scenes/Collection/Components/CollectionHubsRails/FeaturedCollections/__tests__/FeaturedCollectionsRail-tests.tsx
+++ b/src/lib/Scenes/Collection/Components/CollectionHubsRails/FeaturedCollections/__tests__/FeaturedCollectionsRail-tests.tsx
@@ -1,4 +1,3 @@
-import { Theme } from "@artsy/palette"
 import {
   FeaturedCollectionsRailTestsQuery,
   FeaturedCollectionsRailTestsQueryRawResponse,
@@ -9,10 +8,11 @@ import {
   FeaturedCollectionsRailContainer,
   ImageWrapper,
 } from "lib/Scenes/Collection/Components/CollectionHubsRails/FeaturedCollections/FeaturedCollectionsRail"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { TouchableHighlight } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { useTracking } from "react-tracking"
 import { createMockEnvironment } from "relay-test-utils"
 
@@ -58,12 +58,10 @@ describe("Featured Collections Rail", () => {
       render={({ props, error }) => {
         if (props?.marketingCollection) {
           return (
-            <Theme>
-              <FeaturedCollectionsRailContainer
-                collection={props.marketingCollection}
-                collectionGroup={props.marketingCollection.linkedCollections[0]}
-              />
-            </Theme>
+            <FeaturedCollectionsRailContainer
+              collection={props.marketingCollection}
+              collectionGroup={props.marketingCollection.linkedCollections[0]}
+            />
           )
         } else if (error) {
           console.log(error)
@@ -73,7 +71,7 @@ describe("Featured Collections Rail", () => {
   )
 
   const getWrapper = () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],
@@ -118,30 +116,18 @@ describe("Featured Collections Rail", () => {
     })
 
     it("renders three collections in the Featured Collections Series", () => {
-      const tree = ReactTestRenderer.create(
-        <Theme>
-          <FeaturedCollectionsRail {...props} />
-        </Theme>
-      ).root
+      const tree = renderWithWrappers(<FeaturedCollectionsRail {...props} />).root
 
       expect(tree.findAllByType(ImageWrapper).length).toBe(3)
     })
 
     it("renders the collection hub rail title", () => {
-      const tree = ReactTestRenderer.create(
-        <Theme>
-          <FeaturedCollectionsRail {...props} />
-        </Theme>
-      ).root
+      const tree = renderWithWrappers(<FeaturedCollectionsRail {...props} />).root
       expect(tree.findByProps({ "data-test-id": "group" }).props.children).toBe("Curated Highlights")
     })
 
     it("renders each Featured Collection's title", () => {
-      const tree = ReactTestRenderer.create(
-        <Theme>
-          <FeaturedCollectionsRail {...props} />
-        </Theme>
-      ).root
+      const tree = renderWithWrappers(<FeaturedCollectionsRail {...props} />).root
 
       const title1 = tree.findByProps({ "data-test-id": "title-0" })
       const title2 = tree.findByProps({ "data-test-id": "title-1" })
@@ -153,11 +139,7 @@ describe("Featured Collections Rail", () => {
     })
 
     it("renders each Featured Collection's price guidance metadata", () => {
-      const tree = ReactTestRenderer.create(
-        <Theme>
-          <FeaturedCollectionsRail {...props} />
-        </Theme>
-      ).root
+      const tree = renderWithWrappers(<FeaturedCollectionsRail {...props} />).root
 
       const price1 = tree.findByProps({ "data-test-id": "price-0" })
       const price2 = tree.findByProps({ "data-test-id": "price-1" })
@@ -169,11 +151,7 @@ describe("Featured Collections Rail", () => {
     })
 
     it("navigates to a new collection when tapped", () => {
-      const tree = ReactTestRenderer.create(
-        <Theme>
-          <FeaturedCollectionsRail {...props} />
-        </Theme>
-      ).root
+      const tree = renderWithWrappers(<FeaturedCollectionsRail {...props} />).root
 
       const instance = tree.findAllByType(TouchableHighlight)[0]
       act(() => instance.props.onPress())

--- a/src/lib/Scenes/Collection/Components/CollectionHubsRails/OtherCollections/__tests__/OtherCollectionsRail-tests.tsx
+++ b/src/lib/Scenes/Collection/Components/CollectionHubsRails/OtherCollections/__tests__/OtherCollectionsRail-tests.tsx
@@ -1,4 +1,4 @@
-import { Sans, Theme } from "@artsy/palette"
+import { Sans } from "@artsy/palette"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { CollectionHubRailsOtherCollectionsRailFixture } from "lib/Scenes/Collection/Components/__fixtures__/CollectionFixture"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
@@ -10,9 +10,7 @@ jest.mock("lib/NativeModules/SwitchBoard", () => ({ presentNavigationViewControl
 
 describe("Other Collections Rail", () => {
   const TestRenderer = () => (
-    <Theme>
-      <OtherCollectionsRail {...({ collectionGroup: CollectionHubRailsOtherCollectionsRailFixture } as any)} />
-    </Theme>
+    <OtherCollectionsRail {...({ collectionGroup: CollectionHubRailsOtherCollectionsRailFixture } as any)} />
   )
 
   it("renders a title", () => {

--- a/src/lib/Scenes/Collection/Components/CollectionHubsRails/OtherCollections/__tests__/OtherCollectionsRail-tests.tsx
+++ b/src/lib/Scenes/Collection/Components/CollectionHubsRails/OtherCollections/__tests__/OtherCollectionsRail-tests.tsx
@@ -1,9 +1,9 @@
 import { Sans, Theme } from "@artsy/palette"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { CollectionHubRailsOtherCollectionsRailFixture } from "lib/Scenes/Collection/Components/__fixtures__/CollectionFixture"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { TouchableOpacity } from "react-native"
-import ReactTestRenderer from "react-test-renderer"
 import { CollectionGroupMemberPill, OtherCollectionsRail } from "../OtherCollectionsRail"
 
 jest.mock("lib/NativeModules/SwitchBoard", () => ({ presentNavigationViewController: jest.fn() }))
@@ -16,7 +16,7 @@ describe("Other Collections Rail", () => {
   )
 
   it("renders a title", () => {
-    const { root } = ReactTestRenderer.create(<TestRenderer />)
+    const { root } = renderWithWrappers(<TestRenderer />)
     const {
       props: { children },
     } = root.findByType(Sans)
@@ -25,7 +25,7 @@ describe("Other Collections Rail", () => {
   })
 
   it("renders the other collection pills", () => {
-    const { root } = ReactTestRenderer.create(<TestRenderer />)
+    const { root } = renderWithWrappers(<TestRenderer />)
 
     expect(root.findAllByType(CollectionGroupMemberPill).map(({ props: { children } }) => children)).toEqual([
       "Abstract Expressionist Art",
@@ -35,7 +35,7 @@ describe("Other Collections Rail", () => {
   })
 
   it("navigates to a new collection when a pill is tapped", () => {
-    const { root } = ReactTestRenderer.create(<TestRenderer />)
+    const { root } = renderWithWrappers(<TestRenderer />)
     const [button] = root.findAllByType(TouchableOpacity)
 
     button.props.onPress()

--- a/src/lib/Scenes/Collection/Screens/__tests__/CollectionArtworks-tests.tsx
+++ b/src/lib/Scenes/Collection/Screens/__tests__/CollectionArtworks-tests.tsx
@@ -1,9 +1,8 @@
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
-import { Theme } from "@artsy/palette"
 import {
   CollectionArtworksTestsQuery,
   CollectionArtworksTestsQueryRawResponse,
@@ -17,6 +16,7 @@ import {
 import { filterArtworksParams, FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import { CollectionArtworksFragmentContainer as CollectionArtworks } from "lib/Scenes/Collection/Screens/CollectionArtworks"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { FilterArray } from "lib/utils/ArtworkFiltersStore"
 import { ArtworkFilterContext, ArtworkFilterContextState } from "lib/utils/ArtworkFiltersStore"
 
@@ -40,11 +40,9 @@ describe("CollectionArtworks", () => {
       render={({ props, error }) => {
         if (props?.marketingCollection) {
           return (
-            <Theme>
-              <ArtworkFilterContext.Provider value={{ state, dispatch: jest.fn() }}>
-                <CollectionArtworks collection={props.marketingCollection} scrollToTop={jest.fn()} />
-              </ArtworkFilterContext.Provider>
-            </Theme>
+            <ArtworkFilterContext.Provider value={{ state, dispatch: jest.fn() }}>
+              <CollectionArtworks collection={props.marketingCollection} scrollToTop={jest.fn()} />
+            </ArtworkFilterContext.Provider>
           )
         } else if (error) {
           console.error(error)
@@ -54,7 +52,7 @@ describe("CollectionArtworks", () => {
   )
 
   const getWrapper = (marketingCollection: CollectionArtworksTestsQueryRawResponse["marketingCollection"]) => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],

--- a/src/lib/Scenes/Collection/__tests__/Collection-tests.tsx
+++ b/src/lib/Scenes/Collection/__tests__/Collection-tests.tsx
@@ -1,9 +1,9 @@
 import { CollectionTestsQuery } from "__generated__/CollectionTestsQuery.graphql"
 import { AnimatedBottomButton } from "lib/Components/AnimatedBottomButton"
 import { FilterArtworkButton } from "lib/Components/FilterModal"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 import { CollectionContainer } from "../Collection"
 
@@ -42,7 +42,7 @@ describe("Collection", () => {
   })
 
   it("does not display a filter artworks button by default", () => {
-    const root = ReactTestRenderer.create(<TestRenderer />).root
+    const root = renderWithWrappers(<TestRenderer />).root
 
     expect(root.findAllByType(AnimatedBottomButton)).toHaveLength(0)
     expect(root.findAllByType(FilterArtworkButton)).toHaveLength(0)

--- a/src/lib/Scenes/Consignments/Components/__tests__/FormElements-tests.tsx
+++ b/src/lib/Scenes/Consignments/Components/__tests__/FormElements-tests.tsx
@@ -1,6 +1,6 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import { Row } from "../FormElements"
 
@@ -8,18 +8,16 @@ import { Theme } from "@artsy/palette"
 
 describe("Row", () => {
   it("row passes style props, and other props into the view", () => {
-    const tree = renderer
-      .create(
-        <Theme>
-          <Row
-            renderToHardwareTextureAndroid={true}
-            style={{
-              scaleX: 23,
-            }}
-          />
-        </Theme>
-      )
-      .toJSON()
+    const tree = renderWithWrappers(
+      <Theme>
+        <Row
+          renderToHardwareTextureAndroid={true}
+          style={{
+            scaleX: 23,
+          }}
+        />
+      </Theme>
+    ).toJSON()
     // @ts-ignore STRICTNESS_MIGRATION
     expect(tree.props.renderToHardwareTextureAndroid).toBeTruthy()
 

--- a/src/lib/Scenes/Consignments/Components/__tests__/FormElements-tests.tsx
+++ b/src/lib/Scenes/Consignments/Components/__tests__/FormElements-tests.tsx
@@ -4,19 +4,15 @@ import "react-native"
 
 import { Row } from "../FormElements"
 
-import { Theme } from "@artsy/palette"
-
 describe("Row", () => {
   it("row passes style props, and other props into the view", () => {
     const tree = renderWithWrappers(
-      <Theme>
-        <Row
-          renderToHardwareTextureAndroid={true}
-          style={{
-            scaleX: 23,
-          }}
-        />
-      </Theme>
+      <Row
+        renderToHardwareTextureAndroid={true}
+        style={{
+          scaleX: 23,
+        }}
+      />
     ).toJSON()
     // @ts-ignore STRICTNESS_MIGRATION
     expect(tree.props.renderToHardwareTextureAndroid).toBeTruthy()

--- a/src/lib/Scenes/Consignments/Components/__tests__/ImageSelection-tests.tsx
+++ b/src/lib/Scenes/Consignments/Components/__tests__/ImageSelection-tests.tsx
@@ -1,12 +1,12 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
 
 import ImageSelection from "../ImageSelection"
 
 const uri = "https://d32dm0rphc51dk.cloudfront.net/WAlGHmjlxTn3USMllNt4rA/large.jpg"
 
 it("renders without throwing an error", () => {
-  renderer.create(<ImageSelection data={[{ image: { uri } }, { image: { uri } }, { image: { uri } }]} />)
+  renderWithWrappers(<ImageSelection data={[{ image: { uri } }, { image: { uri } }, { image: { uri } }]} />)
 })
 
 it("updates state on selection", () => {

--- a/src/lib/Scenes/Consignments/Components/__tests__/TextArea-tests.tsx
+++ b/src/lib/Scenes/Consignments/Components/__tests__/TextArea-tests.tsx
@@ -2,32 +2,27 @@ import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import TextArea from "../TextArea"
 
-import { Theme } from "@artsy/palette"
 import { extractText } from "lib/tests/extractText"
 
 it("shows the placeholder when text is empty", () => {
   const component = renderWithWrappers(
-    <Theme>
-      <TextArea
-        text={{
-          placeholder: "some placeholder text",
-        }}
-      />
-    </Theme>
+    <TextArea
+      text={{
+        placeholder: "some placeholder text",
+      }}
+    />
   )
   expect(extractText(component.root)).toMatch("some placeholder text")
 })
 
 it("doesn't show placeholder when initial text is present", () => {
   const component = renderWithWrappers(
-    <Theme>
-      <TextArea
-        text={{
-          placeholder: "some placeholder text",
-          value: "any text at all",
-        }}
-      />
-    </Theme>
+    <TextArea
+      text={{
+        placeholder: "some placeholder text",
+        value: "any text at all",
+      }}
+    />
   )
   expect(extractText(component.root)).not.toMatch("some placeholder text")
 })

--- a/src/lib/Scenes/Consignments/Components/__tests__/TextArea-tests.tsx
+++ b/src/lib/Scenes/Consignments/Components/__tests__/TextArea-tests.tsx
@@ -1,12 +1,12 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
 import TextArea from "../TextArea"
 
 import { Theme } from "@artsy/palette"
 import { extractText } from "lib/tests/extractText"
 
 it("shows the placeholder when text is empty", () => {
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <Theme>
       <TextArea
         text={{
@@ -19,7 +19,7 @@ it("shows the placeholder when text is empty", () => {
 })
 
 it("doesn't show placeholder when initial text is present", () => {
-  const component = renderer.create(
+  const component = renderWithWrappers(
     <Theme>
       <TextArea
         text={{

--- a/src/lib/Scenes/Consignments/Components/__tests__/TextInput-tests.tsx
+++ b/src/lib/Scenes/Consignments/Components/__tests__/TextInput-tests.tsx
@@ -1,34 +1,28 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
+import { ActivityIndicator } from "react-native"
 import Text from "../TextInput"
 
-import { Theme } from "@artsy/palette"
-import { ActivityIndicator } from "react-native"
-
 it("shows an activity indicator when searching ", () => {
-  const component = renderer.create(
-    <Theme>
-      <Text
-        text={{
-          value: "My mocked",
-        }}
-        searching={true}
-      />
-    </Theme>
+  const component = renderWithWrappers(
+    <Text
+      text={{
+        value: "My mocked",
+      }}
+      searching={true}
+    />
   )
   expect(component.root.findAllByType(ActivityIndicator)).toHaveLength(1)
 })
 
 it("does not have an activity when searching ", () => {
-  const component = renderer.create(
-    <Theme>
-      <Text
-        text={{
-          value: "My mocked",
-        }}
-        searching={false}
-      />
-    </Theme>
+  const component = renderWithWrappers(
+    <Text
+      text={{
+        value: "My mocked",
+      }}
+      searching={false}
+    />
   )
   expect(component.root.findAllByType(ActivityIndicator)).toHaveLength(0)
 })

--- a/src/lib/Scenes/Consignments/Components/__tests__/Toggle-tests.tsx
+++ b/src/lib/Scenes/Consignments/Components/__tests__/Toggle-tests.tsx
@@ -1,11 +1,11 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
 import Toggle from "../Toggle"
 
 import { Theme } from "@artsy/palette"
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <Toggle selected={true} left="L" right="R" />
     </Theme>

--- a/src/lib/Scenes/Consignments/Components/__tests__/Toggle-tests.tsx
+++ b/src/lib/Scenes/Consignments/Components/__tests__/Toggle-tests.tsx
@@ -2,12 +2,6 @@ import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import Toggle from "../Toggle"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <Toggle selected={true} left="L" right="R" />
-    </Theme>
-  )
+  renderWithWrappers(<Toggle selected={true} left="L" right="R" />)
 })

--- a/src/lib/Scenes/Consignments/Screens/__tests__/Edition-tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/__tests__/Edition-tests.tsx
@@ -5,32 +5,24 @@ import "react-native"
 import Text from "../../Components/TextInput"
 import Edition from "../Edition"
 
-import { Theme } from "@artsy/palette"
-
 const nav = {} as any
 const route = {} as any
 
 it("renders without throwing an error", () => {
-  const tree = renderWithWrappers(
-    <Theme>
-      <Edition navigator={nav} route={route} setup={{}} updateWithEdition={() => ""} />
-    </Theme>
-  )
+  const tree = renderWithWrappers(<Edition navigator={nav} route={route} setup={{}} updateWithEdition={() => ""} />)
   expect(tree.root.findAllByType(Text)).toHaveLength(0)
 })
 
 it("Shows and additional 2 inputs when there's edition info", () => {
   const tree = renderWithWrappers(
-    <Theme>
-      <Edition
-        navigator={nav}
-        route={route}
-        setup={{
-          editionInfo: {},
-        }}
-        updateWithEdition={() => ""}
-      />
-    </Theme>
+    <Edition
+      navigator={nav}
+      route={route}
+      setup={{
+        editionInfo: {},
+      }}
+      updateWithEdition={() => ""}
+    />
   )
   expect(tree.root.findAllByType(Text)).toHaveLength(2)
 })

--- a/src/lib/Scenes/Consignments/Screens/__tests__/Edition-tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/__tests__/Edition-tests.tsx
@@ -1,6 +1,6 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import Text from "../../Components/TextInput"
 import Edition from "../Edition"
@@ -11,7 +11,7 @@ const nav = {} as any
 const route = {} as any
 
 it("renders without throwing an error", () => {
-  const tree = renderer.create(
+  const tree = renderWithWrappers(
     <Theme>
       <Edition navigator={nav} route={route} setup={{}} updateWithEdition={() => ""} />
     </Theme>
@@ -20,7 +20,7 @@ it("renders without throwing an error", () => {
 })
 
 it("Shows and additional 2 inputs when there's edition info", () => {
-  const tree = renderer.create(
+  const tree = renderWithWrappers(
     <Theme>
       <Edition
         navigator={nav}

--- a/src/lib/Scenes/Consignments/Screens/__tests__/Location-tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/__tests__/Location-tests.tsx
@@ -1,6 +1,6 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 import Location from "../Location"
 
 import { Theme } from "@artsy/palette"
@@ -8,7 +8,7 @@ import { Theme } from "@artsy/palette"
 it("renders without throwing an error", () => {
   const nav = {} as any
   const route = {} as any
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <Location navigator={nav} route={route} />
     </Theme>

--- a/src/lib/Scenes/Consignments/Screens/__tests__/Location-tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/__tests__/Location-tests.tsx
@@ -3,14 +3,8 @@ import React from "react"
 import "react-native"
 import Location from "../Location"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing an error", () => {
   const nav = {} as any
   const route = {} as any
-  renderWithWrappers(
-    <Theme>
-      <Location navigator={nav} route={route} />
-    </Theme>
-  )
+  renderWithWrappers(<Location navigator={nav} route={route} />)
 })

--- a/src/lib/Scenes/Consignments/Screens/__tests__/Metadata-tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/__tests__/Metadata-tests.tsx
@@ -5,8 +5,6 @@ import "react-native"
 import { ConsignmentMetadata } from "../../index"
 import Metadata from "../Metadata"
 
-import { Theme } from "@artsy/palette"
-
 const nav = {} as any
 const route = {} as any
 
@@ -26,20 +24,12 @@ const exampleMetadata: ConsignmentMetadata = {
 describe("state", () => {
   it("is set up with empty consignment metadata", () => {
     const consignmentMetadata = {} as ConsignmentMetadata
-    const tree = renderWithWrappers(
-      <Theme>
-        <Metadata navigator={nav} route={route} metadata={consignmentMetadata} />
-      </Theme>
-    )
+    const tree = renderWithWrappers(<Metadata navigator={nav} route={route} metadata={consignmentMetadata} />)
     expect(tree.root.findByProps({ testID: "consigments-metatdata-title" }).props.text.value).toBeFalsy()
   })
 
   it("is set up with filled consignment metadata", () => {
-    const tree = renderWithWrappers(
-      <Theme>
-        <Metadata navigator={nav} route={route} metadata={exampleMetadata} />
-      </Theme>
-    )
+    const tree = renderWithWrappers(<Metadata navigator={nav} route={route} metadata={exampleMetadata} />)
 
     expect(tree.root.findByProps({ testID: "consigments-metatdata-title" }).props.text.value).toBeTruthy()
   })

--- a/src/lib/Scenes/Consignments/Screens/__tests__/Metadata-tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/__tests__/Metadata-tests.tsx
@@ -1,6 +1,6 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import { ConsignmentMetadata } from "../../index"
 import Metadata from "../Metadata"
@@ -26,7 +26,7 @@ const exampleMetadata: ConsignmentMetadata = {
 describe("state", () => {
   it("is set up with empty consignment metadata", () => {
     const consignmentMetadata = {} as ConsignmentMetadata
-    const tree = renderer.create(
+    const tree = renderWithWrappers(
       <Theme>
         <Metadata navigator={nav} route={route} metadata={consignmentMetadata} />
       </Theme>
@@ -35,7 +35,7 @@ describe("state", () => {
   })
 
   it("is set up with filled consignment metadata", () => {
-    const tree = renderer.create(
+    const tree = renderWithWrappers(
       <Theme>
         <Metadata navigator={nav} route={route} metadata={exampleMetadata} />
       </Theme>

--- a/src/lib/Scenes/Consignments/Screens/__tests__/Overview-tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/__tests__/Overview-tests.tsx
@@ -14,19 +14,13 @@ jest.mock("@react-native-community/cameraroll", () => jest.fn())
 
 import SelectFromPhotoLibrary from "../SelectFromPhotoLibrary"
 
-import { Theme } from "@artsy/palette"
-
 const nav = {} as any
 const route = {} as any
 
 const anything = expect.anything
 
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <Overview navigator={nav} route={route} setup={{}} />
-    </Theme>
-  )
+  renderWithWrappers(<Overview navigator={nav} route={route} setup={{}} />)
 })
 
 describe("Opening the right page", () => {

--- a/src/lib/Scenes/Consignments/Screens/__tests__/Overview-tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/__tests__/Overview-tests.tsx
@@ -1,6 +1,6 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import Artist from "../ConsignmentsArtist"
 import Edition from "../Edition"
@@ -22,7 +22,7 @@ const route = {} as any
 const anything = expect.anything
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <Overview navigator={nav} route={route} setup={{}} />
     </Theme>

--- a/src/lib/Scenes/Consignments/Screens/__tests__/Provenance-tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/__tests__/Provenance-tests.tsx
@@ -1,6 +1,6 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 import Provenance from "../Provenance"
 
 import { Theme } from "@artsy/palette"
@@ -48,7 +48,7 @@ it("renders without throwing a error", () => {
   const nav = {} as any
   const route = {} as any
 
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <Provenance navigator={nav} route={route} />
     </Theme>
@@ -60,7 +60,7 @@ describe("with an existing state", () => {
     const nav = {} as any
     const route = {} as any
 
-    renderer.create(
+    renderWithWrappers(
       <Theme>
         <Provenance navigator={nav} route={route} provenance="Acquired by my father somewhere" />
       </Theme>

--- a/src/lib/Scenes/Consignments/Screens/__tests__/Provenance-tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/__tests__/Provenance-tests.tsx
@@ -3,8 +3,6 @@ import React from "react"
 import "react-native"
 import Provenance from "../Provenance"
 
-import { Theme } from "@artsy/palette"
-
 const emptyProps = { navigator: {} as any, route: {} as any }
 
 describe("callbacks", () => {
@@ -48,11 +46,7 @@ it("renders without throwing a error", () => {
   const nav = {} as any
   const route = {} as any
 
-  renderWithWrappers(
-    <Theme>
-      <Provenance navigator={nav} route={route} />
-    </Theme>
-  )
+  renderWithWrappers(<Provenance navigator={nav} route={route} />)
 })
 
 describe("with an existing state", () => {
@@ -60,10 +54,6 @@ describe("with an existing state", () => {
     const nav = {} as any
     const route = {} as any
 
-    renderWithWrappers(
-      <Theme>
-        <Provenance navigator={nav} route={route} provenance="Acquired by my father somewhere" />
-      </Theme>
-    )
+    renderWithWrappers(<Provenance navigator={nav} route={route} provenance="Acquired by my father somewhere" />)
   })
 })

--- a/src/lib/Scenes/Consignments/Screens/__tests__/SelectFromPhotoLibrary-tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/__tests__/SelectFromPhotoLibrary-tests.tsx
@@ -10,7 +10,6 @@ const realAlert = Alert.alert
 const realLinking = Linking.openURL
 
 jest.mock("lib/NativeModules/triggerCamera", () => ({ triggerCamera: jest.fn() }))
-import { Theme } from "@artsy/palette"
 import { triggerCamera } from "lib/NativeModules/triggerCamera"
 const triggerMock = triggerCamera as jest.Mock<any>
 
@@ -34,11 +33,7 @@ afterAll(() => {
 })
 
 it("renders without throwing a error", () => {
-  renderWithWrappers(
-    <Theme>
-      <SelectFromPhotoLibrary {...emptyProps} />
-    </Theme>
-  )
+  renderWithWrappers(<SelectFromPhotoLibrary {...emptyProps} />)
 })
 
 it("adds new photo to the list, and selects it", () => {

--- a/src/lib/Scenes/Consignments/Screens/__tests__/SelectFromPhotoLibrary-tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/__tests__/SelectFromPhotoLibrary-tests.tsx
@@ -1,7 +1,7 @@
 import CameraRoll from "@react-native-community/cameraroll"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { Alert, Linking, NativeModules } from "react-native"
-import * as renderer from "react-test-renderer"
 
 jest.mock("@react-native-community/cameraroll", () => ({ getPhotos: jest.fn() }))
 
@@ -34,7 +34,7 @@ afterAll(() => {
 })
 
 it("renders without throwing a error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <SelectFromPhotoLibrary {...emptyProps} />
     </Theme>

--- a/src/lib/Scenes/Consignments/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/Consignments/__tests__/index-tests.tsx
@@ -1,6 +1,6 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 jest.mock("@react-native-community/cameraroll", () => jest.fn())
 
@@ -13,7 +13,7 @@ jest.unmock("react-relay")
 it("renders without throwing an error", () => {
   const props: any = { navigator: {}, route: {} }
 
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <Consignments {...props} />
     </Theme>

--- a/src/lib/Scenes/Consignments/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/Consignments/__tests__/index-tests.tsx
@@ -6,16 +6,10 @@ jest.mock("@react-native-community/cameraroll", () => jest.fn())
 
 import { Consignments } from "../"
 
-import { Theme } from "@artsy/palette"
-
 jest.unmock("react-relay")
 
 it("renders without throwing an error", () => {
   const props: any = { navigator: {}, route: {} }
 
-  renderWithWrappers(
-    <Theme>
-      <Consignments {...props} />
-    </Theme>
-  )
+  renderWithWrappers(<Consignments {...props} />)
 })

--- a/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/Components/__tests__/ArtistList-tests.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/Components/__tests__/ArtistList-tests.tsx
@@ -1,13 +1,12 @@
-import { Theme } from "@artsy/palette"
 import React from "react"
 import "react-native"
 import { graphql, QueryRenderer } from "react-relay"
-import { create } from "react-test-renderer"
 import { useTracking } from "react-tracking"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 
 import { ArtistListTestsQuery } from "__generated__/ArtistListTestsQuery.graphql"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import { ArtistListFragmentContainer } from "../ArtistList"
 
@@ -30,24 +29,22 @@ describe("ArtistList", () => {
   })
 
   const TestRenderer = () => (
-    <Theme>
-      <QueryRenderer<ArtistListTestsQuery>
-        environment={mockEnvironment}
-        query={graphql`
-          query ArtistListTestsQuery {
-            targetSupply {
-              ...ArtistList_targetSupply
-            }
+    <QueryRenderer<ArtistListTestsQuery>
+      environment={mockEnvironment}
+      query={graphql`
+        query ArtistListTestsQuery {
+          targetSupply {
+            ...ArtistList_targetSupply
           }
-        `}
-        render={renderWithLoadProgress(ArtistListFragmentContainer)}
-        variables={{}}
-      />
-    </Theme>
+        }
+      `}
+      render={renderWithLoadProgress(ArtistListFragmentContainer)}
+      variables={{}}
+    />
   )
 
   it("renders an item for each artist", () => {
-    const tree = create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
 
     const targetSupply = makeTargetSupply([
       { name: "artist #1" },
@@ -72,7 +69,7 @@ describe("ArtistList", () => {
   })
 
   it("tracks an event for tapping an artist", () => {
-    const tree = create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
 
     const artist = {
       internalID: "artist-id",

--- a/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/Components/__tests__/RecentlySold-tests.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/Components/__tests__/RecentlySold-tests.tsx
@@ -1,13 +1,12 @@
-import { Theme } from "@artsy/palette"
 import React from "react"
 import "react-native"
 import { graphql, QueryRenderer } from "react-relay"
-import { create } from "react-test-renderer"
 import { useTracking } from "react-tracking"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 
 import { RecentlySoldTestsQuery } from "__generated__/RecentlySoldTestsQuery.graphql"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import { RecentlySoldFragmentContainer } from "../RecentlySold"
 
@@ -30,24 +29,22 @@ describe("RecentlySold", () => {
   })
 
   const TestRenderer = () => (
-    <Theme>
-      <QueryRenderer<RecentlySoldTestsQuery>
-        environment={mockEnvironment}
-        query={graphql`
-          query RecentlySoldTestsQuery {
-            targetSupply {
-              ...RecentlySold_targetSupply
-            }
+    <QueryRenderer<RecentlySoldTestsQuery>
+      environment={mockEnvironment}
+      query={graphql`
+        query RecentlySoldTestsQuery {
+          targetSupply {
+            ...RecentlySold_targetSupply
           }
-        `}
-        render={renderWithLoadProgress(RecentlySoldFragmentContainer)}
-        variables={{}}
-      />
-    </Theme>
+        }
+      `}
+      render={renderWithLoadProgress(RecentlySoldFragmentContainer)}
+      variables={{}}
+    />
   )
 
   it("renders sale message if artwork has realized price", () => {
-    const tree = create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
 
     const artwork = {
       realizedPrice: "$1,200",
@@ -65,7 +62,7 @@ describe("RecentlySold", () => {
   })
 
   it("does not render any sale message if artwork has no realized price", () => {
-    const tree = create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
 
     const artwork = {
       realizedPrice: null,
@@ -83,7 +80,7 @@ describe("RecentlySold", () => {
   })
 
   it("renders an artwork for each artist", () => {
-    const tree = create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
 
     const targetSupply = makeTargetSupply([
       {
@@ -119,7 +116,7 @@ describe("RecentlySold", () => {
   })
 
   it("tracks an event for tapping an artwork", () => {
-    const tree = create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
 
     const artwork = {
       internalID: "artwork-id",

--- a/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/Consignments/v2/Screens/ConsignmentsHome/__tests__/index-tests.tsx
@@ -1,7 +1,6 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
-import { Theme } from "@artsy/palette"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import { create } from "react-test-renderer"
 import { useTracking } from "react-tracking"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { ArtistList } from "../Components/ArtistList"
@@ -27,15 +26,11 @@ describe("ConsignmentsHome index", () => {
   })
 
   const TestWrapper = () => {
-    return (
-      <Theme>
-        <ConsignmentsHomeQueryRenderer environment={mockEnvironment} />
-      </Theme>
-    )
+    return <ConsignmentsHomeQueryRenderer environment={mockEnvironment} />
   }
 
   it("renders dynamic components", () => {
-    const tree = create(<TestWrapper />)
+    const tree = renderWithWrappers(<TestWrapper />)
 
     mockEnvironment.mock.resolveMostRecentOperation(MockPayloadGenerator.generate)
 
@@ -44,7 +39,7 @@ describe("ConsignmentsHome index", () => {
   })
 
   it("tracks a cta tap in the header", () => {
-    const tree = create(<TestWrapper />)
+    const tree = renderWithWrappers(<TestWrapper />)
     mockEnvironment.mock.resolveMostRecentOperation(MockPayloadGenerator.generate)
 
     tree.root.findByProps({ "data-test-id": "header-cta" }).props.onPress()
@@ -60,7 +55,7 @@ describe("ConsignmentsHome index", () => {
   })
 
   it("tracks a cta tap in the footer", () => {
-    const tree = create(<TestWrapper />)
+    const tree = renderWithWrappers(<TestWrapper />)
     mockEnvironment.mock.resolveMostRecentOperation(MockPayloadGenerator.generate)
 
     tree.root.findByProps({ "data-test-id": "footer-cta" }).props.onPress()

--- a/src/lib/Scenes/Fair/Components/FairBoothPreview/Components/__tests__/FairBoothPreviewHeader-tests.tsx
+++ b/src/lib/Scenes/Fair/Components/FairBoothPreview/Components/__tests__/FairBoothPreviewHeader-tests.tsx
@@ -1,19 +1,16 @@
-import { Theme } from "@artsy/palette"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import { create } from "react-test-renderer"
 import { FairBoothPreviewHeader } from "../FairBoothPreviewHeader"
 
 describe("FairBoothPreviewHeader", () => {
   it("renders without throwing an error", () => {
-    create(
-      <Theme>
-        <FairBoothPreviewHeader
-          name="A Partner"
-          location="Booth 21"
-          url="http://placehold.it/200x200"
-          onViewFairBoothPressed={jest.fn()}
-        />
-      </Theme>
+    renderWithWrappers(
+      <FairBoothPreviewHeader
+        name="A Partner"
+        location="Booth 21"
+        url="http://placehold.it/200x200"
+        onViewFairBoothPressed={jest.fn()}
+      />
     )
   })
 })

--- a/src/lib/Scenes/Fair/Components/__tests__/ArtistsExhibitorsWorksLink-tests.tsx
+++ b/src/lib/Scenes/Fair/Components/__tests__/ArtistsExhibitorsWorksLink-tests.tsx
@@ -1,5 +1,5 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
 import { ArtistsExhibitorsWorksLink } from "../ArtistsExhibitorsWorksLink"
 
 const onViewAllExhibitorsPressed = jest.fn()
@@ -8,12 +8,12 @@ const data = {
 }
 describe("ArtistsExhibitorsWorksLink", () => {
   it("renders without throwing an error", () => {
-    renderer.create(<ArtistsExhibitorsWorksLink {...(data as any)} />)
+    renderWithWrappers(<ArtistsExhibitorsWorksLink {...(data as any)} />)
   })
 
   it("passes a function as a prop when clicked", () => {
-    const component = renderer.create(<ArtistsExhibitorsWorksLink {...(data as any)} />).getInstance()
-    // @ts-ignore STRICTNESS_MIGRATION
+    const wrappedComponent = renderWithWrappers(<ArtistsExhibitorsWorksLink {...(data as any)} />)
+    const component = wrappedComponent.root.findByType(ArtistsExhibitorsWorksLink).instance
     component.props.onViewAllExhibitorsPressed()
     expect(onViewAllExhibitorsPressed).toHaveBeenCalled()
   })

--- a/src/lib/Scenes/Feature/__tests__/Feature-tests.tsx
+++ b/src/lib/Scenes/Feature/__tests__/Feature-tests.tsx
@@ -1,8 +1,7 @@
-import { Theme } from "@artsy/palette"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import { create } from "react-test-renderer"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { FeatureQueryRenderer } from "../Feature"
 
@@ -17,11 +16,7 @@ beforeEach(() => {
 
 describe(FeatureQueryRenderer, () => {
   it("renders without failing", () => {
-    const tree = create(
-      <Theme>
-        <FeatureQueryRenderer slug="anything" />
-      </Theme>
-    )
+    const tree = renderWithWrappers(<FeatureQueryRenderer slug="anything" />)
 
     mockRelayEnvironment.mock.resolveMostRecentOperation(op => {
       return MockPayloadGenerator.generate(op, {

--- a/src/lib/Scenes/Feature/components/__tests__/FeatureMarkdown-tests.tsx
+++ b/src/lib/Scenes/Feature/components/__tests__/FeatureMarkdown-tests.tsx
@@ -1,17 +1,11 @@
-import { Theme } from "@artsy/palette"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import { create } from "react-test-renderer"
 import { FeatureMarkdown } from "../FeatureMarkdown"
 
 describe(FeatureMarkdown, () => {
   it("renders markdown", () => {
-    const root = create(
-      <Theme>
-        <FeatureMarkdown content="this is _some_ **markdown**" />
-      </Theme>
-    )
-
+    const root = renderWithWrappers(<FeatureMarkdown content="this is _some_ **markdown**" />)
     expect(extractText(root.root)).toContain("this is some markdown")
   })
 })

--- a/src/lib/Scenes/Home/Components/__tests__/CollectionsRail-tests.tsx
+++ b/src/lib/Scenes/Home/Components/__tests__/CollectionsRail-tests.tsx
@@ -2,7 +2,7 @@ import { cloneDeep, first } from "lodash"
 import React from "react"
 import "react-native"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 jest.mock("lib/NativeModules/SwitchBoard", () => ({
@@ -10,9 +10,9 @@ jest.mock("lib/NativeModules/SwitchBoard", () => ({
 }))
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 
-import { Theme } from "@artsy/palette"
 import { CollectionsRailTestsQuery } from "__generated__/CollectionsRailTestsQuery.graphql"
 import { CardRailCard } from "lib/Components/Home/CardRailCard"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { useTracking } from "react-tracking"
 import HomeAnalytics from "../../homeAnalytics"
 import { CollectionsRailFragmentContainer } from "../CollectionsRail"
@@ -39,12 +39,10 @@ describe("CollectionsRailFragmentContainer", () => {
       render={({ props, error }) => {
         if (props) {
           return (
-            <Theme>
-              <CollectionsRailFragmentContainer
-                collectionsModule={props.homePage?.marketingCollectionsModule!}
-                scrollRef={mockScrollRef}
-              />
-            </Theme>
+            <CollectionsRailFragmentContainer
+              collectionsModule={props.homePage?.marketingCollectionsModule!}
+              scrollRef={mockScrollRef}
+            />
           )
         } else if (error) {
           console.log(error)
@@ -58,7 +56,7 @@ describe("CollectionsRailFragmentContainer", () => {
   })
 
   it("doesn't throw when rendered", () => {
-    ReactTestRenderer.create(<TestRenderer />)
+    renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],
@@ -77,7 +75,7 @@ describe("CollectionsRailFragmentContainer", () => {
       // @ts-ignore
       result.artworksConnection.edges = []
     })
-    ReactTestRenderer.create(<TestRenderer />)
+    renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],
@@ -91,7 +89,7 @@ describe("CollectionsRailFragmentContainer", () => {
   })
 
   it("routes to collection URL", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],
@@ -117,7 +115,7 @@ describe("CollectionsRailFragmentContainer", () => {
       }
     })
 
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],

--- a/src/lib/Scenes/Home/Components/__tests__/EmailConfirmationBanner-tests.tsx
+++ b/src/lib/Scenes/Home/Components/__tests__/EmailConfirmationBanner-tests.tsx
@@ -1,13 +1,14 @@
-import { Sans, Theme } from "@artsy/palette"
+import { Sans } from "@artsy/palette"
 import React from "react"
 import { TouchableWithoutFeedback } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
-import { create, ReactTestRenderer } from "react-test-renderer"
+import { ReactTestRenderer } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 import { EmailConfirmationBanner_me } from "__generated__/EmailConfirmationBanner_me.graphql"
 import { EmailConfirmationBannerTestsQuery } from "__generated__/EmailConfirmationBannerTestsQuery.graphql"
 import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { EmailConfirmationBannerFragmentContainer } from "../EmailConfirmationBanner"
 
 jest.unmock("react-relay")
@@ -29,11 +30,7 @@ describe("EmailConfirmationBanner", () => {
       variables={{}}
       render={({ props, error }) => {
         if (props) {
-          return (
-            <Theme>
-              <EmailConfirmationBannerFragmentContainer {...(props as any)} />
-            </Theme>
-          )
+          return <EmailConfirmationBannerFragmentContainer {...(props as any)} />
         } else if (error) {
           console.log(error)
         }
@@ -42,7 +39,7 @@ describe("EmailConfirmationBanner", () => {
   )
 
   const mount = (data: { me: Omit<EmailConfirmationBanner_me, " $refType"> }) => {
-    const component = create(<TestRenderer />)
+    const component = renderWithWrappers(<TestRenderer />)
     env.mock.resolveMostRecentOperation({ data, errors: [] })
     return component
   }

--- a/src/lib/Scenes/Home/Components/__tests__/FairsRail-tests.tsx
+++ b/src/lib/Scenes/Home/Components/__tests__/FairsRail-tests.tsx
@@ -1,7 +1,7 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { cloneDeep } from "lodash"
 import React from "react"
 import "react-native"
-import ReactTestRenderer from "react-test-renderer"
 
 import { FairsRail_fairsModule } from "__generated__/FairsRail_fairsModule.graphql"
 import { extractText } from "lib/tests/extractText"
@@ -63,7 +63,7 @@ const fairsModule: Omit<FairsRail_fairsModule, " $refType"> = {
 }
 
 it("renders without throwing an error", () => {
-  ReactTestRenderer.create(
+  renderWithWrappers(
     <Theme>
       <FairsRailFragmentContainer fairsModule={fairsModule as any} scrollRef={mockScrollRef} />
     </Theme>
@@ -79,7 +79,7 @@ it("renders without throwing an error when missing artworks", () => {
     result.otherArtworks.edges = []
   })
   expect(() =>
-    ReactTestRenderer.create(
+    renderWithWrappers(
       <Theme>
         <FairsRailFragmentContainer fairsModule={fairsCopy as any} scrollRef={mockScrollRef} />
       </Theme>
@@ -92,7 +92,7 @@ describe("location", () => {
     const fairsCopy = cloneDeep(fairsModule)
     // @ts-ignore
     fairsCopy.results[0].location.city = "New Yawk"
-    const tree = ReactTestRenderer.create(
+    const tree = renderWithWrappers(
       <Theme>
         <FairsRailFragmentContainer fairsModule={fairsCopy as any} scrollRef={mockScrollRef} />
       </Theme>
@@ -106,7 +106,7 @@ describe("location", () => {
     const fairsCopy = cloneDeep(fairsModule)
     // @ts-ignore
     fairsCopy.results[0].location.country = "Canada"
-    const tree = ReactTestRenderer.create(
+    const tree = renderWithWrappers(
       <Theme>
         <FairsRailFragmentContainer fairsModule={fairsCopy as any} scrollRef={mockScrollRef} />
       </Theme>
@@ -128,7 +128,7 @@ describe("analytics", () => {
 
   it("tracks fair thumbnail taps", () => {
     const fairsCopy = cloneDeep(fairsModule)
-    const tree = ReactTestRenderer.create(
+    const tree = renderWithWrappers(
       <Theme>
         <FairsRailFragmentContainer fairsModule={fairsCopy as any} scrollRef={mockScrollRef} />
       </Theme>

--- a/src/lib/Scenes/Home/Components/__tests__/FairsRail-tests.tsx
+++ b/src/lib/Scenes/Home/Components/__tests__/FairsRail-tests.tsx
@@ -7,7 +7,6 @@ import { FairsRail_fairsModule } from "__generated__/FairsRail_fairsModule.graph
 import { extractText } from "lib/tests/extractText"
 import { FairsRailFragmentContainer } from "../FairsRail"
 
-import { Theme } from "@artsy/palette"
 import { CardRailCard } from "lib/Components/Home/CardRailCard"
 import { useTracking } from "react-tracking"
 import HomeAnalytics from "../../homeAnalytics"
@@ -63,11 +62,7 @@ const fairsModule: Omit<FairsRail_fairsModule, " $refType"> = {
 }
 
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <FairsRailFragmentContainer fairsModule={fairsModule as any} scrollRef={mockScrollRef} />
-    </Theme>
-  )
+  renderWithWrappers(<FairsRailFragmentContainer fairsModule={fairsModule as any} scrollRef={mockScrollRef} />)
 })
 
 it("renders without throwing an error when missing artworks", () => {
@@ -79,11 +74,7 @@ it("renders without throwing an error when missing artworks", () => {
     result.otherArtworks.edges = []
   })
   expect(() =>
-    renderWithWrappers(
-      <Theme>
-        <FairsRailFragmentContainer fairsModule={fairsCopy as any} scrollRef={mockScrollRef} />
-      </Theme>
-    )
+    renderWithWrappers(<FairsRailFragmentContainer fairsModule={fairsCopy as any} scrollRef={mockScrollRef} />)
   ).not.toThrow()
 })
 
@@ -93,9 +84,7 @@ describe("location", () => {
     // @ts-ignore
     fairsCopy.results[0].location.city = "New Yawk"
     const tree = renderWithWrappers(
-      <Theme>
-        <FairsRailFragmentContainer fairsModule={fairsCopy as any} scrollRef={mockScrollRef} />
-      </Theme>
+      <FairsRailFragmentContainer fairsModule={fairsCopy as any} scrollRef={mockScrollRef} />
     )
     expect(extractText(tree.root.findAllByProps({ "data-test-id": "card-subtitle" })[0])).toMatchInlineSnapshot(
       `"Monday–Friday  •  New Yawk"`
@@ -107,9 +96,7 @@ describe("location", () => {
     // @ts-ignore
     fairsCopy.results[0].location.country = "Canada"
     const tree = renderWithWrappers(
-      <Theme>
-        <FairsRailFragmentContainer fairsModule={fairsCopy as any} scrollRef={mockScrollRef} />
-      </Theme>
+      <FairsRailFragmentContainer fairsModule={fairsCopy as any} scrollRef={mockScrollRef} />
     )
     expect(extractText(tree.root.findAllByProps({ "data-test-id": "card-subtitle" })[0])).toMatchInlineSnapshot(
       `"Monday–Friday  •  Canada"`
@@ -129,9 +116,7 @@ describe("analytics", () => {
   it("tracks fair thumbnail taps", () => {
     const fairsCopy = cloneDeep(fairsModule)
     const tree = renderWithWrappers(
-      <Theme>
-        <FairsRailFragmentContainer fairsModule={fairsCopy as any} scrollRef={mockScrollRef} />
-      </Theme>
+      <FairsRailFragmentContainer fairsModule={fairsCopy as any} scrollRef={mockScrollRef} />
     )
     const cards = tree.root.findAllByType(CardRailCard)
     cards[0].props.onPress()

--- a/src/lib/Scenes/Home/Components/__tests__/HomeHero-tests.tsx
+++ b/src/lib/Scenes/Home/Components/__tests__/HomeHero-tests.tsx
@@ -1,10 +1,10 @@
 import { HomeHeroTestsQuery } from "__generated__/HomeHeroTestsQuery.graphql"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { Image, TouchableOpacity } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
-import { create } from "react-test-renderer"
 import { useTracking } from "react-tracking"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { HomeHeroContainer } from "../HomeHero"
@@ -46,7 +46,7 @@ describe("HomeHero", () => {
   )
 
   it(`renders all the things`, () => {
-    const tree = create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     environment.mock.resolveMostRecentOperation(op =>
       MockPayloadGenerator.generate(op, {
         HomePageHeroUnit() {
@@ -65,7 +65,7 @@ describe("HomeHero", () => {
   })
 
   it(`only shows the credit line after the image has loaded`, () => {
-    const tree = create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     environment.mock.resolveMostRecentOperation(op =>
       MockPayloadGenerator.generate(op, {
         HomePageHeroUnit() {
@@ -85,7 +85,7 @@ describe("HomeHero", () => {
   })
 
   it("is tappable", () => {
-    const tree = create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     environment.mock.resolveMostRecentOperation(op =>
       MockPayloadGenerator.generate(op, {
         HomePageHeroUnit() {

--- a/src/lib/Scenes/Home/Components/__tests__/SalesRail-tests.tsx
+++ b/src/lib/Scenes/Home/Components/__tests__/SalesRail-tests.tsx
@@ -7,8 +7,6 @@ import "react-native"
 import { SalesRail_salesModule } from "__generated__/SalesRail_salesModule.graphql"
 import { extractText } from "lib/tests/extractText"
 
-import { Theme } from "@artsy/palette"
-
 jest.mock("lib/NativeModules/SwitchBoard", () => ({
   presentNavigationViewController: jest.fn(),
 }))
@@ -64,11 +62,7 @@ const salesModule: Omit<SalesRail_salesModule, " $refType"> = {
 
 it("doesn't throw when rendered", () => {
   expect(() =>
-    renderWithWrappers(
-      <Theme>
-        <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
-      </Theme>
-    )
+    renderWithWrappers(<SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />)
   ).not.toThrow()
 })
 
@@ -79,11 +73,7 @@ it("looks correct when rendered with sales missing artworks", () => {
     result.saleArtworksConnection.edges = []
   })
   expect(() =>
-    renderWithWrappers(
-      <Theme>
-        <SalesRailFragmentContainer salesModule={salesCopy as any} scrollRef={mockScrollRef} />
-      </Theme>
-    )
+    renderWithWrappers(<SalesRailFragmentContainer salesModule={salesCopy as any} scrollRef={mockScrollRef} />)
   ).not.toThrow()
 })
 
@@ -94,9 +84,7 @@ describe("image handling", () => {
     // @ts-ignore
     sale!.saleArtworksConnection!.edges = edges
     return renderWithWrappers(
-      <Theme>
-        <SalesRailFragmentContainer salesModule={{ results: [sale] } as any} scrollRef={mockScrollRef} />
-      </Theme>
+      <SalesRailFragmentContainer salesModule={{ results: [sale] } as any} scrollRef={mockScrollRef} />
     )
   }
 
@@ -137,9 +125,7 @@ describe("image handling", () => {
 
 it("renders the correct subtitle based on auction type", async () => {
   const tree = renderWithWrappers(
-    <Theme>
-      <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
-    </Theme>
+    <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
   )
   const subtitles = tree.root.findAllByProps({ "data-test-id": "sale-subtitle" })
   // Timed sale
@@ -152,9 +138,7 @@ it("renders the correct subtitle based on auction type", async () => {
 
 it("routes to live URL if present, otherwise href", () => {
   const tree = renderWithWrappers(
-    <Theme>
-      <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
-    </Theme>
+    <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
   )
   // Timed sale
   // @ts-ignore STRICTNESS_MIGRATION
@@ -180,9 +164,7 @@ describe("analytics", () => {
 
   it("tracks auction header taps", () => {
     const tree = renderWithWrappers(
-      <Theme>
-        <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
-      </Theme>
+      <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
     )
     tree.root.findByType(SectionTitle as any).props.onPress()
     expect(trackEvent).toHaveBeenCalledWith(HomeAnalytics.auctionHeaderTapEvent())
@@ -190,9 +172,7 @@ describe("analytics", () => {
 
   it("tracks auction thumbnail taps", () => {
     const tree = renderWithWrappers(
-      <Theme>
-        <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
-      </Theme>
+      <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
     )
     const cards = tree.root.findAllByType(CardRailCard)
     cards[0].props.onPress()

--- a/src/lib/Scenes/Home/Components/__tests__/SalesRail-tests.tsx
+++ b/src/lib/Scenes/Home/Components/__tests__/SalesRail-tests.tsx
@@ -1,8 +1,8 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { cloneDeep } from "lodash"
 import { first, last } from "lodash"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 
 import { SalesRail_salesModule } from "__generated__/SalesRail_salesModule.graphql"
 import { extractText } from "lib/tests/extractText"
@@ -64,7 +64,7 @@ const salesModule: Omit<SalesRail_salesModule, " $refType"> = {
 
 it("doesn't throw when rendered", () => {
   expect(() =>
-    renderer.create(
+    renderWithWrappers(
       <Theme>
         <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
       </Theme>
@@ -79,7 +79,7 @@ it("looks correct when rendered with sales missing artworks", () => {
     result.saleArtworksConnection.edges = []
   })
   expect(() =>
-    renderer.create(
+    renderWithWrappers(
       <Theme>
         <SalesRailFragmentContainer salesModule={salesCopy as any} scrollRef={mockScrollRef} />
       </Theme>
@@ -93,7 +93,7 @@ describe("image handling", () => {
     const sale = results[0]
     // @ts-ignore
     sale!.saleArtworksConnection!.edges = edges
-    return renderer.create(
+    return renderWithWrappers(
       <Theme>
         <SalesRailFragmentContainer salesModule={{ results: [sale] } as any} scrollRef={mockScrollRef} />
       </Theme>
@@ -136,7 +136,7 @@ describe("image handling", () => {
 })
 
 it("renders the correct subtitle based on auction type", async () => {
-  const tree = renderer.create(
+  const tree = renderWithWrappers(
     <Theme>
       <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
     </Theme>
@@ -151,7 +151,7 @@ it("renders the correct subtitle based on auction type", async () => {
 })
 
 it("routes to live URL if present, otherwise href", () => {
-  const tree = renderer.create(
+  const tree = renderWithWrappers(
     <Theme>
       <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
     </Theme>
@@ -179,7 +179,7 @@ describe("analytics", () => {
   })
 
   it("tracks auction header taps", () => {
-    const tree = renderer.create(
+    const tree = renderWithWrappers(
       <Theme>
         <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
       </Theme>
@@ -189,7 +189,7 @@ describe("analytics", () => {
   })
 
   it("tracks auction thumbnail taps", () => {
-    const tree = renderer.create(
+    const tree = renderWithWrappers(
       <Theme>
         <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
       </Theme>

--- a/src/lib/Scenes/Home/__tests__/Home-tests.tsx
+++ b/src/lib/Scenes/Home/__tests__/Home-tests.tsx
@@ -1,6 +1,6 @@
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import React from "react"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 jest.mock("lib/Components/Home/ArtistRails/ArtistRail", () => ({
@@ -23,6 +23,7 @@ jest.mock("lib/relay/createEnvironment", () => ({
 import { EmailConfirmationBanner } from "lib/Scenes/Home/Components/EmailConfirmationBanner"
 import { SalesRailFragmentContainer } from "lib/Scenes/Home/Components/SalesRail"
 import { AppStoreProvider } from "lib/store/AppStore"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { FairsRailFragmentContainer } from "../Components/FairsRail"
 import { HomeQueryRenderer } from "../Home"
 
@@ -39,7 +40,7 @@ const TestRenderer: React.FC = () => {
 
 describe(HomeQueryRenderer, () => {
   it("always renders sales and fairs", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     expect(env.mock.getMostRecentOperation().request.node.operation.name).toBe("HomeQuery")
 
     act(() => {
@@ -63,7 +64,7 @@ describe(HomeQueryRenderer, () => {
   })
 
   it("renders an email confirmation banner", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     expect(env.mock.getMostRecentOperation().request.node.operation.name).toBe("HomeQuery")
 
     act(() => {

--- a/src/lib/Scenes/Home/__tests__/TabBar-tests.tsx
+++ b/src/lib/Scenes/Home/__tests__/TabBar-tests.tsx
@@ -4,12 +4,6 @@ import { Animated } from "react-native"
 
 import TabBar from "lib/Components/TabBar"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <TabBar tabs={["Page 1", "Page 2", "Page 3"]} scrollValue={new Animated.Value(0)} />
-    </Theme>
-  )
+  renderWithWrappers(<TabBar tabs={["Page 1", "Page 2", "Page 3"]} scrollValue={new Animated.Value(0)} />)
 })

--- a/src/lib/Scenes/Home/__tests__/TabBar-tests.tsx
+++ b/src/lib/Scenes/Home/__tests__/TabBar-tests.tsx
@@ -1,13 +1,13 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { Animated } from "react-native"
-import * as renderer from "react-test-renderer"
 
 import TabBar from "lib/Components/TabBar"
 
 import { Theme } from "@artsy/palette"
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <TabBar tabs={["Page 1", "Page 2", "Page 3"]} scrollValue={new Animated.Value(0)} />
     </Theme>

--- a/src/lib/Scenes/MyBids/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/MyBids/__tests__/index-tests.tsx
@@ -1,7 +1,6 @@
-import { Theme } from "@artsy/palette"
 import React from "react"
 import { FlatList } from "react-native"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 import { MyBids_me } from "__generated__/MyBids_me.graphql"
@@ -10,6 +9,7 @@ import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { extractText } from "lib/tests/extractText"
 import { PlaceholderText } from "lib/utils/placeholders"
 
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { lotStandings, sales } from "../__fixtures__/MyBidsQuery"
 import { MyBidsQueryRenderer, RecentlyClosedLot, UpcomingLot } from "../index"
 
@@ -22,21 +22,13 @@ const env = (defaultEnvironment as any) as ReturnType<typeof createMockEnvironme
 
 describe(MyBidsQueryRenderer, () => {
   it("spins until the operation resolves", () => {
-    const tree = ReactTestRenderer.create(
-      <Theme>
-        <MyBidsQueryRenderer />
-      </Theme>
-    )
+    const tree = renderWithWrappers(<MyBidsQueryRenderer />)
 
     expect(tree.root.findAllByType(PlaceholderText).length).not.toBe(0)
   })
 
   it("renders upon success", () => {
-    const tree = ReactTestRenderer.create(
-      <Theme>
-        <MyBidsQueryRenderer />
-      </Theme>
-    )
+    const tree = renderWithWrappers(<MyBidsQueryRenderer />)
     expect(env.mock.getMostRecentOperation().request.node.operation.name).toBe("MyBidsQuery")
 
     act(() => {
@@ -83,11 +75,7 @@ describe(MyBidsQueryRenderer, () => {
   })
 
   it.skip("renders null upon failure", () => {
-    const tree = ReactTestRenderer.create(
-      <Theme>
-        <MyBidsQueryRenderer />
-      </Theme>
-    )
+    const tree = renderWithWrappers(<MyBidsQueryRenderer />)
 
     act(() => {
       env.mock.rejectMostRecentOperation(new Error())

--- a/src/lib/Scenes/MyProfile/__tests__/LoggedInUserInfo-tests.tsx
+++ b/src/lib/Scenes/MyProfile/__tests__/LoggedInUserInfo-tests.tsx
@@ -1,9 +1,10 @@
-import { Serif, Theme } from "@artsy/palette"
+import { Serif } from "@artsy/palette"
 import Spinner from "lib/Components/Spinner"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 import { UserProfileQueryRenderer } from "../LoggedInUserInfo"
 
@@ -16,20 +17,12 @@ const env = (defaultEnvironment as any) as ReturnType<typeof createMockEnvironme
 
 describe(UserProfileQueryRenderer, () => {
   it("spins until the operation resolves", () => {
-    const tree = ReactTestRenderer.create(
-      <Theme>
-        <UserProfileQueryRenderer />
-      </Theme>
-    )
+    const tree = renderWithWrappers(<UserProfileQueryRenderer />)
     expect(tree.root.findAllByType(Spinner)).toHaveLength(1)
   })
 
   it("renders upon sucess", () => {
-    const tree = ReactTestRenderer.create(
-      <Theme>
-        <UserProfileQueryRenderer />
-      </Theme>
-    )
+    const tree = renderWithWrappers(<UserProfileQueryRenderer />)
     expect(env.mock.getMostRecentOperation().request.node.operation.name).toBe("LoggedInUserInfoQuery")
 
     act(() => {
@@ -50,11 +43,7 @@ describe(UserProfileQueryRenderer, () => {
   })
 
   it("renders null upon failure", () => {
-    const tree = ReactTestRenderer.create(
-      <Theme>
-        <UserProfileQueryRenderer />
-      </Theme>
-    )
+    const tree = renderWithWrappers(<UserProfileQueryRenderer />)
 
     act(() => {
       env.mock.rejectMostRecentOperation(new Error())

--- a/src/lib/Scenes/MyProfile/__tests__/MyProfile-tests.tsx
+++ b/src/lib/Scenes/MyProfile/__tests__/MyProfile-tests.tsx
@@ -1,5 +1,5 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
 
 import { MyProfileQueryRenderer } from "../MyProfile"
 
@@ -7,5 +7,5 @@ jest.mock("../LoggedInUserInfo")
 jest.unmock("react-relay")
 
 it("renders without throwing an error", () => {
-  renderer.create(<MyProfileQueryRenderer />)
+  renderWithWrappers(<MyProfileQueryRenderer />)
 })

--- a/src/lib/Scenes/MyProfile/__tests__/MyProfilePushNotifications-tests.tsx
+++ b/src/lib/Scenes/MyProfile/__tests__/MyProfilePushNotifications-tests.tsx
@@ -1,9 +1,10 @@
 import React from "react"
 
-import { Sans, Theme } from "@artsy/palette"
+import { Sans } from "@artsy/palette"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { NativeModules, Switch } from "react-native"
-import { act, create } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 import {
   AllowPushNotificationsBanner,
@@ -34,11 +35,7 @@ describe(SwitchMenu, () => {
       description: "Switch Menu Description",
       disabled: false,
     }
-    const switchMenuInstance = create(
-      <Theme>
-        <SwitchMenu {...props} />
-      </Theme>
-    )
+    const switchMenuInstance = renderWithWrappers(<SwitchMenu {...props} />)
     // default state
     expect(switchMenuInstance.root.findByType(Switch).props.disabled).toBe(false)
     expect(switchMenuInstance.root.findAllByType(Sans)[0].props.color).toEqual("black100")
@@ -52,11 +49,7 @@ describe(SwitchMenu, () => {
       description: "Switch Menu Description",
       disabled: true,
     }
-    const switchMenuInstance = create(
-      <Theme>
-        <SwitchMenu {...props} />
-      </Theme>
-    )
+    const switchMenuInstance = renderWithWrappers(<SwitchMenu {...props} />)
     // default state
     expect(switchMenuInstance.root.findByType(Switch).props.disabled).toBe(true)
     expect(switchMenuInstance.root.findAllByType(Sans)[0].props.color).toEqual("black60")
@@ -65,21 +58,13 @@ describe(SwitchMenu, () => {
 
 describe(MyProfilePushNotificationsQueryRenderer, () => {
   it("Loads until the operation resolves", () => {
-    const tree = create(
-      <Theme>
-        <MyProfilePushNotificationsQueryRenderer />
-      </Theme>
-    )
+    const tree = renderWithWrappers(<MyProfilePushNotificationsQueryRenderer />)
     expect(tree.root.findAllByType(MyProfilePushNotifications)).toHaveLength(1)
     expect(tree.root.findByType(MyProfilePushNotifications).props.isLoading).toEqual(true)
   })
 
   it("renders without throwing an error", () => {
-    const tree = create(
-      <Theme>
-        <MyProfilePushNotificationsQueryRenderer />
-      </Theme>
-    )
+    const tree = renderWithWrappers(<MyProfilePushNotificationsQueryRenderer />)
 
     expect(env.mock.getMostRecentOperation().request.node.operation.name).toBe("MyProfilePushNotificationsQuery")
 
@@ -107,11 +92,7 @@ describe(MyProfilePushNotificationsQueryRenderer, () => {
   it("should show the allow notification banner if the user was never prompted to allow push notifications", () => {
     mockFetchNotificationPermissions.mockImplementationOnce(cb => cb(null, PushAuthorizationStatus.NotDetermined))
 
-    const tree = create(
-      <Theme>
-        <MyProfilePushNotificationsQueryRenderer />
-      </Theme>
-    )
+    const tree = renderWithWrappers(<MyProfilePushNotificationsQueryRenderer />)
 
     expect(env.mock.getMostRecentOperation().request.node.operation.name).toBe("MyProfilePushNotificationsQuery")
 

--- a/src/lib/Scenes/Partner/Components/__tests__/PartnerArtwork-tests.tsx
+++ b/src/lib/Scenes/Partner/Components/__tests__/PartnerArtwork-tests.tsx
@@ -1,10 +1,9 @@
+import { PartnerArtworkTestsQuery } from "__generated__/PartnerArtworkTestsQuery.graphql"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
-
-import { Theme } from "@artsy/palette"
-import { PartnerArtworkTestsQuery } from "__generated__/PartnerArtworkTestsQuery.graphql"
 import { PartnerArtworkFixture } from "../__fixtures__/PartnerArtwork-fixture"
 import { PartnerArtworkFragmentContainer as PartnerArtwork } from "../PartnerArtwork"
 
@@ -26,11 +25,7 @@ describe("PartnerArtwork", () => {
         variables={{}}
         render={({ props, error }) => {
           if (props?.partner) {
-            return (
-              <Theme>
-                <PartnerArtwork partner={props.partner} />
-              </Theme>
-            )
+            return <PartnerArtwork partner={props.partner} />
           } else if (error) {
             console.log(error)
           }
@@ -38,7 +33,7 @@ describe("PartnerArtwork", () => {
       />
     )
 
-    ReactTestRenderer.create(<TestRenderer />)
+    renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],

--- a/src/lib/Scenes/Partner/Components/__tests__/PartnerHeader-tests.tsx
+++ b/src/lib/Scenes/Partner/Components/__tests__/PartnerHeader-tests.tsx
@@ -1,9 +1,10 @@
-import { Button, Theme } from "@artsy/palette"
+import { Button } from "@artsy/palette"
 import { PartnerHeaderTestsQuery } from "__generated__/PartnerHeaderTestsQuery.graphql"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 import { PartnerHeaderContainer as PartnerHeader } from "../PartnerHeader"
 
@@ -24,11 +25,7 @@ describe("PartnerHeader", () => {
       variables={{}}
       render={({ props, error }) => {
         if (props?.partner) {
-          return (
-            <Theme>
-              <PartnerHeader partner={props.partner} />
-            </Theme>
-          )
+          return <PartnerHeader partner={props.partner} />
         } else if (error) {
           console.log(error)
         }
@@ -37,7 +34,7 @@ describe("PartnerHeader", () => {
   )
 
   it("renders artwork counts", async () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],
@@ -51,7 +48,7 @@ describe("PartnerHeader", () => {
   })
 
   it("renders the partner name", async () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],
@@ -65,7 +62,7 @@ describe("PartnerHeader", () => {
   })
 
   it("renders the follow button", async () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],

--- a/src/lib/Scenes/Partner/Components/__tests__/PartnerOverview-tests.tsx
+++ b/src/lib/Scenes/Partner/Components/__tests__/PartnerOverview-tests.tsx
@@ -1,10 +1,10 @@
-import { Theme } from "@artsy/palette"
 import { PartnerOverviewTestsQuery } from "__generated__/PartnerOverviewTestsQuery.graphql"
 import { ArtistListItem } from "lib/Components/ArtistListItem"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 import { PartnerOverviewFragmentContainer as PartnerOverview } from "../PartnerOverview"
 
@@ -43,11 +43,7 @@ describe("PartnerOverview", () => {
       variables={{}}
       render={({ props, error }) => {
         if (props?.partner) {
-          return (
-            <Theme>
-              <PartnerOverview partner={props.partner} />
-            </Theme>
-          )
+          return <PartnerOverview partner={props.partner} />
         } else if (error) {
           console.log(error)
         }
@@ -62,7 +58,7 @@ describe("PartnerOverview", () => {
         edges: artists,
       },
     }
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],
@@ -82,7 +78,7 @@ describe("PartnerOverview", () => {
         bio: "Nullam quis risus eget urna mollis ornare vel eu leo.",
       },
     }
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],
@@ -102,7 +98,7 @@ describe("PartnerOverview", () => {
       },
     }
 
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],

--- a/src/lib/Scenes/Sales/Components/ZeroState/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/Sales/Components/ZeroState/__tests__/index-tests.tsx
@@ -3,12 +3,6 @@ import React from "react"
 import "react-native"
 import { ZeroState } from "../index"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <ZeroState />
-    </Theme>
-  )
+  renderWithWrappers(<ZeroState />)
 })

--- a/src/lib/Scenes/Sales/Components/ZeroState/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/Sales/Components/ZeroState/__tests__/index-tests.tsx
@@ -1,12 +1,12 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 import { ZeroState } from "../index"
 
 import { Theme } from "@artsy/palette"
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <ZeroState />
     </Theme>

--- a/src/lib/Scenes/Sales/Components/__tests__/SaleListItem-tests.tsx
+++ b/src/lib/Scenes/Sales/Components/__tests__/SaleListItem-tests.tsx
@@ -2,13 +2,13 @@ import moment from "moment"
 import React from "react"
 import "react-native"
 
-import * as renderer from "react-test-renderer"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import SaleListItem from "../SaleListItem"
 
 import { Theme } from "@artsy/palette"
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <SaleListItem sale={props as any} containerWidth={750} />
     </Theme>

--- a/src/lib/Scenes/Sales/Components/__tests__/SaleListItem-tests.tsx
+++ b/src/lib/Scenes/Sales/Components/__tests__/SaleListItem-tests.tsx
@@ -5,14 +5,8 @@ import "react-native"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import SaleListItem from "../SaleListItem"
 
-import { Theme } from "@artsy/palette"
-
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <SaleListItem sale={props as any} containerWidth={750} />
-    </Theme>
-  )
+  renderWithWrappers(<SaleListItem sale={props as any} containerWidth={750} />)
 })
 
 const props = {

--- a/src/lib/Scenes/Search/__tests__/AutosuggestResults-tests.tsx
+++ b/src/lib/Scenes/Search/__tests__/AutosuggestResults-tests.tsx
@@ -4,17 +4,15 @@ import { AutosuggestResultsQueryRawResponse } from "__generated__/AutosuggestRes
 import Spinner from "lib/Components/Spinner"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { extractText } from "lib/tests/extractText"
+import { componentWithWrappers, renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { CatchErrors } from "lib/utils/CatchErrors"
 import React from "react"
 import { FlatList } from "react-native"
 import { act } from "react-test-renderer"
-import ReactTestRenderer from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 import { AutosuggestResults } from "../AutosuggestResults"
 import { SearchContext } from "../SearchContext"
 import { SearchResult } from "../SearchResult"
-
-/* tslint:disable use-wrapped-components */
 
 const FixturePage1: AutosuggestResultsQueryRawResponse = {
   results: {
@@ -157,12 +155,12 @@ describe("AutosuggestResults", () => {
   })
 
   it(`has no elements to begin with`, async () => {
-    const tree = ReactTestRenderer.create(<TestWrapper query="" />)
+    const tree = renderWithWrappers(<TestWrapper query="" />)
     expect(tree.root.findAllByType(SearchResult)).toHaveLength(0)
   })
 
   it(`has some elements to begin with if you give it some`, async () => {
-    const tree = ReactTestRenderer.create(<TestWrapper query="michael" />)
+    const tree = renderWithWrappers(<TestWrapper query="michael" />)
     expect(tree.root.findAllByType(SearchResult)).toHaveLength(0)
 
     expect(env.mock.getMostRecentOperation().request.node.operation.name).toBe("AutosuggestResultsQuery")
@@ -176,7 +174,7 @@ describe("AutosuggestResults", () => {
   })
 
   it(`doesn't call loadMore until you start scrolling`, () => {
-    const tree = ReactTestRenderer.create(<TestWrapper query="michael" />)
+    const tree = renderWithWrappers(<TestWrapper query="michael" />)
     act(() => {
       env.mock.resolveMostRecentOperation({ errors: [], data: FixturePage1 })
     })
@@ -224,7 +222,7 @@ describe("AutosuggestResults", () => {
   })
 
   it(`scrolls back to the top when the query changes`, async () => {
-    const tree = ReactTestRenderer.create(<TestWrapper query="michael" />)
+    const tree = renderWithWrappers(<TestWrapper query="michael" />)
     act(() => {
       env.mock.resolveMostRecentOperation({ errors: [], data: FixturePage1 })
     })
@@ -232,7 +230,7 @@ describe("AutosuggestResults", () => {
     tree.root.findByType(FlatList).instance.scrollToOffset = scrollToOffsetMock
 
     act(() => {
-      tree.update(<TestWrapper query="michaela" />)
+      tree.update(componentWithWrappers(<TestWrapper query="michaela" />))
     })
     act(() => {
       env.mock.resolveMostRecentOperation({ errors: [], data: FixturePage1 })
@@ -242,7 +240,7 @@ describe("AutosuggestResults", () => {
   })
 
   it(`shows the loading spinner until there's no more data`, async () => {
-    const tree = ReactTestRenderer.create(<TestWrapper query="michael" />)
+    const tree = renderWithWrappers(<TestWrapper query="michael" />)
     act(() => env.mock.resolveMostRecentOperation({ errors: [], data: FixturePage1 }))
     expect(tree.root.findAllByType(Spinner)).toHaveLength(1)
 
@@ -258,7 +256,7 @@ describe("AutosuggestResults", () => {
   })
 
   it(`gives an appropriate message when there's no search results`, () => {
-    const tree = ReactTestRenderer.create(<TestWrapper query="michael" />)
+    const tree = renderWithWrappers(<TestWrapper query="michael" />)
     act(() => env.mock.resolveMostRecentOperation({ errors: [], data: FixtureEmpty }))
 
     expect(tree.root.findAllByType(SearchResult)).toHaveLength(0)
@@ -266,14 +264,14 @@ describe("AutosuggestResults", () => {
   })
 
   it(`optionally hides the result type`, () => {
-    const tree = ReactTestRenderer.create(<TestWrapper query="michael" showResultType={false} />)
+    const tree = renderWithWrappers(<TestWrapper query="michael" showResultType={false} />)
     act(() => env.mock.resolveMostRecentOperation({ errors: [], data: FixturePage1 }))
     expect(extractText(tree.root)).not.toContain("Artist")
   })
 
   it(`allows for custom touch handlers on search result items`, () => {
     const spy = jest.fn()
-    const tree = ReactTestRenderer.create(<TestWrapper query="michael" showResultType={false} onResultPress={spy} />)
+    const tree = renderWithWrappers(<TestWrapper query="michael" showResultType={false} onResultPress={spy} />)
     act(() => env.mock.resolveMostRecentOperation({ errors: [], data: FixturePage1 }))
     tree.root.findByType(SearchResult).props.onResultPress()
     expect(spy).toHaveBeenCalled()

--- a/src/lib/Scenes/Search/__tests__/AutosuggestResults-tests.tsx
+++ b/src/lib/Scenes/Search/__tests__/AutosuggestResults-tests.tsx
@@ -7,11 +7,14 @@ import { extractText } from "lib/tests/extractText"
 import { CatchErrors } from "lib/utils/CatchErrors"
 import React from "react"
 import { FlatList } from "react-native"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
+import ReactTestRenderer from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 import { AutosuggestResults } from "../AutosuggestResults"
 import { SearchContext } from "../SearchContext"
 import { SearchResult } from "../SearchResult"
+
+/* tslint:disable use-wrapped-components */
 
 const FixturePage1: AutosuggestResultsQueryRawResponse = {
   results: {
@@ -172,7 +175,7 @@ describe("AutosuggestResults", () => {
     expect(tree.root.findAllByType(SearchResult)).toHaveLength(1)
   })
 
-  it(`doesn't call loadMore untill you start scrolling`, () => {
+  it(`doesn't call loadMore until you start scrolling`, () => {
     const tree = ReactTestRenderer.create(<TestWrapper query="michael" />)
     act(() => {
       env.mock.resolveMostRecentOperation({ errors: [], data: FixturePage1 })

--- a/src/lib/Scenes/Search/__tests__/AutosuggestResults-tests.tsx
+++ b/src/lib/Scenes/Search/__tests__/AutosuggestResults-tests.tsx
@@ -4,7 +4,7 @@ import { AutosuggestResultsQueryRawResponse } from "__generated__/AutosuggestRes
 import Spinner from "lib/Components/Spinner"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { extractText } from "lib/tests/extractText"
-import { componentWithWrappers, renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { CatchErrors } from "lib/utils/CatchErrors"
 import React from "react"
 import { FlatList } from "react-native"
@@ -230,7 +230,7 @@ describe("AutosuggestResults", () => {
     tree.root.findByType(FlatList).instance.scrollToOffset = scrollToOffsetMock
 
     act(() => {
-      tree.update(componentWithWrappers(<TestWrapper query="michaela" />))
+      tree.update(<TestWrapper query="michaela" />)
     })
     act(() => {
       env.mock.resolveMostRecentOperation({ errors: [], data: FixturePage1 })

--- a/src/lib/Scenes/Search/__tests__/CityGuideCTA-tests.tsx
+++ b/src/lib/Scenes/Search/__tests__/CityGuideCTA-tests.tsx
@@ -1,8 +1,8 @@
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { Image, TouchableOpacity } from "react-native"
-import { create } from "react-test-renderer"
 import { CityGuideCTA } from "../CityGuideCTA"
 
 jest.mock("lib/NativeModules/SwitchBoard", () => ({
@@ -11,13 +11,13 @@ jest.mock("lib/NativeModules/SwitchBoard", () => ({
 
 describe("Search page empty state", () => {
   it(`renders correctly`, async () => {
-    const tree = create(<CityGuideCTA />)
+    const tree = renderWithWrappers(<CityGuideCTA />)
     expect(extractText(tree.root)).toContain("Explore Art on View")
     expect(tree.root.findAllByType(Image)).toHaveLength(2)
   })
 
   it(`navigates to cityGuide link`, () => {
-    const tree = create(<CityGuideCTA />)
+    const tree = renderWithWrappers(<CityGuideCTA />)
     tree.root.findByType(TouchableOpacity).props.onPress()
     expect(SwitchBoard.presentNavigationViewController).toHaveBeenCalledWith(expect.anything(), "/local-discovery")
   })

--- a/src/lib/Scenes/Search/__tests__/RecentSearches-tests.tsx
+++ b/src/lib/Scenes/Search/__tests__/RecentSearches-tests.tsx
@@ -1,8 +1,9 @@
 import { extractText } from "lib/tests/extractText"
 import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React, { MutableRefObject } from "react"
 import { Text, View } from "react-native"
-import { act, create, ReactTestRenderer } from "react-test-renderer"
+import { act, ReactTestRenderer } from "react-test-renderer"
 import { ProvideRecentSearches, RecentSearch, useRecentSearches } from "../RecentSearches"
 
 const TestItem: React.FC<{ href: string; onPress(): void }> = ({ href }) => {
@@ -69,7 +70,7 @@ describe(useRecentSearches, () => {
       tree.unmount()
     }
     act(() => {
-      tree = create(jsx || <TestPage testRef={testRef} />)
+      tree = renderWithWrappers(jsx || <TestPage testRef={testRef} />)
     })
     await flushPromiseQueue()
   }

--- a/src/lib/Scenes/Search/__tests__/Search-tests.tsx
+++ b/src/lib/Scenes/Search/__tests__/Search-tests.tsx
@@ -1,7 +1,7 @@
 import { extractText } from "lib/tests/extractText"
 import React from "react"
 import { TextInput } from "react-native"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { CatchErrors } from "../../../utils/CatchErrors"
 import { AutosuggestResults } from "../AutosuggestResults"
 import { RecentSearches, useRecentSearches } from "../RecentSearches"
@@ -10,6 +10,7 @@ import { Search } from "../Search"
 jest.mock("lib/utils/hardware", () => ({
   isPad: jest.fn(),
 }))
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { isPad } from "lib/utils/hardware"
 import { CityGuideCTA } from "../CityGuideCTA"
 
@@ -32,7 +33,7 @@ const TestWrapper: typeof Search = props => (
 
 describe("The Search page", () => {
   it(`has an empty state`, async () => {
-    const tree = ReactTestRenderer.create(<TestWrapper />)
+    const tree = renderWithWrappers(<TestWrapper />)
     expect(tree.root.findAllByType(RecentSearches)).toHaveLength(1)
     expect(tree.root.findAllByType(AutosuggestResults)).toHaveLength(0)
     expect(extractText(tree.root.findByType(CityGuideCTA))).toContain("Explore Art on View")
@@ -41,7 +42,7 @@ describe("The Search page", () => {
   it(`does not show city guide entrance when on iPad`, async () => {
     const isPadMock = isPad as jest.Mock
     isPadMock.mockImplementationOnce(() => true)
-    const tree = ReactTestRenderer.create(<TestWrapper />)
+    const tree = renderWithWrappers(<TestWrapper />)
     expect(extractText(tree.root)).toContain("Search for artists, artworks, galleries, shows, and more")
     expect(tree.root.findAllByType(CityGuideCTA)).toHaveLength(0)
   })
@@ -64,7 +65,7 @@ describe("The Search page", () => {
     })
     const isPadMock = isPad as jest.Mock
     isPadMock.mockImplementationOnce(() => false)
-    const tree = ReactTestRenderer.create(<TestWrapper />)
+    const tree = renderWithWrappers(<TestWrapper />)
     expect(extractText(tree.root.findByType(CityGuideCTA))).toContain("Explore Art on View")
   })
 
@@ -85,7 +86,7 @@ describe("The Search page", () => {
       deleteRecentSearch: jest.fn(),
     })
 
-    const tree = ReactTestRenderer.create(<TestWrapper />)
+    const tree = renderWithWrappers(<TestWrapper />)
     expect(extractText(tree.root)).not.toContain("Search for artists, artworks, galleries, shows, and more")
     expect(useRecentSearchesMock).toBeCalled()
     expect(tree.root.findAllByType(RecentSearches)).toHaveLength(1)
@@ -93,7 +94,7 @@ describe("The Search page", () => {
   })
 
   it(`shows the cancel button when the input focues`, () => {
-    const tree = ReactTestRenderer.create(<TestWrapper />)
+    const tree = renderWithWrappers(<TestWrapper />)
     expect(extractText(tree.root)).not.toContain("Cancel")
     act(() => {
       tree.root.findByType(TextInput).props.onFocus()
@@ -102,7 +103,7 @@ describe("The Search page", () => {
   })
 
   it(`passes the query to the AutosuggestResults when the query.length is >= 2`, async () => {
-    const tree = ReactTestRenderer.create(<TestWrapper />)
+    const tree = renderWithWrappers(<TestWrapper />)
 
     act(() => {
       tree.root.findByType(TextInput).props.onChangeText("m")

--- a/src/lib/Scenes/Search/__tests__/SearchResult-tests.tsx
+++ b/src/lib/Scenes/Search/__tests__/SearchResult-tests.tsx
@@ -1,7 +1,7 @@
 import { CloseIcon } from "@artsy/palette"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { extractText } from "lib/tests/extractText"
-import { componentWithWrappers, renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { CatchErrors } from "lib/utils/CatchErrors"
 import React from "react"
 import { TouchableOpacity } from "react-native"
@@ -60,7 +60,7 @@ describe(SearchResult, () => {
     const tree = renderWithWrappers(<TestWrapper result={result} />)
     expect(tree.root.findAllByType(CloseIcon)).toHaveLength(0)
     act(() => {
-      tree.update(componentWithWrappers(<TestWrapper result={result} onDelete={() => void 0} />))
+      tree.update(<TestWrapper result={result} onDelete={() => void 0} />)
     })
     expect(tree.root.findAllByType(CloseIcon)).toHaveLength(1)
   })
@@ -94,15 +94,13 @@ describe(SearchResult, () => {
     expect(extractText(tree.root.findByProps({ weight: "medium" }))).toBe("ãn")
 
     tree.update(
-      componentWithWrappers(
-        <TestWrapper
-          result={{
-            ...result,
-            displayLabel: "Joãn Miró",
-          }}
-          highlight="Miro"
-        />
-      )
+      <TestWrapper
+        result={{
+          ...result,
+          displayLabel: "Joãn Miró",
+        }}
+        highlight="Miro"
+      />
     )
 
     expect(extractText(tree.root.findByProps({ weight: "medium" }))).toBe("Miró")

--- a/src/lib/Scenes/Search/__tests__/SearchResult-tests.tsx
+++ b/src/lib/Scenes/Search/__tests__/SearchResult-tests.tsx
@@ -1,10 +1,11 @@
-import { CloseIcon, Theme } from "@artsy/palette"
+import { CloseIcon } from "@artsy/palette"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { extractText } from "lib/tests/extractText"
+import { componentWithWrappers, renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { CatchErrors } from "lib/utils/CatchErrors"
 import React from "react"
 import { TouchableOpacity } from "react-native"
-import { act, create } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { ProvideRecentSearches, useRecentSearches } from "../RecentSearches"
 import { SearchContext } from "../SearchContext"
 import { SearchResult } from "../SearchResult"
@@ -33,11 +34,9 @@ const _TestWrapper: typeof SearchResult = props => {
 const TestWrapper: typeof SearchResult = props => (
   <SearchContext.Provider value={{ inputRef: { current: { blur: inputBlurMock } as any }, queryRef: { current: "" } }}>
     <ProvideRecentSearches>
-      <Theme>
-        <CatchErrors>
-          <_TestWrapper {...props} />
-        </CatchErrors>
-      </Theme>
+      <CatchErrors>
+        <_TestWrapper {...props} />
+      </CatchErrors>
     </ProvideRecentSearches>
   </SearchContext.Provider>
 )
@@ -51,23 +50,23 @@ describe(SearchResult, () => {
     SwitchBoard.presentNavigationViewController.mockClear()
   })
   it(`works`, async () => {
-    const tree = create(<TestWrapper result={result} />)
+    const tree = renderWithWrappers(<TestWrapper result={result} />)
 
     expect(extractText(tree.root)).toContain("Banksy")
     expect(extractText(tree.root)).toContain("Artist")
   })
 
   it("has an optional onDelete action which shows a close button", () => {
-    const tree = create(<TestWrapper result={result} />)
+    const tree = renderWithWrappers(<TestWrapper result={result} />)
     expect(tree.root.findAllByType(CloseIcon)).toHaveLength(0)
     act(() => {
-      tree.update(<TestWrapper result={result} onDelete={() => void 0} />)
+      tree.update(componentWithWrappers(<TestWrapper result={result} onDelete={() => void 0} />))
     })
     expect(tree.root.findAllByType(CloseIcon)).toHaveLength(1)
   })
 
   it("blurs the input and navigates to the correct page when tapped", async () => {
-    const tree = create(<TestWrapper result={result} />)
+    const tree = renderWithWrappers(<TestWrapper result={result} />)
     expect(SwitchBoard.presentNavigationViewController).not.toHaveBeenCalled()
     tree.root.findByType(TouchableOpacity).props.onPress()
     await new Promise(r => setTimeout(r, 50))
@@ -76,13 +75,13 @@ describe(SearchResult, () => {
   })
 
   it(`highlights a part of the string if possible`, async () => {
-    const tree = create(<TestWrapper result={result} highlight="an" />)
+    const tree = renderWithWrappers(<TestWrapper result={result} highlight="an" />)
 
     expect(extractText(tree.root.findByProps({ weight: "medium" }))).toBe("an")
   })
 
   it(`highlights a part of the string even when the string has diacritics but the highlight doesn't`, async () => {
-    const tree = create(
+    const tree = renderWithWrappers(
       <TestWrapper
         result={{
           ...result,
@@ -95,20 +94,22 @@ describe(SearchResult, () => {
     expect(extractText(tree.root.findByProps({ weight: "medium" }))).toBe("ãn")
 
     tree.update(
-      <TestWrapper
-        result={{
-          ...result,
-          displayLabel: "Joãn Miró",
-        }}
-        highlight="Miro"
-      />
+      componentWithWrappers(
+        <TestWrapper
+          result={{
+            ...result,
+            displayLabel: "Joãn Miró",
+          }}
+          highlight="Miro"
+        />
+      )
     )
 
     expect(extractText(tree.root.findByProps({ weight: "medium" }))).toBe("Miró")
   })
 
   it(`updates recent searches by default`, async () => {
-    const tree = create(<TestWrapper result={result} />)
+    const tree = renderWithWrappers(<TestWrapper result={result} />)
     expect(SwitchBoard.presentNavigationViewController).not.toHaveBeenCalled()
     expect(recentSearchesArray).toHaveLength(0)
     act(() => {
@@ -119,7 +120,7 @@ describe(SearchResult, () => {
   })
 
   it(`won't update recent searches if told not to`, async () => {
-    const tree = create(<TestWrapper result={result} updateRecentSearchesOnTap={false} />)
+    const tree = renderWithWrappers(<TestWrapper result={result} updateRecentSearchesOnTap={false} />)
     expect(SwitchBoard.presentNavigationViewController).not.toHaveBeenCalled()
     expect(recentSearchesArray).toHaveLength(0)
     act(() => {
@@ -130,13 +131,13 @@ describe(SearchResult, () => {
   })
 
   it(`optionally hides the entity type`, () => {
-    const tree = create(<TestWrapper result={result} showResultType={false} />)
+    const tree = renderWithWrappers(<TestWrapper result={result} showResultType={false} />)
     expect(extractText(tree.root)).not.toContain("Artist")
   })
 
   it(`allows for custom touch handlers on search result items`, () => {
     const spy = jest.fn()
-    const tree = create(<TestWrapper result={result} onResultPress={spy} />)
+    const tree = renderWithWrappers(<TestWrapper result={result} onResultPress={spy} />)
     tree.root.findByType(TouchableOpacity).props.onPress()
     expect(spy).toHaveBeenCalled()
   })

--- a/src/lib/Scenes/Show/Components/ShowHeader/Components/__tests__/Carousel-tests.tsx
+++ b/src/lib/Scenes/Show/Components/ShowHeader/Components/__tests__/Carousel-tests.tsx
@@ -1,5 +1,5 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import * as renderer from "react-test-renderer"
 
 import { Carousel } from "../Carousel"
 
@@ -7,7 +7,7 @@ import { Theme } from "@artsy/palette"
 
 describe("Carousel", () => {
   it("renders without throwing an error", () => {
-    renderer.create(
+    renderWithWrappers(
       <Theme>
         <Carousel sources={images} />
       </Theme>

--- a/src/lib/Scenes/Show/Components/ShowHeader/Components/__tests__/Carousel-tests.tsx
+++ b/src/lib/Scenes/Show/Components/ShowHeader/Components/__tests__/Carousel-tests.tsx
@@ -3,15 +3,9 @@ import React from "react"
 
 import { Carousel } from "../Carousel"
 
-import { Theme } from "@artsy/palette"
-
 describe("Carousel", () => {
   it("renders without throwing an error", () => {
-    renderWithWrappers(
-      <Theme>
-        <Carousel sources={images} />
-      </Theme>
-    )
+    renderWithWrappers(<Carousel sources={images} />)
   })
 })
 

--- a/src/lib/Scenes/Show/Components/ShowHeader/__tests__/ShowHeader-tests.tsx
+++ b/src/lib/Scenes/Show/Components/ShowHeader/__tests__/ShowHeader-tests.tsx
@@ -1,10 +1,10 @@
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
-import { Theme } from "@artsy/palette"
 import { ShowHeaderTestsQuery } from "__generated__/ShowHeaderTestsQuery.graphql"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { ShowHeaderContainer } from "../ShowHeader"
 
 jest.unmock("react-relay")
@@ -24,18 +24,14 @@ it("renders without throwing an error", () => {
       variables={{}}
       render={({ props, error }) => {
         if (props?.show) {
-          return (
-            <Theme>
-              <ShowHeaderContainer show={props.show} />
-            </Theme>
-          )
+          return <ShowHeaderContainer show={props.show} />
         } else if (error) {
           console.log(error)
         }
       }}
     />
   )
-  ReactTestRenderer.create(<TestRenderer />)
+  renderWithWrappers(<TestRenderer />)
   act(() => {
     env.mock.resolveMostRecentOperation({
       errors: [],

--- a/src/lib/Scenes/Show/Components/Shows/Components/__tests__/ShowItem-tests.tsx
+++ b/src/lib/Scenes/Show/Components/Shows/Components/__tests__/ShowItem-tests.tsx
@@ -1,11 +1,11 @@
 import { Theme } from "@artsy/palette"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 import { ShowItem } from "../ShowItem"
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <ShowItem show={data as any} />
     </Theme>

--- a/src/lib/Scenes/Show/Components/Shows/Components/__tests__/ShowItem-tests.tsx
+++ b/src/lib/Scenes/Show/Components/Shows/Components/__tests__/ShowItem-tests.tsx
@@ -1,15 +1,10 @@
-import { Theme } from "@artsy/palette"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
 import { ShowItem } from "../ShowItem"
 
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <ShowItem show={data as any} />
-    </Theme>
-  )
+  renderWithWrappers(<ShowItem show={data as any} />)
 })
 
 const data = {

--- a/src/lib/Scenes/Show/Components/Shows/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/Show/Components/Shows/__tests__/index-tests.tsx
@@ -1,4 +1,3 @@
-import { Theme } from "@artsy/palette"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
@@ -6,11 +5,7 @@ import { NearbyShows as _nearbyShows } from "../../../__fixtures__/NearbyShowsFi
 import { Shows } from "../index"
 
 it("renders without throwing an error", () => {
-  renderWithWrappers(
-    <Theme>
-      <Shows show={data as any} />
-    </Theme>
-  )
+  renderWithWrappers(<Shows show={data as any} />)
 })
 
 const data = {

--- a/src/lib/Scenes/Show/Components/Shows/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/Show/Components/Shows/__tests__/index-tests.tsx
@@ -1,12 +1,12 @@
 import { Theme } from "@artsy/palette"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import "react-native"
-import * as renderer from "react-test-renderer"
 import { NearbyShows as _nearbyShows } from "../../../__fixtures__/NearbyShowsFixture"
 import { Shows } from "../index"
 
 it("renders without throwing an error", () => {
-  renderer.create(
+  renderWithWrappers(
     <Theme>
       <Shows show={data as any} />
     </Theme>

--- a/src/lib/Scenes/Show/Components/__tests__/ShowEventSection-tests.tsx
+++ b/src/lib/Scenes/Show/Components/__tests__/ShowEventSection-tests.tsx
@@ -1,10 +1,9 @@
+import { ShowEventSectionTestsQuery } from "__generated__/ShowEventSectionTestsQuery.graphql"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
-
-import { Theme } from "@artsy/palette"
-import { ShowEventSectionTestsQuery } from "__generated__/ShowEventSectionTestsQuery.graphql"
 import { ShowEventSectionContainer as ShowEventSection } from "../ShowEventSection"
 
 jest.unmock("react-relay")
@@ -27,18 +26,14 @@ describe("ShowEventSection", () => {
         variables={{}}
         render={({ props, error }) => {
           if (props?.show) {
-            return (
-              <Theme>
-                <ShowEventSection event={props.show.events![0]!} />
-              </Theme>
-            )
+            return <ShowEventSection event={props.show.events![0]!} />
           } else if (error) {
             console.log(error)
           }
         }}
       />
     )
-    ReactTestRenderer.create(<TestRenderer />)
+    renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],

--- a/src/lib/Scenes/Show/Screens/__tests__/Detail-tests.tsx
+++ b/src/lib/Scenes/Show/Screens/__tests__/Detail-tests.tsx
@@ -1,11 +1,11 @@
-import { Theme } from "@artsy/palette"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 import { DetailTestsQuery } from "__generated__/DetailTestsQuery.graphql"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { DetailContainer } from "../Detail"
 
 jest.unmock("react-relay")
@@ -25,18 +25,14 @@ it("Renders the Show Detail Screen", async () => {
       variables={{}}
       render={({ props, error }) => {
         if (props?.show) {
-          return (
-            <Theme>
-              <DetailContainer show={props.show} />
-            </Theme>
-          )
+          return <DetailContainer show={props.show} />
         } else if (error) {
           console.log(error)
         }
       }}
     />
   )
-  const tree = ReactTestRenderer.create(<TestRenderer />)
+  const tree = renderWithWrappers(<TestRenderer />)
   act(() => {
     env.mock.resolveMostRecentOperation({
       errors: [],

--- a/src/lib/Scenes/Show/Screens/__tests__/MoreInfo-tests.tsx
+++ b/src/lib/Scenes/Show/Screens/__tests__/MoreInfo-tests.tsx
@@ -1,11 +1,12 @@
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 import { MoreInfoTestsQuery } from "__generated__/MoreInfoTestsQuery.graphql"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { MoreInfoContainer } from "../MoreInfo"
 
 jest.unmock("react-relay")
@@ -32,7 +33,7 @@ it("Renders the Show MoreInfo screen without throwing an error", async () => {
       }}
     />
   )
-  const tree = ReactTestRenderer.create(<TestRenderer />)
+  const tree = renderWithWrappers(<TestRenderer />)
   act(() => {
     env.mock.resolveMostRecentOperation({
       errors: [],

--- a/src/lib/Scenes/Show/Screens/__tests__/ShowArtists-tests.tsx
+++ b/src/lib/Scenes/Show/Screens/__tests__/ShowArtists-tests.tsx
@@ -1,9 +1,10 @@
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 import { ShowArtistsTestsQuery } from "__generated__/ShowArtistsTestsQuery.graphql"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { ShowArtistsContainer as ShowArtistsScreen } from "../../../../Scenes/Show/Screens/ShowArtists"
 
 jest.unmock("react-relay")
@@ -31,7 +32,7 @@ describe("AllArtists", () => {
         }}
       />
     )
-    ReactTestRenderer.create(<TestRenderer />)
+    renderWithWrappers(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation({
         errors: [],

--- a/src/lib/Scenes/Show/Screens/__tests__/ShowArtworks-tests.tsx
+++ b/src/lib/Scenes/Show/Screens/__tests__/ShowArtworks-tests.tsx
@@ -1,9 +1,10 @@
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 import { ShowArtworksTestsQuery } from "__generated__/ShowArtworksTestsQuery.graphql"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { ShowArtworksContainer as ShowArtworks } from "../../../../Scenes/Show/Screens/ShowArtworks"
 
 jest.unmock("react-relay")
@@ -30,7 +31,7 @@ it("renders without throwing an error", async () => {
       }}
     />
   )
-  ReactTestRenderer.create(<TestRenderer />)
+  renderWithWrappers(<TestRenderer />)
   act(() => {
     env.mock.resolveMostRecentOperation({
       errors: [],

--- a/src/lib/Scenes/Show/__tests__/Show-tests.tsx
+++ b/src/lib/Scenes/Show/__tests__/Show-tests.tsx
@@ -1,9 +1,10 @@
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 import { ShowTestsQuery } from "__generated__/ShowTestsQuery.graphql"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { ShowContainer } from "../Show"
 
 jest.unmock("react-relay")
@@ -30,7 +31,7 @@ it("renders the Show screen", async () => {
       }}
     />
   )
-  ReactTestRenderer.create(<TestRenderer />)
+  renderWithWrappers(<TestRenderer />)
   act(() => {
     env.mock.resolveMostRecentOperation({
       errors: [],

--- a/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomArtworkRail-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomArtworkRail-tests.tsx
@@ -1,4 +1,3 @@
-import { Theme } from "@artsy/palette"
 import { ViewingRoomArtworkRailTestsQuery } from "__generated__/ViewingRoomArtworkRailTestsQuery.graphql"
 import { ArtworkTileRail } from "lib/Components/ArtworkTileRail"
 import { SectionTitle } from "lib/Components/SectionTitle"
@@ -20,20 +19,18 @@ jest.mock("lib/NativeModules/SwitchBoard", () => ({
 describe("ViewingRoomArtworkRail", () => {
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
   const TestRenderer = () => (
-    <Theme>
-      <QueryRenderer<ViewingRoomArtworkRailTestsQuery>
-        environment={mockEnvironment}
-        query={graphql`
-          query ViewingRoomArtworkRailTestsQuery {
-            viewingRoom(id: "unused") {
-              ...ViewingRoomArtworkRail_viewingRoom
-            }
+    <QueryRenderer<ViewingRoomArtworkRailTestsQuery>
+      environment={mockEnvironment}
+      query={graphql`
+        query ViewingRoomArtworkRailTestsQuery {
+          viewingRoom(id: "unused") {
+            ...ViewingRoomArtworkRail_viewingRoom
           }
-        `}
-        render={renderWithLoadProgress(ViewingRoomArtworkRailContainer)}
-        variables={{}}
-      />
-    </Theme>
+        }
+      `}
+      render={renderWithLoadProgress(ViewingRoomArtworkRailContainer)}
+      variables={{}}
+    />
   )
   beforeEach(() => {
     mockEnvironment = createMockEnvironment()

--- a/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomArtworkRail-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomArtworkRail-tests.tsx
@@ -4,10 +4,10 @@ import { ArtworkTileRail } from "lib/Components/ArtworkTileRail"
 import { SectionTitle } from "lib/Components/SectionTitle"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer from "react-test-renderer"
 import { useTracking } from "react-tracking"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { tracks, ViewingRoomArtworkRailContainer } from "../ViewingRoomArtworkRail"
@@ -39,7 +39,7 @@ describe("ViewingRoomArtworkRail", () => {
     mockEnvironment = createMockEnvironment()
   })
   it("renders a title for the rail", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation => {
       const result = MockPayloadGenerator.generate(operation)
       return result
@@ -48,7 +48,7 @@ describe("ViewingRoomArtworkRail", () => {
   })
 
   it("navigates to the artworks screen + calls tracking when title is tapped", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation => {
       const result = MockPayloadGenerator.generate(operation, {
         ViewingRoom: () => ({
@@ -70,7 +70,7 @@ describe("ViewingRoomArtworkRail", () => {
   })
 
   it("renders one artwork card per edge", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation => {
       const result = MockPayloadGenerator.generate(operation, {
         ViewingRoom: () => ({

--- a/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomHeader-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomHeader-tests.tsx
@@ -2,10 +2,10 @@ import { Theme } from "@artsy/palette"
 import { ViewingRoomHeaderTestsQuery } from "__generated__/ViewingRoomHeaderTestsQuery.graphql"
 import { CountdownTimer } from "lib/Components/Countdown/CountdownTimer"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer from "react-test-renderer"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { PartnerIconImage, ViewingRoomHeaderContainer } from "../ViewingRoomHeader"
 
@@ -33,7 +33,7 @@ describe("ViewingRoomHeader", () => {
     mockEnvironment = createMockEnvironment()
   })
   it("renders a background image", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation => {
       const result = MockPayloadGenerator.generate(operation, {
         ViewingRoom: () => ({ heroImage: { imageURLs: { normalized: "Foo" } } }),
@@ -44,7 +44,7 @@ describe("ViewingRoomHeader", () => {
     expect(tree.root.findByProps({ "data-test-id": "background-image" }).props.imageURL).toBe("Foo")
   })
   it("renders a title", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation => {
       const result = MockPayloadGenerator.generate(operation, {
         ViewingRoom: () => ({ title: "Foo" }),
@@ -55,7 +55,7 @@ describe("ViewingRoomHeader", () => {
   })
 
   it("renders a countdown timer for scheduled", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation =>
       MockPayloadGenerator.generate(operation, {
         ViewingRoom: () => ({ title: "ok", status: "scheduled" }),
@@ -65,7 +65,7 @@ describe("ViewingRoomHeader", () => {
   })
 
   it("renders a countdown timer for live", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation =>
       MockPayloadGenerator.generate(operation, {
         ViewingRoom: () => ({ title: "ok", status: "live" }),
@@ -75,7 +75,7 @@ describe("ViewingRoomHeader", () => {
   })
 
   it("doesn't render a countdown timer for closed", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation =>
       MockPayloadGenerator.generate(operation, {
         ViewingRoom: () => ({ title: "ok", status: "closed" }),
@@ -85,7 +85,7 @@ describe("ViewingRoomHeader", () => {
   })
 
   it("renders partner name", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation => {
       const result = MockPayloadGenerator.generate(operation, {
         ViewingRoom: () => ({ partner: { name: "Foo" } }),
@@ -95,7 +95,7 @@ describe("ViewingRoomHeader", () => {
     expect(extractText(tree.root.findByProps({ "data-test-id": "partner-name" }))).toBe("Foo")
   })
   it("renders partner logo", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation => {
       const result = MockPayloadGenerator.generate(operation, {
         ViewingRoom: () => ({
@@ -112,7 +112,7 @@ describe("ViewingRoomHeader", () => {
   })
 
   it("doesn't render logo (and doesn't crash) if partner profile is null", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation => {
       const result = MockPayloadGenerator.generate(operation, {
         ViewingRoom: () => ({

--- a/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomHeader-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomHeader-tests.tsx
@@ -1,4 +1,3 @@
-import { Theme } from "@artsy/palette"
 import { ViewingRoomHeaderTestsQuery } from "__generated__/ViewingRoomHeaderTestsQuery.graphql"
 import { CountdownTimer } from "lib/Components/Countdown/CountdownTimer"
 import { extractText } from "lib/tests/extractText"
@@ -14,20 +13,18 @@ jest.unmock("react-relay")
 describe("ViewingRoomHeader", () => {
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
   const TestRenderer = () => (
-    <Theme>
-      <QueryRenderer<ViewingRoomHeaderTestsQuery>
-        environment={mockEnvironment}
-        query={graphql`
-          query ViewingRoomHeaderTestsQuery {
-            viewingRoom(id: "unused") {
-              ...ViewingRoomHeader_viewingRoom
-            }
+    <QueryRenderer<ViewingRoomHeaderTestsQuery>
+      environment={mockEnvironment}
+      query={graphql`
+        query ViewingRoomHeaderTestsQuery {
+          viewingRoom(id: "unused") {
+            ...ViewingRoomHeader_viewingRoom
           }
-        `}
-        render={renderWithLoadProgress(ViewingRoomHeaderContainer)}
-        variables={{}}
-      />
-    </Theme>
+        }
+      `}
+      render={renderWithLoadProgress(ViewingRoomHeaderContainer)}
+      variables={{}}
+    />
   )
   beforeEach(() => {
     mockEnvironment = createMockEnvironment()

--- a/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomSubsections-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomSubsections-tests.tsx
@@ -1,4 +1,4 @@
-import { Box, Theme } from "@artsy/palette"
+import { Box } from "@artsy/palette"
 import { ViewingRoomSubsectionsTestsQuery } from "__generated__/ViewingRoomSubsectionsTestsQuery.graphql"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
@@ -12,20 +12,18 @@ jest.unmock("react-relay")
 describe("ViewingRoomSubsections", () => {
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
   const TestRenderer = () => (
-    <Theme>
-      <QueryRenderer<ViewingRoomSubsectionsTestsQuery>
-        environment={mockEnvironment}
-        query={graphql`
-          query ViewingRoomSubsectionsTestsQuery {
-            viewingRoom(id: "unused") {
-              ...ViewingRoomSubsections_viewingRoom
-            }
+    <QueryRenderer<ViewingRoomSubsectionsTestsQuery>
+      environment={mockEnvironment}
+      query={graphql`
+        query ViewingRoomSubsectionsTestsQuery {
+          viewingRoom(id: "unused") {
+            ...ViewingRoomSubsections_viewingRoom
           }
-        `}
-        render={renderWithLoadProgress(ViewingRoomSubsectionsContainer)}
-        variables={{}}
-      />
-    </Theme>
+        }
+      `}
+      render={renderWithLoadProgress(ViewingRoomSubsectionsContainer)}
+      variables={{}}
+    />
   )
   beforeEach(() => {
     mockEnvironment = createMockEnvironment()

--- a/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomSubsections-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomSubsections-tests.tsx
@@ -1,9 +1,9 @@
 import { Box, Theme } from "@artsy/palette"
 import { ViewingRoomSubsectionsTestsQuery } from "__generated__/ViewingRoomSubsectionsTestsQuery.graphql"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer from "react-test-renderer"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { ViewingRoomSubsectionsContainer } from "../ViewingRoomSubsections"
 
@@ -31,7 +31,7 @@ describe("ViewingRoomSubsections", () => {
     mockEnvironment = createMockEnvironment()
   })
   it("renders a Box for each subsection", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation => {
       const result = MockPayloadGenerator.generate(operation)
       return result

--- a/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomViewWorksButton-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomViewWorksButton-tests.tsx
@@ -1,4 +1,3 @@
-import { Theme } from "@artsy/palette"
 import { ViewingRoomViewWorksButtonTestsQuery } from "__generated__/ViewingRoomViewWorksButtonTestsQuery.graphql"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
@@ -18,20 +17,18 @@ jest.mock("lib/NativeModules/SwitchBoard", () => ({
 describe("ViewingRoomViewWorksButton", () => {
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
   const TestRenderer = () => (
-    <Theme>
-      <QueryRenderer<ViewingRoomViewWorksButtonTestsQuery>
-        environment={mockEnvironment}
-        query={graphql`
-          query ViewingRoomViewWorksButtonTestsQuery {
-            viewingRoom(id: "unused") {
-              ...ViewingRoomViewWorksButton_viewingRoom
-            }
+    <QueryRenderer<ViewingRoomViewWorksButtonTestsQuery>
+      environment={mockEnvironment}
+      query={graphql`
+        query ViewingRoomViewWorksButtonTestsQuery {
+          viewingRoom(id: "unused") {
+            ...ViewingRoomViewWorksButton_viewingRoom
           }
-        `}
-        render={renderWithLoadProgress(ViewingRoomViewWorksButtonContainer)}
-        variables={{}}
-      />
-    </Theme>
+        }
+      `}
+      render={renderWithLoadProgress(ViewingRoomViewWorksButtonContainer)}
+      variables={{}}
+    />
   )
   beforeEach(() => {
     mockEnvironment = createMockEnvironment()

--- a/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomViewWorksButton-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomViewWorksButton-tests.tsx
@@ -1,11 +1,11 @@
 import { Theme } from "@artsy/palette"
 import { ViewingRoomViewWorksButtonTestsQuery } from "__generated__/ViewingRoomViewWorksButtonTestsQuery.graphql"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import React from "react"
 import { TouchableWithoutFeedback } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer from "react-test-renderer"
 import { useTracking } from "react-tracking"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { tracks, ViewingRoomViewWorksButtonContainer } from "../ViewingRoomViewWorksButton"
@@ -38,7 +38,7 @@ describe("ViewingRoomViewWorksButton", () => {
   })
 
   it("navigates to artworks page + calls tracking on button press", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation => {
       const result = MockPayloadGenerator.generate(operation, {
         ViewingRoom: () => ({

--- a/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomsListFeatured-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomsListFeatured-tests.tsx
@@ -1,4 +1,3 @@
-import { Theme } from "@artsy/palette"
 import { ViewingRoomsListFeaturedTestsQuery } from "__generated__/ViewingRoomsListFeaturedTestsQuery.graphql"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
@@ -14,22 +13,20 @@ jest.unmock("react-relay")
 describe(FeaturedRail, () => {
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
   const TestRenderer = () => (
-    <Theme>
-      <RelayEnvironmentProvider environment={mockEnvironment}>
-        <QueryRenderer<ViewingRoomsListFeaturedTestsQuery>
-          environment={mockEnvironment}
-          query={graphql`
-            query ViewingRoomsListFeaturedTestsQuery {
-              featured: viewingRooms(featured: true) {
-                ...ViewingRoomsListFeatured_featured
-              }
+    <RelayEnvironmentProvider environment={mockEnvironment}>
+      <QueryRenderer<ViewingRoomsListFeaturedTestsQuery>
+        environment={mockEnvironment}
+        query={graphql`
+          query ViewingRoomsListFeaturedTestsQuery {
+            featured: viewingRooms(featured: true) {
+              ...ViewingRoomsListFeatured_featured
             }
-          `}
-          variables={{}}
-          render={renderWithLoadProgress(FeaturedRail)}
-        />
-      </RelayEnvironmentProvider>
-    </Theme>
+          }
+        `}
+        variables={{}}
+        render={renderWithLoadProgress(FeaturedRail)}
+      />
+    </RelayEnvironmentProvider>
   )
 
   beforeEach(() => {

--- a/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomsListFeatured-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomsListFeatured-tests.tsx
@@ -1,10 +1,10 @@
 import { Theme } from "@artsy/palette"
 import { ViewingRoomsListFeaturedTestsQuery } from "__generated__/ViewingRoomsListFeaturedTestsQuery.graphql"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import { MediumCard } from "palette"
 import React from "react"
 import { QueryRenderer } from "react-relay"
-import ReactTestRenderer from "react-test-renderer"
 import { graphql, RelayEnvironmentProvider } from "relay-hooks"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { FeaturedRail } from "../ViewingRoomsListFeatured"
@@ -37,7 +37,7 @@ describe(FeaturedRail, () => {
   })
 
   it("shows some cards", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation =>
       MockPayloadGenerator.generate(operation, {
         Query: () => ({

--- a/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoom-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoom-tests.tsx
@@ -1,11 +1,12 @@
 import { ViewingRoomTestsQuery } from "__generated__/ViewingRoomTestsQuery.graphql"
 import { AnimatedBottomButton } from "lib/Components/AnimatedBottomButton"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import React from "react"
 import { FlatList } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer, { act } from "react-test-renderer"
+import { act } from "react-test-renderer"
 import { useTracking } from "react-tracking"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { ViewingRoomArtworkRailContainer } from "../Components/ViewingRoomArtworkRail"
@@ -36,7 +37,7 @@ describe("ViewingRoom", () => {
 
   describe("not yet open", () => {
     it("does not render normal sections", () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       mockEnvironment.mock.resolveMostRecentOperation(operation => {
         const result = MockPayloadGenerator.generate(operation, {
           ViewingRoom: () => ({ status: "scheduled" }),
@@ -51,7 +52,7 @@ describe("ViewingRoom", () => {
       expect(tree.root.findAllByType(ViewingRoomSubsections)).toHaveLength(0)
     })
     it("renders an 'opening soon' message", () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       mockEnvironment.mock.resolveMostRecentOperation(operation => {
         const result = MockPayloadGenerator.generate(operation, {
           ViewingRoom: () => ({ status: "scheduled" }),
@@ -69,7 +70,7 @@ describe("ViewingRoom", () => {
       status: "live",
     }
     it("renders an intro statement", () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       mockEnvironment.mock.resolveMostRecentOperation(operation => {
         const result = MockPayloadGenerator.generate(operation, {
           ViewingRoom: () => ({ introStatement: "Foo", ...defaultProps }),
@@ -80,7 +81,7 @@ describe("ViewingRoom", () => {
     })
 
     it("renders an artwork rail", () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       mockEnvironment.mock.resolveMostRecentOperation(operation => {
         const result = MockPayloadGenerator.generate(operation, {
           ViewingRoom: () => ({ ...defaultProps }),
@@ -91,7 +92,7 @@ describe("ViewingRoom", () => {
     })
 
     it("renders a pull quote", () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       mockEnvironment.mock.resolveMostRecentOperation(operation => {
         const result = MockPayloadGenerator.generate(operation, {
           ViewingRoom: () => ({ pullQuote: "Foo", ...defaultProps }),
@@ -101,7 +102,7 @@ describe("ViewingRoom", () => {
       expect(extractText(tree.root.findByProps({ "data-test-id": "pull-quote" }))).toEqual("Foo")
     })
     it("renders a body", () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       mockEnvironment.mock.resolveMostRecentOperation(operation => {
         const result = MockPayloadGenerator.generate(operation, {
           ViewingRoom: () => ({ body: "Foo", ...defaultProps }),
@@ -111,7 +112,7 @@ describe("ViewingRoom", () => {
       expect(extractText(tree.root.findByProps({ "data-test-id": "body" }))).toEqual("Foo")
     })
     it("renders the subsections", () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       mockEnvironment.mock.resolveMostRecentOperation(operation => {
         const result = MockPayloadGenerator.generate(operation, {
           ViewingRoom: () => ({ ...defaultProps }),
@@ -122,7 +123,7 @@ describe("ViewingRoom", () => {
     })
 
     it("renders a button + calls tracking when body enters viewport", () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       mockEnvironment.mock.resolveMostRecentOperation(operation => {
         const result = MockPayloadGenerator.generate(operation, {
           ViewingRoom: () => ({
@@ -151,7 +152,7 @@ describe("ViewingRoom", () => {
 
   describe("closed (past end datetime)", () => {
     it("does not render normal sections", () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       mockEnvironment.mock.resolveMostRecentOperation(operation => {
         const result = MockPayloadGenerator.generate(operation, {
           ViewingRoom: () => ({ status: "closed" }),
@@ -167,7 +168,7 @@ describe("ViewingRoom", () => {
     })
 
     it("renders a 'closed' message", () => {
-      const tree = ReactTestRenderer.create(<TestRenderer />)
+      const tree = renderWithWrappers(<TestRenderer />)
       mockEnvironment.mock.resolveMostRecentOperation(operation => {
         const result = MockPayloadGenerator.generate(operation, {
           ViewingRoom: () => ({ status: "closed" }),

--- a/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomArtwork-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomArtwork-tests.tsx
@@ -1,7 +1,7 @@
 import { Button, Theme } from "@artsy/palette"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import ReactTestRenderer from "react-test-renderer"
 import { RelayEnvironmentProvider } from "relay-hooks"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { ViewingRoomArtworkQueryRenderer } from "../ViewingRoomArtwork"
@@ -29,7 +29,7 @@ describe("ViewingRoomArtwork", () => {
   })
 
   it("links to the artwork screen", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation => {
       const result = MockPayloadGenerator.generate(operation, {
         Artwork: () => ({

--- a/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomArtwork-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomArtwork-tests.tsx
@@ -1,4 +1,4 @@
-import { Button, Theme } from "@artsy/palette"
+import { Button } from "@artsy/palette"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
@@ -14,14 +14,12 @@ jest.mock("lib/NativeModules/SwitchBoard", () => ({
 describe("ViewingRoomArtwork", () => {
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
   const TestRenderer = () => (
-    <Theme>
-      <RelayEnvironmentProvider environment={mockEnvironment}>
-        <ViewingRoomArtworkQueryRenderer
-          viewing_room_id="zero-dot-dot-dot-alessandro-pessoli"
-          artwork_id="alessandro-pessoli-ardente-primavera-number-1"
-        />
-      </RelayEnvironmentProvider>
-    </Theme>
+    <RelayEnvironmentProvider environment={mockEnvironment}>
+      <ViewingRoomArtworkQueryRenderer
+        viewing_room_id="zero-dot-dot-dot-alessandro-pessoli"
+        artwork_id="alessandro-pessoli-ardente-primavera-number-1"
+      />
+    </RelayEnvironmentProvider>
   )
 
   beforeEach(() => {

--- a/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomArtworks-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomArtworks-tests.tsx
@@ -1,12 +1,12 @@
 import { ViewingRoomArtworksTestsQuery } from "__generated__/ViewingRoomArtworksTestsQuery.graphql"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import { Touchable } from "palette"
 import React from "react"
 import { FlatList, TouchableHighlight } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
-import ReactTestRenderer from "react-test-renderer"
 import { useTracking } from "react-tracking"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { tracks, ViewingRoomArtworksContainer } from "../ViewingRoomArtworks"
@@ -37,7 +37,7 @@ describe("ViewingRoom", () => {
   })
 
   it("renders a flatlist with one artwork", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation => {
       const result = MockPayloadGenerator.generate(operation, {
         ViewingRoom: () => ({ artworksConnection: { edges: ["Foo"] } }),
@@ -49,7 +49,7 @@ describe("ViewingRoom", () => {
   })
 
   it("renders additional information if it exists", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation => {
       const result = MockPayloadGenerator.generate(operation, {
         ViewingRoom: () => ({
@@ -73,7 +73,7 @@ describe("ViewingRoom", () => {
   })
 
   it("navigates to artwork screen + calls tracking on press", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation => {
       const result = MockPayloadGenerator.generate(operation, {
         ViewingRoom: () => ({

--- a/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomsList-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomsList-tests.tsx
@@ -1,6 +1,6 @@
 import { Theme } from "@artsy/palette"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import ReactTestRenderer from "react-test-renderer"
 import { RelayEnvironmentProvider } from "relay-hooks"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { ViewingRoomsListItem } from "../Components/ViewingRoomsListItem"
@@ -23,7 +23,7 @@ describe("ViewingRoomsList", () => {
   })
 
   it("renders viewing rooms", () => {
-    const tree = ReactTestRenderer.create(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />)
 
     mockEnvironment.mock.resolveMostRecentOperation(operation =>
       MockPayloadGenerator.generate(operation, {

--- a/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomsList-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomsList-tests.tsx
@@ -1,4 +1,3 @@
-import { Theme } from "@artsy/palette"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { RelayEnvironmentProvider } from "relay-hooks"
@@ -12,9 +11,7 @@ describe("ViewingRoomsList", () => {
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
   const TestRenderer = () => (
     <RelayEnvironmentProvider environment={mockEnvironment}>
-      <Theme>
-        <ViewingRoomsListQueryRenderer />
-      </Theme>
+      <ViewingRoomsListQueryRenderer />
     </RelayEnvironmentProvider>
   )
 

--- a/src/lib/tests/renderWithLayout.tsx
+++ b/src/lib/tests/renderWithLayout.tsx
@@ -1,9 +1,9 @@
-import * as renderer from "react-test-renderer"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 
 /** Renders a React Component with specified layout using onLayout callback */
 export const renderWithLayout = (component: any, layout: { width?: number; height?: number }) => {
   // create the component with renderer
-  component = renderer.create(component)
+  component = renderWithWrappers(component)
 
   // create a nativeEvent with desired dimensions
   const mockNativeEvent = {

--- a/src/lib/tests/renderWithWrappers.tsx
+++ b/src/lib/tests/renderWithWrappers.tsx
@@ -1,0 +1,14 @@
+import { Theme } from "@artsy/palette"
+import React from "react"
+import * as renderer from "react-test-renderer"
+import { ReactElement } from "simple-markdown"
+
+/*
+ * Renders a React Component with our page wrappers
+ * only <Theme> for now
+ */
+export const renderWithWrappers = (component: ReactElement) => {
+  const wrappedComponent = <Theme>{component}</Theme>
+  const renderedComponent = renderer.create(wrappedComponent)
+  return renderedComponent
+}

--- a/src/lib/tests/renderWithWrappers.tsx
+++ b/src/lib/tests/renderWithWrappers.tsx
@@ -12,6 +12,13 @@ export const renderWithWrappers = (component: ReactElement) => {
   const wrappedComponent = componentWithWrappers(component)
   // tslint:disable-next-line:use-wrapped-components
   const renderedComponent = ReactTestRenderer.create(wrappedComponent)
+
+  // monkey patch update method to wrap components
+  const originalUpdate = renderedComponent.update
+  renderedComponent.update = (nextElement: ReactElement) => {
+    originalUpdate(componentWithWrappers(nextElement))
+  }
+
   return renderedComponent
 }
 

--- a/src/lib/tests/renderWithWrappers.tsx
+++ b/src/lib/tests/renderWithWrappers.tsx
@@ -1,6 +1,6 @@
 import { Theme } from "@artsy/palette"
 import React from "react"
-import * as renderer from "react-test-renderer"
+import ReactTestRenderer from "react-test-renderer"
 import { ReactElement } from "simple-markdown"
 
 /*
@@ -9,6 +9,7 @@ import { ReactElement } from "simple-markdown"
  */
 export const renderWithWrappers = (component: ReactElement) => {
   const wrappedComponent = <Theme>{component}</Theme>
-  const renderedComponent = renderer.create(wrappedComponent)
+  // tslint:disable-next-line:use-wrapped-components
+  const renderedComponent = ReactTestRenderer.create(wrappedComponent)
   return renderedComponent
 }

--- a/src/lib/tests/renderWithWrappers.tsx
+++ b/src/lib/tests/renderWithWrappers.tsx
@@ -3,13 +3,23 @@ import React from "react"
 import ReactTestRenderer from "react-test-renderer"
 import { ReactElement } from "simple-markdown"
 
-/*
+/**
  * Renders a React Component with our page wrappers
  * only <Theme> for now
+ * @param component
  */
 export const renderWithWrappers = (component: ReactElement) => {
-  const wrappedComponent = <Theme>{component}</Theme>
+  const wrappedComponent = componentWithWrappers(component)
   // tslint:disable-next-line:use-wrapped-components
   const renderedComponent = ReactTestRenderer.create(wrappedComponent)
   return renderedComponent
+}
+
+/**
+ * Returns given component wrapped with our page wrappers
+ * only <Theme> for now
+ * @param component
+ */
+export const componentWithWrappers = (component: ReactElement) => {
+  return <Theme>{component}</Theme>
 }

--- a/src/lib/utils/__tests__/placeholders-tests.tsx
+++ b/src/lib/utils/__tests__/placeholders-tests.tsx
@@ -1,14 +1,14 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import ReactTestRenderer from "react-test-renderer"
 import { PlaceholderBox, PlaceholderRaggedText, ProvidePlaceholderContext } from "../placeholders"
 
 describe(PlaceholderBox, () => {
   it(`requires a placeholder context`, async () => {
     expect(() => {
-      ReactTestRenderer.create(<PlaceholderBox width={400} />)
+      renderWithWrappers(<PlaceholderBox width={400} />)
     }).toThrowErrorMatchingInlineSnapshot(`"You're using a Placeholder outside of a PlaceholderContext"`)
 
-    ReactTestRenderer.create(
+    renderWithWrappers(
       <ProvidePlaceholderContext>
         <PlaceholderBox width={400} />
       </ProvidePlaceholderContext>
@@ -18,7 +18,7 @@ describe(PlaceholderBox, () => {
 
 describe(PlaceholderRaggedText, () => {
   it(`creates the right number of placeholders matching the given number of lines`, () => {
-    const tree = ReactTestRenderer.create(
+    const tree = renderWithWrappers(
       <ProvidePlaceholderContext>
         <PlaceholderRaggedText numLines={4} />
       </ProvidePlaceholderContext>

--- a/src/lib/utils/__tests__/renderWithLoadProgress-tests.tsx
+++ b/src/lib/utils/__tests__/renderWithLoadProgress-tests.tsx
@@ -1,8 +1,8 @@
 import Spinner from "lib/Components/Spinner"
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { Text } from "react-native"
-import ReactTestRenderer from "react-test-renderer"
 import renderWithLoadProgress from "../renderWithLoadProgress"
 
 describe(renderWithLoadProgress, () => {
@@ -12,7 +12,7 @@ describe(renderWithLoadProgress, () => {
     expect(React.isValidElement(result)).toBeTruthy()
 
     // @ts-ignore STRICTNESS_MIGRATION
-    const tree = ReactTestRenderer.create(result)
+    const tree = renderWithWrappers(result)
     expect(tree.root.findByType(Spinner)).toBeTruthy()
   })
   it(`renders the real content when the graphqls are done`, () => {
@@ -22,7 +22,7 @@ describe(renderWithLoadProgress, () => {
     )({ error: null, props: {}, retry: () => null })
     expect(React.isValidElement(result)).toBeTruthy()
     // @ts-ignore STRICTNESS_MIGRATION
-    const tree = ReactTestRenderer.create(result)
+    const tree = renderWithWrappers(result)
     expect(extractText(tree.root)).toBe("the real content")
   })
 })

--- a/src/lib/utils/__tests__/renderWithPlaceholder-tests.tsx
+++ b/src/lib/utils/__tests__/renderWithPlaceholder-tests.tsx
@@ -1,7 +1,7 @@
 import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { Text } from "react-native"
-import ReactTestRenderer from "react-test-renderer"
 import { renderWithPlaceholder } from "../renderWithPlaceholder"
 
 describe(renderWithPlaceholder, () => {
@@ -14,7 +14,7 @@ describe(renderWithPlaceholder, () => {
     expect(React.isValidElement(result)).toBeTruthy()
 
     // @ts-ignore STRICTNESS_MIGRATION
-    const tree = ReactTestRenderer.create(result)
+    const tree = renderWithWrappers(result)
     expect(extractText(tree.root)).toBe("this is the placeholder")
   })
   it(`renders the real content when the graphqls are done`, () => {
@@ -24,7 +24,7 @@ describe(renderWithPlaceholder, () => {
     })({ error: null, props: {}, retry: () => null })
     expect(React.isValidElement(result)).toBeTruthy()
     // @ts-ignore STRICTNESS_MIGRATION
-    const tree = ReactTestRenderer.create(result)
+    const tree = renderWithWrappers(result)
     expect(extractText(tree.root)).toBe("the real content")
   })
 })

--- a/src/lib/utils/getTestWrapper.tsx
+++ b/src/lib/utils/getTestWrapper.tsx
@@ -7,12 +7,12 @@
  *  const { text }  = getTestSnapshot(<MyComponent title='Hi!' />)
  *  expect(text).toContain('Hi!')
  */
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import "react-native"
-import renderer from "react-test-renderer"
 
 export function getTestWrapper(TestComponent: any /* STRICTNESS_MIGRATION */) {
   try {
-    const snapshot = renderer.create(TestComponent)
+    const snapshot = renderWithWrappers(TestComponent)
     const text = JSON.stringify(snapshot.toJSON())
     const json = snapshot.toTree()
 
@@ -38,6 +38,6 @@ export function getTestWrapper(TestComponent: any /* STRICTNESS_MIGRATION */) {
  */
 
 export function getTextTree(TestComponent: any /* STRICTNESS_MIGRATION */) {
-  const snapshot = renderer.create(TestComponent)
+  const snapshot = renderWithWrappers(TestComponent)
   return JSON.stringify(snapshot.toJSON())
 }

--- a/tslint-rules/useWrappedComponentsRule.js
+++ b/tslint-rules/useWrappedComponentsRule.js
@@ -4,10 +4,7 @@ const Lint = require("tslint")
 const tsutils = require("tsutils")
 const ts = require("typescript")
 
-const AUTOFIX = false
-
-const FAILURE_STRING =
-  "Please use renderWithWrappers() rather than ReactTestRenderer.create() 🙏\n(Feel free to ping the MX team for questions or feedback about this rule.)"
+const FAILURE_STRING = "Please use renderWithWrappers() rather than ReactTestRenderer.create() 🙏\n(Feel free to ping the MX team for questions or feedback about this rule.)"
 
 class Rule extends Lint.Rules.AbstractRule {
   /**
@@ -17,10 +14,10 @@ class Rule extends Lint.Rules.AbstractRule {
     ruleName: "use-wrapped-components",
     type: "maintainability",
     description:
-      "In the app we wrap all our pages to make functionality accessible to subcomponents. We provide a helper function to do the same in our tests.",
+      "In the app we wrap all our Pages to make functionality accessible to subcomponents. We provide a helper function to do the same in our tests.",
     descriptionDetails:
-      "TBD",
-    hasFix: AUTOFIX,
+      "In the app we wrap all our Pages to make functionality accessible to subcomponents. We provide a helper function to do the same in our tests. Many components implicity depend on these wrappers.",
+    hasFix: false,
     optionsDescription: "No options",
     options: {},
     typescriptOnly: false,
@@ -37,15 +34,12 @@ class Rule extends Lint.Rules.AbstractRule {
 module.exports.Rule = Rule
 
 /**
- * @param {ts.Node} node
+ * @param {ts.CallExpression} node
  */
 function isIncorrectComponentCreate(node) {
-  if (tsutils.isCallExpression(node)) {
-    const trimmedNodeText = node.expression.getFullText().trim()
-    const containsText = (trimmedNodeText === "ReactTestRenderer.create" || trimmedNodeText === "renderer.create")
-    return containsText
-  }
-  return false
+  const trimmedNodeText = node.expression.getFullText().trim()
+  const containsText = (trimmedNodeText === "ReactTestRenderer.create" || trimmedNodeText === "renderer.create")
+  return containsText
 }
 
 /**
@@ -57,12 +51,14 @@ function walk(ctx) {
    */
   function cb(node) {
     if (
-      isIncorrectComponentCreate(node)
+      tsutils.isCallExpression(node) && isIncorrectComponentCreate(node)
     ) {
+      // TODO: Can this be a suggestion rather than an autofix?
+      // const fix = new Lint.Replacement(node.getStart(), node.expression.getFullText().trim().length, "renderWithWrappers");
       ctx.addFailureAt(
         node.getStart(),
         node.getWidth(),
-        FAILURE_STRING
+        FAILURE_STRING,
       )
       return
     }

--- a/tslint-rules/useWrappedComponentsRule.js
+++ b/tslint-rules/useWrappedComponentsRule.js
@@ -1,0 +1,72 @@
+// @ts-check
+
+const Lint = require("tslint")
+const tsutils = require("tsutils")
+const ts = require("typescript")
+
+const AUTOFIX = false
+
+const FAILURE_STRING =
+  "Please use renderWithWrappers() rather than ReactTestRenderer.create() 🙏\n(Feel free to ping the MX team for questions or feedback about this rule.)"
+
+class Rule extends Lint.Rules.AbstractRule {
+  /**
+   * @type {Lint.IRuleMetadata}
+   */
+  metadata = {
+    ruleName: "use-wrapped-components",
+    type: "maintainability",
+    description:
+      "In the app we wrap all our pages to make functionality accessible to subcomponents. We provide a helper function to do the same in our tests.",
+    descriptionDetails:
+      "TBD",
+    hasFix: AUTOFIX,
+    optionsDescription: "No options",
+    options: {},
+    typescriptOnly: false,
+  }
+
+  /**
+   * @param {ts.SourceFile} sourceFile
+   * @returns {Lint.RuleFailure[]}
+   */
+  apply(sourceFile) {
+    return this.applyWithFunction(sourceFile, walk)
+  }
+}
+module.exports.Rule = Rule
+
+/**
+ * @param {ts.Node} node
+ */
+function isIncorrectComponentCreate(node) {
+  if (tsutils.isCallExpression(node)) {
+    const trimmedNodeText = node.expression.getFullText().trim()
+    const containsText = (trimmedNodeText === "ReactTestRenderer.create" || trimmedNodeText === "renderer.create")
+    return containsText
+  }
+  return false
+}
+
+/**
+ * @param {Lint.WalkContext<void>} ctx
+ */
+function walk(ctx) {
+  /**
+   * @param {ts.Node} node
+   */
+  function cb(node) {
+    if (
+      isIncorrectComponentCreate(node)
+    ) {
+      ctx.addFailureAt(
+        node.getStart(),
+        node.getWidth(),
+        FAILURE_STRING
+      )
+      return
+    }
+    return ts.forEachChild(node, cb)
+  }
+  return ts.forEachChild(ctx.sourceFile, cb)
+}

--- a/tslint.json
+++ b/tslint.json
@@ -6,6 +6,7 @@
     "use-wrapped-components": true,
     "arrow-parens": false,
     "interface-name": [true, "never-prefix"],
+    "import-blacklist": [true, { "react-test-renderer": ["create"] }],
     "max-classes-per-file": false,
     "member-access": [false, "check-accessor", "check-constructor"],
     "no-console": [true, ["error", ["warn", "error"]]],

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
   "rulesDirectory": "./tslint-rules",
   "rules": {
     "jsx-safe-conditionals": true,
+    "use-wrapped-components": true,
     "arrow-parens": false,
     "interface-name": [true, "never-prefix"],
     "max-classes-per-file": false,


### PR DESCRIPTION
The type of this PR is: **Dev Experience**

This PR resolves **[MX-447]**

### Description

- Adds a helper function to create wrapped components in tests (only adds Theme for now): https://github.com/artsy/eigen/blob/6d60e2ccb9dbd361c080d51b95e79a31f1baa53f/src/lib/tests/renderWithWrappers.tsx
- Adds a lint rule to detect unwrapped component creation in tests: https://github.com/artsy/eigen/blob/6d60e2ccb9dbd361c080d51b95e79a31f1baa53f/tslint-rules/useWrappedComponentsRule.js
- Updates tests to use new helper where possible, disables lint rule in a few more complex cases

### TODO

- [ ] ~~Make lint rule a little more robust if possible, right now checking for strings~~
- [ ] ~~Add auto fix to lint rule~~ 
       - Would prefer this to be a suggestion rather than auto fix on save but couldn't find a way to do that
- [x] Update tests with lint rule disabled where possible 
- [x] Remove redundant Theme components in updated tests

#skip_new_tests

[MX-447]: https://artsyproduct.atlassian.net/browse/MX-447