### PR TITLE
Fix date for submission tags #trivial

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -167,15 +167,18 @@ lane :promote_beta do
   puts 'Tagging submission and pushing to GitHub.'
 
   # Apple's API returns truncated version/build numbers (eg: 2020.03.19.18 becomes 2020.3.19.18)
-  # So we re-compute this based on the same information as the :ship_beta lane.
-  root = File.expand_path('..', __dir__)
-  changelog_yaml = File.read('../CHANGELOG.yml')
-  changelog_data = YAML.safe_load(changelog_yaml)
-  latest_version = changelog_data['upcoming']['version']
-  bundle_version = `/usr/libexec/PlistBuddy -c "print CFBundleVersion" #{File.join(root, 'Artsy/App_Resources/Artsy-Info.plist')}`.strip
+  # So we need to add back leading zeroes
+  build_version_components = beta.build_version.split('.')
+  detruncated_components = build_version_components.map do |comp|
+    if comp.length == 1
+      '0' + comp
+    else
+      comp
+    end
+  end
+  build_version = detruncated_components.join('.')
 
-  tag_and_push(tag: "#{latest_version}-#{bundle_version}-submission")
-
+  tag_and_push(tag: "#{beta.train_version}-#{build_version}-submission")
   puts 'All done.'
 end
 


### PR DESCRIPTION
The type of this PR is: **Bugfix**

### Description

Worked on in knowledge share, our submission tags are incorrectly being tagged with an old date taken from the plist.
See an example here: https://github.com/artsy/eigen/releases/tag/6.6.4-2019.05.24.09-submission
This instead uses the latest test flight build version and addresses the issue of truncating build version called out in the comment by appending leading zeros to any truncated values.

Co-authored-by: @ds300
Co-authored-by: @MounirDhahri 
Co-authored-by: @pvinis 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] ~I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.~ Manually tested with a test lane but should confirm on next submission that this is tagged correctly
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
