### PR TITLE
feat: Adds view showing more info about fairs

### DIFF
--- a/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
+++ b/Artsy/View_Controllers/Admin/ARAdminSettingsViewController.m
@@ -125,7 +125,7 @@ NSString *const ARRecordingScreen = @"ARRecordingScreen";
 - (ARCellData *)generateFair2
 {
     return [self tappableCellDataWithTitle:@"→ Fair2" selection:^{
-        [[ARTopMenuViewController sharedController] pushViewController:[[ARComponentViewController alloc] initWithEmission:nil moduleName:@"Fair2" initialProperties:@{@"fairID": @"art-basel-hong-kong-2020"}] animated:YES];
+        [[ARTopMenuViewController sharedController] pushViewController:[[ARComponentViewController alloc] initWithEmission:nil moduleName:@"Fair2" initialProperties:@{@"fairID": @"art-basel-hong-kong-2019"}] animated:YES];
     }];
 }
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -11,6 +11,7 @@ upcoming:
     - Add header for Fair2 (visible only to admins) - will
     - Add editorial for Fair2 (visible only to admins) - damon
     - Add collections rail for Fair2 (visible only to admins) - damon
+    - Add More Info view for Fiar2 (visible only to admins) - will
   user_facing:
     - Fix navigation bug on Artwork consign button - david
     - Add auction lots rail to the auctions screen - mounir

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -12,6 +12,7 @@ upcoming:
     - Add editorial for Fair2 (visible only to admins) - damon
     - Add collections rail for Fair2 (visible only to admins) - damon
     - Add More Info view for Fiar2 (visible only to admins) - will
+    - Add More Info view for Fair2 (visible only to admins) - will
   user_facing:
     - Fix navigation bug on Artwork consign button - david
     - Add auction lots rail to the auctions screen - mounir

--- a/src/__generated__/Fair2HeaderTestsQuery.graphql.ts
+++ b/src/__generated__/Fair2HeaderTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 9b7e1104d471e0f53cec7853bb32df27 */
+/* @relayHash 5b08dd3295760f5d39e310a8a4227f08 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -80,10 +80,10 @@ fragment Fair2Header_fair on Fair {
     id
   }
   ticketsLink
-  hours(format: HTML)
-  links(format: HTML)
-  tickets(format: HTML)
-  contact(format: HTML)
+  hours(format: MARKDOWN)
+  links(format: MARKDOWN)
+  tickets(format: MARKDOWN)
+  contact(format: MARKDOWN)
 }
 */
 
@@ -121,7 +121,7 @@ v4 = [
   {
     "kind": "Literal",
     "name": "format",
-    "value": "HTML"
+    "value": "MARKDOWN"
   }
 ];
 return {
@@ -286,28 +286,28 @@ return {
             "alias": null,
             "name": "hours",
             "args": (v4/*: any*/),
-            "storageKey": "hours(format:\"HTML\")"
+            "storageKey": "hours(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "links",
             "args": (v4/*: any*/),
-            "storageKey": "links(format:\"HTML\")"
+            "storageKey": "links(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "tickets",
             "args": (v4/*: any*/),
-            "storageKey": "tickets(format:\"HTML\")"
+            "storageKey": "tickets(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "contact",
             "args": (v4/*: any*/),
-            "storageKey": "contact(format:\"HTML\")"
+            "storageKey": "contact(format:\"MARKDOWN\")"
           },
           (v3/*: any*/)
         ]
@@ -317,7 +317,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "Fair2HeaderTestsQuery",
-    "id": "f18d6bddb902e5c91aec785ee3162d3f",
+    "id": "bb7c7c68f5493b1342f22acb61e03dbf",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/Fair2Header_fair.graphql.ts
+++ b/src/__generated__/Fair2Header_fair.graphql.ts
@@ -48,7 +48,7 @@ v1 = [
   {
     "kind": "Literal",
     "name": "format",
-    "value": "HTML"
+    "value": "MARKDOWN"
   }
 ];
 return {
@@ -177,31 +177,31 @@ return {
       "alias": null,
       "name": "hours",
       "args": (v1/*: any*/),
-      "storageKey": "hours(format:\"HTML\")"
+      "storageKey": "hours(format:\"MARKDOWN\")"
     },
     {
       "kind": "ScalarField",
       "alias": null,
       "name": "links",
       "args": (v1/*: any*/),
-      "storageKey": "links(format:\"HTML\")"
+      "storageKey": "links(format:\"MARKDOWN\")"
     },
     {
       "kind": "ScalarField",
       "alias": null,
       "name": "tickets",
       "args": (v1/*: any*/),
-      "storageKey": "tickets(format:\"HTML\")"
+      "storageKey": "tickets(format:\"MARKDOWN\")"
     },
     {
       "kind": "ScalarField",
       "alias": null,
       "name": "contact",
       "args": (v1/*: any*/),
-      "storageKey": "contact(format:\"HTML\")"
+      "storageKey": "contact(format:\"MARKDOWN\")"
     }
   ]
 };
 })();
-(node as any).hash = '802361372c22c48ee8b199e39f67eea1';
+(node as any).hash = '45891118801486778b80c302d68fa0c5';
 export default node;

--- a/src/__generated__/Fair2MoreInfoQuery.graphql.ts
+++ b/src/__generated__/Fair2MoreInfoQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 281b6e303689af82c7c59bcd932f5dff */
+/* @relayHash 403a186d4db96cdf9812f6e767f9dc43 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -30,7 +30,20 @@ query Fair2MoreInfoQuery(
 }
 
 fragment Fair2MoreInfo_fair on Fair {
+  about
   name
+  slug
+  tagline
+  location {
+    summary
+    id
+  }
+  ticketsLink
+  hours(format: MARKDOWN)
+  links(format: MARKDOWN)
+  tickets(format: MARKDOWN)
+  summary
+  contact(format: MARKDOWN)
 }
 */
 
@@ -48,6 +61,27 @@ v1 = [
     "kind": "Variable",
     "name": "id",
     "variableName": "fairID"
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "summary",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "MARKDOWN"
   }
 ];
 return {
@@ -94,6 +128,13 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
+            "name": "about",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
             "name": "name",
             "args": null,
             "storageKey": null
@@ -101,10 +142,67 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
-            "name": "id",
+            "name": "slug",
             "args": null,
             "storageKey": null
-          }
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "tagline",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "location",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Location",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/)
+            ]
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "ticketsLink",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "hours",
+            "args": (v4/*: any*/),
+            "storageKey": "hours(format:\"MARKDOWN\")"
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "links",
+            "args": (v4/*: any*/),
+            "storageKey": "links(format:\"MARKDOWN\")"
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "tickets",
+            "args": (v4/*: any*/),
+            "storageKey": "tickets(format:\"MARKDOWN\")"
+          },
+          (v2/*: any*/),
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "contact",
+            "args": (v4/*: any*/),
+            "storageKey": "contact(format:\"MARKDOWN\")"
+          },
+          (v3/*: any*/)
         ]
       }
     ]
@@ -112,7 +210,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "Fair2MoreInfoQuery",
-    "id": "74cf5002917c67948cfc73d444c195cd",
+    "id": "5093169439cf0d7d60fe685be9e02742",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/Fair2MoreInfoQuery.graphql.ts
+++ b/src/__generated__/Fair2MoreInfoQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 403a186d4db96cdf9812f6e767f9dc43 */
+/* @relayHash fbb4f03121074e5f3905a13089462047 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -34,7 +34,16 @@ fragment Fair2MoreInfo_fair on Fair {
   name
   slug
   tagline
+  profile {
+    name
+    id
+  }
   location {
+    ...LocationMap_location
+    coordinates {
+      lat
+      lng
+    }
     summary
     id
   }
@@ -44,6 +53,37 @@ fragment Fair2MoreInfo_fair on Fair {
   tickets(format: MARKDOWN)
   summary
   contact(format: MARKDOWN)
+}
+
+fragment LocationMap_location on Location {
+  id
+  internalID
+  city
+  address
+  address_2: address2
+  postal_code: postalCode
+  summary
+  coordinates {
+    lat
+    lng
+  }
+  day_schedules: daySchedules {
+    start_time: startTime
+    end_time: endTime
+    day_of_week: dayOfWeek
+  }
+  openingHours {
+    __typename
+    ... on OpeningHoursArray {
+      schedules {
+        days
+        hours
+      }
+    }
+    ... on OpeningHoursText {
+      text
+    }
+  }
 }
 */
 
@@ -66,7 +106,7 @@ v1 = [
 v2 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "summary",
+  "name": "name",
   "args": null,
   "storageKey": null
 },
@@ -77,7 +117,14 @@ v3 = {
   "args": null,
   "storageKey": null
 },
-v4 = [
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "summary",
+  "args": null,
+  "storageKey": null
+},
+v5 = [
   {
     "kind": "Literal",
     "name": "format",
@@ -132,13 +179,7 @@ return {
             "args": null,
             "storageKey": null
           },
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "name",
-            "args": null,
-            "storageKey": null
-          },
+          (v2/*: any*/),
           {
             "kind": "ScalarField",
             "alias": null,
@@ -156,14 +197,181 @@ return {
           {
             "kind": "LinkedField",
             "alias": null,
+            "name": "profile",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "Profile",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/)
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
             "name": "location",
             "storageKey": null,
             "args": null,
             "concreteType": "Location",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
-              (v3/*: any*/)
+              (v3/*: any*/),
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "internalID",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "city",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "address",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": "address_2",
+                "name": "address2",
+                "args": null,
+                "storageKey": null
+              },
+              {
+                "kind": "ScalarField",
+                "alias": "postal_code",
+                "name": "postalCode",
+                "args": null,
+                "storageKey": null
+              },
+              (v4/*: any*/),
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "coordinates",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "LatLng",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "lat",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "lng",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": "day_schedules",
+                "name": "daySchedules",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "DaySchedule",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": "start_time",
+                    "name": "startTime",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": "end_time",
+                    "name": "endTime",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": "day_of_week",
+                    "name": "dayOfWeek",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "openingHours",
+                "storageKey": null,
+                "args": null,
+                "concreteType": null,
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "__typename",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "type": "OpeningHoursArray",
+                    "selections": [
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "schedules",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "FormattedDaySchedules",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "days",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "hours",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "type": "OpeningHoursText",
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "text",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ]
+              }
             ]
           },
           {
@@ -177,29 +385,29 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "hours",
-            "args": (v4/*: any*/),
+            "args": (v5/*: any*/),
             "storageKey": "hours(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "links",
-            "args": (v4/*: any*/),
+            "args": (v5/*: any*/),
             "storageKey": "links(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "tickets",
-            "args": (v4/*: any*/),
+            "args": (v5/*: any*/),
             "storageKey": "tickets(format:\"MARKDOWN\")"
           },
-          (v2/*: any*/),
+          (v4/*: any*/),
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "contact",
-            "args": (v4/*: any*/),
+            "args": (v5/*: any*/),
             "storageKey": "contact(format:\"MARKDOWN\")"
           },
           (v3/*: any*/)
@@ -210,7 +418,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "Fair2MoreInfoQuery",
-    "id": "5093169439cf0d7d60fe685be9e02742",
+    "id": "31eda9a44bf2d56a001d7ec59c33c2ec",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/Fair2MoreInfoQuery.graphql.ts
+++ b/src/__generated__/Fair2MoreInfoQuery.graphql.ts
@@ -1,0 +1,122 @@
+/* tslint:disable */
+/* eslint-disable */
+/* @relayHash 281b6e303689af82c7c59bcd932f5dff */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type Fair2MoreInfoQueryVariables = {
+    fairID: string;
+};
+export type Fair2MoreInfoQueryResponse = {
+    readonly fair: {
+        readonly " $fragmentRefs": FragmentRefs<"Fair2MoreInfo_fair">;
+    } | null;
+};
+export type Fair2MoreInfoQuery = {
+    readonly response: Fair2MoreInfoQueryResponse;
+    readonly variables: Fair2MoreInfoQueryVariables;
+};
+
+
+
+/*
+query Fair2MoreInfoQuery(
+  $fairID: String!
+) {
+  fair(id: $fairID) @principalField {
+    ...Fair2MoreInfo_fair
+    id
+  }
+}
+
+fragment Fair2MoreInfo_fair on Fair {
+  name
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "fairID",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "fairID"
+  }
+];
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "Fair2MoreInfoQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "fair",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "Fair2MoreInfo_fair",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "Fair2MoreInfoQuery",
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "fair",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "name",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "id",
+            "args": null,
+            "storageKey": null
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "Fair2MoreInfoQuery",
+    "id": "74cf5002917c67948cfc73d444c195cd",
+    "text": null,
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = 'c0b78e780c064aed6d48946928a2bcb0';
+export default node;

--- a/src/__generated__/Fair2MoreInfoTestsQuery.graphql.ts
+++ b/src/__generated__/Fair2MoreInfoTestsQuery.graphql.ts
@@ -1,29 +1,78 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash e08eaf8794c32dbeeefa862bce13f179 */
+/* @relayHash c13fe0c1f0d6f74dde886c6302078d19 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type Fair2MoreInfoQueryVariables = {
+export type Fair2MoreInfoTestsQueryVariables = {
     fairID: string;
 };
-export type Fair2MoreInfoQueryResponse = {
+export type Fair2MoreInfoTestsQueryResponse = {
     readonly fair: {
         readonly " $fragmentRefs": FragmentRefs<"Fair2MoreInfo_fair">;
     } | null;
 };
-export type Fair2MoreInfoQuery = {
-    readonly response: Fair2MoreInfoQueryResponse;
-    readonly variables: Fair2MoreInfoQueryVariables;
+export type Fair2MoreInfoTestsQueryRawResponse = {
+    readonly fair: ({
+        readonly about: string | null;
+        readonly name: string | null;
+        readonly tagline: string | null;
+        readonly profile: ({
+            readonly name: string | null;
+            readonly id: string | null;
+        }) | null;
+        readonly location: ({
+            readonly id: string;
+            readonly internalID: string;
+            readonly city: string | null;
+            readonly address: string | null;
+            readonly address_2: string | null;
+            readonly postal_code: string | null;
+            readonly summary: string | null;
+            readonly coordinates: ({
+                readonly lat: number | null;
+                readonly lng: number | null;
+            }) | null;
+            readonly day_schedules: ReadonlyArray<({
+                readonly start_time: number | null;
+                readonly end_time: number | null;
+                readonly day_of_week: string | null;
+            }) | null> | null;
+            readonly openingHours: ({
+                readonly __typename: "OpeningHoursArray";
+                readonly schedules: ReadonlyArray<({
+                    readonly days: string | null;
+                    readonly hours: string | null;
+                }) | null> | null;
+            } | {
+                readonly __typename: "OpeningHoursText";
+                readonly text: string | null;
+            } | {
+                readonly __typename: string | null;
+            }) | null;
+        }) | null;
+        readonly ticketsLink: string | null;
+        readonly hours: string | null;
+        readonly links: string | null;
+        readonly tickets: string | null;
+        readonly summary: string | null;
+        readonly contact: string | null;
+        readonly id: string | null;
+    }) | null;
+};
+export type Fair2MoreInfoTestsQuery = {
+    readonly response: Fair2MoreInfoTestsQueryResponse;
+    readonly variables: Fair2MoreInfoTestsQueryVariables;
+    readonly rawResponse: Fair2MoreInfoTestsQueryRawResponse;
 };
 
 
 
 /*
-query Fair2MoreInfoQuery(
+query Fair2MoreInfoTestsQuery(
   $fairID: String!
 ) {
-  fair(id: $fairID) @principalField {
+  fair(id: $fairID) {
     ...Fair2MoreInfo_fair
     id
   }
@@ -134,7 +183,7 @@ return {
   "kind": "Request",
   "fragment": {
     "kind": "Fragment",
-    "name": "Fair2MoreInfoQuery",
+    "name": "Fair2MoreInfoTestsQuery",
     "type": "Query",
     "metadata": null,
     "argumentDefinitions": (v0/*: any*/),
@@ -159,7 +208,7 @@ return {
   },
   "operation": {
     "kind": "Operation",
-    "name": "Fair2MoreInfoQuery",
+    "name": "Fair2MoreInfoTestsQuery",
     "argumentDefinitions": (v0/*: any*/),
     "selections": [
       {
@@ -409,12 +458,12 @@ return {
   },
   "params": {
     "operationKind": "query",
-    "name": "Fair2MoreInfoQuery",
-    "id": "d208d155c557ae4aa88edf113c7ddef2",
+    "name": "Fair2MoreInfoTestsQuery",
+    "id": "44635ee5734a14f12974fde627e6000d",
     "text": null,
     "metadata": {}
   }
 };
 })();
-(node as any).hash = 'c0b78e780c064aed6d48946928a2bcb0';
+(node as any).hash = 'c75f58ca32cf8f91786e6fcab00ac7f8';
 export default node;

--- a/src/__generated__/Fair2MoreInfo_fair.graphql.ts
+++ b/src/__generated__/Fair2MoreInfo_fair.graphql.ts
@@ -1,0 +1,35 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type Fair2MoreInfo_fair = {
+    readonly name: string | null;
+    readonly " $refType": "Fair2MoreInfo_fair";
+};
+export type Fair2MoreInfo_fair$data = Fair2MoreInfo_fair;
+export type Fair2MoreInfo_fair$key = {
+    readonly " $data"?: Fair2MoreInfo_fair$data;
+    readonly " $fragmentRefs": FragmentRefs<"Fair2MoreInfo_fair">;
+};
+
+
+
+const node: ReaderFragment = {
+  "kind": "Fragment",
+  "name": "Fair2MoreInfo_fair",
+  "type": "Fair",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "name",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+};
+(node as any).hash = 'a9d2269dd3b64cc657384b71307b72fc';
+export default node;

--- a/src/__generated__/Fair2MoreInfo_fair.graphql.ts
+++ b/src/__generated__/Fair2MoreInfo_fair.graphql.ts
@@ -4,7 +4,19 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type Fair2MoreInfo_fair = {
+    readonly about: string | null;
     readonly name: string | null;
+    readonly slug: string;
+    readonly tagline: string | null;
+    readonly location: {
+        readonly summary: string | null;
+    } | null;
+    readonly ticketsLink: string | null;
+    readonly hours: string | null;
+    readonly links: string | null;
+    readonly tickets: string | null;
+    readonly summary: string | null;
+    readonly contact: string | null;
     readonly " $refType": "Fair2MoreInfo_fair";
 };
 export type Fair2MoreInfo_fair$data = Fair2MoreInfo_fair;
@@ -15,7 +27,22 @@ export type Fair2MoreInfo_fair$key = {
 
 
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "summary",
+  "args": null,
+  "storageKey": null
+},
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "MARKDOWN"
+  }
+];
+return {
   "kind": "Fragment",
   "name": "Fair2MoreInfo_fair",
   "type": "Fair",
@@ -25,11 +52,81 @@ const node: ReaderFragment = {
     {
       "kind": "ScalarField",
       "alias": null,
+      "name": "about",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
       "name": "name",
       "args": null,
       "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "slug",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "tagline",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "location",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Location",
+      "plural": false,
+      "selections": [
+        (v0/*: any*/)
+      ]
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "ticketsLink",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "hours",
+      "args": (v1/*: any*/),
+      "storageKey": "hours(format:\"MARKDOWN\")"
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "links",
+      "args": (v1/*: any*/),
+      "storageKey": "links(format:\"MARKDOWN\")"
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "tickets",
+      "args": (v1/*: any*/),
+      "storageKey": "tickets(format:\"MARKDOWN\")"
+    },
+    (v0/*: any*/),
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "contact",
+      "args": (v1/*: any*/),
+      "storageKey": "contact(format:\"MARKDOWN\")"
     }
   ]
 };
-(node as any).hash = 'a9d2269dd3b64cc657384b71307b72fc';
+})();
+(node as any).hash = '4ae3c17624fb18f5a51b5543602ead6a';
 export default node;

--- a/src/__generated__/Fair2MoreInfo_fair.graphql.ts
+++ b/src/__generated__/Fair2MoreInfo_fair.graphql.ts
@@ -6,7 +6,6 @@ import { FragmentRefs } from "relay-runtime";
 export type Fair2MoreInfo_fair = {
     readonly about: string | null;
     readonly name: string | null;
-    readonly slug: string;
     readonly tagline: string | null;
     readonly profile: {
         readonly name: string | null;
@@ -72,13 +71,6 @@ return {
       "storageKey": null
     },
     (v0/*: any*/),
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "slug",
-      "args": null,
-      "storageKey": null
-    },
     {
       "kind": "ScalarField",
       "alias": null,
@@ -179,5 +171,5 @@ return {
   ]
 };
 })();
-(node as any).hash = 'fff28916fcb01e8d4fa3465946d0bfce';
+(node as any).hash = 'e97c82f264b236875fa1acdf28507f9f';
 export default node;

--- a/src/__generated__/Fair2MoreInfo_fair.graphql.ts
+++ b/src/__generated__/Fair2MoreInfo_fair.graphql.ts
@@ -8,8 +8,16 @@ export type Fair2MoreInfo_fair = {
     readonly name: string | null;
     readonly slug: string;
     readonly tagline: string | null;
+    readonly profile: {
+        readonly name: string | null;
+    } | null;
     readonly location: {
+        readonly coordinates: {
+            readonly lat: number | null;
+            readonly lng: number | null;
+        } | null;
         readonly summary: string | null;
+        readonly " $fragmentRefs": FragmentRefs<"LocationMap_location">;
     } | null;
     readonly ticketsLink: string | null;
     readonly hours: string | null;
@@ -31,11 +39,18 @@ const node: ReaderFragment = (function(){
 var v0 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "summary",
   "args": null,
   "storageKey": null
 },
-v1 = [
+v2 = [
   {
     "kind": "Literal",
     "name": "format",
@@ -56,13 +71,7 @@ return {
       "args": null,
       "storageKey": null
     },
-    {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "name",
-      "args": null,
-      "storageKey": null
-    },
+    (v0/*: any*/),
     {
       "kind": "ScalarField",
       "alias": null,
@@ -80,13 +89,55 @@ return {
     {
       "kind": "LinkedField",
       "alias": null,
+      "name": "profile",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "Profile",
+      "plural": false,
+      "selections": [
+        (v0/*: any*/)
+      ]
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
       "name": "location",
       "storageKey": null,
       "args": null,
       "concreteType": "Location",
       "plural": false,
       "selections": [
-        (v0/*: any*/)
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "coordinates",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "LatLng",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "lat",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "lng",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        },
+        (v1/*: any*/),
+        {
+          "kind": "FragmentSpread",
+          "name": "LocationMap_location",
+          "args": null
+        }
       ]
     },
     {
@@ -100,33 +151,33 @@ return {
       "kind": "ScalarField",
       "alias": null,
       "name": "hours",
-      "args": (v1/*: any*/),
+      "args": (v2/*: any*/),
       "storageKey": "hours(format:\"MARKDOWN\")"
     },
     {
       "kind": "ScalarField",
       "alias": null,
       "name": "links",
-      "args": (v1/*: any*/),
+      "args": (v2/*: any*/),
       "storageKey": "links(format:\"MARKDOWN\")"
     },
     {
       "kind": "ScalarField",
       "alias": null,
       "name": "tickets",
-      "args": (v1/*: any*/),
+      "args": (v2/*: any*/),
       "storageKey": "tickets(format:\"MARKDOWN\")"
     },
-    (v0/*: any*/),
+    (v1/*: any*/),
     {
       "kind": "ScalarField",
       "alias": null,
       "name": "contact",
-      "args": (v1/*: any*/),
+      "args": (v2/*: any*/),
       "storageKey": "contact(format:\"MARKDOWN\")"
     }
   ]
 };
 })();
-(node as any).hash = '4ae3c17624fb18f5a51b5543602ead6a';
+(node as any).hash = 'fff28916fcb01e8d4fa3465946d0bfce';
 export default node;

--- a/src/__generated__/Fair2Query.graphql.ts
+++ b/src/__generated__/Fair2Query.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash c39e37749425bad8a8e8af3c990da1ab */
+/* @relayHash 85ff45ab38cebdc053600ca2f04a6080 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -86,10 +86,10 @@ fragment Fair2Header_fair on Fair {
     id
   }
   ticketsLink
-  hours(format: HTML)
-  links(format: HTML)
-  tickets(format: HTML)
-  contact(format: HTML)
+  hours(format: MARKDOWN)
+  links(format: MARKDOWN)
+  tickets(format: MARKDOWN)
+  contact(format: MARKDOWN)
 }
 
 fragment Fair2_fair on Fair {
@@ -163,7 +163,7 @@ v7 = [
   {
     "kind": "Literal",
     "name": "format",
-    "value": "HTML"
+    "value": "MARKDOWN"
   }
 ];
 return {
@@ -500,28 +500,28 @@ return {
             "alias": null,
             "name": "hours",
             "args": (v7/*: any*/),
-            "storageKey": "hours(format:\"HTML\")"
+            "storageKey": "hours(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "links",
             "args": (v7/*: any*/),
-            "storageKey": "links(format:\"HTML\")"
+            "storageKey": "links(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "tickets",
             "args": (v7/*: any*/),
-            "storageKey": "tickets(format:\"HTML\")"
+            "storageKey": "tickets(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "contact",
             "args": (v7/*: any*/),
-            "storageKey": "contact(format:\"HTML\")"
+            "storageKey": "contact(format:\"MARKDOWN\")"
           },
           (v3/*: any*/)
         ]
@@ -531,7 +531,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "Fair2Query",
-    "id": "9f2bd57d17a9a8222ec848f15fc5976d",
+    "id": "95c68061aa0206a0bb3c479146cd5024",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/Fair2TestsQuery.graphql.ts
+++ b/src/__generated__/Fair2TestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 1fe38ec59d67a627dbc8e93b9926e16a */
+/* @relayHash 66f21628aaffb51a10185d6d09c4ec56 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -148,10 +148,10 @@ fragment Fair2Header_fair on Fair {
     id
   }
   ticketsLink
-  hours(format: HTML)
-  links(format: HTML)
-  tickets(format: HTML)
-  contact(format: HTML)
+  hours(format: MARKDOWN)
+  links(format: MARKDOWN)
+  tickets(format: MARKDOWN)
+  contact(format: MARKDOWN)
 }
 
 fragment Fair2_fair on Fair {
@@ -225,7 +225,7 @@ v7 = [
   {
     "kind": "Literal",
     "name": "format",
-    "value": "HTML"
+    "value": "MARKDOWN"
   }
 ];
 return {
@@ -562,28 +562,28 @@ return {
             "alias": null,
             "name": "hours",
             "args": (v7/*: any*/),
-            "storageKey": "hours(format:\"HTML\")"
+            "storageKey": "hours(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "links",
             "args": (v7/*: any*/),
-            "storageKey": "links(format:\"HTML\")"
+            "storageKey": "links(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "tickets",
             "args": (v7/*: any*/),
-            "storageKey": "tickets(format:\"HTML\")"
+            "storageKey": "tickets(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "contact",
             "args": (v7/*: any*/),
-            "storageKey": "contact(format:\"HTML\")"
+            "storageKey": "contact(format:\"MARKDOWN\")"
           },
           (v3/*: any*/)
         ]
@@ -593,7 +593,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "Fair2TestsQuery",
-    "id": "168707dfe472631168e73b124e4dbfbd",
+    "id": "25a9b84dd20d4460a29311053138a18e",
     "text": null,
     "metadata": {}
   }

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -48,8 +48,8 @@ import {
   FairMoreInfoQueryRenderer,
 } from "./Scenes/Fair"
 import { FairQueryRenderer } from "./Scenes/Fair/Fair"
-import { Fair2MoreInfoQueryRenderer } from "./Scenes/Fair2/Components/Fair2MoreInfo"
 import { Fair2QueryRenderer } from "./Scenes/Fair2/Fair2"
+import { Fair2MoreInfoQueryRenderer } from "./Scenes/Fair2/Fair2MoreInfo"
 import { Favorites } from "./Scenes/Favorites/Favorites"
 import { FeatureQueryRenderer } from "./Scenes/Feature/Feature"
 import { HomeQueryRenderer } from "./Scenes/Home/Home"

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -48,6 +48,7 @@ import {
   FairMoreInfoQueryRenderer,
 } from "./Scenes/Fair"
 import { FairQueryRenderer } from "./Scenes/Fair/Fair"
+import { Fair2MoreInfoQueryRenderer } from "./Scenes/Fair2/Components/Fair2MoreInfo"
 import { Fair2QueryRenderer } from "./Scenes/Fair2/Fair2"
 import { Favorites } from "./Scenes/Favorites/Favorites"
 import { FeatureQueryRenderer } from "./Scenes/Feature/Feature"
@@ -384,6 +385,7 @@ export const modules = defineModules({
   Conversation: { Component: Conversation, onlyShowInTabName: "inbox" },
   Fair: { Component: FairQueryRenderer, fullBleed: true },
   Fair2: { Component: Fair2QueryRenderer, fullBleed: true },
+  Fair2MoreInfo: { Component: Fair2MoreInfoQueryRenderer },
   FairArtists: { Component: FairArtists },
   FairArtworks: { Component: FairArtworks },
   FairBMWArtActivation: { Component: FairBMWArtActivation, fullBleed: true },

--- a/src/lib/Scenes/Fair2/Components/Fair2Header.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2Header.tsx
@@ -61,7 +61,7 @@ export const Fair2Header: React.FC<Fair2HeaderProps> = ({ fair }) => {
         <Text variant="text">{previewText}</Text>
         {!!canShowMoreInfoLink && (
           <TouchableOpacity onPress={() => handleNavigation(slug)}>
-            <Flex flexDirection="row" justifyContent="flex-start">
+            <Flex py={2} flexDirection="row" justifyContent="flex-start">
               <Text variant="mediumText">More info</Text>
               <ChevronIcon mr="-5px" mt="2px" />
             </Flex>
@@ -94,10 +94,10 @@ export const Fair2HeaderFragmentContainer = createFragmentContainer(Fair2Header,
         summary
       }
       ticketsLink
-      hours(format: HTML)
-      links(format: HTML)
-      tickets(format: HTML)
-      contact(format: HTML)
+      hours(format: MARKDOWN)
+      links(format: MARKDOWN)
+      tickets(format: MARKDOWN)
+      contact(format: MARKDOWN)
     }
   `,
 })

--- a/src/lib/Scenes/Fair2/Components/Fair2Header.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2Header.tsx
@@ -1,8 +1,8 @@
 import { Fair2Header_fair } from "__generated__/Fair2Header_fair.graphql"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
-import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { navigate } from "lib/navigation/navigate"
 import { Box, ChevronIcon, Flex, Text } from "palette"
-import React, { useRef } from "react"
+import React from "react"
 import { Dimensions, TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 
@@ -27,13 +27,8 @@ export const Fair2Header: React.FC<Fair2HeaderProps> = ({ fair }) => {
     !!summary ||
     !!tickets
 
-  const navRef = useRef<any>()
-  const handleNavigation = (fairSlug: string) => {
-    return SwitchBoard.presentNavigationViewController(navRef.current, `/fair2/${fairSlug}/info`)
-  }
-
   return (
-    <Box ref={navRef}>
+    <Box>
       {!!image && (
         <Flex alignItems="center" justifyContent="center" style={{ position: "relative" }}>
           <OpaqueImageView width={screenWidth} height={screenWidth / image.aspectRatio} imageURL={image.url} />
@@ -60,7 +55,7 @@ export const Fair2Header: React.FC<Fair2HeaderProps> = ({ fair }) => {
         </Text>
         <Text variant="text">{previewText}</Text>
         {!!canShowMoreInfoLink && (
-          <TouchableOpacity onPress={() => handleNavigation(slug)}>
+          <TouchableOpacity onPress={() => navigate(`/fair2/${slug}/info`)}>
             <Flex py={2} flexDirection="row" justifyContent="flex-start">
               <Text variant="mediumText">More info</Text>
               <ChevronIcon mr="-5px" mt="2px" />

--- a/src/lib/Scenes/Fair2/Components/Fair2MoreInfo.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2MoreInfo.tsx
@@ -4,11 +4,13 @@ import { LocationMapContainer, PartnerType } from "lib/Components/LocationMap"
 import { Markdown } from "lib/Components/Markdown"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
+import { defaultRules } from "lib/utils/renderMarkdown"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import { Box, Spacer, Text, Theme } from "palette"
 import React, { useRef } from "react"
 import { ScrollView, TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { blockRegex } from "simple-markdown"
 
 interface Fair2MoreInfoQueryRendererProps {
   fairID: string
@@ -17,6 +19,20 @@ interface Fair2MoreInfoQueryRendererProps {
 interface Fair2MoreInfoProps {
   fair: Fair2MoreInfo_fair
 }
+
+// Default markdown rules center align text, which we don't want.
+const markdownRules = defaultRules(false, {
+  paragraph: {
+    match: blockRegex(/^((?:[^\n]|\n(?! *\n))+)(?:\n *)/),
+    react: (node, output, state) => {
+      return (
+        <Text variant="text" key={state.key} textAlign="left">
+          {output(node.content, state)}
+        </Text>
+      )
+    },
+  },
+})
 
 export const Fair2MoreInfo: React.FC<Fair2MoreInfoProps> = ({ fair }) => {
   const navRef = useRef<any>()
@@ -37,20 +53,20 @@ export const Fair2MoreInfo: React.FC<Fair2MoreInfoProps> = ({ fair }) => {
           {!!fair.summary && (
             <>
               <Text variant="text">{fair.summary}</Text>
-              <Spacer my={2} />
+              <Spacer my={1} />
             </>
           )}
           {!!fair.about && (
             <>
               <Text variant="text">{fair.about}</Text>
-              <Spacer my={2} />
+              <Spacer my={1} />
             </>
           )}
 
           {!!fair.tagline && (
             <>
               <Text variant="text">{fair.tagline}</Text>
-              <Spacer my={2} />
+              <Spacer my={1} />
             </>
           )}
 
@@ -65,22 +81,22 @@ export const Fair2MoreInfo: React.FC<Fair2MoreInfoProps> = ({ fair }) => {
                   partnerName={fair.profile?.name ?? fair.name}
                 />
               )}
-              <Spacer my={2} />
+              <Spacer my={1} />
             </>
           )}
 
           {!!fair.hours && (
             <>
               <Text variant="mediumText">Hours</Text>
-              <Markdown>{fair.hours}</Markdown>
-              <Spacer my={3} />
+              <Markdown rules={markdownRules}>{fair.hours}</Markdown>
+              <Spacer my={1} />
             </>
           )}
           {!!fair.tickets && (
             <>
               <Text variant="mediumText">Tickets</Text>
-              <Markdown>{fair.tickets}</Markdown>
-              <Spacer my={2} />
+              <Markdown rules={markdownRules}>{fair.tickets}</Markdown>
+              <Spacer my={1} />
             </>
           )}
           {!!fair.ticketsLink && (
@@ -88,21 +104,21 @@ export const Fair2MoreInfo: React.FC<Fair2MoreInfoProps> = ({ fair }) => {
               <TouchableOpacity onPress={() => handleNavigation(fair.ticketsLink!)}>
                 <Text variant="mediumText">Buy Tickets</Text>
               </TouchableOpacity>
-              <Spacer my={2} />
+              <Spacer my={1} />
             </>
           )}
           {!!fair.links && (
             <>
               <Text variant="mediumText">Links</Text>
-              <Markdown>{fair.links}</Markdown>
-              <Spacer my={2} />
+              <Markdown rules={markdownRules}>{fair.links}</Markdown>
+              <Spacer my={1} />
             </>
           )}
           {!!fair.contact && (
             <>
               <Text variant="mediumText">Contact</Text>
-              <Markdown>{fair.contact}</Markdown>
-              <Spacer my={2} />
+              <Markdown rules={markdownRules}>{fair.contact}</Markdown>
+              <Spacer my={1} />
             </>
           )}
         </Box>

--- a/src/lib/Scenes/Fair2/Components/Fair2MoreInfo.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2MoreInfo.tsx
@@ -1,10 +1,12 @@
 import { Fair2MoreInfo_fair } from "__generated__/Fair2MoreInfo_fair.graphql"
 import { Fair2MoreInfoQuery } from "__generated__/Fair2MoreInfoQuery.graphql"
+import { Markdown } from "lib/Components/Markdown"
+import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
-import { Text, Theme } from "palette"
-import React from "react"
-import { FlatList } from "react-native"
+import { Box, Spacer, Text, Theme } from "palette"
+import React, { useRef } from "react"
+import { ScrollView, TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 
 interface Fair2MoreInfoQueryRendererProps {
@@ -16,27 +18,105 @@ interface Fair2MoreInfoProps {
 }
 
 export const Fair2MoreInfo: React.FC<Fair2MoreInfoProps> = ({ fair }) => {
-  const sections = ["foo"]
+  const navRef = useRef<any>()
+  const handleNavigation = (link: string) => {
+    return SwitchBoard.presentNavigationViewController(navRef.current, link)
+  }
+
   return (
-    <Theme>
-      <FlatList
-        data={sections}
-        keyExtractor={(_item, index) => String(index)}
-        renderItem={({ item }): null | any => {
-          switch (item) {
-            case "foo":
-              return <Text variant="text">{fair.name}</Text>
-          }
-        }}
-      />
-    </Theme>
+    <ScrollView ref={navRef}>
+      <Theme>
+        <Box p={2}>
+          <Text variant="largeTitle">About</Text>
+
+          <Spacer my={1} />
+
+          {!!fair.summary && (
+            <>
+              <Text variant="text">{fair.summary}</Text>
+              <Spacer my={3} />
+            </>
+          )}
+          {!!fair.about && (
+            <>
+              <Text variant="text">{fair.about}</Text>
+              <Spacer my={3} />
+            </>
+          )}
+
+          {!!fair.tagline && (
+            <>
+              <Text variant="text">{fair.tagline}</Text>
+              <Spacer my={3} />
+            </>
+          )}
+
+          {!!fair.location?.summary && (
+            <>
+              <Text variant="mediumText">Location</Text>
+              <Text variant="text">{fair.location?.summary}</Text>
+              <Spacer my={3} />
+            </>
+          )}
+
+          {!!fair.hours && (
+            <>
+              <Text variant="mediumText">Hours</Text>
+              <Markdown>{fair.hours}</Markdown>
+              <Spacer my={3} />
+            </>
+          )}
+          {!!fair.tickets && (
+            <>
+              <Text variant="mediumText">Tickets</Text>
+              <Markdown>{fair.tickets}</Markdown>
+              <Spacer my={3} />
+            </>
+          )}
+          {!!fair.ticketsLink && (
+            <>
+              <TouchableOpacity onPress={() => handleNavigation(fair.ticketsLink!)}>
+                <Text variant="mediumText">Buy Tickets</Text>
+              </TouchableOpacity>
+              <Spacer my={3} />
+            </>
+          )}
+          {!!fair.links && (
+            <>
+              <Text variant="mediumText">Links</Text>
+              <Markdown>{fair.links}</Markdown>
+              <Spacer my={3} />
+            </>
+          )}
+          {!!fair.contact && (
+            <>
+              <Text variant="mediumText">Contact</Text>
+              <Markdown>{fair.contact}</Markdown>
+              <Spacer my={3} />
+            </>
+          )}
+        </Box>
+      </Theme>
+    </ScrollView>
   )
 }
 
 export const Fair2MoreInfoFragmentContainer = createFragmentContainer(Fair2MoreInfo, {
   fair: graphql`
     fragment Fair2MoreInfo_fair on Fair {
+      about
       name
+      slug
+      tagline
+      location {
+        summary
+      }
+      ticketsLink
+      hours(format: MARKDOWN)
+      links(format: MARKDOWN)
+      tickets(format: MARKDOWN)
+      summary
+      contact(format: MARKDOWN)
     }
   `,
 })

--- a/src/lib/Scenes/Fair2/Components/Fair2MoreInfo.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2MoreInfo.tsx
@@ -1,5 +1,6 @@
 import { Fair2MoreInfo_fair } from "__generated__/Fair2MoreInfo_fair.graphql"
 import { Fair2MoreInfoQuery } from "__generated__/Fair2MoreInfoQuery.graphql"
+import { LocationMapContainer, PartnerType } from "lib/Components/LocationMap"
 import { Markdown } from "lib/Components/Markdown"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
@@ -22,6 +23,8 @@ export const Fair2MoreInfo: React.FC<Fair2MoreInfoProps> = ({ fair }) => {
   const handleNavigation = (link: string) => {
     return SwitchBoard.presentNavigationViewController(navRef.current, link)
   }
+  const coordinates = fair.location?.coordinates
+  const shouldShowLocationMap = coordinates && coordinates?.lat && coordinates?.lng
 
   return (
     <ScrollView ref={navRef}>
@@ -34,28 +37,35 @@ export const Fair2MoreInfo: React.FC<Fair2MoreInfoProps> = ({ fair }) => {
           {!!fair.summary && (
             <>
               <Text variant="text">{fair.summary}</Text>
-              <Spacer my={3} />
+              <Spacer my={2} />
             </>
           )}
           {!!fair.about && (
             <>
               <Text variant="text">{fair.about}</Text>
-              <Spacer my={3} />
+              <Spacer my={2} />
             </>
           )}
 
           {!!fair.tagline && (
             <>
               <Text variant="text">{fair.tagline}</Text>
-              <Spacer my={3} />
+              <Spacer my={2} />
             </>
           )}
 
-          {!!fair.location?.summary && (
+          {!!fair.location && (
             <>
               <Text variant="mediumText">Location</Text>
-              <Text variant="text">{fair.location?.summary}</Text>
-              <Spacer my={3} />
+              {!!fair.location?.summary && <Text variant="text">{fair.location?.summary}</Text>}
+              {!!shouldShowLocationMap && (
+                <LocationMapContainer
+                  location={fair.location}
+                  partnerType={PartnerType.fair}
+                  partnerName={fair.profile?.name ?? fair.name}
+                />
+              )}
+              <Spacer my={2} />
             </>
           )}
 
@@ -70,7 +80,7 @@ export const Fair2MoreInfo: React.FC<Fair2MoreInfoProps> = ({ fair }) => {
             <>
               <Text variant="mediumText">Tickets</Text>
               <Markdown>{fair.tickets}</Markdown>
-              <Spacer my={3} />
+              <Spacer my={2} />
             </>
           )}
           {!!fair.ticketsLink && (
@@ -78,21 +88,21 @@ export const Fair2MoreInfo: React.FC<Fair2MoreInfoProps> = ({ fair }) => {
               <TouchableOpacity onPress={() => handleNavigation(fair.ticketsLink!)}>
                 <Text variant="mediumText">Buy Tickets</Text>
               </TouchableOpacity>
-              <Spacer my={3} />
+              <Spacer my={2} />
             </>
           )}
           {!!fair.links && (
             <>
               <Text variant="mediumText">Links</Text>
               <Markdown>{fair.links}</Markdown>
-              <Spacer my={3} />
+              <Spacer my={2} />
             </>
           )}
           {!!fair.contact && (
             <>
               <Text variant="mediumText">Contact</Text>
               <Markdown>{fair.contact}</Markdown>
-              <Spacer my={3} />
+              <Spacer my={2} />
             </>
           )}
         </Box>
@@ -108,7 +118,15 @@ export const Fair2MoreInfoFragmentContainer = createFragmentContainer(Fair2MoreI
       name
       slug
       tagline
+      profile {
+        name
+      }
       location {
+        ...LocationMap_location
+        coordinates {
+          lat
+          lng
+        }
         summary
       }
       ticketsLink

--- a/src/lib/Scenes/Fair2/Components/Fair2MoreInfo.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2MoreInfo.tsx
@@ -1,0 +1,59 @@
+import { Fair2MoreInfo_fair } from "__generated__/Fair2MoreInfo_fair.graphql"
+import { Fair2MoreInfoQuery } from "__generated__/Fair2MoreInfoQuery.graphql"
+import { defaultEnvironment } from "lib/relay/createEnvironment"
+import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
+import { Text, Theme } from "palette"
+import React from "react"
+import { FlatList } from "react-native"
+import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+
+interface Fair2MoreInfoQueryRendererProps {
+  fairID: string
+}
+
+interface Fair2MoreInfoProps {
+  fair: Fair2MoreInfo_fair
+}
+
+export const Fair2MoreInfo: React.FC<Fair2MoreInfoProps> = ({ fair }) => {
+  const sections = ["foo"]
+  return (
+    <Theme>
+      <FlatList
+        data={sections}
+        keyExtractor={(_item, index) => String(index)}
+        renderItem={({ item }): null | any => {
+          switch (item) {
+            case "foo":
+              return <Text variant="text">{fair.name}</Text>
+          }
+        }}
+      />
+    </Theme>
+  )
+}
+
+export const Fair2MoreInfoFragmentContainer = createFragmentContainer(Fair2MoreInfo, {
+  fair: graphql`
+    fragment Fair2MoreInfo_fair on Fair {
+      name
+    }
+  `,
+})
+
+export const Fair2MoreInfoQueryRenderer: React.FC<Fair2MoreInfoQueryRendererProps> = ({ fairID }) => {
+  return (
+    <QueryRenderer<Fair2MoreInfoQuery>
+      environment={defaultEnvironment}
+      query={graphql`
+        query Fair2MoreInfoQuery($fairID: String!) {
+          fair(id: $fairID) @principalField {
+            ...Fair2MoreInfo_fair
+          }
+        }
+      `}
+      variables={{ fairID }}
+      render={renderWithLoadProgress(Fair2MoreInfoFragmentContainer)}
+    />
+  )
+}

--- a/src/lib/Scenes/Fair2/Components/Fair2MoreInfo.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2MoreInfo.tsx
@@ -2,6 +2,7 @@ import { Fair2MoreInfo_fair } from "__generated__/Fair2MoreInfo_fair.graphql"
 import { Fair2MoreInfoQuery } from "__generated__/Fair2MoreInfoQuery.graphql"
 import { LocationMapContainer, PartnerType } from "lib/Components/LocationMap"
 import { Markdown } from "lib/Components/Markdown"
+import { LinkText } from "lib/Components/Text/LinkText"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { defaultRules } from "lib/utils/renderMarkdown"
@@ -45,7 +46,7 @@ export const Fair2MoreInfo: React.FC<Fair2MoreInfoProps> = ({ fair }) => {
   return (
     <ScrollView ref={navRef}>
       <Theme>
-        <Box p={2}>
+        <Box px={2} pb={2} pt={6}>
           <Text variant="largeTitle">About</Text>
 
           <Spacer my={1} />
@@ -102,7 +103,7 @@ export const Fair2MoreInfo: React.FC<Fair2MoreInfoProps> = ({ fair }) => {
           {!!fair.ticketsLink && (
             <>
               <TouchableOpacity onPress={() => handleNavigation(fair.ticketsLink!)}>
-                <Text variant="mediumText">Buy Tickets</Text>
+                <LinkText>Buy Tickets</LinkText>
               </TouchableOpacity>
               <Spacer my={1} />
             </>

--- a/src/lib/Scenes/Fair2/Fair2MoreInfo.tsx
+++ b/src/lib/Scenes/Fair2/Fair2MoreInfo.tsx
@@ -133,7 +133,6 @@ export const Fair2MoreInfoFragmentContainer = createFragmentContainer(Fair2MoreI
     fragment Fair2MoreInfo_fair on Fair {
       about
       name
-      slug
       tagline
       profile {
         name

--- a/src/lib/Scenes/Fair2/Fair2MoreInfo.tsx
+++ b/src/lib/Scenes/Fair2/Fair2MoreInfo.tsx
@@ -3,12 +3,12 @@ import { Fair2MoreInfoQuery } from "__generated__/Fair2MoreInfoQuery.graphql"
 import { LocationMapContainer, PartnerType } from "lib/Components/LocationMap"
 import { Markdown } from "lib/Components/Markdown"
 import { LinkText } from "lib/Components/Text/LinkText"
-import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { navigate } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { defaultRules } from "lib/utils/renderMarkdown"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import { Box, Spacer, Text, Theme } from "palette"
-import React, { useRef } from "react"
+import React from "react"
 import { ScrollView, TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import { blockRegex } from "simple-markdown"
@@ -36,15 +36,11 @@ const markdownRules = defaultRules(false, {
 })
 
 export const Fair2MoreInfo: React.FC<Fair2MoreInfoProps> = ({ fair }) => {
-  const navRef = useRef<any>()
-  const handleNavigation = (link: string) => {
-    return SwitchBoard.presentNavigationViewController(navRef.current, link)
-  }
   const coordinates = fair.location?.coordinates
   const shouldShowLocationMap = coordinates && coordinates?.lat && coordinates?.lng
 
   return (
-    <ScrollView ref={navRef}>
+    <ScrollView>
       <Theme>
         <Box px={2} pb={2} pt={6}>
           <Text variant="largeTitle">About</Text>
@@ -102,7 +98,7 @@ export const Fair2MoreInfo: React.FC<Fair2MoreInfoProps> = ({ fair }) => {
           )}
           {!!fair.ticketsLink && (
             <>
-              <TouchableOpacity onPress={() => handleNavigation(fair.ticketsLink!)}>
+              <TouchableOpacity onPress={() => navigate(fair.ticketsLink!)}>
                 <LinkText>Buy Tickets</LinkText>
               </TouchableOpacity>
               <Spacer my={1} />

--- a/src/lib/Scenes/Fair2/__tests__/Fair2Header-tests.tsx
+++ b/src/lib/Scenes/Fair2/__tests__/Fair2Header-tests.tsx
@@ -1,6 +1,6 @@
 import { Fair2HeaderTestsQuery, Fair2HeaderTestsQueryRawResponse } from "__generated__/Fair2HeaderTestsQuery.graphql"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
-import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { navigate } from "lib/navigation/navigate"
 import { Fair2Header, Fair2HeaderFragmentContainer } from "lib/Scenes/Fair2/Components/Fair2Header"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
@@ -10,9 +10,6 @@ import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 
 jest.unmock("react-relay")
-jest.mock("lib/NativeModules/SwitchBoard", () => ({
-  presentNavigationViewController: jest.fn(),
-}))
 
 describe("Fair2Header", () => {
   let env: ReturnType<typeof createMockEnvironment>
@@ -92,10 +89,7 @@ describe("Fair2Header", () => {
   it("navigates to the fair info page on press of More Info", () => {
     const wrapper = getWrapper().root.findByType(TouchableOpacity)
     wrapper.props.onPress()
-    expect(SwitchBoard.presentNavigationViewController).toHaveBeenCalledWith(
-      expect.anything(),
-      "/fair2/art-basel-hong-kong-2020/info"
-    )
+    expect(navigate).toHaveBeenCalledWith("/fair2/art-basel-hong-kong-2020/info")
   })
 
   it("does not show the More Info link if there is no info to show", () => {

--- a/src/lib/Scenes/Fair2/__tests__/Fair2MoreInfo-tests.tsx
+++ b/src/lib/Scenes/Fair2/__tests__/Fair2MoreInfo-tests.tsx
@@ -1,9 +1,9 @@
 import { Fair2MoreInfoTestsQueryRawResponse } from "__generated__/Fair2MoreInfoTestsQuery.graphql"
+import { LocationMapContainer } from "lib/Components/LocationMap"
 import { renderRelayTree } from "lib/tests/renderRelayTree"
 import React from "react"
 import { graphql } from "react-relay"
 import { Fair2MoreInfoFragmentContainer } from "../Fair2MoreInfo"
-import { LocationMapContainer } from "lib/Components/LocationMap"
 
 jest.unmock("react-relay")
 

--- a/src/lib/Scenes/Fair2/__tests__/Fair2MoreInfo-tests.tsx
+++ b/src/lib/Scenes/Fair2/__tests__/Fair2MoreInfo-tests.tsx
@@ -1,0 +1,102 @@
+import { Fair2MoreInfoTestsQueryRawResponse } from "__generated__/Fair2MoreInfoTestsQuery.graphql"
+import { renderRelayTree } from "lib/tests/renderRelayTree"
+import React from "react"
+import { graphql } from "react-relay"
+import { Fair2MoreInfoFragmentContainer } from "../Fair2MoreInfo"
+import { LocationMapContainer } from "lib/Components/LocationMap"
+
+jest.unmock("react-relay")
+
+describe("Fair2MoreInfo", () => {
+  const getWrapper = async (testFixture: Fair2MoreInfoTestsQueryRawResponse) => {
+    return renderRelayTree({
+      Component: ({ fair }) => {
+        return <Fair2MoreInfoFragmentContainer fair={fair} />
+      },
+      query: graphql`
+        query Fair2MoreInfoTestsQuery($fairID: String!) @raw_response_type {
+          fair(id: $fairID) {
+            ...Fair2MoreInfo_fair
+          }
+        }
+      `,
+      variables: { fairID: "art-basel-hong-kong-2019" },
+      mockData: testFixture,
+    })
+  }
+
+  it("displays more information about the fair", async () => {
+    const wrapper = await getWrapper(Fair2MoreInfoFixture)
+    expect(wrapper.text()).toContain("This is the about.")
+    expect(wrapper.text()).toContain("Buy lots of art")
+    expect(wrapper.text()).toContain("LocationA big expo center")
+    expect(wrapper.text()).toContain("HoursOpen every day at 5am")
+    expect(wrapper.text()).toContain("TicketsTicket info")
+    expect(wrapper.text()).toContain("ContactArt Basel Hong Kong")
+    expect(wrapper.text()).toContain("Buy Tickets")
+    expect(wrapper.text()).toContain("LinksGoogle it")
+    expect(wrapper.find(LocationMapContainer).length).toBe(1)
+  })
+
+  it("handles missing information", async () => {
+    const Fair2MoreInfoMissingInfo = {
+      fair: {
+        ...Fair2MoreInfoFixture.fair,
+        about: "",
+        tagline: "",
+        location: null,
+        ticketsLink: "",
+        hours: "",
+        links: "",
+        tickets: "",
+        contact: "",
+        summary: "",
+      },
+    } as Fair2MoreInfoTestsQueryRawResponse
+    const wrapper = await getWrapper(Fair2MoreInfoMissingInfo)
+    expect(wrapper.text()).not.toContain("Location")
+    expect(wrapper.text()).not.toContain("Hours")
+    expect(wrapper.text()).not.toContain("Buy Tickets")
+    expect(wrapper.text()).not.toContain("Links")
+    expect(wrapper.text()).not.toContain("Tickets")
+    expect(wrapper.text()).not.toContain("Contact")
+    expect(wrapper.find(LocationMapContainer).length).toBe(0)
+  })
+})
+
+const Fair2MoreInfoFixture: Fair2MoreInfoTestsQueryRawResponse = {
+  fair: {
+    name: "Art Basel Hong Kong 2019",
+    about: "This is the about.",
+    summary: "This is the summary.",
+    id: "xyz123",
+    location: {
+      id: "cde123",
+      summary: "A big expo center",
+      internalID: "asdfasdf",
+      postal_code: null,
+      city: null,
+      address: "",
+      address_2: "",
+      coordinates: {
+        lat: 1,
+        lng: 1,
+      },
+      day_schedules: null,
+      openingHours: {
+        __typename: "OpeningHoursText",
+        text: null,
+      },
+    },
+    profile: {
+      id: "abc123",
+      name: "Art Basel Hong Kong 2019",
+    },
+    tagline: "Buy lots of art",
+    links: "Google it",
+    contact: "Art Basel Hong Kong",
+    hours: "Open every day at 5am",
+    tickets: "Ticket info",
+    ticketsLink: "Ticket link",
+  },
+}

--- a/src/lib/navigation/routes.tsx
+++ b/src/lib/navigation/routes.tsx
@@ -114,6 +114,7 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
     new RouteMatcher("/partner-locations/:partnerID", "PartnerLocations"),
 
     new RouteMatcher("/fair2/:fairID", "Fair2"),
+    new RouteMatcher("/fair2/:fairID/info", "Fair2MoreInfo"),
     new RouteMatcher("/fair/:fairID/artworks", "FairArtworks"),
     new RouteMatcher("/fair/:fairID/artists", "FairArtists"),
     new RouteMatcher("/fair/:fairID/exhibitors", "FairExhibitors"),


### PR DESCRIPTION
The type of this PR is: **feature**

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[FX-2209]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-2209]

### Description

- Adds `Fair2MoreInfo` view that gives additional information about a fair. The implementation follows our implementation in Force when possible: https://github.com/artsy/force/pull/6119.
- Migrates routing/navigation logic to new routing logic per https://github.com/artsy/eigen/pull/3771.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))

![Screen Shot 2020-09-25 at 2 12 37 PM](https://user-images.githubusercontent.com/4432348/94303453-d3d00480-ff3b-11ea-84f4-28e3b8b0a829.png)

![Screen Shot 2020-09-25 at 2 12 40 PM](https://user-images.githubusercontent.com/4432348/94303450-d2064100-ff3b-11ea-84b0-9c1256d398fa.png)

[FX-2209]: https://artsyproduct.atlassian.net/browse/FX-2209
[FX-2209]: https://artsyproduct.atlassian.net/browse/FX-2209