### PR TITLE
docs: Rename map_to_app, add relay container docs #trivial

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,4 +2,4 @@
 
 Eigen was created as an Objective-C application. Later, Swift was added. But in early 2016, we began a slow migration to React Native through a separate repo called Emission (for React Native components). You can [read about React Native on our Engineering Blog](https://artsy.github.io/series/react-native-at-artsy/). In 2020, [we merged Emisison and Eigen](https://github.com/artsy/eigen/pull/3022) into one repository.
 
-Check out the [Map to the App](./map_to_the_app.md) for more info.
+Check out the [Preferred Practices](./preferred_practices.md) for more info.

--- a/docs/preferred_practices.md
+++ b/docs/preferred_practices.md
@@ -71,6 +71,12 @@ Data should be loaded from [Metaphysics](https://github.com/artsy/metaphysics), 
   - [A top-level Relay component](https://github.com/artsy/eigen/blob/39644610eb2a5609d992f434a7b37b46e0953ff4/src/lib/Scenes/Collection/Collection.tsx)
   - [A fragment container](https://github.com/artsy/eigen/blob/39644610eb2a5609d992f434a7b37b46e0953ff4/src/lib/Scenes/Collection/Components/FeaturedArtists.tsx)
 
+### Prefer Relay containers (Higher Order Components) over Hooks
+
+We have a preference for Relay containers due to `relay-hooks` hooks not being compatible with Relay containers which represent the majority of our components using Relay.
+
+- [Relay Container approach](https://github.com/artsy/eigen/blob/21fbf9e24eaa281f3e16609da5d38a9fb62a5449/src/lib/Scenes/MyAccount/MyAccount.tsx#L70)
+
 ### styled-system / styled-components
 
 - Our use of [styled-components](https://www.styled-components.com) was supplemented by [styled-system](https://github.com/jxnblk/styled-system) in [#1016](https://github.com/artsy/emission/pull/1016).


### PR DESCRIPTION
Co-authored-by: Mounir Dhahri <mounir.dhahri@ensi-uma.tn>

The type of this PR is: **Documentation**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->


### Description

- Renames map_to_app to preferred_practices 
- Adds section in preferred_practices on relay containers

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434