### PR TITLE
fix: conform ipad empty search screen to iphone

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -7,9 +7,9 @@ upcoming:
     - Migrates config to react-native-config, removes cocoapods-keys - ash
     - Removes DSL-style analytics for native code - ash
     - Removes ReactiveObjC dependency - ash
+    - Conform iPad empty search screen to iPhone - adamb
   user_facing:
     - Fix shows save button - mounir
-
 
 releases:
   - version: 6.6.1

--- a/src/lib/Scenes/Search/Search.tsx
+++ b/src/lib/Scenes/Search/Search.tsx
@@ -1,4 +1,4 @@
-import { color, Flex, Serif, Spacer } from "@artsy/palette"
+import { color, Flex, Spacer } from "@artsy/palette"
 import { SearchInput } from "lib/Components/SearchInput"
 import { isPad } from "lib/utils/hardware"
 import { Schema } from "lib/utils/track"
@@ -10,39 +10,11 @@ import { AutosuggestResults } from "./AutosuggestResults"
 import { CityGuideCTA } from "./CityGuideCTA"
 import { RecentSearches } from "./RecentSearches"
 import { SearchContext, useSearchProviderValues } from "./SearchContext"
-import { useRecentSearches } from "./SearchModel"
 
 export const Search: React.FC = () => {
   const [query, setQuery] = useState("")
-  const recentSearches = useRecentSearches()
   const { trackEvent } = useTracking()
   const searchProviderValues = useSearchProviderValues(query)
-  const showCityGuide = !isPad()
-
-  const renderContent = () => {
-    if (query.length >= 2) {
-      return <AutosuggestResults query={query} />
-    }
-    if (showCityGuide) {
-      return (
-        <Scrollable>
-          <RecentSearches />
-          <Spacer mb={3} />
-          <CityGuideCTA />
-          <Spacer mb="40px" />
-        </Scrollable>
-      )
-    }
-    if (recentSearches.length) {
-      return (
-        <Scrollable>
-          <RecentSearches />
-          <Spacer mb="40px" />
-        </Scrollable>
-      )
-    }
-    return <LegacyEmptyState />
-  }
 
   return (
     <SearchContext.Provider value={searchProviderValues}>
@@ -73,7 +45,16 @@ export const Search: React.FC = () => {
             }}
           />
         </Flex>
-        {renderContent()}
+        {query.length >= 2 ? (
+          <AutosuggestResults query={query} />
+        ) : (
+          <Scrollable>
+            <RecentSearches />
+            <Spacer mb={3} />
+            {!isPad() && <CityGuideCTA />}
+            <Spacer mb="40px" />
+          </Scrollable>
+        )}
       </KeyboardAvoidingView>
     </SearchContext.Provider>
   )
@@ -87,15 +68,3 @@ const Scrollable = styled(ScrollView).attrs({
   padding: 0 20px;
   padding-top: 20px;
 `
-
-const LegacyEmptyState: React.FC<{}> = ({}) => {
-  return (
-    <Flex style={{ flex: 1 }} alignItems="center" justifyContent="center">
-      <Flex maxWidth={250}>
-        <Serif textAlign="center" size="3">
-          Search for artists, artworks, galleries, shows, and more.
-        </Serif>
-      </Flex>
-    </Flex>
-  )
-}

--- a/src/lib/Scenes/Search/__tests__/Search-tests.tsx
+++ b/src/lib/Scenes/Search/__tests__/Search-tests.tsx
@@ -61,7 +61,6 @@ describe("The Search page", () => {
     const isPadMock = isPad as jest.Mock
     isPadMock.mockImplementationOnce(() => true)
     const tree = renderWithWrappers(<TestWrapper />)
-    expect(extractText(tree.root)).toContain("Search for artists, artworks, galleries, shows, and more")
     expect(tree.root.findAllByType(CityGuideCTA)).toHaveLength(0)
   })
 
@@ -85,7 +84,6 @@ describe("The Search page", () => {
     })
 
     const tree = renderWithWrappers(<TestWrapper />)
-    expect(extractText(tree.root)).not.toContain("Search for artists, artworks, galleries, shows, and more")
     expect(tree.root.findAllByType(RecentSearches)).toHaveLength(1)
     expect(tree.root.findAllByType(AutosuggestResults)).toHaveLength(0)
   })


### PR DESCRIPTION
The type of this PR is: Enhancement

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [MX-425]

### Description

Conforms the iPad view to the iPhone, minus City Guide.

![image](https://user-images.githubusercontent.com/1815204/91171657-1ef7bd00-e6db-11ea-8e77-f17b8ac6ac61.png)

I also refactored the code slightly to make it (to my mind) more readable, but others may disagree - I'm open to change it back, obvs!

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434
[MX-425]: https://artsyproduct.atlassian.net/browse/MX-425