### PR TITLE
Push deep link VCs after main nav VC loads

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -11,6 +11,7 @@ upcoming:
     - Begins refactoring the app to be oriented around react-native - david
     - Conform iPad empty search screen to iPhone - adamb
     - Adds scaffold for new sale page - ash
+    - Fix deep link handling edge case - david
   user_facing:
     - Fix shows save button - mounir
     - Fix app crash when opened from a 404 page - mounir


### PR DESCRIPTION
The type of this PR is: **Bugfix**

### Description

This fixes an edge case introduced by #3714 that prevented deep links from being handled correctly.

Basically the problem is that after #3714 it took a little longer for the `ARTopMenuViewController` singleton to reach a state where it is ready to properly handle pushing VCs.

`ARTopMenuViewController` is going to be disappearing very soon so I put a band-aid on the issue here, by adding `pushViewController` method calls to a queue until `ARTopMenuViewController` finishes loading, and then processing them.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
  - Not sure it's worth testing this since it's going to be deleted so soon and this whole class lacks test coverage anyhow.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
