### PR TITLE
Fix artwork page consignment link

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -24,6 +24,7 @@ upcoming:
     - Adds new inquiry buttons and modal behind lab option - lily
     - Fix new works for you rail sorting- mounir
     - Fix missing date issue on auctions rail at home - mounir
+    - Fix navigation bug on Artwork consign button - david
 
 releases:
   - version: 6.6.2

--- a/src/lib/Scenes/Artwork/Components/ArtworkExtraLinks/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkExtraLinks/__tests__/index-tests.tsx
@@ -18,10 +18,29 @@ import { ArtworkExtraLinks_artwork } from "__generated__/ArtworkExtraLinks_artwo
 import { AuctionTimerState } from "lib/Components/Bidding/Components/Timer"
 import { postEvent } from "lib/NativeModules/Events"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
-import { mockTracking } from "lib/tests/mockTracking"
+import { __appStoreTestUtils__, AppStoreProvider } from "lib/store/AppStore"
+
+function getWrapper({
+  artwork,
+  auctionState,
+}: {
+  artwork: ArtworkExtraLinks_artwork
+  auctionState?: AuctionTimerState
+}) {
+  return mount(
+    <AppStoreProvider>
+      <Theme>
+        <ArtworkExtraLinks artwork={artwork} auctionState={auctionState!} />
+      </Theme>
+    </AppStoreProvider>
+  )
+}
 
 describe("ArtworkExtraLinks", () => {
-  it("redirects to consignments flow when consignments link is clicked", () => {
+  beforeEach(() => {
+    ;(SwitchBoard.presentNavigationViewController as jest.Mock).mockReset()
+  })
+  it("redirects to /sales when consignments link is clicked from outside of sell tab", () => {
     const artwork = {
       ...ArtworkFixture,
       isForSale: true,
@@ -32,22 +51,38 @@ describe("ArtworkExtraLinks", () => {
         },
       ],
     }
-    const component = mount(
-      <Theme>
-        <ArtworkExtraLinks
-          artwork={artwork}
-          // @ts-ignore STRICTNESS_MIGRATION
-          auctionState={null}
-        />
-      </Theme>
-    )
+
+    const component = getWrapper({ artwork })
     const consignmentsLink = component.find(Text).at(1)
     // @ts-ignore STRICTNESS_MIGRATION
     const texts = component.find(Sans).map((x) => x.text())
 
     expect(texts[0]).toContain("Consign with Artsy.")
     consignmentsLink.props().onPress()
-    expect(SwitchBoard.presentNavigationViewController).toHaveBeenCalledWith(expect.anything(), "/consign/submission")
+    expect(SwitchBoard.presentNavigationViewController).toHaveBeenCalledWith(expect.anything(), "/sales")
+  })
+
+  it("redirects to /collections/my-collection/marketing-landing when consignments link is clicked from within sell tab", () => {
+    const artwork = {
+      ...ArtworkFixture,
+      isForSale: true,
+      artists: [
+        {
+          name: "Santa",
+          isConsignable: true,
+        },
+      ],
+    }
+
+    __appStoreTestUtils__?.injectState({ native: { sessionState: { selectedTab: "sell" } } })
+    const component = getWrapper({ artwork })
+    const consignmentsLink = component.find(Text).at(1)
+
+    consignmentsLink.props().onPress()
+    expect(SwitchBoard.presentNavigationViewController).toHaveBeenCalledWith(
+      expect.anything(),
+      "/collections/my-collection/marketing-landing"
+    )
   })
 
   describe("for an artwork with more than 1 consignable artist", () => {
@@ -66,15 +101,7 @@ describe("ArtworkExtraLinks", () => {
           },
         ],
       }
-      const component = mount(
-        <Theme>
-          <ArtworkExtraLinks
-            artwork={artwork}
-            // @ts-ignore STRICTNESS_MIGRATION
-            auctionState={null}
-          />
-        </Theme>
-      )
+      const component = getWrapper({ artwork })
       expect(component.text()).toContain("Want to sell a work by these artists?")
     })
 
@@ -90,15 +117,7 @@ describe("ArtworkExtraLinks", () => {
         ],
       }
 
-      const component = mount(
-        <Theme>
-          <ArtworkExtraLinks
-            artwork={artwork}
-            // @ts-ignore STRICTNESS_MIGRATION
-            auctionState={null}
-          />
-        </Theme>
-      )
+      const component = getWrapper({ artwork })
       expect(component.text()).toContain("Consign with Artsy.")
     })
 
@@ -113,15 +132,7 @@ describe("ArtworkExtraLinks", () => {
           },
         ],
       }
-      const component = mount(
-        <Theme>
-          <ArtworkExtraLinks
-            artwork={artwork}
-            // @ts-ignore STRICTNESS_MIGRATION
-            auctionState={null}
-          />
-        </Theme>
-      )
+      const component = getWrapper({ artwork })
       expect(component).toEqual({})
     })
   })
@@ -138,15 +149,7 @@ describe("ArtworkExtraLinks", () => {
           },
         ],
       }
-      const component = mount(
-        <Theme>
-          <ArtworkExtraLinks
-            artwork={artwork}
-            // @ts-ignore STRICTNESS_MIGRATION
-            auctionState={null}
-          />
-        </Theme>
-      )
+      const component = getWrapper({ artwork })
       expect(component.text()).toContain("Want to sell a work by Santa?")
     })
 
@@ -161,15 +164,7 @@ describe("ArtworkExtraLinks", () => {
           },
         ],
       }
-      const component = mount(
-        <Theme>
-          <ArtworkExtraLinks
-            artwork={artwork}
-            // @ts-ignore STRICTNESS_MIGRATION
-            auctionState={null}
-          />
-        </Theme>
-      )
+      const component = getWrapper({ artwork })
       expect(component.text()).toContain("Consign with Artsy.")
     })
   })
@@ -189,15 +184,7 @@ describe("ArtworkExtraLinks", () => {
         ],
       }
 
-      const component = mount(
-        <Theme>
-          <ArtworkExtraLinks
-            artwork={artwork}
-            // @ts-ignore STRICTNESS_MIGRATION
-            auctionState={null}
-          />
-        </Theme>
-      )
+      const component = getWrapper({ artwork })
       expect(component.text()).not.toContain("Read our FAQ")
       expect(component.text()).not.toContain("ask a specialist")
     })
@@ -216,15 +203,7 @@ describe("ArtworkExtraLinks", () => {
         ],
       }
 
-      const component = mount(
-        <Theme>
-          <ArtworkExtraLinks
-            artwork={artwork}
-            // @ts-ignore STRICTNESS_MIGRATION
-            auctionState={null}
-          />
-        </Theme>
-      )
+      const component = getWrapper({ artwork })
       expect(component.text()).toContain("Read our FAQ")
       expect(component.text()).toContain("ask a specialist")
     })
@@ -238,15 +217,7 @@ describe("ArtworkExtraLinks", () => {
         artists: [{ name: "Santa", isConsignable: true }],
       }
 
-      const component = mount(
-        <Theme>
-          <ArtworkExtraLinks
-            artwork={artwork}
-            // @ts-ignore STRICTNESS_MIGRATION
-            auctionState={null}
-          />
-        </Theme>
-      )
+      const component = getWrapper({ artwork })
       expect(component.text()).toContain("Read our FAQ")
       expect(component.text()).toContain("ask a specialist")
     })
@@ -272,12 +243,7 @@ describe("ArtworkExtraLinks", () => {
       ],
     }
 
-    const Component = mockTracking(() => (
-      <Theme>
-        <ArtworkExtraLinks artwork={artwork} auctionState={AuctionTimerState.CLOSING} />
-      </Theme>
-    ))
-    const component = mount(<Component />)
+    const component = getWrapper({ artwork, auctionState: AuctionTimerState.CLOSING })
 
     it("renders Auction specific text", () => {
       expect(component.find(Sans).at(0).text()).toContain(
@@ -308,51 +274,30 @@ describe("ArtworkExtraLinks", () => {
         ],
       }
 
-      const componentWithNoLink = mount(
-        <Theme>
-          <ArtworkExtraLinks
-            artwork={notForSaleArtwork}
-            // @ts-ignore STRICTNESS_MIGRATION
-            auctionState={null}
-          />
-        </Theme>
-      )
+      const componentWithNoLink = getWrapper({ artwork: notForSaleArtwork })
       expect(componentWithNoLink.find(Sans).length).toEqual(0)
     })
 
     it("hides auction links when auctionState is closed", () => {
-      const componentWithEndedAuctionState = mount(
-        <Theme>
-          <ArtworkExtraLinks artwork={artwork} auctionState={AuctionTimerState.CLOSED} />
-        </Theme>
-      )
+      const componentWithEndedAuctionState = getWrapper({ artwork, auctionState: AuctionTimerState.CLOSED })
       expect(componentWithEndedAuctionState.text()).not.toContain("By placing a bid you agree to")
     })
 
     it("displays auction links when auctionState is closing", () => {
-      const componentWithEndedAuctionState = mount(
-        <Theme>
-          <ArtworkExtraLinks artwork={artwork} auctionState={AuctionTimerState.CLOSING} />
-        </Theme>
-      )
+      const componentWithEndedAuctionState = getWrapper({ artwork, auctionState: AuctionTimerState.CLOSING })
       expect(componentWithEndedAuctionState.text()).toContain("By placing a bid you agree to")
     })
 
     it("displays auction links when auctionState is live_integration_upcoming", () => {
-      const componentWithEndedAuctionState = mount(
-        <Theme>
-          <ArtworkExtraLinks artwork={artwork} auctionState={AuctionTimerState.LIVE_INTEGRATION_UPCOMING} />
-        </Theme>
-      )
+      const componentWithEndedAuctionState = getWrapper({
+        artwork,
+        auctionState: AuctionTimerState.LIVE_INTEGRATION_UPCOMING,
+      })
       expect(componentWithEndedAuctionState.text()).toContain("By placing a bid you agree to")
     })
 
     it("displays auction links when auctionState is inProgress", () => {
-      const componentWithEndedAuctionState = mount(
-        <Theme>
-          <ArtworkExtraLinks artwork={artwork} auctionState={AuctionTimerState.CLOSING} />
-        </Theme>
-      )
+      const componentWithEndedAuctionState = getWrapper({ artwork, auctionState: AuctionTimerState.CLOSING })
       expect(componentWithEndedAuctionState.text()).toContain("By placing a bid you agree to")
     })
 

--- a/src/lib/Scenes/Artwork/Components/__tests__/CommercialInformation-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/CommercialInformation-tests.tsx
@@ -2,6 +2,7 @@
 import { mount } from "enzyme"
 import { ArtworkFixture } from "lib/__fixtures__/ArtworkFixture"
 import { Countdown } from "lib/Components/Bidding/Components/Timer"
+import { AppStoreProvider } from "lib/store/AppStore"
 import "moment-timezone"
 import { Sans, Theme } from "palette"
 import React from "react"
@@ -12,6 +13,14 @@ import { BuyNowButton } from "../CommercialButtons/BuyNowButton"
 import { CommercialButtons } from "../CommercialButtons/CommercialButtons"
 import { CommercialEditionSetInformation } from "../CommercialEditionSetInformation"
 import { CommercialInformationTimerWrapper, SaleAvailability } from "../CommercialInformation"
+
+const Wrapper: React.FC<{}> = ({ children }) => {
+  return (
+    <Theme>
+      <AppStoreProvider>{children}</AppStoreProvider>
+    </Theme>
+  )
+}
 
 jest.mock("lib/NativeModules/SwitchBoard", () => ({
   presentNavigationViewController: jest.fn(),
@@ -26,19 +35,13 @@ describe("CommercialInformation", () => {
     }
 
     const component = mount(
-      <Theme>
+      <Wrapper>
         <CommercialInformationTimerWrapper artwork={ForSaleArtwork as any} me={{ identityVerified: false } as any} />
-      </Theme>
+      </Wrapper>
     )
 
     expect(component.text()).toContain("For sale")
-    expect(
-      component
-        .find(Sans)
-        .at(1)
-        .render()
-        .text()
-    ).toMatchInlineSnapshot(`"From I'm a Gallery"`)
+    expect(component.find(Sans).at(1).render().text()).toMatchInlineSnapshot(`"From I'm a Gallery"`)
     expect(component.find(ArtworkExtraLinks).text()).toContain("Consign with Artsy.")
   })
 
@@ -50,18 +53,13 @@ describe("CommercialInformation", () => {
     }
 
     const component = mount(
-      <Theme>
+      <Wrapper>
         <CommercialInformationTimerWrapper artwork={OnHoldArtwork as any} me={{ identityVerified: false } as any} />
-      </Theme>
+      </Wrapper>
     )
 
     expect(component.text()).toContain("On hold")
-    expect(
-      component
-        .find(SaleAvailability)
-        .first()
-        .prop("dotColor")
-    ).toEqual("#F1AF1B")
+    expect(component.find(SaleAvailability).first().prop("dotColor")).toEqual("#F1AF1B")
   })
 
   it("renders red indicator and correct message when artwork is sold", () => {
@@ -72,18 +70,13 @@ describe("CommercialInformation", () => {
     }
 
     const component = mount(
-      <Theme>
+      <Wrapper>
         <CommercialInformationTimerWrapper artwork={SoldArtwork as any} me={{ identityVerified: false } as any} />
-      </Theme>
+      </Wrapper>
     )
 
     expect(component.text()).toContain("Sold")
-    expect(
-      component
-        .find(SaleAvailability)
-        .first()
-        .prop("dotColor")
-    ).toEqual("#F7625A")
+    expect(component.find(SaleAvailability).first().prop("dotColor")).toEqual("#F7625A")
   })
 
   it("renders green indicator and correct message when artwork is for sale", () => {
@@ -94,18 +87,13 @@ describe("CommercialInformation", () => {
     }
 
     const component = mount(
-      <Theme>
+      <Wrapper>
         <CommercialInformationTimerWrapper artwork={ForSaleArtwork as any} me={{ identityVerified: false } as any} />
-      </Theme>
+      </Wrapper>
     )
 
     expect(component.text()).toContain("For sale")
-    expect(
-      component
-        .find(SaleAvailability)
-        .first()
-        .prop("dotColor")
-    ).toEqual("#0EDA83")
+    expect(component.find(SaleAvailability).first().prop("dotColor")).toEqual("#0EDA83")
   })
 
   it("renders Bidding Closed and no CommercialButtons for auction works when the auction has ended", () => {
@@ -119,12 +107,12 @@ describe("CommercialInformation", () => {
       },
     }
     const component = mount(
-      <Theme>
+      <Wrapper>
         <CommercialInformationTimerWrapper
           artwork={workInEndedAuction as any}
           me={{ identityVerified: false } as any}
         />
-      </Theme>
+      </Wrapper>
     )
 
     expect(component.text()).toContain("Bidding closed")
@@ -142,12 +130,12 @@ describe("CommercialInformation", () => {
     }
 
     const component = mount(
-      <Theme>
+      <Wrapper>
         <CommercialInformationTimerWrapper
           artwork={CommercialInformationArtworkClosedAuction as any}
           me={{ identityVerified: false } as any}
         />
-      </Theme>
+      </Wrapper>
     )
     expect(component.text()).toContain("Bidding closed")
     expect(component.text()).not.toContain("I'm a Gallery")
@@ -196,12 +184,12 @@ describe("CommercialInformation", () => {
       },
     }
     const component = mount(
-      <Theme>
+      <Wrapper>
         <CommercialInformationTimerWrapper
           artwork={CommercialInformationArtworkNoData as any}
           me={{ identityVerified: false } as any}
         />
-      </Theme>
+      </Wrapper>
     )
     expect(component.text()).not.toContain("For sale")
     expect(component.text()).not.toContain("I'm a Gallery")
@@ -215,33 +203,29 @@ describe("CommercialInformation", () => {
       isForSale: false,
     }
     const component = mount(
-      <Theme>
+      <Wrapper>
         <CommercialInformationTimerWrapper
           artwork={CommercialInformationArtworkNonCommercial as any}
           me={{ identityVerified: false } as any}
         />
-      </Theme>
+      </Wrapper>
     )
     expect(component.find(Sans).at(1).render().text()).toMatchInlineSnapshot(`"At I'm a Gallery"`)
   })
 
   it("renders consign with Artsy text", () => {
     const component = mount(
-      <Theme>
+      <Wrapper>
         <CommercialInformationTimerWrapper
           artwork={CommercialInformationArtwork as any}
           me={{ identityVerified: false } as any}
         />
-      </Theme>
+      </Wrapper>
     )
 
-    expect(
-      component
-        .find(Sans)
-        .at(2)
-        .render()
-        .text()
-    ).toMatchInlineSnapshot(`"Want to sell a work by Santa Claus? Consign with Artsy."`)
+    expect(component.find(Sans).at(2).render().text()).toMatchInlineSnapshot(
+      `"Want to sell a work by Santa Claus? Consign with Artsy."`
+    )
   })
 
   it("when edition set is selected its internalID is passed to CommercialButtons for mutation", () => {
@@ -278,12 +262,12 @@ describe("CommercialInformation", () => {
     }
 
     const component = mount(
-      <Theme>
+      <Wrapper>
         <CommercialInformationTimerWrapper
           artwork={artworkWithEditionSets as any}
           me={{ identityVerified: false } as any}
         />
-      </Theme>
+      </Wrapper>
     )
 
     // Expect the component to default to first edition set's internalID
@@ -300,13 +284,13 @@ describe("CommercialInformation", () => {
 describe("CommercialInformation buttons and coundtown timer", () => {
   it("renders CountDownTimer and BidButton when Artwork is in an auction", () => {
     const component = mount(
-      <Theme>
+      <Wrapper>
         <CommercialInformationTimerWrapper
           artwork={CommercialInformationArtworkInAuction as any}
           me={{ identityVerified: false } as any}
           tracking={{ trackEvent: jest.fn() } as any}
         />
-      </Theme>
+      </Wrapper>
     )
     expect(component.find(Countdown).length).toEqual(1)
     expect(component.find(BidButton).length).toEqual(1)
@@ -321,13 +305,13 @@ describe("CommercialInformation buttons and coundtown timer", () => {
     }
 
     const component = mount(
-      <Theme>
+      <Wrapper>
         <CommercialInformationTimerWrapper
           artwork={CommercialInformationSoldArtworkInAuction as any}
           me={{ identityVerified: false } as any}
           tracking={{ trackEvent: jest.fn() } as any}
         />
-      </Theme>
+      </Wrapper>
     )
     expect(component.find(Countdown).length).toEqual(0)
     expect(component.find(BidButton).length).toEqual(0)
@@ -336,12 +320,12 @@ describe("CommercialInformation buttons and coundtown timer", () => {
 
   it("doesn't render CountDownTimer or BidButton when not in auction", () => {
     const component = mount(
-      <Theme>
+      <Wrapper>
         <CommercialInformationTimerWrapper
           artwork={CommercialInformationAcquierableArtwork as any}
           me={{ identityVerified: false } as any}
         />
-      </Theme>
+      </Wrapper>
     )
     expect(component.find(Countdown).length).toEqual(0)
     expect(component.find(BidButton).length).toEqual(0)
@@ -371,12 +355,12 @@ describe("ArtworkExtraLinks", () => {
     }
 
     const component = mount(
-      <Theme>
+      <Wrapper>
         <CommercialInformationTimerWrapper
           artwork={inquireableArtwork as any}
           me={{ identityVerified: false } as any}
         />
-      </Theme>
+      </Wrapper>
     )
     expect(component.find(ArtworkExtraLinks).length).toEqual(0)
   })
@@ -394,12 +378,12 @@ describe("ArtworkExtraLinks", () => {
     }
 
     const component = mount(
-      <Theme>
+      <Wrapper>
         <CommercialInformationTimerWrapper
           artwork={acquireableArtwork as any}
           me={{ identityVerified: false } as any}
         />
-      </Theme>
+      </Wrapper>
     )
     expect(component.find(ArtworkExtraLinks).length).toEqual(1)
   })
@@ -417,9 +401,9 @@ describe("ArtworkExtraLinks", () => {
     }
 
     const component = mount(
-      <Theme>
+      <Wrapper>
         <CommercialInformationTimerWrapper artwork={offerableArtwork as any} me={{ identityVerified: false } as any} />
-      </Theme>
+      </Wrapper>
     )
     expect(component.find(ArtworkExtraLinks).length).toEqual(1)
   })
@@ -431,13 +415,13 @@ describe("ArtworkExtraLinks", () => {
     }
 
     const component = mount(
-      <Theme>
+      <Wrapper>
         <CommercialInformationTimerWrapper
           artwork={nonConsignableBiddableArtwork as any}
           me={{ identityVerified: false } as any}
           tracking={{ trackEvent: jest.fn() } as any}
         />
-      </Theme>
+      </Wrapper>
     )
     expect(component.find(ArtworkExtraLinks).length).toEqual(1)
   })


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [CSGN-287]

### Description

This fixes an issue where tapping 'consign with artsy' on the artwork page would open the sell tab landing page in an undismissable modal without actually switching tab.

Now it just switches to the sell tab, unless it's already in the sell tab, in which case it pushes a new version of the landing page on the nav stack. This mirrors the behaviour of the consignments CTA on the artist page.

#### Before

![consign-link-before](https://user-images.githubusercontent.com/1242537/93236190-69b6a300-f776-11ea-9295-8bb9a3329ff7.gif)

#### After

![consign-link-after](https://user-images.githubusercontent.com/1242537/93236208-6fac8400-f776-11ea-97ad-ea8fa966156e.gif)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[CSGN-287]: https://artsyproduct.atlassian.net/browse/CSGN-287