### PR TITLE
group lots by whether sale is closed, not per-lot

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,6 +3,7 @@ upcoming:
   date: TBD
   dev:
     - Connects new My Bids view to causality's lot standings - erik
+    - Continued enhancements for user clarity to My Bids view - erik
     - Make TS type for app module names - david
     - Disable idfa collection in Segment - brian
     - Removes AFNetworking/UIKit subspec - ash

--- a/src/__generated__/MyBidsQuery.graphql.ts
+++ b/src/__generated__/MyBidsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 937299fbbc04c84db416b42dbb9ce010 */
+/* @relayHash ea7ce7decd6dedb01d1e0755f0841fdf */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -101,6 +101,7 @@ fragment MyBids_me on Me {
             ...SaleCard_sale
             internalID
             displayTimelyAt
+            status
             id
           }
           id
@@ -432,7 +433,14 @@ return {
                                   (v2/*: any*/)
                                 ]
                               },
-                              (v0/*: any*/)
+                              (v0/*: any*/),
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "status",
+                                "args": null,
+                                "storageKey": null
+                              }
                             ]
                           }
                         ]
@@ -452,7 +460,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "MyBidsQuery",
-    "id": "5feb6d845487b8b8d696e0cce082eb2b",
+    "id": "491575e8d9b9f682de1cb678fd351c4b",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/MyBids_me.graphql.ts
+++ b/src/__generated__/MyBids_me.graphql.ts
@@ -17,6 +17,7 @@ export type MyBids_me = {
                     readonly sale: {
                         readonly internalID: string;
                         readonly displayTimelyAt: string | null;
+                        readonly status: string | null;
                         readonly " $fragmentRefs": FragmentRefs<"SaleCard_sale">;
                     } | null;
                 } | null;
@@ -135,6 +136,13 @@ return {
                           "storageKey": null
                         },
                         {
+                          "kind": "ScalarField",
+                          "alias": null,
+                          "name": "status",
+                          "args": null,
+                          "storageKey": null
+                        },
+                        {
                           "kind": "FragmentSpread",
                           "name": "SaleCard_sale",
                           "args": null
@@ -162,5 +170,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '53ca1c55ab57a2b2a7a6ccbbcae0a8a3';
+(node as any).hash = '95570b09bc04c0c77982c525ba366efb';
 export default node;

--- a/src/__generated__/MyProfileQuery.graphql.ts
+++ b/src/__generated__/MyProfileQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 9b48561dd37d914e64cdb6d73a15862f */
+/* @relayHash 00028f2337a5c110e6990ae22f9095a4 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -30,8 +30,11 @@ fragment MyProfile_me on Me {
   auctionsLotStandingConnection(first: 25) {
     edges {
       node {
-        lotState {
-          soldStatus
+        saleArtwork {
+          sale {
+            status
+            id
+          }
           id
         }
         id
@@ -175,18 +178,30 @@ return {
                       {
                         "kind": "LinkedField",
                         "alias": null,
-                        "name": "lotState",
+                        "name": "saleArtwork",
                         "storageKey": null,
                         "args": null,
-                        "concreteType": "AuctionsLotState",
+                        "concreteType": "SaleArtwork",
                         "plural": false,
                         "selections": [
                           {
-                            "kind": "ScalarField",
+                            "kind": "LinkedField",
                             "alias": null,
-                            "name": "soldStatus",
+                            "name": "sale",
+                            "storageKey": null,
                             "args": null,
-                            "storageKey": null
+                            "concreteType": "Sale",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "status",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              (v1/*: any*/)
+                            ]
                           },
                           (v1/*: any*/)
                         ]
@@ -416,7 +431,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "MyProfileQuery",
-    "id": "6eae9fea95b6186fc2dfa1a16166a444",
+    "id": "1e30423524fdc3e975fdd15db57d8dc5",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/MyProfileRefetchQuery.graphql.ts
+++ b/src/__generated__/MyProfileRefetchQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 7a6259fb0dfc617435954a8f42a1987c */
+/* @relayHash 794aee83758270cab14bbcb67288971b */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -30,8 +30,11 @@ fragment MyProfile_me on Me {
   auctionsLotStandingConnection(first: 25) {
     edges {
       node {
-        lotState {
-          soldStatus
+        saleArtwork {
+          sale {
+            status
+            id
+          }
           id
         }
         id
@@ -175,18 +178,30 @@ return {
                       {
                         "kind": "LinkedField",
                         "alias": null,
-                        "name": "lotState",
+                        "name": "saleArtwork",
                         "storageKey": null,
                         "args": null,
-                        "concreteType": "AuctionsLotState",
+                        "concreteType": "SaleArtwork",
                         "plural": false,
                         "selections": [
                           {
-                            "kind": "ScalarField",
+                            "kind": "LinkedField",
                             "alias": null,
-                            "name": "soldStatus",
+                            "name": "sale",
+                            "storageKey": null,
                             "args": null,
-                            "storageKey": null
+                            "concreteType": "Sale",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "status",
+                                "args": null,
+                                "storageKey": null
+                              },
+                              (v1/*: any*/)
+                            ]
                           },
                           (v1/*: any*/)
                         ]
@@ -416,7 +431,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "MyProfileRefetchQuery",
-    "id": "34c6d0b9d80d4806a29e14f6f8cb630e",
+    "id": "0d5e09f1cd174ea453dcdfb104dfb95e",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/MyProfile_me.graphql.ts
+++ b/src/__generated__/MyProfile_me.graphql.ts
@@ -3,15 +3,16 @@
 
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type AuctionsSoldStatus = "ForSale" | "Passed" | "Sold" | "%future added value";
 export type MyProfile_me = {
     readonly name: string | null;
     readonly auctionsLotStandingConnection: {
         readonly edges: ReadonlyArray<{
             readonly node: {
-                readonly lotState: {
-                    readonly soldStatus: AuctionsSoldStatus;
-                };
+                readonly saleArtwork: {
+                    readonly sale: {
+                        readonly status: string | null;
+                    } | null;
+                } | null;
             };
         } | null> | null;
     };
@@ -85,18 +86,29 @@ const node: ReaderFragment = {
                 {
                   "kind": "LinkedField",
                   "alias": null,
-                  "name": "lotState",
+                  "name": "saleArtwork",
                   "storageKey": null,
                   "args": null,
-                  "concreteType": "AuctionsLotState",
+                  "concreteType": "SaleArtwork",
                   "plural": false,
                   "selections": [
                     {
-                      "kind": "ScalarField",
+                      "kind": "LinkedField",
                       "alias": null,
-                      "name": "soldStatus",
+                      "name": "sale",
+                      "storageKey": null,
                       "args": null,
-                      "storageKey": null
+                      "concreteType": "Sale",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "kind": "ScalarField",
+                          "alias": null,
+                          "name": "status",
+                          "args": null,
+                          "storageKey": null
+                        }
+                      ]
                     }
                   ]
                 }
@@ -175,5 +187,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = '17a714901290859ff55b6d58d799b195';
+(node as any).hash = '2fc2f67bff0f4b8d637c6c768edebe52';
 export default node;

--- a/src/lib/Scenes/MyBids/Components/ClosedLot.tsx
+++ b/src/lib/Scenes/MyBids/Components/ClosedLot.tsx
@@ -9,9 +9,15 @@ import { LotFragmentContainer as Lot } from "./Lot"
 
 type BidderResult = "won" | "lost" | "passed"
 
-export const ClosedLot = ({ lotStanding }: { lotStanding: ClosedLot_lotStanding }) => {
+export const ClosedLot = ({
+  lotStanding,
+  withTimelyInfo = false,
+}: {
+  lotStanding: ClosedLot_lotStanding
+  withTimelyInfo?: boolean
+}) => {
   const sellingPrice = lotStanding?.lotState?.sellingPrice?.displayAmount
-  const displayTime = lotStanding?.saleArtwork?.sale?.displayTimelyAt!
+  const subtitle = withTimelyInfo ? capitalize(lotStanding?.saleArtwork?.sale?.displayTimelyAt!) : undefined
 
   const result: BidderResult =
     lotStanding?.lotState.soldStatus === "Passed" ? "passed" : lotStanding?.isHighestBidder ? "won" : "lost"
@@ -26,7 +32,7 @@ export const ClosedLot = ({ lotStanding }: { lotStanding: ClosedLot_lotStanding 
   const Result = bidderMessages[result]
 
   return (
-    <Lot saleArtwork={lotStanding.saleArtwork!} subtitle={capitalize(displayTime)} ArtworkBadge={Badge}>
+    <Lot saleArtwork={lotStanding.saleArtwork!} subtitle={subtitle} ArtworkBadge={Badge}>
       <Flex flexDirection="row">
         <Text variant="caption">{sellingPrice}</Text>
       </Flex>

--- a/src/lib/Scenes/MyBids/Components/ClosedLot.tsx
+++ b/src/lib/Scenes/MyBids/Components/ClosedLot.tsx
@@ -12,7 +12,6 @@ type BidderResult = "won" | "lost" | "passed"
 export const ClosedLot = ({ lotStanding }: { lotStanding: ClosedLot_lotStanding }) => {
   const sellingPrice = lotStanding?.lotState?.sellingPrice?.displayAmount
   const displayTime = lotStanding?.saleArtwork?.sale?.displayTimelyAt!
-  console.log(lotStanding)
 
   const result: BidderResult =
     lotStanding?.lotState.soldStatus === "Passed" ? "passed" : lotStanding?.isHighestBidder ? "won" : "lost"

--- a/src/lib/Scenes/MyBids/Components/ClosedLot.tsx
+++ b/src/lib/Scenes/MyBids/Components/ClosedLot.tsx
@@ -12,6 +12,7 @@ type BidderResult = "won" | "lost" | "passed"
 export const ClosedLot = ({ lotStanding }: { lotStanding: ClosedLot_lotStanding }) => {
   const sellingPrice = lotStanding?.lotState?.sellingPrice?.displayAmount
   const displayTime = lotStanding?.saleArtwork?.sale?.displayTimelyAt!
+  console.log(lotStanding)
 
   const result: BidderResult =
     lotStanding?.lotState.soldStatus === "Passed" ? "passed" : lotStanding?.isHighestBidder ? "won" : "lost"

--- a/src/lib/Scenes/MyBids/__fixtures__/MyBidsQuery.ts
+++ b/src/lib/Scenes/MyBids/__fixtures__/MyBidsQuery.ts
@@ -1,3 +1,56 @@
+const swannSale = {
+  internalID: "swann",
+  href: "/auction/swann-auction-galleries-lgbtq-plus-art-material-culture-and-history",
+  endAt: null,
+  liveStartAt: "2020-08-13T16:00:00+00:00",
+  displayTimelyAt: "live in 10d",
+  timeZone: "America/New_York",
+  status: "open",
+  name: "Swann Auction Galleries: LGBTQ+ Art, Material Culture & History",
+  slug: "swann-auction-galleries-lgbtq-plus-art-material-culture-and-history",
+
+  coverImage: {
+    url: "https://d32dm0rphc51dk.cloudfront.net/1tJKlnBgHGvZSCZPlAvwAQ/wide.jpg",
+  },
+  partner: {
+    name: "Swann Auction Galleries",
+  },
+}
+
+const swannEnded = {
+  ...swannSale,
+  name: "Swann, but closed",
+  internalID: "swann-ended",
+  status: "closed",
+  displayTimelyAt: "",
+}
+
+const heritageSale = {
+  internalID: "heritage",
+  saleType: "auction",
+  href: "/auction/heritage-urban-art-summer-skate",
+  endAt: "2020-08-05T15:00:00+00:00",
+  status: "open",
+  displayTimelyAt: "live in 2d",
+  timeZone: "America/Chicago",
+  name: "Heritage: Urban Art Summer Skate",
+  slug: "heritage-urban-art-summer-skate",
+  coverImage: {
+    url: "https://d32dm0rphc51dk.cloudfront.net/JOeiPjbfKixGJbQjQHubXA/source.jpg",
+  },
+  partner: {
+    name: "Heritage Auctions",
+  },
+}
+
+const heritageEnded = {
+  ...heritageSale,
+  name: "Heritage but closed",
+  internalID: "heritage-ended",
+  status: "closed",
+  displayTimelyAt: "",
+}
+
 export const me = {
   auctionsLotStandingConnection: {
     edges: [
@@ -6,6 +59,7 @@ export const me = {
         node: {
           isHighestBidder: true,
           lotState: {
+            internalID: "lot-0",
             saleId: "swann",
             bidCount: 1,
             soldStatus: "ForSale",
@@ -18,40 +72,25 @@ export const me = {
             },
           },
           saleArtwork: {
-            id: "U2FsZUFydHdvcms6NWYyODM2MzRmOTc5N2UwMDA3ZGM1MDU1",
+            internalID: "lot-0",
             lotLabel: "3",
             artwork: {
-              artistNames: "Maskull Lasserre",
+              artistNames: "Open Swann RNM Artist",
               href: "/artwork/maskull-lasserre-painting",
               image: {
                 url: "https://d2v80f5yrouhh2.cloudfront.net/zrtyPc3hnFNl-1yv80qS2w/medium.jpg",
               },
             },
-            sale: {
-              internalID: "swann",
-              href: "/auction/swann-auction-galleries-lgbtq-plus-art-material-culture-and-history",
-              endAt: null,
-              liveStartAt: "2020-08-13T16:00:00+00:00",
-              displayTimelyAt: "live in 10d",
-              timeZone: "America/New_York",
-              name: "Swann Auction Galleries: LGBTQ+ Art, Material Culture & History",
-              slug: "swann-auction-galleries-lgbtq-plus-art-material-culture-and-history",
-              coverImage: {
-                url: "https://d32dm0rphc51dk.cloudfront.net/1tJKlnBgHGvZSCZPlAvwAQ/wide.jpg",
-              },
-              partner: {
-                name: "Swann Auction Galleries",
-              },
-            },
+            sale: swannSale,
           },
         },
       },
-
       {
         // Winning
         node: {
           isHighestBidder: true,
           lotState: {
+            internalID: "lot-1",
             bidCount: 2,
             saleId: "heritage",
             soldStatus: "ForSale",
@@ -65,40 +104,26 @@ export const me = {
           },
 
           saleArtwork: {
-            id: "U2FsZUFydHdvcms6NWYyODM2MzNmOTc5N2UwMDA3ZGM1MDRk",
+            internalID: "lot-1",
             lotLabel: "2",
             artwork: {
-              artistNames: "Zach Eugene Salinger-Simonson",
+              artistNames: "Open Heritage Winning Artist",
               href: "/artwork/zach-eugene-salinger-simonson-ennui",
               image: {
                 url: "https://d2v80f5yrouhh2.cloudfront.net/NtVjXx1dzUIsOfFdyW0XZw/medium.jpg",
               },
             },
-            sale: {
-              internalID: "heritage",
-              saleType: "auction",
-              href: "/auction/heritage-urban-art-summer-skate",
-              endAt: null,
-              liveStartAt: "2020-08-05T15:00:00+00:00",
-              displayTimelyAt: "live in 2d",
-              timeZone: "America/Chicago",
-              name: "Heritage: Urban Art Summer Skate",
-              slug: "heritage-urban-art-summer-skate",
-              coverImage: {
-                url: "https://d32dm0rphc51dk.cloudfront.net/JOeiPjbfKixGJbQjQHubXA/source.jpg",
-              },
-              partner: {
-                name: "Heritage Auctions",
-              },
-            },
+            sale: heritageSale,
           },
         },
       },
+
       {
         // Outbid
         node: {
           isHighestBidder: false,
           lotState: {
+            internalID: "lot-2",
             saleId: "swann",
             bidCount: 1,
             soldStatus: "ForSale",
@@ -112,41 +137,27 @@ export const me = {
           },
 
           saleArtwork: {
-            id: "U2FsZUFydHdvcms6NWYyODM2MzFmOTc5N2UwMDA3ZGM1MDQ1",
+            internalID: "lot-2",
             lotLabel: "1",
             artwork: {
-              artistNames: "Leif Erik Nygards",
+              artistNames: "Open Swann Outbid Artist",
               href: "/artwork/leif-erik-nygards-surrealism",
               image: {
                 url: "https://d2v80f5yrouhh2.cloudfront.net/dwqgENIWYbWFU_wntBtxFg/medium.jpg",
               },
             },
-            sale: {
-              internalID: "swann",
-              href: "/auction/swann-auction-galleries-lgbtq-plus-art-material-culture-and-history",
-              endAt: null,
-              liveStartAt: "2020-08-13T16:00:00+00:00",
-              displayTimelyAt: "live in 10d",
-              timeZone: "America/New_York",
-              name: "Swann Auction Galleries: LGBTQ+ Art, Material Culture & History",
-              slug: "swann-auction-galleries-lgbtq-plus-art-material-culture-and-history",
-              coverImage: {
-                url: "https://d32dm0rphc51dk.cloudfront.net/1tJKlnBgHGvZSCZPlAvwAQ/wide.jpg",
-              },
-              partner: {
-                name: "Swann Auction Galleries",
-              },
-            },
+            sale: swannSale,
           },
         },
       },
 
       // same sales but ENDED added to sale ids and a final stated added to soldStatus
       {
-        // Reserve not met
+        // Passed
         node: {
           isHighestBidder: true,
           lotState: {
+            internalID: "lot-3",
             saleId: "swann-ended",
             bidCount: 1,
             soldStatus: "Passed",
@@ -159,26 +170,26 @@ export const me = {
             },
           },
           saleArtwork: {
-            id: "U2FsZUFydHdvcms6NWYyODM2MzRmOTc5N2UwMDA3ZGM1MDU1",
+            internalID: "lot-3",
             lotLabel: "3",
             artwork: {
-              artistNames: "Maskull Lasserre",
+              artistNames: "Closed Swann RNM Artist",
               href: "/artwork/maskull-lasserre-painting",
               image: {
                 url: "https://d2v80f5yrouhh2.cloudfront.net/zrtyPc3hnFNl-1yv80qS2w/medium.jpg",
               },
             },
-            sale: {
-              displayTimelyAt: "Closed on 7/15/20",
-            },
+            sale: swannEnded,
           },
         },
       },
+
       {
         // Winning
         node: {
           isHighestBidder: true,
           lotState: {
+            internalID: "lot-4",
             bidCount: 2,
             saleId: "heritage-ended",
             soldStatus: "Sold",
@@ -192,26 +203,26 @@ export const me = {
           },
 
           saleArtwork: {
-            id: "U2FsZUFydHdvcms6NWYyODM2MzNmOTc5N2UwMDA3ZGM1MDRk",
+            internalID: "lot-4",
             lotLabel: "2",
             artwork: {
-              artistNames: "Zach Eugene Salinger-Simonson",
+              artistNames: "Closed Heritage Winning Artist",
               href: "/artwork/zach-eugene-salinger-simonson-ennui",
               image: {
                 url: "https://d2v80f5yrouhh2.cloudfront.net/NtVjXx1dzUIsOfFdyW0XZw/medium.jpg",
               },
-              sale: {
-                displayTimelyAt: "Closed on 7/12/20",
-              },
             },
+            sale: heritageEnded,
           },
         },
       },
+
       {
         // Outbid
         node: {
           isHighestBidder: false,
           lotState: {
+            internalID: "lot-5",
             saleId: "swann-ended",
             bidCount: 1,
             soldStatus: "Sold",
@@ -225,21 +236,31 @@ export const me = {
           },
 
           saleArtwork: {
-            id: "U2FsZUFydHdvcms6NWYyODM2MzFmOTc5N2UwMDA3ZGM1MDQ1",
+            internalID: "lot-5",
             lotLabel: "1",
             artwork: {
-              artistNames: "Leif Erik Nygards",
+              artistNames: "Closed Swann Outbid Artist",
               href: "/artwork/leif-erik-nygards-surrealism",
               image: {
                 url: "https://d2v80f5yrouhh2.cloudfront.net/dwqgENIWYbWFU_wntBtxFg/medium.jpg",
               },
             },
-            sale: {
-              displayTimelyAt: "Closed on 7/15/20",
-            },
+            sale: swannEnded,
           },
         },
       },
     ],
   },
+}
+
+// OO Sales are online-only, others are Live Auction Integration
+const [rnm, winningOO, outbid, passedClosed, winningClosedOO, outbidClosed] = me.auctionsLotStandingConnection.edges
+
+export const lotStandings = {
+  rnm,
+  winningOO,
+  outbid,
+  passedClosed,
+  winningClosedOO,
+  outbidClosed,
 }

--- a/src/lib/Scenes/MyBids/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/MyBids/__tests__/index-tests.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { act } from "react-test-renderer"
+import { act, ReactTestInstance } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 import { defaultEnvironment } from "lib/relay/createEnvironment"
@@ -18,6 +18,19 @@ jest.mock("lib/relay/createEnvironment", () => ({
 
 jest.unmock("react-relay")
 const env = (defaultEnvironment as any) as ReturnType<typeof createMockEnvironment>
+
+const activeSectionLots = (root: ReactTestInstance): ReactTestInstance[] => {
+  const activeSection = root.findByProps({ "data-test-id": "active-section" })
+  const activeLotsinActive = activeSection.findAllByType(ActiveLot)
+  const completedLotsinActive = activeSection.findAllByType(ClosedLot)
+  const activeLots = [...activeLotsinActive, ...completedLotsinActive]
+  return activeLots
+}
+
+const closedSectionLots = (root: ReactTestInstance): ReactTestInstance[] => {
+  const closedSection = root.findByProps({ "data-test-id": "closed-section" })
+  return closedSection.findAllByType(ClosedLot)
+}
 
 describe(MyBidsQueryRenderer, () => {
   it("spins until the operation resolves", () => {
@@ -40,45 +53,44 @@ describe(MyBidsQueryRenderer, () => {
     })
 
     expect(extractText(tree.root)).toContain("Active")
-    expect(extractText(tree.root)).toContain("Recently Closed")
+    expect(extractText(tree.root)).toContain("Closed")
     expect(extractText(tree.root)).toContain("Heritage: Urban Art Summer Skate")
     expect(extractText(tree.root)).toContain("Swann Auction Galleries: LGBTQ+ Art, Material Culture & History")
 
-    const upcomingLots = tree.root.findAllByType(ActiveLot)
+    const activeLots = activeSectionLots(tree.root).map(extractText)
 
     // Active lots are sorted by sale so in a different order than recently closed lots
 
-    expect(extractText(upcomingLots[0])).toContain("Open Swann RNM Artist")
-    expect(extractText(upcomingLots[0])).toContain("1 bid")
-    expect(extractText(upcomingLots[0])).toContain("Reserve not met")
+    expect(activeLots[0]).toContain("Open Swann RNM Artist")
+    expect(activeLots[0]).toContain("1 bid")
+    expect(activeLots[0]).toContain("Reserve not met")
 
-    expect(extractText(upcomingLots[2])).toContain("Open Heritage Winning Artist")
-    expect(extractText(upcomingLots[2])).toContain("2 bids")
-    expect(extractText(upcomingLots[2])).toContain("Winning")
+    expect(activeLots[2]).toContain("Open Heritage Winning Artist")
+    expect(activeLots[2]).toContain("2 bids")
+    expect(activeLots[2]).toContain("Winning")
 
-    expect(extractText(upcomingLots[1])).toContain("Open Swann Outbid Artist")
-    expect(extractText(upcomingLots[1])).toContain("1 bid")
-    expect(extractText(upcomingLots[1])).toContain("Outbid")
+    expect(activeLots[1]).toContain("Open Swann Outbid Artist")
+    expect(activeLots[1]).toContain("1 bid")
+    expect(activeLots[1]).toContain("Outbid")
 
-    const closedLots = tree.root.findAllByType(ClosedLot)
+    const closedLots = closedSectionLots(tree.root).map(extractText)
 
-    expect(extractText(closedLots[0])).toContain("Closed Swann RNM Artist")
-    expect(extractText(closedLots[0])).toContain("Passed")
+    expect(closedLots[0]).toContain("Closed Swann RNM Artist")
+    expect(closedLots[0]).toContain("Passed")
 
-    expect(extractText(closedLots[1])).toContain("Closed Heritage Winning Artist")
-    expect(extractText(closedLots[1])).toContain("You won!")
+    expect(closedLots[1]).toContain("Closed Heritage Winning Artist")
+    expect(closedLots[1]).toContain("You won!")
 
-    expect(extractText(closedLots[2])).toContain("Closed Swann Outbid Artist")
-    expect(extractText(closedLots[2])).toContain("Outbid")
+    expect(closedLots[2]).toContain("Closed Swann Outbid Artist")
+    expect(closedLots[2]).toContain("Outbid")
   })
 
-  it.only("renders a completed lot in an ongoing live sale in the 'active' column", () => {
+  it("renders a completed lot in an ongoing live sale in the 'active' column", () => {
     const stillLiveSale = lsFixtures.rnm.node.saleArtwork.sale
     const passedLotInLiveAuction = merge(lsFixtures.passedClosed, {
       node: { saleArtwork: { lotState: { saleId: stillLiveSale.internalID }, sale: stillLiveSale } },
     })
 
-    console.log(passedLotInLiveAuction.node, passedLotInLiveAuction.node.saleArtwork.artwork)
     const me = {
       auctionsLotStandingConnection: {
         edges: [passedLotInLiveAuction],
@@ -97,10 +109,9 @@ describe(MyBidsQueryRenderer, () => {
       })
     })
 
-    const activeLots = tree.root.findAllByType(ActiveLot)
-    expect(activeLots.length).toEqual(1)
-
+    const activeLots = activeSectionLots(tree.root).map(extractText)
     const lot = activeLots[0]
+
     expect(extractText(lot)).toContain("Closed Swann RNM Artist")
     expect(extractText(lot)).toContain("Passed")
   })

--- a/src/lib/Scenes/MyBids/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/MyBids/__tests__/index-tests.tsx
@@ -7,9 +7,10 @@ import { extractText } from "lib/tests/extractText"
 import { PlaceholderText } from "lib/utils/placeholders"
 
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
-import { me } from "../__fixtures__/MyBidsQuery"
+import { merge } from "lodash"
+import { MyBidsQueryRenderer } from ".."
+import { lotStandings as lsFixtures, me as meFixture } from "../__fixtures__/MyBidsQuery"
 import { ActiveLotFragmentContainer as ActiveLot, ClosedLotFragmentContainer as ClosedLot } from "../Components"
-import { MyBidsQueryRenderer } from "../index"
 
 jest.mock("lib/relay/createEnvironment", () => ({
   defaultEnvironment: require("relay-test-utils").createMockEnvironment(),
@@ -33,7 +34,7 @@ describe(MyBidsQueryRenderer, () => {
       env.mock.resolveMostRecentOperation({
         errors: [],
         data: {
-          me,
+          me: meFixture,
         },
       })
     })
@@ -44,29 +45,64 @@ describe(MyBidsQueryRenderer, () => {
     expect(extractText(tree.root)).toContain("Swann Auction Galleries: LGBTQ+ Art, Material Culture & History")
 
     const upcomingLots = tree.root.findAllByType(ActiveLot)
+
     // Active lots are sorted by sale so in a different order than recently closed lots
-    expect(extractText(upcomingLots[0])).toContain("Maskull Lasserre")
+
+    expect(extractText(upcomingLots[0])).toContain("Open Swann RNM Artist")
     expect(extractText(upcomingLots[0])).toContain("1 bid")
     expect(extractText(upcomingLots[0])).toContain("Reserve not met")
 
-    expect(extractText(upcomingLots[1])).toContain("Leif Erik Nygards")
+    expect(extractText(upcomingLots[2])).toContain("Open Heritage Winning Artist")
+    expect(extractText(upcomingLots[2])).toContain("2 bids")
+    expect(extractText(upcomingLots[2])).toContain("Winning")
+
+    expect(extractText(upcomingLots[1])).toContain("Open Swann Outbid Artist")
     expect(extractText(upcomingLots[1])).toContain("1 bid")
     expect(extractText(upcomingLots[1])).toContain("Outbid")
 
-    expect(extractText(upcomingLots[2])).toContain("Zach Eugene Salinger-Simonson")
-    expect(extractText(upcomingLots[2])).toContain("2 bids")
-    expect(extractText(upcomingLots[2])).toContain("Highest bid")
+    const closedLots = tree.root.findAllByType(ClosedLot)
 
-    const recentlyClosedLot = tree.root.findAllByType(ClosedLot)
+    expect(extractText(closedLots[0])).toContain("Closed Swann RNM Artist")
+    expect(extractText(closedLots[0])).toContain("Passed")
 
-    expect(extractText(recentlyClosedLot[0])).toContain("Maskull Lasserre")
-    expect(extractText(recentlyClosedLot[0])).toContain("Passed")
+    expect(extractText(closedLots[1])).toContain("Closed Heritage Winning Artist")
+    expect(extractText(closedLots[1])).toContain("You won!")
 
-    expect(extractText(recentlyClosedLot[1])).toContain("Zach Eugene Salinger-Simonson")
-    expect(extractText(recentlyClosedLot[1])).toContain("You won!")
+    expect(extractText(closedLots[2])).toContain("Closed Swann Outbid Artist")
+    expect(extractText(closedLots[2])).toContain("Outbid")
+  })
 
-    expect(extractText(recentlyClosedLot[2])).toContain("Leif Erik Nygards")
-    expect(extractText(recentlyClosedLot[2])).toContain("Outbid")
+  it.only("renders a completed lot in an ongoing live sale in the 'active' column", () => {
+    const stillLiveSale = lsFixtures.rnm.node.saleArtwork.sale
+    const passedLotInLiveAuction = merge(lsFixtures.passedClosed, {
+      node: { saleArtwork: { lotState: { saleId: stillLiveSale.internalID }, sale: stillLiveSale } },
+    })
+
+    console.log(passedLotInLiveAuction.node, passedLotInLiveAuction.node.saleArtwork.artwork)
+    const me = {
+      auctionsLotStandingConnection: {
+        edges: [passedLotInLiveAuction],
+      },
+    }
+
+    const tree = renderWithWrappers(<MyBidsQueryRenderer />)
+    expect(env.mock.getMostRecentOperation().request.node.operation.name).toBe("MyBidsQuery")
+
+    act(() => {
+      env.mock.resolveMostRecentOperation({
+        errors: [],
+        data: {
+          me,
+        },
+      })
+    })
+
+    const activeLots = tree.root.findAllByType(ActiveLot)
+    expect(activeLots.length).toEqual(1)
+
+    const lot = activeLots[0]
+    expect(extractText(lot)).toContain("Closed Swann RNM Artist")
+    expect(extractText(lot)).toContain("Passed")
   })
 
   it.skip("renders null upon failure", () => {

--- a/src/lib/Scenes/MyBids/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/MyBids/__tests__/index-tests.tsx
@@ -63,26 +63,34 @@ describe(MyBidsQueryRenderer, () => {
 
     expect(activeLots[0]).toContain("Open Swann RNM Artist")
     expect(activeLots[0]).toContain("1 bid")
+    expect(activeLots[0]).toContain("Lot 3")
     expect(activeLots[0]).toContain("Reserve not met")
-
-    expect(activeLots[2]).toContain("Open Heritage Winning Artist")
-    expect(activeLots[2]).toContain("2 bids")
-    expect(activeLots[2]).toContain("Winning")
 
     expect(activeLots[1]).toContain("Open Swann Outbid Artist")
     expect(activeLots[1]).toContain("1 bid")
+    expect(activeLots[1]).toContain("Lot 1")
     expect(activeLots[1]).toContain("Outbid")
+
+    expect(activeLots[2]).toContain("Open Heritage Winning Artist")
+    expect(activeLots[2]).toContain("2 bids")
+    expect(activeLots[2]).toContain("Lot 2")
+    expect(activeLots[2]).toContain("Winning")
 
     const closedLots = closedSectionLots(tree.root).map(extractText)
 
+    // TODO: Final specs call for lot numbers to be replaced by a 'closed m dd' message but
+    // this is not easily derived yet from displayTimelyAt
     expect(closedLots[0]).toContain("Closed Swann RNM Artist")
     expect(closedLots[0]).toContain("Passed")
+    expect(closedLots[0]).toContain("Lot 3")
 
     expect(closedLots[1]).toContain("Closed Heritage Winning Artist")
     expect(closedLots[1]).toContain("You won!")
+    expect(closedLots[1]).toContain("Lot 2")
 
     expect(closedLots[2]).toContain("Closed Swann Outbid Artist")
     expect(closedLots[2]).toContain("Outbid")
+    expect(closedLots[2]).toContain("Lot 1")
   })
 
   it("renders a completed lot in an ongoing live sale in the 'active' column", () => {
@@ -114,6 +122,7 @@ describe(MyBidsQueryRenderer, () => {
 
     expect(extractText(lot)).toContain("Closed Swann RNM Artist")
     expect(extractText(lot)).toContain("Passed")
+    expect(activeLots[0]).toContain("Lot 3")
   })
 
   it.skip("renders null upon failure", () => {

--- a/src/lib/Scenes/MyBids/helpers/lotStanding.ts
+++ b/src/lib/Scenes/MyBids/helpers/lotStanding.ts
@@ -4,3 +4,6 @@ export const lotInActiveSale: (lotStanding: {
   const status = lotStanding?.saleArtwork?.sale?.status
   return !!status && ["open", "preview"].includes(status)
 }
+
+export const lotStandingIsClosed: (lotStanding: { lotState?: { soldStatus?: string } }) => boolean = (lotStanding) =>
+  !!(lotStanding.lotState?.soldStatus && ["Sold", "Passed"].includes(lotStanding.lotState.soldStatus))

--- a/src/lib/Scenes/MyBids/helpers/lotStanding.ts
+++ b/src/lib/Scenes/MyBids/helpers/lotStanding.ts
@@ -1,2 +1,6 @@
-export const lotStandingIsClosed: (lotStanding: { lotState?: { soldStatus?: string } }) => boolean = (lotStanding) =>
-  !!(lotStanding.lotState?.soldStatus && ["Sold", "Passed"].includes(lotStanding.lotState.soldStatus))
+export const lotInActiveSale: (lotStanding: {
+  saleArtwork: { sale: { status: string | null } | null } | null
+}) => boolean = (lotStanding) => {
+  const status = lotStanding?.saleArtwork?.sale?.status
+  return !!status && ["open", "preview"].includes(status)
+}

--- a/src/lib/Scenes/MyBids/index.tsx
+++ b/src/lib/Scenes/MyBids/index.tsx
@@ -17,7 +17,7 @@ import {
   MyBidsPlaceholder,
   SaleCardFragmentContainer,
 } from "./Components"
-import { lotStandingIsClosed } from "./helpers/lotStanding"
+import { lotInActiveSale } from "./helpers/lotStanding"
 
 export interface MyBidsProps {
   me: MyBids_me
@@ -28,12 +28,12 @@ class MyBids extends React.Component<MyBidsProps> {
     const { me } = this.props
     const lotStandings = extractNodes(me?.auctionsLotStandingConnection)
 
-    const [recentlyClosedStandings, activeStandings] = partition(lotStandings, lotStandingIsClosed)
-
-    const activeBySaleId = groupBy(
-      activeStandings.filter((ls) => ls != null),
-      (ls) => ls?.saleArtwork?.sale?.internalID
+    const [activeStandings, closedStandings] = partition(
+      lotStandings.filter((ls) => !!ls),
+      (ls) => lotInActiveSale(ls)
     )
+
+    const activeBySaleId = groupBy(activeStandings, (ls) => ls?.saleArtwork?.sale?.internalID)
 
     return (
       <Flex flex={1}>
@@ -76,7 +76,7 @@ class MyBids extends React.Component<MyBidsProps> {
               content: (
                 <StickyTabPageScrollView>
                   <Flex mt={1}>
-                    {recentlyClosedStandings?.map((ls) => {
+                    {closedStandings?.map((ls) => {
                       return !!ls && <ClosedLot lotStanding={ls} key={ls?.lotState?.internalID} />
                     })}
                   </Flex>
@@ -109,6 +109,7 @@ const MyBidsContainer = createFragmentContainer(MyBids, {
                 ...SaleCard_sale
                 internalID
                 displayTimelyAt
+                status
               }
             }
           }

--- a/src/lib/Scenes/MyBids/index.tsx
+++ b/src/lib/Scenes/MyBids/index.tsx
@@ -81,7 +81,12 @@ class MyBids extends React.Component<MyBidsProps> {
                     {closedStandings?.map((ls) => {
                       return (
                         !!ls && (
-                          <ClosedLot data-test-id="closed-sale-lot" lotStanding={ls} key={ls?.lotState?.internalID} />
+                          <ClosedLot
+                            withTimelyInfo
+                            data-test-id="closed-sale-lot"
+                            lotStanding={ls}
+                            key={ls?.lotState?.internalID}
+                          />
                         )
                       )
                     })}

--- a/src/lib/Scenes/MyBids/index.tsx
+++ b/src/lib/Scenes/MyBids/index.tsx
@@ -17,7 +17,7 @@ import {
   MyBidsPlaceholder,
   SaleCardFragmentContainer,
 } from "./Components"
-import { lotInActiveSale } from "./helpers/lotStanding"
+import { lotInActiveSale, lotStandingIsClosed } from "./helpers/lotStanding"
 
 export interface MyBidsProps {
   me: MyBids_me
@@ -49,7 +49,7 @@ class MyBids extends React.Component<MyBidsProps> {
             {
               title: `Active`,
               content: (
-                <StickyTabPageScrollView>
+                <StickyTabPageScrollView data-test-id="active-section">
                   <Spacer my={1} />
 
                   <Join separator={<Spacer my={1} />}>
@@ -58,10 +58,12 @@ class MyBids extends React.Component<MyBidsProps> {
                       return (
                         <SaleCardFragmentContainer key={saleId} sale={sale}>
                           <Join separator={<Separator my={1} />}>
-                            {activeLotStandings?.map(
-                              (ls) =>
-                                !!(ls && sale) && <ActiveLot lotStanding={ls as any} key={ls?.lotState?.internalID} />
-                            )}
+                            {activeLotStandings?.map((ls) => {
+                              if (ls && sale) {
+                                const LotInfoComponent = lotStandingIsClosed(ls) ? ClosedLot : ActiveLot
+                                return <LotInfoComponent lotStanding={ls as any} key={ls?.lotState?.internalID} />
+                              }
+                            })}
                           </Join>
                         </SaleCardFragmentContainer>
                       )
@@ -72,12 +74,16 @@ class MyBids extends React.Component<MyBidsProps> {
               ),
             },
             {
-              title: `Recently Closed`,
+              title: `Closed`,
               content: (
-                <StickyTabPageScrollView>
+                <StickyTabPageScrollView data-test-id="closed-section">
                   <Flex mt={1}>
                     {closedStandings?.map((ls) => {
-                      return !!ls && <ClosedLot lotStanding={ls} key={ls?.lotState?.internalID} />
+                      return (
+                        !!ls && (
+                          <ClosedLot data-test-id="closed-sale-lot" lotStanding={ls} key={ls?.lotState?.internalID} />
+                        )
+                      )
                     })}
                   </Flex>
                   <Spacer my={2} />

--- a/src/lib/Scenes/MyProfile/MyProfile.tsx
+++ b/src/lib/Scenes/MyProfile/MyProfile.tsx
@@ -12,7 +12,7 @@ import React, { useCallback, useRef, useState } from "react"
 import { Alert, FlatList, NativeModules, RefreshControl, ScrollView } from "react-native"
 import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
 import { SmallTileRailContainer } from "../Home/Components/SmallTileRail"
-import { lotStandingIsClosed } from "../MyBids/helpers/lotStanding"
+import { lotInActiveSale } from "../MyBids/helpers/lotStanding"
 import { MyProfileMenuItem } from "./Components/MyProfileMenuItem"
 
 const MyProfile: React.FC<{ me: MyProfile_me; relay: RelayRefetchProp }> = ({ me, relay }) => {
@@ -28,7 +28,7 @@ const MyProfile: React.FC<{ me: MyProfile_me; relay: RelayRefetchProp }> = ({ me
       listRef.current?.scrollToOffset({ offset: 0, animated: false })
     })
   }, [])
-  const activeBidCount = extractNodes(me.auctionsLotStandingConnection).filter((ls) => !lotStandingIsClosed(ls)).length
+  const activeBidCount = extractNodes(me.auctionsLotStandingConnection).filter((ls) => !lotInActiveSale(ls)).length
 
   return (
     <ScrollView ref={navRef} refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />}>
@@ -125,8 +125,10 @@ const MyProfileContainer = createRefetchContainer(
         auctionsLotStandingConnection(first: 25) {
           edges {
             node {
-              lotState {
-                soldStatus
+              saleArtwork {
+                sale {
+                  status
+                }
               }
             }
           }


### PR DESCRIPTION
The type of this PR is: Enhancement

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->



### Description
This PR updates our My Bids screen to group lots by whether their _associated sale_ is closed or pre-closed, not by whether each individual lot is closed. This is to keep lots in a Live Auction Integration sale from disappearing into the 'closed' view while the sale is ongoing.
<!-- Implementation description -->

### PR Checklist (tick all before merging)


- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


![image](https://user-images.githubusercontent.com/9088720/93103253-6b9b3c00-f67a-11ea-9d65-d2776e6467d7.png)


[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434