### PR TITLE
[PURCHASE-2051] Restyle reply box

### DIFF
--- a/src/lib/Components/Inbox/Conversations/Composer.tsx
+++ b/src/lib/Components/Inbox/Conversations/Composer.tsx
@@ -1,8 +1,8 @@
 import React from "react"
 import { Dimensions, TextInput, TouchableWithoutFeedback } from "react-native"
 
+import { Button, color, themeProps } from "@artsy/palette"
 import colors from "lib/data/colors"
-import fonts from "lib/data/fonts"
 import styled from "styled-components/native"
 
 import { ScreenDimensionsContext } from "lib/utils/useScreenDimensions"
@@ -17,28 +17,16 @@ interface ContainerProps {
 const Container = styled.View`
   flex-direction: row;
   justify-content: space-between;
-  align-items: center;
-  border-width: 1;
-  border-color: ${colors["gray-regular"]};
-  border-radius: 3;
-  margin: 0 20px 20px;
+  align-items: flex-start;
+  border-top-width: 1;
+  border-top-color: ${color("black10")};
+  padding: 10px;
   background-color: ${(p: ContainerProps) => (p.active ? "white" : colors["gray-light"])};
 `
 
 const StyledKeyboardAvoidingView = styled.KeyboardAvoidingView`
   flex: 1;
   ${isPad ? "width: 708; align-self: center;" : ""};
-`
-
-interface StyledSendButtonProps {
-  disabled: boolean
-}
-
-export const SendButton = styled.Text`
-  font-family: ${fonts["avant-garde-regular"]};
-  font-size: 12;
-  margin-right: 10;
-  color: ${(p: StyledSendButtonProps) => (p.disabled ? colors["gray-regular"] : colors["purple-regular"])};
 `
 
 interface Props {
@@ -90,12 +78,14 @@ export default class Composer extends React.Component<Props, State> {
     // The TextInput loses its isFocused() callback as a styled component
     const inputStyles = {
       flex: 1,
-      fontFamily: fonts["garamond-regular"],
       fontSize: 13,
       paddingLeft: 10,
       paddingTop: 13,
       paddingBottom: 10,
       paddingRight: 10,
+      borderColor: this.state.active ? color("purple100") : "transparent",
+      borderWidth: 1,
+      fontFamily: themeProps.fontFamily.sans.regular as string,
     }
 
     const disableSendButton = !(this.state.text && this.state.text.length) || this.props.disabled
@@ -107,7 +97,7 @@ export default class Composer extends React.Component<Props, State> {
             {this.props.children}
             <Container active={this.state.active}>
               <TextInput
-                placeholder={"Reply..."}
+                placeholder={"Type your message"}
                 placeholderTextColor={colors["gray-semibold"]}
                 keyboardAppearance={"dark"}
                 onEndEditing={() => this.setState({ active: false })}
@@ -120,7 +110,9 @@ export default class Composer extends React.Component<Props, State> {
                 autoFocus={typeof jest === "undefined" /* TODO: https://github.com/facebook/jest/issues/3707 */}
               />
               <TouchableWithoutFeedback disabled={disableSendButton} onPress={this.submitText.bind(this)}>
-                <SendButton disabled={!!disableSendButton}>Send</SendButton>
+                <Button ml={1} disabled={!!disableSendButton}>
+                  Send
+                </Button>
               </TouchableWithoutFeedback>
             </Container>
           </StyledKeyboardAvoidingView>

--- a/src/lib/Components/Inbox/Conversations/__tests__/Composer-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/__tests__/Composer-tests.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@artsy/palette"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { TextInput } from "react-native"
@@ -5,7 +6,7 @@ import { TouchableWithoutFeedback } from "react-native"
 
 jest.unmock("react-tracking")
 
-import Composer, { SendButton } from "../Composer"
+import Composer from "../Composer"
 
 it("renders without throwing a error", () => {
   renderWithWrappers(<Composer />)
@@ -18,7 +19,7 @@ describe("regarding the send button", () => {
     // This is because the component is wrapped by react-tracking, which changes the tree structure
     const tree = renderWithWrappers(<Composer value={overrideText} disabled={true} />)
 
-    expect(tree.root.findByType(SendButton).props.disabled).toBeTruthy()
+    expect(tree.root.findByType(Button).props.disabled).toBeTruthy()
   })
 
   it("calls onSubmit with the text when send button is pressed", () => {


### PR DESCRIPTION
The type of this PR is: Enhancement

This PR resolves [PURCHASE-2051]

### Description

Re-styled reply box on inbox to look more like web. Currently looks like this:
<img width="386" alt="Screenshot 2020-08-22 at 00 45 53" src="https://user-images.githubusercontent.com/7117670/90941547-b4acf700-e412-11ea-83a3-3e10b63f262f.png">

This PR makes it look like this:
<img width="388" alt="Screenshot 2020-08-22 at 00 44 44" src="https://user-images.githubusercontent.com/7117670/90941564-becef580-e412-11ea-95c0-2c14715e6d5b.png">

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[PURCHASE-2051]: https://artsyproduct.atlassian.net/browse/PURCHASE-2051