### PR TITLE
[MX-483] Update subtitles to sentence case

### DIFF
--- a/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
+++ b/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
@@ -179,14 +179,14 @@ const ArtistRail: React.FC<Props & RailScrollProps> = props => {
   const title = (): string => {
     switch (props.rail.key) {
       case "TRENDING":
-        return "Trending Artists on Artsy"
+        return "Trending artists on Artsy"
       case "SUGGESTED":
-        return "Recommended Artists"
+        return "Recommended artists"
       case "POPULAR":
-        return "Popular Artists on Artsy"
+        return "Popular artists on Artsy"
       default:
         console.error("Unrecognized artist rail key", props.rail.key)
-        return "Recommended Artists"
+        return "Recommended artists"
     }
   }
 

--- a/src/lib/Scenes/City/CityPicker.tsx
+++ b/src/lib/Scenes/City/CityPicker.tsx
@@ -45,7 +45,7 @@ export class CityPicker extends Component<Props, State> {
   handleLogo(screenHeight: number) {
     return (
       <Sans size={dimensions(screenHeight)[screen(screenHeight)].logoFontSize} weight="medium" ml={2} mt={2}>
-        Presented in Partnership with BMW
+        Presented in partnership with BMW
       </Sans>
     )
   }
@@ -110,7 +110,7 @@ export class CityPicker extends Component<Props, State> {
             </Box>
           ))}
           <LogoContainer>
-            <BMWSponsorship url={sponsoredContentUrl} logoText="Presented in Partnership with BMW" />
+            <BMWSponsorship url={sponsoredContentUrl} logoText="Presented in partnership with BMW" />
           </LogoContainer>
         </Box>
       </Overlay>

--- a/src/lib/Scenes/City/Components/SavedEventSection/index.tsx
+++ b/src/lib/Scenes/City/Components/SavedEventSection/index.tsx
@@ -60,7 +60,7 @@ export class SavedEventSection extends Component<any> {
     return (
       <>
         <Box mx={2} py={2}>
-          <BMWSponsorship url={sponsoredContentUrl} logoText="Presented in Partnership with BMW" />
+          <BMWSponsorship url={sponsoredContentUrl} logoText="Presented in partnership with BMW" />
         </Box>
         <Box mx={2} mb={2}>
           <SavedBox p={1}>{hasSaves ? hasSavesComponent : hasNoSavesComponent}</SavedBox>

--- a/src/lib/Scenes/MyProfile/MyProfile.tsx
+++ b/src/lib/Scenes/MyProfile/MyProfile.tsx
@@ -41,7 +41,7 @@ const MyProfile: React.FC<{ me: MyProfile_me; relay: RelayRefetchProp }> = ({ me
         />
       )}
       <MyProfileMenuItem
-        title="Saves and Follows"
+        title="Saves and follows"
         onPress={() => SwitchBoard.presentNavigationViewController(navRef.current!, "favorites")}
       />
       {!!recentlySavedArtworks.length && (
@@ -58,17 +58,17 @@ const MyProfile: React.FC<{ me: MyProfile_me; relay: RelayRefetchProp }> = ({ me
         onPress={() => SwitchBoard.presentNavigationViewController(navRef.current!, "my-profile/payment")}
       />
       <MyProfileMenuItem
-        title="Push Notifications"
+        title="Push notifications"
         onPress={() => SwitchBoard.presentNavigationViewController(navRef.current!, "my-profile/push-notifications")}
       />
       <MyProfileMenuItem
-        title="Send Feedback"
+        title="Send feedback"
         onPress={() => {
           SwitchBoard.presentEmailComposer(navRef.current!, "feedback@artsy.net", "Feedback from the Artsy app")
         }}
       />
       <MyProfileMenuItem
-        title="Personal Data Request"
+        title="Personal data request"
         onPress={() => SwitchBoard.presentNavigationViewController(navRef.current!, "privacy-request")}
       />
       <MyProfileMenuItem title="Log out" onPress={confirmLogout} chevron={null} />

--- a/src/lib/Scenes/Search/CityGuideCTA.tsx
+++ b/src/lib/Scenes/Search/CityGuideCTA.tsx
@@ -10,7 +10,7 @@ export class CityGuideCTA extends React.Component {
     const cityGuideMapImage = require("../../../../images/city-guide-bg.png")
     return (
       <Flex>
-        <SectionTitle title="Explore Art on View" />
+        <SectionTitle title="Explore art on view" />
         <TouchableOpacity onPress={() => SwitchBoard.presentNavigationViewController(this, "/local-discovery")}>
           <Flex style={{ borderWidth: 1, borderColor: color("black10"), borderRadius: 4, overflow: "hidden" }}>
             <Image source={cityGuideMapImage} style={{ width: "100%" }} />
@@ -22,7 +22,7 @@ export class CityGuideCTA extends React.Component {
                 Browse fairs and shows in different cities
               </Sans>
               <Spacer mb={1} />
-              <BMWSponsorship logoText="Presented in Partnership with BMW" pressable={false} />
+              <BMWSponsorship logoText="Presented in partnership with BMW" pressable={false} />
             </Flex>
           </Flex>
         </TouchableOpacity>

--- a/src/lib/Scenes/Search/RecentSearches.tsx
+++ b/src/lib/Scenes/Search/RecentSearches.tsx
@@ -79,7 +79,7 @@ export const RecentSearches: React.FC = () => {
   const { recentSearches, deleteRecentSearch } = useRecentSearches()
   return (
     <>
-      <SectionTitle title="Recent Searches" />
+      <SectionTitle title="Recent searches" />
       {recentSearches.length ? (
         <SearchResultList
           results={recentSearches.slice(0, 5).map(({ props: result }) => (

--- a/src/lib/Scenes/Search/__tests__/CityGuideCTA-tests.tsx
+++ b/src/lib/Scenes/Search/__tests__/CityGuideCTA-tests.tsx
@@ -12,7 +12,7 @@ jest.mock("lib/NativeModules/SwitchBoard", () => ({
 describe("Search page empty state", () => {
   it(`renders correctly`, async () => {
     const tree = create(<CityGuideCTA />)
-    expect(extractText(tree.root)).toContain("Explore Art on View")
+    expect(extractText(tree.root)).toContain("Explore art on view")
     expect(tree.root.findAllByType(Image)).toHaveLength(2)
   })
 

--- a/src/lib/Scenes/Search/__tests__/Search-tests.tsx
+++ b/src/lib/Scenes/Search/__tests__/Search-tests.tsx
@@ -66,7 +66,7 @@ describe("The Search page", () => {
     const isPadMock = isPad as jest.Mock
     isPadMock.mockImplementationOnce(() => false)
     const tree = renderWithWrappers(<TestWrapper />)
-    expect(extractText(tree.root.findByType(CityGuideCTA))).toContain("Explore art on View")
+    expect(extractText(tree.root.findByType(CityGuideCTA))).toContain("Explore art on view")
   })
 
   it(`shows recent searches when there are recent searches`, () => {

--- a/src/lib/Scenes/Search/__tests__/Search-tests.tsx
+++ b/src/lib/Scenes/Search/__tests__/Search-tests.tsx
@@ -35,7 +35,7 @@ describe("The Search page", () => {
     const tree = ReactTestRenderer.create(<TestWrapper />)
     expect(tree.root.findAllByType(RecentSearches)).toHaveLength(1)
     expect(tree.root.findAllByType(AutosuggestResults)).toHaveLength(0)
-    expect(extractText(tree.root.findByType(CityGuideCTA))).toContain("Explore Art on View")
+    expect(extractText(tree.root.findByType(CityGuideCTA))).toContain("Explore art on view")
   })
 
   it(`does not show city guide entrance when on iPad`, async () => {
@@ -65,7 +65,7 @@ describe("The Search page", () => {
     const isPadMock = isPad as jest.Mock
     isPadMock.mockImplementationOnce(() => false)
     const tree = ReactTestRenderer.create(<TestWrapper />)
-    expect(extractText(tree.root.findByType(CityGuideCTA))).toContain("Explore Art on View")
+    expect(extractText(tree.root.findByType(CityGuideCTA))).toContain("Explore art on view")
   })
 
   it(`shows recent searches when there are recent searches`, () => {

--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomsHomeRail.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomsHomeRail.tsx
@@ -31,7 +31,7 @@ export const ViewingRoomsHomeRail: React.FC<ViewingRoomsHomeRailProps> = props =
     <View ref={navRef}>
       <Flex mx="2">
         <SectionTitle
-          title="Viewing Rooms"
+          title="Viewing rooms"
           onPress={() => {
             trackEvent(tracks.tappedViewingRoomsHeader())
             SwitchBoard.presentNavigationViewController(navRef.current, "/viewing-rooms")


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR resolves **[MX-483]**

### Description
Most of our section titles are currently using title case, but Brand has suggested we move to sentence case as its more approachable/welcoming! 

Slack thread for reference: https://artsy.slack.com/archives/CV68RJVV3/p1594923419020700
<!-- Implementation description -->

### Screenshots
**_Home tab screenshots will be available once [this PR](https://github.com/artsy/metaphysics/pull/2610) is merged_**
___
**_My profile tab_**
<img width="282" alt="Screenshot 2020-08-12 at 15 31 32" src="https://user-images.githubusercontent.com/11945712/90021025-fde1a600-dcb0-11ea-9477-2926c5b73256.png">
___
**_Search Tab_**
<img width="305" alt="Screenshot 2020-08-12 at 15 31 48" src="https://user-images.githubusercontent.com/11945712/90021034-ffab6980-dcb0-11ea-98f4-32e838c7665b.png">

#trivial

[MX-483]: https://artsyproduct.atlassian.net/browse/MX-483