### PR TITLE
fix ArtworkArtists padding

### DIFF
--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -216,16 +216,15 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ViewableItemRefs> = 
         switch (item) {
           case "topArtistSeries":
             return (
-              <Box my={1}>
-                <ArtistSeriesMoreSeriesFragmentContainer
-                  contextScreenOwnerId={artist.internalID}
-                  contextScreenOwnerSlug={artist.slug}
-                  contextScreenOwnerType={OwnerType.artist}
-                  contextModule={ContextModule.artistSeriesRail}
-                  artist={artist}
-                  artistSeriesHeader="Top Artist Series"
-                />
-              </Box>
+              <ArtistSeriesMoreSeriesFragmentContainer
+                contextScreenOwnerId={artist.internalID}
+                contextScreenOwnerSlug={artist.slug}
+                contextScreenOwnerType={OwnerType.artist}
+                contextModule={ContextModule.artistSeriesRail}
+                artist={artist}
+                artistSeriesHeader="Top Artist Series"
+                mt={2}
+              />
             )
           case "notableWorks":
             return <ArtistNotableWorksRailFragmentContainer artist={artist} {...props} />


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves https://www.notion.so/artsy/UI-ArtistSeries-work-added-inconsistent-padding-at-top-of-ArtistArtworks-tab-content-2cbf56880f764330a11e75705c12e37c

### Description

![image](https://user-images.githubusercontent.com/1242537/93112405-dfa40700-f6af-11ea-9331-c8f6a1137b68.png)

![image](https://user-images.githubusercontent.com/1242537/93112437-ea5e9c00-f6af-11ea-99f7-e56798299085.png)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
