### PR TITLE
Move artwork categories to a common util file

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,6 +3,7 @@ upcoming:
   date: TBD
   dev:
     - Move auction CTA button to RN - pavlos
+    - Move artwork categories to a common util file - ashley
   user_facing:
     - Fix navigation bug on Artwork consign button - david
     - Add auction lots rail to the auctions screen - mounir

--- a/src/lib/Scenes/Consignments/Screens/Metadata.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Metadata.tsx
@@ -12,7 +12,7 @@ import {
 } from "react-native"
 import NavigatorIOS from "react-native-navigator-ios"
 
-import { ConsignmentSubmissionCategoryAggregation } from "__generated__/createConsignmentSubmissionMutation.graphql"
+import { artworkMediumCategories } from "lib/utils/artworkMediumCategories"
 import { Serif, Theme } from "palette"
 import { ConsignmentMetadata } from "../"
 import { BottomAlignedButton } from "../Components/BottomAlignedButton"
@@ -26,25 +26,6 @@ interface Props extends ViewProperties {
   updateWithMetadata?: (result: ConsignmentMetadata) => void
   metadata: ConsignmentMetadata
 }
-
-// See: https://github.com/artsy/force/blob/814a03a579290eaac74f910a0db28c2afd9b1753/desktop/apps/consign/client/reducers.js#L22-L38
-const categoryOptions = [
-  { name: "Painting", value: "PAINTING" },
-  { name: "Sculpture", value: "SCULPTURE" },
-  { name: "Photography", value: "PHOTOGRAPHY" },
-  { name: "Print", value: "PRINT" },
-  { name: "Drawing, Collage or other Work on Paper", value: "DRAWING_COLLAGE_OR_OTHER_WORK_ON_PAPER" },
-  { name: "Mixed Media", value: "MIXED_MEDIA" },
-  { name: "Performance Art", value: "PERFORMANCE_ART" },
-  { name: "Installation", value: "INSTALLATION" },
-  { name: "Video/Film/Animation", value: "VIDEO_FILM_ANIMATION" },
-  { name: "Architecture", value: "ARCHITECTURE" },
-  { name: "Fashion Design and Wearable Art", value: "FASHION_DESIGN_AND_WEARABLE_ART" },
-  { name: "Jewelry", value: "JEWELRY" },
-  { name: "Design/Decorative Art", value: "DESIGN_DECORATIVE_ART" },
-  { name: "Textile Arts", value: "TEXTILE_ARTS" },
-  { name: "Other", value: "OTHER" },
-] as Array<{ name: string; value: ConsignmentSubmissionCategoryAggregation }>
 
 interface State extends ConsignmentMetadata {
   showPicker?: boolean
@@ -115,8 +96,8 @@ export default class Metadata extends React.Component<Props, State> {
   showCategorySelection = () => {
     Keyboard.dismiss()
 
-    const category = this.state.category || categoryOptions[0].value
-    const categoryName = this.state.categoryName || categoryOptions[0].name
+    const category = this.state.category || artworkMediumCategories[0].value
+    const categoryName = this.state.categoryName || artworkMediumCategories[0].label
     this.animateStateChange({ showPicker: true, categoryName, category })
   }
 
@@ -124,8 +105,8 @@ export default class Metadata extends React.Component<Props, State> {
   // @ts-ignore STRICTNESS_MIGRATION
   changeCategoryValue = (_value, index) => {
     this.setState({
-      categoryName: categoryOptions[index].name,
-      category: categoryOptions[index].value,
+      categoryName: artworkMediumCategories[index].label,
+      category: artworkMediumCategories[index].value,
     })
   }
 
@@ -277,8 +258,8 @@ export default class Metadata extends React.Component<Props, State> {
               selectedValue={this.state.category}
               onValueChange={this.changeCategoryValue}
             >
-              {categoryOptions.map((opt) => (
-                <Picker.Item color="black" label={opt.name} value={opt.value} key={opt.value} />
+              {artworkMediumCategories.map((category) => (
+                <Picker.Item color="black" label={category.label} value={category.value} key={category.value} />
               ))}
             </Picker>
           ) : null}

--- a/src/lib/Scenes/MyCollection/Screens/AddArtwork/Components/MediumPicker.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/AddArtwork/Components/MediumPicker.tsx
@@ -1,6 +1,7 @@
 import { ConsignmentSubmissionCategoryAggregation } from "__generated__/createConsignmentSubmissionMutation.graphql"
 import { Select } from "lib/Components/Select"
 import { useArtworkForm } from "lib/Scenes/MyCollection/Screens/AddArtwork/Form/useArtworkForm"
+import { artworkMediumCategories } from "lib/utils/artworkMediumCategories"
 import React, { useRef } from "react"
 
 export const MediumPicker: React.FC = () => {
@@ -19,30 +20,7 @@ export const MediumPicker: React.FC = () => {
       enableSearch={false}
       title="Medium"
       placeholder="Select"
-      options={mediumOptions}
+      options={artworkMediumCategories}
     />
   )
 }
-
-interface Medium {
-  label: string
-  value: ConsignmentSubmissionCategoryAggregation
-}
-
-const mediumOptions: Medium[] = [
-  { label: "Painting", value: "PAINTING" },
-  { label: "Sculpture", value: "SCULPTURE" },
-  { label: "Photography", value: "PHOTOGRAPHY" },
-  { label: "Print", value: "PRINT" },
-  { label: "Drawing, Collage or other Work on Paper", value: "DRAWING_COLLAGE_OR_OTHER_WORK_ON_PAPER" },
-  { label: "Mixed Media", value: "MIXED_MEDIA" },
-  { label: "Performance Art", value: "PERFORMANCE_ART" },
-  { label: "Installation", value: "INSTALLATION" },
-  { label: "Video/Film/Animation", value: "VIDEO_FILM_ANIMATION" },
-  { label: "Architecture", value: "ARCHITECTURE" },
-  { label: "Fashion Design and Wearable Art", value: "FASHION_DESIGN_AND_WEARABLE_ART" },
-  { label: "Jewelry", value: "JEWELRY" },
-  { label: "Design/Decorative Art", value: "DESIGN_DECORATIVE_ART" },
-  { label: "Textile Arts", value: "TEXTILE_ARTS" },
-  { label: "Other", value: "OTHER" },
-]

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkList/MyCollectionArtworkListItem.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkList/MyCollectionArtworkListItem.tsx
@@ -1,7 +1,8 @@
 import { MyCollectionArtworkListItem_artwork } from "__generated__/MyCollectionArtworkListItem_artwork.graphql"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
-import { formatMedium } from "lib/Scenes/MyCollection/utils/formatArtworkMedium"
+import { artworkMediumCategories } from "lib/utils/artworkMediumCategories"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
+import { capitalize } from "lodash"
 import { Box, color, Flex, Sans } from "palette"
 import React from "react"
 import { GestureResponderEvent } from "react-native"
@@ -16,6 +17,10 @@ interface MyCollectionArtworkListItemProps {
 export const MyCollectionArtworkListItem: React.FC<MyCollectionArtworkListItemProps> = ({ artwork, onPress }) => {
   const imageURL = artwork?.image?.url
   const { width } = useScreenDimensions()
+  const mediums: { [medium: string]: string } = artworkMediumCategories.reduce(
+    (acc, cur) => ({ ...acc, [cur.value]: cur.label }),
+    {}
+  )
 
   const Image = () =>
     !!imageURL ? (
@@ -27,7 +32,7 @@ export const MyCollectionArtworkListItem: React.FC<MyCollectionArtworkListItemPr
   const Medium = () =>
     !!artwork.medium ? (
       <Sans size="3t" color="black60" numberOfLines={1}>
-        {formatMedium(artwork.medium)}
+        {mediums[artwork.medium] || capitalize(artwork.medium)}
       </Sans>
     ) : null
 

--- a/src/lib/utils/__tests__/artworkMediumCategories-tests.ts
+++ b/src/lib/utils/__tests__/artworkMediumCategories-tests.ts
@@ -1,0 +1,23 @@
+import { artworkMediumCategories } from "../artworkMediumCategories"
+
+describe("artworkMediumCategories", () => {
+  it("maps raw (Gravity) artwork category labels to their respective values", () => {
+    expect(artworkMediumCategories.reduce((acc, cur) => ({ ...acc, [cur.value]: cur.label }), {})).toEqual({
+      ARCHITECTURE: "Architecture",
+      DESIGN_DECORATIVE_ART: "Design/Decorative Art",
+      DRAWING_COLLAGE_OR_OTHER_WORK_ON_PAPER: "Drawing, Collage or other Work on Paper",
+      FASHION_DESIGN_AND_WEARABLE_ART: "Fashion Design and Wearable Art",
+      INSTALLATION: "Installation",
+      JEWELRY: "Jewelry",
+      MIXED_MEDIA: "Mixed Media",
+      OTHER: "Other",
+      PAINTING: "Painting",
+      PERFORMANCE_ART: "Performance Art",
+      PHOTOGRAPHY: "Photography",
+      PRINT: "Print",
+      SCULPTURE: "Sculpture",
+      TEXTILE_ARTS: "Textile Arts",
+      VIDEO_FILM_ANIMATION: "Video/Film/Animation",
+    })
+  })
+})

--- a/src/lib/utils/artworkMediumCategories.ts
+++ b/src/lib/utils/artworkMediumCategories.ts
@@ -1,0 +1,24 @@
+import { ConsignmentSubmissionCategoryAggregation } from "__generated__/createConsignmentSubmissionMutation.graphql"
+
+interface Medium {
+  label: string
+  value: ConsignmentSubmissionCategoryAggregation
+}
+
+export const artworkMediumCategories: Medium[] = [
+  { label: "Painting", value: "PAINTING" },
+  { label: "Sculpture", value: "SCULPTURE" },
+  { label: "Photography", value: "PHOTOGRAPHY" },
+  { label: "Print", value: "PRINT" },
+  { label: "Drawing, Collage or other Work on Paper", value: "DRAWING_COLLAGE_OR_OTHER_WORK_ON_PAPER" },
+  { label: "Mixed Media", value: "MIXED_MEDIA" },
+  { label: "Performance Art", value: "PERFORMANCE_ART" },
+  { label: "Installation", value: "INSTALLATION" },
+  { label: "Video/Film/Animation", value: "VIDEO_FILM_ANIMATION" },
+  { label: "Architecture", value: "ARCHITECTURE" },
+  { label: "Fashion Design and Wearable Art", value: "FASHION_DESIGN_AND_WEARABLE_ART" },
+  { label: "Jewelry", value: "JEWELRY" },
+  { label: "Design/Decorative Art", value: "DESIGN_DECORATIVE_ART" },
+  { label: "Textile Arts", value: "TEXTILE_ARTS" },
+  { label: "Other", value: "OTHER" },
+]


### PR DESCRIPTION
The type of this PR is: **Enhancement/Documentation**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->



### Description

Refactors duplicated artwork categories to a single utility file for use throughout the app. The raw values come from Gravity so any changes upstream can be maintained here. 

<!-- Implementation description -->
Unchanged files that still render mediums as expected:
<img width="275" alt="Screen Shot 2020-09-16 at 7 36 02 PM" src="https://user-images.githubusercontent.com/10385964/93403035-61cd3080-f854-11ea-8802-08d2e305fbda.png">
<img width="298" alt="Screen Shot 2020-09-16 at 7 36 16 PM" src="https://user-images.githubusercontent.com/10385964/93403036-6265c700-f854-11ea-8ce4-9790e6c0bd50.png">

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434