### PR TITLE
Fix issue with register by field on auctions rail

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -22,6 +22,7 @@ upcoming:
     - Fix app crash when tapping fair map - brian
     - Adds new inquiry buttons and modal behind lab option - lily
     - Fix new works for you rail sorting- mounir
+    - Fix missing date issue on auctions rail at home - mounir
 
 releases:
   - version: 6.6.2

--- a/src/lib/Scenes/Home/Components/SalesRail.tsx
+++ b/src/lib/Scenes/Home/Components/SalesRail.tsx
@@ -34,6 +34,14 @@ const SalesRail: React.FC<Props & RailScrollProps> = (props) => {
   const listRef = useRef<FlatList<any>>()
   const tracking = useTracking()
 
+  const getSaleSubtitle = (liveStartAt?: string | null, displayTimelyAt?: string | null) => {
+    const subtitle = !!liveStartAt ? "Live Auction" : "Timed Auction"
+    // We are getting a line break from metaphysics that is used in viewing rooms
+    // See https://www.notion.so/artsy/Seeing-register-by-in-time-field-on-Auction-cards-9e2e742a85e5457db62607a1655507cd
+    const dateAt = capitalize(displayTimelyAt?.replace(/(\n)/gm, " ") || "")
+    return subtitle + " • " + dateAt
+  }
+
   useImperativeHandle(props.scrollRef, () => ({
     scrollToTop: () => listRef.current?.scrollToOffset({ offset: 0, animated: false }),
   }))
@@ -99,9 +107,8 @@ const SalesRail: React.FC<Props & RailScrollProps> = (props) => {
                   <Sans numberOfLines={2} weight="medium" size="3t">
                     {result?./* STRICTNESS_MIGRATION */ name}
                   </Sans>
-                  <Sans numberOfLines={1} size="3t" color="black60" data-test-id="sale-subtitle">
-                    {!!result?./* STRICTNESS_MIGRATION */ liveStartAt ? "Live Auction" : "Timed Auction"} •{" "}
-                    {capitalize(result?.displayTimelyAt! /* STRICTNESS_MIGRATION */)}
+                  <Sans numberOfLines={1} size="3t" color="black60" data-test-id="sale-subtitle" ellipsizeMode="middle">
+                    {getSaleSubtitle(result?.liveStartAt, result?.displayTimelyAt).trim()}
                   </Sans>
                 </MetadataContainer>
               </View>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This resolves https://www.notion.so/artsy/Seeing-register-by-in-time-field-on-Auction-cards-9e2e742a85e5457db62607a1655507cd

### Description
Fix issue with register by at Auctions rail on Home screen
<img width="287" alt="Screenshot 2020-09-14 at 18 10 01" src="https://user-images.githubusercontent.com/11945712/93110654-e9c90400-f6b5-11ea-939f-65847c1b1712.png">

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434