### PR TITLE
fix for vr subsections margin

### DIFF
--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomSubsections.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomSubsections.tsx
@@ -16,14 +16,18 @@ export const ViewingRoomSubsections: React.FC<ViewingRoomSubsectionProps> = (pro
       {subsections.map((subsection, index) => (
         <Box key={index} mt="3">
           {!!subsection.title && (
-            <Text mb="1" mx="2" variant="title" style={maxWidth}>
-              {subsection.title}
-            </Text>
+            <Box mx="2" testID="subsection">
+              <Text mb="1" variant="title" style={maxWidth}>
+                {subsection.title}
+              </Text>
+            </Box>
           )}
           {!!subsection.body && (
-            <Text mb="2" mx="2" variant="text" style={maxWidth}>
-              {subsection.body}
-            </Text>
+            <Box mx="2">
+              <Text mb="2" variant="text" style={maxWidth}>
+                {subsection.body}
+              </Text>
+            </Box>
           )}
           {!!subsection.image?.imageURLs?.normalized && (
             <OpaqueImageView
@@ -32,9 +36,11 @@ export const ViewingRoomSubsections: React.FC<ViewingRoomSubsectionProps> = (pro
             />
           )}
           {!!subsection.caption && (
-            <Text mt="1" mx="2" variant="caption" color="black60">
-              {subsection.caption}
-            </Text>
+            <Box mx="2">
+              <Text mt="1" variant="caption" color="black60">
+                {subsection.caption}
+              </Text>
+            </Box>
           )}
         </Box>
       ))}

--- a/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomSubsections-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomSubsections-tests.tsx
@@ -28,12 +28,13 @@ describe("ViewingRoomSubsections", () => {
   beforeEach(() => {
     mockEnvironment = createMockEnvironment()
   })
+
   it("renders a Box for each subsection", () => {
     const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironment.mock.resolveMostRecentOperation((operation) => {
       const result = MockPayloadGenerator.generate(operation)
       return result
     })
-    expect(tree.root.findAllByType(Box)).toHaveLength(1)
+    expect(tree.root.findAllByType(Box).filter((box) => box.props.testID === "subsection")).toHaveLength(1)
   })
 })


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves https://www.notion.so/artsy/UI-Viewing-room-page-padding-is-gone-46a54ca7a0ca4e56bf7ea6ffa705589b

### Description

<!-- Implementation description -->

I fixed the margins for VR subsections. #trivial

I noticed that the issue actually is a bit deeper, so I created https://artsyproduct.atlassian.net/browse/MX-534 to investigate and fix.


Before
<img width="393" alt="Screenshot 2020-09-14 at 16 17 51" src="https://user-images.githubusercontent.com/100233/93106503-a324db00-f6b0-11ea-9e10-d4555633236f.png">

After
<img width="412" alt="Screenshot 2020-09-14 at 16 25 10" src="https://user-images.githubusercontent.com/100233/93106518-a8822580-f6b0-11ea-9122-ff2f32b10d42.png">


### PR Checklist (tick all before merging)



<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434