### PR TITLE
[MX-462] - Disable idfa access by Facebook sdk

### DIFF
--- a/Artsy/App_Resources/Artsy-Info.plist
+++ b/Artsy/App_Resources/Artsy-Info.plist
@@ -73,6 +73,8 @@
 	<string>308278682573501</string>
 	<key>FacebookDisplayName</key>
 	<string>Artsy</string>
+	<key>FacebookAdvertiserIDCollectionEnabled</key>
+	<false/>
 	<key>GITCommitRev</key>
 	<string>4f76194c</string>
 	<key>GITCommitSha</key>

--- a/Artsy/Networking/ARAuthProviders.m
+++ b/Artsy/Networking/ARAuthProviders.m
@@ -4,8 +4,8 @@
 
 #import <AFOAuth1Client/AFOAuth1Client.h>
 #import <AFOAuth1Client/AFOAuth1Token.h>
-#import <FBSDKLoginKit/FBSDKLoginKit.h>
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
+#import <FBSDKLoginKit/FBSDKLoginKit.h>
 
 #import <ARAnalytics/ARAnalytics.h>
 #import "ARAnalyticsConstants.h"
@@ -18,7 +18,9 @@
     NSParameterAssert(success);
 
     FBSDKLoginManager *login = [[FBSDKLoginManager alloc] init];
-    [login logInWithReadPermissions:@[ @"email" ] fromViewController:nil handler:^(FBSDKLoginManagerLoginResult *result, NSError *error) {
+    [login logInWithPermissions:@[@"email"]
+    fromViewController:nil
+               handler:^(FBSDKLoginManagerLoginResult *result, NSError *error) {
         if (error) {
             ARErrorLog(@"Failed to log in to Facebook: %@", error.localizedDescription);
             failure(error);
@@ -32,8 +34,8 @@
           failure(error);
 
         } else {
-            FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc] initWithGraphPath:@"me?fields=name,id,email" parameters:nil];
-            
+            FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc] initWithGraphPath:@"me?fields=name,id,email" parameters:@{ @"message" : @"This is a status update" }];
+
             // We need to disable FB's in-house error reporting so we can show our own
             [request setGraphErrorRecoveryDisabled:YES];
             [request startWithCompletionHandler:^(FBSDKGraphRequestConnection *connection, NSDictionary *user, NSError *error) {

--- a/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
+++ b/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
@@ -1,6 +1,5 @@
 #import <MobileCoreServices/MobileCoreServices.h>
 #import <ReplayKit/ReplayKit.h>
-#import <AdSupport/ASIdentifierManager.h>
 
 #import "ARAdminSettingsViewController.h"
 #import "AREchoContentsViewController.h"
@@ -86,8 +85,7 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
 
     ARSectionData *toggleSections = [[ARSectionData alloc] initWithCellDataArray:@[
        [self generateOnScreenAnalytics],
-       [self generateOnScreenMartsy],
-       [self copyAdvertisingID]
+       [self generateOnScreenMartsy]
     ]];
     toggleSections.headerTitle = @"Options";
     [tableViewData addSectionData:toggleSections];
@@ -141,15 +139,6 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
 {
     return [self tappableCellDataWithTitle:@"Restart" selection:^{
         exit(0);
-    }];
-}
-
-- (ARCellData *)copyAdvertisingID
-{
-    return [self tappableCellDataWithTitle:@"Copy Advertising ID" selectionWithCell:^(UITableViewCell *cell) {
-        NSUUID *adId = [[ASIdentifierManager sharedManager] advertisingIdentifier];
-        [[UIPasteboard generalPasteboard] setValue:[adId UUIDString] forPasteboardType:(NSString *)kUTTypePlainText];
-        cell.textLabel.text = @"Copied";
     }];
 }
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -15,6 +15,7 @@ upcoming:
     - Fix deep link handling edge case - david
     - Connects new My Bids view to causality's lot standings - erik
     - Removes AFNetworking/UIKit subspec - ash
+    - Disable facebook access to idfa - brian
   user_facing:
     - Fix shows save button - mounir
     - Fix hidden slider handle bug in refine - brian

--- a/Podfile
+++ b/Podfile
@@ -120,8 +120,8 @@ target 'Artsy' do
   pod 'Pulley', git: 'https://github.com/l2succes/Pulley.git', branch: 'master'
 
   # Facebook
-  pod 'FBSDKCoreKit', '~> 4.33'
-  pod 'FBSDKLoginKit', '~> 4.33'
+  pod 'FBSDKCoreKit', '~> 7.1.1'
+  pod 'FBSDKLoginKit', '~> 7.1.1'
 
   # Analytics
   pod 'Analytics'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -35,12 +35,12 @@ PODS:
     - "Artsy+UIColors (~> 3.0)"
     - "Artsy+UIFonts"
     - "UIView+BooleanAnimations"
-  - Bolts (1.9.0):
-    - Bolts/AppLinks (= 1.9.0)
-    - Bolts/Tasks (= 1.9.0)
-  - Bolts/AppLinks (1.9.0):
+  - Bolts (1.9.1):
+    - Bolts/AppLinks (= 1.9.1)
+    - Bolts/Tasks (= 1.9.1)
+  - Bolts/AppLinks (1.9.1):
     - Bolts/Tasks
-  - Bolts/Tasks (1.9.0)
+  - Bolts/Tasks (1.9.1)
   - boost-for-react-native (1.63.0)
   - BVLinearGradient (2.5.6):
     - React
@@ -118,9 +118,9 @@ PODS:
     - React-Core (= 0.62.1)
     - React-jsi (= 0.62.1)
     - ReactCommon/turbomodule/core (= 0.62.1)
-  - FBSDKCoreKit (4.37.0):
-    - Bolts (~> 1.7)
-  - FBSDKLoginKit (4.37.0):
+  - FBSDKCoreKit (4.44.1):
+    - Bolts (~> 1.9)
+  - FBSDKLoginKit (4.44.1):
     - FBSDKCoreKit
   - FBSnapshotTestCase (2.1.4):
     - FBSnapshotTestCase/SwiftSupport (= 2.1.4)
@@ -771,7 +771,7 @@ SPEC CHECKSUMS:
   "Artsy+UIFonts": 597c44f264aead6bdc21898b690addd90e14edbd
   "Artsy+UILabels": 7cb6e290a4f70dddba037b7dbeb21e90b49d7275
   Artsy-UIButtons: 3c396f0fad352a7b0332100e0ffcb0ca577e0082
-  Bolts: ac6567323eac61e203f6a9763667d0f711be34c8
+  Bolts: 8c1e8aab2f603387b8b9924f57d1d64f43d3ffdc
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   CocoaLumberjack: 27ae9abcd376c3e4ee726ecd4adfd7b093ddef3f
@@ -784,8 +784,8 @@ SPEC CHECKSUMS:
   Extraction: 2be993a17f8f8c4fac988ebecaed93a409181faf
   FBLazyVector: 95ee3e58937a6052f86b0e32f142388c22fa22c5
   FBReactNativeSpec: 26dd6459299e48cd64eb397c45635e466dba9f45
-  FBSDKCoreKit: fe5f3474499a81963e11e3f3a5c753d0a95ca2b4
-  FBSDKLoginKit: 2f7249686d1e30ce8a5ef5400eedf50b3e3df332
+  FBSDKCoreKit: a823ae35bdb60ebb8d7a7e51abe7c5d87d2bfced
+  FBSDKLoginKit: 54ae59987f2a8703021557c90a9aebb9e5c2bef6
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   FLKAutoLayout: 106b14dbae09d32c6730190f4e78a959759ba4a4
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -35,12 +35,6 @@ PODS:
     - "Artsy+UIColors (~> 3.0)"
     - "Artsy+UIFonts"
     - "UIView+BooleanAnimations"
-  - Bolts (1.9.1):
-    - Bolts/AppLinks (= 1.9.1)
-    - Bolts/Tasks (= 1.9.1)
-  - Bolts/AppLinks (1.9.1):
-    - Bolts/Tasks
-  - Bolts/Tasks (1.9.1)
   - boost-for-react-native (1.63.0)
   - BVLinearGradient (2.5.6):
     - React
@@ -118,10 +112,16 @@ PODS:
     - React-Core (= 0.62.1)
     - React-jsi (= 0.62.1)
     - ReactCommon/turbomodule/core (= 0.62.1)
-  - FBSDKCoreKit (4.44.1):
-    - Bolts (~> 1.9)
-  - FBSDKLoginKit (4.44.1):
-    - FBSDKCoreKit
+  - FBSDKCoreKit (7.1.1):
+    - FBSDKCoreKit/Basics (= 7.1.1)
+    - FBSDKCoreKit/Core (= 7.1.1)
+  - FBSDKCoreKit/Basics (7.1.1)
+  - FBSDKCoreKit/Core (7.1.1):
+    - FBSDKCoreKit/Basics
+  - FBSDKLoginKit (7.1.1):
+    - FBSDKLoginKit/Login (= 7.1.1)
+  - FBSDKLoginKit/Login (7.1.1):
+    - FBSDKCoreKit (~> 7.1.1)
   - FBSnapshotTestCase (2.1.4):
     - FBSnapshotTestCase/SwiftSupport (= 2.1.4)
   - FBSnapshotTestCase/Core (2.1.4)
@@ -484,8 +484,8 @@ DEPENDENCIES:
   - Extraction
   - FBLazyVector (from `node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `node_modules/react-native/Libraries/FBReactNativeSpec`)
-  - FBSDKCoreKit (~> 4.33)
-  - FBSDKLoginKit (~> 4.33)
+  - FBSDKCoreKit (~> 7.1.1)
+  - FBSDKLoginKit (~> 7.1.1)
   - FBSnapshotTestCase
   - FLKAutoLayout (from `https://github.com/orta/FLKAutoLayout.git`, branch `v1`)
   - Folly (from `node_modules/react-native/third-party-podspecs/Folly.podspec`)
@@ -565,7 +565,6 @@ SPEC REPOS:
     - AFNetworking
     - Analytics
     - ARAnalytics
-    - Bolts
     - boost-for-react-native
     - DHCShakeNotifier
     - EDColor
@@ -771,7 +770,6 @@ SPEC CHECKSUMS:
   "Artsy+UIFonts": 597c44f264aead6bdc21898b690addd90e14edbd
   "Artsy+UILabels": 7cb6e290a4f70dddba037b7dbeb21e90b49d7275
   Artsy-UIButtons: 3c396f0fad352a7b0332100e0ffcb0ca577e0082
-  Bolts: 8c1e8aab2f603387b8b9924f57d1d64f43d3ffdc
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   CocoaLumberjack: 27ae9abcd376c3e4ee726ecd4adfd7b093ddef3f
@@ -784,8 +782,8 @@ SPEC CHECKSUMS:
   Extraction: 2be993a17f8f8c4fac988ebecaed93a409181faf
   FBLazyVector: 95ee3e58937a6052f86b0e32f142388c22fa22c5
   FBReactNativeSpec: 26dd6459299e48cd64eb397c45635e466dba9f45
-  FBSDKCoreKit: a823ae35bdb60ebb8d7a7e51abe7c5d87d2bfced
-  FBSDKLoginKit: 54ae59987f2a8703021557c90a9aebb9e5c2bef6
+  FBSDKCoreKit: b46507dc8b8cefed31d644e74d7cc30e2a715ef8
+  FBSDKLoginKit: 1a61d79e2b25e2fc0d03dccab1e34b38bbdf2546
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   FLKAutoLayout: 106b14dbae09d32c6730190f4e78a959759ba4a4
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
@@ -861,6 +859,6 @@ SPEC CHECKSUMS:
   "XCTest+OHHTTPStubSuiteCleanUp": 4469ec8863c6bc022c5089a9b94233eb3416c5ee
   Yoga: 50fb6eb13d2152e7363293ff603385db380815b1
 
-PODFILE CHECKSUM: f4d3a058efae4a0c50c717249f6eaf4d8926cd22
+PODFILE CHECKSUM: 436875f0df88fbb6a7ca67ddf75df4beee50121d
 
 COCOAPODS: 1.7.5


### PR DESCRIPTION
The type of this PR is: **Chore**

This PR resolves [MX-462]

### Description

- Updates Facebook sdk to version that supports disabling access to idfa
- Adds plist value to disable access
- Removes access to idfa in admin menu

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[MX-462]: https://artsyproduct.atlassian.net/browse/MX-462