### PR TITLE
[PURCHASE-2052] Add Download option for non-preview-able attachments

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -11,6 +11,7 @@ upcoming:
     - Migrate away from UIWebview - mounir
     - Removes more unused Objective-C code - ash
     - Change IDFA for AppStoreConnect to false - pavlos
+    - Add download option for non-preview-able conversation attachments - sepand
   user_facing:
     - Fix app crash when tapping fair map - brian
 

--- a/src/__generated__/ConversationQuery.graphql.ts
+++ b/src/__generated__/ConversationQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 2c2a90acc660917b1906a2f76cdb5b67 */
+/* @relayHash c34dbefcbe9e5ac64d8e95b4d7a3a88d */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -62,6 +62,12 @@ fragment Conversation_me on Me {
   }
 }
 
+fragment FileDownload_attachment on Attachment {
+  fileName
+  downloadURL
+  ...AttachmentPreview_attachment
+}
+
 fragment ImagePreview_attachment on Attachment {
   download_url: downloadURL
   ...AttachmentPreview_attachment
@@ -78,11 +84,12 @@ fragment Message_message on Message {
   attachments {
     id
     internalID
-    content_type: contentType
-    download_url: downloadURL
-    file_name: fileName
+    contentType
+    downloadURL
+    fileName
     ...ImagePreview_attachment
     ...PDFPreview_attachment
+    ...FileDownload_attachment
   }
 }
 
@@ -143,7 +150,7 @@ fragment Messages_conversation on Conversation {
 }
 
 fragment PDFPreview_attachment on Attachment {
-  file_name: fileName
+  fileName
   ...AttachmentPreview_attachment
 }
 
@@ -475,8 +482,22 @@ return {
                               (v2/*: any*/),
                               {
                                 "kind": "ScalarField",
-                                "alias": "content_type",
+                                "alias": null,
                                 "name": "contentType",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "downloadURL",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "fileName",
                                 "args": null,
                                 "storageKey": null
                               },
@@ -484,13 +505,6 @@ return {
                                 "kind": "ScalarField",
                                 "alias": "download_url",
                                 "name": "downloadURL",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": "file_name",
-                                "name": "fileName",
                                 "args": null,
                                 "storageKey": null
                               }
@@ -659,7 +673,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ConversationQuery",
-    "id": "83e1d230b94e76a748b04140984ab9e0",
+    "id": "51789683034c59c1246d2167e6e4d455",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/FileDownload_attachment.graphql.ts
+++ b/src/__generated__/FileDownload_attachment.graphql.ts
@@ -3,22 +3,23 @@
 
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type PDFPreview_attachment = {
+export type FileDownload_attachment = {
     readonly fileName: string;
+    readonly downloadURL: string;
     readonly " $fragmentRefs": FragmentRefs<"AttachmentPreview_attachment">;
-    readonly " $refType": "PDFPreview_attachment";
+    readonly " $refType": "FileDownload_attachment";
 };
-export type PDFPreview_attachment$data = PDFPreview_attachment;
-export type PDFPreview_attachment$key = {
-    readonly " $data"?: PDFPreview_attachment$data;
-    readonly " $fragmentRefs": FragmentRefs<"PDFPreview_attachment">;
+export type FileDownload_attachment$data = FileDownload_attachment;
+export type FileDownload_attachment$key = {
+    readonly " $data"?: FileDownload_attachment$data;
+    readonly " $fragmentRefs": FragmentRefs<"FileDownload_attachment">;
 };
 
 
 
 const node: ReaderFragment = {
   "kind": "Fragment",
-  "name": "PDFPreview_attachment",
+  "name": "FileDownload_attachment",
   "type": "Attachment",
   "metadata": null,
   "argumentDefinitions": [],
@@ -31,11 +32,18 @@ const node: ReaderFragment = {
       "storageKey": null
     },
     {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "downloadURL",
+      "args": null,
+      "storageKey": null
+    },
+    {
       "kind": "FragmentSpread",
       "name": "AttachmentPreview_attachment",
       "args": null
     }
   ]
 };
-(node as any).hash = '807f52ff34b3d5fea81b65e141c22b0b';
+(node as any).hash = '3535ae92c946cf2e14fdc4cd5aabefe9';
 export default node;

--- a/src/__generated__/Message_message.graphql.ts
+++ b/src/__generated__/Message_message.graphql.ts
@@ -14,10 +14,10 @@ export type Message_message = {
     readonly attachments: ReadonlyArray<{
         readonly id: string;
         readonly internalID: string;
-        readonly content_type: string;
-        readonly download_url: string;
-        readonly file_name: string;
-        readonly " $fragmentRefs": FragmentRefs<"ImagePreview_attachment" | "PDFPreview_attachment">;
+        readonly contentType: string;
+        readonly downloadURL: string;
+        readonly fileName: string;
+        readonly " $fragmentRefs": FragmentRefs<"ImagePreview_attachment" | "PDFPreview_attachment" | "FileDownload_attachment">;
     } | null> | null;
     readonly " $refType": "Message_message";
 };
@@ -107,21 +107,21 @@ const node: ReaderFragment = {
         },
         {
           "kind": "ScalarField",
-          "alias": "content_type",
+          "alias": null,
           "name": "contentType",
           "args": null,
           "storageKey": null
         },
         {
           "kind": "ScalarField",
-          "alias": "download_url",
+          "alias": null,
           "name": "downloadURL",
           "args": null,
           "storageKey": null
         },
         {
           "kind": "ScalarField",
-          "alias": "file_name",
+          "alias": null,
           "name": "fileName",
           "args": null,
           "storageKey": null
@@ -135,10 +135,15 @@ const node: ReaderFragment = {
           "kind": "FragmentSpread",
           "name": "PDFPreview_attachment",
           "args": null
+        },
+        {
+          "kind": "FragmentSpread",
+          "name": "FileDownload_attachment",
+          "args": null
         }
       ]
     }
   ]
 };
-(node as any).hash = 'e87e0a2f78edb5b5f30bd98cbe4234f4';
+(node as any).hash = 'ff69fae6b933d05a4c49315b173217a4';
 export default node;

--- a/src/__generated__/MessagesQuery.graphql.ts
+++ b/src/__generated__/MessagesQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash dc784d12a169533d28a6fcbf160e3f63 */
+/* @relayHash f92f3e07540779e4a45c7c483c9758df */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -53,6 +53,12 @@ fragment AttachmentPreview_attachment on Attachment {
   internalID
 }
 
+fragment FileDownload_attachment on Attachment {
+  fileName
+  downloadURL
+  ...AttachmentPreview_attachment
+}
+
 fragment ImagePreview_attachment on Attachment {
   download_url: downloadURL
   ...AttachmentPreview_attachment
@@ -69,11 +75,12 @@ fragment Message_message on Message {
   attachments {
     id
     internalID
-    content_type: contentType
-    download_url: downloadURL
-    file_name: fileName
+    contentType
+    downloadURL
+    fileName
     ...ImagePreview_attachment
     ...PDFPreview_attachment
+    ...FileDownload_attachment
   }
 }
 
@@ -134,7 +141,7 @@ fragment Messages_conversation_2QE1um on Conversation {
 }
 
 fragment PDFPreview_attachment on Attachment {
-  file_name: fileName
+  fileName
   ...AttachmentPreview_attachment
 }
 
@@ -489,8 +496,22 @@ return {
                               (v3/*: any*/),
                               {
                                 "kind": "ScalarField",
-                                "alias": "content_type",
+                                "alias": null,
                                 "name": "contentType",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "downloadURL",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "fileName",
                                 "args": null,
                                 "storageKey": null
                               },
@@ -498,13 +519,6 @@ return {
                                 "kind": "ScalarField",
                                 "alias": "download_url",
                                 "name": "downloadURL",
-                                "args": null,
-                                "storageKey": null
-                              },
-                              {
-                                "kind": "ScalarField",
-                                "alias": "file_name",
-                                "name": "fileName",
                                 "args": null,
                                 "storageKey": null
                               }
@@ -673,7 +687,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "MessagesQuery",
-    "id": "d5401fbd049722de6e2426172ac15930",
+    "id": "3b5ac687f040e2e4f5a6c77b76d25213",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/SendConversationMessageMutation.graphql.ts
+++ b/src/__generated__/SendConversationMessageMutation.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 7033f9c6544d49429db39eeb347f2c5c */
+/* @relayHash 5da3a2ca77efa1bc01906f3422bc2e5f */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -55,6 +55,12 @@ fragment AttachmentPreview_attachment on Attachment {
   internalID
 }
 
+fragment FileDownload_attachment on Attachment {
+  fileName
+  downloadURL
+  ...AttachmentPreview_attachment
+}
+
 fragment ImagePreview_attachment on Attachment {
   download_url: downloadURL
   ...AttachmentPreview_attachment
@@ -71,16 +77,17 @@ fragment Message_message on Message {
   attachments {
     id
     internalID
-    content_type: contentType
-    download_url: downloadURL
-    file_name: fileName
+    contentType
+    downloadURL
+    fileName
     ...ImagePreview_attachment
     ...PDFPreview_attachment
+    ...FileDownload_attachment
   }
 }
 
 fragment PDFPreview_attachment on Attachment {
-  file_name: fileName
+  fileName
   ...AttachmentPreview_attachment
 }
 */
@@ -269,8 +276,22 @@ return {
                       },
                       {
                         "kind": "ScalarField",
-                        "alias": "content_type",
+                        "alias": null,
                         "name": "contentType",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "downloadURL",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "fileName",
                         "args": null,
                         "storageKey": null
                       },
@@ -278,13 +299,6 @@ return {
                         "kind": "ScalarField",
                         "alias": "download_url",
                         "name": "downloadURL",
-                        "args": null,
-                        "storageKey": null
-                      },
-                      {
-                        "kind": "ScalarField",
-                        "alias": "file_name",
-                        "name": "fileName",
                         "args": null,
                         "storageKey": null
                       }
@@ -301,7 +315,7 @@ return {
   "params": {
     "operationKind": "mutation",
     "name": "SendConversationMessageMutation",
-    "id": "5518cc4fbdbc60ee5dc61063dea01c6a",
+    "id": "d42d84aa40de0e45af9c3ba76c8a2e60",
     "text": null,
     "metadata": {}
   }

--- a/src/lib/Components/Inbox/Conversations/Message.tsx
+++ b/src/lib/Components/Inbox/Conversations/Message.tsx
@@ -11,6 +11,7 @@ import colors from "lib/data/colors"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { BodyText, FromSignatureText, MetadataText, SmallHeadline } from "../Typography"
 import Avatar from "./Avatar"
+import { FileDownloadFragmentContainer as FileDownload } from "./Preview/Attachment/FileDownload"
 import ImagePreview from "./Preview/Attachment/ImagePreview"
 import PDFPreview from "./Preview/Attachment/PDFPreview"
 
@@ -104,9 +105,9 @@ export class Message extends React.Component<Props> {
       SwitchBoard.presentMediaPreviewController(
         this,
         // @ts-ignore STRICTNESS_MIGRATION
-        attachment.download_url,
+        attachment.downloadURL,
         // @ts-ignore STRICTNESS_MIGRATION
-        attachment.content_type,
+        attachment.contentType,
         // @ts-ignore STRICTNESS_MIGRATION
         attachment.internalID
       )
@@ -115,7 +116,7 @@ export class Message extends React.Component<Props> {
     // @ts-ignore STRICTNESS_MIGRATION
     return attachments.map((attachment) => {
       // @ts-ignore STRICTNESS_MIGRATION
-      if (attachment.content_type.startsWith("image")) {
+      if (attachment.contentType.startsWith("image")) {
         return (
           // @ts-ignore STRICTNESS_MIGRATION
           <PreviewContainer key={attachment.id}>
@@ -124,11 +125,17 @@ export class Message extends React.Component<Props> {
         )
       }
       // @ts-ignore STRICTNESS_MIGRATION
-      if (attachment.content_type === "application/pdf") {
+      else if (attachment.contentType === "application/pdf") {
         return (
           // @ts-ignore STRICTNESS_MIGRATION
           <PreviewContainer key={attachment.id}>
             <PDFPreview attachment={attachment as any} onSelected={previewAttachment} />
+          </PreviewContainer>
+        )
+      } else if (attachment?.id) {
+        return (
+          <PreviewContainer key={attachment.id}>
+            <FileDownload attachment={attachment} />
           </PreviewContainer>
         )
       }
@@ -220,11 +227,12 @@ export default createFragmentContainer(Message, {
       attachments {
         id
         internalID
-        content_type: contentType
-        download_url: downloadURL
-        file_name: fileName
+        contentType
+        downloadURL
+        fileName
         ...ImagePreview_attachment
         ...PDFPreview_attachment
+        ...FileDownload_attachment
       }
     }
   `,

--- a/src/lib/Components/Inbox/Conversations/Preview/Attachment/FileDownload.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/Attachment/FileDownload.tsx
@@ -1,0 +1,39 @@
+import { Text } from "palette"
+import React from "react"
+import { Linking } from "react-native"
+import { createFragmentContainer, graphql } from "react-relay"
+
+import AttachmentPreview, { AttachmentProps } from "./AttachmentPreview"
+
+import { FileDownload_attachment } from "__generated__/FileDownload_attachment.graphql"
+import { DownloadIcon } from "palette"
+import { AttachmentContainer, AttachmentTextContainer } from "./PDFPreview"
+
+interface Props extends AttachmentProps {
+  attachment: FileDownload_attachment
+}
+
+const downloadFile = (attachment: FileDownload_attachment) => {
+  Linking.openURL(attachment.downloadURL)
+}
+
+export const FileDownload: React.SFC<Props> = ({ attachment }) => (
+  <AttachmentPreview attachment={attachment} onSelected={() => downloadFile(attachment)}>
+    <AttachmentContainer>
+      <DownloadIcon width="40px" height="40px" mx={1} my={0.5} />
+      <AttachmentTextContainer>
+        <Text>{attachment.fileName}</Text>
+      </AttachmentTextContainer>
+    </AttachmentContainer>
+  </AttachmentPreview>
+)
+
+export const FileDownloadFragmentContainer = createFragmentContainer(FileDownload, {
+  attachment: graphql`
+    fragment FileDownload_attachment on Attachment {
+      fileName
+      downloadURL
+      ...AttachmentPreview_attachment
+    }
+  `,
+})

--- a/src/lib/Components/Inbox/Conversations/Preview/Attachment/PDFPreview.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/Attachment/PDFPreview.tsx
@@ -1,5 +1,6 @@
+import { Text } from "palette"
 import React from "react"
-import { Image, Text } from "react-native"
+import { Image } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components/native"
 
@@ -9,19 +10,18 @@ import AttachmentPreview, { AttachmentProps } from "./AttachmentPreview"
 
 import { PDFPreview_attachment } from "__generated__/PDFPreview_attachment.graphql"
 
-const Container = styled.View`
+export const AttachmentContainer = styled.View`
   border-width: 1;
   border-color: ${colors["gray-regular"]};
   flex: 1;
   flex-direction: row;
 `
 
-const TextContainer = styled.View`
+export const AttachmentTextContainer = styled.View`
   flex: 1;
   flex-direction: column;
   align-self: center;
 `
-
 const Icon = styled(Image)`
   resize-mode: contain;
   width: 40;
@@ -37,19 +37,19 @@ interface Props extends AttachmentProps {
 
 export const PDFPreview: React.SFC<Props> = ({ attachment, onSelected }) => (
   <AttachmentPreview attachment={attachment as any} onSelected={onSelected}>
-    <Container>
+    <AttachmentContainer>
       <Icon source={require("../../../../../../../images/pdf.png")} />
-      <TextContainer>
-        <Text>{attachment.file_name}</Text>
-      </TextContainer>
-    </Container>
+      <AttachmentTextContainer>
+        <Text>{attachment.fileName}</Text>
+      </AttachmentTextContainer>
+    </AttachmentContainer>
   </AttachmentPreview>
 )
 
 export default createFragmentContainer(PDFPreview, {
   attachment: graphql`
     fragment PDFPreview_attachment on Attachment {
-      file_name: fileName
+      fileName
       ...AttachmentPreview_attachment
     }
   `,

--- a/src/lib/Components/Inbox/Conversations/Preview/Attachment/__tests__/FileDownload-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/Attachment/__tests__/FileDownload-tests.tsx
@@ -1,0 +1,20 @@
+import { FileDownload_attachment } from "__generated__/FileDownload_attachment.graphql"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import React from "react"
+import "react-native"
+import { Linking } from "react-native"
+
+import AttachmentPreview from "../AttachmentPreview"
+import { FileDownloadFragmentContainer as FileDownload } from "../FileDownload"
+
+Linking.openURL = jest.fn()
+it("opens file url when it is selected", async () => {
+  const component = renderWithWrappers(<FileDownload attachment={attachment as any} />)
+  component.root.findByType(AttachmentPreview).props.onSelected()
+  expect(Linking.openURL).toBeCalledWith(attachment.downloadURL)
+})
+
+const attachment: Omit<FileDownload_attachment, " $refType" | " $fragmentRefs"> = {
+  fileName: "This is a great ZIP file telling you all about cats",
+  downloadURL: "http://example.com/cats.zip",
+}

--- a/src/lib/Components/Inbox/Conversations/Preview/Attachment/__tests__/PDFPreview-tests.tsx
+++ b/src/lib/Components/Inbox/Conversations/Preview/Attachment/__tests__/PDFPreview-tests.tsx
@@ -10,5 +10,5 @@ it("renders without throwing an error", () => {
 
 const attachment = {
   id: "cats",
-  file_name: "This is a great PDF telling you all about cats",
+  fileName: "This is a great PDF telling you all about cats",
 }


### PR DESCRIPTION
The type of this PR is: Enhancement

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [PURCHASE-2052]

### Description

**Problem:**
Only PDF and Image attachments are displayed in conversation. This hasn't been reported by any collectors since this has been launched a couple of years ago. I noticed it while doing QA.

**Solution:**
Add `FileDownload` component for other content types. It downloads the file in Safari. Since nobody has noticed this problem before a lightweight solution should be enough for now.

While at it also did some 🐍 -> 🐫 case updates.

cc: @jo-rs 

<details><summary>Screenshots</summary>


Before:


<img width="412" alt="Screen Shot 2020-09-03 at 2 02 17 PM" src="https://user-images.githubusercontent.com/687513/92156422-f36d8480-edf6-11ea-9360-2022e74be081.png">

---

After:


<img width="414" alt="Screen Shot 2020-09-03 at 2 01 29 PM" src="https://user-images.githubusercontent.com/687513/92156486-10a25300-edf7-11ea-9a57-3b2a32239a94.png">

</details>

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.


[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434
[PURCHASE-2052]: https://artsyproduct.atlassian.net/browse/PURCHASE-2052