### PR TITLE
tooling: Adding a new checkbox in the pr template for changelog #trivial

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -12,7 +12,6 @@ upcoming:
     - Add header for Fair2 (visible only to admins) - will
     - Add editorial for Fair2 (visible only to admins) - damon
     - Add collections rail for Fair2 (visible only to admins) - damon
-    - Add More Info view for Fiar2 (visible only to admins) - will
     - Add More Info view for Fair2 (visible only to admins) - will
     - Add Artworks/Exhibitors rails to Fair2 - sweir
   user_facing:

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -19,3 +19,4 @@ This PR resolves [MX-]
 - [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
 - [ ] I have documented any follow-up work that this PR will require, or it does not require any.
 - [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
+- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


### PR DESCRIPTION
The type of this PR is: **DX**

<!-- Bugfix/Feature/Enhancement/Documentation -->

### Description

We added the changelog after the change in https://github.com/artsy/peril-settings/pull/167.


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one. 
