### PR TITLE
Make mocked relay error more obvious

### DIFF
--- a/src/lib/tests/renderWithWrappers.tsx
+++ b/src/lib/tests/renderWithWrappers.tsx
@@ -11,16 +11,29 @@ import { ReactElement } from "simple-markdown"
  */
 export const renderWithWrappers = (component: ReactElement) => {
   const wrappedComponent = componentWithWrappers(component)
-  // tslint:disable-next-line:use-wrapped-components
-  const renderedComponent = ReactTestRenderer.create(wrappedComponent)
+  try {
+    // tslint:disable-next-line:use-wrapped-components
+    const renderedComponent = ReactTestRenderer.create(wrappedComponent)
 
-  // monkey patch update method to wrap components
-  const originalUpdate = renderedComponent.update
-  renderedComponent.update = (nextElement: ReactElement) => {
-    originalUpdate(componentWithWrappers(nextElement))
+    // monkey patch update method to wrap components
+    const originalUpdate = renderedComponent.update
+    renderedComponent.update = (nextElement: ReactElement) => {
+      originalUpdate(componentWithWrappers(nextElement))
+    }
+
+    return renderedComponent
+  } catch (error) {
+    if (error.message.includes("Element type is invalid")) {
+      throw new Error(
+        'Error: Relay test component failed to render. Did you forget to add `jest.unmock("react-relay")` at the top ' +
+          "of your test?" +
+          "\n\n" +
+          error
+      )
+    } else {
+      throw new Error(error.message)
+    }
   }
-
-  return renderedComponent
 }
 
 /**


### PR DESCRIPTION
The type of this PR is: **Enhancement**

### Description

When writing a relay test today I found myself hopelessly lost as to why the test renderer wasn't rendering the `<QueryRenderer>`. It turns out I forgot to add `jest.unmock('react-relay')` at the top of my test.

This updates our `renderWithWrappers` function to check for this condition, and to alert the user of the possibility. 

<img width="628" alt="Screen Shot 2020-09-24 at 5 47 46 PM" src="https://user-images.githubusercontent.com/236943/94214449-716cfa80-fe8e-11ea-9dbc-f5eb26b9aff3.png">

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
