### PR TITLE
[FX-2246] Utilizes state to track loading

### DIFF
--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -186,7 +186,6 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ViewableItemRefs> = 
             connection={artist.artworks}
             loadMore={relay.loadMore}
             hasMore={relay.hasMore}
-            isLoading={relay.isLoading}
             {...props}
             contextScreenOwnerType={OwnerType.artist}
             contextScreenOwnerId={artist.internalID}

--- a/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -10,7 +10,6 @@ import React from "react"
 import { Dimensions, LayoutChangeEvent, ScrollView, StyleSheet, View, ViewStyle } from "react-native"
 import { createFragmentContainer, RelayPaginationProp } from "react-relay"
 
-import Spinner from "../Spinner"
 import Artwork from "./ArtworkGridItem"
 
 import { isCloseToBottom } from "lib/utils/isCloseToBottom"
@@ -84,11 +83,11 @@ interface PrivateProps {
   connection: InfiniteScrollArtworksGrid_connection
   loadMore: RelayPaginationProp["loadMore"]
   hasMore: RelayPaginationProp["hasMore"]
-  isLoading: RelayPaginationProp["isLoading"]
 }
 
 interface State {
   sectionDimension: number
+  isLoading: boolean
 }
 
 class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, State> {
@@ -104,14 +103,18 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
 
   state = {
     sectionDimension: 0,
+    isLoading: false,
   }
 
   fetchNextPage = () => {
-    if (!this.props.hasMore() || this.props.isLoading()) {
+    if (!this.props.hasMore() || this.state.isLoading) {
       return
     }
 
+    this.setState({ isLoading: true })
+
     this.props.loadMore(this.props.pageSize!, (error) => {
+      this.setState({ isLoading: false })
       if (error) {
         // FIXME: Handle error
         console.error("InfiniteScrollGrid.tsx", error.message)
@@ -254,7 +257,7 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
 
   render() {
     const artworks = this.state.sectionDimension ? this.renderSections() : null
-    const { shouldAddPadding, autoFetch, hasMore, isLoading, stickyHeaderIndices } = this.props
+    const { shouldAddPadding, autoFetch, hasMore, stickyHeaderIndices } = this.props
     const boxPadding = shouldAddPadding ? 2 : 0
 
     return (
@@ -281,16 +284,18 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
             </View>
           </Box>
 
-          {!autoFetch && !!hasMore() && !isLoading() && (
-            <Button variant="secondaryGray" size="large" block onPress={this.fetchNextPage}>
+          {!autoFetch && !!hasMore() && (
+            <Button
+              mt={5}
+              mb={3}
+              variant="secondaryGray"
+              size="large"
+              block
+              onPress={this.fetchNextPage}
+              loading={this.state.isLoading}
+            >
               Show more
             </Button>
-          )}
-
-          {!!(isLoading() && hasMore()) && (
-            <Box my={2}>
-              <Spinner />
-            </Box>
           )}
         </ScrollView>
       </Theme>

--- a/src/lib/Components/ArtworkGrids/__tests__/InfiniteScrollArtworksGrid-tests.tsx
+++ b/src/lib/Components/ArtworkGrids/__tests__/InfiniteScrollArtworksGrid-tests.tsx
@@ -59,7 +59,6 @@ describe("Artist Series Artworks", () => {
               connection={artworksConnection}
               loadMore={relayMock.loadMore}
               hasMore={relayMock.hasMore}
-              isLoading={relayMock.isLoading}
             />
           )
         } else if (error) {

--- a/src/lib/Components/FilteredInfiniteScrollGrid/FilteredInfiniteScrollGrid.tsx
+++ b/src/lib/Components/FilteredInfiniteScrollGrid/FilteredInfiniteScrollGrid.tsx
@@ -84,7 +84,6 @@ export class FilteredInfiniteScrollGrid extends React.Component<Props, State> {
             connection={filterArtworksConnection}
             loadMore={this.props.relay.loadMore}
             hasMore={this.props.relay.hasMore}
-            isLoading={this.props.relay.isLoading}
             shouldAddPadding={true}
             hideBackButtonOnScroll={this.props.hideBackButtonOnScroll}
             HeaderComponent={

--- a/src/lib/Containers/Gene.tsx
+++ b/src/lib/Containers/Gene.tsx
@@ -211,7 +211,6 @@ export class Gene extends React.Component<Props, State> {
                     // @ts-ignore STRICTNESS_MIGRATION
                     connection={this.props.gene.artworks}
                     hasMore={this.props.relay.hasMore}
-                    isLoading={this.props.relay.isLoading}
                     loadMore={this.props.relay.loadMore}
                     HeaderComponent={this.renderStickyRefineSection()}
                     stickyHeaderIndices={[0]}

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
@@ -73,7 +73,6 @@ export const ArtistSeriesArtworks: React.FC<ArtistSeriesArtworksProps> = ({ arti
           connection={artworks}
           loadMore={relay.loadMore}
           hasMore={relay.hasMore}
-          isLoading={relay.isLoading}
           autoFetch={false}
           pageSize={ARTIST_SERIES_PAGE_SIZE}
           contextScreenOwnerType={OwnerType.artistSeries}

--- a/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -80,7 +80,6 @@ export const CollectionArtworks: React.FC<CollectionArtworksProps> = ({ collecti
         connection={artworks}
         loadMore={relay.loadMore}
         hasMore={relay.hasMore}
-        isLoading={relay.isLoading}
         contextScreenOwnerType={OwnerType.collection}
         contextScreenOwnerId={collection.id}
         contextScreenOwnerSlug={collection.slug}

--- a/src/lib/Scenes/Partner/Components/PartnerArtwork.tsx
+++ b/src/lib/Scenes/Partner/Components/PartnerArtwork.tsx
@@ -17,12 +17,7 @@ export const PartnerArtwork: React.FC<{
     <StickyTabPageScrollView>
       <Spacer mb={2} />
       {artworks ? (
-        <InfiniteScrollArtworksGrid
-          connection={artworks}
-          loadMore={relay.loadMore}
-          hasMore={relay.hasMore}
-          isLoading={relay.isLoading}
-        />
+        <InfiniteScrollArtworksGrid connection={artworks} loadMore={relay.loadMore} hasMore={relay.hasMore} />
       ) : (
         <TabEmptyState text="There is no artwork from this gallery yet" />
       )}

--- a/src/lib/Scenes/Sales/Components/LotsByFollowedArtists.tsx
+++ b/src/lib/Scenes/Sales/Components/LotsByFollowedArtists.tsx
@@ -29,7 +29,6 @@ export class LotsByFollowedArtists extends Component<Props> {
           <InfiniteScrollArtworksGrid
             loadMore={this.props.relay.loadMore}
             hasMore={this.props.relay.hasMore}
-            isLoading={this.props.relay.isLoading}
             // @ts-ignore STRICTNESS_MIGRATION
             connection={this.props.me.lotsByFollowedArtistsConnection}
             HeaderComponent={<SectionTitle title={title} />}


### PR DESCRIPTION
#trivial

The type of this PR is: **Fix**

This PR resolves [FX-2246]

### Description

The [`isLoading` function](https://relay.dev/docs/en/pagination-container#isloading) provided by Relay pagination containers does not trigger a render. It "is convenient for avoiding duplicate load calls" rather than transitioning the state of the UI. This PR just switches it to a simple state flag and removes what, I assume, is some code that was not actually rendering. [It *looks* like this broke in this commit.](https://github.com/artsy/eigen/commit/1090fc6251514ba157220c86fdcc0f1827eed5b2)

I did not include a spec for this because of the simplicity, but let me know if you believe it should have one and I'll add it.

-----

![](http://static.damonzucconi.com/_capture/HilYOyj81ERL.gif)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[FX-2246]: https://artsyproduct.atlassian.net/browse/FX-2246