### PR TITLE
add active lot standing count to profile page

### DIFF
--- a/src/__generated__/MyBidsQuery.graphql.ts
+++ b/src/__generated__/MyBidsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash ca07e31b8e0748c6bc1712dbd1fe7ab3 */
+/* @relayHash 8c9a80911b249d4d45ddf69527bcdf1f */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -115,6 +115,7 @@ fragment SaleCard_sale on Sale {
   href
   name
   liveStartAt
+  endAt
   displayTimelyAt
   coverImage {
     url
@@ -394,6 +395,13 @@ return {
                                 "storageKey": null
                               },
                               {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "endAt",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
                                 "kind": "LinkedField",
                                 "alias": null,
                                 "name": "coverImage",
@@ -444,7 +452,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "MyBidsQuery",
-    "id": "042c99463b706a2a8a35d4b0a5337c71",
+    "id": "7114b24c69da6fdf8a952cc998dded17",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/MyProfileQuery.graphql.ts
+++ b/src/__generated__/MyProfileQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 23ea35fe2689b0ce1b8cd90428af9c90 */
+/* @relayHash 9b48561dd37d914e64cdb6d73a15862f */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -27,6 +27,17 @@ query MyProfileQuery {
 
 fragment MyProfile_me on Me {
   name
+  auctionsLotStandingConnection(first: 25) {
+    edges {
+      node {
+        lotState {
+          soldStatus
+          id
+        }
+        id
+      }
+    }
+  }
   followsAndSaves {
     artworksConnection(first: 10, private: true) {
       edges {
@@ -128,6 +139,65 @@ return {
         "plural": false,
         "selections": [
           (v0/*: any*/),
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "auctionsLotStandingConnection",
+            "storageKey": "auctionsLotStandingConnection(first:25)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 25
+              }
+            ],
+            "concreteType": "AuctionsLotStandingConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "AuctionsLotStandingEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "AuctionsLotStanding",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "lotState",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "AuctionsLotState",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "soldStatus",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v1/*: any*/)
+                        ]
+                      },
+                      (v1/*: any*/)
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
           {
             "kind": "LinkedField",
             "alias": null,
@@ -346,7 +416,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "MyProfileQuery",
-    "id": "8fcc1a1acbbae5fac55635c6a0bb5ae4",
+    "id": "6eae9fea95b6186fc2dfa1a16166a444",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/MyProfileRefetchQuery.graphql.ts
+++ b/src/__generated__/MyProfileRefetchQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash caf1691739272cb17c0c0e643bdbaf4d */
+/* @relayHash 7a6259fb0dfc617435954a8f42a1987c */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -27,6 +27,17 @@ query MyProfileRefetchQuery {
 
 fragment MyProfile_me on Me {
   name
+  auctionsLotStandingConnection(first: 25) {
+    edges {
+      node {
+        lotState {
+          soldStatus
+          id
+        }
+        id
+      }
+    }
+  }
   followsAndSaves {
     artworksConnection(first: 10, private: true) {
       edges {
@@ -128,6 +139,65 @@ return {
         "plural": false,
         "selections": [
           (v0/*: any*/),
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "auctionsLotStandingConnection",
+            "storageKey": "auctionsLotStandingConnection(first:25)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 25
+              }
+            ],
+            "concreteType": "AuctionsLotStandingConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "AuctionsLotStandingEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "AuctionsLotStanding",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "lotState",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "AuctionsLotState",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "soldStatus",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v1/*: any*/)
+                        ]
+                      },
+                      (v1/*: any*/)
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
           {
             "kind": "LinkedField",
             "alias": null,
@@ -346,7 +416,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "MyProfileRefetchQuery",
-    "id": "76b66bc5167185631145099b5a0a8a28",
+    "id": "34c6d0b9d80d4806a29e14f6f8cb630e",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/MyProfile_me.graphql.ts
+++ b/src/__generated__/MyProfile_me.graphql.ts
@@ -3,8 +3,18 @@
 
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type AuctionsSoldStatus = "ForSale" | "Passed" | "Sold" | "%future added value";
 export type MyProfile_me = {
     readonly name: string | null;
+    readonly auctionsLotStandingConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly lotState: {
+                    readonly soldStatus: AuctionsSoldStatus;
+                };
+            };
+        } | null> | null;
+    };
     readonly followsAndSaves: {
         readonly artworksConnection: {
             readonly edges: ReadonlyArray<{
@@ -38,6 +48,63 @@ const node: ReaderFragment = {
       "name": "name",
       "args": null,
       "storageKey": null
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "auctionsLotStandingConnection",
+      "storageKey": "auctionsLotStandingConnection(first:25)",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 25
+        }
+      ],
+      "concreteType": "AuctionsLotStandingConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "AuctionsLotStandingEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "AuctionsLotStanding",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "lotState",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "AuctionsLotState",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "soldStatus",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     },
     {
       "kind": "LinkedField",
@@ -108,5 +175,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = 'c6f0faf5b6fc841743fed82de0587763';
+(node as any).hash = '17a714901290859ff55b6d58d799b195';
 export default node;

--- a/src/__generated__/SaleCard_sale.graphql.ts
+++ b/src/__generated__/SaleCard_sale.graphql.ts
@@ -7,6 +7,7 @@ export type SaleCard_sale = {
     readonly href: string | null;
     readonly name: string | null;
     readonly liveStartAt: string | null;
+    readonly endAt: string | null;
     readonly displayTimelyAt: string | null;
     readonly coverImage: {
         readonly url: string | null;
@@ -57,6 +58,13 @@ return {
     {
       "kind": "ScalarField",
       "alias": null,
+      "name": "endAt",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
       "name": "displayTimelyAt",
       "args": null,
       "storageKey": null
@@ -94,5 +102,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '1fe9adac34a46876b6a80f18dd4f8696';
+(node as any).hash = '3187ddee85492956a3a4e453a92d5894';
 export default node;

--- a/src/lib/Scenes/MyBids/Components/ActiveLot.tsx
+++ b/src/lib/Scenes/MyBids/Components/ActiveLot.tsx
@@ -4,7 +4,7 @@ import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { LotFragmentContainer as Lot } from "./Lot"
 
-const ActiveLot = ({ lotStanding }: { lotStanding: ActiveLot_lotStanding }) => {
+export const ActiveLot = ({ lotStanding }: { lotStanding: ActiveLot_lotStanding }) => {
   const sellingPrice = lotStanding?.lotState?.sellingPrice?.displayAmount
   const bidCount = lotStanding?.lotState?.bidCount
   const { saleArtwork, lotState } = lotStanding
@@ -21,15 +21,15 @@ const ActiveLot = ({ lotStanding }: { lotStanding: ActiveLot_lotStanding }) => {
           </Text>
         </Flex>
         <Flex flexDirection="row" alignItems="center">
-          {lotStanding?.isHighestBidder && lotStanding.lotState.reserveStatus !== "ReserveNotMet" ? (
+          {lotStanding?.isHighestBidder && lotStanding.lotState.reserveStatus === "ReserveNotMet" ? (
             <>
               <CheckCircleFillIcon fill="green100" />
-              <Text variant="caption"> Highest Bid</Text>
+              <Text variant="caption"> Reserve not met</Text>
             </>
           ) : lotStanding?.isHighestBidder ? (
             <>
               <XCircleIcon fill="red100" />
-              <Text variant="caption"> Reserve not met</Text>
+              <Text variant="caption"> Highest bid</Text>
             </>
           ) : (
             <>

--- a/src/lib/Scenes/MyBids/Components/SaleCard.tsx
+++ b/src/lib/Scenes/MyBids/Components/SaleCard.tsx
@@ -61,6 +61,7 @@ export const SaleCardFragmentContainer = createFragmentContainer(SaleCard, {
       href
       name
       liveStartAt
+      endAt
       displayTimelyAt
       coverImage {
         url

--- a/src/lib/Scenes/MyBids/__tests__/ActiveLot-tests.tsx
+++ b/src/lib/Scenes/MyBids/__tests__/ActiveLot-tests.tsx
@@ -1,0 +1,89 @@
+import React from "react"
+
+import { ActiveLot_lotStanding } from "__generated__/ActiveLot_lotStanding.graphql"
+import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { merge } from "lodash"
+import { ActiveLot } from "../Components/ActiveLot"
+
+const defaultLotStanding = {
+  isHighestBidder: true,
+  lotState: {
+    internalID: "123",
+    bidCount: 1,
+    soldStatus: "Passed",
+    reserveStatus: "ReserveMet",
+    sellingPrice: {
+      displayAmount: "CHF 1,800",
+    },
+    askingPrice: {
+      displayAmount: "CHF 2,000",
+    },
+  },
+  saleArtwork: {
+    lotLabel: "3",
+    artwork: {
+      artistNames: "Maskull Lasserre",
+      href: "/artwork/maskull-lasserre-painting",
+      image: {
+        url: "https://d2v80f5yrouhh2.cloudfront.net/zrtyPc3hnFNl-1yv80qS2w/medium.jpg",
+      },
+    },
+    sale: {
+      displayTimelyAt: "Closed on 7/15/20",
+    },
+  },
+}
+
+const lotStandingFixture = (overrides = {}) => {
+  return (merge({}, defaultLotStanding, overrides) as unknown) as ActiveLot_lotStanding
+}
+
+describe(ActiveLot, () => {
+  describe("User winning status", () => {
+    it("says 'Highest bid' if the user is winning the lot", () => {
+      const tree = renderWithWrappers(
+        <ActiveLot
+          lotStanding={lotStandingFixture({ isHighestBidder: true, lotState: { reserveStatus: "ReserveMet" } })}
+        />
+      )
+      expect(extractText(tree.root)).toContain("Highest bid")
+    })
+
+    it("says 'Highest bid' if the user is has the high bid and reserveStatus is UnknownReserve", () => {
+      const tree = renderWithWrappers(
+        <ActiveLot
+          lotStanding={lotStandingFixture({ isHighestBidder: true, lotState: { reserveStatus: "UnknownReserve" } })}
+        />
+      )
+      expect(extractText(tree.root)).toContain("Highest bid")
+    })
+
+    it("says 'outbid' if the user is outbid on the lot", () => {
+      const tree = renderWithWrappers(
+        <ActiveLot
+          lotStanding={lotStandingFixture({ isHighestBidder: false, lotState: { reserveStatus: "ReserveMet" } })}
+        />
+      )
+      expect(extractText(tree.root)).toContain("Outbid")
+    })
+
+    it("says 'Reserve not met' if the user is winning the lot, but the reserveStatus is ReserveNotMet", () => {
+      const tree = renderWithWrappers(
+        <ActiveLot
+          lotStanding={lotStandingFixture({ isHighestBidder: true, lotState: { reserveStatus: "ReserveNotMet" } })}
+        />
+      )
+      expect(extractText(tree.root)).toContain("Reserve not met")
+    })
+
+    it("says 'Outbid' if the user is outbid on the lot, but the reserveStatus is ReserveNotMet", () => {
+      const tree = renderWithWrappers(
+        <ActiveLot
+          lotStanding={lotStandingFixture({ isHighestBidder: false, lotState: { reserveStatus: "ReserveNotMet" } })}
+        />
+      )
+      expect(extractText(tree.root)).toContain("Outbid")
+    })
+  })
+})

--- a/src/lib/Scenes/MyBids/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/MyBids/__tests__/index-tests.tsx
@@ -58,7 +58,7 @@ describe(MyBidsQueryRenderer, () => {
 
     expect(extractText(upcomingLots[2])).toContain("Zach Eugene Salinger-Simonson")
     expect(extractText(upcomingLots[2])).toContain("2 bids")
-    expect(extractText(upcomingLots[2])).toContain("Highest Bid")
+    expect(extractText(upcomingLots[2])).toContain("Highest bid")
 
     const recentlyClosedLot = tree.root.findAllByType(RecentlyClosedLot)
 

--- a/src/lib/Scenes/MyBids/helpers/lotStanding.ts
+++ b/src/lib/Scenes/MyBids/helpers/lotStanding.ts
@@ -1,0 +1,2 @@
+export const lotStandingIsClosed: (lotStanding: { lotState?: { soldStatus?: string } }) => boolean = lotStanding =>
+  !!(lotStanding.lotState?.soldStatus && ["Sold", "Passed"].includes(lotStanding.lotState.soldStatus))

--- a/src/lib/Scenes/MyBids/index.tsx
+++ b/src/lib/Scenes/MyBids/index.tsx
@@ -17,6 +17,7 @@ import {
   RecentlyClosedLotFragmentContainer as RecentlyClosedLot,
   SaleCardFragmentContainer,
 } from "./Components"
+import { lotStandingIsClosed } from "./helpers/lotStanding"
 
 export interface MyBidsProps {
   me: MyBids_me
@@ -27,10 +28,7 @@ class MyBids extends React.Component<MyBidsProps> {
     const { me } = this.props
     const lotStandings = extractNodes(me?.auctionsLotStandingConnection)
 
-    const [recentlyClosedStandings, activeStandings] = partition(
-      lotStandings,
-      ls => ls?.lotState?.soldStatus && ["Sold", "Passed"].includes(ls.lotState.soldStatus)
-    )
+    const [recentlyClosedStandings, activeStandings] = partition(lotStandings, lotStandingIsClosed)
 
     const activeBySaleId = groupBy(
       activeStandings.filter(ls => ls != null),

--- a/src/lib/Scenes/MyProfile/MyProfile.tsx
+++ b/src/lib/Scenes/MyProfile/MyProfile.tsx
@@ -41,16 +41,8 @@ const MyProfile: React.FC<{ me: MyProfile_me; relay: RelayRefetchProp }> = ({ me
         <MyProfileMenuItem
           title="My Bids"
           onPress={() => SwitchBoard.presentNavigationViewController(navRef.current!, "my-bids")}
-          chevron={
-            <Flex flexDirection="row" alignItems="center">
-              {activeBidCount > 0 && (
-                <Sans size="4" color="black60" mr={1}>
-                  {activeBidCount} Active
-                </Sans>
-              )}
-              <ChevronIcon direction="right" fill="black60" />
-            </Flex>
-          }
+          value={activeBidCount > 0 && `${activeBidCount} active`}
+          chevron={<ChevronIcon direction="right" fill="black60" />}
         />
       )}
       <MyProfileMenuItem

--- a/src/lib/Scenes/MyProfile/MyProfile.tsx
+++ b/src/lib/Scenes/MyProfile/MyProfile.tsx
@@ -7,11 +7,12 @@ import { extractNodes } from "lib/utils/extractNodes"
 import { PlaceholderBox, PlaceholderText } from "lib/utils/placeholders"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { times } from "lodash"
-import { Flex, Join, Sans, Separator, Spacer } from "palette"
+import { ChevronIcon, Flex, Join, Sans, Separator, Spacer } from "palette"
 import React, { useCallback, useRef, useState } from "react"
 import { Alert, FlatList, NativeModules, RefreshControl, ScrollView } from "react-native"
 import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
 import { SmallTileRailContainer } from "../Home/Components/SmallTileRail"
+import { lotStandingIsClosed } from "../MyBids/helpers/lotStanding"
 import { MyProfileMenuItem } from "./Components/MyProfileMenuItem"
 
 const MyProfile: React.FC<{ me: MyProfile_me; relay: RelayRefetchProp }> = ({ me, relay }) => {
@@ -27,6 +28,7 @@ const MyProfile: React.FC<{ me: MyProfile_me; relay: RelayRefetchProp }> = ({ me
       listRef.current?.scrollToOffset({ offset: 0, animated: false })
     })
   }, [])
+  const activeBidCount = extractNodes(me.auctionsLotStandingConnection).filter(ls => !lotStandingIsClosed(ls)).length
 
   return (
     <ScrollView ref={navRef} refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />}>
@@ -39,6 +41,16 @@ const MyProfile: React.FC<{ me: MyProfile_me; relay: RelayRefetchProp }> = ({ me
         <MyProfileMenuItem
           title="My Bids"
           onPress={() => SwitchBoard.presentNavigationViewController(navRef.current!, "my-bids")}
+          chevron={
+            <Flex flexDirection="row" alignItems="center">
+              {activeBidCount > 0 && (
+                <Sans size="4" color="black60" mr={1}>
+                  {activeBidCount} Active
+                </Sans>
+              )}
+              <ChevronIcon direction="right" fill="black60" />
+            </Flex>
+          }
         />
       )}
       <MyProfileMenuItem
@@ -118,6 +130,15 @@ const MyProfileContainer = createRefetchContainer(
     me: graphql`
       fragment MyProfile_me on Me {
         name
+        auctionsLotStandingConnection(first: 25) {
+          edges {
+            node {
+              lotState {
+                soldStatus
+              }
+            }
+          }
+        }
         followsAndSaves {
           artworksConnection(first: 10, private: true) {
             edges {


### PR DESCRIPTION
_One question about testing: We don't have a high-level test for the MyProfile screen where I could check for active bid count. Is this okay to skip for now in order to QA in tomorrow's session?_
The type of this PR is: Enhancement

<!-- Bugfix/Feature/Enhancement/Documentation -->

### Description
  This PR adds the active lot count to the user profile page. It needs tests and is blocked by (includes commits from) #3787. Once that is merged I will rebase and add tests here.

It also fixes a few visual bugs:
- missing/broken sale end time on sale card
- Reserve not met message should not should for live lots with UnknownReserve status

One point of note - I created a `lotStandingIsClosed` helper since I was reusing this logic, and imported it into the MyProfile screen from the `MyBids` screen helpers directory. I don't know if that is okay.


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.  _TODO: I'm not sure the best way to do this or if we should for this feature - it is small and would require some new test setup that I haven't done yet. If we deploy this we could QA it tomorrow._
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))

![image](https://user-images.githubusercontent.com/9088720/91621221-5c20b100-e960-11ea-942e-de2065c213ad.png)
