### PR TITLE
[My Collection] Use product defined ranges to display liquidity values as text

### DIFF
--- a/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/ArtworkInsights/MyCollectionArtworkArtistMarket.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/ArtworkInsights/MyCollectionArtworkArtistMarket.tsx
@@ -43,6 +43,21 @@ const MyCollectionArtworkArtistMarket: React.FC<MyCollectionArtworkArtistMarketP
 
   const formattedDemandTrend = getFormattedDemandTrend() as string
 
+  const formatLiquidityRank = (rank: number): string => {
+    switch (true) {
+      case rank < Number(0.25):
+        return "Low"
+      case rank >= 0.25 && rank < 0.7:
+        return "Medium"
+      case rank >= 0.7 && rank < 0.85:
+        return "High"
+      case rank >= 0.85:
+        return "Very High"
+      default:
+        return ""
+    }
+  }
+
   return (
     <ScreenMargin>
       <InfoButton
@@ -57,7 +72,7 @@ const MyCollectionArtworkArtistMarket: React.FC<MyCollectionArtworkArtistMarketP
       <Field label="Avg. Annual Lots Sold" value={`${annualLotsSold}`} />
       <Field label="Sell-through Rate" value={`${sellThroughRate}%`} />
       <Field label="Median Sale Price to Estimate" value={`${medianSaleToEstimateRatio}x`} />
-      <Field label="Liquidity" value={`${liquidityRank} - ? - Very high`} />
+      {!Number.isNaN(liquidityRank) && <Field label="Liquidity" value={formatLiquidityRank(liquidityRank!)} />}
       <Field label="1-Year Trend" value={formattedDemandTrend} />
     </ScreenMargin>
   )


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CSGN-385](https://artsyproduct.atlassian.net/browse/CSGN-385)

### Description
Replaces the static integer values for Liquidity with a string representation (Low, Medium, High, Very High).
<!-- Implementation description -->

*After*
<img width="300" alt="Screen Shot 2020-09-23 at 2 29 17 PM" src="https://user-images.githubusercontent.com/10385964/94054795-1366e700-fdaa-11ea-88e3-22913d43bcad.png">

*Before*
<img width="285" alt="Screen Shot 2020-09-23 at 2 33 51 PM" src="https://user-images.githubusercontent.com/10385964/94054777-0ea23300-fdaa-11ea-8eed-aa8280120530.png">

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
#trivial 

[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434