### PR TITLE
FX-2213, FX-2214, FX-2215: Adds the Artworks and Exhibitors content to fair page

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -13,6 +13,7 @@ upcoming:
     - Add collections rail for Fair2 (visible only to admins) - damon
     - Add More Info view for Fiar2 (visible only to admins) - will
     - Add More Info view for Fair2 (visible only to admins) - will
+    - Add Artworks/Exhibitors rails to Fair2 - sweir
   user_facing:
     - Fix navigation bug on Artwork consign button - david
     - Add auction lots rail to the auctions screen - mounir

--- a/src/__generated__/Fair2ArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/Fair2ArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,0 +1,554 @@
+/* tslint:disable */
+/* eslint-disable */
+/* @relayHash 035630ed3da36e316048838bcae01ce5 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type Fair2ArtworksInfiniteScrollGridQueryVariables = {
+    id: string;
+    count: number;
+    cursor?: string | null;
+    sort?: string | null;
+};
+export type Fair2ArtworksInfiniteScrollGridQueryResponse = {
+    readonly fair: {
+        readonly " $fragmentRefs": FragmentRefs<"Fair2Artworks_fair">;
+    } | null;
+};
+export type Fair2ArtworksInfiniteScrollGridQuery = {
+    readonly response: Fair2ArtworksInfiniteScrollGridQueryResponse;
+    readonly variables: Fair2ArtworksInfiniteScrollGridQueryVariables;
+};
+
+
+
+/*
+query Fair2ArtworksInfiniteScrollGridQuery(
+  $id: String!
+  $cursor: String
+  $sort: String
+) {
+  fair(id: $id) {
+    ...Fair2Artworks_fair_1RfMLO
+    id
+  }
+}
+
+fragment ArtworkGridItem_artwork on Artwork {
+  title
+  date
+  saleMessage
+  slug
+  internalID
+  artistNames
+  href
+  sale {
+    isAuction
+    isClosed
+    displayTimelyAt
+    endAt
+    id
+  }
+  saleArtwork {
+    counts {
+      bidderPositions
+    }
+    currentBid {
+      display
+    }
+    lotLabel
+    id
+  }
+  partner {
+    name
+    id
+  }
+  image {
+    url(version: "large")
+    aspectRatio
+  }
+}
+
+fragment Fair2Artworks_fair_1RfMLO on Fair {
+  slug
+  internalID
+  fairArtworks: filterArtworksConnection(first: 20, sort: $sort, after: $cursor) {
+    edges {
+      node {
+        id
+        __typename
+      }
+      cursor
+    }
+    counts {
+      total
+    }
+    ...InfiniteScrollArtworksGrid_connection
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    id
+  }
+}
+
+fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
+  pageInfo {
+    hasNextPage
+    startCursor
+    endCursor
+  }
+  edges {
+    __typename
+    node {
+      slug
+      id
+      image {
+        aspectRatio
+      }
+      ...ArtworkGridItem_artwork
+    }
+    ... on Node {
+      id
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "id",
+    "type": "String!",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "count",
+    "type": "Int!",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "cursor",
+    "type": "String",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "sort",
+    "type": "String",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "kind": "Variable",
+  "name": "sort",
+  "variableName": "sort"
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "slug",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "internalID",
+  "args": null,
+  "storageKey": null
+},
+v5 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "cursor"
+  },
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 20
+  },
+  (v2/*: any*/)
+],
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "Fair2ArtworksInfiniteScrollGridQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "fair",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "Fair2Artworks_fair",
+            "args": [
+              {
+                "kind": "Variable",
+                "name": "count",
+                "variableName": "count"
+              },
+              {
+                "kind": "Variable",
+                "name": "cursor",
+                "variableName": "cursor"
+              },
+              (v2/*: any*/)
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "Fair2ArtworksInfiniteScrollGridQuery",
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "fair",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          (v4/*: any*/),
+          {
+            "kind": "LinkedField",
+            "alias": "fairArtworks",
+            "name": "filterArtworksConnection",
+            "storageKey": null,
+            "args": (v5/*: any*/),
+            "concreteType": "FilterArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "plural": false,
+                    "selections": [
+                      (v6/*: any*/),
+                      (v3/*: any*/),
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "image",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "aspectRatio",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "url",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "large"
+                              }
+                            ],
+                            "storageKey": "url(version:\"large\")"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "title",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "date",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "saleMessage",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      (v4/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "artistNames",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "href",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "sale",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "isAuction",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "isClosed",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayTimelyAt",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "endAt",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v6/*: any*/)
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "saleArtwork",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "counts",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCounts",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "bidderPositions",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "currentBid",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCurrentBid",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "display",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "lotLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v6/*: any*/)
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "partner",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Partner",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "name",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v6/*: any*/)
+                        ]
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "__typename",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "cursor",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  (v6/*: any*/)
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "counts",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "FilterArtworksCounts",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "total",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageInfo",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "hasNextPage",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "startCursor",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "endCursor",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              (v6/*: any*/)
+            ]
+          },
+          {
+            "kind": "LinkedHandle",
+            "alias": "fairArtworks",
+            "name": "filterArtworksConnection",
+            "args": (v5/*: any*/),
+            "handle": "connection",
+            "key": "Fair_fairArtworks",
+            "filters": [
+              "sort"
+            ]
+          },
+          (v6/*: any*/)
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "Fair2ArtworksInfiniteScrollGridQuery",
+    "id": "0595860e5a896cfa58cf8d13da741928",
+    "text": null,
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = 'dbda278577964d7bf3dd6eb2f8807367';
+export default node;

--- a/src/__generated__/Fair2ArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/Fair2ArtworksTestsQuery.graphql.ts
@@ -1,0 +1,572 @@
+/* tslint:disable */
+/* eslint-disable */
+/* @relayHash 056a09e1db046d1fed052a2b3430ef53 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type Fair2ArtworksTestsQueryVariables = {
+    fairID: string;
+};
+export type Fair2ArtworksTestsQueryResponse = {
+    readonly fair: {
+        readonly " $fragmentRefs": FragmentRefs<"Fair2Artworks_fair">;
+    } | null;
+};
+export type Fair2ArtworksTestsQueryRawResponse = {
+    readonly fair: ({
+        readonly slug: string;
+        readonly internalID: string;
+        readonly fairArtworks: ({
+            readonly edges: ReadonlyArray<({
+                readonly node: ({
+                    readonly id: string;
+                    readonly slug: string;
+                    readonly image: ({
+                        readonly aspectRatio: number;
+                        readonly url: string | null;
+                    }) | null;
+                    readonly title: string | null;
+                    readonly date: string | null;
+                    readonly saleMessage: string | null;
+                    readonly internalID: string;
+                    readonly artistNames: string | null;
+                    readonly href: string | null;
+                    readonly sale: ({
+                        readonly isAuction: boolean | null;
+                        readonly isClosed: boolean | null;
+                        readonly displayTimelyAt: string | null;
+                        readonly endAt: string | null;
+                        readonly id: string | null;
+                    }) | null;
+                    readonly saleArtwork: ({
+                        readonly counts: ({
+                            readonly bidderPositions: number | null;
+                        }) | null;
+                        readonly currentBid: ({
+                            readonly display: string | null;
+                        }) | null;
+                        readonly lotLabel: string | null;
+                        readonly id: string | null;
+                    }) | null;
+                    readonly partner: ({
+                        readonly name: string | null;
+                        readonly id: string | null;
+                    }) | null;
+                    readonly __typename: "Artwork";
+                }) | null;
+                readonly cursor: string;
+                readonly id: string | null;
+            }) | null> | null;
+            readonly counts: ({
+                readonly total: number | null;
+            }) | null;
+            readonly pageInfo: {
+                readonly hasNextPage: boolean;
+                readonly startCursor: string | null;
+                readonly endCursor: string | null;
+            };
+            readonly id: string | null;
+        }) | null;
+        readonly id: string | null;
+    }) | null;
+};
+export type Fair2ArtworksTestsQuery = {
+    readonly response: Fair2ArtworksTestsQueryResponse;
+    readonly variables: Fair2ArtworksTestsQueryVariables;
+    readonly rawResponse: Fair2ArtworksTestsQueryRawResponse;
+};
+
+
+
+/*
+query Fair2ArtworksTestsQuery(
+  $fairID: String!
+) {
+  fair(id: $fairID) {
+    ...Fair2Artworks_fair
+    id
+  }
+}
+
+fragment ArtworkGridItem_artwork on Artwork {
+  title
+  date
+  saleMessage
+  slug
+  internalID
+  artistNames
+  href
+  sale {
+    isAuction
+    isClosed
+    displayTimelyAt
+    endAt
+    id
+  }
+  saleArtwork {
+    counts {
+      bidderPositions
+    }
+    currentBid {
+      display
+    }
+    lotLabel
+    id
+  }
+  partner {
+    name
+    id
+  }
+  image {
+    url(version: "large")
+    aspectRatio
+  }
+}
+
+fragment Fair2Artworks_fair on Fair {
+  slug
+  internalID
+  fairArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch") {
+    edges {
+      node {
+        id
+        __typename
+      }
+      cursor
+    }
+    counts {
+      total
+    }
+    ...InfiniteScrollArtworksGrid_connection
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    id
+  }
+}
+
+fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
+  pageInfo {
+    hasNextPage
+    startCursor
+    endCursor
+  }
+  edges {
+    __typename
+    node {
+      slug
+      id
+      image {
+        aspectRatio
+      }
+      ...ArtworkGridItem_artwork
+    }
+    ... on Node {
+      id
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "fairID",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "fairID"
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "slug",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "internalID",
+  "args": null,
+  "storageKey": null
+},
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 20
+  },
+  {
+    "kind": "Literal",
+    "name": "sort",
+    "value": "-decayed_merch"
+  }
+],
+v5 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+};
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "Fair2ArtworksTestsQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "fair",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "Fair2Artworks_fair",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "Fair2ArtworksTestsQuery",
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "fair",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "kind": "LinkedField",
+            "alias": "fairArtworks",
+            "name": "filterArtworksConnection",
+            "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")",
+            "args": (v4/*: any*/),
+            "concreteType": "FilterArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "plural": false,
+                    "selections": [
+                      (v5/*: any*/),
+                      (v2/*: any*/),
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "image",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "aspectRatio",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "url",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "large"
+                              }
+                            ],
+                            "storageKey": "url(version:\"large\")"
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "title",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "date",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "saleMessage",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      (v3/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "artistNames",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "href",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "sale",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "isAuction",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "isClosed",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayTimelyAt",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "endAt",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v5/*: any*/)
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "saleArtwork",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "counts",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCounts",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "bidderPositions",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "currentBid",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCurrentBid",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "display",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "lotLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v5/*: any*/)
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "partner",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Partner",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "name",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v5/*: any*/)
+                        ]
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "__typename",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "cursor",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  (v5/*: any*/)
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "counts",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "FilterArtworksCounts",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "total",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageInfo",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "hasNextPage",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "startCursor",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "endCursor",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              (v5/*: any*/)
+            ]
+          },
+          {
+            "kind": "LinkedHandle",
+            "alias": "fairArtworks",
+            "name": "filterArtworksConnection",
+            "args": (v4/*: any*/),
+            "handle": "connection",
+            "key": "Fair_fairArtworks",
+            "filters": [
+              "sort"
+            ]
+          },
+          (v5/*: any*/)
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "Fair2ArtworksTestsQuery",
+    "id": "6f0b6148204dc6f8b4aa88fb9fa7d223",
+    "text": null,
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = '881b47371d0a4e8752cf54d0748f8904';
+export default node;

--- a/src/__generated__/Fair2Artworks_fair.graphql.ts
+++ b/src/__generated__/Fair2Artworks_fair.graphql.ts
@@ -1,0 +1,192 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type Fair2Artworks_fair = {
+    readonly slug: string;
+    readonly internalID: string;
+    readonly fairArtworks: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly id: string;
+            } | null;
+        } | null> | null;
+        readonly counts: {
+            readonly total: number | null;
+        } | null;
+        readonly " $fragmentRefs": FragmentRefs<"InfiniteScrollArtworksGrid_connection">;
+    } | null;
+    readonly " $refType": "Fair2Artworks_fair";
+};
+export type Fair2Artworks_fair$data = Fair2Artworks_fair;
+export type Fair2Artworks_fair$key = {
+    readonly " $data"?: Fair2Artworks_fair$data;
+    readonly " $fragmentRefs": FragmentRefs<"Fair2Artworks_fair">;
+};
+
+
+
+const node: ReaderFragment = {
+  "kind": "Fragment",
+  "name": "Fair2Artworks_fair",
+  "type": "Fair",
+  "metadata": {
+    "connection": [
+      {
+        "count": null,
+        "cursor": "cursor",
+        "direction": "forward",
+        "path": [
+          "fairArtworks"
+        ]
+      }
+    ]
+  },
+  "argumentDefinitions": [
+    {
+      "kind": "LocalArgument",
+      "name": "count",
+      "type": "Int",
+      "defaultValue": 20
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "cursor",
+      "type": "String",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "sort",
+      "type": "String",
+      "defaultValue": "-decayed_merch"
+    }
+  ],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "slug",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "internalID",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "LinkedField",
+      "alias": "fairArtworks",
+      "name": "__Fair_fairArtworks_connection",
+      "storageKey": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "sort",
+          "variableName": "sort"
+        }
+      ],
+      "concreteType": "FilterArtworksConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "FilterArtworksEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "Artwork",
+              "plural": false,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "id",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "__typename",
+                  "args": null,
+                  "storageKey": null
+                }
+              ]
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "cursor",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        },
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "counts",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "FilterArtworksCounts",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "total",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        },
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "pageInfo",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "endCursor",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "hasNextPage",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        },
+        {
+          "kind": "FragmentSpread",
+          "name": "InfiniteScrollArtworksGrid_connection",
+          "args": null
+        }
+      ]
+    }
+  ]
+};
+(node as any).hash = 'bb5394b06085e2888272e96a0b1cbbec';
+export default node;

--- a/src/__generated__/Fair2ExhibitorRailTestsQuery.graphql.ts
+++ b/src/__generated__/Fair2ExhibitorRailTestsQuery.graphql.ts
@@ -1,0 +1,501 @@
+/* tslint:disable */
+/* eslint-disable */
+/* @relayHash ceb522353f9ecc39b7758fbbef3fb522 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type Fair2ExhibitorRailTestsQueryVariables = {
+    showID: string;
+};
+export type Fair2ExhibitorRailTestsQueryResponse = {
+    readonly show: {
+        readonly " $fragmentRefs": FragmentRefs<"Fair2ExhibitorRail_show">;
+    } | null;
+};
+export type Fair2ExhibitorRailTestsQueryRawResponse = {
+    readonly show: ({
+        readonly internalID: string;
+        readonly href: string | null;
+        readonly partner: ({
+            readonly __typename: "Partner";
+            readonly id: string | null;
+            readonly name: string | null;
+        } | {
+            readonly __typename: "ExternalPartner";
+            readonly id: string | null;
+            readonly name: string | null;
+        } | {
+            readonly __typename: string | null;
+            readonly id: string | null;
+        }) | null;
+        readonly counts: ({
+            readonly artworks: number | null;
+        }) | null;
+        readonly artworks: ({
+            readonly edges: ReadonlyArray<({
+                readonly node: ({
+                    readonly href: string | null;
+                    readonly artistNames: string | null;
+                    readonly id: string;
+                    readonly image: ({
+                        readonly imageURL: string | null;
+                        readonly aspectRatio: number;
+                    }) | null;
+                    readonly saleMessage: string | null;
+                    readonly saleArtwork: ({
+                        readonly openingBid: ({
+                            readonly display: string | null;
+                        }) | null;
+                        readonly highestBid: ({
+                            readonly display: string | null;
+                        }) | null;
+                        readonly currentBid: ({
+                            readonly display: string | null;
+                        }) | null;
+                        readonly counts: ({
+                            readonly bidderPositions: number | null;
+                        }) | null;
+                        readonly id: string | null;
+                    }) | null;
+                    readonly sale: ({
+                        readonly isClosed: boolean | null;
+                        readonly isAuction: boolean | null;
+                        readonly endAt: string | null;
+                        readonly id: string | null;
+                    }) | null;
+                    readonly title: string | null;
+                    readonly internalID: string;
+                    readonly slug: string;
+                }) | null;
+            }) | null> | null;
+        }) | null;
+        readonly id: string | null;
+    }) | null;
+};
+export type Fair2ExhibitorRailTestsQuery = {
+    readonly response: Fair2ExhibitorRailTestsQueryResponse;
+    readonly variables: Fair2ExhibitorRailTestsQueryVariables;
+    readonly rawResponse: Fair2ExhibitorRailTestsQueryRawResponse;
+};
+
+
+
+/*
+query Fair2ExhibitorRailTestsQuery(
+  $showID: String!
+) {
+  show(id: $showID) {
+    ...Fair2ExhibitorRail_show
+    id
+  }
+}
+
+fragment Fair2ExhibitorRail_show on Show {
+  internalID
+  href
+  partner {
+    __typename
+    ... on Partner {
+      name
+    }
+    ... on ExternalPartner {
+      name
+      id
+    }
+    ... on Node {
+      id
+    }
+  }
+  counts {
+    artworks
+  }
+  artworks: artworksConnection(first: 20) {
+    edges {
+      node {
+        href
+        artistNames
+        id
+        image {
+          imageURL
+          aspectRatio
+        }
+        saleMessage
+        saleArtwork {
+          openingBid {
+            display
+          }
+          highestBid {
+            display
+          }
+          currentBid {
+            display
+          }
+          counts {
+            bidderPositions
+          }
+          id
+        }
+        sale {
+          isClosed
+          isAuction
+          endAt
+          id
+        }
+        title
+        internalID
+        slug
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "showID",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "showID"
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "internalID",
+  "args": null,
+  "storageKey": null
+},
+v3 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
+  "args": null,
+  "storageKey": null
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v5 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "name",
+    "args": null,
+    "storageKey": null
+  }
+],
+v6 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "display",
+    "args": null,
+    "storageKey": null
+  }
+];
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "Fair2ExhibitorRailTestsQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "show",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Show",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "Fair2ExhibitorRail_show",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "Fair2ExhibitorRailTestsQuery",
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "show",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Show",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "partner",
+            "storageKey": null,
+            "args": null,
+            "concreteType": null,
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "__typename",
+                "args": null,
+                "storageKey": null
+              },
+              (v4/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "type": "Partner",
+                "selections": (v5/*: any*/)
+              },
+              {
+                "kind": "InlineFragment",
+                "type": "ExternalPartner",
+                "selections": (v5/*: any*/)
+              }
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "counts",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "ShowCounts",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "artworks",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": "artworks",
+            "name": "artworksConnection",
+            "storageKey": "artworksConnection(first:20)",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 20
+              }
+            ],
+            "concreteType": "ArtworkConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtworkEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "artistNames",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      (v4/*: any*/),
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "image",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "imageURL",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "aspectRatio",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "saleMessage",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "saleArtwork",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "openingBid",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkOpeningBid",
+                            "plural": false,
+                            "selections": (v6/*: any*/)
+                          },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "highestBid",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkHighestBid",
+                            "plural": false,
+                            "selections": (v6/*: any*/)
+                          },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "currentBid",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCurrentBid",
+                            "plural": false,
+                            "selections": (v6/*: any*/)
+                          },
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "counts",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkCounts",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "kind": "ScalarField",
+                                "alias": null,
+                                "name": "bidderPositions",
+                                "args": null,
+                                "storageKey": null
+                              }
+                            ]
+                          },
+                          (v4/*: any*/)
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "sale",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "isClosed",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "isAuction",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "endAt",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v4/*: any*/)
+                        ]
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "title",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      (v2/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "slug",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          (v4/*: any*/)
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "Fair2ExhibitorRailTestsQuery",
+    "id": "ba6daf19783fc4e5c956a2260c421deb",
+    "text": null,
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = '39d3dee7a9b03f6d52dea4731805ca74';
+export default node;

--- a/src/__generated__/Fair2ExhibitorRail_show.graphql.ts
+++ b/src/__generated__/Fair2ExhibitorRail_show.graphql.ts
@@ -1,0 +1,338 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type Fair2ExhibitorRail_show = {
+    readonly internalID: string;
+    readonly href: string | null;
+    readonly partner: {
+        readonly name?: string | null;
+    } | null;
+    readonly counts: {
+        readonly artworks: number | null;
+    } | null;
+    readonly artworks: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly href: string | null;
+                readonly artistNames: string | null;
+                readonly id: string;
+                readonly image: {
+                    readonly imageURL: string | null;
+                    readonly aspectRatio: number;
+                } | null;
+                readonly saleMessage: string | null;
+                readonly saleArtwork: {
+                    readonly openingBid: {
+                        readonly display: string | null;
+                    } | null;
+                    readonly highestBid: {
+                        readonly display: string | null;
+                    } | null;
+                    readonly currentBid: {
+                        readonly display: string | null;
+                    } | null;
+                    readonly counts: {
+                        readonly bidderPositions: number | null;
+                    } | null;
+                } | null;
+                readonly sale: {
+                    readonly isClosed: boolean | null;
+                    readonly isAuction: boolean | null;
+                    readonly endAt: string | null;
+                } | null;
+                readonly title: string | null;
+                readonly internalID: string;
+                readonly slug: string;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "Fair2ExhibitorRail_show";
+};
+export type Fair2ExhibitorRail_show$data = Fair2ExhibitorRail_show;
+export type Fair2ExhibitorRail_show$key = {
+    readonly " $data"?: Fair2ExhibitorRail_show$data;
+    readonly " $fragmentRefs": FragmentRefs<"Fair2ExhibitorRail_show">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "internalID",
+  "args": null,
+  "storageKey": null
+},
+v1 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
+  "args": null,
+  "storageKey": null
+},
+v2 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "name",
+    "args": null,
+    "storageKey": null
+  }
+],
+v3 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "display",
+    "args": null,
+    "storageKey": null
+  }
+];
+return {
+  "kind": "Fragment",
+  "name": "Fair2ExhibitorRail_show",
+  "type": "Show",
+  "metadata": null,
+  "argumentDefinitions": [],
+  "selections": [
+    (v0/*: any*/),
+    (v1/*: any*/),
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "partner",
+      "storageKey": null,
+      "args": null,
+      "concreteType": null,
+      "plural": false,
+      "selections": [
+        {
+          "kind": "InlineFragment",
+          "type": "Partner",
+          "selections": (v2/*: any*/)
+        },
+        {
+          "kind": "InlineFragment",
+          "type": "ExternalPartner",
+          "selections": (v2/*: any*/)
+        }
+      ]
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "counts",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "ShowCounts",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "artworks",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    },
+    {
+      "kind": "LinkedField",
+      "alias": "artworks",
+      "name": "artworksConnection",
+      "storageKey": "artworksConnection(first:20)",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 20
+        }
+      ],
+      "concreteType": "ArtworkConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "ArtworkEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "Artwork",
+              "plural": false,
+              "selections": [
+                (v1/*: any*/),
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "artistNames",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "id",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "image",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "Image",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "imageURL",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "aspectRatio",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "saleMessage",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "saleArtwork",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "SaleArtwork",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "LinkedField",
+                      "alias": null,
+                      "name": "openingBid",
+                      "storageKey": null,
+                      "args": null,
+                      "concreteType": "SaleArtworkOpeningBid",
+                      "plural": false,
+                      "selections": (v3/*: any*/)
+                    },
+                    {
+                      "kind": "LinkedField",
+                      "alias": null,
+                      "name": "highestBid",
+                      "storageKey": null,
+                      "args": null,
+                      "concreteType": "SaleArtworkHighestBid",
+                      "plural": false,
+                      "selections": (v3/*: any*/)
+                    },
+                    {
+                      "kind": "LinkedField",
+                      "alias": null,
+                      "name": "currentBid",
+                      "storageKey": null,
+                      "args": null,
+                      "concreteType": "SaleArtworkCurrentBid",
+                      "plural": false,
+                      "selections": (v3/*: any*/)
+                    },
+                    {
+                      "kind": "LinkedField",
+                      "alias": null,
+                      "name": "counts",
+                      "storageKey": null,
+                      "args": null,
+                      "concreteType": "SaleArtworkCounts",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "kind": "ScalarField",
+                          "alias": null,
+                          "name": "bidderPositions",
+                          "args": null,
+                          "storageKey": null
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "sale",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "Sale",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "isClosed",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "isAuction",
+                      "args": null,
+                      "storageKey": null
+                    },
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "endAt",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "title",
+                  "args": null,
+                  "storageKey": null
+                },
+                (v0/*: any*/),
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "slug",
+                  "args": null,
+                  "storageKey": null
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+})();
+(node as any).hash = '0706ce7454c0ec85a52f96e1874c00c7';
+export default node;

--- a/src/__generated__/Fair2ExhibitorsQuery.graphql.ts
+++ b/src/__generated__/Fair2ExhibitorsQuery.graphql.ts
@@ -1,0 +1,592 @@
+/* tslint:disable */
+/* eslint-disable */
+/* @relayHash 909e8ca611e6322eca22b4e3e59fcca8 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type Fair2ExhibitorsQueryVariables = {
+    id: string;
+    first: number;
+    after?: string | null;
+};
+export type Fair2ExhibitorsQueryResponse = {
+    readonly fair: {
+        readonly " $fragmentRefs": FragmentRefs<"Fair2Exhibitors_fair">;
+    } | null;
+};
+export type Fair2ExhibitorsQuery = {
+    readonly response: Fair2ExhibitorsQueryResponse;
+    readonly variables: Fair2ExhibitorsQueryVariables;
+};
+
+
+
+/*
+query Fair2ExhibitorsQuery(
+  $id: String!
+  $first: Int!
+  $after: String
+) {
+  fair(id: $id) {
+    ...Fair2Exhibitors_fair_2HEEH6
+    id
+  }
+}
+
+fragment Fair2ExhibitorRail_show on Show {
+  internalID
+  href
+  partner {
+    __typename
+    ... on Partner {
+      name
+    }
+    ... on ExternalPartner {
+      name
+      id
+    }
+    ... on Node {
+      id
+    }
+  }
+  counts {
+    artworks
+  }
+  artworks: artworksConnection(first: 20) {
+    edges {
+      node {
+        href
+        artistNames
+        id
+        image {
+          imageURL
+          aspectRatio
+        }
+        saleMessage
+        saleArtwork {
+          openingBid {
+            display
+          }
+          highestBid {
+            display
+          }
+          currentBid {
+            display
+          }
+          counts {
+            bidderPositions
+          }
+          id
+        }
+        sale {
+          isClosed
+          isAuction
+          endAt
+          id
+        }
+        title
+        internalID
+        slug
+      }
+    }
+  }
+}
+
+fragment Fair2Exhibitors_fair_2HEEH6 on Fair {
+  slug
+  exhibitors: showsConnection(first: $first, after: $after, sort: FEATURED_ASC) {
+    edges {
+      node {
+        id
+        counts {
+          artworks
+        }
+        partner {
+          __typename
+          ... on Partner {
+            id
+          }
+          ... on ExternalPartner {
+            id
+          }
+          ... on Node {
+            id
+          }
+        }
+        ...Fair2ExhibitorRail_show
+        __typename
+      }
+      cursor
+    }
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "id",
+    "type": "String!",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "first",
+    "type": "Int!",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "after",
+    "type": "String",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "kind": "Variable",
+  "name": "after",
+  "variableName": "after"
+},
+v3 = {
+  "kind": "Variable",
+  "name": "first",
+  "variableName": "first"
+},
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "slug",
+  "args": null,
+  "storageKey": null
+},
+v5 = [
+  (v2/*: any*/),
+  (v3/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "sort",
+    "value": "FEATURED_ASC"
+  }
+],
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v8 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "name",
+    "args": null,
+    "storageKey": null
+  }
+],
+v9 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "internalID",
+  "args": null,
+  "storageKey": null
+},
+v10 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
+  "args": null,
+  "storageKey": null
+},
+v11 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "display",
+    "args": null,
+    "storageKey": null
+  }
+];
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "Fair2ExhibitorsQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "fair",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "Fair2Exhibitors_fair",
+            "args": [
+              (v2/*: any*/),
+              (v3/*: any*/)
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "Fair2ExhibitorsQuery",
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "fair",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "plural": false,
+        "selections": [
+          (v4/*: any*/),
+          {
+            "kind": "LinkedField",
+            "alias": "exhibitors",
+            "name": "showsConnection",
+            "storageKey": null,
+            "args": (v5/*: any*/),
+            "concreteType": "ShowConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ShowEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Show",
+                    "plural": false,
+                    "selections": [
+                      (v6/*: any*/),
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "counts",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "ShowCounts",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "artworks",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "partner",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": null,
+                        "plural": false,
+                        "selections": [
+                          (v7/*: any*/),
+                          (v6/*: any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "type": "Partner",
+                            "selections": (v8/*: any*/)
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "type": "ExternalPartner",
+                            "selections": (v8/*: any*/)
+                          }
+                        ]
+                      },
+                      (v9/*: any*/),
+                      (v10/*: any*/),
+                      {
+                        "kind": "LinkedField",
+                        "alias": "artworks",
+                        "name": "artworksConnection",
+                        "storageKey": "artworksConnection(first:20)",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "first",
+                            "value": 20
+                          }
+                        ],
+                        "concreteType": "ArtworkConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "edges",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "ArtworkEdge",
+                            "plural": true,
+                            "selections": [
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "node",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "Artwork",
+                                "plural": false,
+                                "selections": [
+                                  (v10/*: any*/),
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "artistNames",
+                                    "args": null,
+                                    "storageKey": null
+                                  },
+                                  (v6/*: any*/),
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "image",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "imageURL",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "aspectRatio",
+                                        "args": null,
+                                        "storageKey": null
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "saleMessage",
+                                    "args": null,
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "saleArtwork",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "SaleArtwork",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "kind": "LinkedField",
+                                        "alias": null,
+                                        "name": "openingBid",
+                                        "storageKey": null,
+                                        "args": null,
+                                        "concreteType": "SaleArtworkOpeningBid",
+                                        "plural": false,
+                                        "selections": (v11/*: any*/)
+                                      },
+                                      {
+                                        "kind": "LinkedField",
+                                        "alias": null,
+                                        "name": "highestBid",
+                                        "storageKey": null,
+                                        "args": null,
+                                        "concreteType": "SaleArtworkHighestBid",
+                                        "plural": false,
+                                        "selections": (v11/*: any*/)
+                                      },
+                                      {
+                                        "kind": "LinkedField",
+                                        "alias": null,
+                                        "name": "currentBid",
+                                        "storageKey": null,
+                                        "args": null,
+                                        "concreteType": "SaleArtworkCurrentBid",
+                                        "plural": false,
+                                        "selections": (v11/*: any*/)
+                                      },
+                                      {
+                                        "kind": "LinkedField",
+                                        "alias": null,
+                                        "name": "counts",
+                                        "storageKey": null,
+                                        "args": null,
+                                        "concreteType": "SaleArtworkCounts",
+                                        "plural": false,
+                                        "selections": [
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "bidderPositions",
+                                            "args": null,
+                                            "storageKey": null
+                                          }
+                                        ]
+                                      },
+                                      (v6/*: any*/)
+                                    ]
+                                  },
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "sale",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "Sale",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "isClosed",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "isAuction",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "endAt",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      (v6/*: any*/)
+                                    ]
+                                  },
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "title",
+                                    "args": null,
+                                    "storageKey": null
+                                  },
+                                  (v9/*: any*/),
+                                  (v4/*: any*/)
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      (v7/*: any*/)
+                    ]
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "cursor",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageInfo",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "endCursor",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "hasNextPage",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "LinkedHandle",
+            "alias": "exhibitors",
+            "name": "showsConnection",
+            "args": (v5/*: any*/),
+            "handle": "connection",
+            "key": "Fair2ExhibitorsQuery_exhibitors",
+            "filters": [
+              "sort"
+            ]
+          },
+          (v6/*: any*/)
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "Fair2ExhibitorsQuery",
+    "id": "8a81b1c3f04e5672bd1ff6d51955996e",
+    "text": null,
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = '9ff75032c29a470bcdf4a8d256b0df1b';
+export default node;

--- a/src/__generated__/Fair2ExhibitorsTestsQuery.graphql.ts
+++ b/src/__generated__/Fair2ExhibitorsTestsQuery.graphql.ts
@@ -1,0 +1,641 @@
+/* tslint:disable */
+/* eslint-disable */
+/* @relayHash c5fa36db9dbda4d492ae3d3def7c7931 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type Fair2ExhibitorsTestsQueryVariables = {
+    fairID: string;
+};
+export type Fair2ExhibitorsTestsQueryResponse = {
+    readonly fair: {
+        readonly " $fragmentRefs": FragmentRefs<"Fair2Exhibitors_fair">;
+    } | null;
+};
+export type Fair2ExhibitorsTestsQueryRawResponse = {
+    readonly fair: ({
+        readonly slug: string;
+        readonly exhibitors: ({
+            readonly edges: ReadonlyArray<({
+                readonly node: ({
+                    readonly id: string;
+                    readonly counts: ({
+                        readonly artworks: number | null;
+                    }) | null;
+                    readonly partner: ({
+                        readonly __typename: "Partner";
+                        readonly id: string | null;
+                        readonly name: string | null;
+                    } | {
+                        readonly __typename: "ExternalPartner";
+                        readonly id: string | null;
+                        readonly name: string | null;
+                    } | {
+                        readonly __typename: string | null;
+                        readonly id: string | null;
+                    }) | null;
+                    readonly internalID: string;
+                    readonly href: string | null;
+                    readonly artworks: ({
+                        readonly edges: ReadonlyArray<({
+                            readonly node: ({
+                                readonly href: string | null;
+                                readonly artistNames: string | null;
+                                readonly id: string;
+                                readonly image: ({
+                                    readonly imageURL: string | null;
+                                    readonly aspectRatio: number;
+                                }) | null;
+                                readonly saleMessage: string | null;
+                                readonly saleArtwork: ({
+                                    readonly openingBid: ({
+                                        readonly display: string | null;
+                                    }) | null;
+                                    readonly highestBid: ({
+                                        readonly display: string | null;
+                                    }) | null;
+                                    readonly currentBid: ({
+                                        readonly display: string | null;
+                                    }) | null;
+                                    readonly counts: ({
+                                        readonly bidderPositions: number | null;
+                                    }) | null;
+                                    readonly id: string | null;
+                                }) | null;
+                                readonly sale: ({
+                                    readonly isClosed: boolean | null;
+                                    readonly isAuction: boolean | null;
+                                    readonly endAt: string | null;
+                                    readonly id: string | null;
+                                }) | null;
+                                readonly title: string | null;
+                                readonly internalID: string;
+                                readonly slug: string;
+                            }) | null;
+                        }) | null> | null;
+                    }) | null;
+                    readonly __typename: "Show";
+                }) | null;
+                readonly cursor: string;
+            }) | null> | null;
+            readonly pageInfo: {
+                readonly endCursor: string | null;
+                readonly hasNextPage: boolean;
+            };
+        }) | null;
+        readonly id: string | null;
+    }) | null;
+};
+export type Fair2ExhibitorsTestsQuery = {
+    readonly response: Fair2ExhibitorsTestsQueryResponse;
+    readonly variables: Fair2ExhibitorsTestsQueryVariables;
+    readonly rawResponse: Fair2ExhibitorsTestsQueryRawResponse;
+};
+
+
+
+/*
+query Fair2ExhibitorsTestsQuery(
+  $fairID: String!
+) {
+  fair(id: $fairID) {
+    ...Fair2Exhibitors_fair
+    id
+  }
+}
+
+fragment Fair2ExhibitorRail_show on Show {
+  internalID
+  href
+  partner {
+    __typename
+    ... on Partner {
+      name
+    }
+    ... on ExternalPartner {
+      name
+      id
+    }
+    ... on Node {
+      id
+    }
+  }
+  counts {
+    artworks
+  }
+  artworks: artworksConnection(first: 20) {
+    edges {
+      node {
+        href
+        artistNames
+        id
+        image {
+          imageURL
+          aspectRatio
+        }
+        saleMessage
+        saleArtwork {
+          openingBid {
+            display
+          }
+          highestBid {
+            display
+          }
+          currentBid {
+            display
+          }
+          counts {
+            bidderPositions
+          }
+          id
+        }
+        sale {
+          isClosed
+          isAuction
+          endAt
+          id
+        }
+        title
+        internalID
+        slug
+      }
+    }
+  }
+}
+
+fragment Fair2Exhibitors_fair on Fair {
+  slug
+  exhibitors: showsConnection(first: 15, sort: FEATURED_ASC) {
+    edges {
+      node {
+        id
+        counts {
+          artworks
+        }
+        partner {
+          __typename
+          ... on Partner {
+            id
+          }
+          ... on ExternalPartner {
+            id
+          }
+          ... on Node {
+            id
+          }
+        }
+        ...Fair2ExhibitorRail_show
+        __typename
+      }
+      cursor
+    }
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "LocalArgument",
+    "name": "fairID",
+    "type": "String!",
+    "defaultValue": null
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "fairID"
+  }
+],
+v2 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "slug",
+  "args": null,
+  "storageKey": null
+},
+v3 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 15
+  },
+  {
+    "kind": "Literal",
+    "name": "sort",
+    "value": "FEATURED_ASC"
+  }
+],
+v4 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v5 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "__typename",
+  "args": null,
+  "storageKey": null
+},
+v6 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "name",
+    "args": null,
+    "storageKey": null
+  }
+],
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "internalID",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "href",
+  "args": null,
+  "storageKey": null
+},
+v9 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "display",
+    "args": null,
+    "storageKey": null
+  }
+];
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "Fair2ExhibitorsTestsQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "fair",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": "Fair2Exhibitors_fair",
+            "args": null
+          }
+        ]
+      }
+    ]
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "Fair2ExhibitorsTestsQuery",
+    "argumentDefinitions": (v0/*: any*/),
+    "selections": [
+      {
+        "kind": "LinkedField",
+        "alias": null,
+        "name": "fair",
+        "storageKey": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "kind": "LinkedField",
+            "alias": "exhibitors",
+            "name": "showsConnection",
+            "storageKey": "showsConnection(first:15,sort:\"FEATURED_ASC\")",
+            "args": (v3/*: any*/),
+            "concreteType": "ShowConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ShowEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Show",
+                    "plural": false,
+                    "selections": [
+                      (v4/*: any*/),
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "counts",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "ShowCounts",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "artworks",
+                            "args": null,
+                            "storageKey": null
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "partner",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": null,
+                        "plural": false,
+                        "selections": [
+                          (v5/*: any*/),
+                          (v4/*: any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "type": "Partner",
+                            "selections": (v6/*: any*/)
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "type": "ExternalPartner",
+                            "selections": (v6/*: any*/)
+                          }
+                        ]
+                      },
+                      (v7/*: any*/),
+                      (v8/*: any*/),
+                      {
+                        "kind": "LinkedField",
+                        "alias": "artworks",
+                        "name": "artworksConnection",
+                        "storageKey": "artworksConnection(first:20)",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "first",
+                            "value": 20
+                          }
+                        ],
+                        "concreteType": "ArtworkConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "edges",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "ArtworkEdge",
+                            "plural": true,
+                            "selections": [
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "node",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "Artwork",
+                                "plural": false,
+                                "selections": [
+                                  (v8/*: any*/),
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "artistNames",
+                                    "args": null,
+                                    "storageKey": null
+                                  },
+                                  (v4/*: any*/),
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "image",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "imageURL",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "aspectRatio",
+                                        "args": null,
+                                        "storageKey": null
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "saleMessage",
+                                    "args": null,
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "saleArtwork",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "SaleArtwork",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "kind": "LinkedField",
+                                        "alias": null,
+                                        "name": "openingBid",
+                                        "storageKey": null,
+                                        "args": null,
+                                        "concreteType": "SaleArtworkOpeningBid",
+                                        "plural": false,
+                                        "selections": (v9/*: any*/)
+                                      },
+                                      {
+                                        "kind": "LinkedField",
+                                        "alias": null,
+                                        "name": "highestBid",
+                                        "storageKey": null,
+                                        "args": null,
+                                        "concreteType": "SaleArtworkHighestBid",
+                                        "plural": false,
+                                        "selections": (v9/*: any*/)
+                                      },
+                                      {
+                                        "kind": "LinkedField",
+                                        "alias": null,
+                                        "name": "currentBid",
+                                        "storageKey": null,
+                                        "args": null,
+                                        "concreteType": "SaleArtworkCurrentBid",
+                                        "plural": false,
+                                        "selections": (v9/*: any*/)
+                                      },
+                                      {
+                                        "kind": "LinkedField",
+                                        "alias": null,
+                                        "name": "counts",
+                                        "storageKey": null,
+                                        "args": null,
+                                        "concreteType": "SaleArtworkCounts",
+                                        "plural": false,
+                                        "selections": [
+                                          {
+                                            "kind": "ScalarField",
+                                            "alias": null,
+                                            "name": "bidderPositions",
+                                            "args": null,
+                                            "storageKey": null
+                                          }
+                                        ]
+                                      },
+                                      (v4/*: any*/)
+                                    ]
+                                  },
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "sale",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "Sale",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "isClosed",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "isAuction",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "endAt",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      (v4/*: any*/)
+                                    ]
+                                  },
+                                  {
+                                    "kind": "ScalarField",
+                                    "alias": null,
+                                    "name": "title",
+                                    "args": null,
+                                    "storageKey": null
+                                  },
+                                  (v7/*: any*/),
+                                  (v2/*: any*/)
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      (v5/*: any*/)
+                    ]
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "cursor",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageInfo",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "endCursor",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "hasNextPage",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "LinkedHandle",
+            "alias": "exhibitors",
+            "name": "showsConnection",
+            "args": (v3/*: any*/),
+            "handle": "connection",
+            "key": "Fair2ExhibitorsQuery_exhibitors",
+            "filters": [
+              "sort"
+            ]
+          },
+          (v4/*: any*/)
+        ]
+      }
+    ]
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "Fair2ExhibitorsTestsQuery",
+    "id": "d5c16f38761ab7fc055995dcca65e560",
+    "text": null,
+    "metadata": {}
+  }
+};
+})();
+(node as any).hash = '2b9db9ffc7b72e3d1be66a0ccd70eabf';
+export default node;

--- a/src/__generated__/Fair2Exhibitors_fair.graphql.ts
+++ b/src/__generated__/Fair2Exhibitors_fair.graphql.ts
@@ -1,0 +1,208 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type Fair2Exhibitors_fair = {
+    readonly slug: string;
+    readonly exhibitors: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly id: string;
+                readonly counts: {
+                    readonly artworks: number | null;
+                } | null;
+                readonly partner: {
+                    readonly id?: string;
+                } | null;
+                readonly " $fragmentRefs": FragmentRefs<"Fair2ExhibitorRail_show">;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "Fair2Exhibitors_fair";
+};
+export type Fair2Exhibitors_fair$data = Fair2Exhibitors_fair;
+export type Fair2Exhibitors_fair$key = {
+    readonly " $data"?: Fair2Exhibitors_fair$data;
+    readonly " $fragmentRefs": FragmentRefs<"Fair2Exhibitors_fair">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v1 = [
+  (v0/*: any*/)
+];
+return {
+  "kind": "Fragment",
+  "name": "Fair2Exhibitors_fair",
+  "type": "Fair",
+  "metadata": {
+    "connection": [
+      {
+        "count": "first",
+        "cursor": "after",
+        "direction": "forward",
+        "path": [
+          "exhibitors"
+        ]
+      }
+    ]
+  },
+  "argumentDefinitions": [
+    {
+      "kind": "LocalArgument",
+      "name": "first",
+      "type": "Int",
+      "defaultValue": 15
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "after",
+      "type": "String",
+      "defaultValue": null
+    }
+  ],
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "slug",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "LinkedField",
+      "alias": "exhibitors",
+      "name": "__Fair2ExhibitorsQuery_exhibitors_connection",
+      "storageKey": "__Fair2ExhibitorsQuery_exhibitors_connection(sort:\"FEATURED_ASC\")",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "FEATURED_ASC"
+        }
+      ],
+      "concreteType": "ShowConnection",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "edges",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "ShowEdge",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "node",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "Show",
+              "plural": false,
+              "selections": [
+                (v0/*: any*/),
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "counts",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": "ShowCounts",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "ScalarField",
+                      "alias": null,
+                      "name": "artworks",
+                      "args": null,
+                      "storageKey": null
+                    }
+                  ]
+                },
+                {
+                  "kind": "LinkedField",
+                  "alias": null,
+                  "name": "partner",
+                  "storageKey": null,
+                  "args": null,
+                  "concreteType": null,
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "InlineFragment",
+                      "type": "Partner",
+                      "selections": (v1/*: any*/)
+                    },
+                    {
+                      "kind": "InlineFragment",
+                      "type": "ExternalPartner",
+                      "selections": (v1/*: any*/)
+                    }
+                  ]
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "__typename",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "FragmentSpread",
+                  "name": "Fair2ExhibitorRail_show",
+                  "args": null
+                }
+              ]
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "cursor",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        },
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "pageInfo",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "endCursor",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "hasNextPage",
+              "args": null,
+              "storageKey": null
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+})();
+(node as any).hash = 'dadfbbc40228775a328552e17446ba81';
+export default node;

--- a/src/__generated__/Fair2Query.graphql.ts
+++ b/src/__generated__/Fair2Query.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 85ff45ab38cebdc053600ca2f04a6080 */
+/* @relayHash 720bbc788f5af46c7cc0d927001bb4d6 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -25,6 +25,64 @@ query Fair2Query(
 ) {
   fair(id: $fairID) @principalField {
     ...Fair2_fair
+    id
+  }
+}
+
+fragment ArtworkGridItem_artwork on Artwork {
+  title
+  date
+  saleMessage
+  slug
+  internalID
+  artistNames
+  href
+  sale {
+    isAuction
+    isClosed
+    displayTimelyAt
+    endAt
+    id
+  }
+  saleArtwork {
+    counts {
+      bidderPositions
+    }
+    currentBid {
+      display
+    }
+    lotLabel
+    id
+  }
+  partner {
+    name
+    id
+  }
+  image {
+    url(version: "large")
+    aspectRatio
+  }
+}
+
+fragment Fair2Artworks_fair on Fair {
+  slug
+  internalID
+  fairArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch") {
+    edges {
+      node {
+        id
+        __typename
+      }
+      cursor
+    }
+    counts {
+      total
+    }
+    ...InfiniteScrollArtworksGrid_connection
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
     id
   }
 }
@@ -61,6 +119,98 @@ fragment Fair2Editorial_fair on Fair {
           src: imageURL
         }
       }
+    }
+  }
+}
+
+fragment Fair2ExhibitorRail_show on Show {
+  internalID
+  href
+  partner {
+    __typename
+    ... on Partner {
+      name
+    }
+    ... on ExternalPartner {
+      name
+      id
+    }
+    ... on Node {
+      id
+    }
+  }
+  counts {
+    artworks
+  }
+  artworks: artworksConnection(first: 20) {
+    edges {
+      node {
+        href
+        artistNames
+        id
+        image {
+          imageURL
+          aspectRatio
+        }
+        saleMessage
+        saleArtwork {
+          openingBid {
+            display
+          }
+          highestBid {
+            display
+          }
+          currentBid {
+            display
+          }
+          counts {
+            bidderPositions
+          }
+          id
+        }
+        sale {
+          isClosed
+          isAuction
+          endAt
+          id
+        }
+        title
+        internalID
+        slug
+      }
+    }
+  }
+}
+
+fragment Fair2Exhibitors_fair on Fair {
+  slug
+  exhibitors: showsConnection(first: 15, sort: FEATURED_ASC) {
+    edges {
+      node {
+        id
+        counts {
+          artworks
+        }
+        partner {
+          __typename
+          ... on Partner {
+            id
+          }
+          ... on ExternalPartner {
+            id
+          }
+          ... on Node {
+            id
+          }
+        }
+        ...Fair2ExhibitorRail_show
+        __typename
+      }
+      cursor
+    }
+    pageInfo {
+      endCursor
+      hasNextPage
     }
   }
 }
@@ -102,9 +252,37 @@ fragment Fair2_fair on Fair {
     __typename
     id
   }
+  counts {
+    artworks
+    partnerShows
+  }
   ...Fair2Header_fair
   ...Fair2Editorial_fair
   ...Fair2Collections_fair
+  ...Fair2Artworks_fair
+  ...Fair2Exhibitors_fair
+}
+
+fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
+  pageInfo {
+    hasNextPage
+    startCursor
+    endCursor
+  }
+  edges {
+    __typename
+    node {
+      slug
+      id
+      image {
+        aspectRatio
+      }
+      ...ArtworkGridItem_artwork
+    }
+    ... on Node {
+      id
+    }
+  }
 }
 */
 
@@ -148,23 +326,182 @@ v4 = {
 v5 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "slug",
+  "name": "href",
   "args": null,
   "storageKey": null
 },
 v6 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "slug",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "artworks",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "summary",
   "args": null,
   "storageKey": null
 },
-v7 = [
+v9 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v10 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "aspectRatio",
+  "args": null,
+  "storageKey": null
+},
+v11 = [
   {
     "kind": "Literal",
     "name": "format",
     "value": "MARKDOWN"
   }
+],
+v12 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "internalID",
+  "args": null,
+  "storageKey": null
+},
+v13 = {
+  "kind": "Literal",
+  "name": "first",
+  "value": 20
+},
+v14 = [
+  (v13/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "sort",
+    "value": "-decayed_merch"
+  }
+],
+v15 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "saleMessage",
+  "args": null,
+  "storageKey": null
+},
+v16 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "artistNames",
+  "args": null,
+  "storageKey": null
+},
+v17 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "isAuction",
+  "args": null,
+  "storageKey": null
+},
+v18 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "isClosed",
+  "args": null,
+  "storageKey": null
+},
+v19 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "endAt",
+  "args": null,
+  "storageKey": null
+},
+v20 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "counts",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "SaleArtworkCounts",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "bidderPositions",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+},
+v21 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "display",
+    "args": null,
+    "storageKey": null
+  }
+],
+v22 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "currentBid",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "SaleArtworkCurrentBid",
+  "plural": false,
+  "selections": (v21/*: any*/)
+},
+v23 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "cursor",
+  "args": null,
+  "storageKey": null
+},
+v24 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "hasNextPage",
+  "args": null,
+  "storageKey": null
+},
+v25 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "endCursor",
+  "args": null,
+  "storageKey": null
+},
+v26 = [
+  "sort"
+],
+v27 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 15
+  },
+  {
+    "kind": "Literal",
+    "name": "sort",
+    "value": "FEATURED_ASC"
+  }
+],
+v28 = [
+  (v9/*: any*/)
 ];
 return {
   "kind": "Request",
@@ -248,13 +585,7 @@ return {
                     "selections": [
                       (v3/*: any*/),
                       (v4/*: any*/),
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "href",
-                        "args": null,
-                        "storageKey": null
-                      },
+                      (v5/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -309,7 +640,7 @@ return {
             "selections": [
               (v2/*: any*/),
               (v3/*: any*/),
-              (v5/*: any*/),
+              (v6/*: any*/),
               (v4/*: any*/),
               {
                 "kind": "ScalarField",
@@ -386,21 +717,34 @@ return {
             ]
           },
           {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "counts",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "FairCounts",
+            "plural": false,
+            "selections": [
+              (v7/*: any*/),
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "partnerShows",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          },
+          {
             "kind": "ScalarField",
             "alias": null,
             "name": "about",
             "args": null,
             "storageKey": null
           },
+          (v8/*: any*/),
+          (v9/*: any*/),
           (v6/*: any*/),
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "name",
-            "args": null,
-            "storageKey": null
-          },
-          (v5/*: any*/),
           {
             "kind": "LinkedField",
             "alias": null,
@@ -459,13 +803,7 @@ return {
                 ],
                 "storageKey": "url(version:\"large_rectangle\")"
               },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "aspectRatio",
-                "args": null,
-                "storageKey": null
-              }
+              (v10/*: any*/)
             ]
           },
           {
@@ -484,7 +822,7 @@ return {
             "concreteType": "Location",
             "plural": false,
             "selections": [
-              (v6/*: any*/),
+              (v8/*: any*/),
               (v3/*: any*/)
             ]
           },
@@ -499,29 +837,414 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "hours",
-            "args": (v7/*: any*/),
+            "args": (v11/*: any*/),
             "storageKey": "hours(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "links",
-            "args": (v7/*: any*/),
+            "args": (v11/*: any*/),
             "storageKey": "links(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "tickets",
-            "args": (v7/*: any*/),
+            "args": (v11/*: any*/),
             "storageKey": "tickets(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "contact",
-            "args": (v7/*: any*/),
+            "args": (v11/*: any*/),
             "storageKey": "contact(format:\"MARKDOWN\")"
+          },
+          (v12/*: any*/),
+          {
+            "kind": "LinkedField",
+            "alias": "fairArtworks",
+            "name": "filterArtworksConnection",
+            "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")",
+            "args": (v14/*: any*/),
+            "concreteType": "FilterArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      (v6/*: any*/),
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "image",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": [
+                          (v10/*: any*/),
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "url",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "large"
+                              }
+                            ],
+                            "storageKey": "url(version:\"large\")"
+                          }
+                        ]
+                      },
+                      (v4/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "date",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      (v15/*: any*/),
+                      (v12/*: any*/),
+                      (v16/*: any*/),
+                      (v5/*: any*/),
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "sale",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "plural": false,
+                        "selections": [
+                          (v17/*: any*/),
+                          (v18/*: any*/),
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayTimelyAt",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v19/*: any*/),
+                          (v3/*: any*/)
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "saleArtwork",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "plural": false,
+                        "selections": [
+                          (v20/*: any*/),
+                          (v22/*: any*/),
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "lotLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v3/*: any*/)
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "partner",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Partner",
+                        "plural": false,
+                        "selections": [
+                          (v9/*: any*/),
+                          (v3/*: any*/)
+                        ]
+                      },
+                      (v2/*: any*/)
+                    ]
+                  },
+                  (v23/*: any*/),
+                  (v3/*: any*/)
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "counts",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "FilterArtworksCounts",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "total",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageInfo",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "plural": false,
+                "selections": [
+                  (v24/*: any*/),
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "startCursor",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  (v25/*: any*/)
+                ]
+              },
+              (v3/*: any*/)
+            ]
+          },
+          {
+            "kind": "LinkedHandle",
+            "alias": "fairArtworks",
+            "name": "filterArtworksConnection",
+            "args": (v14/*: any*/),
+            "handle": "connection",
+            "key": "Fair_fairArtworks",
+            "filters": (v26/*: any*/)
+          },
+          {
+            "kind": "LinkedField",
+            "alias": "exhibitors",
+            "name": "showsConnection",
+            "storageKey": "showsConnection(first:15,sort:\"FEATURED_ASC\")",
+            "args": (v27/*: any*/),
+            "concreteType": "ShowConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ShowEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Show",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "counts",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "ShowCounts",
+                        "plural": false,
+                        "selections": [
+                          (v7/*: any*/)
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "partner",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": null,
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v3/*: any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "type": "Partner",
+                            "selections": (v28/*: any*/)
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "type": "ExternalPartner",
+                            "selections": (v28/*: any*/)
+                          }
+                        ]
+                      },
+                      (v12/*: any*/),
+                      (v5/*: any*/),
+                      {
+                        "kind": "LinkedField",
+                        "alias": "artworks",
+                        "name": "artworksConnection",
+                        "storageKey": "artworksConnection(first:20)",
+                        "args": [
+                          (v13/*: any*/)
+                        ],
+                        "concreteType": "ArtworkConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "edges",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "ArtworkEdge",
+                            "plural": true,
+                            "selections": [
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "node",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "Artwork",
+                                "plural": false,
+                                "selections": [
+                                  (v5/*: any*/),
+                                  (v16/*: any*/),
+                                  (v3/*: any*/),
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "image",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "imageURL",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      (v10/*: any*/)
+                                    ]
+                                  },
+                                  (v15/*: any*/),
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "saleArtwork",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "SaleArtwork",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "kind": "LinkedField",
+                                        "alias": null,
+                                        "name": "openingBid",
+                                        "storageKey": null,
+                                        "args": null,
+                                        "concreteType": "SaleArtworkOpeningBid",
+                                        "plural": false,
+                                        "selections": (v21/*: any*/)
+                                      },
+                                      {
+                                        "kind": "LinkedField",
+                                        "alias": null,
+                                        "name": "highestBid",
+                                        "storageKey": null,
+                                        "args": null,
+                                        "concreteType": "SaleArtworkHighestBid",
+                                        "plural": false,
+                                        "selections": (v21/*: any*/)
+                                      },
+                                      (v22/*: any*/),
+                                      (v20/*: any*/),
+                                      (v3/*: any*/)
+                                    ]
+                                  },
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "sale",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "Sale",
+                                    "plural": false,
+                                    "selections": [
+                                      (v18/*: any*/),
+                                      (v17/*: any*/),
+                                      (v19/*: any*/),
+                                      (v3/*: any*/)
+                                    ]
+                                  },
+                                  (v4/*: any*/),
+                                  (v12/*: any*/),
+                                  (v6/*: any*/)
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      (v2/*: any*/)
+                    ]
+                  },
+                  (v23/*: any*/)
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageInfo",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "plural": false,
+                "selections": [
+                  (v25/*: any*/),
+                  (v24/*: any*/)
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "LinkedHandle",
+            "alias": "exhibitors",
+            "name": "showsConnection",
+            "args": (v27/*: any*/),
+            "handle": "connection",
+            "key": "Fair2ExhibitorsQuery_exhibitors",
+            "filters": (v26/*: any*/)
           },
           (v3/*: any*/)
         ]
@@ -531,7 +1254,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "Fair2Query",
-    "id": "95c68061aa0206a0bb3c479146cd5024",
+    "id": "d069675125ae8a3e6e0c188d4db49bda",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/Fair2TestsQuery.graphql.ts
+++ b/src/__generated__/Fair2TestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 66f21628aaffb51a10185d6d09c4ec56 */
+/* @relayHash 2d0aa1329974bdd340bb60c2dfee5ad6 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -46,6 +46,10 @@ export type Fair2TestsQueryRawResponse = {
                 readonly id: string | null;
             }) | null;
         }) | null>;
+        readonly counts: ({
+            readonly artworks: number | null;
+            readonly partnerShows: number | null;
+        }) | null;
         readonly about: string | null;
         readonly summary: string | null;
         readonly name: string | null;
@@ -70,6 +74,126 @@ export type Fair2TestsQueryRawResponse = {
         readonly links: string | null;
         readonly tickets: string | null;
         readonly contact: string | null;
+        readonly internalID: string;
+        readonly fairArtworks: ({
+            readonly edges: ReadonlyArray<({
+                readonly node: ({
+                    readonly id: string;
+                    readonly slug: string;
+                    readonly image: ({
+                        readonly aspectRatio: number;
+                        readonly url: string | null;
+                    }) | null;
+                    readonly title: string | null;
+                    readonly date: string | null;
+                    readonly saleMessage: string | null;
+                    readonly internalID: string;
+                    readonly artistNames: string | null;
+                    readonly href: string | null;
+                    readonly sale: ({
+                        readonly isAuction: boolean | null;
+                        readonly isClosed: boolean | null;
+                        readonly displayTimelyAt: string | null;
+                        readonly endAt: string | null;
+                        readonly id: string | null;
+                    }) | null;
+                    readonly saleArtwork: ({
+                        readonly counts: ({
+                            readonly bidderPositions: number | null;
+                        }) | null;
+                        readonly currentBid: ({
+                            readonly display: string | null;
+                        }) | null;
+                        readonly lotLabel: string | null;
+                        readonly id: string | null;
+                    }) | null;
+                    readonly partner: ({
+                        readonly name: string | null;
+                        readonly id: string | null;
+                    }) | null;
+                    readonly __typename: "Artwork";
+                }) | null;
+                readonly cursor: string;
+                readonly id: string | null;
+            }) | null> | null;
+            readonly counts: ({
+                readonly total: number | null;
+            }) | null;
+            readonly pageInfo: {
+                readonly hasNextPage: boolean;
+                readonly startCursor: string | null;
+                readonly endCursor: string | null;
+            };
+            readonly id: string | null;
+        }) | null;
+        readonly exhibitors: ({
+            readonly edges: ReadonlyArray<({
+                readonly node: ({
+                    readonly id: string;
+                    readonly counts: ({
+                        readonly artworks: number | null;
+                    }) | null;
+                    readonly partner: ({
+                        readonly __typename: "Partner";
+                        readonly id: string | null;
+                        readonly name: string | null;
+                    } | {
+                        readonly __typename: "ExternalPartner";
+                        readonly id: string | null;
+                        readonly name: string | null;
+                    } | {
+                        readonly __typename: string | null;
+                        readonly id: string | null;
+                    }) | null;
+                    readonly internalID: string;
+                    readonly href: string | null;
+                    readonly artworks: ({
+                        readonly edges: ReadonlyArray<({
+                            readonly node: ({
+                                readonly href: string | null;
+                                readonly artistNames: string | null;
+                                readonly id: string;
+                                readonly image: ({
+                                    readonly imageURL: string | null;
+                                    readonly aspectRatio: number;
+                                }) | null;
+                                readonly saleMessage: string | null;
+                                readonly saleArtwork: ({
+                                    readonly openingBid: ({
+                                        readonly display: string | null;
+                                    }) | null;
+                                    readonly highestBid: ({
+                                        readonly display: string | null;
+                                    }) | null;
+                                    readonly currentBid: ({
+                                        readonly display: string | null;
+                                    }) | null;
+                                    readonly counts: ({
+                                        readonly bidderPositions: number | null;
+                                    }) | null;
+                                    readonly id: string | null;
+                                }) | null;
+                                readonly sale: ({
+                                    readonly isClosed: boolean | null;
+                                    readonly isAuction: boolean | null;
+                                    readonly endAt: string | null;
+                                    readonly id: string | null;
+                                }) | null;
+                                readonly title: string | null;
+                                readonly internalID: string;
+                                readonly slug: string;
+                            }) | null;
+                        }) | null> | null;
+                    }) | null;
+                    readonly __typename: "Show";
+                }) | null;
+                readonly cursor: string;
+            }) | null> | null;
+            readonly pageInfo: {
+                readonly endCursor: string | null;
+                readonly hasNextPage: boolean;
+            };
+        }) | null;
         readonly id: string | null;
     }) | null;
 };
@@ -87,6 +211,64 @@ query Fair2TestsQuery(
 ) {
   fair(id: $fairID) {
     ...Fair2_fair
+    id
+  }
+}
+
+fragment ArtworkGridItem_artwork on Artwork {
+  title
+  date
+  saleMessage
+  slug
+  internalID
+  artistNames
+  href
+  sale {
+    isAuction
+    isClosed
+    displayTimelyAt
+    endAt
+    id
+  }
+  saleArtwork {
+    counts {
+      bidderPositions
+    }
+    currentBid {
+      display
+    }
+    lotLabel
+    id
+  }
+  partner {
+    name
+    id
+  }
+  image {
+    url(version: "large")
+    aspectRatio
+  }
+}
+
+fragment Fair2Artworks_fair on Fair {
+  slug
+  internalID
+  fairArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch") {
+    edges {
+      node {
+        id
+        __typename
+      }
+      cursor
+    }
+    counts {
+      total
+    }
+    ...InfiniteScrollArtworksGrid_connection
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
     id
   }
 }
@@ -123,6 +305,98 @@ fragment Fair2Editorial_fair on Fair {
           src: imageURL
         }
       }
+    }
+  }
+}
+
+fragment Fair2ExhibitorRail_show on Show {
+  internalID
+  href
+  partner {
+    __typename
+    ... on Partner {
+      name
+    }
+    ... on ExternalPartner {
+      name
+      id
+    }
+    ... on Node {
+      id
+    }
+  }
+  counts {
+    artworks
+  }
+  artworks: artworksConnection(first: 20) {
+    edges {
+      node {
+        href
+        artistNames
+        id
+        image {
+          imageURL
+          aspectRatio
+        }
+        saleMessage
+        saleArtwork {
+          openingBid {
+            display
+          }
+          highestBid {
+            display
+          }
+          currentBid {
+            display
+          }
+          counts {
+            bidderPositions
+          }
+          id
+        }
+        sale {
+          isClosed
+          isAuction
+          endAt
+          id
+        }
+        title
+        internalID
+        slug
+      }
+    }
+  }
+}
+
+fragment Fair2Exhibitors_fair on Fair {
+  slug
+  exhibitors: showsConnection(first: 15, sort: FEATURED_ASC) {
+    edges {
+      node {
+        id
+        counts {
+          artworks
+        }
+        partner {
+          __typename
+          ... on Partner {
+            id
+          }
+          ... on ExternalPartner {
+            id
+          }
+          ... on Node {
+            id
+          }
+        }
+        ...Fair2ExhibitorRail_show
+        __typename
+      }
+      cursor
+    }
+    pageInfo {
+      endCursor
+      hasNextPage
     }
   }
 }
@@ -164,9 +438,37 @@ fragment Fair2_fair on Fair {
     __typename
     id
   }
+  counts {
+    artworks
+    partnerShows
+  }
   ...Fair2Header_fair
   ...Fair2Editorial_fair
   ...Fair2Collections_fair
+  ...Fair2Artworks_fair
+  ...Fair2Exhibitors_fair
+}
+
+fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
+  pageInfo {
+    hasNextPage
+    startCursor
+    endCursor
+  }
+  edges {
+    __typename
+    node {
+      slug
+      id
+      image {
+        aspectRatio
+      }
+      ...ArtworkGridItem_artwork
+    }
+    ... on Node {
+      id
+    }
+  }
 }
 */
 
@@ -210,23 +512,182 @@ v4 = {
 v5 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "slug",
+  "name": "href",
   "args": null,
   "storageKey": null
 },
 v6 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "slug",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "artworks",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "summary",
   "args": null,
   "storageKey": null
 },
-v7 = [
+v9 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v10 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "aspectRatio",
+  "args": null,
+  "storageKey": null
+},
+v11 = [
   {
     "kind": "Literal",
     "name": "format",
     "value": "MARKDOWN"
   }
+],
+v12 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "internalID",
+  "args": null,
+  "storageKey": null
+},
+v13 = {
+  "kind": "Literal",
+  "name": "first",
+  "value": 20
+},
+v14 = [
+  (v13/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "sort",
+    "value": "-decayed_merch"
+  }
+],
+v15 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "saleMessage",
+  "args": null,
+  "storageKey": null
+},
+v16 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "artistNames",
+  "args": null,
+  "storageKey": null
+},
+v17 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "isAuction",
+  "args": null,
+  "storageKey": null
+},
+v18 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "isClosed",
+  "args": null,
+  "storageKey": null
+},
+v19 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "endAt",
+  "args": null,
+  "storageKey": null
+},
+v20 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "counts",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "SaleArtworkCounts",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "bidderPositions",
+      "args": null,
+      "storageKey": null
+    }
+  ]
+},
+v21 = [
+  {
+    "kind": "ScalarField",
+    "alias": null,
+    "name": "display",
+    "args": null,
+    "storageKey": null
+  }
+],
+v22 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "currentBid",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "SaleArtworkCurrentBid",
+  "plural": false,
+  "selections": (v21/*: any*/)
+},
+v23 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "cursor",
+  "args": null,
+  "storageKey": null
+},
+v24 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "hasNextPage",
+  "args": null,
+  "storageKey": null
+},
+v25 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "endCursor",
+  "args": null,
+  "storageKey": null
+},
+v26 = [
+  "sort"
+],
+v27 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 15
+  },
+  {
+    "kind": "Literal",
+    "name": "sort",
+    "value": "FEATURED_ASC"
+  }
+],
+v28 = [
+  (v9/*: any*/)
 ];
 return {
   "kind": "Request",
@@ -310,13 +771,7 @@ return {
                     "selections": [
                       (v3/*: any*/),
                       (v4/*: any*/),
-                      {
-                        "kind": "ScalarField",
-                        "alias": null,
-                        "name": "href",
-                        "args": null,
-                        "storageKey": null
-                      },
+                      (v5/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -371,7 +826,7 @@ return {
             "selections": [
               (v2/*: any*/),
               (v3/*: any*/),
-              (v5/*: any*/),
+              (v6/*: any*/),
               (v4/*: any*/),
               {
                 "kind": "ScalarField",
@@ -448,21 +903,34 @@ return {
             ]
           },
           {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "counts",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "FairCounts",
+            "plural": false,
+            "selections": [
+              (v7/*: any*/),
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "partnerShows",
+                "args": null,
+                "storageKey": null
+              }
+            ]
+          },
+          {
             "kind": "ScalarField",
             "alias": null,
             "name": "about",
             "args": null,
             "storageKey": null
           },
+          (v8/*: any*/),
+          (v9/*: any*/),
           (v6/*: any*/),
-          {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "name",
-            "args": null,
-            "storageKey": null
-          },
-          (v5/*: any*/),
           {
             "kind": "LinkedField",
             "alias": null,
@@ -521,13 +989,7 @@ return {
                 ],
                 "storageKey": "url(version:\"large_rectangle\")"
               },
-              {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "aspectRatio",
-                "args": null,
-                "storageKey": null
-              }
+              (v10/*: any*/)
             ]
           },
           {
@@ -546,7 +1008,7 @@ return {
             "concreteType": "Location",
             "plural": false,
             "selections": [
-              (v6/*: any*/),
+              (v8/*: any*/),
               (v3/*: any*/)
             ]
           },
@@ -561,29 +1023,414 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "hours",
-            "args": (v7/*: any*/),
+            "args": (v11/*: any*/),
             "storageKey": "hours(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "links",
-            "args": (v7/*: any*/),
+            "args": (v11/*: any*/),
             "storageKey": "links(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "tickets",
-            "args": (v7/*: any*/),
+            "args": (v11/*: any*/),
             "storageKey": "tickets(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "contact",
-            "args": (v7/*: any*/),
+            "args": (v11/*: any*/),
             "storageKey": "contact(format:\"MARKDOWN\")"
+          },
+          (v12/*: any*/),
+          {
+            "kind": "LinkedField",
+            "alias": "fairArtworks",
+            "name": "filterArtworksConnection",
+            "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")",
+            "args": (v14/*: any*/),
+            "concreteType": "FilterArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      (v6/*: any*/),
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "image",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "plural": false,
+                        "selections": [
+                          (v10/*: any*/),
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "url",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "version",
+                                "value": "large"
+                              }
+                            ],
+                            "storageKey": "url(version:\"large\")"
+                          }
+                        ]
+                      },
+                      (v4/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "date",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      (v15/*: any*/),
+                      (v12/*: any*/),
+                      (v16/*: any*/),
+                      (v5/*: any*/),
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "sale",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "plural": false,
+                        "selections": [
+                          (v17/*: any*/),
+                          (v18/*: any*/),
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "displayTimelyAt",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v19/*: any*/),
+                          (v3/*: any*/)
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "saleArtwork",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "plural": false,
+                        "selections": [
+                          (v20/*: any*/),
+                          (v22/*: any*/),
+                          {
+                            "kind": "ScalarField",
+                            "alias": null,
+                            "name": "lotLabel",
+                            "args": null,
+                            "storageKey": null
+                          },
+                          (v3/*: any*/)
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "partner",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "Partner",
+                        "plural": false,
+                        "selections": [
+                          (v9/*: any*/),
+                          (v3/*: any*/)
+                        ]
+                      },
+                      (v2/*: any*/)
+                    ]
+                  },
+                  (v23/*: any*/),
+                  (v3/*: any*/)
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "counts",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "FilterArtworksCounts",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "total",
+                    "args": null,
+                    "storageKey": null
+                  }
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageInfo",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "plural": false,
+                "selections": [
+                  (v24/*: any*/),
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "startCursor",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  (v25/*: any*/)
+                ]
+              },
+              (v3/*: any*/)
+            ]
+          },
+          {
+            "kind": "LinkedHandle",
+            "alias": "fairArtworks",
+            "name": "filterArtworksConnection",
+            "args": (v14/*: any*/),
+            "handle": "connection",
+            "key": "Fair_fairArtworks",
+            "filters": (v26/*: any*/)
+          },
+          {
+            "kind": "LinkedField",
+            "alias": "exhibitors",
+            "name": "showsConnection",
+            "storageKey": "showsConnection(first:15,sort:\"FEATURED_ASC\")",
+            "args": (v27/*: any*/),
+            "concreteType": "ShowConnection",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "edges",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ShowEdge",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "node",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "Show",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "counts",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": "ShowCounts",
+                        "plural": false,
+                        "selections": [
+                          (v7/*: any*/)
+                        ]
+                      },
+                      {
+                        "kind": "LinkedField",
+                        "alias": null,
+                        "name": "partner",
+                        "storageKey": null,
+                        "args": null,
+                        "concreteType": null,
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v3/*: any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "type": "Partner",
+                            "selections": (v28/*: any*/)
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "type": "ExternalPartner",
+                            "selections": (v28/*: any*/)
+                          }
+                        ]
+                      },
+                      (v12/*: any*/),
+                      (v5/*: any*/),
+                      {
+                        "kind": "LinkedField",
+                        "alias": "artworks",
+                        "name": "artworksConnection",
+                        "storageKey": "artworksConnection(first:20)",
+                        "args": [
+                          (v13/*: any*/)
+                        ],
+                        "concreteType": "ArtworkConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "kind": "LinkedField",
+                            "alias": null,
+                            "name": "edges",
+                            "storageKey": null,
+                            "args": null,
+                            "concreteType": "ArtworkEdge",
+                            "plural": true,
+                            "selections": [
+                              {
+                                "kind": "LinkedField",
+                                "alias": null,
+                                "name": "node",
+                                "storageKey": null,
+                                "args": null,
+                                "concreteType": "Artwork",
+                                "plural": false,
+                                "selections": [
+                                  (v5/*: any*/),
+                                  (v16/*: any*/),
+                                  (v3/*: any*/),
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "image",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "kind": "ScalarField",
+                                        "alias": null,
+                                        "name": "imageURL",
+                                        "args": null,
+                                        "storageKey": null
+                                      },
+                                      (v10/*: any*/)
+                                    ]
+                                  },
+                                  (v15/*: any*/),
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "saleArtwork",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "SaleArtwork",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "kind": "LinkedField",
+                                        "alias": null,
+                                        "name": "openingBid",
+                                        "storageKey": null,
+                                        "args": null,
+                                        "concreteType": "SaleArtworkOpeningBid",
+                                        "plural": false,
+                                        "selections": (v21/*: any*/)
+                                      },
+                                      {
+                                        "kind": "LinkedField",
+                                        "alias": null,
+                                        "name": "highestBid",
+                                        "storageKey": null,
+                                        "args": null,
+                                        "concreteType": "SaleArtworkHighestBid",
+                                        "plural": false,
+                                        "selections": (v21/*: any*/)
+                                      },
+                                      (v22/*: any*/),
+                                      (v20/*: any*/),
+                                      (v3/*: any*/)
+                                    ]
+                                  },
+                                  {
+                                    "kind": "LinkedField",
+                                    "alias": null,
+                                    "name": "sale",
+                                    "storageKey": null,
+                                    "args": null,
+                                    "concreteType": "Sale",
+                                    "plural": false,
+                                    "selections": [
+                                      (v18/*: any*/),
+                                      (v17/*: any*/),
+                                      (v19/*: any*/),
+                                      (v3/*: any*/)
+                                    ]
+                                  },
+                                  (v4/*: any*/),
+                                  (v12/*: any*/),
+                                  (v6/*: any*/)
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      (v2/*: any*/)
+                    ]
+                  },
+                  (v23/*: any*/)
+                ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "pageInfo",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "plural": false,
+                "selections": [
+                  (v25/*: any*/),
+                  (v24/*: any*/)
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "LinkedHandle",
+            "alias": "exhibitors",
+            "name": "showsConnection",
+            "args": (v27/*: any*/),
+            "handle": "connection",
+            "key": "Fair2ExhibitorsQuery_exhibitors",
+            "filters": (v26/*: any*/)
           },
           (v3/*: any*/)
         ]
@@ -593,7 +1440,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "Fair2TestsQuery",
-    "id": "25a9b84dd20d4460a29311053138a18e",
+    "id": "d65fcd6ac21a874922132222141b63aa",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/Fair2_fair.graphql.ts
+++ b/src/__generated__/Fair2_fair.graphql.ts
@@ -12,7 +12,11 @@ export type Fair2_fair = {
     readonly marketingCollections: ReadonlyArray<{
         readonly __typename: string;
     } | null>;
-    readonly " $fragmentRefs": FragmentRefs<"Fair2Header_fair" | "Fair2Editorial_fair" | "Fair2Collections_fair">;
+    readonly counts: {
+        readonly artworks: number | null;
+        readonly partnerShows: number | null;
+    } | null;
+    readonly " $fragmentRefs": FragmentRefs<"Fair2Header_fair" | "Fair2Editorial_fair" | "Fair2Collections_fair" | "Fair2Artworks_fair" | "Fair2Exhibitors_fair">;
     readonly " $refType": "Fair2_fair";
 };
 export type Fair2_fair$data = Fair2_fair;
@@ -89,6 +93,31 @@ return {
       "selections": (v0/*: any*/)
     },
     {
+      "kind": "LinkedField",
+      "alias": null,
+      "name": "counts",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "FairCounts",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "artworks",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "partnerShows",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    },
+    {
       "kind": "FragmentSpread",
       "name": "Fair2Header_fair",
       "args": null
@@ -102,9 +131,19 @@ return {
       "kind": "FragmentSpread",
       "name": "Fair2Collections_fair",
       "args": null
+    },
+    {
+      "kind": "FragmentSpread",
+      "name": "Fair2Artworks_fair",
+      "args": null
+    },
+    {
+      "kind": "FragmentSpread",
+      "name": "Fair2Exhibitors_fair",
+      "args": null
     }
   ]
 };
 })();
-(node as any).hash = 'b3405559e962fd4974ccbd337a541e71';
+(node as any).hash = '7b51c9dd38ce8aa614809c2cf6d692b0';
 export default node;

--- a/src/lib/Scenes/Fair2/Components/Fair2Artworks.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2Artworks.tsx
@@ -1,0 +1,92 @@
+import { OwnerType } from "@artsy/cohesion"
+import { Fair2Artworks_fair } from "__generated__/Fair2Artworks_fair.graphql"
+import { InfiniteScrollArtworksGridContainer } from "lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
+import { Box } from "palette"
+import React from "react"
+import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
+
+interface Fair2ArtworksProps {
+  fair: Fair2Artworks_fair
+  relay: RelayPaginationProp
+}
+
+export const Fair2Artworks: React.FC<Fair2ArtworksProps> = ({ fair, relay }) => {
+  const artworks = fair.fairArtworks!
+
+  if ((artworks?.counts?.total ?? 0) === 0) {
+    return null
+  }
+
+  return (
+    <Box mb={3}>
+      <InfiniteScrollArtworksGridContainer
+        connection={artworks}
+        loadMore={relay.loadMore}
+        hasMore={relay.hasMore}
+        isLoading={relay.isLoading}
+        autoFetch={false}
+        pageSize={20}
+        contextScreenOwnerType={OwnerType.fair}
+        contextScreenOwnerId={fair.internalID}
+        contextScreenOwnerSlug={fair.slug}
+      />
+    </Box>
+  )
+}
+
+export const Fair2ArtworksFragmentContainer = createPaginationContainer(
+  Fair2Artworks,
+  {
+    fair: graphql`
+      fragment Fair2Artworks_fair on Fair
+      @argumentDefinitions(
+        count: { type: "Int", defaultValue: 20 }
+        cursor: { type: "String" }
+        sort: { type: "String", defaultValue: "-decayed_merch" }
+      ) {
+        slug
+        internalID
+        fairArtworks: filterArtworksConnection(first: 20, sort: $sort, after: $cursor)
+        @connection(key: "Fair_fairArtworks") {
+          edges {
+            node {
+              id
+            }
+          }
+          counts {
+            total
+          }
+          ...InfiniteScrollArtworksGrid_connection
+        }
+      }
+    `,
+  },
+  {
+    getConnectionFromProps(props) {
+      return props?.fair.fairArtworks
+    },
+    getFragmentVariables(previousVariables, count) {
+      // Relay is unable to infer this for this component, I'm not sure why.
+      return {
+        ...previousVariables,
+        count,
+      }
+    },
+    getVariables(props, { count, cursor }, fragmentVariables) {
+      return {
+        ...fragmentVariables,
+        props,
+        count,
+        cursor,
+        id: props.fair.slug,
+      }
+    },
+    query: graphql`
+      query Fair2ArtworksInfiniteScrollGridQuery($id: String!, $count: Int!, $cursor: String, $sort: String) {
+        fair(id: $id) {
+          ...Fair2Artworks_fair @arguments(count: $count, cursor: $cursor, sort: $sort)
+        }
+      }
+    `,
+  }
+)

--- a/src/lib/Scenes/Fair2/Components/Fair2Artworks.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2Artworks.tsx
@@ -23,7 +23,6 @@ export const Fair2Artworks: React.FC<Fair2ArtworksProps> = ({ fair, relay }) => 
         connection={artworks}
         loadMore={relay.loadMore}
         hasMore={relay.hasMore}
-        isLoading={relay.isLoading}
         autoFetch={false}
         pageSize={20}
         contextScreenOwnerType={OwnerType.fair}

--- a/src/lib/Scenes/Fair2/Components/Fair2Collections.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2Collections.tsx
@@ -1,10 +1,10 @@
 import { Fair2Collections_fair } from "__generated__/Fair2Collections_fair.graphql"
 import { CARD_WIDTH } from "lib/Components/Home/CardRailCard"
 import { CardRailFlatList } from "lib/Components/Home/CardRailFlatList"
-import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { navigate } from "lib/navigation/navigate"
 import { compact } from "lodash"
 import { Box, BoxProps, SmallCard, Text, TouchableWithScale } from "palette"
-import React, { useRef } from "react"
+import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
 type Collection = Fair2Collections_fair["marketingCollections"][number]
@@ -14,14 +14,12 @@ interface Fair2CollectionsProps extends BoxProps {
 }
 
 export const Fair2Collections: React.FC<Fair2CollectionsProps> = ({ fair, ...rest }) => {
-  const ref = useRef<any>()
-
   if (fair.marketingCollections.length === 0) {
     return null
   }
 
   return (
-    <Box ref={ref} {...rest}>
+    <Box {...rest}>
       <Text mx={2} mb={2} variant="subtitle">
         Curated Highlights
       </Text>
@@ -40,7 +38,7 @@ export const Fair2Collections: React.FC<Fair2CollectionsProps> = ({ fair, ...res
             <TouchableWithScale
               key={collection.slug}
               onPress={() => {
-                SwitchBoard.presentNavigationViewController(ref.current, `/collection/${collection.slug}`)
+                navigate(`/collection/${collection.slug}`)
               }}
             >
               <SmallCard width={CARD_WIDTH} images={images} title={collection.title} subtitle={collection.category} />

--- a/src/lib/Scenes/Fair2/Components/Fair2Editorial.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2Editorial.tsx
@@ -1,8 +1,8 @@
 import { Fair2Editorial_fair } from "__generated__/Fair2Editorial_fair.graphql"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
-import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { navigate } from "lib/navigation/navigate"
 import { Box, BoxProps, color, Text, Touchable } from "palette"
-import React, { useRef } from "react"
+import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
 interface Fair2EditorialProps extends BoxProps {
@@ -10,14 +10,12 @@ interface Fair2EditorialProps extends BoxProps {
 }
 
 export const Fair2Editorial: React.FC<Fair2EditorialProps> = ({ fair, ...rest }) => {
-  const ref = useRef<any>()
-
   if (!fair.articles?.edges || fair.articles.edges.length === 0) {
     return null
   }
 
   return (
-    <Box ref={ref} {...rest}>
+    <Box {...rest}>
       <Text mx={2} mb={2} variant="subtitle">
         Related articles
       </Text>
@@ -33,8 +31,7 @@ export const Fair2Editorial: React.FC<Fair2EditorialProps> = ({ fair, ...rest })
               if (!article.href) {
                 return
               }
-
-              SwitchBoard.presentNavigationViewController(ref.current, article.href)
+              navigate(article.href)
             }}
           >
             <Box flexDirection="row" py={1} px={2}>

--- a/src/lib/Scenes/Fair2/Components/Fair2ExhibitorRail.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2ExhibitorRail.tsx
@@ -1,0 +1,122 @@
+import { Fair2ExhibitorRail_show } from "__generated__/Fair2ExhibitorRail_show.graphql"
+import { saleMessageOrBidInfo } from "lib/Components/ArtworkGrids/ArtworkGridItem"
+import { ArtworkTileRailCard } from "lib/Components/ArtworkTileRail"
+import { SectionTitle } from "lib/Components/SectionTitle"
+import { navigate } from "lib/navigation/navigate"
+import { getUrgencyTag } from "lib/utils/getUrgencyTag"
+import { Box, Spacer } from "palette"
+import React from "react"
+import { FlatList } from "react-native"
+import { createFragmentContainer, graphql } from "react-relay"
+
+interface Fair2ExhibitorRailProps {
+  show: Fair2ExhibitorRail_show
+}
+
+const Fair2ExhibitorRail: React.FC<Fair2ExhibitorRailProps> = ({ show }) => {
+  const artworks = show?.artworks?.edges!.map((item) => item?.node)
+  const count = show?.counts?.artworks ?? 0
+  const partnerName = show?.partner?.name ?? ""
+  const viewAllUrl = show?.href
+
+  if (count === 0) {
+    return null
+  }
+
+  return (
+    <>
+      <Box px={2} pb={1}>
+        <SectionTitle
+          title={partnerName}
+          subtitle={`${count} works`}
+          onPress={() => {
+            if (!viewAllUrl) {
+              return
+            }
+            navigate(viewAllUrl)
+          }}
+        />
+      </Box>
+      <FlatList
+        horizontal
+        ListHeaderComponent={() => <Spacer mr={2}></Spacer>}
+        ListFooterComponent={() => <Spacer mr={2}></Spacer>}
+        ItemSeparatorComponent={() => <Spacer width={15}></Spacer>}
+        showsHorizontalScrollIndicator={false}
+        data={artworks}
+        initialNumToRender={3}
+        windowSize={3}
+        renderItem={({ item }) => {
+          return (
+            <ArtworkTileRailCard
+              onPress={() => navigate(item?.href!)}
+              imageURL={item?.image?.imageURL ?? ""}
+              imageSize="small"
+              useSquareAspectRatio
+              artistNames={item?.artistNames}
+              saleMessage={item && saleMessageOrBidInfo({ artwork: item, isSmallTile: true })}
+              urgencyTag={item?.sale?.isAuction && !item?.sale?.isClosed ? getUrgencyTag(item?.sale?.endAt) : null}
+            />
+          )
+        }}
+        keyExtractor={(item, index) => String(item?.internalID || index)}
+      />
+    </>
+  )
+}
+
+export const Fair2ExhibitorRailFragmentContainer = createFragmentContainer(Fair2ExhibitorRail, {
+  show: graphql`
+    fragment Fair2ExhibitorRail_show on Show {
+      internalID
+      href
+      partner {
+        ... on Partner {
+          name
+        }
+        ... on ExternalPartner {
+          name
+        }
+      }
+      counts {
+        artworks
+      }
+      artworks: artworksConnection(first: 20) {
+        edges {
+          node {
+            href
+            artistNames
+            id
+            image {
+              imageURL
+              aspectRatio
+            }
+            saleMessage
+            saleArtwork {
+              openingBid {
+                display
+              }
+              highestBid {
+                display
+              }
+              currentBid {
+                display
+              }
+              counts {
+                bidderPositions
+              }
+            }
+            sale {
+              isClosed
+              isAuction
+              endAt
+            }
+            title
+            internalID
+            slug
+          }
+        }
+      }
+    }
+  `,
+})

--- a/src/lib/Scenes/Fair2/Components/Fair2Exhibitors.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2Exhibitors.tsx
@@ -1,0 +1,109 @@
+import { Fair2Exhibitors_fair } from "__generated__/Fair2Exhibitors_fair.graphql"
+import { Col } from "lib/Components/Bidding/Elements/Grid"
+import { Row } from "lib/Scenes/Consignments/Components/FormElements"
+import { Box, Button } from "palette"
+import React, { useState } from "react"
+import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
+import { Fair2ExhibitorRailFragmentContainer } from "./Fair2ExhibitorRail"
+
+interface Fair2ExhibitorsProps {
+  fair: Fair2Exhibitors_fair
+  relay: RelayPaginationProp
+}
+
+const Fair2Exhibitors: React.FC<Fair2ExhibitorsProps> = ({ fair, relay }) => {
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handlePress = () => {
+    if (!relay.hasMore() || relay.isLoading()) {
+      return
+    }
+
+    setIsLoading(true)
+
+    relay.loadMore(15, (err) => {
+      setIsLoading(false)
+
+      if (err) {
+        console.error(err)
+      }
+    })
+  }
+
+  return (
+    <>
+      {fair?.exhibitors?.edges?.map((item) => {
+        const show = item?.node
+        if ((show?.counts?.artworks ?? 0) === 0 || !show?.partner) {
+          // Skip rendering of booths without artworks
+          return null
+        }
+
+        return (
+          <Box key={show.id} mb={3}>
+            <Fair2ExhibitorRailFragmentContainer key={show.id} show={show} />
+          </Box>
+        )
+      })}
+      <Row>
+        <Col sm={6} mx="15px">
+          <Button
+            variant="secondaryGray"
+            size="large"
+            block
+            loading={isLoading}
+            onPress={handlePress}
+            disabled={!relay.hasMore()}
+          >
+            Show more
+          </Button>
+        </Col>
+      </Row>
+    </>
+  )
+}
+
+export const Fair2ExhibitorsFragmentContainer = createPaginationContainer(
+  Fair2Exhibitors,
+  {
+    fair: graphql`
+      fragment Fair2Exhibitors_fair on Fair
+      @argumentDefinitions(first: { type: "Int", defaultValue: 15 }, after: { type: "String" }) {
+        slug
+        exhibitors: showsConnection(first: $first, after: $after, sort: FEATURED_ASC)
+        @connection(key: "Fair2ExhibitorsQuery_exhibitors") {
+          edges {
+            node {
+              id
+              counts {
+                artworks
+              }
+              partner {
+                ... on Partner {
+                  id
+                }
+                ... on ExternalPartner {
+                  id
+                }
+              }
+              ...Fair2ExhibitorRail_show
+            }
+          }
+        }
+      }
+    `,
+  },
+  {
+    direction: "forward",
+    getVariables({ fair: { slug: id } }, { cursor: after }, { first }) {
+      return { first, after, id }
+    },
+    query: graphql`
+      query Fair2ExhibitorsQuery($id: String!, $first: Int!, $after: String) {
+        fair(id: $id) {
+          ...Fair2Exhibitors_fair @arguments(first: $first, after: $after)
+        }
+      }
+    `,
+  }
+)

--- a/src/lib/Scenes/Fair2/Components/SimpleTabs.tsx
+++ b/src/lib/Scenes/Fair2/Components/SimpleTabs.tsx
@@ -1,0 +1,87 @@
+import { useScreenDimensions } from "lib/utils/useScreenDimensions"
+import { Box, color, Flex, Text } from "palette"
+import React, { Dispatch, ReactElement, SetStateAction } from "react"
+import { TouchableOpacity, View } from "react-native"
+
+export type TabsType = Array<{
+  label: string
+  component: ReactElement
+}>
+
+interface TabChildContentProps {
+  activeTab: number
+  tabs: TabsType
+}
+
+/**
+ * Each "tab" in the "tabs" array is an object containing a label and a
+ * component reference. This method returns the component for the currently-active
+ * tab.
+ */
+export const TabChildContent: React.FC<TabChildContentProps> = ({ activeTab, tabs }) => {
+  const tabToShow = tabs ? tabs[activeTab] : null
+
+  if (!tabToShow) {
+    return null
+  }
+
+  return tabToShow.component
+}
+
+interface TabProps {
+  label: string
+  active: boolean
+  onPress: () => void
+}
+
+/**
+ * The render method for an individual tab. Will underline the currently
+ * active tab.
+ */
+export const Tab: React.FC<TabProps> = ({ label, active, onPress }) => {
+  const { safeAreaInsets } = useScreenDimensions()
+  return (
+    <TouchableOpacity onPress={onPress}>
+      <View
+        style={{
+          marginTop: safeAreaInsets.top,
+          height: 55,
+          alignItems: "center",
+          justifyContent: "center",
+          paddingHorizontal: 15,
+        }}
+      >
+        <Text variant={active ? "mediumText" : "text"}>{label}</Text>
+      </View>
+    </TouchableOpacity>
+  )
+}
+
+interface TabsProps {
+  setActiveTab: Dispatch<SetStateAction<number>>
+  activeTab: number
+  tabs: TabsType
+}
+
+/**
+ * Renders a list of tabs. Evenly-spaces them across the screen.
+ */
+export const Tabs: React.FC<TabsProps> = ({ setActiveTab, activeTab, tabs }) => {
+  const tabWidth = 100 / tabs.length
+  return (
+    <Flex flexDirection="row" backgroundColor="white">
+      {tabs.map(({ label }, index) => {
+        const active = activeTab === index
+        return (
+          <Box
+            width={`${tabWidth}%`}
+            borderBottomColor={active ? color("black100") : color("black10")}
+            borderBottomWidth="1px"
+          >
+            <Tab label={label} onPress={() => setActiveTab(index)} active={active} />
+          </Box>
+        )
+      })}
+    </Flex>
+  )
+}

--- a/src/lib/Scenes/Fair2/Fair2.tsx
+++ b/src/lib/Scenes/Fair2/Fair2.tsx
@@ -1,14 +1,19 @@
 import { Fair2_fair } from "__generated__/Fair2_fair.graphql"
 import { Fair2Query } from "__generated__/Fair2Query.graphql"
+import { AnimatedArtworkFilterButton } from "lib/Components/FilterModal"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
+import { ArtworkFilterContext, ArtworkFilterGlobalStateProvider } from "lib/utils/ArtworkFiltersStore"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
-import { Separator, Theme } from "palette"
-import React from "react"
-import { FlatList } from "react-native"
+import { Box, Separator, Spacer, Theme } from "palette"
+import React, { useRef, useState } from "react"
+import { FlatList, ViewToken } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
-import { Fair2CollectionsFragmentContainer as FairCollections } from "./Components/Fair2Collections"
-import { Fair2EditorialFragmentContainer as FairEditorial } from "./Components/Fair2Editorial"
-import { Fair2HeaderFragmentContainer as FairHeader } from "./Components/Fair2Header"
+import { Fair2ArtworksFragmentContainer } from "./Components/Fair2Artworks"
+import { Fair2CollectionsFragmentContainer } from "./Components/Fair2Collections"
+import { Fair2EditorialFragmentContainer } from "./Components/Fair2Editorial"
+import { Fair2ExhibitorsFragmentContainer } from "./Components/Fair2Exhibitors"
+import { Fair2HeaderFragmentContainer } from "./Components/Fair2Header"
+import { TabChildContent, Tabs, TabsType } from "./Components/SimpleTabs"
 
 interface Fair2QueryRendererProps {
   fairID: string
@@ -18,25 +23,107 @@ interface Fair2Props {
   fair: Fair2_fair
 }
 
+interface ViewableItems {
+  viewableItems?: ViewToken[]
+}
+
 export const Fair2: React.FC<Fair2Props> = ({ fair }) => {
   const hasArticles = !!fair.articles?.edges?.length
   const hasCollections = !!fair.marketingCollections.length
+  const hasArtworks = !!(fair.counts?.artworks ?? 0 > 0)
+  const hasExhibitors = !!(fair.counts?.partnerShows ?? 0 > 0)
 
-  const sections = [
-    <FairHeader fair={fair} />,
-    ...(hasArticles ? [<FairEditorial fair={fair} />] : []),
-    ...(hasCollections ? [<FairCollections fair={fair} />] : []),
+  const [activeTab, setActiveTab] = useState(0)
+  const tabs: TabsType = [
+    {
+      label: "Exhibitors",
+      component: <Fair2ExhibitorsFragmentContainer fair={fair} />,
+    },
+    {
+      label: "Artworks",
+      component: (
+        <Box px="15px">
+          <Fair2ArtworksFragmentContainer fair={fair} />
+        </Box>
+      ),
+    },
   ]
 
+  const flatListRef = useRef<FlatList>(null)
+  const [isFilterArtworksModalVisible, setFilterArtworkModalVisible] = useState(false)
+  const [isArtworksGridVisible, setArtworksGridVisible] = useState(false)
+
+  const viewConfigRef = React.useRef({ viewAreaCoveragePercentThreshold: 30 })
+
+  const viewableItemsChangedRef = React.useRef(({ viewableItems }: ViewableItems) => {
+    const artworksItem = (viewableItems! ?? []).find((viewableItem: ViewToken) => {
+      return viewableItem?.item === "fairTabChildContent"
+    })
+    setArtworksGridVisible(artworksItem?.isViewable ?? false)
+  })
+
+  const handleFilterArtworksModal = () => {
+    setFilterArtworkModalVisible(!isFilterArtworksModalVisible)
+  }
+
+  const sections = [
+    "fairHeader",
+    ...(hasArticles ? ["fairEditorial"] : []),
+    ...(hasCollections ? ["fairCollections"] : []),
+    ...(hasArtworks && hasExhibitors ? ["fairTabs", "fairTabChildContent"] : []),
+  ]
+
+  const tabIndex = sections.indexOf("fairTabs")
+
   return (
-    <Theme>
-      <FlatList
-        data={sections}
-        ItemSeparatorComponent={() => <Separator my={3} />}
-        keyExtractor={(_item, index) => String(index)}
-        renderItem={({ item }) => item}
-      />
-    </Theme>
+    <ArtworkFilterGlobalStateProvider>
+      <ArtworkFilterContext.Consumer>
+        {(context) => (
+          <Theme>
+            <>
+              <FlatList
+                data={sections}
+                ref={flatListRef}
+                viewabilityConfig={viewConfigRef.current}
+                onViewableItemsChanged={viewableItemsChangedRef.current}
+                ItemSeparatorComponent={() => <Spacer mb={3} />}
+                keyExtractor={(_item, index) => String(index)}
+                stickyHeaderIndices={[tabIndex]}
+                renderItem={({ item }): null | any => {
+                  switch (item) {
+                    case "fairHeader": {
+                      return (
+                        <>
+                          <Fair2HeaderFragmentContainer fair={fair} />
+                          <Separator mt={3} />
+                        </>
+                      )
+                    }
+                    case "fairEditorial": {
+                      return <Fair2EditorialFragmentContainer fair={fair} />
+                    }
+                    case "fairCollections": {
+                      return <Fair2CollectionsFragmentContainer fair={fair} />
+                    }
+                    case "fairTabs": {
+                      return <Tabs setActiveTab={setActiveTab} activeTab={activeTab} tabs={tabs} />
+                    }
+                    case "fairTabChildContent": {
+                      return <TabChildContent activeTab={activeTab} fair={fair} tabs={tabs} />
+                    }
+                  }
+                }}
+              />
+              <AnimatedArtworkFilterButton
+                isVisible={isArtworksGridVisible && tabs[activeTab] && tabs[activeTab].label === "Artworks"}
+                count={context.state.appliedFilters.length}
+                onPress={handleFilterArtworksModal}
+              />
+            </>
+          </Theme>
+        )}
+      </ArtworkFilterContext.Consumer>
+    </ArtworkFilterGlobalStateProvider>
   )
 }
 
@@ -51,9 +138,15 @@ export const Fair2FragmentContainer = createFragmentContainer(Fair2, {
       marketingCollections(size: 4) {
         __typename
       }
+      counts {
+        artworks
+        partnerShows
+      }
       ...Fair2Header_fair
       ...Fair2Editorial_fair
       ...Fair2Collections_fair
+      ...Fair2Artworks_fair
+      ...Fair2Exhibitors_fair
     }
   `,
 })

--- a/src/lib/Scenes/Fair2/Fair2.tsx
+++ b/src/lib/Scenes/Fair2/Fair2.tsx
@@ -109,7 +109,7 @@ export const Fair2: React.FC<Fair2Props> = ({ fair }) => {
                       return <Tabs setActiveTab={setActiveTab} activeTab={activeTab} tabs={tabs} />
                     }
                     case "fairTabChildContent": {
-                      return <TabChildContent activeTab={activeTab} fair={fair} tabs={tabs} />
+                      return <TabChildContent activeTab={activeTab} tabs={tabs} />
                     }
                   }
                 }}

--- a/src/lib/Scenes/Fair2/__tests__/Fair2Artworks-tests.tsx
+++ b/src/lib/Scenes/Fair2/__tests__/Fair2Artworks-tests.tsx
@@ -1,0 +1,157 @@
+import {
+  Fair2ArtworksTestsQuery,
+  Fair2ArtworksTestsQueryRawResponse,
+} from "__generated__/Fair2ArtworksTestsQuery.graphql"
+import { InfiniteScrollArtworksGridContainer } from "lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
+import { Fair2ArtworksFragmentContainer } from "lib/Scenes/Fair2/Components/Fair2Artworks"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import { createMockEnvironment } from "relay-test-utils"
+
+jest.unmock("react-relay")
+
+describe("Fair2Artworks", () => {
+  const getWrapper = (fixture = FAIR_2_ARTWORKS_FIXTURE) => {
+    const env = createMockEnvironment()
+
+    const tree = renderWithWrappers(
+      <QueryRenderer<Fair2ArtworksTestsQuery>
+        environment={env}
+        query={graphql`
+          query Fair2ArtworksTestsQuery($fairID: String!) @raw_response_type {
+            fair(id: $fairID) {
+              ...Fair2Artworks_fair
+            }
+          }
+        `}
+        variables={{ fairID: "art-basel-hong-kong-2020" }}
+        render={({ props, error }) => {
+          if (error) {
+            console.log(error)
+            return null
+          }
+
+          if (!props || !props.fair) {
+            return null
+          }
+
+          return <Fair2ArtworksFragmentContainer fair={props.fair} />
+        }}
+      />
+    )
+
+    env.mock.resolveMostRecentOperation({ errors: [], data: fixture })
+
+    return tree
+  }
+
+  it("renders a grid of artworks", () => {
+    const wrapper = getWrapper()
+    expect(wrapper.root.findAllByType(InfiniteScrollArtworksGridContainer)).toHaveLength(1)
+  })
+
+  it("renders null if there are no artworks", () => {
+    const wrapper = getWrapper({
+      fair: {
+        ...FAIR_2_ARTWORKS_FIXTURE.fair,
+        fairArtworks: {
+          ...FAIR_2_ARTWORKS_FIXTURE.fair?.fairArtworks,
+          edges: [],
+          counts: {
+            total: 0,
+          },
+        },
+      },
+    } as Fair2ArtworksTestsQueryRawResponse)
+
+    expect(wrapper.root.findAllByType(InfiniteScrollArtworksGridContainer)).toHaveLength(0)
+  })
+})
+
+const FAIR_2_ARTWORKS_FIXTURE: Fair2ArtworksTestsQueryRawResponse = {
+  fair: {
+    id: "random-relay-id",
+    slug: "art-basel-hong-kong-2020",
+    internalID: "BSON-id-random",
+    fairArtworks: {
+      id: "fa123",
+      counts: {
+        total: 2,
+      },
+      pageInfo: {
+        hasNextPage: false,
+        startCursor: "123",
+        endCursor: "abc",
+      },
+      edges: [
+        {
+          node: {
+            __typename: "Artwork",
+            id: "ggg123",
+            slug: "yayoi-kusama-pumpkin-2222222222222222",
+            href: "/artwork/yayoi-kusama-pumpkin-2222222222222222",
+            internalID: "zzz123",
+            artistNames: "Andy Warhol",
+            image: {
+              aspectRatio: 1.27,
+              url: "https://test.artsy.net/image",
+            },
+            title: "Pumpkin",
+            date: "2020",
+            saleMessage: "Contact For Price",
+            partner: {
+              name: "Important Auction House",
+              id: "ahabc123",
+            },
+            sale: {
+              isAuction: true,
+              isClosed: false,
+              id: "saleabc123",
+              endAt: "2020-01-22",
+              displayTimelyAt: "live in 3d",
+            },
+            saleArtwork: {
+              lotLabel: "1A",
+              counts: {
+                bidderPositions: 0,
+              },
+              currentBid: {
+                display: "USD $2222",
+              },
+              id: "idabc123",
+            },
+          },
+          id: "nodeidabc",
+          cursor: "aaaaa",
+        },
+        {
+          node: {
+            __typename: "Artwork",
+            artistNames: "Andy Warhol",
+            id: "abc123",
+            slug: "yayoi-kusama-pumpkin-33333333333333333",
+            href: "/artwork/yayoi-kusama-pumpkin-33333333333333333",
+            internalID: "xxx123",
+            image: {
+              aspectRatio: 1.43,
+
+              url: "https://test.artsy.net/image2",
+            },
+            title: "Pumpkin",
+            date: "2020",
+            saleMessage: "Contact For Price",
+            partner: {
+              name: "Important Gallery",
+              id: "galleryabc123",
+            },
+            sale: null,
+            saleArtwork: null,
+          },
+          id: "nodeid123",
+          cursor: "aaaaabbbbb",
+        },
+      ],
+    },
+  },
+}

--- a/src/lib/Scenes/Fair2/__tests__/Fair2ExhibitorRail-tests.tsx
+++ b/src/lib/Scenes/Fair2/__tests__/Fair2ExhibitorRail-tests.tsx
@@ -1,0 +1,122 @@
+import {
+  Fair2ExhibitorRailTestsQuery,
+  Fair2ExhibitorRailTestsQueryRawResponse,
+} from "__generated__/Fair2ExhibitorRailTestsQuery.graphql"
+import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import { createMockEnvironment } from "relay-test-utils"
+import { Fair2ExhibitorRailFragmentContainer } from "../Components/Fair2ExhibitorRail"
+
+jest.unmock("react-relay")
+
+describe("FairExhibitors", () => {
+  const getWrapper = (fixture = FAIR_2_EXHIBITOR_RAIL_FIXTURE) => {
+    const env = createMockEnvironment()
+
+    const tree = renderWithWrappers(
+      <QueryRenderer<Fair2ExhibitorRailTestsQuery>
+        environment={env}
+        query={graphql`
+          query Fair2ExhibitorRailTestsQuery($showID: String!) @raw_response_type {
+            show(id: $showID) {
+              ...Fair2ExhibitorRail_show
+            }
+          }
+        `}
+        variables={{ showID: "gagosian-at-art-basel-hong-kong-2020" }}
+        render={({ props, error }) => {
+          if (error) {
+            console.log(error)
+            return null
+          }
+
+          if (!props || !props.show) {
+            return null
+          }
+
+          return <Fair2ExhibitorRailFragmentContainer show={props.show} />
+        }}
+      />
+    )
+
+    env.mock.resolveMostRecentOperation({ errors: [], data: fixture })
+
+    return tree
+  }
+
+  it("renders an exhibitor rail", () => {
+    const wrapper = getWrapper()
+    expect(extractText(wrapper.root)).toContain("First Partner Has Artworks")
+  })
+})
+
+const FAIR_2_EXHIBITOR_RAIL_FIXTURE: Fair2ExhibitorRailTestsQueryRawResponse = {
+  show: {
+    id: "xxx-2",
+    internalID: "xxx-2",
+    counts: { artworks: 10 },
+    href: "/show/example-2",
+    partner: {
+      __typename: "Partner",
+      id: "example-2",
+      name: "First Partner Has Artworks",
+    },
+    artworks: {
+      edges: [
+        {
+          node: {
+            href: "/artwork/cool-artwork-1",
+            artistNames: "Andy Warhol",
+            id: "abc124",
+            saleMessage: "For Sale",
+            image: {
+              aspectRatio: 1.2,
+              imageURL: "image.jpg",
+            },
+            saleArtwork: null,
+            sale: null,
+            title: "Best Artwork Ever",
+            internalID: "artwork1234",
+            slug: "cool-artwork-1",
+          },
+        },
+        {
+          node: {
+            href: "/artwork/cool-artwork-1",
+            artistNames: "Andy Warhol",
+            id: "abc125",
+            saleMessage: "For Sale",
+            image: {
+              aspectRatio: 1.2,
+              imageURL: "image.jpg",
+            },
+            saleArtwork: null,
+            sale: null,
+            title: "Best Artwork Ever",
+            internalID: "artwork1234",
+            slug: "cool-artwork-1",
+          },
+        },
+        {
+          node: {
+            href: "/artwork/cool-artwork-1",
+            artistNames: "Andy Warhol",
+            id: "abc126",
+            saleMessage: "For Sale",
+            image: {
+              aspectRatio: 1.2,
+              imageURL: "image.jpg",
+            },
+            saleArtwork: null,
+            sale: null,
+            title: "Best Artwork Ever",
+            internalID: "artwork1234",
+            slug: "cool-artwork-1",
+          },
+        },
+      ],
+    },
+  },
+}

--- a/src/lib/Scenes/Fair2/__tests__/Fair2Exhibitors-tests.tsx
+++ b/src/lib/Scenes/Fair2/__tests__/Fair2Exhibitors-tests.tsx
@@ -1,0 +1,235 @@
+import {
+  Fair2ExhibitorsTestsQuery,
+  Fair2ExhibitorsTestsQueryRawResponse,
+} from "__generated__/Fair2ExhibitorsTestsQuery.graphql"
+import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import { createMockEnvironment } from "relay-test-utils"
+import { Fair2ExhibitorRailFragmentContainer } from "../Components/Fair2ExhibitorRail"
+import { Fair2ExhibitorsFragmentContainer } from "../Components/Fair2Exhibitors"
+
+jest.unmock("react-relay")
+
+describe("FairExhibitors", () => {
+  const getWrapper = (fixture = FAIR_2_EXHIBITORS_FIXTURE) => {
+    const env = createMockEnvironment()
+
+    const tree = renderWithWrappers(
+      <QueryRenderer<Fair2ExhibitorsTestsQuery>
+        environment={env}
+        query={graphql`
+          query Fair2ExhibitorsTestsQuery($fairID: String!) @raw_response_type {
+            fair(id: $fairID) {
+              ...Fair2Exhibitors_fair
+            }
+          }
+        `}
+        variables={{ fairID: "art-basel-hong-kong-2020" }}
+        render={({ props, error }) => {
+          if (error) {
+            console.log(error)
+            return null
+          }
+
+          if (!props || !props.fair) {
+            return null
+          }
+
+          return <Fair2ExhibitorsFragmentContainer fair={props.fair} />
+        }}
+      />
+    )
+
+    env.mock.resolveMostRecentOperation({ errors: [], data: fixture })
+
+    return tree
+  }
+
+  it("renders the rails from exhibitors that have artworks", () => {
+    const wrapper = getWrapper()
+    expect(wrapper.root.findAllByType(Fair2ExhibitorRailFragmentContainer)).toHaveLength(2)
+  })
+
+  it("skips over any partners with no artworks", () => {
+    const wrapper = getWrapper()
+    expect(extractText(wrapper.root)).not.toContain("Partner Without Artworks")
+  })
+
+  it("renders the show more button", () => {
+    const wrapper = getWrapper()
+    expect(extractText(wrapper.root)).toContain("Show more")
+  })
+})
+
+const FAIR_2_EXHIBITORS_FIXTURE: Fair2ExhibitorsTestsQueryRawResponse = {
+  fair: {
+    id: "xxx",
+    slug: "xxx",
+    exhibitors: {
+      pageInfo: {
+        endCursor: "xxx",
+        hasNextPage: false,
+      },
+      edges: [
+        {
+          cursor: "xxx",
+          node: {
+            __typename: "Show",
+            id: "xxx-1",
+            internalID: "xxx-1",
+            counts: { artworks: 0 },
+            href: "/show/example-1",
+            partner: {
+              __typename: "Partner",
+              id: "example-1",
+              name: "Partner Without Artworks",
+            },
+            artworks: null,
+          },
+        },
+        {
+          cursor: "xxx",
+          node: {
+            __typename: "Show",
+            id: "xxx-2",
+            internalID: "xxx-2",
+            counts: { artworks: 10 },
+            href: "/show/example-2",
+            partner: {
+              __typename: "Partner",
+              id: "example-2",
+              name: "First Partner Has Artworks",
+            },
+            artworks: {
+              edges: [
+                {
+                  node: {
+                    href: "/artwork/cool-artwork-1",
+                    artistNames: "Andy Warhol",
+                    id: "abc124",
+                    saleMessage: "For Sale",
+                    image: {
+                      aspectRatio: 1.2,
+                      imageURL: "image.jpg",
+                    },
+                    saleArtwork: null,
+                    sale: null,
+                    title: "Best Artwork Ever",
+                    internalID: "artwork1234",
+                    slug: "cool-artwork-1",
+                  },
+                },
+                {
+                  node: {
+                    href: "/artwork/cool-artwork-1",
+                    artistNames: "Andy Warhol",
+                    id: "abc125",
+                    saleMessage: "For Sale",
+                    image: {
+                      aspectRatio: 1.2,
+                      imageURL: "image.jpg",
+                    },
+                    saleArtwork: null,
+                    sale: null,
+                    title: "Best Artwork Ever",
+                    internalID: "artwork1234",
+                    slug: "cool-artwork-1",
+                  },
+                },
+                {
+                  node: {
+                    href: "/artwork/cool-artwork-1",
+                    artistNames: "Andy Warhol",
+                    id: "abc126",
+                    saleMessage: "For Sale",
+                    image: {
+                      aspectRatio: 1.2,
+                      imageURL: "image.jpg",
+                    },
+                    saleArtwork: null,
+                    sale: null,
+                    title: "Best Artwork Ever",
+                    internalID: "artwork1234",
+                    slug: "cool-artwork-1",
+                  },
+                },
+              ],
+            },
+          },
+        },
+        {
+          cursor: "xxx",
+          node: {
+            __typename: "Show",
+            id: "xxx-3",
+            internalID: "xxx-3",
+            counts: { artworks: 10 },
+            href: "/show/example-3",
+            partner: {
+              __typename: "Partner",
+              id: "example-3",
+              name: "Second Partner Has Artworks",
+            },
+            artworks: {
+              edges: [
+                {
+                  node: {
+                    href: "/artwork/cool-artwork-1",
+                    artistNames: "Andy Warhol",
+                    id: "abc124",
+                    saleMessage: "For Sale",
+                    image: {
+                      aspectRatio: 1.2,
+                      imageURL: "image.jpg",
+                    },
+                    saleArtwork: null,
+                    sale: null,
+                    title: "Best Artwork Ever",
+                    internalID: "artwork1234",
+                    slug: "cool-artwork-1",
+                  },
+                },
+                {
+                  node: {
+                    href: "/artwork/cool-artwork-1",
+                    artistNames: "Andy Warhol",
+                    id: "abc125",
+                    saleMessage: "For Sale",
+                    image: {
+                      aspectRatio: 1.2,
+                      imageURL: "image.jpg",
+                    },
+                    saleArtwork: null,
+                    sale: null,
+                    title: "Best Artwork Ever",
+                    internalID: "artwork1234",
+                    slug: "cool-artwork-1",
+                  },
+                },
+                {
+                  node: {
+                    href: "/artwork/cool-artwork-1",
+                    artistNames: "Andy Warhol",
+                    id: "abc126",
+                    saleMessage: "For Sale",
+                    image: {
+                      aspectRatio: 1.2,
+                      imageURL: "image.jpg",
+                    },
+                    saleArtwork: null,
+                    sale: null,
+                    title: "Best Artwork Ever",
+                    internalID: "artwork1234",
+                    slug: "cool-artwork-1",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  },
+}


### PR DESCRIPTION
The type of this PR is: **Enhancement**

This PR resolves [FX-2213], [FX-2214], [FX-2215]

### Description

This PR adds the bottom-of-the-page content to the new fair page, which includes the Exhibitors and Artworks shelves/grid.

Some notes:
- To get the sticky header effect, I used the built-in `stickyHeaderIndices` prop on `FlatList`. It seems to work fine, the only weird thing is that when you click into the "Artworks" tab, the screen jumps. I'm pretty sure this is due to how we lazily-load that artworks grid (as the same does not occur when switching to the "Exhibitors" tab).
- The rest is pretty standard and builds off the logic we have on web.
- In order to validate that the basic layout works as-intended, I also included the animated Filter Button in this PR. Will follow up with the actual filtering behavior.

<img width="392" alt="Screen Shot 2020-09-28 at 11 16 20 AM" src="https://user-images.githubusercontent.com/2081340/94451997-0f0d4600-017d-11eb-982d-5da4bd8c4bec.png">
<img width="416" alt="Screen Shot 2020-09-28 at 11 16 26 AM" src="https://user-images.githubusercontent.com/2081340/94452004-103e7300-017d-11eb-98e1-278e58dfafa8.png">
![fairtabs](https://user-images.githubusercontent.com/2081340/94452008-12083680-017d-11eb-9768-fe9d8bc2059b.gif)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [X] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [X] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [X] I have documented any follow-up work that this PR will require, or it does not require any.
- [X] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[FX-2213]: https://artsyproduct.atlassian.net/browse/FX-2213
[FX-2214]: https://artsyproduct.atlassian.net/browse/FX-2214
[FX-2215]: https://artsyproduct.atlassian.net/browse/FX-2215