### PR TITLE
[MX-506] Fix gene tabs strange transition

### DIFF
--- a/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -66,9 +66,6 @@ export interface Props {
   /** Slug of the parent screen's entity where the grid is located. For analytics purposes. */
   contextScreenOwnerSlug?: string
 
-  /** Sticky header  */
-  stickyHeader?: React.ReactElement
-
   /** An array of child indices determining which children get docked to the top of the screen when scrolling.  */
   stickyHeaderIndices?: number[]
 }
@@ -242,7 +239,7 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
 
   render() {
     const artworks = this.state.sectionDimension ? this.renderSections() : null
-    const { shouldAddPadding, autoFetch, hasMore, stickyHeader, isLoading, stickyHeaderIndices } = this.props
+    const { shouldAddPadding, autoFetch, hasMore, isLoading, stickyHeaderIndices } = this.props
     const boxPadding = shouldAddPadding ? 2 : 0
 
     return (
@@ -255,7 +252,6 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
           accessibilityLabel="Artworks ScrollView"
           stickyHeaderIndices={stickyHeaderIndices}
         >
-          {stickyHeader || null}
           {this.renderHeader()}
           <Box px={boxPadding}>
             <View style={styles.container} accessibilityLabel="Artworks Content View">

--- a/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -65,6 +65,12 @@ export interface Props {
 
   /** Slug of the parent screen's entity where the grid is located. For analytics purposes. */
   contextScreenOwnerSlug?: string
+
+  /** Sticky header  */
+  stickyHeader?: React.ReactElement
+
+  /** An array of child indices determining which children get docked to the top of the screen when scrolling.  */
+  stickyHeaderIndices?: number[]
 }
 
 interface PrivateProps {
@@ -236,7 +242,7 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
 
   render() {
     const artworks = this.state.sectionDimension ? this.renderSections() : null
-    const { shouldAddPadding, autoFetch, hasMore, isLoading } = this.props
+    const { shouldAddPadding, autoFetch, hasMore, stickyHeader, isLoading, stickyHeaderIndices } = this.props
     const boxPadding = shouldAddPadding ? 2 : 0
 
     return (
@@ -247,7 +253,9 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
           onLayout={this.onLayout}
           scrollsToTop={false}
           accessibilityLabel="Artworks ScrollView"
+          stickyHeaderIndices={stickyHeaderIndices}
         >
+          {stickyHeader || null}
           {this.renderHeader()}
           <Box px={boxPadding}>
             <View style={styles.container} accessibilityLabel="Artworks Content View">

--- a/src/lib/Containers/Gene.tsx
+++ b/src/lib/Containers/Gene.tsx
@@ -213,7 +213,7 @@ export class Gene extends React.Component<Props, State> {
                     hasMore={this.props.relay.hasMore}
                     isLoading={this.props.relay.isLoading}
                     loadMore={this.props.relay.loadMore}
-                    stickyHeader={this.renderStickyRefineSection()}
+                    HeaderComponent={this.renderStickyRefineSection()}
                     stickyHeaderIndices={[0]}
                   />
                 </StickyTabPageScrollView>

--- a/src/lib/Containers/Gene.tsx
+++ b/src/lib/Containers/Gene.tsx
@@ -102,16 +102,8 @@ export class Gene extends React.Component<Props, State> {
     return [TABS.WORKS, TABS.ABOUT]
   }
 
-  selectedTabTitle = () => {
-    return this.availableTabs()[this.state.selectedTabIndex]
-  }
-
   get commonPadding(): number {
     return isPad ? 40 : 20
-  }
-
-  get showingArtworksSection(): boolean {
-    return this.selectedTabTitle() === TABS.WORKS
   }
 
   /** Top of the Component */
@@ -185,17 +177,13 @@ export class Gene extends React.Component<Props, State> {
 
   /**  Count of the works, and the refine button - sticks to the top of screen when scrolling */
   renderStickyRefineSection = () => {
-    if (!this.showingArtworksSection) {
-      return null
-    }
-    // const topMargin = this.state.showingStickyHeader ? 0 : HeaderHeight
     const separatorColor = this.state.showingStickyHeader ? "white" : colors["gray-regular"]
 
     const refineButtonWidth = 80
     const maxLabelWidth = Dimensions.get("window").width - this.commonPadding * 2 - refineButtonWidth - 10
 
     return (
-      <Box backgroundColor="white" paddingLeft={this.commonPadding} paddingRight={this.commonPadding} paddingTop={15}>
+      <Box backgroundColor="white" paddingTop={15}>
         <Separator style={{ backgroundColor: separatorColor }} />
         <View style={styles.refineContainer}>
           <Sans size="3t" color="black60" maxWidth={maxLabelWidth} marginTop="2px">
@@ -225,6 +213,8 @@ export class Gene extends React.Component<Props, State> {
                     hasMore={this.props.relay.hasMore}
                     isLoading={this.props.relay.isLoading}
                     loadMore={this.props.relay.loadMore}
+                    stickyHeader={this.renderStickyRefineSection()}
+                    stickyHeaderIndices={[0]}
                   />
                 </StickyTabPageScrollView>
               ),
@@ -244,7 +234,6 @@ export class Gene extends React.Component<Props, State> {
                   this.switchSelectionDidChange(index)
                 }}
               />
-              {this.renderStickyRefineSection()}
             </View>
           }
         />


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [MX-506]

### Description
Fix the strange transition that happens when switching between the `Works` and `About` Tabs.

![Screen_Recording_2020-09-10_at_13 32 35](https://user-images.githubusercontent.com/11945712/92724083-58325d00-f36a-11ea-9840-9946a3ad6260.gif)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[MX-506]: https://artsyproduct.atlassian.net/browse/MX-506