### PR TITLE
[MX-547] fix: center filters modal title

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -27,6 +27,7 @@ upcoming:
     - Show up to 50 artist series in the full list of an artist's series - roop
     - Fix layout issue in internal webviews - brian
     - Add about page - mounir
+    - Center filters modal title - mounir
 
 releases:
   - version: 6.6.4

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -301,14 +301,16 @@ export const FilterOptions: React.FC<FilterOptionsProps> = (props) => {
   return (
     <Flex style={{ flex: 1 }}>
       <Flex flexGrow={0} flexDirection="row" justifyContent="space-between">
+        <Flex position="absolute" width="100%" height={67} justifyContent="center" alignItems="center">
+          <Sans size="4" weight="medium">
+            Filter
+          </Sans>
+        </Flex>
         <Flex alignItems="flex-end" mt={0.5} mb={2}>
           <CloseIconContainer hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }} onPress={handleTappingCloseIcon}>
             <CloseIcon fill="black100" />
           </CloseIconContainer>
         </Flex>
-        <Sans size="4" weight="medium" style={{ alignSelf: "center" }}>
-          Filter
-        </Sans>
         <ClearAllButton
           onPress={() => {
             switch (mode) {


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [MX-547]

### Description

While working on the auctions filters I had to fix the title issue
<img width="297" alt="Screenshot 2020-09-28 at 14 16 15" src="https://user-images.githubusercontent.com/11945712/94431144-3243ef80-0195-11eb-8923-2797ded010a8.png">

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434
[MX-547]: https://artsyproduct.atlassian.net/browse/MX-547