### PR TITLE
fix: change "sold by" to "from" in comm partner info

### DIFF
--- a/src/lib/Scenes/Artwork/Components/CommercialPartnerInformation.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialPartnerInformation.tsx
@@ -13,7 +13,7 @@ export class CommercialPartnerInformation extends React.Component<Props> {
     const artworkIsSold = artwork.availability && artwork.availability === "sold"
     const artworkEcommerceAvailable = artwork.isAcquireable || artwork.isOfferable
     const showsSellerInfo = artwork.partner && artwork.partner.name
-    const availabilityDisplayText = artwork.isForSale || artworkIsSold ? "Sold by" : "At"
+    const availabilityDisplayText = artwork.isForSale || artworkIsSold ? "From" : "At"
     return (
       <>
         {showsSellerInfo && (

--- a/src/lib/Scenes/Artwork/Components/__tests__/CommercialPartnerInformation-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/CommercialPartnerInformation-tests.tsx
@@ -20,7 +20,7 @@ describe("CommercialPartnerInformation", () => {
         .at(0)
         .render()
         .text()
-    ).toMatchInlineSnapshot(`"Sold by Bob's Gallery"`)
+    ).toMatchInlineSnapshot(`"From Bob's Gallery"`)
     expect(
       component
         .find(Sans)
@@ -92,7 +92,7 @@ describe("CommercialPartnerInformation", () => {
         .at(0)
         .render()
         .text()
-    ).toMatchInlineSnapshot(`"Sold by Bob's Gallery"`)
+    ).toMatchInlineSnapshot(`"From Bob's Gallery"`)
     expect(component.find(Sans).length).toEqual(1)
   })
 
@@ -118,11 +118,11 @@ describe("CommercialPartnerInformation", () => {
         .at(0)
         .render()
         .text()
-    ).toMatchInlineSnapshot(`"Sold by Bob's Gallery"`)
+    ).toMatchInlineSnapshot(`"From Bob's Gallery"`)
     expect(component.find(Sans).length).toEqual(1)
   })
 
-  it("Says 'At Gallery Name' instead of 'Sold by Gallery Name' and hides shipping info for non-commercial works", () => {
+  it("Says 'At Gallery Name' instead of 'From Gallery Name' and hides shipping info for non-commercial works", () => {
     const CommercialPartnerInformationArtworkClosedAuction = {
       ...CommercialPartnerInformationArtwork,
       availability: null,


### PR DESCRIPTION
The type of this PR is: Enhancement (?)

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [MX-504]

### Description

Replace "Sold by" with "From" in CommercialPartnerInfo

![image](https://user-images.githubusercontent.com/1815204/91159331-37aaa780-e6c8-11ea-86ea-f6288e8c5499.png)

#trivial

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434
[MX-504]: https://artsyproduct.atlassian.net/browse/MX-504