### PR TITLE
fix: empty search message font should be sans

### DIFF
--- a/src/lib/Scenes/Search/AutosuggestResults.tsx
+++ b/src/lib/Scenes/Search/AutosuggestResults.tsx
@@ -1,4 +1,4 @@
-import { Flex, Sans, space } from "@artsy/palette"
+import { Flex, space, Text } from "@artsy/palette"
 import { captureMessage } from "@sentry/react-native"
 import { AutosuggestResults_results } from "__generated__/AutosuggestResults_results.graphql"
 import {
@@ -111,7 +111,7 @@ const AutosuggestResultsFlatList: React.FC<{
       ListEmptyComponent={
         noResults
           ? () => {
-              return <Sans size="3">We couldn't find anything for “{query}”</Sans>
+              return <Text variant="text">We couldn't find anything for “{query}”</Text>
             }
           : null
       }
@@ -204,9 +204,9 @@ export const AutosuggestResults: React.FC<{
             return (
               <Flex alignItems="center" justifyContent="center">
                 <Flex maxWidth={280}>
-                  <Sans size="3" textAlign="center">
+                  <Text variant="text" textAlign="center">
                     There seems to be a problem with the connection. Please try again shortly.
-                  </Sans>
+                  </Text>
                 </Flex>
               </Flex>
             )

--- a/src/lib/Scenes/Search/AutosuggestResults.tsx
+++ b/src/lib/Scenes/Search/AutosuggestResults.tsx
@@ -1,4 +1,4 @@
-import { Flex, Serif, space } from "@artsy/palette"
+import { Flex, Sans, space } from "@artsy/palette"
 import { captureMessage } from "@sentry/react-native"
 import { AutosuggestResults_results } from "__generated__/AutosuggestResults_results.graphql"
 import {
@@ -111,7 +111,7 @@ const AutosuggestResultsFlatList: React.FC<{
       ListEmptyComponent={
         noResults
           ? () => {
-              return <Serif size="3">We couldn't find anything for “{query}”</Serif>
+              return <Sans size="3">We couldn't find anything for “{query}”</Sans>
             }
           : null
       }
@@ -204,9 +204,9 @@ export const AutosuggestResults: React.FC<{
             return (
               <Flex alignItems="center" justifyContent="center">
                 <Flex maxWidth={280}>
-                  <Serif size="3" textAlign="center">
+                  <Sans size="3" textAlign="center">
                     There seems to be a problem with the connection. Please try again shortly.
-                  </Serif>
+                  </Sans>
                 </Flex>
               </Flex>
             )


### PR DESCRIPTION
The type of this PR is: Enhancement

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [MX-497]

### Description

Sets the font of the _We couldn't find anything for "zzzz"_ message to `Sans` instead of `Serif`

![image](https://user-images.githubusercontent.com/1815204/91200851-ffbf5680-e6ff-11ea-8bcf-ab3de0de60ba.png)

#trivial

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434
[MX-497]: https://artsyproduct.atlassian.net/browse/MX-497