### PR TITLE
FX-2265: User can filter artworks within an artist series

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -15,6 +15,7 @@ upcoming:
     - Enable pagination on My Collection artworks screen - ashley
     - Add auction lots grid to the auctions screen - mounir
     - Add auction lots list to the auctions screen - mounir
+    - Enable filtering on artist series views - sweir
 
 releases:
   - version: 6.6.3

--- a/src/__generated__/ArtistSeriesArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 01c68d38251ffdf3edd235c1d4d433f4 */
+/* @relayHash 1db7438ef40a84a6587ea055b455561a */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -9,6 +9,16 @@ export type ArtistSeriesArtworksInfiniteScrollGridQueryVariables = {
     count: number;
     cursor?: string | null;
     sort?: string | null;
+    medium?: string | null;
+    priceRange?: string | null;
+    color?: string | null;
+    partnerID?: string | null;
+    dimensionRange?: string | null;
+    majorPeriods?: Array<string | null> | null;
+    acquireable?: boolean | null;
+    inquireableOnly?: boolean | null;
+    atAuction?: boolean | null;
+    offerable?: boolean | null;
 };
 export type ArtistSeriesArtworksInfiniteScrollGridQueryResponse = {
     readonly artistSeries: {
@@ -27,16 +37,34 @@ query ArtistSeriesArtworksInfiniteScrollGridQuery(
   $id: ID!
   $cursor: String
   $sort: String
+  $medium: String
+  $priceRange: String
+  $color: String
+  $partnerID: ID
+  $dimensionRange: String
+  $majorPeriods: [String]
+  $acquireable: Boolean
+  $inquireableOnly: Boolean
+  $atAuction: Boolean
+  $offerable: Boolean
 ) {
   artistSeries(id: $id) {
-    ...ArtistSeriesArtworks_artistSeries_1RfMLO
+    ...ArtistSeriesArtworks_artistSeries_3m6HS0
   }
 }
 
-fragment ArtistSeriesArtworks_artistSeries_1RfMLO on ArtistSeries {
+fragment ArtistSeriesArtworks_artistSeries_3m6HS0 on ArtistSeries {
   slug
   internalID
-  artistSeriesArtworks: filterArtworksConnection(first: 20, sort: $sort, after: $cursor) {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
     edges {
       node {
         id
@@ -139,6 +167,66 @@ var v0 = [
     "name": "sort",
     "type": "String",
     "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "medium",
+    "type": "String",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "priceRange",
+    "type": "String",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "color",
+    "type": "String",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "partnerID",
+    "type": "ID",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "dimensionRange",
+    "type": "String",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "majorPeriods",
+    "type": "[String]",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "acquireable",
+    "type": "Boolean",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "inquireableOnly",
+    "type": "Boolean",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "atAuction",
+    "type": "Boolean",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "offerable",
+    "type": "Boolean",
+    "defaultValue": null
   }
 ],
 v1 = [
@@ -150,24 +238,75 @@ v1 = [
 ],
 v2 = {
   "kind": "Variable",
+  "name": "acquireable",
+  "variableName": "acquireable"
+},
+v3 = {
+  "kind": "Variable",
+  "name": "atAuction",
+  "variableName": "atAuction"
+},
+v4 = {
+  "kind": "Variable",
+  "name": "color",
+  "variableName": "color"
+},
+v5 = {
+  "kind": "Variable",
+  "name": "dimensionRange",
+  "variableName": "dimensionRange"
+},
+v6 = {
+  "kind": "Variable",
+  "name": "inquireableOnly",
+  "variableName": "inquireableOnly"
+},
+v7 = {
+  "kind": "Variable",
+  "name": "majorPeriods",
+  "variableName": "majorPeriods"
+},
+v8 = {
+  "kind": "Variable",
+  "name": "medium",
+  "variableName": "medium"
+},
+v9 = {
+  "kind": "Variable",
+  "name": "offerable",
+  "variableName": "offerable"
+},
+v10 = {
+  "kind": "Variable",
+  "name": "partnerID",
+  "variableName": "partnerID"
+},
+v11 = {
+  "kind": "Variable",
+  "name": "priceRange",
+  "variableName": "priceRange"
+},
+v12 = {
+  "kind": "Variable",
   "name": "sort",
   "variableName": "sort"
 },
-v3 = {
+v13 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "slug",
   "args": null,
   "storageKey": null
 },
-v4 = {
+v14 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "internalID",
   "args": null,
   "storageKey": null
 },
-v5 = [
+v15 = [
+  (v2/*: any*/),
   {
     "kind": "Variable",
     "name": "after",
@@ -175,12 +314,41 @@ v5 = [
   },
   {
     "kind": "Literal",
+    "name": "aggregations",
+    "value": [
+      "COLOR",
+      "DIMENSION_RANGE",
+      "GALLERY",
+      "INSTITUTION",
+      "MAJOR_PERIOD",
+      "MEDIUM",
+      "PRICE_RANGE"
+    ]
+  },
+  (v3/*: any*/),
+  (v4/*: any*/),
+  (v5/*: any*/),
+  {
+    "kind": "Literal",
     "name": "first",
     "value": 20
   },
-  (v2/*: any*/)
+  (v6/*: any*/),
+  (v7/*: any*/),
+  (v8/*: any*/),
+  (v9/*: any*/),
+  (v10/*: any*/),
+  (v11/*: any*/),
+  (v12/*: any*/)
 ],
-v6 = {
+v16 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v17 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
@@ -209,6 +377,9 @@ return {
             "kind": "FragmentSpread",
             "name": "ArtistSeriesArtworks_artistSeries",
             "args": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
               {
                 "kind": "Variable",
                 "name": "count",
@@ -219,7 +390,14 @@ return {
                 "name": "cursor",
                 "variableName": "cursor"
               },
-              (v2/*: any*/)
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              (v9/*: any*/),
+              (v10/*: any*/),
+              (v11/*: any*/),
+              (v12/*: any*/)
             ]
           }
         ]
@@ -240,17 +418,61 @@ return {
         "concreteType": "ArtistSeries",
         "plural": false,
         "selections": [
-          (v3/*: any*/),
-          (v4/*: any*/),
+          (v13/*: any*/),
+          (v14/*: any*/),
           {
             "kind": "LinkedField",
             "alias": "artistSeriesArtworks",
             "name": "filterArtworksConnection",
             "storageKey": null,
-            "args": (v5/*: any*/),
+            "args": (v15/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "aggregations",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtworksAggregationResults",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "slice",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "counts",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "AggregationCount",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "count",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      (v16/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "value",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ]
+              },
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -269,8 +491,8 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
-                      (v3/*: any*/),
+                      (v17/*: any*/),
+                      (v13/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -323,7 +545,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v4/*: any*/),
+                      (v14/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -375,7 +597,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v6/*: any*/)
+                          (v17/*: any*/)
                         ]
                       },
                       {
@@ -430,7 +652,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v6/*: any*/)
+                          (v17/*: any*/)
                         ]
                       },
                       {
@@ -442,14 +664,8 @@ return {
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "name",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          (v6/*: any*/)
+                          (v16/*: any*/),
+                          (v17/*: any*/)
                         ]
                       },
                       {
@@ -468,7 +684,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  (v6/*: any*/)
+                  (v17/*: any*/)
                 ]
               },
               {
@@ -521,18 +737,29 @@ return {
                   }
                 ]
               },
-              (v6/*: any*/)
+              (v17/*: any*/)
             ]
           },
           {
             "kind": "LinkedHandle",
             "alias": "artistSeriesArtworks",
             "name": "filterArtworksConnection",
-            "args": (v5/*: any*/),
+            "args": (v15/*: any*/),
             "handle": "connection",
             "key": "ArtistSeries_artistSeriesArtworks",
             "filters": [
-              "sort"
+              "sort",
+              "medium",
+              "priceRange",
+              "color",
+              "partnerID",
+              "dimensionRange",
+              "majorPeriods",
+              "acquireable",
+              "inquireableOnly",
+              "atAuction",
+              "offerable",
+              "aggregations"
             ]
           }
         ]
@@ -542,11 +769,11 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesArtworksInfiniteScrollGridQuery",
-    "id": "bae6f0748963bc50d01016dfa55b2569",
+    "id": "3a377a563f1e23519cf79fc8065a9601",
     "text": null,
     "metadata": {}
   }
 };
 })();
-(node as any).hash = '0c72212cf7d87ef79312e2984fe761f0';
+(node as any).hash = '742a3d10392ece79bd222570677b8475';
 export default node;

--- a/src/__generated__/ArtistSeriesArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworksTestsQuery.graphql.ts
@@ -1,9 +1,10 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 4ff5f523eaca55743266c1cce63437c9 */
+/* @relayHash a9c6c14ca31689c352194b74c0e85da2 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 export type ArtistSeriesArtworksTestsQueryVariables = {};
 export type ArtistSeriesArtworksTestsQueryResponse = {
     readonly artistSeries: {
@@ -15,6 +16,14 @@ export type ArtistSeriesArtworksTestsQueryRawResponse = {
         readonly slug: string;
         readonly internalID: string;
         readonly artistSeriesArtworks: ({
+            readonly aggregations: ReadonlyArray<({
+                readonly slice: ArtworkAggregation | null;
+                readonly counts: ReadonlyArray<({
+                    readonly count: number;
+                    readonly name: string;
+                    readonly value: string;
+                }) | null> | null;
+            }) | null> | null;
             readonly edges: ReadonlyArray<({
                 readonly node: ({
                     readonly id: string;
@@ -85,7 +94,15 @@ query ArtistSeriesArtworksTestsQuery {
 fragment ArtistSeriesArtworks_artistSeries on ArtistSeries {
   slug
   internalID
-  artistSeriesArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch") {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
     edges {
       node {
         id
@@ -188,8 +205,31 @@ v2 = {
 v3 = [
   {
     "kind": "Literal",
+    "name": "aggregations",
+    "value": [
+      "COLOR",
+      "DIMENSION_RANGE",
+      "GALLERY",
+      "INSTITUTION",
+      "MAJOR_PERIOD",
+      "MEDIUM",
+      "PRICE_RANGE"
+    ]
+  },
+  {
+    "kind": "Literal",
+    "name": "dimensionRange",
+    "value": "*-*"
+  },
+  {
+    "kind": "Literal",
     "name": "first",
     "value": 20
+  },
+  {
+    "kind": "Literal",
+    "name": "medium",
+    "value": "*"
   },
   {
     "kind": "Literal",
@@ -198,6 +238,13 @@ v3 = [
   }
 ],
 v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
@@ -251,11 +298,55 @@ return {
             "kind": "LinkedField",
             "alias": "artistSeriesArtworks",
             "name": "filterArtworksConnection",
-            "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")",
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:20,medium:\"*\",sort:\"-decayed_merch\")",
             "args": (v3/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "aggregations",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtworksAggregationResults",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "slice",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "counts",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "AggregationCount",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "count",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      (v4/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "value",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ]
+              },
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -274,7 +365,7 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
+                      (v5/*: any*/),
                       (v1/*: any*/),
                       {
                         "kind": "LinkedField",
@@ -380,7 +471,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v4/*: any*/)
+                          (v5/*: any*/)
                         ]
                       },
                       {
@@ -435,7 +526,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v4/*: any*/)
+                          (v5/*: any*/)
                         ]
                       },
                       {
@@ -447,14 +538,8 @@ return {
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "name",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          (v4/*: any*/)
+                          (v4/*: any*/),
+                          (v5/*: any*/)
                         ]
                       },
                       {
@@ -473,7 +558,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  (v4/*: any*/)
+                  (v5/*: any*/)
                 ]
               },
               {
@@ -526,7 +611,7 @@ return {
                   }
                 ]
               },
-              (v4/*: any*/)
+              (v5/*: any*/)
             ]
           },
           {
@@ -537,7 +622,18 @@ return {
             "handle": "connection",
             "key": "ArtistSeries_artistSeriesArtworks",
             "filters": [
-              "sort"
+              "sort",
+              "medium",
+              "priceRange",
+              "color",
+              "partnerID",
+              "dimensionRange",
+              "majorPeriods",
+              "acquireable",
+              "inquireableOnly",
+              "atAuction",
+              "offerable",
+              "aggregations"
             ]
           }
         ]
@@ -547,7 +643,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesArtworksTestsQuery",
-    "id": "19f9d1f3c204a53947ce31f9389fcdbc",
+    "id": "4a64e80870d118e14aca9d72a22b13d8",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeriesArtworks_artistSeries.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworks_artistSeries.graphql.ts
@@ -3,10 +3,19 @@
 
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 export type ArtistSeriesArtworks_artistSeries = {
     readonly slug: string;
     readonly internalID: string;
     readonly artistSeriesArtworks: {
+        readonly aggregations: ReadonlyArray<{
+            readonly slice: ArtworkAggregation | null;
+            readonly counts: ReadonlyArray<{
+                readonly count: number;
+                readonly name: string;
+                readonly value: string;
+            } | null> | null;
+        } | null> | null;
         readonly edges: ReadonlyArray<{
             readonly node: {
                 readonly id: string;
@@ -61,6 +70,66 @@ const node: ReaderFragment = {
       "name": "sort",
       "type": "String",
       "defaultValue": "-decayed_merch"
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "medium",
+      "type": "String",
+      "defaultValue": "*"
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "priceRange",
+      "type": "String",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "color",
+      "type": "String",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "partnerID",
+      "type": "ID",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "dimensionRange",
+      "type": "String",
+      "defaultValue": "*-*"
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "majorPeriods",
+      "type": "[String]",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "acquireable",
+      "type": "Boolean",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "inquireableOnly",
+      "type": "Boolean",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "atAuction",
+      "type": "Boolean",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "offerable",
+      "type": "Boolean",
+      "defaultValue": null
     }
   ],
   "selections": [
@@ -86,6 +155,69 @@ const node: ReaderFragment = {
       "args": [
         {
           "kind": "Variable",
+          "name": "acquireable",
+          "variableName": "acquireable"
+        },
+        {
+          "kind": "Literal",
+          "name": "aggregations",
+          "value": [
+            "COLOR",
+            "DIMENSION_RANGE",
+            "GALLERY",
+            "INSTITUTION",
+            "MAJOR_PERIOD",
+            "MEDIUM",
+            "PRICE_RANGE"
+          ]
+        },
+        {
+          "kind": "Variable",
+          "name": "atAuction",
+          "variableName": "atAuction"
+        },
+        {
+          "kind": "Variable",
+          "name": "color",
+          "variableName": "color"
+        },
+        {
+          "kind": "Variable",
+          "name": "dimensionRange",
+          "variableName": "dimensionRange"
+        },
+        {
+          "kind": "Variable",
+          "name": "inquireableOnly",
+          "variableName": "inquireableOnly"
+        },
+        {
+          "kind": "Variable",
+          "name": "majorPeriods",
+          "variableName": "majorPeriods"
+        },
+        {
+          "kind": "Variable",
+          "name": "medium",
+          "variableName": "medium"
+        },
+        {
+          "kind": "Variable",
+          "name": "offerable",
+          "variableName": "offerable"
+        },
+        {
+          "kind": "Variable",
+          "name": "partnerID",
+          "variableName": "partnerID"
+        },
+        {
+          "kind": "Variable",
+          "name": "priceRange",
+          "variableName": "priceRange"
+        },
+        {
+          "kind": "Variable",
           "name": "sort",
           "variableName": "sort"
         }
@@ -93,6 +225,56 @@ const node: ReaderFragment = {
       "concreteType": "FilterArtworksConnection",
       "plural": false,
       "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "aggregations",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "ArtworksAggregationResults",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "slice",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "counts",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "AggregationCount",
+              "plural": true,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "count",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "name",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "value",
+                  "args": null,
+                  "storageKey": null
+                }
+              ]
+            }
+          ]
+        },
         {
           "kind": "LinkedField",
           "alias": null,
@@ -188,5 +370,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = '12fed3cf8c36f39cfea138b47924c910';
+(node as any).hash = '39063bcc6423e451869bf45145b839ee';
 export default node;

--- a/src/__generated__/ArtistSeriesQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash e0ff1d6dcfcdb4ca8409795746af5a8f */
+/* @relayHash 4eef18487decb000d50c1a1e0ba31ed7 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -31,7 +31,15 @@ query ArtistSeriesQuery(
 fragment ArtistSeriesArtworks_artistSeries on ArtistSeries {
   slug
   internalID
-  artistSeriesArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch") {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
     edges {
       node {
         id
@@ -246,8 +254,31 @@ v8 = {
 v9 = [
   {
     "kind": "Literal",
+    "name": "aggregations",
+    "value": [
+      "COLOR",
+      "DIMENSION_RANGE",
+      "GALLERY",
+      "INSTITUTION",
+      "MAJOR_PERIOD",
+      "MEDIUM",
+      "PRICE_RANGE"
+    ]
+  },
+  {
+    "kind": "Literal",
+    "name": "dimensionRange",
+    "value": "*-*"
+  },
+  {
+    "kind": "Literal",
     "name": "first",
     "value": 20
+  },
+  {
+    "kind": "Literal",
+    "name": "medium",
+    "value": "*"
   },
   {
     "kind": "Literal",
@@ -341,11 +372,55 @@ return {
             "kind": "LinkedField",
             "alias": "artistSeriesArtworks",
             "name": "filterArtworksConnection",
-            "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")",
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:20,medium:\"*\",sort:\"-decayed_merch\")",
             "args": (v9/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "aggregations",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtworksAggregationResults",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "slice",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "counts",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "AggregationCount",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "count",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      (v8/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "value",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ]
+              },
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -615,7 +690,18 @@ return {
             "handle": "connection",
             "key": "ArtistSeries_artistSeriesArtworks",
             "filters": [
-              "sort"
+              "sort",
+              "medium",
+              "priceRange",
+              "color",
+              "partnerID",
+              "dimensionRange",
+              "majorPeriods",
+              "acquireable",
+              "inquireableOnly",
+              "atAuction",
+              "offerable",
+              "aggregations"
             ]
           },
           {
@@ -702,7 +788,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesQuery",
-    "id": "22885ab742e97c9f0adf90fa9129bf86",
+    "id": "aa85e98102c91a8e6653c3faaad30091",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeriesQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 0341c2de201657cc24496d97a3e88f0c */
+/* @relayHash e0ff1d6dcfcdb4ca8409795746af5a8f */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -102,6 +102,9 @@ fragment ArtistSeries_artistSeries on ArtistSeries {
   ...ArtistSeriesArtworks_artistSeries
   artist: artists(size: 1) {
     ...ArtistSeriesMoreSeries_artist
+    artistSeriesConnection(first: 4) {
+      totalCount
+    }
     id
   }
 }
@@ -699,7 +702,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesQuery",
-    "id": "a95c8ac5d661ed8f9601d9c6935d5e5a",
+    "id": "22885ab742e97c9f0adf90fa9129bf86",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 09ded0e4bce2eef1918f645717a6bb56 */
+/* @relayHash ee2b8fab3bb8a6685f5e9ca47cbbb74b */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -191,6 +191,9 @@ fragment ArtistSeries_artistSeries on ArtistSeries {
   ...ArtistSeriesArtworks_artistSeries
   artist: artists(size: 1) {
     ...ArtistSeriesMoreSeries_artist
+    artistSeriesConnection(first: 4) {
+      totalCount
+    }
     id
   }
 }
@@ -780,7 +783,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesTestsQuery",
-    "id": "17d2fc113da16ab3f478e4f214f75997",
+    "id": "4ed89af7cd56e564cb3c44ecd3c765d4",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
@@ -1,9 +1,10 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash ee2b8fab3bb8a6685f5e9ca47cbbb74b */
+/* @relayHash 8990a74f399f3092f06b9295b2914966 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 export type ArtistSeriesTestsQueryVariables = {};
 export type ArtistSeriesTestsQueryResponse = {
     readonly artistSeries: {
@@ -31,6 +32,14 @@ export type ArtistSeriesTestsQueryRawResponse = {
             }) | null;
         }) | null> | null;
         readonly artistSeriesArtworks: ({
+            readonly aggregations: ReadonlyArray<({
+                readonly slice: ArtworkAggregation | null;
+                readonly counts: ReadonlyArray<({
+                    readonly count: number;
+                    readonly name: string;
+                    readonly value: string;
+                }) | null> | null;
+            }) | null> | null;
             readonly edges: ReadonlyArray<({
                 readonly node: ({
                     readonly id: string;
@@ -120,7 +129,15 @@ query ArtistSeriesTestsQuery {
 fragment ArtistSeriesArtworks_artistSeries on ArtistSeries {
   slug
   internalID
-  artistSeriesArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch") {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
     edges {
       node {
         id
@@ -327,8 +344,31 @@ v7 = {
 v8 = [
   {
     "kind": "Literal",
+    "name": "aggregations",
+    "value": [
+      "COLOR",
+      "DIMENSION_RANGE",
+      "GALLERY",
+      "INSTITUTION",
+      "MAJOR_PERIOD",
+      "MEDIUM",
+      "PRICE_RANGE"
+    ]
+  },
+  {
+    "kind": "Literal",
+    "name": "dimensionRange",
+    "value": "*-*"
+  },
+  {
+    "kind": "Literal",
     "name": "first",
     "value": 20
+  },
+  {
+    "kind": "Literal",
+    "name": "medium",
+    "value": "*"
   },
   {
     "kind": "Literal",
@@ -422,11 +462,55 @@ return {
             "kind": "LinkedField",
             "alias": "artistSeriesArtworks",
             "name": "filterArtworksConnection",
-            "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")",
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:20,medium:\"*\",sort:\"-decayed_merch\")",
             "args": (v8/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "aggregations",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtworksAggregationResults",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "slice",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "counts",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "AggregationCount",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "count",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      (v7/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "value",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ]
+              },
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -696,7 +780,18 @@ return {
             "handle": "connection",
             "key": "ArtistSeries_artistSeriesArtworks",
             "filters": [
-              "sort"
+              "sort",
+              "medium",
+              "priceRange",
+              "color",
+              "partnerID",
+              "dimensionRange",
+              "majorPeriods",
+              "acquireable",
+              "inquireableOnly",
+              "atAuction",
+              "offerable",
+              "aggregations"
             ]
           },
           {
@@ -783,7 +878,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesTestsQuery",
-    "id": "4ed89af7cd56e564cb3c44ecd3c765d4",
+    "id": "1aaf3596c9aa848a4b76cf362909d554",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeries_artistSeries.graphql.ts
+++ b/src/__generated__/ArtistSeries_artistSeries.graphql.ts
@@ -8,6 +8,9 @@ export type ArtistSeries_artistSeries = {
     readonly slug: string;
     readonly artistIDs: ReadonlyArray<string>;
     readonly artist: ReadonlyArray<{
+        readonly artistSeriesConnection: {
+            readonly totalCount: number;
+        } | null;
         readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesMoreSeries_artist">;
     } | null> | null;
     readonly " $fragmentRefs": FragmentRefs<"ArtistSeriesHeader_artistSeries" | "ArtistSeriesMeta_artistSeries" | "ArtistSeriesArtworks_artistSeries">;
@@ -65,6 +68,30 @@ const node: ReaderFragment = {
       "plural": true,
       "selections": [
         {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "artistSeriesConnection",
+          "storageKey": "artistSeriesConnection(first:4)",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "first",
+              "value": 4
+            }
+          ],
+          "concreteType": "ArtistSeriesConnection",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "totalCount",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        },
+        {
           "kind": "FragmentSpread",
           "name": "ArtistSeriesMoreSeries_artist",
           "args": null
@@ -88,5 +115,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = 'f7520ea6af7709f9d9c353454d7f7749';
+(node as any).hash = 'a4b3a5706086f1d6fd73bbe788d2e0e9';
 export default node;

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -173,8 +173,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ViewableItemRefs> = 
   const filteredArtworks = () => {
     if (artworksTotal === 0) {
       return (
-        <Box>
-          <Separator />
+        <Box mb="80px" pt={1}>
           <FilteredArtworkGridZeroState id={artist.id} slug={artist.slug} trackClear={trackClear} />
         </Box>
       )

--- a/src/lib/Components/ArtworkGrids/FilteredArtworkGridZeroState.tsx
+++ b/src/lib/Components/ArtworkGrids/FilteredArtworkGridZeroState.tsx
@@ -18,9 +18,9 @@ export const FilteredArtworkGridZeroState: React.FC<ZeroStateProps> = (props) =>
   }
 
   return (
-    <ZeroStateContainer>
+    <Flex flexDirection="column" px={4}>
       <ZeroStateMessage size="3">Unfortunately, there are no works that meet your criteria.</ZeroStateMessage>
-      <ButtonBox>
+      <Flex m="0 auto" pt={2}>
         <Button
           size="medium"
           variant="secondaryGray"
@@ -31,21 +31,12 @@ export const FilteredArtworkGridZeroState: React.FC<ZeroStateProps> = (props) =>
         >
           Clear filters
         </Button>
-      </ButtonBox>
-    </ZeroStateContainer>
+      </Flex>
+    </Flex>
   )
 }
 
 const ZeroStateMessage = styled(Sans)`
   color: ${color("black100")};
   text-align: center;
-`
-const ZeroStateContainer = styled(Flex)`
-  padding: 25px 35px 50px 35px;
-  flex-direction: column;
-`
-
-const ButtonBox = styled(Flex)`
-  margin: 0 auto;
-  padding: 15px 0 25px 0;
 `

--- a/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -268,7 +268,7 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
           </Box>
 
           {!autoFetch && !!hasMore() && (
-            <Button mt={5} mb={3} variant="secondaryGray" size="large" block onPress={this.fetchNextPage}>
+            <Button variant="secondaryGray" size="large" block onPress={this.fetchNextPage}>
               Show more
             </Button>
           )}

--- a/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -267,7 +267,7 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
             </View>
           </Box>
 
-          {!autoFetch && !!hasMore() && (
+          {!autoFetch && !!hasMore() && !isLoading() && (
             <Button variant="secondaryGray" size="large" block onPress={this.fetchNextPage}>
               Show more
             </Button>

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -157,6 +157,7 @@ export interface FilterDisplayConfig {
 export enum FilterModalMode {
   Collection = "Collection",
   ArtistArtworks = "ArtistArtworks",
+  ArtistSeries = "ArtistSeries",
 }
 
 interface FilterOptionsProps {
@@ -221,6 +222,19 @@ export const FilterOptions: React.FC<FilterOptionsProps> = (props) => {
           "dimensionRange",
           "majorPeriods",
           "color",
+        ]
+        break
+      case "ArtistSeries":
+        sortOrder = [
+          "sort",
+          "medium",
+          "priceRange",
+          "waysToBuy",
+          "dimensionRange",
+          "majorPeriods",
+          "color",
+          "gallery",
+          "institution",
         ]
         break
     }
@@ -303,6 +317,9 @@ export const FilterOptions: React.FC<FilterOptionsProps> = (props) => {
                 break
               case "ArtistArtworks":
                 trackClear(PageNames.ArtistPage, OwnerEntityTypes.Artist)
+                break
+              case "ArtistSeries":
+                trackClear(PageNames.ArtistSeriesPage, OwnerEntityTypes.ArtistSeries)
                 break
             }
 

--- a/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
@@ -112,6 +112,15 @@ export const ArtistSeries: React.FC<ArtistSeriesProps> = (props) => {
                         return (
                           <Box px={2}>
                             <ArtistSeriesArtworksFragmentContainer artistSeries={artistSeries} />
+                            <FilterModalNavigator
+                              {...props}
+                              isFilterArtworksModalVisible={isFilterArtworksModalVisible}
+                              id={artistSeries.internalID}
+                              slug={artistSeries.slug}
+                              mode={FilterModalMode.ArtistSeries}
+                              exitModal={handleFilterArtworksModal}
+                              closeModal={closeFilterArtworksModal}
+                            />
                           </Box>
                         )
                       case "artistSeriesMoreSeries":
@@ -127,15 +136,6 @@ export const ArtistSeries: React.FC<ArtistSeriesProps> = (props) => {
                                   artist={artist}
                                   artistSeriesHeader="More series by this artist"
                                   currentArtistSeriesExcluded
-                                />
-                                <FilterModalNavigator
-                                  {...props}
-                                  isFilterArtworksModalVisible={isFilterArtworksModalVisible}
-                                  id={artistSeries.internalID}
-                                  slug={artistSeries.slug}
-                                  mode={FilterModalMode.ArtistSeries}
-                                  exitModal={handleFilterArtworksModal}
-                                  closeModal={closeFilterArtworksModal}
                                 />
                               </Box>
                             </>

--- a/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
@@ -6,16 +6,18 @@ import { ArtistSeriesArtworksFragmentContainer } from "lib/Scenes/ArtistSeries/A
 import { ArtistSeriesHeaderFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesHeader"
 import { ArtistSeriesMetaFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesMeta"
 import { ArtistSeriesMoreSeriesFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
-import { ProvideScreenTracking } from "lib/utils/track"
+import { ProvideScreenTracking, Schema } from "lib/utils/track"
 import { Box, Separator, Spacer, Theme } from "palette"
 import React, { useRef, useState } from "react"
 
-import { AnimatedArtworkFilterButton } from "lib/Components/FilterModal"
+import { AnimatedArtworkFilterButton, FilterModalMode, FilterModalNavigator } from "lib/Components/FilterModal"
+import { ArtworkFilterContext, ArtworkFilterGlobalStateProvider } from "lib/utils/ArtworkFiltersStore"
 import { PlaceholderBox, PlaceholderGrid, PlaceholderText } from "lib/utils/placeholders"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { OwnerEntityTypes, PageNames } from "lib/utils/track/schema"
 import { FlatList, View, ViewToken } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { useTracking } from "react-tracking"
 interface ArtistSeriesProps {
   artistSeries: ArtistSeries_artistSeries
 }
@@ -24,15 +26,14 @@ interface ViewableItems {
   viewableItems?: ViewToken[]
 }
 
-export const ArtistSeries: React.FC<ArtistSeriesProps> = ({ artistSeries }) => {
-  const artist = artistSeries.artist?.[0]
+export const ArtistSeries: React.FC<ArtistSeriesProps> = (props) => {
+  const { artistSeries } = props
+  const tracking = useTracking()
   const flatListRef = useRef<FlatList>(null)
   const [isFilterArtworksModalVisible, setFilterArtworkModalVisible] = useState(false)
   const [isArtworksGridVisible, setArtworksGridVisible] = useState(false)
 
-  const handleFilterArtworksModal = () => {
-    setFilterArtworkModalVisible(!isFilterArtworksModalVisible)
-  }
+  const artist = artistSeries.artist?.[0]
 
   const sections = ["artistSeriesHeader", "artistSeriesMeta", "artistSeriesArtworks", "artistSeriesMoreSeries"]
   const viewConfigRef = React.useRef({ viewAreaCoveragePercentThreshold: 30 })
@@ -44,6 +45,34 @@ export const ArtistSeries: React.FC<ArtistSeriesProps> = ({ artistSeries }) => {
     setArtworksGridVisible(artworksItem?.isViewable ?? false)
   })
 
+  const handleFilterArtworksModal = () => {
+    setFilterArtworkModalVisible(!isFilterArtworksModalVisible)
+  }
+
+  const openFilterArtworksModal = () => {
+    tracking.trackEvent({
+      action_name: "filter",
+      context_screen_owner_type: Schema.OwnerEntityTypes.ArtistSeries,
+      context_screen: Schema.PageNames.ArtistSeriesPage,
+      context_screen_owner_id: artistSeries.internalID,
+      context_screen_owner_slug: artistSeries.slug,
+      action_type: Schema.ActionTypes.Tap,
+    })
+    handleFilterArtworksModal()
+  }
+
+  const closeFilterArtworksModal = () => {
+    tracking.trackEvent({
+      action_name: "closeFilterWindow",
+      context_screen_owner_type: Schema.OwnerEntityTypes.Artist,
+      context_screen: Schema.PageNames.ArtistPage,
+      context_screen_owner_id: artistSeries.internalID,
+      context_screen_owner_slug: artistSeries.slug,
+      action_type: Schema.ActionTypes.Tap,
+    })
+    handleFilterArtworksModal()
+  }
+
   return (
     <ProvideScreenTracking
       info={{
@@ -53,63 +82,78 @@ export const ArtistSeries: React.FC<ArtistSeriesProps> = ({ artistSeries }) => {
         context_screen_owner_id: artistSeries.internalID,
       }}
     >
-      <Theme>
-        <View style={{ flex: 1 }}>
-          <FlatList
-            ref={flatListRef}
-            viewabilityConfig={viewConfigRef.current}
-            onViewableItemsChanged={viewableItemsChangedRef.current}
-            keyExtractor={(_item, index) => String(index)}
-            data={sections}
-            ItemSeparatorComponent={() => <Spacer mb={2} />}
-            renderItem={({ item }): null | any => {
-              switch (item) {
-                case "artistSeriesHeader":
-                  return (
-                    <Box px={2}>
-                      <ArtistSeriesHeaderFragmentContainer artistSeries={artistSeries} />
-                    </Box>
-                  )
-                case "artistSeriesMeta":
-                  return (
-                    <Box px={2} pt={1}>
-                      <ArtistSeriesMetaFragmentContainer artistSeries={artistSeries} />
-                    </Box>
-                  )
-                case "artistSeriesArtworks":
-                  return (
-                    <Box px={2}>
-                      <ArtistSeriesArtworksFragmentContainer artistSeries={artistSeries} />
-                    </Box>
-                  )
-                case "artistSeriesMoreSeries":
-                  return (
-                    !((artist?.artistSeriesConnection?.totalCount ?? 0) === 0) && (
-                      <>
-                        <Separator my={2} />
-                        <Box px={2} pb={2}>
-                          <ArtistSeriesMoreSeriesFragmentContainer
-                            contextScreenOwnerId={artistSeries.internalID}
-                            contextScreenOwnerSlug={artistSeries.slug}
-                            contextScreenOwnerType={OwnerType.artistSeries}
-                            artist={artist}
-                            artistSeriesHeader="More series by this artist"
-                            currentArtistSeriesExcluded
-                          />
-                        </Box>
-                      </>
-                    )
-                  )
-              }
-            }}
-          />
-          <AnimatedArtworkFilterButton
-            isVisible={isArtworksGridVisible}
-            count={1}
-            onPress={handleFilterArtworksModal}
-          />
-        </View>
-      </Theme>
+      <ArtworkFilterGlobalStateProvider>
+        <ArtworkFilterContext.Consumer>
+          {(context) => (
+            <Theme>
+              <View style={{ flex: 1 }}>
+                <FlatList
+                  ref={flatListRef}
+                  viewabilityConfig={viewConfigRef.current}
+                  onViewableItemsChanged={viewableItemsChangedRef.current}
+                  keyExtractor={(_item, index) => String(index)}
+                  data={sections}
+                  ItemSeparatorComponent={() => <Spacer mb={2} />}
+                  renderItem={({ item }): null | any => {
+                    switch (item) {
+                      case "artistSeriesHeader":
+                        return (
+                          <Box px={2}>
+                            <ArtistSeriesHeaderFragmentContainer artistSeries={artistSeries} />
+                          </Box>
+                        )
+                      case "artistSeriesMeta":
+                        return (
+                          <Box px={2} pt={1}>
+                            <ArtistSeriesMetaFragmentContainer artistSeries={artistSeries} />
+                          </Box>
+                        )
+                      case "artistSeriesArtworks":
+                        return (
+                          <Box px={2}>
+                            <ArtistSeriesArtworksFragmentContainer artistSeries={artistSeries} />
+                          </Box>
+                        )
+                      case "artistSeriesMoreSeries":
+                        return (
+                          !((artist?.artistSeriesConnection?.totalCount ?? 0) === 0) && (
+                            <>
+                              <Separator mb={2} />
+                              <Box px={2} pb={2}>
+                                <ArtistSeriesMoreSeriesFragmentContainer
+                                  contextScreenOwnerId={artistSeries.internalID}
+                                  contextScreenOwnerSlug={artistSeries.slug}
+                                  contextScreenOwnerType={OwnerType.artistSeries}
+                                  artist={artist}
+                                  artistSeriesHeader="More series by this artist"
+                                  currentArtistSeriesExcluded
+                                />
+                                <FilterModalNavigator
+                                  {...props}
+                                  isFilterArtworksModalVisible={isFilterArtworksModalVisible}
+                                  id={artistSeries.internalID}
+                                  slug={artistSeries.slug}
+                                  mode={FilterModalMode.ArtistSeries}
+                                  exitModal={handleFilterArtworksModal}
+                                  closeModal={closeFilterArtworksModal}
+                                />
+                              </Box>
+                            </>
+                          )
+                        )
+                    }
+                  }}
+                />
+                <AnimatedArtworkFilterButton
+                  isVisible={isArtworksGridVisible}
+                  count={context.state.appliedFilters.length}
+                  onPress={openFilterArtworksModal}
+                />
+              </View>
+            </Theme>
+          )}
+        </ArtworkFilterContext.Consumer>
+      </ArtworkFilterGlobalStateProvider>
     </ProvideScreenTracking>
   )
 }

--- a/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
@@ -64,8 +64,8 @@ export const ArtistSeries: React.FC<ArtistSeriesProps> = (props) => {
   const closeFilterArtworksModal = () => {
     tracking.trackEvent({
       action_name: "closeFilterWindow",
-      context_screen_owner_type: Schema.OwnerEntityTypes.Artist,
-      context_screen: Schema.PageNames.ArtistPage,
+      context_screen_owner_type: Schema.OwnerEntityTypes.ArtistSeries,
+      context_screen: Schema.PageNames.ArtistSeriesPage,
       context_screen_owner_id: artistSeries.internalID,
       context_screen_owner_slug: artistSeries.slug,
       action_type: Schema.ActionTypes.Tap,

--- a/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
@@ -7,13 +7,13 @@ import { ArtistSeriesHeaderFragmentContainer } from "lib/Scenes/ArtistSeries/Art
 import { ArtistSeriesMetaFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesMeta"
 import { ArtistSeriesMoreSeriesFragmentContainer } from "lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
 import { ProvideScreenTracking } from "lib/utils/track"
-import { Box, Spacer, Theme } from "palette"
-import React from "react"
+import { Box, Separator, Spacer, Theme } from "palette"
+import React, { useRef } from "react"
 
 import { PlaceholderBox, PlaceholderGrid, PlaceholderText } from "lib/utils/placeholders"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { OwnerEntityTypes, PageNames } from "lib/utils/track/schema"
-import { ScrollView } from "react-native"
+import { FlatList, View } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 interface ArtistSeriesProps {
   artistSeries: ArtistSeries_artistSeries
@@ -21,6 +21,12 @@ interface ArtistSeriesProps {
 
 export const ArtistSeries: React.FC<ArtistSeriesProps> = ({ artistSeries }) => {
   const artist = artistSeries.artist?.[0]
+  const flatListRef = useRef<FlatList>(null)
+
+  const sections = ["artistSeriesHeader", "artistSeriesMeta", "artistSeriesArtworks", "artistSeriesMoreSeries"]
+  const viewabilityConfig = {
+    viewAreaCoveragePercentThreshold: 30, // The percentage of the artworks component should be in the screen before toggling the filter button
+  }
 
   return (
     <ProvideScreenTracking
@@ -32,33 +38,55 @@ export const ArtistSeries: React.FC<ArtistSeriesProps> = ({ artistSeries }) => {
       }}
     >
       <Theme>
-        <ScrollView showsVerticalScrollIndicator={false}>
-          <Box px={2}>
-            <ArtistSeriesHeaderFragmentContainer artistSeries={artistSeries} />
-            <ArtistSeriesMetaFragmentContainer artistSeries={artistSeries} />
-            <ArtistSeriesArtworksFragmentContainer artistSeries={artistSeries} />
-          </Box>
-          {
-            /* We don't want to see ArtistSeriesMoreSeries or the Separator when there are no related artist series.
-            However, this component doesn't have access to the count of related artist series. So, we implement the
-            Separator using a border instead, which won't show when there are no children in ArtistSeriesMoreSeries.
-          */
-            !!artist && (
-              <ArtistSeriesMoreSeriesFragmentContainer
-                contextScreenOwnerId={artistSeries.internalID}
-                contextScreenOwnerSlug={artistSeries.slug}
-                contextScreenOwnerType={OwnerType.artistSeries}
-                artist={artist}
-                borderTopWidth="1px"
-                borderTopColor="black10"
-                pt={2}
-                px={2}
-                artistSeriesHeader="More series by this artist"
-                currentArtistSeriesExcluded
-              />
-            )
-          }
-        </ScrollView>
+        <View style={{ flex: 1 }}>
+          <FlatList
+            ref={flatListRef}
+            viewabilityConfig={viewabilityConfig}
+            keyExtractor={(_item, index) => String(index)}
+            data={sections}
+            ItemSeparatorComponent={() => <Spacer mb={2} />}
+            renderItem={({ item }): null | any => {
+              switch (item) {
+                case "artistSeriesHeader":
+                  return (
+                    <Box px={2}>
+                      <ArtistSeriesHeaderFragmentContainer artistSeries={artistSeries} />
+                    </Box>
+                  )
+                case "artistSeriesMeta":
+                  return (
+                    <Box px={2} pt={1}>
+                      <ArtistSeriesMetaFragmentContainer artistSeries={artistSeries} />
+                    </Box>
+                  )
+                case "artistSeriesArtworks":
+                  return (
+                    <Box px={2}>
+                      <ArtistSeriesArtworksFragmentContainer artistSeries={artistSeries} />
+                    </Box>
+                  )
+                case "artistSeriesMoreSeries":
+                  return (
+                    !((artist?.artistSeriesConnection?.totalCount ?? 0) === 0) && (
+                      <>
+                        <Separator my={2} />
+                        <Box px={2} pb={2}>
+                          <ArtistSeriesMoreSeriesFragmentContainer
+                            contextScreenOwnerId={artistSeries.internalID}
+                            contextScreenOwnerSlug={artistSeries.slug}
+                            contextScreenOwnerType={OwnerType.artistSeries}
+                            artist={artist}
+                            artistSeriesHeader="More series by this artist"
+                            currentArtistSeriesExcluded
+                          />
+                        </Box>
+                      </>
+                    )
+                  )
+              }
+            }}
+          />
+        </View>
       </Theme>
     </ProvideScreenTracking>
   )
@@ -78,6 +106,9 @@ export const ArtistSeriesFragmentContainer = createFragmentContainer(ArtistSerie
 
       artist: artists(size: 1) {
         ...ArtistSeriesMoreSeries_artist
+        artistSeriesConnection(first: 4) {
+          totalCount
+        }
       }
     }
   `,

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
@@ -1,38 +1,88 @@
 import { OwnerType } from "@artsy/cohesion"
 import { ArtistSeriesArtworks_artistSeries } from "__generated__/ArtistSeriesArtworks_artistSeries.graphql"
+import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
 import { InfiniteScrollArtworksGridContainer } from "lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
 import { ARTIST_SERIES_PAGE_SIZE } from "lib/data/constants"
-import { Box, Separator } from "palette"
-import React from "react"
+import { ArtworkFilterContext } from "lib/utils/ArtworkFiltersStore"
+import { Schema } from "lib/utils/track"
+import { Box, Separator, Spacer } from "palette"
+import React, { useContext, useEffect } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
+import { useTracking } from "react-tracking"
+import { filterArtworksParams } from "../Collection/Helpers/FilterArtworksHelpers"
 
 interface ArtistSeriesArtworksProps {
   artistSeries: ArtistSeriesArtworks_artistSeries
   relay: RelayPaginationProp
 }
+
+const PAGE_SIZE = 20
+
 export const ArtistSeriesArtworks: React.FC<ArtistSeriesArtworksProps> = ({ artistSeries, relay }) => {
+  const { dispatch, state } = useContext(ArtworkFilterContext)
+  const tracking = useTracking()
+  const filterParams = filterArtworksParams(state.appliedFilters)
+
   const artworks = artistSeries?.artistSeriesArtworks!
 
-  if (artworks?.counts?.total === 0) {
-    return null
+  const trackClear = (id: string, slug: string) => {
+    tracking.trackEvent({
+      action_name: "clearFilters",
+      context_screen: Schema.ContextModules.ArtworkGrid,
+      context_screen_owner_type: Schema.OwnerEntityTypes.ArtistSeries,
+      context_screen_owner_id: id,
+      context_screen_owner_slug: slug,
+      action_type: Schema.ActionTypes.Tap,
+    })
   }
 
-  return (
-    <Box>
-      <Separator mb={2} />
-      <InfiniteScrollArtworksGridContainer
-        connection={artworks}
-        loadMore={relay.loadMore}
-        hasMore={relay.hasMore}
-        isLoading={relay.isLoading}
-        autoFetch={false}
-        pageSize={ARTIST_SERIES_PAGE_SIZE}
-        contextScreenOwnerType={OwnerType.artistSeries}
-        contextScreenOwnerId={artistSeries.internalID}
-        contextScreenOwnerSlug={artistSeries.slug}
-      />
-    </Box>
-  )
+  useEffect(() => {
+    if (state.applyFilters) {
+      relay.refetchConnection(
+        PAGE_SIZE,
+        (error) => {
+          if (error) {
+            throw new Error("ArtistArtworks/ArtistArtworks filter error: " + error.message)
+          }
+        },
+        filterParams
+      )
+    }
+  }, [state.appliedFilters])
+
+  useEffect(() => {
+    dispatch({
+      type: "setAggregations",
+      payload: artworks?.aggregations,
+    })
+  }, [])
+
+  if ((artworks?.counts?.total ?? 0) === 0) {
+    return (
+      <Box>
+        <Separator mb={2} />
+        <FilteredArtworkGridZeroState id={artistSeries.internalID} slug={artistSeries.slug} trackClear={trackClear} />
+        <Spacer mb={1} />
+      </Box>
+    )
+  } else {
+    return (
+      <Box>
+        <Separator mb={2} />
+        <InfiniteScrollArtworksGridContainer
+          connection={artworks}
+          loadMore={relay.loadMore}
+          hasMore={relay.hasMore}
+          isLoading={relay.isLoading}
+          autoFetch={false}
+          pageSize={ARTIST_SERIES_PAGE_SIZE}
+          contextScreenOwnerType={OwnerType.artistSeries}
+          contextScreenOwnerId={artistSeries.internalID}
+          contextScreenOwnerSlug={artistSeries.slug}
+        />
+      </Box>
+    )
+  }
 }
 
 export const ArtistSeriesArtworksFragmentContainer = createPaginationContainer(
@@ -44,11 +94,43 @@ export const ArtistSeriesArtworksFragmentContainer = createPaginationContainer(
         count: { type: "Int", defaultValue: 20 }
         cursor: { type: "String" }
         sort: { type: "String", defaultValue: "-decayed_merch" }
+        medium: { type: "String", defaultValue: "*" }
+        priceRange: { type: "String" }
+        color: { type: "String" }
+        partnerID: { type: "ID" }
+        dimensionRange: { type: "String", defaultValue: "*-*" }
+        majorPeriods: { type: "[String]" }
+        acquireable: { type: "Boolean" }
+        inquireableOnly: { type: "Boolean" }
+        atAuction: { type: "Boolean" }
+        offerable: { type: "Boolean" }
       ) {
         slug
         internalID
-        artistSeriesArtworks: filterArtworksConnection(first: 20, sort: $sort, after: $cursor)
-        @connection(key: "ArtistSeries_artistSeriesArtworks") {
+        artistSeriesArtworks: filterArtworksConnection(
+          first: 20
+          after: $cursor
+          sort: $sort
+          medium: $medium
+          priceRange: $priceRange
+          color: $color
+          partnerID: $partnerID
+          dimensionRange: $dimensionRange
+          majorPeriods: $majorPeriods
+          acquireable: $acquireable
+          inquireableOnly: $inquireableOnly
+          atAuction: $atAuction
+          offerable: $offerable
+          aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]
+        ) @connection(key: "ArtistSeries_artistSeriesArtworks") {
+          aggregations {
+            slice
+            counts {
+              count
+              name
+              value
+            }
+          }
           edges {
             node {
               id
@@ -83,9 +165,39 @@ export const ArtistSeriesArtworksFragmentContainer = createPaginationContainer(
       }
     },
     query: graphql`
-      query ArtistSeriesArtworksInfiniteScrollGridQuery($id: ID!, $count: Int!, $cursor: String, $sort: String) {
+      query ArtistSeriesArtworksInfiniteScrollGridQuery(
+        $id: ID!
+        $count: Int!
+        $cursor: String
+        $sort: String
+        $medium: String
+        $priceRange: String
+        $color: String
+        $partnerID: ID
+        $dimensionRange: String
+        $majorPeriods: [String]
+        $acquireable: Boolean
+        $inquireableOnly: Boolean
+        $atAuction: Boolean
+        $offerable: Boolean
+      ) {
         artistSeries(id: $id) {
-          ...ArtistSeriesArtworks_artistSeries @arguments(count: $count, cursor: $cursor, sort: $sort)
+          ...ArtistSeriesArtworks_artistSeries
+          @arguments(
+            count: $count
+            cursor: $cursor
+            sort: $sort
+            medium: $medium
+            color: $color
+            partnerID: $partnerID
+            priceRange: $priceRange
+            dimensionRange: $dimensionRange
+            majorPeriods: $majorPeriods
+            acquireable: $acquireable
+            inquireableOnly: $inquireableOnly
+            atAuction: $atAuction
+            offerable: $offerable
+          )
         }
       }
     `,

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
@@ -42,7 +42,7 @@ export const ArtistSeriesArtworks: React.FC<ArtistSeriesArtworksProps> = ({ arti
         PAGE_SIZE,
         (error) => {
           if (error) {
-            throw new Error("ArtistArtworks/ArtistArtworks filter error: " + error.message)
+            throw new Error("ArtistSeries/ArtistSeriesArtworks filter error: " + error.message)
           }
         },
         filterParams

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
@@ -19,7 +19,7 @@ export const ArtistSeriesArtworks: React.FC<ArtistSeriesArtworksProps> = ({ arti
 
   return (
     <Box>
-      <Separator my={2} />
+      <Separator mb={2} />
       <InfiniteScrollArtworksGridContainer
         connection={artworks}
         loadMore={relay.loadMore}

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesMeta.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesMeta.tsx
@@ -71,7 +71,7 @@ export const ArtistSeriesMeta: React.FC<ArtistSeriesMetaProps> = ({ artistSeries
 
   return (
     <View ref={metaRef}>
-      <Sans size="8" mt={3} data-test-id="title">
+      <Sans size="8" data-test-id="title">
         {artistSeries.title}
       </Sans>
       {!!artist && (

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeries-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeries-tests.tsx
@@ -100,6 +100,41 @@ describe("Artist Series Rail", () => {
       expect(wrapper.root.findAllByType(ArtistSeriesMoreSeries)).toHaveLength(0)
     })
   })
+
+  describe("with an artist series artist without an artistSeriesConnection", () => {
+    it("does not render ArtistSeriesMoreSeries", () => {
+      const artistSeriesNoMoreSeries = {
+        artistSeries: {
+          ...ArtistSeriesFixture.artistSeries,
+          artist: [
+            {
+              id: "an-id",
+              internalID: "123456ASCFG",
+              artistSeriesConnection: {
+                totalCount: 0,
+                edges: [
+                  {
+                    node: {
+                      slug: "yayoi-kusama-other-fruits",
+                      internalID: "abc",
+                      title: "Other Fruits",
+                      featured: false,
+                      artworksCountMessage: "22 available",
+                      image: {
+                        url: "https://www.images.net/fruits",
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      } as ArtistSeriesTestsQueryRawResponse
+      const wrapper = getWrapper(artistSeriesNoMoreSeries)
+      expect(wrapper.root.findAllByType(ArtistSeriesMoreSeries)).toHaveLength(0)
+    })
+  })
 })
 
 const ArtistSeriesFixture: ArtistSeriesTestsQueryRawResponse = {
@@ -191,7 +226,7 @@ const ArtistSeriesNoArtistFixture: ArtistSeriesTestsQueryRawResponse = {
     },
     artistIDs: [],
     artists: [],
-    artist: [],
+    artist: null,
     artistSeriesArtworks: {
       pageInfo: {
         hasNextPage: false,

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeries-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeries-tests.tsx
@@ -188,6 +188,7 @@ const ArtistSeriesFixture: ArtistSeriesTestsQueryRawResponse = {
         startCursor: "ajdjabnz81",
         endCursor: "aknqa9d81",
       },
+      aggregations: null,
       id: null,
       counts: { total: 4 },
       edges: [
@@ -228,6 +229,7 @@ const ArtistSeriesNoArtistFixture: ArtistSeriesTestsQueryRawResponse = {
     artists: [],
     artist: null,
     artistSeriesArtworks: {
+      aggregations: null,
       pageInfo: {
         hasNextPage: false,
         startCursor: "ajdjabnz81",

--- a/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -64,8 +64,8 @@ export const CollectionArtworks: React.FC<CollectionArtworksProps> = ({ collecti
 
   if (artworksTotal === 0) {
     return (
-      <Box mt={isDepartment ? "0px" : "-50px"}>
-        <Separator />
+      <Box mt={isDepartment ? "0px" : "-50px"} mb="80px">
+        <Separator mb={2} />
         <FilteredArtworkGridZeroState id={collection.id} slug={collection.slug} trackClear={trackClear} />
       </Box>
     )


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-2265]

### Description

This PR adds the ability to filter the artworks on the artist series view. On the way, I had to make a couple of adjustments to existing components.

Full list of changes is:
- Converts the top-level `ArtistSeries` view to be a `FlatList`. This is both because my understanding is that FlatLists are slightly more performant (especially given the artist series view has components far below-the-fold), and because FlatLists provide helpers for understanding the placement of components on the screen-- this made it possible for us to conditionally render the Filter button.
  - Caveat: It's possible you can achieve something similar with a `ScrollView`, but I didn't see anything obvious in my research.
- Using the existing filter components, adds the ability to filter the artworks on the artist series view.
- Slightly adjusts the spacing around the `FilterArtworksZeroState` component, which was somewhat specific to the existing uses but didn't work for artist series.

**Zero state for Artist Series:**
<img width="389" alt="Screen Shot 2020-09-22 at 9 12 11 AM" src="https://user-images.githubusercontent.com/2081340/93893491-ae34c800-fcbb-11ea-8de1-73ee99eddae4.png">

**Zero state for Collections:**
<img width="393" alt="Screen Shot 2020-09-22 at 9 38 57 AM" src="https://user-images.githubusercontent.com/2081340/93893511-b3921280-fcbb-11ea-84a2-ea11b14e37fa.png">

**Full gif of behavior:**
![filter-artist-series](https://user-images.githubusercontent.com/2081340/93893562-c3115b80-fcbb-11ea-9050-ee254fa6ede9.gif)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [X] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [X] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [X] I have documented any follow-up work that this PR will require, or it does not require any.
- [X] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434
[FX-2265]: https://artsyproduct.atlassian.net/browse/FX-2265