### PR TITLE
Feature flag doc updates cleanup remove unnecessary OR #trivial

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -325,6 +325,10 @@ SOFTWARE.
     // Lab options come last (as they are admin/dev controlled, giving them a chance to override)
     [options addEntriesFromDictionary:labOptions];
 
+    options[@"AROptionsPriceTransparency"] = @([options[@"AROptionsPriceTransparency"] boolValue] || [labOptions[AROptionsPriceTransparency] boolValue]);
+    options[@"AROptionsArtistSeries"] = @([options[@"AROptionsArtistSeries"] boolValue] || [labOptions[AROptionsArtistSeries] boolValue]);
+    options[@"AROptionsNewFirstInquiry"] = @([options[@"AROptionsNewFirstInquiry"] boolValue] || [labOptions[AROptionsNewFirstInquiry] boolValue]);
+
     return options;
 }
 

--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -325,10 +325,6 @@ SOFTWARE.
     // Lab options come last (as they are admin/dev controlled, giving them a chance to override)
     [options addEntriesFromDictionary:labOptions];
 
-    options[@"AROptionsPriceTransparency"] = @([options[@"AROptionsPriceTransparency"] boolValue] || [labOptions[AROptionsPriceTransparency] boolValue]);
-    options[@"AROptionsArtistSeries"] = @([options[@"AROptionsArtistSeries"] boolValue] || [labOptions[AROptionsArtistSeries] boolValue]);
-    options[@"AROptionsNewFirstInquiry"] = @([options[@"AROptionsNewFirstInquiry"] boolValue] || [labOptions[AROptionsNewFirstInquiry] boolValue]);
-
     return options;
 }
 

--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -327,7 +327,6 @@ SOFTWARE.
 
     options[@"AROptionsPriceTransparency"] = @([options[@"AROptionsPriceTransparency"] boolValue] || [labOptions[AROptionsPriceTransparency] boolValue]);
     options[@"AROptionsArtistSeries"] = @([options[@"AROptionsArtistSeries"] boolValue] || [labOptions[AROptionsArtistSeries] boolValue]);
-    options[@"AROptionsNewFirstInquiry"] = @([options[@"AROptionsNewFirstInquiry"] boolValue] || [labOptions[AROptionsNewFirstInquiry] boolValue]);
 
     return options;
 }

--- a/Artsy_Tests/View_Controller_Tests/Auction/AuctionViewControllerTests.swift
+++ b/Artsy_Tests/View_Controller_Tests/Auction/AuctionViewControllerTests.swift
@@ -55,7 +55,7 @@ class AuctionViewControllerTests: QuickSpec {
                 dateMock = ARTestContext.freezeTime(now as Date)
 
                 sale = try! Sale(dictionary: ["saleID": "the-tada-sale", "name": "The 🎉 Sale", "endDate": endTime], error: Void())
-                me = try! User()
+                me = User()
                 saleViewModel = Test_SaleViewModel(sale: sale, saleArtworks: [], promotedSaleArtworks: [], bidders: [], lotStandings: [], me: me)
 
                 horizontalSizeClass = UIUserInterfaceSizeClass(rawValue: context()["horizontalSizeClass"] as! Int)

--- a/Artsy_Tests/View_Controller_Tests/Auction/SaleArtworkViewModelTests.swift
+++ b/Artsy_Tests/View_Controller_Tests/Auction/SaleArtworkViewModelTests.swift
@@ -28,14 +28,14 @@ class SaleArtworkViewModelTests: QuickSpec {
             ]
             artworkJSON = [
                 "id": "artwork_id",
-                "artist": artistJSON,
+                "artist": artistJSON!,
                 "title": "roly poly",
-                "images": imagesJSON,
+                "images": imagesJSON!,
             ]
             saleArtwork = SaleArtwork(json:
                 [
                     "id": "sale",
-                    "artwork": artworkJSON,
+                    "artwork": artworkJSON!,
                     "lot_label": "13",
                     "bidder_positions_count": 4,
                     "highest_bid": ["id": "bid-id", "amount_cents": 1_000_00],

--- a/Artsy_Tests/View_Controller_Tests/SaleOnHoldOverlayViewTests.swift
+++ b/Artsy_Tests/View_Controller_Tests/SaleOnHoldOverlayViewTests.swift
@@ -58,7 +58,7 @@ class SaleOnHoldOverlayViewTests: QuickSpec {
                 messages = Observable("initial message")
                 let subject = SaleOnHoldOverlayView(messages: messages)
                 containerView.addSubview(subject)
-                subject.align(toView: containerView)
+                subject.align(toView: containerView!)
             }
 
             it("handles subsequent message updates") {

--- a/Artsy_Tests/View_Tests/Auctions/AuctionTitleViewTests.swift
+++ b/Artsy_Tests/View_Tests/Auctions/AuctionTitleViewTests.swift
@@ -73,9 +73,9 @@ class AuctionTitleViewSpec: QuickSpec {
 
             it("looks good with a sale and user who has already been identity-verified") {
                 let me = try! User(dictionary: [
-                        "userID": ARUserManager.stubUserID(),
-                        "name": ARUserManager.stubUserName(),
-                        "email": ARUserManager.stubUserEmail(),
+                        "userID": ARUserManager.stubUserID()!,
+                        "name": ARUserManager.stubUserName()!,
+                        "email": ARUserManager.stubUserEmail()!,
                         "identityVerified": true
                     ], error: Void())
                 let saleDict : [String: Any] = [

--- a/docs/developing_a_feature.md
+++ b/docs/developing_a_feature.md
@@ -14,7 +14,7 @@ The normal workflow for engineers is to first **add a lab option and put all fea
 
 ## Adding a Lab Option
 
-Let's say you want to add a new feature, called "Marketing Banners". We'll add a new lab option called `ARShowMarketingBanner` (this naming is a convention we borrow from Objective-C). You can access the lab options using through `NativeModules.Emission.options`.
+Let's say you want to add a new feature, called "Marketing Banners". We'll add a new lab option called `ARShowMarketingBanner` (this naming is a convention we borrow from Objective-C). You can access the lab options in typescript using `useEmissionOption('ARShowMarketingBanner')`.
 
 But where are these options set? There are two places and you need to do them both.
 
@@ -46,7 +46,7 @@ This change makes the option available to be toggled by any admin: they can shak
 
 What do we mean when we say "a new feature should be **put behind** a lab option or Echo Feature"? It means that the behaviour of the app changes depending on if this option is set. :
 
-1. Add your option to the Emission types file [`/typings/emission.d.ts`](https://github.com/artsy/eigen/blob/master/typings/emission.d.ts)
+1. Add your option to the Emission native model file [`src/lib/store/NativeModel.ts`](https://github.com/artsy/eigen/blob/master/src/lib/store//NativeModel.ts)
 
 2. Then update Jest's setup file [`src/setupJest.ts`](https://github.com/artsy/eigen/blob/master/src/setupJest.ts#L145).
 


### PR DESCRIPTION
The type of this PR is: **Cleanup**

### Description

- Update some places feature flag docs are out of date
- Fixes some warnings in tests
- Remove unnecessary OR of newly added feature flag

The logical or part came up in this PR: https://github.com/artsy/eigen/pull/3808#discussion_r481372160 
My best guess is the initial price transparency feature flag had a key that didn't match the string for the echo flag so this line was necessary: https://github.com/artsy/eigen/pull/2934/files#diff-fa3274520df88be962c7afc891c3b5edR27. Also we call out in docs that we have had problems with OR'ing these flags so probably do not want to do this. 
https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md#why-do-we-need-to-remove-the-lab-flag-when-adding-echo-flag Unfortunately simply removing the OR is problematic for released features that are counting on this behavior so this was removed from PR. We are going to discuss how to proceed in front-end-ios practice before removing the others.

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
