### PR TITLE
feat: show up to 50 artist series in the full list of series by an artist

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -19,6 +19,7 @@ upcoming:
     - Add auction lots grid to the auctions screen - mounir
     - Add auction lots list to the auctions screen - mounir
     - Enable filtering on artist series views - sweir
+    - Show up to 50 artist series in the full list of an artist's series - roop
 
 releases:
   - version: 6.6.4

--- a/src/__generated__/ArtistSeriesFullArtistSeriesListQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesFullArtistSeriesListQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 0fe7194cdc533de1fc7ef8f2bfb8b59b */
+/* @relayHash c6fb138d008c438a4792735033f339bf */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -30,7 +30,7 @@ query ArtistSeriesFullArtistSeriesListQuery(
 }
 
 fragment ArtistSeriesFullArtistSeriesList_artist on Artist {
-  artistSeriesConnection {
+  artistSeriesConnection(first: 50) {
     edges {
       node {
         slug
@@ -108,8 +108,14 @@ return {
             "kind": "LinkedField",
             "alias": null,
             "name": "artistSeriesConnection",
-            "storageKey": null,
-            "args": null,
+            "storageKey": "artistSeriesConnection(first:50)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 50
+              }
+            ],
             "concreteType": "ArtistSeriesConnection",
             "plural": false,
             "selections": [
@@ -204,7 +210,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesFullArtistSeriesListQuery",
-    "id": "bee36cc611a8d18eb56353793f44e1c4",
+    "id": "d04855d6329516d11952472452952ecc",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeriesFullArtistSeriesListTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesFullArtistSeriesListTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 2001c6fe32df1e0d542e5108725c31c0 */
+/* @relayHash e1b45760809c6ec72167b40e32cf3d15 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -46,7 +46,7 @@ query ArtistSeriesFullArtistSeriesListTestsQuery {
 }
 
 fragment ArtistSeriesFullArtistSeriesList_artist on Artist {
-  artistSeriesConnection {
+  artistSeriesConnection(first: 50) {
     edges {
       node {
         slug
@@ -116,8 +116,14 @@ return {
             "kind": "LinkedField",
             "alias": null,
             "name": "artistSeriesConnection",
-            "storageKey": null,
-            "args": null,
+            "storageKey": "artistSeriesConnection(first:50)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 50
+              }
+            ],
             "concreteType": "ArtistSeriesConnection",
             "plural": false,
             "selections": [
@@ -212,7 +218,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "ArtistSeriesFullArtistSeriesListTestsQuery",
-    "id": "021450d9e02b0e20f41cec2503aec44f",
+    "id": "5ccd06c8080fdf65614a4744a117473a",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/ArtistSeriesFullArtistSeriesList_artist.graphql.ts
+++ b/src/__generated__/ArtistSeriesFullArtistSeriesList_artist.graphql.ts
@@ -39,8 +39,14 @@ const node: ReaderFragment = {
       "kind": "LinkedField",
       "alias": null,
       "name": "artistSeriesConnection",
-      "storageKey": null,
-      "args": null,
+      "storageKey": "artistSeriesConnection(first:50)",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 50
+        }
+      ],
       "concreteType": "ArtistSeriesConnection",
       "plural": false,
       "selections": [
@@ -123,5 +129,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = '18f2747a77bb6e07a33aa8eaa01fe26e';
+(node as any).hash = '005fd788fe343d46f5bebb5663ae6ac2';
 export default node;

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesFullArtistSeriesList.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesFullArtistSeriesList.tsx
@@ -53,7 +53,7 @@ export const FullArtistSeriesList: React.FC<FullArtistSeriesListProps> = ({ arti
 export const ArtistSeriesFullArtistSeriesListFragmentContainer = createFragmentContainer(FullArtistSeriesList, {
   artist: graphql`
     fragment ArtistSeriesFullArtistSeriesList_artist on Artist {
-      artistSeriesConnection {
+      artistSeriesConnection(first: 50) {
         edges {
           node {
             slug


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-2281]

### Description

This is a one-liner change to bump the size of the `artistSeriesConnection` query from the default (20) to a max of 50.

Depends on https://github.com/artsy/gravity/pull/13481, which implements the backend change allowing this max.

![fitty5](https://user-images.githubusercontent.com/140521/94034146-ae05fc80-fd8f-11ea-8527-a0dab24e40d5.gif)

(^39 Kaws series in this list)



### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434
[FX-2281]: https://artsyproduct.atlassian.net/browse/FX-2281