### PR TITLE
[MX-549] - align internal webview to parent vc, add dedicated routes for faqs

### DIFF
--- a/Artsy/View_Controllers/Web_Browsing/ARInternalWebView.m
+++ b/Artsy/View_Controllers/Web_Browsing/ARInternalWebView.m
@@ -34,6 +34,7 @@
     ARInternalMobileWebViewController *webVC = [[ARInternalMobileWebViewController alloc] initWithURL:resolvedURL];
     UIViewController *parentVC = [self reactViewController];
     [parentVC ar_addModernChildViewController:webVC];
+    [self alignToView:parentVC.view];
     [webVC.view alignToView:self];
     self.webViewController = webVC;
 }

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -23,6 +23,7 @@ upcoming:
     - Add LoadFailureView to Viewing Rooms screens for relay errors - pavlos
     - Enable filtering on artist series views - sweir
     - Show up to 50 artist series in the full list of an artist's series - roop
+    - Fix layout issue in internal webviews - brian
 
 releases:
   - version: 6.6.4

--- a/src/lib/navigation/routes.tsx
+++ b/src/lib/navigation/routes.tsx
@@ -127,6 +127,8 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
     new RouteMatcher("/works-for-you", "WorksForYou"),
     new RouteMatcher("/categories", "WebView", () => ({ url: "/categories" })),
     new RouteMatcher("/privacy", "WebView", () => ({ url: "/privacy" })),
+    new RouteMatcher("/auction-faq", "WebView", () => ({ url: "/auction-faq" })),
+    new RouteMatcher("/identity-verification-faq", "WebView", () => ({ url: "/identity-verification-faq" })),
 
     new RouteMatcher("/city-bmw-list/:citySlug", "CityBMWList"),
     new RouteMatcher("/:slug", "VanityURLEntity"),


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [MX-549]

### Description

These routes were actually loading correctly but there was a layout issue with the internal web view component, not really clear how it broke.

- Aligns internal web view native component to parent vc
- Adds dedicated routes for identity verification FAQ and auction FAQ to avoid profile api call in VanityURLEntity

#### Screenshots

![auction-faqs](https://user-images.githubusercontent.com/49686530/94459850-e76eab80-0185-11eb-8db8-f3b9723596f4.png)

![id-verify-faqs](https://user-images.githubusercontent.com/49686530/94459856-e89fd880-0185-11eb-891a-4e3993c9ba69.png)


#### Follow-ups

- The back button is covering the Auction FAQ header in the webview, seems like this is an existing bug in older builds

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[MX-549]: https://artsyproduct.atlassian.net/browse/MX-549