### PR TITLE
refactor(tests): replacing some enzyme with react-test-renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,8 @@
     "@octokit/rest": "16.34.0",
     "@omakase/cli": "0.0.10",
     "@react-native-community/cli-platform-ios": "3.0.0",
+    "@testing-library/jest-native": "3.4.3",
+    "@testing-library/react-native": "7.1.0",
     "@types/chalk": "2.2.0",
     "@types/dedent": "0.7.0",
     "@types/jest": "25.1.5",

--- a/src/lib/Components/Toast/__tests__/Toast-tests.tsx
+++ b/src/lib/Components/Toast/__tests__/Toast-tests.tsx
@@ -21,15 +21,15 @@ describe("Toasts", () => {
   it("renders a toast when", async () => {
     const tree = renderWithWrappers(<TestRenderer />)
 
-    expect(tree.root.findAllByType(Toast)).toHaveLength(0)
+    expect(tree.UNSAFE_queryAllByType(Toast)).toHaveLength(0)
 
-    const buttonInstance = tree.root.findByType(Button)
+    const buttonInstance = tree.UNSAFE_getByType(Button)
     act(() => buttonInstance.props.onPress())
 
-    expect(tree.root.findAllByType(Toast)).toHaveLength(1)
+    expect(tree.UNSAFE_queryAllByType(Toast)).toHaveLength(1)
 
     jest.advanceTimersByTime(3000)
 
-    expect(tree.root.findAllByType(Toast)).toHaveLength(0)
+    expect(tree.UNSAFE_queryAllByType(Toast)).toHaveLength(0)
   })
 })

--- a/src/lib/Scenes/MyBids/__tests__/ActiveLotStanding-tests.tsx
+++ b/src/lib/Scenes/MyBids/__tests__/ActiveLotStanding-tests.tsx
@@ -2,7 +2,7 @@ import React from "react"
 
 import { ActiveLotStanding_lotStanding } from "__generated__/ActiveLotStanding_lotStanding.graphql"
 import { extractText } from "lib/tests/extractText"
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { renderWithWrappers_legacy } from "lib/tests/renderWithWrappers"
 import { merge } from "lodash"
 import { ActiveLotStanding } from "../Components/ActiveLotStanding"
 
@@ -40,7 +40,7 @@ const lotStandingFixture = (overrides = {}) => {
 describe(ActiveLotStanding, () => {
   describe("User winning status", () => {
     it("says 'Highest bid' if the user is winning the lot", () => {
-      const tree = renderWithWrappers(
+      const tree = renderWithWrappers_legacy(
         <ActiveLotStanding
           lotStanding={lotStandingFixture({ isHighestBidder: true, lot: { reserveStatus: "ReserveMet" } })}
         />
@@ -49,7 +49,7 @@ describe(ActiveLotStanding, () => {
     })
 
     it("says 'Highest bid' if the user is has the high bid and reserveStatus is UnknownReserve", () => {
-      const tree = renderWithWrappers(
+      const tree = renderWithWrappers_legacy(
         <ActiveLotStanding
           lotStanding={lotStandingFixture({ isHighestBidder: true, lot: { reserveStatus: "UnknownReserve" } })}
         />
@@ -60,7 +60,7 @@ describe(ActiveLotStanding, () => {
     it("says 'Highest bid' if the user is winning the lot but the reserveStatus is ReserveNotMet in a Live Auction", () => {
       const date = new Date()
       date.setDate(date.getDate() + 1)
-      const tree = renderWithWrappers(
+      const tree = renderWithWrappers_legacy(
         <ActiveLotStanding
           lotStanding={lotStandingFixture({
             isHighestBidder: true,
@@ -73,7 +73,7 @@ describe(ActiveLotStanding, () => {
     })
 
     it("says 'Reserve not met' if the user is winning the lot, but the reserveStatus is ReserveNotMet", () => {
-      const tree = renderWithWrappers(
+      const tree = renderWithWrappers_legacy(
         <ActiveLotStanding
           lotStanding={lotStandingFixture({ isHighestBidder: true, lot: { reserveStatus: "ReserveNotMet" } })}
         />
@@ -82,7 +82,7 @@ describe(ActiveLotStanding, () => {
     })
 
     it("says 'Outbid' if the user is outbid on the lot, but the reserveStatus is ReserveNotMet", () => {
-      const tree = renderWithWrappers(
+      const tree = renderWithWrappers_legacy(
         <ActiveLotStanding
           lotStanding={lotStandingFixture({ isHighestBidder: false, lot: { reserveStatus: "ReserveNotMet" } })}
         />
@@ -91,7 +91,7 @@ describe(ActiveLotStanding, () => {
     })
 
     it("says 'outbid' if the user is outbid on the lot and reserve is met", () => {
-      const tree = renderWithWrappers(
+      const tree = renderWithWrappers_legacy(
         <ActiveLotStanding
           lotStanding={lotStandingFixture({ isHighestBidder: false, lot: { reserveStatus: "ReserveMet" } })}
         />
@@ -102,7 +102,7 @@ describe(ActiveLotStanding, () => {
 
   describe("selling price", () => {
     it("shows floor selling price", () => {
-      const tree = renderWithWrappers(
+      const tree = renderWithWrappers_legacy(
         <ActiveLotStanding
           lotStanding={lotStandingFixture({ isHighestBidder: true, lot: { reserveStatus: "ReserveMet" } })}
         />

--- a/src/lib/Scenes/MyBids/__tests__/ClosedLotStanding-tests.tsx
+++ b/src/lib/Scenes/MyBids/__tests__/ClosedLotStanding-tests.tsx
@@ -2,7 +2,7 @@ import React from "react"
 
 import { ClosedLotStanding_lotStanding } from "__generated__/ClosedLotStanding_lotStanding.graphql"
 import { extractText } from "lib/tests/extractText"
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { renderWithWrappers_legacy } from "lib/tests/renderWithWrappers"
 import { merge } from "lodash"
 import { StarCircleFill } from "palette/svgs/sf"
 import { ClosedLotStanding } from "../Components/ClosedLotStanding"
@@ -44,21 +44,21 @@ const lotStandingFixture = (overrides = {}) => {
 describe(ClosedLotStanding, () => {
   describe("result message", () => {
     it("says 'You won!' if the user won the lot", () => {
-      const tree = renderWithWrappers(
+      const tree = renderWithWrappers_legacy(
         <ClosedLotStanding lotStanding={lotStandingFixture({ isHighestBidder: true, lot: { soldStatus: "Sold" } })} />
       )
       expect(extractText(tree.root)).toContain("You won!")
     })
 
     it("says 'Outbid' if the the lot sold to someone else", () => {
-      const tree = renderWithWrappers(
+      const tree = renderWithWrappers_legacy(
         <ClosedLotStanding lotStanding={lotStandingFixture({ isHighestBidder: false, lot: { soldStatus: "Sold" } })} />
       )
       expect(extractText(tree.root)).toContain("Outbid")
     })
 
     it("says 'Passed' if the lot did not sell at all", () => {
-      const tree = renderWithWrappers(
+      const tree = renderWithWrappers_legacy(
         <ClosedLotStanding lotStanding={lotStandingFixture({ isHighestBidder: true, lot: { soldStatus: "Passed" } })} />
       )
       expect(extractText(tree.root)).toContain("Passed")
@@ -68,7 +68,7 @@ describe(ClosedLotStanding, () => {
   describe("artwork badge", () => {
     it("has a little star badge if the user won the lot", () => {
       expect(
-        renderWithWrappers(
+        renderWithWrappers_legacy(
           <ClosedLotStanding lotStanding={lotStandingFixture({ isHighestBidder: true, lot: { soldStatus: "Sold" } })} />
         ).root.findAllByType(StarCircleFill).length
       ).toBe(1)
@@ -77,14 +77,14 @@ describe(ClosedLotStanding, () => {
 
   describe("closing time", () => {
     it("renders the time the sale ended by default", () => {
-      const tree = renderWithWrappers(<ClosedLotStanding lotStanding={lotStandingFixture()} />)
+      const tree = renderWithWrappers_legacy(<ClosedLotStanding lotStanding={lotStandingFixture()} />)
       expect(extractText(tree.root)).toContain("Closed Aug 5")
     })
   })
 
   describe("selling price", () => {
     it("shows selling price", () => {
-      const tree = renderWithWrappers(<ClosedLotStanding lotStanding={lotStandingFixture()} />)
+      const tree = renderWithWrappers_legacy(<ClosedLotStanding lotStanding={lotStandingFixture()} />)
       expect(extractText(tree.root)).toContain("CHF 1,800")
     })
   })

--- a/src/lib/Scenes/MyBids/__tests__/MyBids-tests.tsx
+++ b/src/lib/Scenes/MyBids/__tests__/MyBids-tests.tsx
@@ -1,6 +1,6 @@
 import { MyBidsTestsQuery } from "__generated__/MyBidsTestsQuery.graphql"
 import { extractText } from "lib/tests/extractText"
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { renderWithWrappers_legacy } from "lib/tests/renderWithWrappers"
 import { PlaceholderText } from "lib/utils/placeholders"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
@@ -56,7 +56,7 @@ describe("My Bids", () => {
   )
 
   const getWrapper = (mockResolvers = {}) => {
-    const tree = renderWithWrappers(<TestRenderer />)
+    const tree = renderWithWrappers_legacy(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation((operation) => MockPayloadGenerator.generate(operation, mockResolvers))
     })
@@ -65,7 +65,7 @@ describe("My Bids", () => {
 
   describe("MyBidsQueryRenderer loading state", () => {
     it("shows placeholder until the operation resolves", () => {
-      const tree = renderWithWrappers(<MyBidsQueryRenderer />)
+      const tree = renderWithWrappers_legacy(<MyBidsQueryRenderer />)
       expect(tree.root.findAllByType(PlaceholderText).length).toBeGreaterThan(0)
     })
   })

--- a/src/lib/Scenes/MyBids/__tests__/SaleCard-tests.tsx
+++ b/src/lib/Scenes/MyBids/__tests__/SaleCard-tests.tsx
@@ -1,6 +1,6 @@
 import { SaleCardTestsQuery } from "__generated__/SaleCardTestsQuery.graphql"
 import { extractText } from "lib/tests/extractText"
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { renderWithWrappers_legacy } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { act } from "react-test-renderer"
@@ -42,7 +42,7 @@ describe("SaleCard", () => {
   )
 
   const getWrapper = (mockResolvers = {}) => {
-    const tree = renderWithWrappers(<TestRenderer />)
+    const tree = renderWithWrappers_legacy(<TestRenderer />)
     act(() => {
       env.mock.resolveMostRecentOperation((operation) => MockPayloadGenerator.generate(operation, mockResolvers))
     })

--- a/src/lib/Scenes/MyBids/__tests__/SaleInfo-tests.tsx
+++ b/src/lib/Scenes/MyBids/__tests__/SaleInfo-tests.tsx
@@ -9,7 +9,7 @@ jest.mock("moment-timezone", () => {
 })
 
 import { extractText } from "lib/tests/extractText"
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { renderWithWrappers_legacy } from "lib/tests/renderWithWrappers"
 import { merge } from "lodash"
 import moment from "moment-timezone"
 import { Text } from "palette"
@@ -18,7 +18,7 @@ import React from "react"
 import { ReactTestRenderer } from "react-test-renderer"
 import { SaleInfo } from "../Components/SaleInfo"
 
-const renderText = (node: React.ReactElement) => extractText(renderWithWrappers(node).root)
+const renderText = (node: React.ReactElement) => extractText(renderWithWrappers_legacy(node).root)
 
 interface SaleInfoProps {
   liveStartAt?: string | null
@@ -39,7 +39,7 @@ describe("<SaleInfo />", () => {
   describe("live sale", () => {
     it("has a lightning bolt", () => {
       expect(
-        renderWithWrappers(
+        renderWithWrappers_legacy(
           <SaleInfo sale={saleFixture({ liveStartAt: "2020-08-01T15:00:00+00:00" })} />
         ).root.findAllByType(BoltFill).length
       ).toEqual(1)
@@ -49,7 +49,7 @@ describe("<SaleInfo />", () => {
       let tree: ReactTestRenderer
       beforeEach(() => {
         const liveStartAt = moment().subtract(5, "minutes").toJSON()
-        tree = renderWithWrappers(<SaleInfo sale={saleFixture({ liveStartAt, status: "open" })} />)
+        tree = renderWithWrappers_legacy(<SaleInfo sale={saleFixture({ liveStartAt, status: "open" })} />)
       })
       it("has a purple100 icon + note if live bidding is active, black60 otherwise", () => {
         expect(tree.root.findByType(BoltFill).props.fill).toMatch("purple100")
@@ -77,7 +77,7 @@ describe("<SaleInfo />", () => {
 
       it("displays an additional timely message in minutes if the sale is within 1 hour", () => {
         const subject = <SaleInfo sale={saleFixture({ liveStartAt: "2020-07-31T06:00:00+00:00" })} />
-        const tree = renderWithWrappers(subject)
+        const tree = renderWithWrappers_legacy(subject)
         const text = renderText(subject)
 
         const lines = tree.root.findAllByType(Text)
@@ -136,9 +136,9 @@ describe("<SaleInfo />", () => {
   describe("timed auction", () => {
     it("has a little stopwatch", () => {
       expect(
-        renderWithWrappers(<SaleInfo sale={saleFixture({ endAt: "2020-08-01T15:00:00+00:00" })} />).root.findAllByType(
-          Stopwatch
-        ).length
+        renderWithWrappers_legacy(
+          <SaleInfo sale={saleFixture({ endAt: "2020-08-01T15:00:00+00:00" })} />
+        ).root.findAllByType(Stopwatch).length
       ).toBe(1)
     })
     describe("time bounds", () => {
@@ -157,7 +157,7 @@ describe("<SaleInfo />", () => {
 
       it("displays an additional timely message in minutes if the sale is within 1 hour", () => {
         const subject = <SaleInfo sale={saleFixture({ endAt: "2020-07-31T06:00:00+00:00" })} />
-        const tree = renderWithWrappers(subject)
+        const tree = renderWithWrappers_legacy(subject)
         const text = renderText(subject)
 
         const lines = tree.root.findAllByType(Text)

--- a/src/lib/tests/renderWithLayout.tsx
+++ b/src/lib/tests/renderWithLayout.tsx
@@ -1,9 +1,9 @@
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { renderWithWrappers_legacy } from "lib/tests/renderWithWrappers"
 
 /** Renders a React Component with specified layout using onLayout callback */
 export const renderWithLayout = (component: any, layout: { width?: number; height?: number }) => {
   // create the component with renderer
-  component = renderWithWrappers(component)
+  component = renderWithWrappers_legacy(component)
 
   // create a nativeEvent with desired dimensions
   const mockNativeEvent = {

--- a/src/lib/tests/renderWithWrappers.tsx
+++ b/src/lib/tests/renderWithWrappers.tsx
@@ -1,3 +1,4 @@
+import { render } from "@testing-library/react-native"
 import { ToastProvider } from "lib/Components/Toast/toastHook"
 import { GlobalStoreProvider } from "lib/store/GlobalStore"
 import { ProvideScreenDimensions } from "lib/utils/useScreenDimensions"
@@ -6,11 +7,32 @@ import React from "react"
 import ReactTestRenderer from "react-test-renderer"
 import { ReactElement } from "simple-markdown"
 
+export const Wrappers: React.FC = ({ children }) => {
+  return (
+    <GlobalStoreProvider>
+      <Theme>
+        <ToastProvider>
+          <ProvideScreenDimensions>{children}</ProvideScreenDimensions>
+        </ToastProvider>
+      </Theme>
+    </GlobalStoreProvider>
+  )
+}
+
+/**
+ * Returns given component wrapped with our page wrappers
+ * @param component
+ */
+export const componentWithWrappers = (component: ReactElement) => {
+  return <Wrappers>{component}</Wrappers>
+}
+
 /**
  * Renders a React Component with our page wrappers
  * @param component
+ * @deprecated Try to use `renderWithWrappers`. If there is any problem and this function works, please report it to CX.
  */
-export const renderWithWrappers = (component: ReactElement) => {
+export const renderWithWrappers_legacy = (component: ReactElement) => {
   const wrappedComponent = componentWithWrappers(component)
   try {
     // tslint:disable-next-line:use-wrapped-components
@@ -38,17 +60,9 @@ export const renderWithWrappers = (component: ReactElement) => {
 }
 
 /**
- * Returns given component wrapped with our page wrappers
+ * Renders a React Component with our page wrappers
  * @param component
  */
-export const componentWithWrappers = (component: ReactElement) => {
-  return (
-    <GlobalStoreProvider>
-      <Theme>
-        <ToastProvider>
-          <ProvideScreenDimensions>{component}</ProvideScreenDimensions>
-        </ToastProvider>
-      </Theme>
-    </GlobalStoreProvider>
-  )
+export const renderWithWrappers = (component: ReactElement) => {
+  return render(component, { wrapper: Wrappers })
 }

--- a/src/lib/tests/setupTestWrapper.tsx
+++ b/src/lib/tests/setupTestWrapper.tsx
@@ -4,7 +4,7 @@ import { act } from "react-test-renderer"
 import { GraphQLTaggedNode, OperationType } from "relay-runtime"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { MockResolvers } from "relay-test-utils/lib/RelayMockPayloadGenerator"
-import { renderWithWrappers } from "./renderWithWrappers"
+import { renderWithWrappers_legacy } from "./renderWithWrappers"
 
 interface SetupTestWrapper<T extends OperationType> {
   // TODO: Component: React.ComponentType<T['response']> type errors here
@@ -37,7 +37,7 @@ export const setupTestWrapper = <T extends OperationType>({
       />
     )
 
-    const wrapper = renderWithWrappers(<TestRenderer />)
+    const wrapper = renderWithWrappers_legacy(<TestRenderer />)
 
     act(() => {
       env.mock.resolveMostRecentOperation((operation) => MockPayloadGenerator.generate(operation, mockResolvers))

--- a/src/lib/utils/__tests__/placeholders-tests.tsx
+++ b/src/lib/utils/__tests__/placeholders-tests.tsx
@@ -1,16 +1,16 @@
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { renderWithWrappers_legacy } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { PlaceholderBox, PlaceholderRaggedText, ProvidePlaceholderContext } from "../placeholders"
 
 describe(PlaceholderBox, () => {
   it(`requires a placeholder context`, () => {
     try {
-      renderWithWrappers(<PlaceholderBox width={400} />)
+      renderWithWrappers_legacy(<PlaceholderBox width={400} />)
     } catch (error) {
       expect(error.message).toContain("Error: You're using a Placeholder outside of a PlaceholderContext")
     }
 
-    renderWithWrappers(
+    renderWithWrappers_legacy(
       <ProvidePlaceholderContext>
         <PlaceholderBox width={400} />
       </ProvidePlaceholderContext>
@@ -20,7 +20,7 @@ describe(PlaceholderBox, () => {
 
 describe(PlaceholderRaggedText, () => {
   it(`creates the right number of placeholders matching the given number of lines`, () => {
-    const tree = renderWithWrappers(
+    const tree = renderWithWrappers_legacy(
       <ProvidePlaceholderContext>
         <PlaceholderRaggedText numLines={4} />
       </ProvidePlaceholderContext>

--- a/src/lib/utils/__tests__/renderWithLoadProgress-tests.tsx
+++ b/src/lib/utils/__tests__/renderWithLoadProgress-tests.tsx
@@ -1,6 +1,6 @@
 import Spinner from "lib/Components/Spinner"
 import { extractText } from "lib/tests/extractText"
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { renderWithWrappers_legacy } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { Text } from "react-native"
 import renderWithLoadProgress from "../renderWithLoadProgress"
@@ -12,7 +12,7 @@ describe(renderWithLoadProgress, () => {
     expect(React.isValidElement(result)).toBeTruthy()
 
     // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-    const tree = renderWithWrappers(result)
+    const tree = renderWithWrappers_legacy(result)
     expect(tree.root.findByType(Spinner)).toBeTruthy()
   })
   it(`renders the real content when the graphqls are done`, () => {
@@ -22,7 +22,7 @@ describe(renderWithLoadProgress, () => {
     )({ error: null, props: {}, retry: () => null })
     expect(React.isValidElement(result)).toBeTruthy()
     // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-    const tree = renderWithWrappers(result)
+    const tree = renderWithWrappers_legacy(result)
     expect(extractText(tree.root)).toBe("the real content")
   })
 })

--- a/src/lib/utils/__tests__/renderWithPlaceholder-tests.tsx
+++ b/src/lib/utils/__tests__/renderWithPlaceholder-tests.tsx
@@ -1,5 +1,5 @@
 import { extractText } from "lib/tests/extractText"
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { renderWithWrappers_legacy } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { Text } from "react-native"
 import { renderWithPlaceholder } from "../renderWithPlaceholder"
@@ -14,7 +14,7 @@ describe(renderWithPlaceholder, () => {
     expect(React.isValidElement(result)).toBeTruthy()
 
     // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-    const tree = renderWithWrappers(result)
+    const tree = renderWithWrappers_legacy(result)
     expect(extractText(tree.root)).toBe("this is the placeholder")
   })
   it(`renders the real content when the graphqls are done`, () => {
@@ -24,7 +24,7 @@ describe(renderWithPlaceholder, () => {
     })({ error: null, props: {}, retry: () => null })
     expect(React.isValidElement(result)).toBeTruthy()
     // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-    const tree = renderWithWrappers(result)
+    const tree = renderWithWrappers_legacy(result)
     expect(extractText(tree.root)).toBe("the real content")
   })
 })

--- a/src/lib/utils/getTestWrapper.tsx
+++ b/src/lib/utils/getTestWrapper.tsx
@@ -7,12 +7,12 @@
  *  const { text }  = getTestSnapshot(<MyComponent title='Hi!' />)
  *  expect(text).toContain('Hi!')
  */
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { renderWithWrappers_legacy } from "lib/tests/renderWithWrappers"
 import "react-native"
 
 export function getTestWrapper(TestComponent: any /* STRICTNESS_MIGRATION */) {
   try {
-    const snapshot = renderWithWrappers(TestComponent)
+    const snapshot = renderWithWrappers_legacy(TestComponent)
     const text = JSON.stringify(snapshot.toJSON())
     const json = snapshot.toTree()
 
@@ -38,6 +38,6 @@ export function getTestWrapper(TestComponent: any /* STRICTNESS_MIGRATION */) {
  */
 
 export function getTextTree(TestComponent: any /* STRICTNESS_MIGRATION */) {
-  const snapshot = renderWithWrappers(TestComponent)
+  const snapshot = renderWithWrappers_legacy(TestComponent)
   return JSON.stringify(snapshot.toJSON())
 }

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -7,6 +7,7 @@
 // Object.assign(babelHelpers, { applyDecoratedDescriptor, initializerDefineProperty })
 // import "@babel/runtime"
 
+import "@testing-library/jest-native/extend-expect"
 import chalk from "chalk"
 // @ts-ignore
 import Enzyme from "enzyme"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2605,6 +2605,25 @@
     "@styled-system/core" "^5.1.2"
     "@styled-system/css" "^5.1.5"
 
+"@testing-library/jest-native@3.4.3":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-native/-/jest-native-3.4.3.tgz#fa6f902a442e2693f27563568a71e61bf11f8a53"
+  integrity sha512-CzHr3FMZCda/ChKEAjt9er9CHmIhgfKRHyeDrK3QoUdQUvlaFGER+WqGLqieJRdjRjpa2ecm+eNm2/+rPSFWkw==
+  dependencies:
+    chalk "^2.4.1"
+    jest-diff "^24.0.0"
+    jest-matcher-utils "^24.0.0"
+    pretty-format "^24.0.0"
+    ramda "^0.26.1"
+    redent "^2.0.0"
+
+"@testing-library/react-native@7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-7.1.0.tgz#6b168aac21522c8a5175461b350336fd79612ac9"
+  integrity sha512-ljVM9KZqG7BT/NFN6CHzdF6MNmM28+k7MEybFJ7FW1wVrhpiY4+hU9ypZ+hboO+MG3KpE2aFBzP4od3gu+Zzdg==
+  dependencies:
+    pretty-format "^26.0.1"
+
 "@turf/along@>= 4.0.0 <7.0.0":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@turf/along/-/along-6.0.1.tgz#595cecdc48fc7fcfa83c940a8e3eb24d4c2e04d4"
@@ -5274,6 +5293,11 @@ detect-port@1.2.1:
     address "^1.0.1"
     debug "^2.6.0"
 
+diff-sequences@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
+  integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
+
 diff-sequences@^25.1.0, diff-sequences@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
@@ -7753,6 +7777,16 @@ jest-diff@25.1.0:
     jest-get-type "^25.1.0"
     pretty-format "^25.1.0"
 
+jest-diff@^24.0.0, jest-diff@^24.9.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
+  integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
+  dependencies:
+    chalk "^2.0.1"
+    diff-sequences "^24.9.0"
+    jest-get-type "^24.9.0"
+    pretty-format "^24.9.0"
+
 jest-diff@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.2.6.tgz#a6d70a9ab74507715ea1092ac513d1ab81c1b5e7"
@@ -7905,6 +7939,16 @@ jest-matcher-utils@21.3.0-beta.15:
     chalk "^2.0.1"
     jest-get-type "21.3.0-beta.15"
     pretty-format "21.3.0-beta.15"
+
+jest-matcher-utils@^24.0.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz#f5b3661d5e628dffe6dd65251dfdae0e87c3a073"
+  integrity sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==
+  dependencies:
+    chalk "^2.0.1"
+    jest-diff "^24.9.0"
+    jest-get-type "^24.9.0"
+    pretty-format "^24.9.0"
 
 jest-matcher-utils@^25.2.7:
   version "25.2.7"
@@ -11105,7 +11149,7 @@ pretty-format@^20.0.3:
     ansi-regex "^2.1.1"
     ansi-styles "^3.0.0"
 
-pretty-format@^24.7.0, pretty-format@^24.9.0:
+pretty-format@^24.0.0, pretty-format@^24.7.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
@@ -11125,7 +11169,7 @@ pretty-format@^25.1.0, pretty-format@^25.2.0, pretty-format@^25.2.6:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
-pretty-format@^26.6.2:
+pretty-format@^26.0.1, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
   integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
@@ -11303,6 +11347,11 @@ railroad-diagrams@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
   integrity sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=
+
+ramda@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 randexp@^0.4.2:
   version "0.4.9"


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [MX-]

### Description

I'd like this merged so we have the dep ready, and we can start using it randomly when we want.

<!-- Implementation description -->


Changes:
- `Button`s have a `HiddenText` in them that is used to make the buttons sized big enough to fit the largest text we will put inside that button. Now it is only used outside tests, because otherwise tests see the buttons having texts like `FollowFollowed` when it's just `Follow`.




~~PR submitted to RNTL: https://github.com/callstack/react-native-testing-library/pull/569~~

### Follow-up work

- [ ] wrapper
I made `renderWithWrappersTL` for this PR because the existing `renderWithWrappers` has some extra things like
```
 const wrappedComponent = componentWithWrappers(component)
  // tslint:disable-next-line:use-wrapped-components
  const renderedComponent = ReactTestRenderer.create(wrappedComponent)
  // monkey patch update method to wrap components
  const originalUpdate = renderedComponent.update
  renderedComponent.update = (nextElement: ReactElement) => {
    originalUpdate(componentWithWrappers(nextElement))
  }
  return renderedComponent
```
that I didn't look too much into. I would like to have a specific case where the new one doesn't work. The eventual follow-up work here would be to only have one of these at some point.

- [ ] Add a TODO on every file using enzyme, to prompt devs to migrate that file from enzyme to RNTL

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434