### PR TITLE
FX-2264/FX-2253/FX-2266: Small QA items for artist series

### DIFF
--- a/src/lib/Components/Artist/ArtistArtworks/ArtistNotableWorksRail.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistNotableWorksRail.tsx
@@ -50,7 +50,7 @@ const ArtistNotableWorksRail: React.FC<ArtistNotableWorksRailProps> = ({ artist 
 
   return (
     <Box>
-      <Box mt={2}>
+      <Box mt={1}>
         <SectionTitle title="Notable Works" />
       </Box>
       <ArtistNotableWorksRailWrapper>

--- a/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -261,7 +261,7 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
 
           {!autoFetch && !!hasMore() && (
             <Button mt={5} mb={3} variant="secondaryGray" size="large" block onPress={this.fetchNextPage}>
-              Show More
+              Show more
             </Button>
           )}
 

--- a/src/lib/Components/HeaderTabGridPlaceholder.tsx
+++ b/src/lib/Components/HeaderTabGridPlaceholder.tsx
@@ -1,4 +1,4 @@
-import { PlaceholderImage, PlaceholderText } from "lib/utils/placeholders"
+import { PlaceholderGrid, PlaceholderText } from "lib/utils/placeholders"
 import { Flex, Separator, Spacer, Theme } from "palette"
 import React from "react"
 
@@ -29,18 +29,7 @@ export const HeaderTabsGridPlaceholder: React.FC = () => (
       <Separator />
       <Spacer mb={3} />
       {/* masonry grid */}
-      <Flex mx={2} flexDirection="row">
-        <Flex mr={1} style={{ flex: 1 }}>
-          <PlaceholderImage height={92} />
-          <PlaceholderImage height={172} />
-          <PlaceholderImage height={82} />
-        </Flex>
-        <Flex ml={1} style={{ flex: 1 }}>
-          <PlaceholderImage height={182} />
-          <PlaceholderImage height={132} />
-          <PlaceholderImage height={86} />
-        </Flex>
-      </Flex>
+      <PlaceholderGrid />
     </Flex>
   </Theme>
 )

--- a/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
@@ -6,13 +6,14 @@ import { ArtistSeriesArtworksFragmentContainer } from "lib/Scenes/ArtistSeries/A
 import { ArtistSeriesHeaderFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesHeader"
 import { ArtistSeriesMetaFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesMeta"
 import { ArtistSeriesMoreSeriesFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
-import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import { ProvideScreenTracking } from "lib/utils/track"
-import { Box, Theme } from "palette"
+import { Box, Separator, space, Spacer, Theme } from "palette"
 import React from "react"
 
+import { PlaceholderBox, PlaceholderGrid, PlaceholderRaggedText, PlaceholderText } from "lib/utils/placeholders"
+import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { OwnerEntityTypes, PageNames } from "lib/utils/track/schema"
-import { ScrollView } from "react-native"
+import { ScrollView, View } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 interface ArtistSeriesProps {
   artistSeries: ArtistSeries_artistSeries
@@ -82,6 +83,33 @@ export const ArtistSeriesFragmentContainer = createFragmentContainer(ArtistSerie
   `,
 })
 
+const ArtistSeriesPlaceholder: React.FC<{}> = ({}) => {
+  return (
+    <View style={{ flex: 1, padding: space(2) }}>
+      {/* Series header image */}
+      <View style={{ flexDirection: "row", justifyContent: "center" }}>
+        <PlaceholderBox height={180} width={180} />
+      </View>
+      <Spacer mb={2} />
+      {/* Artist Series name */}
+      <PlaceholderText width={250} />
+      <Spacer mb={1} />
+      {/* Artist Entity Header */}
+      <PlaceholderText width={250} />
+      <Spacer mb={1} />
+      {/* Series description */}
+      <View style={{ width: 300 }}>
+        <PlaceholderRaggedText numLines={4} />
+      </View>
+      <Spacer mb={3} />
+      <Separator />
+      <Spacer mb={3} />
+      {/* masonry grid */}
+      <PlaceholderGrid />
+    </View>
+  )
+}
+
 export const ArtistSeriesQueryRenderer: React.SFC<{ artistSeriesID: string }> = ({ artistSeriesID }) => {
   return (
     <QueryRenderer<ArtistSeriesQuery>
@@ -97,7 +125,10 @@ export const ArtistSeriesQueryRenderer: React.SFC<{ artistSeriesID: string }> = 
       variables={{
         artistSeriesID,
       }}
-      render={renderWithLoadProgress(ArtistSeriesFragmentContainer)}
+      render={renderWithPlaceholder({
+        Container: ArtistSeriesFragmentContainer,
+        renderPlaceholder: () => <ArtistSeriesPlaceholder />,
+      })}
     />
   )
 }

--- a/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
@@ -7,13 +7,13 @@ import { ArtistSeriesHeaderFragmentContainer } from "lib/Scenes/ArtistSeries/Art
 import { ArtistSeriesMetaFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesMeta"
 import { ArtistSeriesMoreSeriesFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
 import { ProvideScreenTracking } from "lib/utils/track"
-import { Box, Separator, space, Spacer, Theme } from "palette"
+import { Box, Spacer, Theme } from "palette"
 import React from "react"
 
-import { PlaceholderBox, PlaceholderGrid, PlaceholderRaggedText, PlaceholderText } from "lib/utils/placeholders"
+import { PlaceholderBox, PlaceholderGrid, PlaceholderText } from "lib/utils/placeholders"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { OwnerEntityTypes, PageNames } from "lib/utils/track/schema"
-import { ScrollView, View } from "react-native"
+import { ScrollView } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 interface ArtistSeriesProps {
   artistSeries: ArtistSeries_artistSeries
@@ -85,28 +85,23 @@ export const ArtistSeriesFragmentContainer = createFragmentContainer(ArtistSerie
 
 const ArtistSeriesPlaceholder: React.FC<{}> = ({}) => {
   return (
-    <View style={{ flex: 1, padding: space(2) }}>
-      {/* Series header image */}
-      <View style={{ flexDirection: "row", justifyContent: "center" }}>
-        <PlaceholderBox height={180} width={180} />
-      </View>
-      <Spacer mb={2} />
-      {/* Artist Series name */}
-      <PlaceholderText width={250} />
-      <Spacer mb={1} />
-      {/* Artist Entity Header */}
-      <PlaceholderText width={250} />
-      <Spacer mb={1} />
-      {/* Series description */}
-      <View style={{ width: 300 }}>
-        <PlaceholderRaggedText numLines={4} />
-      </View>
-      <Spacer mb={3} />
-      <Separator />
-      <Spacer mb={3} />
-      {/* masonry grid */}
-      <PlaceholderGrid />
-    </View>
+    <Theme>
+      <Box>
+        <Box px="2" pt="1">
+          {/* Series header image */}
+          <PlaceholderBox height={180} width={180} alignSelf="center" />
+          <Spacer mb={2} />
+          {/* Artist Series name */}
+          <PlaceholderText width={220} />
+          {/* Artist series info */}
+          <PlaceholderText width={190} />
+          <PlaceholderText width={190} />
+        </Box>
+        <Spacer mb={2} />
+        {/* masonry grid */}
+        <PlaceholderGrid />
+      </Box>
+    </Theme>
   )
 }
 

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesFullArtistSeriesList.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesFullArtistSeriesList.tsx
@@ -7,9 +7,9 @@ import { ArtistSeriesListItem } from "lib/Scenes/ArtistSeries/ArtistSeriesListIt
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import { ProvideScreenTracking } from "lib/utils/track"
 import { OwnerEntityTypes, PageNames } from "lib/utils/track/schema"
-import { Flex } from "palette"
+import { Box, Flex, Sans } from "palette"
 import React from "react"
-import { ScrollView } from "react-native"
+import { ScrollView, View } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 
 interface FullArtistSeriesListProps {
@@ -30,20 +30,23 @@ export const FullArtistSeriesList: React.FC<FullArtistSeriesListProps> = ({ arti
         context_screen_owner_type: OwnerEntityTypes.AllArtistSeries,
       }}
     >
-      <PageWithSimpleHeader title="Artist Series" noSeparator>
-        <ScrollView style={{ marginTop: 30 }}>
-          {seriesList.map((series, index) => (
-            <Flex key={series?.node?.internalID ?? index} flexDirection="row" mb={1} px={2}>
-              <ArtistSeriesListItem
-                listItem={series}
-                contextModule={ContextModule.artistSeriesRail}
-                contextScreenOwnerType={OwnerType.allArtistSeries}
-                horizontalSlidePosition={index}
-              />
-            </Flex>
-          ))}
-        </ScrollView>
-      </PageWithSimpleHeader>
+      <ScrollView>
+        <Box px="2" py="2">
+          <Sans size="4" weight="medium" textAlign="center">
+            Artist series
+          </Sans>
+        </Box>
+        {seriesList.map((series, index) => (
+          <Flex key={series?.node?.internalID ?? index} flexDirection="row" mb={1} px={2}>
+            <ArtistSeriesListItem
+              listItem={series}
+              contextModule={ContextModule.artistSeriesRail}
+              contextScreenOwnerType={OwnerType.allArtistSeries}
+              horizontalSlidePosition={index}
+            />
+          </Flex>
+        ))}
+      </ScrollView>
     </ProvideScreenTracking>
   )
 }

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesFullArtistSeriesList.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesFullArtistSeriesList.tsx
@@ -1,7 +1,6 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { ArtistSeriesFullArtistSeriesList_artist } from "__generated__/ArtistSeriesFullArtistSeriesList_artist.graphql"
 import { ArtistSeriesFullArtistSeriesListQuery } from "__generated__/ArtistSeriesFullArtistSeriesListQuery.graphql"
-import { PageWithSimpleHeader } from "lib/Components/PageWithSimpleHeader"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { ArtistSeriesListItem } from "lib/Scenes/ArtistSeries/ArtistSeriesListItem"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
@@ -9,7 +8,7 @@ import { ProvideScreenTracking } from "lib/utils/track"
 import { OwnerEntityTypes, PageNames } from "lib/utils/track/schema"
 import { Box, Flex, Sans } from "palette"
 import React from "react"
-import { ScrollView, View } from "react-native"
+import { ScrollView } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 
 interface FullArtistSeriesListProps {

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesFullArtistSeriesList.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesFullArtistSeriesList.tsx
@@ -32,7 +32,7 @@ export const FullArtistSeriesList: React.FC<FullArtistSeriesListProps> = ({ arti
       <ScrollView>
         <Box px="2" py="2">
           <Sans size="4" weight="medium" textAlign="center">
-            Artist series
+            Artist Series
           </Sans>
         </Box>
         {seriesList.map((series, index) => (

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesFullArtistSeriesList-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesFullArtistSeriesList-tests.tsx
@@ -2,9 +2,9 @@ import {
   ArtistSeriesFullArtistSeriesListTestsQuery,
   ArtistSeriesFullArtistSeriesListTestsQueryRawResponse,
 } from "__generated__/ArtistSeriesFullArtistSeriesListTestsQuery.graphql"
-import { PageWithSimpleHeader } from "lib/Components/PageWithSimpleHeader"
 import { ArtistSeriesFullArtistSeriesListFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesFullArtistSeriesList"
 import { ArtistSeriesListItem } from "lib/Scenes/ArtistSeries/ArtistSeriesListItem"
+import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { TouchableOpacity } from "react-native"
@@ -66,7 +66,7 @@ describe("Full Artist Series List", () => {
 
   it("renders the Full Artist Series Page Header", () => {
     const wrapper = getWrapper()
-    expect(wrapper.root.findByType(PageWithSimpleHeader).props.title).toBe("Artist Series")
+    expect(extractText(wrapper.root)).toContain("Artist Series")
   })
 
   it("renders the all of an artist's associated Artist Series", () => {

--- a/src/lib/utils/placeholders.tsx
+++ b/src/lib/utils/placeholders.tsx
@@ -1,4 +1,4 @@
-import { color } from "palette"
+import { color, Flex } from "palette"
 import React, { useContext, useEffect, useMemo, useRef } from "react"
 import { View, ViewStyle } from "react-native"
 import Animated from "react-native-reanimated"
@@ -121,5 +121,22 @@ export const PlaceholderImage: React.FC<{ height: number }> = ({ height }) => {
       <PlaceholderRaggedText numLines={2} seed={height} />
       <View style={{ marginBottom: 20 }} />
     </View>
+  )
+}
+
+export const PlaceholderGrid: React.FC = () => {
+  return (
+    <Flex mx={2} flexDirection="row">
+      <Flex mr={1} style={{ flex: 1 }}>
+        <PlaceholderImage height={92} />
+        <PlaceholderImage height={172} />
+        <PlaceholderImage height={82} />
+      </Flex>
+      <Flex ml={1} style={{ flex: 1 }}>
+        <PlaceholderImage height={182} />
+        <PlaceholderImage height={132} />
+        <PlaceholderImage height={86} />
+      </Flex>
+    </Flex>
   )
 }

--- a/src/lib/utils/placeholders.tsx
+++ b/src/lib/utils/placeholders.tsx
@@ -1,7 +1,9 @@
+import { GenericGridPlaceholder } from "lib/Components/ArtworkGrids/GenericGrid"
 import { color, Flex } from "palette"
 import React, { useContext, useEffect, useMemo, useRef } from "react"
 import { View, ViewStyle } from "react-native"
 import Animated from "react-native-reanimated"
+import { useScreenDimensions } from "./useScreenDimensions"
 
 const PlaceholderContext = React.createContext<{ clock: Animated.Clock }>(null as any)
 
@@ -127,16 +129,7 @@ export const PlaceholderImage: React.FC<{ height: number }> = ({ height }) => {
 export const PlaceholderGrid: React.FC = () => {
   return (
     <Flex mx={2} flexDirection="row">
-      <Flex mr={1} style={{ flex: 1 }}>
-        <PlaceholderImage height={92} />
-        <PlaceholderImage height={172} />
-        <PlaceholderImage height={82} />
-      </Flex>
-      <Flex ml={1} style={{ flex: 1 }}>
-        <PlaceholderImage height={182} />
-        <PlaceholderImage height={132} />
-        <PlaceholderImage height={86} />
-      </Flex>
+      <GenericGridPlaceholder width={useScreenDimensions().width - 40} />
     </Flex>
   )
 }


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves:
[FX-2264]
[FX-2253]
[FX-2266]

### Description

A couple of visual QA items from the artist series launch (we have tickets to track other issues that were brought up!).

In summary:
- Adds a skeleton loading view
![skeleton](https://user-images.githubusercontent.com/2081340/93349418-72a28580-f805-11ea-8822-2325012a41b6.gif)

- Makes the header on the "Full artist list" not sticky
![all-artists](https://user-images.githubusercontent.com/2081340/93349424-78986680-f805-11ea-8bc3-edc5b5da4105.gif)

- Changes case of "show more" button to be sentence case
<img width="352" alt="Screen Shot 2020-09-16 at 10 06 14 AM" src="https://user-images.githubusercontent.com/2081340/93349460-81893800-f805-11ea-9e33-908db44de748.png">

- Updates spacing between Artist Series list and Notable Works rail on artist page
<img width="368" alt="Screen Shot 2020-09-16 at 9 07 33 AM" src="https://user-images.githubusercontent.com/2081340/93349471-84842880-f805-11ea-8041-3d1dcddb899d.png">



### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [X] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [X] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [X] I have documented any follow-up work that this PR will require, or it does not require any.
- [X] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[FX-2264]: https://artsyproduct.atlassian.net/browse/FX-2264
[FX-2253]: https://artsyproduct.atlassian.net/browse/FX-2253
[FX-2266]: https://artsyproduct.atlassian.net/browse/FX-2266

#trivial