### PR TITLE
[FX-2123] Update artworks counts for Artist Series 

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -12,6 +12,7 @@ upcoming:
     - Add Full Artist Series route and view - ashley
     - Add Artist Series to Artist page - ashley
     - Add ability to see related artist series and artist series artworks on the artwork page - will
+    - Add improved artwork counts to Artist Series - roop
 
 releases:
   - version: 6.6.0

--- a/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 4f46990041cce50c1f039c018a9cd969 */
+/* @relayHash 5b784da0b502f3b21d5d2caa660a380f */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -172,7 +172,7 @@ fragment ArtistSeriesMoreSeries_artist on Artist {
         slug
         internalID
         title
-        forSaleArtworksCount
+        artworksCountMessage
         image {
           url
         }
@@ -1020,7 +1020,7 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
-                        "name": "forSaleArtworksCount",
+                        "name": "artworksCountMessage",
                         "args": null,
                         "storageKey": null
                       },
@@ -1076,7 +1076,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistAboveTheFoldQuery",
-    "id": "315ade00ee4427d3d2879e7e125b92f3",
+    "id": "8c4186db08e5f3bb95e6357061854311",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistArtworksQuery.graphql.ts
+++ b/src/__generated__/ArtistArtworksQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 3df346b8fc64acf4069681c95cb3073a */
+/* @relayHash 08c8909e5d6a5dcc7a9f99dd8b1f07a0 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -168,7 +168,7 @@ fragment ArtistSeriesMoreSeries_artist on Artist {
         slug
         internalID
         title
-        forSaleArtworksCount
+        artworksCountMessage
         image {
           url
         }
@@ -1087,7 +1087,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "forSaleArtworksCount",
+                            "name": "artworksCountMessage",
                             "args": null,
                             "storageKey": null
                           },
@@ -1145,7 +1145,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistArtworksQuery",
-    "id": "4e4e408e5dcdc50a1ce1b12b70639e45",
+    "id": "88f0280e4dab091c881804789f4ea314",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeriesFullArtistSeriesListQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesFullArtistSeriesListQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 3d98c1c743081603a44a208641dc1c9e */
+/* @relayHash 4560983de4a4148f2635ddd335376376 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -36,7 +36,7 @@ fragment ArtistSeriesFullArtistSeriesList_artist on Artist {
         slug
         internalID
         title
-        forSaleArtworksCount
+        artworksCountMessage
         image {
           url
         }
@@ -154,7 +154,7 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
-                        "name": "forSaleArtworksCount",
+                        "name": "artworksCountMessage",
                         "args": null,
                         "storageKey": null
                       },
@@ -196,7 +196,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesFullArtistSeriesListQuery",
-    "id": "dd54c7ccee7fa4c3b27983fb043635de",
+    "id": "0efc8bc6adf7b2fc589e24ce903ca4c6",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeriesFullArtistSeriesListTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesFullArtistSeriesListTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 5adc67716db4d322476b24ee1022d44f */
+/* @relayHash e18c1f60d2fb83e09e402a847ded5cd7 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -18,7 +18,7 @@ export type ArtistSeriesFullArtistSeriesListTestsQueryRawResponse = {
                     readonly slug: string;
                     readonly internalID: string;
                     readonly title: string;
-                    readonly forSaleArtworksCount: number;
+                    readonly artworksCountMessage: string | null;
                     readonly image: ({
                         readonly url: string | null;
                     }) | null;
@@ -51,7 +51,7 @@ fragment ArtistSeriesFullArtistSeriesList_artist on Artist {
         slug
         internalID
         title
-        forSaleArtworksCount
+        artworksCountMessage
         image {
           url
         }
@@ -161,7 +161,7 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
-                        "name": "forSaleArtworksCount",
+                        "name": "artworksCountMessage",
                         "args": null,
                         "storageKey": null
                       },
@@ -203,7 +203,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesFullArtistSeriesListTestsQuery",
-    "id": "b242e9b11f5329c7ca05cdbd613b46fb",
+    "id": "ef4577b471f4007266c88f6b2a4e2369",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeriesFullArtistSeriesList_artist.graphql.ts
+++ b/src/__generated__/ArtistSeriesFullArtistSeriesList_artist.graphql.ts
@@ -10,7 +10,7 @@ export type ArtistSeriesFullArtistSeriesList_artist = {
                 readonly slug: string;
                 readonly internalID: string;
                 readonly title: string;
-                readonly forSaleArtworksCount: number;
+                readonly artworksCountMessage: string | null;
                 readonly image: {
                     readonly url: string | null;
                 } | null;
@@ -85,7 +85,7 @@ const node: ReaderFragment = {
                 {
                   "kind": "ScalarField",
                   "alias": null,
-                  "name": "forSaleArtworksCount",
+                  "name": "artworksCountMessage",
                   "args": null,
                   "storageKey": null
                 },
@@ -115,5 +115,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = '763222abfdd23625c9a82b71278ac47f';
+(node as any).hash = '75ecda4bddc8607dd50c88e4a8f1710c';
 export default node;

--- a/src/__generated__/ArtistSeriesMoreSeriesTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesMoreSeriesTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 10d3db9d94ad6d812cc817b06e4c3ca2 */
+/* @relayHash 6bfb8e00cccc8e4c18f0e52c98f121f6 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -23,7 +23,7 @@ export type ArtistSeriesMoreSeriesTestsQueryRawResponse = {
                         readonly slug: string;
                         readonly internalID: string;
                         readonly title: string;
-                        readonly forSaleArtworksCount: number;
+                        readonly artworksCountMessage: string | null;
                         readonly image: ({
                             readonly url: string | null;
                         }) | null;
@@ -61,7 +61,7 @@ fragment ArtistSeriesMoreSeries_artist on Artist {
         slug
         internalID
         title
-        forSaleArtworksCount
+        artworksCountMessage
         image {
           url
         }
@@ -213,7 +213,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "forSaleArtworksCount",
+                            "name": "artworksCountMessage",
                             "args": null,
                             "storageKey": null
                           },
@@ -257,7 +257,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesMoreSeriesTestsQuery",
-    "id": "9b9ecfe9d666dd0211606bc3bc63d45d",
+    "id": "1eb872091f3bb71605b6539b87cb8567",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeriesMoreSeries_artist.graphql.ts
+++ b/src/__generated__/ArtistSeriesMoreSeries_artist.graphql.ts
@@ -12,7 +12,7 @@ export type ArtistSeriesMoreSeries_artist = {
                 readonly slug: string;
                 readonly internalID: string;
                 readonly title: string;
-                readonly forSaleArtworksCount: number;
+                readonly artworksCountMessage: string | null;
                 readonly image: {
                     readonly url: string | null;
                 } | null;
@@ -103,7 +103,7 @@ return {
                 {
                   "kind": "ScalarField",
                   "alias": null,
-                  "name": "forSaleArtworksCount",
+                  "name": "artworksCountMessage",
                   "args": null,
                   "storageKey": null
                 },
@@ -134,5 +134,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '48efbb779aa31a347ca6ed30210370ae';
+(node as any).hash = '7996279a005fd420fce4bd453d0a2fe3';
 export default node;

--- a/src/__generated__/ArtistSeriesQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash b67013c752e061c40ed885b95cb2141c */
+/* @relayHash 8944d46077df7c34d0e9f7466db0d68f */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -81,7 +81,7 @@ fragment ArtistSeriesMoreSeries_artist on Artist {
         slug
         internalID
         title
-        forSaleArtworksCount
+        artworksCountMessage
         image {
           url
         }
@@ -629,7 +629,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "forSaleArtworksCount",
+                            "name": "artworksCountMessage",
                             "args": null,
                             "storageKey": null
                           },
@@ -650,7 +650,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesQuery",
-    "id": "ce9708a46b863d987e976150cce86701",
+    "id": "02078b20fb48b0b488109ba3488e7c05",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 9947a3ede638183a41ac67d10f0f4acc */
+/* @relayHash 12529c56b2acaafaceaf8a2d548b5a51 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -85,7 +85,7 @@ export type ArtistSeriesTestsQueryRawResponse = {
                         readonly slug: string;
                         readonly internalID: string;
                         readonly title: string;
-                        readonly forSaleArtworksCount: number;
+                        readonly artworksCountMessage: string | null;
                         readonly image: ({
                             readonly url: string | null;
                         }) | null;
@@ -164,7 +164,7 @@ fragment ArtistSeriesMoreSeries_artist on Artist {
         slug
         internalID
         title
-        forSaleArtworksCount
+        artworksCountMessage
         image {
           url
         }
@@ -704,7 +704,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "forSaleArtworksCount",
+                            "name": "artworksCountMessage",
                             "args": null,
                             "storageKey": null
                           },
@@ -725,7 +725,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesTestsQuery",
-    "id": "9604369cf57cba77d528c6f4deef395a",
+    "id": "d062813c56ed0d7bcdfcc2690352555a",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtworkBelowTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtworkBelowTheFoldQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 7398e56fc997cbffba52aeb48090cc40 */
+/* @relayHash 84808e805be83ce28ccc670bb5b31739 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -70,7 +70,7 @@ fragment ArtistSeriesMoreSeries_artist on Artist {
         slug
         internalID
         title
-        forSaleArtworksCount
+        artworksCountMessage
         image {
           url
         }
@@ -826,7 +826,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "forSaleArtworksCount",
+                            "name": "artworksCountMessage",
                             "args": null,
                             "storageKey": null
                           },
@@ -1297,7 +1297,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtworkBelowTheFoldQuery",
-    "id": "96df23fe34c4e0e8eae2f122f2baa0cb",
+    "id": "3647c85949d51b49588e6c70042e240b",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtworkRefetchQuery.graphql.ts
+++ b/src/__generated__/ArtworkRefetchQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 139bd2d1138466eb41462f65ee4d0e93 */
+/* @relayHash f9f9c0fe17344646fb839e7bfaee635f */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -71,7 +71,7 @@ fragment ArtistSeriesMoreSeries_artist on Artist {
         slug
         internalID
         title
-        forSaleArtworksCount
+        artworksCountMessage
         image {
           url
         }
@@ -1678,7 +1678,7 @@ return {
                           {
                             "kind": "ScalarField",
                             "alias": null,
-                            "name": "forSaleArtworksCount",
+                            "name": "artworksCountMessage",
                             "args": null,
                             "storageKey": null
                           },
@@ -2129,7 +2129,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtworkRefetchQuery",
-    "id": "acb574b04501ae964e75be66fa1399d7",
+    "id": "2f3f50ce1c143840c849a7bd9e1520cb",
     "text": null,
     "metadata": {}
   }

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesFullArtistSeriesList.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesFullArtistSeriesList.tsx
@@ -42,7 +42,7 @@ export const ArtistSeriesFullArtistSeriesListFragmentContainer = createFragmentC
             slug
             internalID
             title
-            forSaleArtworksCount
+            artworksCountMessage
             image {
               url
             }

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesListItem.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesListItem.tsx
@@ -12,6 +12,8 @@ interface ArtistSeriesListItemProps {
 export const ArtistSeriesListItem: React.FC<ArtistSeriesListItemProps> = ({ listItem }) => {
   const navRef = useRef<Component>(null)
 
+  const artworksCountMessage = listItem?.node?.artworksCountMessage
+
   return (
     <TouchableOpacity
       onPress={() => {
@@ -31,10 +33,9 @@ export const ArtistSeriesListItem: React.FC<ArtistSeriesListItemProps> = ({ list
               <Sans size="3t" data-test-id="title">
                 {listItem?.node?.title}
               </Sans>
-              {// TODO: This component on an Artist page should show the total count of artworks in the series if 0 are for sale. This req needs to be followed up in MP/Gravity first.
-              !!listItem?.node?.forSaleArtworksCount && (
+              {!!artworksCountMessage && (
                 <Sans size="3" color="black60" data-test-id="count">
-                  {`${listItem?.node?.forSaleArtworksCount} Available`}
+                  {artworksCountMessage}
                 </Sans>
               )}
             </Flex>

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries.tsx
@@ -72,7 +72,7 @@ export const ArtistSeriesMoreSeriesFragmentContainer = createFragmentContainer(A
             slug
             internalID
             title
-            forSaleArtworksCount
+            artworksCountMessage
             image {
               url
             }

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeries-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeries-tests.tsx
@@ -111,7 +111,7 @@ const ArtistSeriesFixture: ArtistSeriesTestsQueryRawResponse = {
                 slug: "yayoi-kusama-other-fruits",
                 internalID: "abc123",
                 title: "Other Fruits",
-                forSaleArtworksCount: 22,
+                artworksCountMessage: "22 available",
                 image: {
                   url: "https://www.images.net/fruits",
                 },

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesFullArtistSeriesList-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesFullArtistSeriesList-tests.tsx
@@ -86,7 +86,7 @@ const ArtistSeriesFullArtistSeriesListFixture: ArtistSeriesFullArtistSeriesListT
             slug: "yayoi-kusama-plums",
             internalID: "da821a13-92fc-49c2-bbd5-bebb790f7020",
             title: "plums",
-            forSaleArtworksCount: 40,
+            artworksCountMessage: "40 available",
             image: {
               url: "https://d32dm0rphc51dk.cloudfront.net/bLKO-OQg8UOzKuKcKxXeWQ/main.jpg",
             },
@@ -97,7 +97,7 @@ const ArtistSeriesFullArtistSeriesListFixture: ArtistSeriesFullArtistSeriesListT
             slug: "yayoi-kusama-apricots",
             internalID: "ecfa5731-9d64-4bc2-9f9f-c427a9126064",
             title: "apricots",
-            forSaleArtworksCount: 35,
+            artworksCountMessage: "35 available",
             image: {
               url: "https://d32dm0rphc51dk.cloudfront.net/Oymspr9llGzRC-lTZA8htA/main.jpg",
             },
@@ -108,7 +108,7 @@ const ArtistSeriesFullArtistSeriesListFixture: ArtistSeriesFullArtistSeriesListT
             slug: "yayoi-kusama-pumpkins",
             internalID: "58597ef5-3390-406b-b6d2-d4e308125d0d",
             title: "Pumpkins",
-            forSaleArtworksCount: 25,
+            artworksCountMessage: "25 available",
             image: {
               url: "https://d32dm0rphc51dk.cloudfront.net/dL3hz4h6f_tMHQjVHsdO4w/medium.jpg",
             },
@@ -119,7 +119,7 @@ const ArtistSeriesFullArtistSeriesListFixture: ArtistSeriesFullArtistSeriesListT
             slug: "yayoi-kusama-apples",
             internalID: "5856ee51-35eb-4b75-bb12-15a1cd7e012e",
             title: "apples",
-            forSaleArtworksCount: 15,
+            artworksCountMessage: "15 available",
             image: {
               url: "https://d32dm0rphc51dk.cloudfront.net/Nv63KiPQo91g2-W2V3lgAw/main.jpg",
             },
@@ -130,7 +130,7 @@ const ArtistSeriesFullArtistSeriesListFixture: ArtistSeriesFullArtistSeriesListT
             slug: "yayoi-kusama-grapefruit",
             internalID: "5856ee51-35eb-4b75-bb12-15a1816a9",
             title: "grapefruit",
-            forSaleArtworksCount: 10,
+            artworksCountMessage: "10 available",
             image: {
               url: "https://d32dm0rphc51dk.cloudfront.net/Nv63KiPQo91g2-W2V3lgAw/main.jpg",
             },
@@ -141,7 +141,7 @@ const ArtistSeriesFullArtistSeriesListFixture: ArtistSeriesFullArtistSeriesListT
             slug: "yayoi-kusama-dragonfruit",
             internalID: "5856ee51-35eb-4b75-bb12-15a1cd18161",
             title: "dragonfruit",
-            forSaleArtworksCount: 8,
+            artworksCountMessage: "8 available",
             image: {
               url: "https://d32dm0rphc51dk.cloudfront.net/Nv63KiPQo91g2-W2V3lgAw/main.jpg",
             },

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesListItem-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesListItem-tests.tsx
@@ -35,7 +35,7 @@ describe("ArtistSeriesListItem", () => {
     expect(instance.findByType(OpaqueImageView).props.imageURL).toBe(
       "https://d32dm0rphc51dk.cloudfront.net/dL3hz4h6f_tMHQjVHsdO4w/medium.jpg"
     )
-    expect(instance.findByProps({ "data-test-id": "count" }).props.children).toBe("25 Available")
+    expect(instance.findByProps({ "data-test-id": "count" }).props.children).toBe("25 available")
     expect(instance.findByProps({ "data-test-id": "title" }).props.children).toBe("Pumpkins")
   })
 })
@@ -45,7 +45,7 @@ const ArtistSeriesListItemFixture: ArtistSeriesConnectionEdge = {
     slug: "yayoi-kusama-pumpkins",
     internalID: "58597ef5-3390-406b-b6d2-d4e308125d0d",
     title: "Pumpkins",
-    forSaleArtworksCount: 25,
+    artworksCountMessage: "25 available",
     image: {
       url: "https://d32dm0rphc51dk.cloudfront.net/dL3hz4h6f_tMHQjVHsdO4w/medium.jpg",
     },

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesMoreSeries-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesMoreSeries-tests.tsx
@@ -137,7 +137,7 @@ const ArtistSeriesMoreSeriesFixture: ArtistSeriesMoreSeriesTestsQueryRawResponse
                 slug: "yayoi-kusama-plums",
                 internalID: "da821a13-92fc-49c2-bbd5-bebb790f7020",
                 title: "plums",
-                forSaleArtworksCount: 40,
+                artworksCountMessage: "40 available",
                 image: {
                   url: "https://d32dm0rphc51dk.cloudfront.net/bLKO-OQg8UOzKuKcKxXeWQ/main.jpg",
                 },
@@ -148,7 +148,7 @@ const ArtistSeriesMoreSeriesFixture: ArtistSeriesMoreSeriesTestsQueryRawResponse
                 slug: "yayoi-kusama-apricots",
                 internalID: "ecfa5731-9d64-4bc2-9f9f-c427a9126064",
                 title: "apricots",
-                forSaleArtworksCount: 35,
+                artworksCountMessage: "35 available",
                 image: {
                   url: "https://d32dm0rphc51dk.cloudfront.net/Oymspr9llGzRC-lTZA8htA/main.jpg",
                 },
@@ -159,7 +159,7 @@ const ArtistSeriesMoreSeriesFixture: ArtistSeriesMoreSeriesTestsQueryRawResponse
                 slug: "yayoi-kusama-pumpkins",
                 internalID: "58597ef5-3390-406b-b6d2-d4e308125d0d",
                 title: "Pumpkins",
-                forSaleArtworksCount: 25,
+                artworksCountMessage: "25 available",
                 image: {
                   url: "https://d32dm0rphc51dk.cloudfront.net/dL3hz4h6f_tMHQjVHsdO4w/medium.jpg",
                 },
@@ -170,7 +170,7 @@ const ArtistSeriesMoreSeriesFixture: ArtistSeriesMoreSeriesTestsQueryRawResponse
                 slug: "yayoi-kusama-apples",
                 internalID: "5856ee51-35eb-4b75-bb12-15a1cd7e012e",
                 title: "apples",
-                forSaleArtworksCount: 4,
+                artworksCountMessage: "4 available",
                 image: {
                   url: "https://d32dm0rphc51dk.cloudfront.net/Nv63KiPQo91g2-W2V3lgAw/main.jpg",
                 },
@@ -181,7 +181,7 @@ const ArtistSeriesMoreSeriesFixture: ArtistSeriesMoreSeriesTestsQueryRawResponse
                 slug: "yayoi-kusama-dragonfruit",
                 internalID: "5856ee51-35eb-4b75-bb12-15a1cd18161",
                 title: "dragonfruit",
-                forSaleArtworksCount: 8,
+                artworksCountMessage: "8 available",
                 image: {
                   url: "https://d32dm0rphc51dk.cloudfront.net/Nv63KiPQo91g2-W2V3lgAw/main.jpg",
                 },
@@ -208,7 +208,7 @@ const ArtistSeriesMoreSeriesBelowViewAllThresholdFixture: ArtistSeriesMoreSeries
                 slug: "yayoi-kusama-pumpkins",
                 internalID: "58597ef5-3390-406b-b6d2-d4e308125d0d",
                 title: "Pumpkins",
-                forSaleArtworksCount: 25,
+                artworksCountMessage: "25 available",
                 image: {
                   url: "https://d32dm0rphc51dk.cloudfront.net/dL3hz4h6f_tMHQjVHsdO4w/medium.jpg",
                 },
@@ -219,7 +219,7 @@ const ArtistSeriesMoreSeriesBelowViewAllThresholdFixture: ArtistSeriesMoreSeries
                 slug: "yayoi-kusama-apples",
                 internalID: "5856ee51-35eb-4b75-bb12-15a1cd7e012e",
                 title: "apples",
-                forSaleArtworksCount: 4,
+                artworksCountMessage: "4 available",
                 image: {
                   url: "https://d32dm0rphc51dk.cloudfront.net/Nv63KiPQo91g2-W2V3lgAw/main.jpg",
                 },
@@ -230,7 +230,7 @@ const ArtistSeriesMoreSeriesBelowViewAllThresholdFixture: ArtistSeriesMoreSeries
                 slug: "yayoi-kusama-dragonfruit",
                 internalID: "5856ee51-35eb-4b75-bb12-15a1cd18161",
                 title: "dragonfruit",
-                forSaleArtworksCount: 8,
+                artworksCountMessage: "8 available",
                 image: {
                   url: "https://d32dm0rphc51dk.cloudfront.net/Nv63KiPQo91g2-W2V3lgAw/main.jpg",
                 },


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR resolves **[FX-2123]**

### Description

Updates artwork count that are displayed in the context of Artist Series, such that they have a fallback value when the for-sale artworks count is zero. 

(This fallback is derived in Metaphysics; nothing special being done here other than querying a new `artworksCountMessage` field in the MP schema.)

### Test Plan

Mostly a no-op, but existing test fixtures are updated to reflect the new upstream field being utilized in MP queries

### Screenshots

|Artist Series - more series|Artist - top series|Artist - all series|Artwork - more series|
|---|---|---|---|
|<img height="300" src="https://user-images.githubusercontent.com/140521/90178323-bc68fd80-dd79-11ea-952e-c5a22b648f18.png" title="series - more rail" />|<img height="300" src="https://user-images.githubusercontent.com/140521/90178322-bc68fd80-dd79-11ea-82c7-eaf0c56f6550.png" title="artist - top" />|<img height="300" src="https://user-images.githubusercontent.com/140521/90178321-bc68fd80-dd79-11ea-9f2f-a0d17ed4820e.png" title="artist - all" />|<img height="300" src="https://user-images.githubusercontent.com/140521/90178320-bbd06700-dd79-11ea-97e9-09fcb4417692.png" title="artwork - more" />|


[FX-2123]: https://artsyproduct.atlassian.net/browse/FX-2123