### PR TITLE
Clean up Makefile; fix broken links in documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,8 +155,8 @@ push:
 fpush:
 	if [ "$(LOCAL_BRANCH)" == "master" ]; then echo "In master, not pushing"; else git push origin $(LOCAL_BRANCH):$(BRANCH) --force; fi
 
+# Clear local caches and build files
 flip_table:
-	# Clear local caches and build files
 	@echo 'Clear node modules (┛ಠ_ಠ)┛彡┻━┻'
 	rm -rf node_modules
 	@echo 'Clear cocoapods directory (ノಠ益ಠ)ノ彡┻━┻'
@@ -176,8 +176,8 @@ flip_table:
 	@echo 'Reinstall dependencies ┬─┬ノ( º _ ºノ)'
 	bundle exec pod install --repo-update
 
+# Clear global and local caches and build files
 flip_table_extreme:
-  # Clear global and local caches and build files
 	@echo 'Clean global yarn & pod caches (┛✧Д✧))┛彡┻━┻'
 	yarn cache clean
 	bundle exec pod cache clean --all

--- a/Makefile
+++ b/Makefile
@@ -180,4 +180,4 @@ flip_table_extreme:
 	@echo 'Clean global yarn & pod caches (┛✧Д✧))┛彡┻━┻'
 	yarn cache clean
 	bundle exec pod cache clean --all
-	make flip_table
+	$(MAKE) flip_table

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ artsy:
 	aws s3 cp s3://artsy-citadel/dev/.env.eigen .env.shared
 
 certs:
-	echo "Don't log in with it@artsymail.com, use your account on our Artsy team."
+	@echo "Don't log in with it@artsymail.com, use your account on our Artsy team."
 	bundle exec match appstore
 
 distribute: change_version_to_date set_git_properties setup_fastlane_env

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,6 @@ next: update_bundle_version
 ### General setup
 
 oss:
-	git submodule update --init
 	touch .env.ci
 	cp .env.example .env.shared
 	cp Artsy/App/Echo.json.example Artsy/App/Echo.json

--- a/Makefile
+++ b/Makefile
@@ -166,10 +166,9 @@ flip_table:
 	# but a second try takes it home
 	if ! rm -rf ~/Library/Developer/Xcode/DerivedData; then rm -rf ~/Library/Developer/Xcode/DerivedData; fi
 	@echo 'Clear relay, jest, and metro caches (┛◉Д◉)┛彡┻━┻'
-	rm -rf $TMPDIR/RelayFindGraphQLTags-*
+	rm -rf $(TMPDIR)/RelayFindGraphQLTags-*
 	rm -rf .jest
-	rm -rf $TMPDIR/metro*
-	rm -rf .metro
+	rm -rf $(TMPDIR)/metro* .metro
 	@echo 'Clear build artefacts (╯ರ ~ ರ）╯︵ ┻━┻'
 	rm -rf emission/Pod/Assets/Emission*
 	rm -rf emission/Pod/Assets/assets

--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,12 @@ DEVICE_HOST = platform='iOS Simulator',OS='12.4',name='iPhone X'
 # Disable warnings as errors for now, because we’re currently not getting the same errors during dev as deploy.
 # OTHER_CFLAGS = OTHER_CFLAGS="\$$(inherited) -Werror"
 
-
 GIT_COMMIT_REV = $(shell git log -n1 --format='%h')
 GIT_COMMIT_SHA = $(shell git log -n1 --format='%H')
 GIT_REMOTE_ORIGIN_URL = $(shell git config --get remote.origin.url)
 
 DATE_MONTH = $(shell date "+%e %h" | tr "[:lower:]" "[:upper:]")
 DATE_VERSION = $(shell date "+%Y.%m.%d.%H")
-
-CHANGELOG = CHANGELOG.md
 
 LOCAL_BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
 BRANCH = $(shell echo host=github.com | git credential fill | sed -E 'N; s/.*username=(.+)\n?.*/\1/')-$(shell git rev-parse --abbrev-ref HEAD)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Get setup [here](docs/getting_started.md). Further documentation can be found in
 
 ### Work at Artsy?
 
-Instead of `make oss` below, run `make artsy`. You will need (awscli)[https://formulae.brew.sh/formula/awscli] to get our ENV vars.
+Instead of `make oss` below, run `make artsy`. You will need [awscli](https://formulae.brew.sh/formula/awscli) to get our ENV vars.
 
 The file `Artsy/App/Echo.json` is not checked in (a sample file is included for OSS contributors). When you run `pod install`, the latest `Echo.json` file will be downloaded for you. See note in `Podfile`.
 
@@ -86,8 +86,8 @@ You can learn more about this work from [our blog][footer_blog] and by following
 our [job postings][footer_jobs]!
 
 [footer_website]: https://www.artsy.net/
-[footer_principles]: culture/engineering-principles.md
-[footer_open]: culture/engineering-principles.md#open-source-by-default
+[footer_principles]: https://github.com/artsy/README/blob/master/culture/engineering-principles.md
+[footer_open]: https://github.com/artsy/README/blob/master/culture/engineering-principles.md#open-source-by-default
 [footer_blog]: https://artsy.github.io/
 [footer_twitter]: https://twitter.com/ArtsyOpenSource
 [footer_api]: https://developers.artsy.net/

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -2,7 +2,7 @@
 
 ### Prerequisites
 
-You'll need [Node](https://nodejs.org/en/) and [Yarn](https://yarnpkg.com/en/) installed. The Node version should match [the `engine` version here](https://github.com/artsy/emission/blob/master/package.json).
+You'll need [Node](https://nodejs.org/en/) and [Yarn](https://yarnpkg.com/en/) installed. The Node version should match [the `engine` version here](https://github.com/artsy/eigen/blob/master/package.json).
 
 ### Xcode Version
 


### PR DESCRIPTION
The type of this PR is: Enhancement/Documentation

### Description

While setting up eigen locally, I noticed a few improvements we can do in the makefile and documentation:

* Fixing `$TMPDIR` when clearing cache in `make flip_table`.
* Cleaning up Makefile.
* Fixing broken links in documentation.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
