### PR TITLE
Removes AFNetworking/UIKit subspec

### DIFF
--- a/Artsy/App/ARAppDelegate+Analytics.m
+++ b/Artsy/App/ARAppDelegate+Analytics.m
@@ -4,7 +4,7 @@
 #import <ARAnalytics/ARAnalytics.h>
 #import "ARAnalyticsConstants.h"
 #import <Mantle/NSDictionary+MTLManipulationAdditions.h>
-#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/AFHTTPRequestOperation.h>
 
 #import "AROptions.h"
 #import "Artsy-Swift.h"

--- a/Artsy/Categories/AFNetworking/AFHTTPRequestOperation+JSON.m
+++ b/Artsy/Categories/AFNetworking/AFHTTPRequestOperation+JSON.m
@@ -1,4 +1,4 @@
-#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/AFHTTPRequestOperation.h>
 
 
 @implementation AFHTTPRequestOperation (JSON)

--- a/Artsy/Models/API_Models/Partner_Metadata/Artwork.m
+++ b/Artsy/Models/API_Models/Partner_Metadata/Artwork.m
@@ -19,7 +19,7 @@
 #import "MTLModel+JSON.h"
 
 #import <ObjectiveSugar/ObjectiveSugar.h>
-#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/AFHTTPRequestOperation.h>
 
 // We have to support two different shaped pieces of data
 // for the same fields, so these properties are used in

--- a/Artsy/Networking/API_Modules/ArtsyAPI+Artworks.m
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+Artworks.m
@@ -14,7 +14,7 @@
 #import "MTLModel+JSON.h"
 
 #import <ObjectiveSugar/ObjectiveSugar.h>
-#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/AFHTTPRequestOperation.h>
 #import <ARAnalytics/ARAnalytics.h>
 
 

--- a/Artsy/Networking/API_Modules/ArtsyAPI+ErrorHandlers.m
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+ErrorHandlers.m
@@ -1,6 +1,6 @@
 #import "ArtsyAPI.h"
 
-#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/AFHTTPRequestOperation.h>
 
 @implementation ArtsyAPI (ErrorHandlers)
 

--- a/Artsy/Networking/API_Modules/ArtsyAPI+ListCollection.h
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+ListCollection.h
@@ -1,5 +1,5 @@
 #import "ArtsyAPI.h"
-#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/AFHTTPRequestOperation.h>
 
 
 @interface ArtsyAPI (ListCollection)

--- a/Artsy/Networking/API_Modules/ArtsyAPI+Notifications.h
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+Notifications.h
@@ -1,6 +1,6 @@
 #import "ArtsyAPI.h"
 
-#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/AFHTTPRequestOperation.h>
 
 
 @interface ArtsyAPI (Notifications)

--- a/Artsy/Networking/API_Modules/ArtsyAPI+Sailthru.m
+++ b/Artsy/Networking/API_Modules/ArtsyAPI+Sailthru.m
@@ -1,7 +1,7 @@
 #import "ArtsyAPI+Sailthru.h"
 #import "ARRouter.h"
 
-#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/AFHTTPRequestOperation.h>
 
 @implementation ArtsyAPI (Sailthru)
 

--- a/Artsy/Networking/ARRouter.m
+++ b/Artsy/Networking/ARRouter.m
@@ -22,7 +22,10 @@
 #import <UICKeyChainStore/UICKeyChainStore.h>
 #import <react-native-config/ReactNativeConfig.h>
 #import <ObjectiveSugar/ObjectiveSugar.h>
-#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/AFHTTPRequestOperation.h>
+#import <AFNetworking/AFNetworkReachabilityManager.h>
+#import <AFNetworking/AFURLSessionManager.h>
+#import <AFNetworking/AFHTTPSessionManager.h>
 
 static AFHTTPSessionManager *staticHTTPClient = nil;
 static NSSet *artsyHosts = nil;

--- a/Artsy/Networking/Network_Models/ARFavoritesNetworkModel.m
+++ b/Artsy/Networking/Network_Models/ARFavoritesNetworkModel.m
@@ -1,5 +1,5 @@
 #import "ARFavoritesNetworkModel.h"
-#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/AFHTTPRequestOperation.h>
 #import "ARFavoritesNetworkModel+Private.h"
 
 

--- a/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/ARPersonalizeViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/Onboarding_stages/5-_Onboarding_Personalization/ARPersonalizeViewController.m
@@ -22,7 +22,7 @@
 #import <Artsy-UIButtons/ARButtonSubclasses.h>
 #import <UIView+BooleanAnimations/UIView+BooleanAnimations.h>
 #import <ObjectiveSugar/ObjectiveSugar.h>
-#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/AFHTTPRequestOperation.h>
 #import <FLKAutoLayout/UIView+FLKAutoLayout.h>
 
 // maxim's sneaky last comment in Eigen (for a dummy commit). This can be removed when you find it ;).

--- a/Artsy/View_Controllers/Util/Logging/ARHTTPRequestOperationLogger.m
+++ b/Artsy/View_Controllers/Util/Logging/ARHTTPRequestOperationLogger.m
@@ -3,7 +3,7 @@
 #import "ARLogger.h"
 
 #import <objc/runtime.h>
-#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/AFHTTPRequestOperation.h>
 
 @implementation ARHTTPRequestOperationLogger
 

--- a/Artsy_Tests/Networking_Tests/AFHTTPRequestOperationJSONTests.m
+++ b/Artsy_Tests/Networking_Tests/AFHTTPRequestOperationJSONTests.m
@@ -1,6 +1,6 @@
 #import "AFHTTPRequestOperation+JSON.h"
 
-#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/AFHTTPRequestOperation.h>
 
 SpecBegin(AFHTTPRequestOperationJSONTests)
 

--- a/Artsy_Tests/Stubs/OHHTTPStubs+Artsy.m
+++ b/Artsy_Tests/Stubs/OHHTTPStubs+Artsy.m
@@ -2,7 +2,7 @@
 #import "ARRouter.h"
 
 #import <OHHTTPStubs/OHHTTPStubs.h>
-#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/AFHTTPRequestOperation.h>
 
 
 @implementation OHHTTPStubs (Artsy)

--- a/Artsy_Tests/Supporting_Files/Artsy_Tests-Prefix.pch
+++ b/Artsy_Tests/Supporting_Files/Artsy_Tests-Prefix.pch
@@ -13,7 +13,7 @@
     #define failure(...) EXP_failure((__VA_ARGS__))
 
     // Pods that come in from the other target
-    #import <AFNetworking/AFNetworking.h>
+    #import <AFNetworking/AFHTTPRequestOperation.h>
     #import <ISO8601DateFormatter/ISO8601DateFormatter.h>
     #import <UICKeyChainStore/UICKeyChainStore.h>
     #import <Mantle/Mantle.h>

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -14,6 +14,7 @@ upcoming:
     - Adds scaffold for new sale page - ash
     - Fix deep link handling edge case - david
     - Connects new My Bids view to causality's lot standings - erik
+    - Removes AFNetworking/UIKit subspec - ash
   user_facing:
     - Fix shows save button - mounir
     - Fix hidden slider handle bug in refine - brian

--- a/Podfile
+++ b/Podfile
@@ -25,8 +25,8 @@ system 'yarn install --ignore-engines' if installing_pods
 
 target 'Artsy' do
   # Networking
-  pod 'AFNetworking', '~> 2.5'
-  pod 'AFOAuth1Client', git: 'https://github.com/lxcid/AFOAuth1Client.git', tag: '0.4.0'
+  pod 'AFNetworking', '~> 2.5', subspecs: ['Reachability', 'Serialization', 'Security', 'NSURLSession', 'NSURLConnection']
+  pod 'AFOAuth1Client', git: 'https://github.com/artsy/AFOAuth1Client.git', tag: '0.4.0-subspec-fix'
   pod 'AFNetworkActivityLogger'
   pod 'SDWebImage', '>= 3.7.2' # 3.7.2 contains a fix that allows you to not force decoding each image, which uses lots of memory
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,29 +4,21 @@ PODS:
   - AFNetworkActivityLogger (2.0.4):
     - AFNetworking/NSURLConnection (~> 2.0)
     - AFNetworking/NSURLSession (~> 2.0)
-  - AFNetworking (2.5.4):
-    - AFNetworking/NSURLConnection (= 2.5.4)
-    - AFNetworking/NSURLSession (= 2.5.4)
-    - AFNetworking/Reachability (= 2.5.4)
-    - AFNetworking/Security (= 2.5.4)
-    - AFNetworking/Serialization (= 2.5.4)
-    - AFNetworking/UIKit (= 2.5.4)
-  - AFNetworking/NSURLConnection (2.5.4):
+  - AFNetworking/NSURLConnection (2.7.0):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/NSURLSession (2.5.4):
+  - AFNetworking/NSURLSession (2.7.0):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/Reachability (2.5.4)
-  - AFNetworking/Security (2.5.4)
-  - AFNetworking/Serialization (2.5.4)
-  - AFNetworking/UIKit (2.5.4):
-    - AFNetworking/NSURLConnection
-    - AFNetworking/NSURLSession
+  - AFNetworking/Reachability (2.7.0)
+  - AFNetworking/Security (2.7.0)
+  - AFNetworking/Serialization (2.7.0)
   - AFOAuth1Client (0.4.0):
-    - AFNetworking (~> 2.5)
+    - AFNetworking/NSURLConnection (~> 2.5)
+    - AFNetworking/NSURLSession (~> 2.5)
+    - AFNetworking/Serialization (~> 2.5)
   - Analytics (3.6.9)
   - ARAnalytics/CoreIOS (5.0.1)
   - ARAnalytics/Segmentio (5.0.1):
@@ -467,8 +459,12 @@ PODS:
 DEPENDENCIES:
   - Aerodramus
   - AFNetworkActivityLogger
-  - AFNetworking (~> 2.5)
-  - AFOAuth1Client (from `https://github.com/lxcid/AFOAuth1Client.git`, tag `0.4.0`)
+  - AFNetworking/NSURLConnection (~> 2.5)
+  - AFNetworking/NSURLSession (~> 2.5)
+  - AFNetworking/Reachability (~> 2.5)
+  - AFNetworking/Security (~> 2.5)
+  - AFNetworking/Serialization (~> 2.5)
+  - AFOAuth1Client (from `https://github.com/artsy/AFOAuth1Client.git`, tag `0.4.0-subspec-fix`)
   - Analytics
   - ARAnalytics/Segmentio
   - ARCollectionViewMasonryLayout (from `https://github.com/ashfurrow/ARCollectionViewMasonryLayout`)
@@ -618,8 +614,8 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   AFOAuth1Client:
-    :git: https://github.com/lxcid/AFOAuth1Client.git
-    :tag: 0.4.0
+    :git: https://github.com/artsy/AFOAuth1Client.git
+    :tag: 0.4.0-subspec-fix
   ARCollectionViewMasonryLayout:
     :git: https://github.com/ashfurrow/ARCollectionViewMasonryLayout
   ARGenericTableViewController:
@@ -729,8 +725,8 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   AFOAuth1Client:
-    :git: https://github.com/lxcid/AFOAuth1Client.git
-    :tag: 0.4.0
+    :git: https://github.com/artsy/AFOAuth1Client.git
+    :tag: 0.4.0-subspec-fix
   ARCollectionViewMasonryLayout:
     :commit: f22180d0267567fd3db62f903eaef1119b5c1f2d
     :git: https://github.com/ashfurrow/ARCollectionViewMasonryLayout
@@ -765,8 +761,8 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Aerodramus: 16b609776c84b6e0e785bb0ca1604b98473a8376
   AFNetworkActivityLogger: 121486778117d53b3ab1c61d264b88081d0c3eee
-  AFNetworking: 05edc0ac4c4c8cf57bcf4b84be5b0744b6d8e71e
-  AFOAuth1Client: 07ccc935ba06ac8d023c16d39a5bdf04bc6f92e1
+  AFNetworking: 8dd5f9b9691e09186393069a12cc3b5ed7c8b511
+  AFOAuth1Client: 155a6237e57987cac18dac2ccd17cea5d324ad1a
   Analytics: 6541ce337e99d9f7a2240a8b3953940a7be5f998
   ARAnalytics: 896e530551168721fbb8852e044b8afb9baffdde
   ARCollectionViewMasonryLayout: 97cb468434b546b79a98c7c0908447ff803eb85e
@@ -865,6 +861,6 @@ SPEC CHECKSUMS:
   "XCTest+OHHTTPStubSuiteCleanUp": 4469ec8863c6bc022c5089a9b94233eb3416c5ee
   Yoga: 50fb6eb13d2152e7363293ff603385db380815b1
 
-PODFILE CHECKSUM: 20ddd72ba752db0e619c0baa8c3c48e37980d819
+PODFILE CHECKSUM: f4d3a058efae4a0c50c717249f6eaf4d8926cd22
 
 COCOAPODS: 1.7.5


### PR DESCRIPTION
The type of this PR is: **Upkeep**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [MX-286]

### Description

<!-- Implementation description -->

This PR removes the `AFNetworking/UIKit` dependency (by specifying all the other `AFNetworking/*` subspecs explicitly). This removes the code in AFNetworking that referenced `UIWebView`, without having to go through an arduous AFNetworking upgrade. We weren't using the `UIWebView` code anyway – I'm grateful to the AFNetworking maintainers that they were so forward-thinking in dividing up the dependency into thoughtful subspecs. I also had to update all our `#import` statements.

I got the idea here: https://github.com/AFNetworking/AFNetworking/issues/4428#issuecomment-527956472 Really great workaround, especially considering how (longterm) we want to move away from AFNetworking and towards all network requests being done from React Native.

One of our dependencies, `AFOAuth1Client`, also needed a change to specify only the subspecs it needed to, which I did in this fork: https://github.com/artsy/AFOAuth1Client/commit/599ac2bf177d390ec0850ed0ba79c91a2707777c

<img width="469" alt="Screen Shot 2020-09-01 at 12 45 35" src="https://user-images.githubusercontent.com/498212/91882502-0cd4cc00-ec51-11ea-9ec3-ec5f53250718.png">

The only code left that references UIWebView is either covered by #3748 or by upgrading our Facebook SDK version.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434
[MX-286]: https://artsyproduct.atlassian.net/browse/MX-286