### PR TITLE
User can see artist's artist series on the artwork page

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -10,7 +10,7 @@ upcoming:
     - fix follow button going off screen, partner page - brian
     - Add Full Artist Series route and view - ashley
     - Add Artist Series to Artist page - ashley
-    - Add ability to see related artist series artworks on the artwork page - will
+    - Add ability to see related artist series and artist series artworks on the artwork page - will
 
 releases:
   - version: 6.6.0

--- a/src/__generated__/ArtworkBelowTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtworkBelowTheFoldQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 9b3d056007d54201a3af42a70cf9e518 */
+/* @relayHash 7398e56fc997cbffba52aeb48090cc40 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -58,6 +58,24 @@ fragment ArtistListItem_artist on Artist {
   deathday
   image {
     url
+  }
+}
+
+fragment ArtistSeriesMoreSeries_artist on Artist {
+  internalID
+  artistSeriesConnection(first: 4) {
+    totalCount
+    edges {
+      node {
+        slug
+        internalID
+        title
+        forSaleArtworksCount
+        image {
+          url
+        }
+      }
+    }
   }
 }
 
@@ -137,6 +155,10 @@ fragment Artwork_artworkBelowTheFold on Artwork {
     biography_blurb: biographyBlurb {
       text
     }
+    artistSeriesConnection(first: 4) {
+      totalCount
+    }
+    ...ArtistSeriesMoreSeries_artist
     id
   }
   sale {
@@ -426,7 +448,33 @@ v9 = {
     }
   ]
 },
-v10 = [
+v10 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "title",
+  "args": null,
+  "storageKey": null
+},
+v11 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "url",
+    "args": null,
+    "storageKey": null
+  }
+],
+v12 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "image",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Image",
+  "plural": false,
+  "selections": (v11/*: any*/)
+},
+v13 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -442,30 +490,21 @@ v10 = [
     "storageKey": null
   }
 ],
-v11 = {
+v14 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "__typename",
   "args": null,
   "storageKey": null
 },
-v12 = {
+v15 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "isAuction",
   "args": null,
   "storageKey": null
 },
-v13 = [
-  {
-    "kind": "ScalarField",
-    "alias": null,
-    "name": "url",
-    "args": null,
-    "storageKey": null
-  }
-],
-v14 = {
+v16 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "coverImage",
@@ -473,36 +512,19 @@ v14 = {
   "args": null,
   "concreteType": "Image",
   "plural": false,
-  "selections": (v13/*: any*/)
+  "selections": (v11/*: any*/)
 },
-v15 = {
+v17 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "exhibitionPeriod",
   "args": null,
   "storageKey": null
 },
-v16 = {
-  "kind": "LinkedField",
-  "alias": null,
-  "name": "image",
-  "storageKey": null,
-  "args": null,
-  "concreteType": "Image",
-  "plural": false,
-  "selections": (v13/*: any*/)
-},
-v17 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "aspectRatio",
-  "args": null,
-  "storageKey": null
-},
 v18 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "title",
+  "name": "aspectRatio",
   "args": null,
   "storageKey": null
 },
@@ -536,7 +558,7 @@ v22 = {
   "concreteType": "Sale",
   "plural": false,
   "selections": [
-    (v12/*: any*/),
+    (v15/*: any*/),
     {
       "kind": "ScalarField",
       "alias": null,
@@ -758,6 +780,64 @@ return {
             "plural": false,
             "selections": [
               (v9/*: any*/),
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "artistSeriesConnection",
+                "storageKey": "artistSeriesConnection(first:4)",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 4
+                  }
+                ],
+                "concreteType": "ArtistSeriesConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "totalCount",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "edges",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ArtistSeriesEdge",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "node",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "ArtistSeries",
+                        "plural": false,
+                        "selections": [
+                          (v4/*: any*/),
+                          (v7/*: any*/),
+                          (v10/*: any*/),
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "forSaleArtworksCount",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v12/*: any*/)
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              (v7/*: any*/),
               (v2/*: any*/)
             ]
           },
@@ -809,7 +889,7 @@ return {
             "args": null,
             "concreteType": "ArtworkInfoRow",
             "plural": false,
-            "selections": (v10/*: any*/)
+            "selections": (v13/*: any*/)
           },
           {
             "kind": "ScalarField",
@@ -826,7 +906,7 @@ return {
             "args": null,
             "concreteType": "ArtworkInfoRow",
             "plural": false,
-            "selections": (v10/*: any*/)
+            "selections": (v13/*: any*/)
           },
           {
             "kind": "LinkedField",
@@ -836,7 +916,7 @@ return {
             "args": null,
             "concreteType": "ArtworkInfoRow",
             "plural": false,
-            "selections": (v10/*: any*/)
+            "selections": (v13/*: any*/)
           },
           {
             "kind": "LinkedField",
@@ -846,7 +926,7 @@ return {
             "args": null,
             "concreteType": "ArtworkInfoRow",
             "plural": false,
-            "selections": (v10/*: any*/)
+            "selections": (v13/*: any*/)
           },
           {
             "kind": "ScalarField",
@@ -885,13 +965,13 @@ return {
             "concreteType": null,
             "plural": false,
             "selections": [
-              (v11/*: any*/),
+              (v14/*: any*/),
               (v2/*: any*/),
               {
                 "kind": "InlineFragment",
                 "type": "Sale",
                 "selections": [
-                  (v12/*: any*/),
+                  (v15/*: any*/),
                   (v3/*: any*/),
                   {
                     "kind": "ScalarField",
@@ -908,7 +988,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  (v14/*: any*/)
+                  (v16/*: any*/)
                 ]
               },
               {
@@ -917,8 +997,8 @@ return {
                 "selections": [
                   (v3/*: any*/),
                   (v5/*: any*/),
-                  (v15/*: any*/),
-                  (v16/*: any*/)
+                  (v17/*: any*/),
+                  (v12/*: any*/)
                 ]
               },
               {
@@ -929,7 +1009,7 @@ return {
                   (v4/*: any*/),
                   (v3/*: any*/),
                   (v5/*: any*/),
-                  (v15/*: any*/),
+                  (v17/*: any*/),
                   {
                     "kind": "ScalarField",
                     "alias": null,
@@ -937,7 +1017,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  (v14/*: any*/)
+                  (v16/*: any*/)
                 ]
               }
             ]
@@ -1014,10 +1094,10 @@ return {
                                 ],
                                 "storageKey": "url(version:\"large\")"
                               },
-                              (v17/*: any*/)
+                              (v18/*: any*/)
                             ]
                           },
-                          (v18/*: any*/),
+                          (v10/*: any*/),
                           (v19/*: any*/),
                           (v20/*: any*/),
                           (v4/*: any*/),
@@ -1033,8 +1113,8 @@ return {
                   }
                 ]
               },
-              (v11/*: any*/),
-              (v18/*: any*/),
+              (v14/*: any*/),
+              (v10/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -1138,13 +1218,13 @@ return {
                                         "args": null,
                                         "storageKey": null
                                       },
-                                      (v17/*: any*/)
+                                      (v18/*: any*/)
                                     ]
                                   },
                                   (v22/*: any*/),
                                   (v23/*: any*/),
                                   (v20/*: any*/),
-                                  (v18/*: any*/),
+                                  (v10/*: any*/),
                                   (v19/*: any*/),
                                   (v24/*: any*/)
                                 ]
@@ -1205,7 +1285,7 @@ return {
                 "args": null,
                 "storageKey": null
               },
-              (v16/*: any*/)
+              (v12/*: any*/)
             ]
           },
           (v4/*: any*/),
@@ -1217,7 +1297,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtworkBelowTheFoldQuery",
-    "id": "595e90c87bd069e28149c01c56b87976",
+    "id": "96df23fe34c4e0e8eae2f122f2baa0cb",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtworkRefetchQuery.graphql.ts
+++ b/src/__generated__/ArtworkRefetchQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 141e453f7bfab18a518e497d2ff414e2 */
+/* @relayHash 139bd2d1138466eb41462f65ee4d0e93 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -59,6 +59,24 @@ fragment ArtistListItem_artist on Artist {
   deathday
   image {
     url
+  }
+}
+
+fragment ArtistSeriesMoreSeries_artist on Artist {
+  internalID
+  artistSeriesConnection(first: 4) {
+    totalCount
+    edges {
+      node {
+        slug
+        internalID
+        title
+        forSaleArtworksCount
+        image {
+          url
+        }
+      }
+    }
   }
 }
 
@@ -245,6 +263,10 @@ fragment Artwork_artworkBelowTheFold on Artwork {
     biography_blurb: biographyBlurb {
       text
     }
+    artistSeriesConnection(first: 4) {
+      totalCount
+    }
+    ...ArtistSeriesMoreSeries_artist
     id
   }
   sale {
@@ -1609,7 +1631,65 @@ return {
             "selections": [
               (v7/*: any*/),
               (v2/*: any*/),
-              (v9/*: any*/)
+              (v9/*: any*/),
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "artistSeriesConnection",
+                "storageKey": "artistSeriesConnection(first:4)",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 4
+                  }
+                ],
+                "concreteType": "ArtistSeriesConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "totalCount",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "edges",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "ArtistSeriesEdge",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "node",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "ArtistSeries",
+                        "plural": false,
+                        "selections": [
+                          (v4/*: any*/),
+                          (v3/*: any*/),
+                          (v5/*: any*/),
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "forSaleArtworksCount",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v12/*: any*/)
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              (v3/*: any*/)
             ]
           },
           {
@@ -2049,7 +2129,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtworkRefetchQuery",
-    "id": "8f3ffd7a174c65cfe8c959aaa8208451",
+    "id": "acb574b04501ae964e75be66fa1399d7",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/Artwork_artworkBelowTheFold.graphql.ts
+++ b/src/__generated__/Artwork_artworkBelowTheFold.graphql.ts
@@ -17,6 +17,10 @@ export type Artwork_artworkBelowTheFold = {
         readonly biography_blurb: {
             readonly text: string | null;
         } | null;
+        readonly artistSeriesConnection: {
+            readonly totalCount: number;
+        } | null;
+        readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesMoreSeries_artist">;
     } | null;
     readonly sale: {
         readonly id: string;
@@ -212,6 +216,35 @@ return {
               "storageKey": null
             }
           ]
+        },
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "artistSeriesConnection",
+          "storageKey": "artistSeriesConnection(first:4)",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "first",
+              "value": 4
+            }
+          ],
+          "concreteType": "ArtistSeriesConnection",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "totalCount",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        },
+        {
+          "kind": "FragmentSpread",
+          "name": "ArtistSeriesMoreSeries_artist",
+          "args": null
         }
       ]
     },
@@ -486,5 +519,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '3a6548470cdd6c57bfac174808f9803d';
+(node as any).hash = '590e311accee554e4216f15a72e5c4e1';
 export default node;

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -215,7 +215,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ViewableItemRefs> = 
         switch (item) {
           case "topArtistSeries":
             return (
-              <Box mx={-2} my={1}>
+              <Box my={1}>
                 <ArtistSeriesMoreSeriesFragmentContainer artist={artist} artistSeriesHeader="Top Artist Series" />
               </Box>
             )

--- a/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
@@ -35,7 +35,8 @@ export const ArtistSeries: React.FC<ArtistSeriesProps> = ({ artistSeries }) => {
             artist={artist}
             borderTopWidth="1px"
             borderTopColor="black10"
-            mt={1}
+            pt={2}
+            px={2}
             artistSeriesHeader="More series by this artist"
             currentArtistSeriesExcluded
           />

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesFullArtistSeriesList.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesFullArtistSeriesList.tsx
@@ -24,7 +24,7 @@ export const FullArtistSeriesList: React.FC<FullArtistSeriesListProps> = ({ arti
     <PageWithSimpleHeader title="Artist Series" noSeparator>
       <ScrollView style={{ marginTop: 30 }}>
         {seriesList.map((series, index) => (
-          <Flex key={series?.node?.internalID ?? index} flexDirection="row" mb={1}>
+          <Flex key={series?.node?.internalID ?? index} flexDirection="row" mb={1} px={2}>
             <ArtistSeriesListItem listItem={series} />
           </Flex>
         ))}

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesListItem.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesListItem.tsx
@@ -18,7 +18,7 @@ export const ArtistSeriesListItem: React.FC<ArtistSeriesListItemProps> = ({ list
         SwitchBoard.presentNavigationViewController(navRef.current!, `/artist-series/${listItem?.node?.slug}`)
       }}
     >
-      <Flex ref={navRef} flexDirection="row" mb={1} mx={2} justifyContent="space-between">
+      <Flex ref={navRef} flexDirection="row" mb={1} justifyContent="space-between">
         <Flex flexDirection="row" justifyContent="space-between" width="100%">
           <Flex flexDirection="row">
             <OpaqueImageView

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries.tsx
@@ -33,7 +33,7 @@ export const ArtistSeriesMoreSeries: React.FC<ArtistSeriesMoreSeriesProps> = ({
 
   return (
     <Flex {...rest} ref={navRef}>
-      <Flex mb="15px" px={2} mt={2} flexDirection="row" justifyContent="space-between">
+      <Flex mb="15px" flexDirection="row" justifyContent="space-between">
         <Sans size="4t" data-test-id="header">
           {artistSeriesHeader}
         </Sans>

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -7,6 +7,7 @@ import { ArtworkBelowTheFoldQuery } from "__generated__/ArtworkBelowTheFoldQuery
 import { ArtworkMarkAsRecentlyViewedQuery } from "__generated__/ArtworkMarkAsRecentlyViewedQuery.graphql"
 import { RetryErrorBoundary } from "lib/Components/RetryErrorBoundary"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
+import { ArtistSeriesMoreSeriesFragmentContainer as ArtistSeriesMoreSeries } from "lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
 import { AboveTheFoldQueryRenderer } from "lib/utils/AboveTheFoldQueryRenderer"
 import {
   PlaceholderBox,
@@ -142,6 +143,11 @@ export class Artwork extends React.Component<Props, State> {
     return featureFlagEnabled && numArtistSeriesArtworks > 0
   }
 
+  shouldRenderArtistSeriesMoreSeries = () => {
+    const featureFlagEnabled = NativeModules.Emission.options.AROptionsArtistSeries
+    return featureFlagEnabled && (this.props.artworkBelowTheFold.artist?.artistSeriesConnection?.totalCount ?? 0) > 0
+  }
+
   onRefresh = (cb?: () => any) => {
     if (this.state.refreshing) {
       return
@@ -253,6 +259,13 @@ export class Artwork extends React.Component<Props, State> {
       })
     }
 
+    if (this.shouldRenderArtistSeriesMoreSeries()) {
+      sections.push({
+        key: "artistSeriesMoreSeries",
+        element: <ArtistSeriesMoreSeries artist={artist} artistSeriesHeader={"Other series from this artist"} />,
+      })
+    }
+
     if (this.shouldRenderOtherWorks()) {
       sections.push({
         key: "otherWorks",
@@ -318,6 +331,10 @@ export const ArtworkContainer = createRefetchContainer(
           biography_blurb: biographyBlurb {
             text
           }
+          artistSeriesConnection(first: 4) {
+            totalCount
+          }
+          ...ArtistSeriesMoreSeries_artist
         }
         sale {
           id


### PR DESCRIPTION
The type of this PR is: **feature**

This PR resolves **[FX-2021](https://artsyproduct.atlassian.net/browse/FX-2021)**

### Description

- Adds ability for users to see artist series from the artist on the artwork page (if the artist series feature flag is enabled)

### Test Plan

- @williardx to test in beta

### Screenshots

![Screen Shot 2020-08-11 at 2 47 34 PM](https://user-images.githubusercontent.com/4432348/89936503-bdffbd80-dbe1-11ea-8712-6e03dab519af.png)

