### PR TITLE
feat(My Collection): show edition data in form by default

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -7221,7 +7221,7 @@ input MyCollectionUpdateArtworkInput {
   costMinor: Int
   date: String
   depth: String
-  editionNumber: Int
+  editionNumber: String
   editionSize: String
   height: String
   medium: String

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -7179,7 +7179,7 @@ input MyCollectionCreateArtworkInput {
   costMinor: Int
   date: String
   depth: String
-  editionNumber: Int
+  editionNumber: String
   editionSize: String
   height: String
   medium: String!

--- a/src/__generated__/MyCollectionArtworkDetailQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkDetailQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash f252670895510b43af32d355a4dff47f */
+/* @relayHash 2ce5c8ed136103a28e2b019e94f645ff */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -20,6 +20,8 @@ export type MyCollectionArtworkDetailQueryResponse = {
         readonly costCurrencyCode: string | null;
         readonly date: string | null;
         readonly depth: string | null;
+        readonly editionSize: string | null;
+        readonly editionNumber: string | null;
         readonly height: string | null;
         readonly id: string;
         readonly image: {
@@ -61,6 +63,8 @@ query MyCollectionArtworkDetailQuery(
     costCurrencyCode
     date
     depth
+    editionSize
+    editionNumber
     height
     id
     image {
@@ -180,6 +184,8 @@ fragment MyCollectionArtworkMeta_artwork on Artwork {
   costCurrencyCode
   date
   depth
+  editionSize
+  editionNumber
   height
   id
   image {
@@ -281,18 +287,32 @@ v8 = {
 v9 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "height",
+  "name": "editionSize",
   "args": null,
   "storageKey": null
 },
 v10 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "editionNumber",
+  "args": null,
+  "storageKey": null
+},
+v11 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "height",
+  "args": null,
+  "storageKey": null
+},
+v12 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "id",
   "args": null,
   "storageKey": null
 },
-v11 = [
+v13 = [
   {
     "kind": "ScalarField",
     "alias": null,
@@ -301,7 +321,7 @@ v11 = [
     "storageKey": null
   }
 ],
-v12 = {
+v14 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "image",
@@ -309,44 +329,44 @@ v12 = {
   "args": null,
   "concreteType": "Image",
   "plural": false,
-  "selections": (v11/*: any*/)
+  "selections": (v13/*: any*/)
 },
-v13 = {
+v15 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "medium",
   "args": null,
   "storageKey": null
 },
-v14 = {
+v16 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "metric",
   "args": null,
   "storageKey": null
 },
-v15 = {
+v17 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "slug",
   "args": null,
   "storageKey": null
 },
-v16 = {
+v18 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "title",
   "args": null,
   "storageKey": null
 },
-v17 = {
+v19 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "width",
   "args": null,
   "storageKey": null
 },
-v18 = [
+v20 = [
   {
     "kind": "Variable",
     "name": "artistId",
@@ -358,7 +378,7 @@ v18 = [
     "variableName": "medium"
   }
 ],
-v19 = {
+v21 = {
   "kind": "Literal",
   "name": "first",
   "value": 3
@@ -401,13 +421,15 @@ return {
           (v8/*: any*/),
           (v9/*: any*/),
           (v10/*: any*/),
+          (v11/*: any*/),
           (v12/*: any*/),
-          (v2/*: any*/),
-          (v13/*: any*/),
           (v14/*: any*/),
+          (v2/*: any*/),
           (v15/*: any*/),
           (v16/*: any*/),
           (v17/*: any*/),
+          (v18/*: any*/),
+          (v19/*: any*/),
           {
             "kind": "FragmentSpread",
             "name": "MyCollectionArtworkHeader_artwork",
@@ -430,7 +452,7 @@ return {
         "alias": null,
         "name": "marketPriceInsights",
         "storageKey": null,
-        "args": (v18/*: any*/),
+        "args": (v20/*: any*/),
         "concreteType": "MarketPriceInsights",
         "plural": false,
         "selections": [
@@ -467,15 +489,15 @@ return {
             "plural": false,
             "selections": [
               (v2/*: any*/),
-              (v10/*: any*/),
-              (v15/*: any*/),
+              (v12/*: any*/),
+              (v17/*: any*/),
               {
                 "kind": "LinkedField",
                 "alias": null,
                 "name": "auctionResultsConnection",
                 "storageKey": "auctionResultsConnection(first:3,sort:\"DATE_DESC\")",
                 "args": [
-                  (v19/*: any*/),
+                  (v21/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "sort",
@@ -504,7 +526,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v2/*: any*/),
-                          (v16/*: any*/),
+                          (v18/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -529,7 +551,7 @@ return {
                                 "args": null,
                                 "concreteType": "Image",
                                 "plural": false,
-                                "selections": (v11/*: any*/)
+                                "selections": (v13/*: any*/)
                               }
                             ]
                           },
@@ -579,7 +601,7 @@ return {
                               }
                             ]
                           },
-                          (v10/*: any*/)
+                          (v12/*: any*/)
                         ]
                       }
                     ]
@@ -592,7 +614,7 @@ return {
                 "name": "articlesConnection",
                 "storageKey": "articlesConnection(first:3,inEditorialFeed:true,sort:\"PUBLISHED_AT_DESC\")",
                 "args": [
-                  (v19/*: any*/),
+                  (v21/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "inEditorialFeed",
@@ -625,7 +647,7 @@ return {
                         "concreteType": "Article",
                         "plural": false,
                         "selections": [
-                          (v15/*: any*/),
+                          (v17/*: any*/),
                           (v2/*: any*/),
                           {
                             "kind": "ScalarField",
@@ -657,7 +679,7 @@ return {
                                 "args": null,
                                 "storageKey": null
                               },
-                              (v10/*: any*/)
+                              (v12/*: any*/)
                             ]
                           },
                           {
@@ -681,9 +703,9 @@ return {
                             "args": null,
                             "concreteType": "Image",
                             "plural": false,
-                            "selections": (v11/*: any*/)
+                            "selections": (v13/*: any*/)
                           },
-                          (v10/*: any*/)
+                          (v12/*: any*/)
                         ]
                       }
                     ]
@@ -700,13 +722,15 @@ return {
           (v8/*: any*/),
           (v9/*: any*/),
           (v10/*: any*/),
+          (v11/*: any*/),
           (v12/*: any*/),
-          (v2/*: any*/),
-          (v13/*: any*/),
           (v14/*: any*/),
+          (v2/*: any*/),
           (v15/*: any*/),
           (v16/*: any*/),
-          (v17/*: any*/)
+          (v17/*: any*/),
+          (v18/*: any*/),
+          (v19/*: any*/)
         ]
       },
       {
@@ -714,7 +738,7 @@ return {
         "alias": null,
         "name": "marketPriceInsights",
         "storageKey": null,
-        "args": (v18/*: any*/),
+        "args": (v20/*: any*/),
         "concreteType": "MarketPriceInsights",
         "plural": false,
         "selections": [
@@ -802,7 +826,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "MyCollectionArtworkDetailQuery",
-    "id": "a8025ca8a8a85a69db602d1cdf2efe71",
+    "id": "b91eec4ed0232fbbc793c2e32b66641f",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/MyCollectionArtworkDetail_sharedProps.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkDetail_sharedProps.graphql.ts
@@ -13,6 +13,8 @@ export type MyCollectionArtworkDetail_sharedProps = {
     readonly costCurrencyCode: string | null;
     readonly date: string | null;
     readonly depth: string | null;
+    readonly editionSize: string | null;
+    readonly editionNumber: string | null;
     readonly height: string | null;
     readonly id: string;
     readonly image: {
@@ -106,6 +108,20 @@ return {
     {
       "kind": "ScalarField",
       "alias": null,
+      "name": "editionSize",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "editionNumber",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
       "name": "height",
       "args": null,
       "storageKey": null
@@ -174,5 +190,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '97687953da52ac8984f2ed61a5860642';
+(node as any).hash = 'deb0461bc27776da85cea94bc72dc72f';
 export default node;

--- a/src/__generated__/MyCollectionArtworkListItemTestsQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkListItemTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash ac2b80d4e459526219aa49194cb961a7 */
+/* @relayHash 0989387b8bf20c3b4b93c5febce40686 */
 
 import { ConcreteRequest } from "relay-runtime";
 export type MyCollectionArtworkListItemTestsQueryVariables = {};
@@ -15,6 +15,8 @@ export type MyCollectionArtworkListItemTestsQueryResponse = {
         readonly costCurrencyCode: string | null;
         readonly date: string | null;
         readonly depth: string | null;
+        readonly editionSize: string | null;
+        readonly editionNumber: string | null;
         readonly height: string | null;
         readonly id: string;
         readonly image: {
@@ -48,6 +50,8 @@ query MyCollectionArtworkListItemTestsQuery {
     costCurrencyCode
     date
     depth
+    editionSize
+    editionNumber
     height
     id
     image {
@@ -123,18 +127,32 @@ v7 = {
 v8 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "height",
+  "name": "editionSize",
   "args": null,
   "storageKey": null
 },
 v9 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "editionNumber",
   "args": null,
   "storageKey": null
 },
 v10 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "height",
+  "args": null,
+  "storageKey": null
+},
+v11 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "id",
+  "args": null,
+  "storageKey": null
+},
+v12 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "image",
@@ -152,48 +170,48 @@ v10 = {
     }
   ]
 },
-v11 = {
+v13 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "medium",
   "args": null,
   "storageKey": null
 },
-v12 = {
+v14 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "metric",
   "args": null,
   "storageKey": null
 },
-v13 = {
+v15 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "slug",
   "args": null,
   "storageKey": null
 },
-v14 = {
+v16 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "title",
   "args": null,
   "storageKey": null
 },
-v15 = {
+v17 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "width",
   "args": null,
   "storageKey": null
 },
-v16 = {
+v18 = {
   "type": "ID",
   "enumValues": null,
   "plural": false,
   "nullable": false
 },
-v17 = {
+v19 = {
   "type": "String",
   "enumValues": null,
   "plural": false,
@@ -238,12 +256,14 @@ return {
           (v8/*: any*/),
           (v9/*: any*/),
           (v10/*: any*/),
-          (v1/*: any*/),
           (v11/*: any*/),
           (v12/*: any*/),
+          (v1/*: any*/),
           (v13/*: any*/),
           (v14/*: any*/),
-          (v15/*: any*/)
+          (v15/*: any*/),
+          (v16/*: any*/),
+          (v17/*: any*/)
         ]
       }
     ]
@@ -272,7 +292,7 @@ return {
             "plural": false,
             "selections": [
               (v1/*: any*/),
-              (v9/*: any*/)
+              (v11/*: any*/)
             ]
           },
           (v2/*: any*/),
@@ -284,12 +304,14 @@ return {
           (v8/*: any*/),
           (v9/*: any*/),
           (v10/*: any*/),
-          (v1/*: any*/),
           (v11/*: any*/),
           (v12/*: any*/),
+          (v1/*: any*/),
           (v13/*: any*/),
           (v14/*: any*/),
-          (v15/*: any*/)
+          (v15/*: any*/),
+          (v16/*: any*/),
+          (v17/*: any*/)
         ]
       }
     ]
@@ -297,7 +319,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "MyCollectionArtworkListItemTestsQuery",
-    "id": "89b41bb5433d9334a23873894f1257bd",
+    "id": "d5e3d7a80451b0f2f13b2389f2281bbf",
     "text": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -307,45 +329,47 @@ return {
           "plural": false,
           "nullable": true
         },
-        "artwork.id": (v16/*: any*/),
+        "artwork.id": (v18/*: any*/),
         "artwork.artist": {
           "type": "Artist",
           "enumValues": null,
           "plural": false,
           "nullable": true
         },
-        "artwork.artistNames": (v17/*: any*/),
-        "artwork.category": (v17/*: any*/),
+        "artwork.artistNames": (v19/*: any*/),
+        "artwork.category": (v19/*: any*/),
         "artwork.costMinor": {
           "type": "Int",
           "enumValues": null,
           "plural": false,
           "nullable": true
         },
-        "artwork.costCurrencyCode": (v17/*: any*/),
-        "artwork.date": (v17/*: any*/),
-        "artwork.depth": (v17/*: any*/),
-        "artwork.height": (v17/*: any*/),
+        "artwork.costCurrencyCode": (v19/*: any*/),
+        "artwork.date": (v19/*: any*/),
+        "artwork.depth": (v19/*: any*/),
+        "artwork.editionSize": (v19/*: any*/),
+        "artwork.editionNumber": (v19/*: any*/),
+        "artwork.height": (v19/*: any*/),
         "artwork.image": {
           "type": "Image",
           "enumValues": null,
           "plural": false,
           "nullable": true
         },
-        "artwork.internalID": (v16/*: any*/),
-        "artwork.medium": (v17/*: any*/),
-        "artwork.metric": (v17/*: any*/),
-        "artwork.slug": (v16/*: any*/),
-        "artwork.title": (v17/*: any*/),
-        "artwork.width": (v17/*: any*/),
-        "artwork.artist.internalID": (v16/*: any*/),
+        "artwork.internalID": (v18/*: any*/),
+        "artwork.medium": (v19/*: any*/),
+        "artwork.metric": (v19/*: any*/),
+        "artwork.slug": (v18/*: any*/),
+        "artwork.title": (v19/*: any*/),
+        "artwork.width": (v19/*: any*/),
+        "artwork.artist.internalID": (v18/*: any*/),
         "artwork.artist.id": {
           "type": "ID",
           "enumValues": null,
           "plural": false,
           "nullable": true
         },
-        "artwork.image.url": (v17/*: any*/)
+        "artwork.image.url": (v19/*: any*/)
       }
     }
   }

--- a/src/__generated__/MyCollectionArtworkListItem_artwork.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkListItem_artwork.graphql.ts
@@ -13,6 +13,8 @@ export type MyCollectionArtworkListItem_artwork = {
     readonly costCurrencyCode: string | null;
     readonly date: string | null;
     readonly depth: string | null;
+    readonly editionSize: string | null;
+    readonly editionNumber: string | null;
     readonly height: string | null;
     readonly id: string;
     readonly image: {
@@ -100,6 +102,20 @@ return {
       "kind": "ScalarField",
       "alias": null,
       "name": "depth",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "editionSize",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "editionNumber",
       "args": null,
       "storageKey": null
     },

--- a/src/__generated__/MyCollectionArtworkListPaginationQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkListPaginationQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 81dc3c6a2736210e94f9c5ddbe032f6f */
+/* @relayHash 5132bfaf640936333b13799f5e1950fa */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -42,6 +42,8 @@ fragment MyCollectionArtworkListItem_artwork on Artwork {
   costCurrencyCode
   date
   depth
+  editionSize
+  editionNumber
   height
   id
   image {
@@ -292,6 +294,20 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
+                        "name": "editionSize",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "editionNumber",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
                         "name": "height",
                         "args": null,
                         "storageKey": null
@@ -379,7 +395,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "MyCollectionArtworkListPaginationQuery",
-    "id": "e1069a11d1252a9fb993d8f8cef91d66",
+    "id": "4c14c4daf846aa976b5e94113562df3b",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/MyCollectionArtworkListQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkListQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 712d9f1d75aa2257493ce46d5231e313 */
+/* @relayHash 8842d9125e81f99f97e2f99e13cb390c */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -36,6 +36,8 @@ fragment MyCollectionArtworkListItem_artwork on Artwork {
   costCurrencyCode
   date
   depth
+  editionSize
+  editionNumber
   height
   id
   image {
@@ -256,6 +258,20 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
+                        "name": "editionSize",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "editionNumber",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
                         "name": "height",
                         "args": null,
                         "storageKey": null
@@ -343,7 +359,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "MyCollectionArtworkListQuery",
-    "id": "7ddc2daee72b7af5bd1945f9a331d4d3",
+    "id": "a1f97bad46de1abd85ae6e8c2ae1a377",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/MyCollectionArtworkListTestsQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkListTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 0deb3e71263d8415271782e01999ce3c */
+/* @relayHash 8172752d925ab26efe3e33622c806bec */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -36,6 +36,8 @@ fragment MyCollectionArtworkListItem_artwork on Artwork {
   costCurrencyCode
   date
   depth
+  editionSize
+  editionNumber
   height
   id
   image {
@@ -274,6 +276,20 @@ return {
                       {
                         "kind": "ScalarField",
                         "alias": null,
+                        "name": "editionSize",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "editionNumber",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
                         "name": "height",
                         "args": null,
                         "storageKey": null
@@ -361,7 +377,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "MyCollectionArtworkListTestsQuery",
-    "id": "bb5964492d40862140cf957f860bfa04",
+    "id": "3acb5a54bc244a009c083d151774aa65",
     "text": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -424,6 +440,8 @@ return {
         "me.myCollectionConnection.edges.node.costCurrencyCode": (v4/*: any*/),
         "me.myCollectionConnection.edges.node.date": (v4/*: any*/),
         "me.myCollectionConnection.edges.node.depth": (v4/*: any*/),
+        "me.myCollectionConnection.edges.node.editionSize": (v4/*: any*/),
+        "me.myCollectionConnection.edges.node.editionNumber": (v4/*: any*/),
         "me.myCollectionConnection.edges.node.height": (v4/*: any*/),
         "me.myCollectionConnection.edges.node.image": {
           "type": "Image",

--- a/src/__generated__/MyCollectionArtworkMetaTestsQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkMetaTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 631eff845e23832169bfbc9ead3e84ae */
+/* @relayHash 559543db0f093bf624ee9b3326557017 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -36,6 +36,8 @@ fragment MyCollectionArtworkMeta_artwork on Artwork {
   costCurrencyCode
   date
   depth
+  editionSize
+  editionNumber
   height
   id
   image {
@@ -183,6 +185,20 @@ return {
           {
             "kind": "ScalarField",
             "alias": null,
+            "name": "editionSize",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "editionNumber",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
             "name": "height",
             "args": null,
             "storageKey": null
@@ -249,7 +265,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "MyCollectionArtworkMetaTestsQuery",
-    "id": "aac1d97677369d81e2a075340fde312b",
+    "id": "ae1fd3275b0e12d911ca8dc92f8a9fab",
     "text": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -277,6 +293,8 @@ return {
         "artwork.costCurrencyCode": (v4/*: any*/),
         "artwork.date": (v4/*: any*/),
         "artwork.depth": (v4/*: any*/),
+        "artwork.editionSize": (v4/*: any*/),
+        "artwork.editionNumber": (v4/*: any*/),
         "artwork.height": (v4/*: any*/),
         "artwork.image": {
           "type": "Image",

--- a/src/__generated__/MyCollectionArtworkMeta_artwork.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkMeta_artwork.graphql.ts
@@ -13,6 +13,8 @@ export type MyCollectionArtworkMeta_artwork = {
     readonly costCurrencyCode: string | null;
     readonly date: string | null;
     readonly depth: string | null;
+    readonly editionSize: string | null;
+    readonly editionNumber: string | null;
     readonly height: string | null;
     readonly id: string;
     readonly image: {
@@ -100,6 +102,20 @@ return {
       "kind": "ScalarField",
       "alias": null,
       "name": "depth",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "editionSize",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "editionNumber",
       "args": null,
       "storageKey": null
     },

--- a/src/__generated__/MyCollectionArtworkModelCreateArtworkMutation.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkModelCreateArtworkMutation.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 87110181faf533b605a71e1b0f96dbe0 */
+/* @relayHash fa7f3e5cb2b79a6fe5e01811fe45d43b */
 
 import { ConcreteRequest } from "relay-runtime";
 export type MyCollectionCreateArtworkInput = {
@@ -32,6 +32,8 @@ export type MyCollectionArtworkModelCreateArtworkMutationResponse = {
                     readonly medium: string | null;
                     readonly internalID: string;
                     readonly slug: string;
+                    readonly editionNumber: string | null;
+                    readonly editionSize: string | null;
                 } | null;
             } | null;
             readonly mutationError?: {
@@ -61,6 +63,8 @@ mutation MyCollectionArtworkModelCreateArtworkMutation(
             medium
             internalID
             slug
+            editionNumber
+            editionSize
             id
           }
         }
@@ -120,6 +124,20 @@ v5 = {
   "storageKey": null
 },
 v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "editionNumber",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "editionSize",
+  "args": null,
+  "storageKey": null
+},
+v8 = {
   "kind": "ClientExtension",
   "selections": [
     {
@@ -131,7 +149,7 @@ v6 = {
     }
   ]
 },
-v7 = {
+v9 = {
   "kind": "InlineFragment",
   "type": "MyCollectionArtworkMutationFailure",
   "selections": [
@@ -207,15 +225,17 @@ return {
                           (v2/*: any*/),
                           (v3/*: any*/),
                           (v4/*: any*/),
-                          (v5/*: any*/)
+                          (v5/*: any*/),
+                          (v6/*: any*/),
+                          (v7/*: any*/)
                         ]
                       },
-                      (v6/*: any*/)
+                      (v8/*: any*/)
                     ]
                   }
                 ]
               },
-              (v7/*: any*/)
+              (v9/*: any*/)
             ]
           }
         ]
@@ -278,6 +298,8 @@ return {
                           (v3/*: any*/),
                           (v4/*: any*/),
                           (v5/*: any*/),
+                          (v6/*: any*/),
+                          (v7/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -287,12 +309,12 @@ return {
                           }
                         ]
                       },
-                      (v6/*: any*/)
+                      (v8/*: any*/)
                     ]
                   }
                 ]
               },
-              (v7/*: any*/)
+              (v9/*: any*/)
             ]
           }
         ]
@@ -302,11 +324,11 @@ return {
   "params": {
     "operationKind": "mutation",
     "name": "MyCollectionArtworkModelCreateArtworkMutation",
-    "id": "aa25b79f9c3fd0de4251b7f8136567d9",
+    "id": "5dc3e97a9d6d9f3aa62ed1112330aedc",
     "text": null,
     "metadata": {}
   }
 };
 })();
-(node as any).hash = '48ecd70a5b8dfe2d7227a96895948f89';
+(node as any).hash = '2fd85d12e6759b6310fee89658c2b9d1';
 export default node;

--- a/src/__generated__/MyCollectionArtworkModelCreateArtworkMutation.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkModelCreateArtworkMutation.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash fa7f3e5cb2b79a6fe5e01811fe45d43b */
+/* @relayHash 55d94b960bf6042d4cf8df0e06a60184 */
 
 import { ConcreteRequest } from "relay-runtime";
 export type MyCollectionCreateArtworkInput = {
@@ -11,7 +11,7 @@ export type MyCollectionCreateArtworkInput = {
     costMinor?: number | null;
     date?: string | null;
     depth?: string | null;
-    editionNumber?: number | null;
+    editionNumber?: string | null;
     editionSize?: string | null;
     height?: string | null;
     medium: string;

--- a/src/__generated__/MyCollectionArtworkModelUpdateArtworkMutation.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkModelUpdateArtworkMutation.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash b81a0c8fb7aa418acf2f3a3dc3b269df */
+/* @relayHash e86485b40afeced73875b989210a540f */
 
 import { ConcreteRequest } from "relay-runtime";
 export type MyCollectionUpdateArtworkInput = {
@@ -12,7 +12,7 @@ export type MyCollectionUpdateArtworkInput = {
     costMinor?: number | null;
     date?: string | null;
     depth?: string | null;
-    editionNumber?: number | null;
+    editionNumber?: string | null;
     editionSize?: string | null;
     height?: string | null;
     medium?: string | null;
@@ -30,6 +30,8 @@ export type MyCollectionArtworkModelUpdateArtworkMutationResponse = {
                 readonly medium: string | null;
                 readonly id: string;
                 readonly internalID: string;
+                readonly editionNumber: string | null;
+                readonly editionSize: string | null;
             } | null;
         } | null;
     } | null;
@@ -53,6 +55,8 @@ mutation MyCollectionArtworkModelUpdateArtworkMutation(
           medium
           id
           internalID
+          editionNumber
+          editionSize
         }
       }
     }
@@ -107,6 +111,20 @@ v2 = {
           "kind": "ScalarField",
           "alias": null,
           "name": "internalID",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "editionNumber",
+          "args": null,
+          "storageKey": null
+        },
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "editionSize",
           "args": null,
           "storageKey": null
         }
@@ -188,11 +206,11 @@ return {
   "params": {
     "operationKind": "mutation",
     "name": "MyCollectionArtworkModelUpdateArtworkMutation",
-    "id": "863d4d31b6cbe0096b63432387b2e069",
+    "id": "61dae8fb35398a15d74734dc9af54e6c",
     "text": null,
     "metadata": {}
   }
 };
 })();
-(node as any).hash = 'e469f0ec5892608703eddd6467a77489';
+(node as any).hash = 'c1a9a05edb35f618d01d3383aac261d4';
 export default node;

--- a/src/lib/Scenes/MyCollection/Screens/AddArtwork/Screens/AdditionalDetails.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/AddArtwork/Screens/AdditionalDetails.tsx
@@ -6,13 +6,19 @@ import { ScreenMargin } from "lib/Scenes/MyCollection/Components/ScreenMargin"
 import { useArtworkForm } from "lib/Scenes/MyCollection/Screens/AddArtwork/Form/useArtworkForm"
 import { AppStore } from "lib/store/AppStore"
 import { Box, Flex, Join, Sans, space, Spacer } from "palette"
-import React, { useRef, useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 
 export const AdditionalDetails = () => {
-  const [isEdition, setIsEdition] = useState(false) // TODO: pass in edition props from db to compute initial state
+  const { formik } = useArtworkForm()
+  const [isEdition, setIsEdition] = useState(false)
   const pricePaidCurrencyInputRef = useRef<Select<string>>(null)
   const navActions = AppStore.actions.myCollection.navigation
-  const { formik } = useArtworkForm()
+  const formValue = formik?.values
+  const validatedEdition: boolean = !!formValue?.editionNumber!
+
+  useEffect(() => {
+    setIsEdition(validatedEdition)
+  }, [])
 
   return (
     <Box>
@@ -25,21 +31,22 @@ export const AdditionalDetails = () => {
               placeholder="Title"
               onChangeText={formik.handleChange("title")}
               onBlur={formik.handleBlur("title")}
-              defaultValue={formik.values.title}
               data-test-id="TitleInput"
+              defaultValue={formValue.title}
             />
             <Input
               title="Date"
               placeholder="Date"
               onChangeText={formik.handleChange("date")}
               onBlur={formik.handleBlur("date")}
-              defaultValue={formik.values.date}
               data-test-id="DateInput"
+              defaultValue={formValue.date}
             />
 
             <Checkbox
               onPress={() => setIsEdition(!isEdition)}
               data-test-id="EditionCheckbox"
+              checked={validatedEdition}
               // disabled={isLoading}
             >
               <Sans size="3" color="black60">
@@ -53,7 +60,7 @@ export const AdditionalDetails = () => {
                   placeholder="Edition number"
                   onChangeText={formik.handleChange("editionNumber")}
                   onBlur={formik.handleBlur("editionNumber")}
-                  defaultValue={String(formik.values.editionNumber)}
+                  defaultValue={formValue.editionNumber!}
                   style={{ marginRight: space(1) }}
                   data-test-id="EditionNumberInput"
                 />
@@ -61,8 +68,8 @@ export const AdditionalDetails = () => {
                   placeholder="Edition size"
                   onChangeText={formik.handleChange("editionSize")}
                   onBlur={formik.handleBlur("editionSize")}
-                  defaultValue={formik.values.editionSize}
                   data-test-id="EditionSizeInput"
+                  defaultValue={formValue.editionSize}
                 />
               </Flex>
             )}
@@ -72,8 +79,8 @@ export const AdditionalDetails = () => {
               placeholder="Materials"
               onChangeText={formik.handleChange("category")}
               onBlur={formik.handleBlur("category")}
-              defaultValue={formik.values.category}
               data-test-id="MaterialsInput"
+              defaultValue={formValue.category}
             />
 
             <Input
@@ -81,15 +88,15 @@ export const AdditionalDetails = () => {
               placeholder="Price paid"
               onChangeText={formik.handleChange("costMinor")}
               onBlur={formik.handleBlur("costMinor")}
-              defaultValue={String(formik.values.costMinor)}
               data-test-id="PricePaidInput"
+              defaultValue={String(formValue.costMinor)}
             />
 
             <Select
               title="Currency"
               placeholder="Currency"
               options={pricePaidCurrencySelectOptions}
-              value={formik.values.costCurrencyCode}
+              value={formValue.costCurrencyCode}
               enableSearch={false}
               showTitleLabel={false}
               ref={pricePaidCurrencyInputRef}

--- a/src/lib/Scenes/MyCollection/Screens/AddArtwork/Screens/AdditionalDetails.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/AddArtwork/Screens/AdditionalDetails.tsx
@@ -6,19 +6,15 @@ import { ScreenMargin } from "lib/Scenes/MyCollection/Components/ScreenMargin"
 import { useArtworkForm } from "lib/Scenes/MyCollection/Screens/AddArtwork/Form/useArtworkForm"
 import { AppStore } from "lib/store/AppStore"
 import { Box, Flex, Join, Sans, space, Spacer } from "palette"
-import React, { useEffect, useRef, useState } from "react"
+import React, { useRef, useState } from "react"
 
 export const AdditionalDetails = () => {
   const { formik } = useArtworkForm()
-  const [isEdition, setIsEdition] = useState(false)
+  const formikValues = formik?.values
+  const hasEditionNumber: boolean = !!formikValues?.editionNumber!
+  const [isEdition, setIsEdition] = useState(hasEditionNumber)
   const pricePaidCurrencyInputRef = useRef<Select<string>>(null)
   const navActions = AppStore.actions.myCollection.navigation
-  const formValue = formik?.values
-  const validatedEdition: boolean = !!formValue?.editionNumber!
-
-  useEffect(() => {
-    setIsEdition(validatedEdition)
-  }, [])
 
   return (
     <Box>
@@ -32,7 +28,7 @@ export const AdditionalDetails = () => {
               onChangeText={formik.handleChange("title")}
               onBlur={formik.handleBlur("title")}
               data-test-id="TitleInput"
-              defaultValue={formValue.title}
+              defaultValue={formikValues.title}
             />
             <Input
               title="Date"
@@ -40,13 +36,13 @@ export const AdditionalDetails = () => {
               onChangeText={formik.handleChange("date")}
               onBlur={formik.handleBlur("date")}
               data-test-id="DateInput"
-              defaultValue={formValue.date}
+              defaultValue={formikValues.date}
             />
 
             <Checkbox
               onPress={() => setIsEdition(!isEdition)}
               data-test-id="EditionCheckbox"
-              checked={validatedEdition}
+              checked={hasEditionNumber}
               // disabled={isLoading}
             >
               <Sans size="3" color="black60">
@@ -60,7 +56,7 @@ export const AdditionalDetails = () => {
                   placeholder="Edition number"
                   onChangeText={formik.handleChange("editionNumber")}
                   onBlur={formik.handleBlur("editionNumber")}
-                  defaultValue={formValue.editionNumber!}
+                  defaultValue={formikValues.editionNumber!}
                   style={{ marginRight: space(1) }}
                   data-test-id="EditionNumberInput"
                 />
@@ -69,7 +65,7 @@ export const AdditionalDetails = () => {
                   onChangeText={formik.handleChange("editionSize")}
                   onBlur={formik.handleBlur("editionSize")}
                   data-test-id="EditionSizeInput"
-                  defaultValue={formValue.editionSize}
+                  defaultValue={formikValues.editionSize}
                 />
               </Flex>
             )}
@@ -80,7 +76,7 @@ export const AdditionalDetails = () => {
               onChangeText={formik.handleChange("category")}
               onBlur={formik.handleBlur("category")}
               data-test-id="MaterialsInput"
-              defaultValue={formValue.category}
+              defaultValue={formikValues.category}
             />
 
             <Input
@@ -89,14 +85,14 @@ export const AdditionalDetails = () => {
               onChangeText={formik.handleChange("costMinor")}
               onBlur={formik.handleBlur("costMinor")}
               data-test-id="PricePaidInput"
-              defaultValue={String(formValue.costMinor)}
+              defaultValue={String(formikValues.costMinor)}
             />
 
             <Select
               title="Currency"
               placeholder="Currency"
               options={pricePaidCurrencySelectOptions}
-              value={formValue.costCurrencyCode}
+              value={formikValues.costCurrencyCode}
               enableSearch={false}
               showTitleLabel={false}
               ref={pricePaidCurrencyInputRef}

--- a/src/lib/Scenes/MyCollection/Screens/AddArtwork/Screens/__tests__/AdditionalDetails-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/AddArtwork/Screens/__tests__/AdditionalDetails-tests.tsx
@@ -1,4 +1,5 @@
 import { useFormikContext } from "formik"
+import { Checkbox } from "lib/Components/Bidding/Components/Checkbox"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { AdditionalDetails } from "../AdditionalDetails"
@@ -6,9 +7,9 @@ import { AdditionalDetails } from "../AdditionalDetails"
 jest.mock("formik")
 
 describe("AdditionalDetails", () => {
-  beforeEach(() => {
-    const useFormikContextMock = useFormikContext as jest.Mock
+  const useFormikContextMock = useFormikContext as jest.Mock
 
+  beforeEach(() => {
     useFormikContextMock.mockImplementation(() => ({
       handleBlur: jest.fn(),
       handleChange: jest.fn(),
@@ -16,6 +17,23 @@ describe("AdditionalDetails", () => {
         medium: "Painting",
       },
     }))
+  })
+
+  it("renders edition form data by default if present", () => {
+    useFormikContextMock.mockImplementation(() => ({
+      handleBlur: jest.fn(),
+      handleChange: jest.fn(),
+      values: {
+        editionSize: "10x30x10",
+        editionNumber: "1",
+      },
+    }))
+
+    const wrapper = renderWithWrappers(<AdditionalDetails />)
+
+    expect(wrapper.root.findByType(Checkbox).props.checked).toBe(true)
+    expect(wrapper.root.findByProps({ "data-test-id": "EditionSizeInput" }).props.defaultValue).toBe("10x30x10")
+    expect(wrapper.root.findByProps({ "data-test-id": "EditionNumberInput" }).props.defaultValue).toBe("1")
   })
 
   it("renders correct fields", () => {

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/MyCollectionArtworkMeta.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/MyCollectionArtworkMeta.tsx
@@ -22,6 +22,8 @@ export const MyCollectionArtworkMeta: React.FC<MyCollectionArtworkMetaProps> = (
     costCurrencyCode,
     date,
     depth,
+    editionNumber,
+    editionSize,
     height,
     medium,
     metric,
@@ -45,7 +47,8 @@ export const MyCollectionArtworkMeta: React.FC<MyCollectionArtworkMetaProps> = (
         <Field label="Category" value={capitalize(medium as string)} />
         <Field label="Materials" value={capitalize(category as string)} />
         <Field label="Dimensions" value={dimensions} />
-        <Field label="Edition" value="TODO" />
+        <Field label="Edition number" value={editionNumber} />
+        <Field label="Edition size" value={editionSize} />
         <Field label="Price paid" value={`${costMinor} ${costCurrencyCode}`} />
       </ScreenMargin>
     )
@@ -54,7 +57,8 @@ export const MyCollectionArtworkMeta: React.FC<MyCollectionArtworkMetaProps> = (
       <ScreenMargin>
         <Field label="Category" value={capitalize(medium as string)} />
         <Field label="Dimensions" value={dimensions} />
-        <Field label="Edition" value="TODO" />
+        <Field label="Edition number" value={editionNumber} />
+        <Field label="Edition size" value={editionSize} />
         <Field label="Price paid" value={`${costMinor} ${costCurrencyCode}`} />
 
         <Spacer my={0.5} />

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/__tests__/MyCollectionArtworkMeta-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/__tests__/MyCollectionArtworkMeta-tests.tsx
@@ -45,6 +45,8 @@ describe("MyCollectionArtworkMeta", () => {
     costMinor: 200,
     costCurrencyCode: "USD",
     date: "Jan 20th",
+    editionSize: "10x10x10",
+    editionNumber: "1",
     height: 20,
     width: 30,
     depth: 40,
@@ -78,13 +80,15 @@ describe("MyCollectionArtworkMeta", () => {
         expect(text).toContain("Oil")
         expect(text).toContain("Dimension")
         expect(text).toContain("20 × 30 × 40 in")
-        expect(text).toContain("Edition")
-        expect(text).toContain("TODO")
+        expect(text).toContain("Edition size")
+        expect(text).toContain("10x10x10")
+        expect(text).toContain("Edition number")
+        expect(text).toContain("1")
         expect(text).toContain("Price paid")
         expect(text).toContain("200 USD")
       })
 
-      it("fires the naviggateToViewAllArtworkDetails action on button click", () => {
+      it("fires the navigateToViewAllArtworkDetails action on button click", () => {
         const spy = jest.fn()
         AppStore.actions.myCollection.navigation.navigateToViewAllArtworkDetails = spy as any
         const wrapper = renderWithWrappers(<TestRenderer viewAll={false} />)
@@ -116,8 +120,10 @@ describe("MyCollectionArtworkMeta", () => {
         expect(text).toContain("Painting")
         expect(text).toContain("Dimension")
         expect(text).toContain("20 × 30 × 40 in")
-        expect(text).toContain("Edition")
-        expect(text).toContain("TODO")
+        expect(text).toContain("Edition size")
+        expect(text).toContain("10x10x10")
+        expect(text).toContain("Edition number")
+        expect(text).toContain("1")
         expect(text).toContain("Price paid")
         expect(text).toContain("200 USD")
       })

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/MyCollectionArtworkDetail.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/MyCollectionArtworkDetail.tsx
@@ -89,6 +89,8 @@ export const ArtworkMetaProps = graphql`
     costCurrencyCode
     date
     depth
+    editionSize
+    editionNumber
     height
     id
     image {

--- a/src/lib/Scenes/MyCollection/State/MyCollectionArtworkModel.tsx
+++ b/src/lib/Scenes/MyCollection/State/MyCollectionArtworkModel.tsx
@@ -25,7 +25,7 @@ export interface ArtworkFormValues {
   date: string
   depth: string
   editionSize: string
-  editionNumber: string | null
+  editionNumber: string
   height: string
   medium: string
   metric: Metric
@@ -44,7 +44,7 @@ const initialFormValues: ArtworkFormValues = {
   date: "",
   depth: "",
   editionSize: "",
-  editionNumber: null,
+  editionNumber: "",
   height: "",
   medium: "",
   metric: "",

--- a/src/lib/Scenes/MyCollection/State/MyCollectionArtworkModel.tsx
+++ b/src/lib/Scenes/MyCollection/State/MyCollectionArtworkModel.tsx
@@ -25,7 +25,7 @@ export interface ArtworkFormValues {
   date: string
   depth: string
   editionSize: string
-  editionNumber: number | null
+  editionNumber: string | null
   height: string
   medium: string
   metric: Metric
@@ -158,6 +158,8 @@ export const MyCollectionArtworkModel: MyCollectionArtworkModel = {
                       medium
                       internalID
                       slug
+                      editionNumber
+                      editionSize
                     }
                   }
                 }
@@ -244,8 +246,8 @@ export const MyCollectionArtworkModel: MyCollectionArtworkModel = {
       depth: artwork.depth,
       costMinor: artwork.costMinor,
       costCurrencyCode: artwork.costCurrencyCode,
-      // editionSize: artwork.editionSize,
-      // editionNumber: artwork.editionSize,
+      editionSize: artwork.editionSize,
+      editionNumber: artwork.editionNumber,
       height: artwork.height,
       medium: artwork.medium,
       metric: artwork.metric,
@@ -253,6 +255,7 @@ export const MyCollectionArtworkModel: MyCollectionArtworkModel = {
       title: artwork.title,
       width: artwork.width,
     }
+
     actions.setFormValues(editProps)
   }),
 
@@ -271,6 +274,8 @@ export const MyCollectionArtworkModel: MyCollectionArtworkModel = {
                     medium
                     id
                     internalID
+                    editionNumber
+                    editionSize
                   }
                 }
 

--- a/src/lib/Scenes/MyCollection/State/MyCollectionNavigationModel.tsx
+++ b/src/lib/Scenes/MyCollection/State/MyCollectionNavigationModel.tsx
@@ -57,7 +57,11 @@ export interface MyCollectionNavigationModel {
   navigateToAllArticles: Action<MyCollectionNavigationModel, string>
   navigateToArtworkDetail: Action<
     MyCollectionNavigationModel,
-    { artistInternalID: string; artworkSlug: string; medium: string | null }
+    {
+      artistInternalID: string
+      artworkSlug: string
+      medium: string | null
+    }
   >
   navigateToViewAllArtworkDetails: Action<MyCollectionNavigationModel, { passProps: any }> // FIXME: any
 


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CSGN-379]

### Description

When an artwork in My Collection has edition data, we should show it by default in the form.

Artwork with edition data:
![editioned](https://user-images.githubusercontent.com/10385964/94625295-6b0fc180-0286-11eb-8c27-394d86ffb37b.gif)

Artwork without edition data:
![non-editioned](https://user-images.githubusercontent.com/10385964/94625303-706d0c00-0286-11eb-917f-5f726e43b8fc.gif)

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))


#trivial 

[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434

[CSGN-379]: https://artsyproduct.atlassian.net/browse/CSGN-379