### PR TITLE
[MyCollection] Clean up navigation between MyCollection and consignments

### DIFF
--- a/src/lib/Scenes/Consignments/Screens/Overview.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Overview.tsx
@@ -26,6 +26,7 @@ interface Props extends ViewProperties {
   navigator: NavigatorIOS
   route: Route // this gets set by NavigatorIOS
   setup: ConsignmentSetup
+  isArrivingFromMyCollection?: boolean
 }
 
 interface State extends ConsignmentSetup {
@@ -283,9 +284,11 @@ export default class Overview extends React.Component<Props, State> {
                 </Button>
               )}
               <Spacer mb={1} />
-              <Button variant="noOutline" onPress={() => SwitchBoard.dismissModalViewController(this)}>
-                Close
-              </Button>
+              {!this.props.isArrivingFromMyCollection && (
+                <Button variant="noOutline" onPress={() => SwitchBoard.dismissModalViewController(this)}>
+                  Close
+                </Button>
+              )}
             </Flex>
           </View>
         </ScrollView>

--- a/src/lib/Scenes/MyCollection/Boot.tsx
+++ b/src/lib/Scenes/MyCollection/Boot.tsx
@@ -34,7 +34,7 @@ export const setupMyCollectionScreen = (Component: React.ComponentType<any>) => 
     }, [])
 
     return (
-      <View ref={navViewRef}>
+      <View ref={navViewRef} style={{ flex: 1 }}>
         <FormikProvider value={initialForm}>
           <Component {...props} />
           <Modal />

--- a/src/lib/Scenes/MyCollection/Components/Navigator.tsx
+++ b/src/lib/Scenes/MyCollection/Components/Navigator.tsx
@@ -1,16 +1,18 @@
 import { AppStore } from "lib/store/AppStore"
-import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { useEffect } from "react"
 import React from "react"
 import NavigatorIOS, { Route } from "react-native-navigator-ios"
 
+/**
+ * Navigator is a helper component for automatically connecting a component tree
+ * to State/MyCollectionNavigationModel. When wrapped, we can dispatch actions
+ * and push / pop views from a central location (the model) to NavigatorIOS.
+ */
 export const Navigator: React.FC<Route> = ({ children, title = "" }) => {
-  const dimensions = useScreenDimensions()
-
   return (
     <NavigatorIOS
       navigationBarHidden={true}
-      style={{ height: dimensions.height }}
+      style={{ flex: 1 }}
       initialRoute={{
         title,
         component: ({ navigator }) => {

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/MyCollectionArtworkDetail.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/MyCollectionArtworkDetail.tsx
@@ -50,13 +50,13 @@ const MyCollectionArtworkDetail: React.FC<MyCollectionArtworkDetailProps> = ({ a
           <WhySell />
 
           <ScreenMargin>
-            <Button size="large" block onPress={() => navActions.navigateToConsign()}>
+            <Button size="large" block onPress={() => navActions.navigateToConsignSubmission()}>
               Submit this work
             </Button>
 
             <Spacer my={0.5} />
 
-            <Button size="large" variant="secondaryGray" block>
+            <Button size="large" variant="secondaryGray" block onPress={() => navActions.navigateToConsignLearnMore()}>
               Learn more
             </Button>
           </ScreenMargin>

--- a/src/lib/Scenes/MyCollection/Screens/ConsignmentsHome/ConsignmentsHome.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ConsignmentsHome/ConsignmentsHome.tsx
@@ -3,6 +3,7 @@ import { ConsignmentsHome_targetSupply } from "__generated__/ConsignmentsHome_ta
 import { ConsignmentsHomeQuery } from "__generated__/ConsignmentsHomeQuery.graphql"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
+import { AppStore } from "lib/store/AppStore"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { Join, Separator } from "palette"
 import React, { useRef } from "react"
@@ -19,14 +20,18 @@ import { RecentlySoldFragmentContainer as RecentlySold } from "./Components/Rece
 interface Props {
   targetSupply: ConsignmentsHome_targetSupply
   isLoading?: boolean
+  isArrivingFromMyCollection?: boolean
 }
 
-export const ConsignmentsHome: React.FC<Props> = ({ targetSupply, isLoading }) => {
+export const ConsignmentsHome: React.FC<Props> = ({ targetSupply, isLoading, isArrivingFromMyCollection }) => {
   const navRef = useRef<ScrollView>(null)
   const tracking = useTracking()
 
   const handleConsignPress = (tappedConsignArgs: TappedConsignArgs) => {
-    if (navRef.current) {
+    if (isArrivingFromMyCollection) {
+      const navActions = AppStore.actions.myCollection.navigation
+      navActions.navigateToConsignSubmission()
+    } else if (navRef.current) {
       tracking.trackEvent(tappedConsign(tappedConsignArgs))
       const route = "/collections/my-collection/artworks/new/submissions/new"
       SwitchBoard.presentModalViewController(navRef.current, route)
@@ -57,9 +62,13 @@ const ConsignmentsHomeContainer = createFragmentContainer(ConsignmentsHome, {
 
 interface ConsignmentsHomeQueryRendererProps {
   environment?: RelayModernEnvironment
+  isArrivingFromMyCollection?: boolean
 }
 
-export const ConsignmentsHomeQueryRenderer: React.FC<ConsignmentsHomeQueryRendererProps> = ({ environment }) => {
+export const ConsignmentsHomeQueryRenderer: React.FC<ConsignmentsHomeQueryRendererProps> = ({
+  environment,
+  isArrivingFromMyCollection,
+}) => {
   return (
     <QueryRenderer<ConsignmentsHomeQuery>
       environment={environment || defaultEnvironment}
@@ -72,6 +81,7 @@ export const ConsignmentsHomeQueryRenderer: React.FC<ConsignmentsHomeQueryRender
         }
       `}
       render={renderWithPlaceholder({
+        initialProps: { isArrivingFromMyCollection },
         Container: ConsignmentsHomeContainer,
         renderPlaceholder: () => <ConsignmentsHome isLoading={true} targetSupply={null as any} />,
       })}

--- a/src/lib/Scenes/MyCollection/Screens/ConsignmentsHome/ConsignmentsSubmissionForm.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ConsignmentsHome/ConsignmentsSubmissionForm.tsx
@@ -7,8 +7,10 @@ import { Theme } from "palette"
 import React from "react"
 import NavigatorIOS from "react-native-navigator-ios"
 
-export const ConsignmentsSubmissionForm = () => {
-  const initialRoute = { component: Overview }
+export const ConsignmentsSubmissionForm: React.FC<{ isArrivingFromMyCollection?: boolean }> = ({
+  isArrivingFromMyCollection,
+}) => {
+  const initialRoute = { component: Overview, passProps: { isArrivingFromMyCollection } }
 
   return (
     <Theme>

--- a/src/lib/Scenes/MyCollection/State/MyCollectionNavigationModel.tsx
+++ b/src/lib/Scenes/MyCollection/State/MyCollectionNavigationModel.tsx
@@ -1,5 +1,6 @@
 import { Action, action, Thunk, thunk, ThunkOn, thunkOn } from "easy-peasy"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { ConsignmentsHomeQueryRenderer } from "lib/Scenes/MyCollection/Screens/ConsignmentsHome/ConsignmentsHome"
 import { AppStoreModel } from "lib/store/AppStoreModel"
 import { isEmpty } from "lodash"
 import { RefObject } from "react"
@@ -8,6 +9,7 @@ import { AddArtworkTitleAndYear } from "../Screens/AddArtwork/Screens/AddArtwork
 import { AdditionalDetails } from "../Screens/AddArtwork/Screens/AdditionalDetails"
 import { AddArtworkAddPhotos } from "../Screens/AddArtwork/Screens/AddPhotos"
 import { ViewAllDetails } from "../Screens/ArtworkDetail/Screens/ViewAllDetails"
+import { ConsignmentsSubmissionForm } from "../Screens/ConsignmentsHome/ConsignmentsSubmissionForm"
 
 type ModalType = "add" | "edit" | null
 type InfoModalType = "demandIndex" | "priceEstimate" | "artistMarket" | "auctionResults" | null
@@ -49,13 +51,10 @@ export interface MyCollectionNavigationModel {
   navigateToAddAdditionalDetails: Action<MyCollectionNavigationModel>
   navigateToArtworkDetail: Action<MyCollectionNavigationModel, string>
   navigateToViewAllArtworkDetails: Action<MyCollectionNavigationModel, { passProps: any }> // FIXME: any
-  navigateToArtworkList: Action<MyCollectionNavigationModel>
-  navigateToHome: Action<MyCollectionNavigationModel>
-  navigateToMarketingHome: Action<MyCollectionNavigationModel>
 
   // External app locations
-  navigateToConsign: Action<MyCollectionNavigationModel>
-  navigateToArtist: Action<MyCollectionNavigationModel>
+  navigateToConsignSubmission: Action<MyCollectionNavigationModel>
+  navigateToConsignLearnMore: Action<MyCollectionNavigationModel>
 }
 
 export const MyCollectionNavigationModel: MyCollectionNavigationModel = {
@@ -189,30 +188,27 @@ export const MyCollectionNavigationModel: MyCollectionNavigationModel = {
     })
   }),
 
-  navigateToArtworkList: action((state) => {
-    SwitchBoard.presentNavigationViewController(state.sessionState.navViewRef.current, "/my-collection/artwork-list")
-  }),
-
-  navigateToMarketingHome: action((state) => {
-    SwitchBoard.presentNavigationViewController(state.sessionState.navViewRef.current, "/my-collection/marketing-home")
-  }),
-
-  navigateToHome: action((state) => {
-    SwitchBoard.presentNavigationViewController(state.sessionState.navViewRef.current, "/my-collection/home")
-  }),
-
   /**
-   * External app navigtion
+   * Pages outside of MyCollection
    */
 
-  navigateToConsign: action((state) => {
-    SwitchBoard.presentModalViewController(
-      state.sessionState.navViewRef.current,
-      "/collections/my-collection/artworks/new/submissions/new"
-    )
+  navigateToConsignLearnMore: action((state) => {
+    state.sessionState.navigator?.push({
+      component: ConsignmentsHomeQueryRenderer,
+      passProps: {
+        // TODO: Eventually, when consignments submissions and MyCollection are merged, these flags can go away
+        isArrivingFromMyCollection: true,
+      },
+    })
   }),
 
-  navigateToArtist: action((state) => {
-    SwitchBoard.presentModalViewController(state.sessionState.navViewRef.current, "/artist/cindy-sherman")
+  navigateToConsignSubmission: action((state) => {
+    state.sessionState.navigator?.push({
+      component: ConsignmentsSubmissionForm,
+      passProps: {
+        // TODO: Eventually, when consignments submissions and MyCollection are merged, these flags can go away
+        isArrivingFromMyCollection: true,
+      },
+    })
   }),
 }


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves https://artsyproduct.atlassian.net/browse/CSGN-372

### Description

This cleans up our navigation between MyCollections screens and Consignments home / submission, etc, now that we have a good NavigatorIOS abstraction in place to push to these views. 

cc @artsy/csgn-devs 

![nav](https://user-images.githubusercontent.com/236943/93638770-b84d8280-f9ac-11ea-9a2c-f1a01f94a11c.gif)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))

#minor 

[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434