### PR TITLE
Use values from MP for VR countdown

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -8,6 +8,7 @@ upcoming:
     - Refactor recent searches to use easy-peasy - brian, mounir, david
     - Add easy-peasy app store persistence & migration - david
   user_facing:
+    - Use better countdown for VR opening and closing - pavlos
     - Prevent follow button going off screen in artist page - brian
     - don't show password on wrong password entry - brian
     - fix follow button going off screen, partner page - brian

--- a/src/__generated__/ViewingRoomHeaderTestsQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomHeaderTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash cd87edd5bce79e76f31b2b060cc232eb */
+/* @relayHash a650b26c8ee271f013b7ffcecea3d7f7 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -26,8 +26,8 @@ query ViewingRoomHeaderTestsQuery {
 
 fragment ViewingRoomHeader_viewingRoom on ViewingRoom {
   title
-  startAt
-  endAt
+  distanceToOpen(short: false)
+  distanceToClose(short: false)
   status
   heroImage: image {
     imageURLs {
@@ -56,7 +56,14 @@ var v0 = [
     "value": "unused"
   }
 ],
-v1 = {
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "short",
+    "value": false
+  }
+],
+v2 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
@@ -114,16 +121,16 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "startAt",
-            "args": null,
-            "storageKey": null
+            "name": "distanceToOpen",
+            "args": (v1/*: any*/),
+            "storageKey": "distanceToOpen(short:false)"
           },
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "endAt",
-            "args": null,
-            "storageKey": null
+            "name": "distanceToClose",
+            "args": (v1/*: any*/),
+            "storageKey": "distanceToClose(short:false)"
           },
           {
             "kind": "ScalarField",
@@ -217,10 +224,10 @@ return {
                       }
                     ]
                   },
-                  (v1/*: any*/)
+                  (v2/*: any*/)
                 ]
               },
-              (v1/*: any*/)
+              (v2/*: any*/)
             ]
           }
         ]
@@ -230,7 +237,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomHeaderTestsQuery",
-    "id": "cc31f302bef8b032187a7ede771e2255",
+    "id": "87af01df93247085be990c1d09009b9a",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomHeader_viewingRoom.graphql.ts
+++ b/src/__generated__/ViewingRoomHeader_viewingRoom.graphql.ts
@@ -5,8 +5,8 @@ import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ViewingRoomHeader_viewingRoom = {
     readonly title: string;
-    readonly startAt: unknown | null;
-    readonly endAt: unknown | null;
+    readonly distanceToOpen: string | null;
+    readonly distanceToClose: string | null;
     readonly status: string;
     readonly heroImage: {
         readonly imageURLs: {
@@ -32,7 +32,15 @@ export type ViewingRoomHeader_viewingRoom$key = {
 
 
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "short",
+    "value": false
+  }
+];
+return {
   "kind": "Fragment",
   "name": "ViewingRoomHeader_viewingRoom",
   "type": "ViewingRoom",
@@ -49,16 +57,16 @@ const node: ReaderFragment = {
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "startAt",
-      "args": null,
-      "storageKey": null
+      "name": "distanceToOpen",
+      "args": (v0/*: any*/),
+      "storageKey": "distanceToOpen(short:false)"
     },
     {
       "kind": "ScalarField",
       "alias": null,
-      "name": "endAt",
-      "args": null,
-      "storageKey": null
+      "name": "distanceToClose",
+      "args": (v0/*: any*/),
+      "storageKey": "distanceToClose(short:false)"
     },
     {
       "kind": "ScalarField",
@@ -158,5 +166,6 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = '1bd673fdca7fc92603d11a33b71b92e4';
+})();
+(node as any).hash = '53b1b0f1de0b200a125685c0e73aba2e';
 export default node;

--- a/src/__generated__/ViewingRoomQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 905708fec3f3de322041b483b3aa08db */
+/* @relayHash 74dda949b5f0c332402352987e7cd561 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -55,8 +55,8 @@ fragment ViewingRoomArtworkRail_viewingRoom on ViewingRoom {
 
 fragment ViewingRoomHeader_viewingRoom on ViewingRoom {
   title
-  startAt
-  endAt
+  distanceToOpen(short: false)
+  distanceToClose(short: false)
   status
   heroImage: image {
     imageURLs {
@@ -199,7 +199,14 @@ v9 = {
       "storageKey": null
     }
   ]
-};
+},
+v10 = [
+  {
+    "kind": "Literal",
+    "name": "short",
+    "value": false
+  }
+];
 return {
   "kind": "Request",
   "fragment": {
@@ -465,16 +472,16 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "startAt",
-            "args": null,
-            "storageKey": null
+            "name": "distanceToOpen",
+            "args": (v10/*: any*/),
+            "storageKey": "distanceToOpen(short:false)"
           },
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "endAt",
-            "args": null,
-            "storageKey": null
+            "name": "distanceToClose",
+            "args": (v10/*: any*/),
+            "storageKey": "distanceToClose(short:false)"
           },
           {
             "kind": "LinkedField",
@@ -495,7 +502,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomQuery",
-    "id": "7c7e022bd25094e566a7c827f2f26237",
+    "id": "dbe7f4b800524c3912402370f5efb384",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ViewingRoomTestsQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash f8cd6aee1f28129c24f52e80ecf8dfd1 */
+/* @relayHash 46b33bb96042efecd17d99be0631cf2b */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -51,8 +51,8 @@ fragment ViewingRoomArtworkRail_viewingRoom on ViewingRoom {
 
 fragment ViewingRoomHeader_viewingRoom on ViewingRoom {
   title
-  startAt
-  endAt
+  distanceToOpen(short: false)
+  distanceToClose(short: false)
   status
   heroImage: image {
     imageURLs {
@@ -187,7 +187,14 @@ v8 = {
       "storageKey": null
     }
   ]
-};
+},
+v9 = [
+  {
+    "kind": "Literal",
+    "name": "short",
+    "value": false
+  }
+];
 return {
   "kind": "Request",
   "fragment": {
@@ -453,16 +460,16 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "startAt",
-            "args": null,
-            "storageKey": null
+            "name": "distanceToOpen",
+            "args": (v9/*: any*/),
+            "storageKey": "distanceToOpen(short:false)"
           },
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "endAt",
-            "args": null,
-            "storageKey": null
+            "name": "distanceToClose",
+            "args": (v9/*: any*/),
+            "storageKey": "distanceToClose(short:false)"
           },
           {
             "kind": "LinkedField",
@@ -483,7 +490,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ViewingRoomTestsQuery",
-    "id": "5d3f33e5253f3d25f1a3bbba5d2000d5",
+    "id": "e41c84f4022c387738f8087439a1fae5",
     "text": null,
     "metadata": {}
   }

--- a/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomHeader-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomHeader-tests.tsx
@@ -1,5 +1,5 @@
+import { Text } from "@artsy/palette"
 import { ViewingRoomHeaderTestsQuery } from "__generated__/ViewingRoomHeaderTestsQuery.graphql"
-import { CountdownTimer } from "lib/Components/Countdown/CountdownTimer"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
@@ -55,20 +55,40 @@ describe("ViewingRoomHeader", () => {
     const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation =>
       MockPayloadGenerator.generate(operation, {
-        ViewingRoom: () => ({ title: "ok", status: "scheduled" }),
+        ViewingRoom: () => ({ title: "ok", status: "scheduled", distanceToOpen: "3 days" }),
       })
     )
-    expect(tree.root.findAllByType(CountdownTimer)).toHaveLength(1)
+    expect(tree.root.findAllByType(Text)[2].props.children).toBe("Opens in 3 days")
+  })
+
+  it("doesn't render a countdown timer for scheduled if distanceToOpen is null", () => {
+    const tree = renderWithWrappers(<TestRenderer />)
+    mockEnvironment.mock.resolveMostRecentOperation(operation =>
+      MockPayloadGenerator.generate(operation, {
+        ViewingRoom: () => ({ title: "ok", status: "scheduled", distanceToOpen: null }),
+      })
+    )
+    expect(tree.root.findAllByType(Text)).toHaveLength(2)
   })
 
   it("renders a countdown timer for live", () => {
     const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation(operation =>
       MockPayloadGenerator.generate(operation, {
-        ViewingRoom: () => ({ title: "ok", status: "live" }),
+        ViewingRoom: () => ({ title: "ok", status: "live", distanceToClose: "3 days" }),
       })
     )
-    expect(tree.root.findAllByType(CountdownTimer)).toHaveLength(1)
+    expect(tree.root.findAllByType(Text)[2].props.children).toBe("Closes in 3 days")
+  })
+
+  it("doesn't render a countdown timer for live is distanceToClose is null", () => {
+    const tree = renderWithWrappers(<TestRenderer />)
+    mockEnvironment.mock.resolveMostRecentOperation(operation =>
+      MockPayloadGenerator.generate(operation, {
+        ViewingRoom: () => ({ title: "ok", status: "live", distanceToClose: null }),
+      })
+    )
+    expect(tree.root.findAllByType(Text)).toHaveLength(2)
   })
 
   it("doesn't render a countdown timer for closed", () => {
@@ -78,7 +98,7 @@ describe("ViewingRoomHeader", () => {
         ViewingRoom: () => ({ title: "ok", status: "closed" }),
       })
     )
-    expect(tree.root.findAllByType(CountdownTimer)).toHaveLength(0)
+    expect(tree.root.findAllByType(Text)[2].props.children).toBe("Closed")
   })
 
   it("renders partner name", () => {


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [GALL-2977]

### Description

<!-- Implementation description -->
Temporarily we added a countdown using the `startAt` and `endAt` in the VR countdown for opening and closing. We now changed this to use the right thing, which is `distanceToOpen` and `distanceToClose` from MP.
<img width="383" alt="Screenshot 2020-08-14 at 18 11 16" src="https://user-images.githubusercontent.com/100233/90269838-90bd4480-de59-11ea-9a32-9aee0b39d2f2.png">
### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434
[GALL-2977]: https://artsyproduct.atlassian.net/browse/GALL-2977