### PR TITLE
Fixes deploys by removing Fastfile check #trivial

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,12 +18,15 @@ lane :ship_beta do
 
   latest_version = readme_data['upcoming']['version']
 
-  client = Spaceship::Tunes.login(ENV['FASTLANE_USERNAME'], ENV['FASTLANE_PASSWORD'])
-  client.team_id = '479887'
-  app = Spaceship::Tunes::Application.find('net.artsy.artsy')
+  # Outputs version to Actions.lane_context[SharedValues::LATEST_VERSION]
+  app_store_build_number(
+    app_identifier: 'net.artsy.artsy',
+    version: 'latest',
+    team_id: '479887'
+  )
 
   # Fail early if we need to make a new version on iTunes
-  if app.latest_version.version != latest_version
+  if Actions.lane_context[SharedValues::LATEST_VERSION] != latest_version
     raise "You need to create an app version for #{latest_version} in iTunes before deploying"
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,18 +18,6 @@ lane :ship_beta do
 
   latest_version = readme_data['upcoming']['version']
 
-  # Outputs version to Actions.lane_context[SharedValues::LATEST_VERSION]
-  app_store_build_number(
-    app_identifier: 'net.artsy.artsy',
-    version: 'latest',
-    team_id: '479887'
-  )
-
-  # Fail early if we need to make a new version on iTunes
-  if Actions.lane_context[SharedValues::LATEST_VERSION] != latest_version
-    raise "You need to create an app version for #{latest_version} in iTunes before deploying"
-  end
-
   upcoming = readme_data['upcoming']
   commit = `git log -n1 --format='%h'`.strip
   notes = upcoming['user_facing'] || []

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,12 +13,12 @@ before_all do
 end
 
 lane :ship_beta do
-  readme_yaml = File.read('../CHANGELOG.yml')
-  readme_data = YAML.safe_load(readme_yaml)
+  changelog_yaml = File.read('../CHANGELOG.yml')
+  changelog_data = YAML.safe_load(changelog_yaml)
 
-  latest_version = readme_data['upcoming']['version']
+  latest_version = changelog_data['upcoming']['version']
 
-  upcoming = readme_data['upcoming']
+  upcoming = changelog_data['upcoming']
   commit = `git log -n1 --format='%h'`.strip
   notes = upcoming['user_facing'] || []
   beta_readme = "## #{upcoming['version']} - #{commit} \n\n - #{notes.join "\n - "} \n\n"
@@ -169,9 +169,9 @@ lane :promote_beta do
   # Apple's API returns truncated version/build numbers (eg: 2020.03.19.18 becomes 2020.3.19.18)
   # So we re-compute this based on the same information as the :ship_beta lane.
   root = File.expand_path('..', __dir__)
-  readme_yaml = File.read('../CHANGELOG.yml')
-  readme_data = YAML.safe_load(readme_yaml)
-  latest_version = readme_data['upcoming']['version']
+  changelog_yaml = File.read('../CHANGELOG.yml')
+  changelog_data = YAML.safe_load(changelog_yaml)
+  latest_version = changelog_data['upcoming']['version']
   bundle_version = `/usr/libexec/PlistBuddy -c "print CFBundleVersion" #{File.join(root, 'Artsy/App_Resources/Artsy-Info.plist')}`.strip
 
   tag_and_push(tag: "#{latest_version}-#{bundle_version}-submission")


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->



### Description

<!-- Implementation description -->

This is part of ongoing work to get our deploys working again. We ran into [this issue](https://github.com/fastlane/fastlane/issues/17140) but the fix [here](https://github.com/fastlane/fastlane/pull/17148) didn't work. @joshdholtz was kind enough to open #3821 but we still saw errors based on version number mismatches.

Stepping back, the code that was now failing was a check to make sure beta deploys failed early. This was important a few years ago when beta deploys took 45 minutes. Now they take a lot less (we have sophisticated CI caching) and it was only the check that was causing our current problem. So I just removed the check. The new build is [running here](https://app.circleci.com/pipelines/github/artsy/eigen/4977/workflows/b55c5a31-114e-4838-89c1-d29ad6758ea6/jobs/17727).

I cherry-picked in the commit from #3821 so @joshdholtz gets the credit for having a commit in our repo's default branch, and I cleaned up some variable names too.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
  - I'm going to open a ticket to move away from the deprecated `Tunes` API in our Fastfile.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434