### PR TITLE
Avoids installing CocoaPods on CI if cache is available #trivial

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ commands:
             - v5-pods-{{ checksum ".manifests/cocoapods" }}
       - run:
           name: Install Pods
-          command: bundle exec pod install
+          command: bundle exec pod check --ignore-dev-pods || bundle exec pod install
       - run:
           name: Update echo
           command: ls Artsy/App/Echo.json || make update_echo
@@ -227,7 +227,8 @@ jobs:
       - bundle-js
       - run:
           name: Generate app_build manifest
-          command: ./scripts/generate-manifest.js .manifests/app_build '^\./manifests/native_code' '^emission/Pod/Assets/'
+          command:
+            ./scripts/generate-manifest.js .manifests/app_build '^\./manifests/native_code' '^emission/Pod/Assets/'
       - store_artifacts:
           path: .manifests
       - persist_to_workspace:
@@ -298,8 +299,7 @@ jobs:
 
       - run:
           name: Danger
-          command: bundle exec danger --danger_id=circle
-            --dangerfile=Dangerfile.circle.rb --verbose
+          command: bundle exec danger --danger_id=circle --dangerfile=Dangerfile.circle.rb --verbose
 
       - await-previous-builds:
           branch: beta


### PR DESCRIPTION
The type of this PR is: **enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description


I noticed when merging a few PRs in a row that `pod install` was being ran every build, despite having manifest-style caching like our other dependencies. This isn't a huge deal but it takes a minute or two for CocoaPods just to download the podspecs to do dependency resolution. We already have [`cocoapods-check`](https://github.com/square/cocoapods-check) in our `Gemfile`, which compares `Podfile.lock` to `Pods/Manifest.lock` and returns the resulting exit code. This should shave some time off our builds. 

I tried to think of a reason this wouldn't work, but I think it should be safe. Open to feedback here.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434