### PR TITLE
chore: [MX-286] migrate away from UIWebView

### DIFF
--- a/Artsy_Tests/View_Controller_Tests/Web_Browsing/ARExternalWebBrowserViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Web_Browsing/ARExternalWebBrowserViewControllerTests.m
@@ -3,11 +3,6 @@
 #import "ARWebViewCacheHost.h"
 #import <WebKit/WKUIDelegate.h>
 
-
-@interface ARExternalWebBrowserViewController (Tests) <UIScrollViewDelegate>
-@property (readonly, nonatomic, strong) UIWebView *webView;
-@end
-
 SpecBegin(ARExternalWebBrowserViewController);
 
 __block ARExternalWebBrowserViewController *vc;

--- a/Artsy_Tests/View_Controller_Tests/Web_Browsing/ARInternalMobileWebViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Web_Browsing/ARInternalMobileWebViewControllerTests.m
@@ -20,7 +20,6 @@ static WKNavigationAction *StubNavActionForRequest(NSURLRequest *request, WKNavi
 
 @property (nonatomic, strong) ARInternalShareValidator *shareValidator;
 - (NSURLRequest *)requestWithURL:(NSURL *)url;
-@property (nonatomic, strong) UIWebView *webView;
 - (WKNavigationActionPolicy)shouldLoadNavigationAction:(WKNavigationAction *)navigationAction;
 
 @end

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -8,6 +8,7 @@ upcoming:
     - Removes AFNetworking/UIKit subspec - ash
     - Disable facebook access to idfa - brian
     - Adds lab option for new inquiry flow - lily
+    - Migrate away from UIWebview - mounir
   user_facing:
     - Fix app crash when tapping fair map - brian
 


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR resolves [MX-286]

### Description

Migrate to `WKWebView ` because Apple will stop accepting submissions of app updates that use UIWebView APIs starting from December 2020. See https://developer.apple.com/documentation/uikit/uiwebview for more information.

There were only 2 references for UIWebView in the project after [this commit](https://github.com/artsy/eigen/commit/f3c8ad009a75072b57141e0013bb95d5d0c033aa) and [this PR](https://github.com/artsy/eigen/pull/3806)
_The remaining instances are part of react-native code and they are not used anywhere_
____
**Before**
<img width="1435" alt="Screenshot 2020-09-02 at 10 55 30" src="https://user-images.githubusercontent.com/11945712/91961030-ed9a7500-ed0a-11ea-9ee4-7e2a07bb1ed6.png">

**After**
<img width="1436" alt="Screenshot 2020-09-02 at 10 54 42" src="https://user-images.githubusercontent.com/11945712/91961020-ea06ee00-ed0a-11ea-94dc-72e32b55e639.png">

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))

[MX-286]: https://artsyproduct.atlassian.net/browse/MX-286