### PR TITLE
[MX-553] fix: Bottom buttons in modals are obscured by keyboard

### DIFF
--- a/src/lib/Components/Buttons/BottomAlignedButtonWrapper.tsx
+++ b/src/lib/Components/Buttons/BottomAlignedButtonWrapper.tsx
@@ -1,6 +1,6 @@
+import { ICON_HEIGHT } from "lib/Scenes/BottomTabs/BottomTabsIcon"
 import React from "react"
 import { Dimensions, KeyboardAvoidingView, View } from "react-native"
-import { CARD_STACK_OVERLAY_HEIGHT } from "../FancyModal/FancyModalCard"
 
 export interface BottomAlignedProps extends React.Props<JSX.Element> {
   onPress: () => void
@@ -15,7 +15,7 @@ const defaultVerticalOffset = isPhoneX ? 30 : 15
 const BottomAlignedButtonWrapper: React.FC<BottomAlignedProps> = (props) => (
   <KeyboardAvoidingView
     behavior="padding"
-    keyboardVerticalOffset={props.verticalOffset || defaultVerticalOffset + CARD_STACK_OVERLAY_HEIGHT}
+    keyboardVerticalOffset={props.verticalOffset || defaultVerticalOffset + ICON_HEIGHT}
     style={{ flex: 1 }}
   >
     <View key="space-eater" style={{ flexGrow: 1 }}>

--- a/src/lib/Components/Buttons/BottomAlignedButtonWrapper.tsx
+++ b/src/lib/Components/Buttons/BottomAlignedButtonWrapper.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { Dimensions, KeyboardAvoidingView, View } from "react-native"
+import { CARD_STACK_OVERLAY_HEIGHT } from "../FancyModal/FancyModalCard"
 
 export interface BottomAlignedProps extends React.Props<JSX.Element> {
   onPress: () => void
@@ -14,7 +15,7 @@ const defaultVerticalOffset = isPhoneX ? 30 : 15
 const BottomAlignedButtonWrapper: React.FC<BottomAlignedProps> = (props) => (
   <KeyboardAvoidingView
     behavior="padding"
-    keyboardVerticalOffset={props.verticalOffset || defaultVerticalOffset}
+    keyboardVerticalOffset={props.verticalOffset || defaultVerticalOffset + CARD_STACK_OVERLAY_HEIGHT}
     style={{ flex: 1 }}
   >
     <View key="space-eater" style={{ flexGrow: 1 }}>

--- a/src/lib/Scenes/Consignments/Components/BottomAlignedButton.tsx
+++ b/src/lib/Scenes/Consignments/Components/BottomAlignedButton.tsx
@@ -1,7 +1,7 @@
-import { useScreenDimensions } from "lib/utils/useScreenDimensions"
+import { CARD_STACK_OVERLAY_HEIGHT } from "lib/Components/FancyModal/FancyModalCard"
 import { Box, Button, Separator, Spacer } from "palette"
 import React from "react"
-import { KeyboardAvoidingView, View } from "react-native"
+import { Dimensions, KeyboardAvoidingView, View } from "react-native"
 
 export interface BottomAlignedProps extends React.Props<JSX.Element> {
   onPress: () => void
@@ -10,10 +10,13 @@ export interface BottomAlignedProps extends React.Props<JSX.Element> {
   verticalOffset?: number
 }
 
+const isPhoneX = Dimensions.get("window").height === 812 && Dimensions.get("window").width === 375
+const defaultVerticalOffset = isPhoneX ? 34 : 20
+
 export const BottomAlignedButton: React.FC<BottomAlignedProps> = ({ buttonText, onPress, children, disabled }) => (
   <KeyboardAvoidingView
     behavior="padding"
-    keyboardVerticalOffset={useScreenDimensions().safeAreaInsets.top}
+    keyboardVerticalOffset={defaultVerticalOffset + CARD_STACK_OVERLAY_HEIGHT}
     style={{ flex: 1 }}
   >
     <View key="space-eater" style={{ flexGrow: 1 }}>

--- a/src/lib/Scenes/Consignments/Components/BottomAlignedButton.tsx
+++ b/src/lib/Scenes/Consignments/Components/BottomAlignedButton.tsx
@@ -1,7 +1,8 @@
-import { CARD_STACK_OVERLAY_HEIGHT } from "lib/Components/FancyModal/FancyModalCard"
+import { ICON_HEIGHT } from "lib/Scenes/BottomTabs/BottomTabsIcon"
+import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { Box, Button, Separator, Spacer } from "palette"
 import React from "react"
-import { Dimensions, KeyboardAvoidingView, View } from "react-native"
+import { KeyboardAvoidingView, View } from "react-native"
 
 export interface BottomAlignedProps extends React.Props<JSX.Element> {
   onPress: () => void
@@ -10,13 +11,10 @@ export interface BottomAlignedProps extends React.Props<JSX.Element> {
   verticalOffset?: number
 }
 
-const isPhoneX = Dimensions.get("window").height === 812 && Dimensions.get("window").width === 375
-const defaultVerticalOffset = isPhoneX ? 34 : 20
-
 export const BottomAlignedButton: React.FC<BottomAlignedProps> = ({ buttonText, onPress, children, disabled }) => (
   <KeyboardAvoidingView
     behavior="padding"
-    keyboardVerticalOffset={defaultVerticalOffset + CARD_STACK_OVERLAY_HEIGHT}
+    keyboardVerticalOffset={useScreenDimensions().safeAreaInsets.top + ICON_HEIGHT}
     style={{ flex: 1 }}
   >
     <View key="space-eater" style={{ flexGrow: 1 }}>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [MX-553]

### Description
The Bottom buttons in modals are obscured by the keyboard.

**Before:**
![Group 2](https://user-images.githubusercontent.com/11945712/94465227-de023500-01bf-11eb-874d-7ee6c2e8ab36.png)

___
**After**
<img width="567" alt="Screenshot 2020-09-28 at 19 06 27" src="https://user-images.githubusercontent.com/11945712/94465259-e8bcca00-01bf-11eb-9d36-2e2ef1e14d1d.png">
<img width="570" alt="Screenshot 2020-09-28 at 19 14 46" src="https://user-images.githubusercontent.com/11945712/94465263-ebb7ba80-01bf-11eb-9178-3a4ba891ea1d.png">

___

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


[MX-553]: https://artsyproduct.atlassian.net/browse/MX-553