### PR TITLE
fix: fix MyProfileMenuItem

### DIFF
--- a/src/lib/Scenes/MyProfile/Components/MyProfileMenuItem.tsx
+++ b/src/lib/Scenes/MyProfile/Components/MyProfileMenuItem.tsx
@@ -10,7 +10,7 @@ export const MyProfileMenuItem: React.FC<{
 }> = ({ title, value, onPress, chevron = <ChevronIcon direction="right" fill="black60" />, ellipsizeMode }) => {
   return (
     <Touchable onPress={onPress} underlayColor={color("black5")}>
-      <Flex flexDirection="row" alignItems="center" py={7.5} px="2" pr="15px">
+      <Flex flexDirection="row" alignItems="center" justifyContent="space-between" py={7.5} px="2" pr="15px">
         <Flex mr="2">
           <Sans size="4">{title}</Sans>
         </Flex>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description
While testing some stuff on `MyProfile` tab I noticed that we broke the `MyProfileMenuItem`

**Before**
<img width="301" alt="Screenshot 2020-09-28 at 14 58 10" src="https://user-images.githubusercontent.com/11945712/94435149-0b88b780-019b-11eb-91d5-1b23928d68bc.png">

**After**
<img width="797" alt="Group 1 (2)" src="https://user-images.githubusercontent.com/11945712/94435093-fdd33200-019a-11eb-843c-4994493e8b68.png">

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))

#trivial

[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434