### PR TITLE
FX-2216: Allows filtering on new fair page by defaults + Artists I Follow

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -14,6 +14,7 @@ upcoming:
     - Add collections rail for Fair2 (visible only to admins) - damon
     - Add More Info view for Fair2 (visible only to admins) - will
     - Add Artworks/Exhibitors rails to Fair2 - sweir
+    - Adds ability to filter Fair2 page by artists I follow - sweir
   user_facing:
     - Fix navigation bug on Artwork consign button - david
     - Add auction lots rail to the auctions screen - mounir

--- a/src/__generated__/Fair2ArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/Fair2ArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 035630ed3da36e316048838bcae01ce5 */
+/* @relayHash 2d86dae683f4b5dc4ada3d11d510ee77 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -9,6 +9,16 @@ export type Fair2ArtworksInfiniteScrollGridQueryVariables = {
     count: number;
     cursor?: string | null;
     sort?: string | null;
+    medium?: string | null;
+    priceRange?: string | null;
+    color?: string | null;
+    partnerID?: string | null;
+    dimensionRange?: string | null;
+    majorPeriods?: Array<string | null> | null;
+    acquireable?: boolean | null;
+    inquireableOnly?: boolean | null;
+    atAuction?: boolean | null;
+    offerable?: boolean | null;
 };
 export type Fair2ArtworksInfiniteScrollGridQueryResponse = {
     readonly fair: {
@@ -27,9 +37,19 @@ query Fair2ArtworksInfiniteScrollGridQuery(
   $id: String!
   $cursor: String
   $sort: String
+  $medium: String
+  $priceRange: String
+  $color: String
+  $partnerID: ID
+  $dimensionRange: String
+  $majorPeriods: [String]
+  $acquireable: Boolean
+  $inquireableOnly: Boolean
+  $atAuction: Boolean
+  $offerable: Boolean
 ) {
   fair(id: $id) {
-    ...Fair2Artworks_fair_1RfMLO
+    ...Fair2Artworks_fair_3m6HS0
     id
   }
 }
@@ -69,10 +89,18 @@ fragment ArtworkGridItem_artwork on Artwork {
   }
 }
 
-fragment Fair2Artworks_fair_1RfMLO on Fair {
+fragment Fair2Artworks_fair_3m6HS0 on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 20, sort: $sort, after: $cursor) {
+  fairArtworks: filterArtworksConnection(first: 20, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
     edges {
       node {
         id
@@ -140,6 +168,66 @@ var v0 = [
     "name": "sort",
     "type": "String",
     "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "medium",
+    "type": "String",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "priceRange",
+    "type": "String",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "color",
+    "type": "String",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "partnerID",
+    "type": "ID",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "dimensionRange",
+    "type": "String",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "majorPeriods",
+    "type": "[String]",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "acquireable",
+    "type": "Boolean",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "inquireableOnly",
+    "type": "Boolean",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "atAuction",
+    "type": "Boolean",
+    "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "offerable",
+    "type": "Boolean",
+    "defaultValue": null
   }
 ],
 v1 = [
@@ -151,24 +239,75 @@ v1 = [
 ],
 v2 = {
   "kind": "Variable",
+  "name": "acquireable",
+  "variableName": "acquireable"
+},
+v3 = {
+  "kind": "Variable",
+  "name": "atAuction",
+  "variableName": "atAuction"
+},
+v4 = {
+  "kind": "Variable",
+  "name": "color",
+  "variableName": "color"
+},
+v5 = {
+  "kind": "Variable",
+  "name": "dimensionRange",
+  "variableName": "dimensionRange"
+},
+v6 = {
+  "kind": "Variable",
+  "name": "inquireableOnly",
+  "variableName": "inquireableOnly"
+},
+v7 = {
+  "kind": "Variable",
+  "name": "majorPeriods",
+  "variableName": "majorPeriods"
+},
+v8 = {
+  "kind": "Variable",
+  "name": "medium",
+  "variableName": "medium"
+},
+v9 = {
+  "kind": "Variable",
+  "name": "offerable",
+  "variableName": "offerable"
+},
+v10 = {
+  "kind": "Variable",
+  "name": "partnerID",
+  "variableName": "partnerID"
+},
+v11 = {
+  "kind": "Variable",
+  "name": "priceRange",
+  "variableName": "priceRange"
+},
+v12 = {
+  "kind": "Variable",
   "name": "sort",
   "variableName": "sort"
 },
-v3 = {
+v13 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "slug",
   "args": null,
   "storageKey": null
 },
-v4 = {
+v14 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "internalID",
   "args": null,
   "storageKey": null
 },
-v5 = [
+v15 = [
+  (v2/*: any*/),
   {
     "kind": "Variable",
     "name": "after",
@@ -176,12 +315,41 @@ v5 = [
   },
   {
     "kind": "Literal",
+    "name": "aggregations",
+    "value": [
+      "COLOR",
+      "DIMENSION_RANGE",
+      "GALLERY",
+      "INSTITUTION",
+      "MAJOR_PERIOD",
+      "MEDIUM",
+      "PRICE_RANGE"
+    ]
+  },
+  (v3/*: any*/),
+  (v4/*: any*/),
+  (v5/*: any*/),
+  {
+    "kind": "Literal",
     "name": "first",
     "value": 20
   },
-  (v2/*: any*/)
+  (v6/*: any*/),
+  (v7/*: any*/),
+  (v8/*: any*/),
+  (v9/*: any*/),
+  (v10/*: any*/),
+  (v11/*: any*/),
+  (v12/*: any*/)
 ],
-v6 = {
+v16 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v17 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
@@ -210,6 +378,9 @@ return {
             "kind": "FragmentSpread",
             "name": "Fair2Artworks_fair",
             "args": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
               {
                 "kind": "Variable",
                 "name": "count",
@@ -220,7 +391,14 @@ return {
                 "name": "cursor",
                 "variableName": "cursor"
               },
-              (v2/*: any*/)
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              (v9/*: any*/),
+              (v10/*: any*/),
+              (v11/*: any*/),
+              (v12/*: any*/)
             ]
           }
         ]
@@ -241,17 +419,61 @@ return {
         "concreteType": "Fair",
         "plural": false,
         "selections": [
-          (v3/*: any*/),
-          (v4/*: any*/),
+          (v13/*: any*/),
+          (v14/*: any*/),
           {
             "kind": "LinkedField",
             "alias": "fairArtworks",
             "name": "filterArtworksConnection",
             "storageKey": null,
-            "args": (v5/*: any*/),
+            "args": (v15/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "aggregations",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtworksAggregationResults",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "slice",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "counts",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "AggregationCount",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "count",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      (v16/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "value",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ]
+              },
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -270,8 +492,8 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
-                      (v3/*: any*/),
+                      (v17/*: any*/),
+                      (v13/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -324,7 +546,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v4/*: any*/),
+                      (v14/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -376,7 +598,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v6/*: any*/)
+                          (v17/*: any*/)
                         ]
                       },
                       {
@@ -431,7 +653,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v6/*: any*/)
+                          (v17/*: any*/)
                         ]
                       },
                       {
@@ -443,14 +665,8 @@ return {
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "name",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          (v6/*: any*/)
+                          (v16/*: any*/),
+                          (v17/*: any*/)
                         ]
                       },
                       {
@@ -469,7 +685,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  (v6/*: any*/)
+                  (v17/*: any*/)
                 ]
               },
               {
@@ -522,21 +738,32 @@ return {
                   }
                 ]
               },
-              (v6/*: any*/)
+              (v17/*: any*/)
             ]
           },
           {
             "kind": "LinkedHandle",
             "alias": "fairArtworks",
             "name": "filterArtworksConnection",
-            "args": (v5/*: any*/),
+            "args": (v15/*: any*/),
             "handle": "connection",
             "key": "Fair_fairArtworks",
             "filters": [
-              "sort"
+              "sort",
+              "medium",
+              "priceRange",
+              "color",
+              "partnerID",
+              "dimensionRange",
+              "majorPeriods",
+              "acquireable",
+              "inquireableOnly",
+              "atAuction",
+              "offerable",
+              "aggregations"
             ]
           },
-          (v6/*: any*/)
+          (v17/*: any*/)
         ]
       }
     ]
@@ -544,11 +771,11 @@ return {
   "params": {
     "operationKind": "query",
     "name": "Fair2ArtworksInfiniteScrollGridQuery",
-    "id": "0595860e5a896cfa58cf8d13da741928",
+    "id": "040feb62a5b71eea83527574f4ac1214",
     "text": null,
     "metadata": {}
   }
 };
 })();
-(node as any).hash = 'dbda278577964d7bf3dd6eb2f8807367';
+(node as any).hash = 'b420066c7f027022a70a6010df418107';
 export default node;

--- a/src/__generated__/Fair2ArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/Fair2ArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 2d86dae683f4b5dc4ada3d11d510ee77 */
+/* @relayHash ba01eb311a2c680d98a464425fcbc6f8 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -19,6 +19,7 @@ export type Fair2ArtworksInfiniteScrollGridQueryVariables = {
     inquireableOnly?: boolean | null;
     atAuction?: boolean | null;
     offerable?: boolean | null;
+    includeArtworksByFollowedArtists?: boolean | null;
 };
 export type Fair2ArtworksInfiniteScrollGridQueryResponse = {
     readonly fair: {
@@ -47,9 +48,10 @@ query Fair2ArtworksInfiniteScrollGridQuery(
   $inquireableOnly: Boolean
   $atAuction: Boolean
   $offerable: Boolean
+  $includeArtworksByFollowedArtists: Boolean
 ) {
   fair(id: $id) {
-    ...Fair2Artworks_fair_3m6HS0
+    ...Fair2Artworks_fair_2dIbwR
     id
   }
 }
@@ -89,10 +91,10 @@ fragment ArtworkGridItem_artwork on Artwork {
   }
 }
 
-fragment Fair2Artworks_fair_3m6HS0 on Fair {
+fragment Fair2Artworks_fair_2dIbwR on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 20, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  fairArtworks: filterArtworksConnection(first: 20, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, includeArtworksByFollowedArtists: $includeArtworksByFollowedArtists, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS]) {
     aggregations {
       slice
       counts {
@@ -110,6 +112,7 @@ fragment Fair2Artworks_fair_3m6HS0 on Fair {
     }
     counts {
       total
+      followedArtists
     }
     ...InfiniteScrollArtworksGrid_connection
     pageInfo {
@@ -228,6 +231,12 @@ var v0 = [
     "name": "offerable",
     "type": "Boolean",
     "defaultValue": null
+  },
+  {
+    "kind": "LocalArgument",
+    "name": "includeArtworksByFollowedArtists",
+    "type": "Boolean",
+    "defaultValue": null
   }
 ],
 v1 = [
@@ -259,54 +268,59 @@ v5 = {
 },
 v6 = {
   "kind": "Variable",
+  "name": "includeArtworksByFollowedArtists",
+  "variableName": "includeArtworksByFollowedArtists"
+},
+v7 = {
+  "kind": "Variable",
   "name": "inquireableOnly",
   "variableName": "inquireableOnly"
 },
-v7 = {
+v8 = {
   "kind": "Variable",
   "name": "majorPeriods",
   "variableName": "majorPeriods"
 },
-v8 = {
+v9 = {
   "kind": "Variable",
   "name": "medium",
   "variableName": "medium"
 },
-v9 = {
+v10 = {
   "kind": "Variable",
   "name": "offerable",
   "variableName": "offerable"
 },
-v10 = {
+v11 = {
   "kind": "Variable",
   "name": "partnerID",
   "variableName": "partnerID"
 },
-v11 = {
+v12 = {
   "kind": "Variable",
   "name": "priceRange",
   "variableName": "priceRange"
 },
-v12 = {
+v13 = {
   "kind": "Variable",
   "name": "sort",
   "variableName": "sort"
 },
-v13 = {
+v14 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "slug",
   "args": null,
   "storageKey": null
 },
-v14 = {
+v15 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "internalID",
   "args": null,
   "storageKey": null
 },
-v15 = [
+v16 = [
   (v2/*: any*/),
   {
     "kind": "Variable",
@@ -323,7 +337,8 @@ v15 = [
       "INSTITUTION",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "FOLLOWED_ARTISTS"
     ]
   },
   (v3/*: any*/),
@@ -340,16 +355,17 @@ v15 = [
   (v9/*: any*/),
   (v10/*: any*/),
   (v11/*: any*/),
-  (v12/*: any*/)
+  (v12/*: any*/),
+  (v13/*: any*/)
 ],
-v16 = {
+v17 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v17 = {
+v18 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
@@ -398,7 +414,8 @@ return {
               (v9/*: any*/),
               (v10/*: any*/),
               (v11/*: any*/),
-              (v12/*: any*/)
+              (v12/*: any*/),
+              (v13/*: any*/)
             ]
           }
         ]
@@ -419,14 +436,14 @@ return {
         "concreteType": "Fair",
         "plural": false,
         "selections": [
-          (v13/*: any*/),
           (v14/*: any*/),
+          (v15/*: any*/),
           {
             "kind": "LinkedField",
             "alias": "fairArtworks",
             "name": "filterArtworksConnection",
             "storageKey": null,
-            "args": (v15/*: any*/),
+            "args": (v16/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
@@ -462,7 +479,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v16/*: any*/),
+                      (v17/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -492,8 +509,8 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v17/*: any*/),
-                      (v13/*: any*/),
+                      (v18/*: any*/),
+                      (v14/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -546,7 +563,7 @@ return {
                         "args": null,
                         "storageKey": null
                       },
-                      (v14/*: any*/),
+                      (v15/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -598,7 +615,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v17/*: any*/)
+                          (v18/*: any*/)
                         ]
                       },
                       {
@@ -653,7 +670,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v17/*: any*/)
+                          (v18/*: any*/)
                         ]
                       },
                       {
@@ -665,8 +682,8 @@ return {
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          (v16/*: any*/),
-                          (v17/*: any*/)
+                          (v17/*: any*/),
+                          (v18/*: any*/)
                         ]
                       },
                       {
@@ -685,7 +702,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  (v17/*: any*/)
+                  (v18/*: any*/)
                 ]
               },
               {
@@ -701,6 +718,13 @@ return {
                     "kind": "ScalarField",
                     "alias": null,
                     "name": "total",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "followedArtists",
                     "args": null,
                     "storageKey": null
                   }
@@ -738,14 +762,14 @@ return {
                   }
                 ]
               },
-              (v17/*: any*/)
+              (v18/*: any*/)
             ]
           },
           {
             "kind": "LinkedHandle",
             "alias": "fairArtworks",
             "name": "filterArtworksConnection",
-            "args": (v15/*: any*/),
+            "args": (v16/*: any*/),
             "handle": "connection",
             "key": "Fair_fairArtworks",
             "filters": [
@@ -760,10 +784,11 @@ return {
               "inquireableOnly",
               "atAuction",
               "offerable",
+              "includeArtworksByFollowedArtists",
               "aggregations"
             ]
           },
-          (v17/*: any*/)
+          (v18/*: any*/)
         ]
       }
     ]
@@ -771,11 +796,11 @@ return {
   "params": {
     "operationKind": "query",
     "name": "Fair2ArtworksInfiniteScrollGridQuery",
-    "id": "040feb62a5b71eea83527574f4ac1214",
+    "id": "fcdea0be7e98f849780d8e4cba8e8d4a",
     "text": null,
     "metadata": {}
   }
 };
 })();
-(node as any).hash = 'b420066c7f027022a70a6010df418107';
+(node as any).hash = '8ed13d227f3756132d2ba11ebc6a208a';
 export default node;

--- a/src/__generated__/Fair2ArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/Fair2ArtworksTestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash face18160a7bfd5ab276bc892c68aa60 */
+/* @relayHash f67657e16126495e33710170a1ccc04d */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -68,6 +68,7 @@ export type Fair2ArtworksTestsQueryRawResponse = {
             }) | null> | null;
             readonly counts: ({
                 readonly total: number | null;
+                readonly followedArtists: number | null;
             }) | null;
             readonly pageInfo: {
                 readonly hasNextPage: boolean;
@@ -135,7 +136,7 @@ fragment ArtworkGridItem_artwork on Artwork {
 fragment Fair2Artworks_fair on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  fairArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS]) {
     aggregations {
       slice
       counts {
@@ -153,6 +154,7 @@ fragment Fair2Artworks_fair on Fair {
     }
     counts {
       total
+      followedArtists
     }
     ...InfiniteScrollArtworksGrid_connection
     pageInfo {
@@ -227,7 +229,8 @@ v4 = [
       "INSTITUTION",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "FOLLOWED_ARTISTS"
     ]
   },
   {
@@ -312,7 +315,7 @@ return {
             "kind": "LinkedField",
             "alias": "fairArtworks",
             "name": "filterArtworksConnection",
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:20,medium:\"*\",sort:\"-decayed_merch\")",
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\"],dimensionRange:\"*-*\",first:20,medium:\"*\",sort:\"-decayed_merch\")",
             "args": (v4/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
@@ -590,6 +593,13 @@ return {
                     "name": "total",
                     "args": null,
                     "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "followedArtists",
+                    "args": null,
+                    "storageKey": null
                   }
                 ]
               },
@@ -647,6 +657,7 @@ return {
               "inquireableOnly",
               "atAuction",
               "offerable",
+              "includeArtworksByFollowedArtists",
               "aggregations"
             ]
           },
@@ -658,7 +669,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "Fair2ArtworksTestsQuery",
-    "id": "2ca3759fa6fbcaf53dfac98903a54baa",
+    "id": "421cb2e3fa86613cd4ece8d49988b650",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/Fair2ArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/Fair2ArtworksTestsQuery.graphql.ts
@@ -1,9 +1,10 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 056a09e1db046d1fed052a2b3430ef53 */
+/* @relayHash face18160a7bfd5ab276bc892c68aa60 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 export type Fair2ArtworksTestsQueryVariables = {
     fairID: string;
 };
@@ -17,6 +18,14 @@ export type Fair2ArtworksTestsQueryRawResponse = {
         readonly slug: string;
         readonly internalID: string;
         readonly fairArtworks: ({
+            readonly aggregations: ReadonlyArray<({
+                readonly slice: ArtworkAggregation | null;
+                readonly counts: ReadonlyArray<({
+                    readonly count: number;
+                    readonly name: string;
+                    readonly value: string;
+                }) | null> | null;
+            }) | null> | null;
             readonly edges: ReadonlyArray<({
                 readonly node: ({
                     readonly id: string;
@@ -126,7 +135,15 @@ fragment ArtworkGridItem_artwork on Artwork {
 fragment Fair2Artworks_fair on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch") {
+  fairArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
     edges {
       node {
         id
@@ -202,8 +219,31 @@ v3 = {
 v4 = [
   {
     "kind": "Literal",
+    "name": "aggregations",
+    "value": [
+      "COLOR",
+      "DIMENSION_RANGE",
+      "GALLERY",
+      "INSTITUTION",
+      "MAJOR_PERIOD",
+      "MEDIUM",
+      "PRICE_RANGE"
+    ]
+  },
+  {
+    "kind": "Literal",
+    "name": "dimensionRange",
+    "value": "*-*"
+  },
+  {
+    "kind": "Literal",
     "name": "first",
     "value": 20
+  },
+  {
+    "kind": "Literal",
+    "name": "medium",
+    "value": "*"
   },
   {
     "kind": "Literal",
@@ -212,6 +252,13 @@ v4 = [
   }
 ],
 v5 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "id",
@@ -265,11 +312,55 @@ return {
             "kind": "LinkedField",
             "alias": "fairArtworks",
             "name": "filterArtworksConnection",
-            "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")",
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:20,medium:\"*\",sort:\"-decayed_merch\")",
             "args": (v4/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "aggregations",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtworksAggregationResults",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "slice",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "counts",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "AggregationCount",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "count",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      (v5/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "value",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ]
+              },
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -288,7 +379,7 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/),
+                      (v6/*: any*/),
                       (v2/*: any*/),
                       {
                         "kind": "LinkedField",
@@ -394,7 +485,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v5/*: any*/)
+                          (v6/*: any*/)
                         ]
                       },
                       {
@@ -449,7 +540,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v5/*: any*/)
+                          (v6/*: any*/)
                         ]
                       },
                       {
@@ -461,14 +552,8 @@ return {
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          {
-                            "kind": "ScalarField",
-                            "alias": null,
-                            "name": "name",
-                            "args": null,
-                            "storageKey": null
-                          },
-                          (v5/*: any*/)
+                          (v5/*: any*/),
+                          (v6/*: any*/)
                         ]
                       },
                       {
@@ -487,7 +572,7 @@ return {
                     "args": null,
                     "storageKey": null
                   },
-                  (v5/*: any*/)
+                  (v6/*: any*/)
                 ]
               },
               {
@@ -540,7 +625,7 @@ return {
                   }
                 ]
               },
-              (v5/*: any*/)
+              (v6/*: any*/)
             ]
           },
           {
@@ -551,10 +636,21 @@ return {
             "handle": "connection",
             "key": "Fair_fairArtworks",
             "filters": [
-              "sort"
+              "sort",
+              "medium",
+              "priceRange",
+              "color",
+              "partnerID",
+              "dimensionRange",
+              "majorPeriods",
+              "acquireable",
+              "inquireableOnly",
+              "atAuction",
+              "offerable",
+              "aggregations"
             ]
           },
-          (v5/*: any*/)
+          (v6/*: any*/)
         ]
       }
     ]
@@ -562,7 +658,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "Fair2ArtworksTestsQuery",
-    "id": "6f0b6148204dc6f8b4aa88fb9fa7d223",
+    "id": "2ca3759fa6fbcaf53dfac98903a54baa",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/Fair2Artworks_fair.graphql.ts
+++ b/src/__generated__/Fair2Artworks_fair.graphql.ts
@@ -23,6 +23,7 @@ export type Fair2Artworks_fair = {
         } | null> | null;
         readonly counts: {
             readonly total: number | null;
+            readonly followedArtists: number | null;
         } | null;
         readonly " $fragmentRefs": FragmentRefs<"InfiniteScrollArtworksGrid_connection">;
     } | null;
@@ -130,6 +131,12 @@ const node: ReaderFragment = {
       "name": "offerable",
       "type": "Boolean",
       "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "includeArtworksByFollowedArtists",
+      "type": "Boolean",
+      "defaultValue": null
     }
   ],
   "selections": [
@@ -168,7 +175,8 @@ const node: ReaderFragment = {
             "INSTITUTION",
             "MAJOR_PERIOD",
             "MEDIUM",
-            "PRICE_RANGE"
+            "PRICE_RANGE",
+            "FOLLOWED_ARTISTS"
           ]
         },
         {
@@ -185,6 +193,11 @@ const node: ReaderFragment = {
           "kind": "Variable",
           "name": "dimensionRange",
           "variableName": "dimensionRange"
+        },
+        {
+          "kind": "Variable",
+          "name": "includeArtworksByFollowedArtists",
+          "variableName": "includeArtworksByFollowedArtists"
         },
         {
           "kind": "Variable",
@@ -333,6 +346,13 @@ const node: ReaderFragment = {
               "name": "total",
               "args": null,
               "storageKey": null
+            },
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "followedArtists",
+              "args": null,
+              "storageKey": null
             }
           ]
         },
@@ -370,5 +390,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = '4da05c767329e5cb16192c4109565936';
+(node as any).hash = '06024cf92938979a780c90b0f06f4c06';
 export default node;

--- a/src/__generated__/Fair2Artworks_fair.graphql.ts
+++ b/src/__generated__/Fair2Artworks_fair.graphql.ts
@@ -3,10 +3,19 @@
 
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 export type Fair2Artworks_fair = {
     readonly slug: string;
     readonly internalID: string;
     readonly fairArtworks: {
+        readonly aggregations: ReadonlyArray<{
+            readonly slice: ArtworkAggregation | null;
+            readonly counts: ReadonlyArray<{
+                readonly count: number;
+                readonly name: string;
+                readonly value: string;
+            } | null> | null;
+        } | null> | null;
         readonly edges: ReadonlyArray<{
             readonly node: {
                 readonly id: string;
@@ -61,6 +70,66 @@ const node: ReaderFragment = {
       "name": "sort",
       "type": "String",
       "defaultValue": "-decayed_merch"
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "medium",
+      "type": "String",
+      "defaultValue": "*"
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "priceRange",
+      "type": "String",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "color",
+      "type": "String",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "partnerID",
+      "type": "ID",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "dimensionRange",
+      "type": "String",
+      "defaultValue": "*-*"
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "majorPeriods",
+      "type": "[String]",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "acquireable",
+      "type": "Boolean",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "inquireableOnly",
+      "type": "Boolean",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "atAuction",
+      "type": "Boolean",
+      "defaultValue": null
+    },
+    {
+      "kind": "LocalArgument",
+      "name": "offerable",
+      "type": "Boolean",
+      "defaultValue": null
     }
   ],
   "selections": [
@@ -86,6 +155,69 @@ const node: ReaderFragment = {
       "args": [
         {
           "kind": "Variable",
+          "name": "acquireable",
+          "variableName": "acquireable"
+        },
+        {
+          "kind": "Literal",
+          "name": "aggregations",
+          "value": [
+            "COLOR",
+            "DIMENSION_RANGE",
+            "GALLERY",
+            "INSTITUTION",
+            "MAJOR_PERIOD",
+            "MEDIUM",
+            "PRICE_RANGE"
+          ]
+        },
+        {
+          "kind": "Variable",
+          "name": "atAuction",
+          "variableName": "atAuction"
+        },
+        {
+          "kind": "Variable",
+          "name": "color",
+          "variableName": "color"
+        },
+        {
+          "kind": "Variable",
+          "name": "dimensionRange",
+          "variableName": "dimensionRange"
+        },
+        {
+          "kind": "Variable",
+          "name": "inquireableOnly",
+          "variableName": "inquireableOnly"
+        },
+        {
+          "kind": "Variable",
+          "name": "majorPeriods",
+          "variableName": "majorPeriods"
+        },
+        {
+          "kind": "Variable",
+          "name": "medium",
+          "variableName": "medium"
+        },
+        {
+          "kind": "Variable",
+          "name": "offerable",
+          "variableName": "offerable"
+        },
+        {
+          "kind": "Variable",
+          "name": "partnerID",
+          "variableName": "partnerID"
+        },
+        {
+          "kind": "Variable",
+          "name": "priceRange",
+          "variableName": "priceRange"
+        },
+        {
+          "kind": "Variable",
           "name": "sort",
           "variableName": "sort"
         }
@@ -93,6 +225,56 @@ const node: ReaderFragment = {
       "concreteType": "FilterArtworksConnection",
       "plural": false,
       "selections": [
+        {
+          "kind": "LinkedField",
+          "alias": null,
+          "name": "aggregations",
+          "storageKey": null,
+          "args": null,
+          "concreteType": "ArtworksAggregationResults",
+          "plural": true,
+          "selections": [
+            {
+              "kind": "ScalarField",
+              "alias": null,
+              "name": "slice",
+              "args": null,
+              "storageKey": null
+            },
+            {
+              "kind": "LinkedField",
+              "alias": null,
+              "name": "counts",
+              "storageKey": null,
+              "args": null,
+              "concreteType": "AggregationCount",
+              "plural": true,
+              "selections": [
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "count",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "name",
+                  "args": null,
+                  "storageKey": null
+                },
+                {
+                  "kind": "ScalarField",
+                  "alias": null,
+                  "name": "value",
+                  "args": null,
+                  "storageKey": null
+                }
+              ]
+            }
+          ]
+        },
         {
           "kind": "LinkedField",
           "alias": null,
@@ -188,5 +370,5 @@ const node: ReaderFragment = {
     }
   ]
 };
-(node as any).hash = 'bb5394b06085e2888272e96a0b1cbbec';
+(node as any).hash = '4da05c767329e5cb16192c4109565936';
 export default node;

--- a/src/__generated__/Fair2Query.graphql.ts
+++ b/src/__generated__/Fair2Query.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash a0a8086dd6ef1af76cf4ce369de19c9f */
+/* @relayHash ce92ec48331df1395742527ce43a481c */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -67,7 +67,7 @@ fragment ArtworkGridItem_artwork on Artwork {
 fragment Fair2Artworks_fair on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  fairArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS]) {
     aggregations {
       slice
       counts {
@@ -85,6 +85,7 @@ fragment Fair2Artworks_fair on Fair {
     }
     counts {
       total
+      followedArtists
     }
     ...InfiniteScrollArtworksGrid_connection
     pageInfo {
@@ -405,7 +406,8 @@ v14 = [
       "INSTITUTION",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "FOLLOWED_ARTISTS"
     ]
   },
   {
@@ -896,7 +898,7 @@ return {
             "kind": "LinkedField",
             "alias": "fairArtworks",
             "name": "filterArtworksConnection",
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:20,medium:\"*\",sort:\"-decayed_merch\")",
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\"],dimensionRange:\"*-*\",first:20,medium:\"*\",sort:\"-decayed_merch\")",
             "args": (v14/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
@@ -1080,6 +1082,13 @@ return {
                     "name": "total",
                     "args": null,
                     "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "followedArtists",
+                    "args": null,
+                    "storageKey": null
                   }
                 ]
               },
@@ -1125,6 +1134,7 @@ return {
               "inquireableOnly",
               "atAuction",
               "offerable",
+              "includeArtworksByFollowedArtists",
               "aggregations"
             ]
           },
@@ -1343,7 +1353,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "Fair2Query",
-    "id": "695c9cc74e935509b0a5fbe98e40098a",
+    "id": "c15d20223eeeffe06769d94edd3adcbb",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/Fair2Query.graphql.ts
+++ b/src/__generated__/Fair2Query.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 720bbc788f5af46c7cc0d927001bb4d6 */
+/* @relayHash a0a8086dd6ef1af76cf4ce369de19c9f */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -67,7 +67,15 @@ fragment ArtworkGridItem_artwork on Artwork {
 fragment Fair2Artworks_fair on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch") {
+  fairArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
     edges {
       node {
         id
@@ -243,6 +251,8 @@ fragment Fair2Header_fair on Fair {
 }
 
 fragment Fair2_fair on Fair {
+  internalID
+  slug
   articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {
     edges {
       __typename
@@ -305,87 +315,110 @@ v1 = [
 v2 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__typename",
+  "name": "internalID",
   "args": null,
   "storageKey": null
 },
 v3 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "slug",
   "args": null,
   "storageKey": null
 },
 v4 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "title",
+  "name": "__typename",
   "args": null,
   "storageKey": null
 },
 v5 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "href",
+  "name": "id",
   "args": null,
   "storageKey": null
 },
 v6 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "slug",
+  "name": "title",
   "args": null,
   "storageKey": null
 },
 v7 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "artworks",
+  "name": "href",
   "args": null,
   "storageKey": null
 },
 v8 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "summary",
+  "name": "artworks",
   "args": null,
   "storageKey": null
 },
 v9 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "summary",
   "args": null,
   "storageKey": null
 },
 v10 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v11 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "aspectRatio",
   "args": null,
   "storageKey": null
 },
-v11 = [
+v12 = [
   {
     "kind": "Literal",
     "name": "format",
     "value": "MARKDOWN"
   }
 ],
-v12 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "internalID",
-  "args": null,
-  "storageKey": null
-},
 v13 = {
   "kind": "Literal",
   "name": "first",
   "value": 20
 },
 v14 = [
+  {
+    "kind": "Literal",
+    "name": "aggregations",
+    "value": [
+      "COLOR",
+      "DIMENSION_RANGE",
+      "GALLERY",
+      "INSTITUTION",
+      "MAJOR_PERIOD",
+      "MEDIUM",
+      "PRICE_RANGE"
+    ]
+  },
+  {
+    "kind": "Literal",
+    "name": "dimensionRange",
+    "value": "*-*"
+  },
   (v13/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "medium",
+    "value": "*"
+  },
   {
     "kind": "Literal",
     "name": "sort",
@@ -486,9 +519,6 @@ v25 = {
   "storageKey": null
 },
 v26 = [
-  "sort"
-],
-v27 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -500,8 +530,8 @@ v27 = [
     "value": "FEATURED_ASC"
   }
 ],
-v28 = [
-  (v9/*: any*/)
+v27 = [
+  (v10/*: any*/)
 ];
 return {
   "kind": "Request",
@@ -544,6 +574,8 @@ return {
         "concreteType": "Fair",
         "plural": false,
         "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
           {
             "kind": "LinkedField",
             "alias": "articles",
@@ -573,7 +605,7 @@ return {
                 "concreteType": "ArticleEdge",
                 "plural": true,
                 "selections": [
-                  (v2/*: any*/),
+                  (v4/*: any*/),
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -583,9 +615,9 @@ return {
                     "concreteType": "Article",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
-                      (v4/*: any*/),
                       (v5/*: any*/),
+                      (v6/*: any*/),
+                      (v7/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -638,10 +670,10 @@ return {
             "concreteType": "MarketingCollection",
             "plural": true,
             "selections": [
-              (v2/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
               (v3/*: any*/),
               (v6/*: any*/),
-              (v4/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -706,12 +738,12 @@ return {
                               }
                             ]
                           },
-                          (v3/*: any*/)
+                          (v5/*: any*/)
                         ]
                       }
                     ]
                   },
-                  (v3/*: any*/)
+                  (v5/*: any*/)
                 ]
               }
             ]
@@ -725,7 +757,7 @@ return {
             "concreteType": "FairCounts",
             "plural": false,
             "selections": [
-              (v7/*: any*/),
+              (v8/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -742,9 +774,8 @@ return {
             "args": null,
             "storageKey": null
           },
-          (v8/*: any*/),
           (v9/*: any*/),
-          (v6/*: any*/),
+          (v10/*: any*/),
           {
             "kind": "LinkedField",
             "alias": null,
@@ -778,7 +809,7 @@ return {
                   }
                 ]
               },
-              (v3/*: any*/)
+              (v5/*: any*/)
             ]
           },
           {
@@ -803,7 +834,7 @@ return {
                 ],
                 "storageKey": "url(version:\"large_rectangle\")"
               },
-              (v10/*: any*/)
+              (v11/*: any*/)
             ]
           },
           {
@@ -822,8 +853,8 @@ return {
             "concreteType": "Location",
             "plural": false,
             "selections": [
-              (v8/*: any*/),
-              (v3/*: any*/)
+              (v9/*: any*/),
+              (v5/*: any*/)
             ]
           },
           {
@@ -837,40 +868,83 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "hours",
-            "args": (v11/*: any*/),
+            "args": (v12/*: any*/),
             "storageKey": "hours(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "links",
-            "args": (v11/*: any*/),
+            "args": (v12/*: any*/),
             "storageKey": "links(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "tickets",
-            "args": (v11/*: any*/),
+            "args": (v12/*: any*/),
             "storageKey": "tickets(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "contact",
-            "args": (v11/*: any*/),
+            "args": (v12/*: any*/),
             "storageKey": "contact(format:\"MARKDOWN\")"
           },
-          (v12/*: any*/),
           {
             "kind": "LinkedField",
             "alias": "fairArtworks",
             "name": "filterArtworksConnection",
-            "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")",
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:20,medium:\"*\",sort:\"-decayed_merch\")",
             "args": (v14/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "aggregations",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtworksAggregationResults",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "slice",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "counts",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "AggregationCount",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "count",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      (v10/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "value",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ]
+              },
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -889,8 +963,8 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
+                      (v5/*: any*/),
                       (v3/*: any*/),
-                      (v6/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -900,7 +974,7 @@ return {
                         "concreteType": "Image",
                         "plural": false,
                         "selections": [
-                          (v10/*: any*/),
+                          (v11/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -916,7 +990,7 @@ return {
                           }
                         ]
                       },
-                      (v4/*: any*/),
+                      (v6/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -925,9 +999,9 @@ return {
                         "storageKey": null
                       },
                       (v15/*: any*/),
-                      (v12/*: any*/),
+                      (v2/*: any*/),
                       (v16/*: any*/),
-                      (v5/*: any*/),
+                      (v7/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -947,7 +1021,7 @@ return {
                             "storageKey": null
                           },
                           (v19/*: any*/),
-                          (v3/*: any*/)
+                          (v5/*: any*/)
                         ]
                       },
                       {
@@ -968,7 +1042,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v5/*: any*/)
                         ]
                       },
                       {
@@ -980,15 +1054,15 @@ return {
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          (v9/*: any*/),
-                          (v3/*: any*/)
+                          (v10/*: any*/),
+                          (v5/*: any*/)
                         ]
                       },
-                      (v2/*: any*/)
+                      (v4/*: any*/)
                     ]
                   },
                   (v23/*: any*/),
-                  (v3/*: any*/)
+                  (v5/*: any*/)
                 ]
               },
               {
@@ -1029,7 +1103,7 @@ return {
                   (v25/*: any*/)
                 ]
               },
-              (v3/*: any*/)
+              (v5/*: any*/)
             ]
           },
           {
@@ -1039,14 +1113,27 @@ return {
             "args": (v14/*: any*/),
             "handle": "connection",
             "key": "Fair_fairArtworks",
-            "filters": (v26/*: any*/)
+            "filters": [
+              "sort",
+              "medium",
+              "priceRange",
+              "color",
+              "partnerID",
+              "dimensionRange",
+              "majorPeriods",
+              "acquireable",
+              "inquireableOnly",
+              "atAuction",
+              "offerable",
+              "aggregations"
+            ]
           },
           {
             "kind": "LinkedField",
             "alias": "exhibitors",
             "name": "showsConnection",
             "storageKey": "showsConnection(first:15,sort:\"FEATURED_ASC\")",
-            "args": (v27/*: any*/),
+            "args": (v26/*: any*/),
             "concreteType": "ShowConnection",
             "plural": false,
             "selections": [
@@ -1068,7 +1155,7 @@ return {
                     "concreteType": "Show",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
+                      (v5/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -1078,7 +1165,7 @@ return {
                         "concreteType": "ShowCounts",
                         "plural": false,
                         "selections": [
-                          (v7/*: any*/)
+                          (v8/*: any*/)
                         ]
                       },
                       {
@@ -1090,22 +1177,22 @@ return {
                         "concreteType": null,
                         "plural": false,
                         "selections": [
-                          (v2/*: any*/),
-                          (v3/*: any*/),
+                          (v4/*: any*/),
+                          (v5/*: any*/),
                           {
                             "kind": "InlineFragment",
                             "type": "Partner",
-                            "selections": (v28/*: any*/)
+                            "selections": (v27/*: any*/)
                           },
                           {
                             "kind": "InlineFragment",
                             "type": "ExternalPartner",
-                            "selections": (v28/*: any*/)
+                            "selections": (v27/*: any*/)
                           }
                         ]
                       },
-                      (v12/*: any*/),
-                      (v5/*: any*/),
+                      (v2/*: any*/),
+                      (v7/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": "artworks",
@@ -1135,9 +1222,9 @@ return {
                                 "concreteType": "Artwork",
                                 "plural": false,
                                 "selections": [
-                                  (v5/*: any*/),
+                                  (v7/*: any*/),
                                   (v16/*: any*/),
-                                  (v3/*: any*/),
+                                  (v5/*: any*/),
                                   {
                                     "kind": "LinkedField",
                                     "alias": null,
@@ -1154,7 +1241,7 @@ return {
                                         "args": null,
                                         "storageKey": null
                                       },
-                                      (v10/*: any*/)
+                                      (v11/*: any*/)
                                     ]
                                   },
                                   (v15/*: any*/),
@@ -1189,7 +1276,7 @@ return {
                                       },
                                       (v22/*: any*/),
                                       (v20/*: any*/),
-                                      (v3/*: any*/)
+                                      (v5/*: any*/)
                                     ]
                                   },
                                   {
@@ -1204,19 +1291,19 @@ return {
                                       (v18/*: any*/),
                                       (v17/*: any*/),
                                       (v19/*: any*/),
-                                      (v3/*: any*/)
+                                      (v5/*: any*/)
                                     ]
                                   },
-                                  (v4/*: any*/),
-                                  (v12/*: any*/),
-                                  (v6/*: any*/)
+                                  (v6/*: any*/),
+                                  (v2/*: any*/),
+                                  (v3/*: any*/)
                                 ]
                               }
                             ]
                           }
                         ]
                       },
-                      (v2/*: any*/)
+                      (v4/*: any*/)
                     ]
                   },
                   (v23/*: any*/)
@@ -1241,12 +1328,14 @@ return {
             "kind": "LinkedHandle",
             "alias": "exhibitors",
             "name": "showsConnection",
-            "args": (v27/*: any*/),
+            "args": (v26/*: any*/),
             "handle": "connection",
             "key": "Fair2ExhibitorsQuery_exhibitors",
-            "filters": (v26/*: any*/)
+            "filters": [
+              "sort"
+            ]
           },
-          (v3/*: any*/)
+          (v5/*: any*/)
         ]
       }
     ]
@@ -1254,7 +1343,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "Fair2Query",
-    "id": "d069675125ae8a3e6e0c188d4db49bda",
+    "id": "695c9cc74e935509b0a5fbe98e40098a",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/Fair2TestsQuery.graphql.ts
+++ b/src/__generated__/Fair2TestsQuery.graphql.ts
@@ -1,9 +1,10 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 2d0aa1329974bdd340bb60c2dfee5ad6 */
+/* @relayHash 920c096ef4d775d21abc8b987616b713 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 export type Fair2TestsQueryVariables = {
     fairID: string;
 };
@@ -14,6 +15,8 @@ export type Fair2TestsQueryResponse = {
 };
 export type Fair2TestsQueryRawResponse = {
     readonly fair: ({
+        readonly internalID: string;
+        readonly slug: string;
         readonly articles: ({
             readonly edges: ReadonlyArray<({
                 readonly __typename: string;
@@ -53,7 +56,6 @@ export type Fair2TestsQueryRawResponse = {
         readonly about: string | null;
         readonly summary: string | null;
         readonly name: string | null;
-        readonly slug: string;
         readonly profile: ({
             readonly icon: ({
                 readonly url: string | null;
@@ -74,8 +76,15 @@ export type Fair2TestsQueryRawResponse = {
         readonly links: string | null;
         readonly tickets: string | null;
         readonly contact: string | null;
-        readonly internalID: string;
         readonly fairArtworks: ({
+            readonly aggregations: ReadonlyArray<({
+                readonly slice: ArtworkAggregation | null;
+                readonly counts: ReadonlyArray<({
+                    readonly count: number;
+                    readonly name: string;
+                    readonly value: string;
+                }) | null> | null;
+            }) | null> | null;
             readonly edges: ReadonlyArray<({
                 readonly node: ({
                     readonly id: string;
@@ -253,7 +262,15 @@ fragment ArtworkGridItem_artwork on Artwork {
 fragment Fair2Artworks_fair on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch") {
+  fairArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
     edges {
       node {
         id
@@ -429,6 +446,8 @@ fragment Fair2Header_fair on Fair {
 }
 
 fragment Fair2_fair on Fair {
+  internalID
+  slug
   articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {
     edges {
       __typename
@@ -491,87 +510,110 @@ v1 = [
 v2 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "__typename",
+  "name": "internalID",
   "args": null,
   "storageKey": null
 },
 v3 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "id",
+  "name": "slug",
   "args": null,
   "storageKey": null
 },
 v4 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "title",
+  "name": "__typename",
   "args": null,
   "storageKey": null
 },
 v5 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "href",
+  "name": "id",
   "args": null,
   "storageKey": null
 },
 v6 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "slug",
+  "name": "title",
   "args": null,
   "storageKey": null
 },
 v7 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "artworks",
+  "name": "href",
   "args": null,
   "storageKey": null
 },
 v8 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "summary",
+  "name": "artworks",
   "args": null,
   "storageKey": null
 },
 v9 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "name",
+  "name": "summary",
   "args": null,
   "storageKey": null
 },
 v10 = {
   "kind": "ScalarField",
   "alias": null,
+  "name": "name",
+  "args": null,
+  "storageKey": null
+},
+v11 = {
+  "kind": "ScalarField",
+  "alias": null,
   "name": "aspectRatio",
   "args": null,
   "storageKey": null
 },
-v11 = [
+v12 = [
   {
     "kind": "Literal",
     "name": "format",
     "value": "MARKDOWN"
   }
 ],
-v12 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "internalID",
-  "args": null,
-  "storageKey": null
-},
 v13 = {
   "kind": "Literal",
   "name": "first",
   "value": 20
 },
 v14 = [
+  {
+    "kind": "Literal",
+    "name": "aggregations",
+    "value": [
+      "COLOR",
+      "DIMENSION_RANGE",
+      "GALLERY",
+      "INSTITUTION",
+      "MAJOR_PERIOD",
+      "MEDIUM",
+      "PRICE_RANGE"
+    ]
+  },
+  {
+    "kind": "Literal",
+    "name": "dimensionRange",
+    "value": "*-*"
+  },
   (v13/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "medium",
+    "value": "*"
+  },
   {
     "kind": "Literal",
     "name": "sort",
@@ -672,9 +714,6 @@ v25 = {
   "storageKey": null
 },
 v26 = [
-  "sort"
-],
-v27 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -686,8 +725,8 @@ v27 = [
     "value": "FEATURED_ASC"
   }
 ],
-v28 = [
-  (v9/*: any*/)
+v27 = [
+  (v10/*: any*/)
 ];
 return {
   "kind": "Request",
@@ -730,6 +769,8 @@ return {
         "concreteType": "Fair",
         "plural": false,
         "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
           {
             "kind": "LinkedField",
             "alias": "articles",
@@ -759,7 +800,7 @@ return {
                 "concreteType": "ArticleEdge",
                 "plural": true,
                 "selections": [
-                  (v2/*: any*/),
+                  (v4/*: any*/),
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -769,9 +810,9 @@ return {
                     "concreteType": "Article",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
-                      (v4/*: any*/),
                       (v5/*: any*/),
+                      (v6/*: any*/),
+                      (v7/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -824,10 +865,10 @@ return {
             "concreteType": "MarketingCollection",
             "plural": true,
             "selections": [
-              (v2/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
               (v3/*: any*/),
               (v6/*: any*/),
-              (v4/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -892,12 +933,12 @@ return {
                               }
                             ]
                           },
-                          (v3/*: any*/)
+                          (v5/*: any*/)
                         ]
                       }
                     ]
                   },
-                  (v3/*: any*/)
+                  (v5/*: any*/)
                 ]
               }
             ]
@@ -911,7 +952,7 @@ return {
             "concreteType": "FairCounts",
             "plural": false,
             "selections": [
-              (v7/*: any*/),
+              (v8/*: any*/),
               {
                 "kind": "ScalarField",
                 "alias": null,
@@ -928,9 +969,8 @@ return {
             "args": null,
             "storageKey": null
           },
-          (v8/*: any*/),
           (v9/*: any*/),
-          (v6/*: any*/),
+          (v10/*: any*/),
           {
             "kind": "LinkedField",
             "alias": null,
@@ -964,7 +1004,7 @@ return {
                   }
                 ]
               },
-              (v3/*: any*/)
+              (v5/*: any*/)
             ]
           },
           {
@@ -989,7 +1029,7 @@ return {
                 ],
                 "storageKey": "url(version:\"large_rectangle\")"
               },
-              (v10/*: any*/)
+              (v11/*: any*/)
             ]
           },
           {
@@ -1008,8 +1048,8 @@ return {
             "concreteType": "Location",
             "plural": false,
             "selections": [
-              (v8/*: any*/),
-              (v3/*: any*/)
+              (v9/*: any*/),
+              (v5/*: any*/)
             ]
           },
           {
@@ -1023,40 +1063,83 @@ return {
             "kind": "ScalarField",
             "alias": null,
             "name": "hours",
-            "args": (v11/*: any*/),
+            "args": (v12/*: any*/),
             "storageKey": "hours(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "links",
-            "args": (v11/*: any*/),
+            "args": (v12/*: any*/),
             "storageKey": "links(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "tickets",
-            "args": (v11/*: any*/),
+            "args": (v12/*: any*/),
             "storageKey": "tickets(format:\"MARKDOWN\")"
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "contact",
-            "args": (v11/*: any*/),
+            "args": (v12/*: any*/),
             "storageKey": "contact(format:\"MARKDOWN\")"
           },
-          (v12/*: any*/),
           {
             "kind": "LinkedField",
             "alias": "fairArtworks",
             "name": "filterArtworksConnection",
-            "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")",
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:20,medium:\"*\",sort:\"-decayed_merch\")",
             "args": (v14/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
             "selections": [
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "aggregations",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "ArtworksAggregationResults",
+                "plural": true,
+                "selections": [
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "slice",
+                    "args": null,
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "LinkedField",
+                    "alias": null,
+                    "name": "counts",
+                    "storageKey": null,
+                    "args": null,
+                    "concreteType": "AggregationCount",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "count",
+                        "args": null,
+                        "storageKey": null
+                      },
+                      (v10/*: any*/),
+                      {
+                        "kind": "ScalarField",
+                        "alias": null,
+                        "name": "value",
+                        "args": null,
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ]
+              },
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -1075,8 +1158,8 @@ return {
                     "concreteType": "Artwork",
                     "plural": false,
                     "selections": [
+                      (v5/*: any*/),
                       (v3/*: any*/),
-                      (v6/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -1086,7 +1169,7 @@ return {
                         "concreteType": "Image",
                         "plural": false,
                         "selections": [
-                          (v10/*: any*/),
+                          (v11/*: any*/),
                           {
                             "kind": "ScalarField",
                             "alias": null,
@@ -1102,7 +1185,7 @@ return {
                           }
                         ]
                       },
-                      (v4/*: any*/),
+                      (v6/*: any*/),
                       {
                         "kind": "ScalarField",
                         "alias": null,
@@ -1111,9 +1194,9 @@ return {
                         "storageKey": null
                       },
                       (v15/*: any*/),
-                      (v12/*: any*/),
+                      (v2/*: any*/),
                       (v16/*: any*/),
-                      (v5/*: any*/),
+                      (v7/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -1133,7 +1216,7 @@ return {
                             "storageKey": null
                           },
                           (v19/*: any*/),
-                          (v3/*: any*/)
+                          (v5/*: any*/)
                         ]
                       },
                       {
@@ -1154,7 +1237,7 @@ return {
                             "args": null,
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v5/*: any*/)
                         ]
                       },
                       {
@@ -1166,15 +1249,15 @@ return {
                         "concreteType": "Partner",
                         "plural": false,
                         "selections": [
-                          (v9/*: any*/),
-                          (v3/*: any*/)
+                          (v10/*: any*/),
+                          (v5/*: any*/)
                         ]
                       },
-                      (v2/*: any*/)
+                      (v4/*: any*/)
                     ]
                   },
                   (v23/*: any*/),
-                  (v3/*: any*/)
+                  (v5/*: any*/)
                 ]
               },
               {
@@ -1215,7 +1298,7 @@ return {
                   (v25/*: any*/)
                 ]
               },
-              (v3/*: any*/)
+              (v5/*: any*/)
             ]
           },
           {
@@ -1225,14 +1308,27 @@ return {
             "args": (v14/*: any*/),
             "handle": "connection",
             "key": "Fair_fairArtworks",
-            "filters": (v26/*: any*/)
+            "filters": [
+              "sort",
+              "medium",
+              "priceRange",
+              "color",
+              "partnerID",
+              "dimensionRange",
+              "majorPeriods",
+              "acquireable",
+              "inquireableOnly",
+              "atAuction",
+              "offerable",
+              "aggregations"
+            ]
           },
           {
             "kind": "LinkedField",
             "alias": "exhibitors",
             "name": "showsConnection",
             "storageKey": "showsConnection(first:15,sort:\"FEATURED_ASC\")",
-            "args": (v27/*: any*/),
+            "args": (v26/*: any*/),
             "concreteType": "ShowConnection",
             "plural": false,
             "selections": [
@@ -1254,7 +1350,7 @@ return {
                     "concreteType": "Show",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
+                      (v5/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": null,
@@ -1264,7 +1360,7 @@ return {
                         "concreteType": "ShowCounts",
                         "plural": false,
                         "selections": [
-                          (v7/*: any*/)
+                          (v8/*: any*/)
                         ]
                       },
                       {
@@ -1276,22 +1372,22 @@ return {
                         "concreteType": null,
                         "plural": false,
                         "selections": [
-                          (v2/*: any*/),
-                          (v3/*: any*/),
+                          (v4/*: any*/),
+                          (v5/*: any*/),
                           {
                             "kind": "InlineFragment",
                             "type": "Partner",
-                            "selections": (v28/*: any*/)
+                            "selections": (v27/*: any*/)
                           },
                           {
                             "kind": "InlineFragment",
                             "type": "ExternalPartner",
-                            "selections": (v28/*: any*/)
+                            "selections": (v27/*: any*/)
                           }
                         ]
                       },
-                      (v12/*: any*/),
-                      (v5/*: any*/),
+                      (v2/*: any*/),
+                      (v7/*: any*/),
                       {
                         "kind": "LinkedField",
                         "alias": "artworks",
@@ -1321,9 +1417,9 @@ return {
                                 "concreteType": "Artwork",
                                 "plural": false,
                                 "selections": [
-                                  (v5/*: any*/),
+                                  (v7/*: any*/),
                                   (v16/*: any*/),
-                                  (v3/*: any*/),
+                                  (v5/*: any*/),
                                   {
                                     "kind": "LinkedField",
                                     "alias": null,
@@ -1340,7 +1436,7 @@ return {
                                         "args": null,
                                         "storageKey": null
                                       },
-                                      (v10/*: any*/)
+                                      (v11/*: any*/)
                                     ]
                                   },
                                   (v15/*: any*/),
@@ -1375,7 +1471,7 @@ return {
                                       },
                                       (v22/*: any*/),
                                       (v20/*: any*/),
-                                      (v3/*: any*/)
+                                      (v5/*: any*/)
                                     ]
                                   },
                                   {
@@ -1390,19 +1486,19 @@ return {
                                       (v18/*: any*/),
                                       (v17/*: any*/),
                                       (v19/*: any*/),
-                                      (v3/*: any*/)
+                                      (v5/*: any*/)
                                     ]
                                   },
-                                  (v4/*: any*/),
-                                  (v12/*: any*/),
-                                  (v6/*: any*/)
+                                  (v6/*: any*/),
+                                  (v2/*: any*/),
+                                  (v3/*: any*/)
                                 ]
                               }
                             ]
                           }
                         ]
                       },
-                      (v2/*: any*/)
+                      (v4/*: any*/)
                     ]
                   },
                   (v23/*: any*/)
@@ -1427,12 +1523,14 @@ return {
             "kind": "LinkedHandle",
             "alias": "exhibitors",
             "name": "showsConnection",
-            "args": (v27/*: any*/),
+            "args": (v26/*: any*/),
             "handle": "connection",
             "key": "Fair2ExhibitorsQuery_exhibitors",
-            "filters": (v26/*: any*/)
+            "filters": [
+              "sort"
+            ]
           },
-          (v3/*: any*/)
+          (v5/*: any*/)
         ]
       }
     ]
@@ -1440,7 +1538,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "Fair2TestsQuery",
-    "id": "d65fcd6ac21a874922132222141b63aa",
+    "id": "90b6b598bcee4b8f7d10dce517bebb1a",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/Fair2TestsQuery.graphql.ts
+++ b/src/__generated__/Fair2TestsQuery.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 920c096ef4d775d21abc8b987616b713 */
+/* @relayHash cdd83a16bdd14d8b76924b6ebbc11d03 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -127,6 +127,7 @@ export type Fair2TestsQueryRawResponse = {
             }) | null> | null;
             readonly counts: ({
                 readonly total: number | null;
+                readonly followedArtists: number | null;
             }) | null;
             readonly pageInfo: {
                 readonly hasNextPage: boolean;
@@ -262,7 +263,7 @@ fragment ArtworkGridItem_artwork on Artwork {
 fragment Fair2Artworks_fair on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  fairArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS]) {
     aggregations {
       slice
       counts {
@@ -280,6 +281,7 @@ fragment Fair2Artworks_fair on Fair {
     }
     counts {
       total
+      followedArtists
     }
     ...InfiniteScrollArtworksGrid_connection
     pageInfo {
@@ -600,7 +602,8 @@ v14 = [
       "INSTITUTION",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "FOLLOWED_ARTISTS"
     ]
   },
   {
@@ -1091,7 +1094,7 @@ return {
             "kind": "LinkedField",
             "alias": "fairArtworks",
             "name": "filterArtworksConnection",
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:20,medium:\"*\",sort:\"-decayed_merch\")",
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\"],dimensionRange:\"*-*\",first:20,medium:\"*\",sort:\"-decayed_merch\")",
             "args": (v14/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "plural": false,
@@ -1275,6 +1278,13 @@ return {
                     "name": "total",
                     "args": null,
                     "storageKey": null
+                  },
+                  {
+                    "kind": "ScalarField",
+                    "alias": null,
+                    "name": "followedArtists",
+                    "args": null,
+                    "storageKey": null
                   }
                 ]
               },
@@ -1320,6 +1330,7 @@ return {
               "inquireableOnly",
               "atAuction",
               "offerable",
+              "includeArtworksByFollowedArtists",
               "aggregations"
             ]
           },
@@ -1538,7 +1549,7 @@ return {
   "params": {
     "operationKind": "query",
     "name": "Fair2TestsQuery",
-    "id": "90b6b598bcee4b8f7d10dce517bebb1a",
+    "id": "9ececaf96a76b586004a36e549184705",
     "text": null,
     "metadata": {}
   }

--- a/src/__generated__/Fair2_fair.graphql.ts
+++ b/src/__generated__/Fair2_fair.graphql.ts
@@ -4,6 +4,8 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type Fair2_fair = {
+    readonly internalID: string;
+    readonly slug: string;
     readonly articles: {
         readonly edges: ReadonlyArray<{
             readonly __typename: string;
@@ -44,6 +46,20 @@ return {
   "metadata": null,
   "argumentDefinitions": [],
   "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "internalID",
+      "args": null,
+      "storageKey": null
+    },
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "slug",
+      "args": null,
+      "storageKey": null
+    },
     {
       "kind": "LinkedField",
       "alias": "articles",
@@ -145,5 +161,5 @@ return {
   ]
 };
 })();
-(node as any).hash = '7b51c9dd38ce8aa614809c2cf6d692b0';
+(node as any).hash = '1598f12e2e9b1fee9f5d08fc5dd01221';
 export default node;

--- a/src/lib/Components/ArtworkFilterOptions/ArtistsIFollowOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/ArtistsIFollowOptions.tsx
@@ -1,0 +1,37 @@
+import { FilterDisplayName, FilterParamName } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
+import { ArtworkFilterContext, FilterData, useSelectedOptionsDisplay } from "lib/utils/ArtworkFiltersStore"
+import React, { useContext } from "react"
+import { NavigatorIOS } from "react-native"
+import { MultiSelectOptionScreen } from "./MultiSelectOption"
+
+interface ArtistsIFollowOptionsScreenProps {
+  navigator: NavigatorIOS
+}
+
+export const ArtistsIFollowOptionsScreen: React.FC<ArtistsIFollowOptionsScreenProps> = ({ navigator }) => {
+  const { dispatch } = useContext(ArtworkFilterContext)
+  const selectedOptions = useSelectedOptionsDisplay()
+
+  const artistsIFollowFilterNames = [FilterParamName.artistsIFollow]
+  const artistsIFollowOptions = selectedOptions.filter((value) => artistsIFollowFilterNames.includes(value.paramName))
+
+  const selectOption = (option: FilterData, updatedValue: boolean) => {
+    dispatch({
+      type: "selectFilters",
+      payload: {
+        displayText: option.displayText,
+        paramValue: updatedValue,
+        paramName: option.paramName,
+      },
+    })
+  }
+
+  return (
+    <MultiSelectOptionScreen
+      onSelect={selectOption}
+      filterHeaderText={FilterDisplayName.artistsIFollow}
+      filterOptions={artistsIFollowOptions}
+      navigator={navigator}
+    />
+  )
+}

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -158,6 +158,7 @@ export enum FilterModalMode {
   Collection = "Collection",
   ArtistArtworks = "ArtistArtworks",
   ArtistSeries = "ArtistSeries",
+  Fair = "Fair",
 }
 
 interface FilterOptionsProps {
@@ -225,6 +226,19 @@ export const FilterOptions: React.FC<FilterOptionsProps> = (props) => {
         ]
         break
       case "ArtistSeries":
+        sortOrder = [
+          "sort",
+          "medium",
+          "priceRange",
+          "waysToBuy",
+          "dimensionRange",
+          "majorPeriods",
+          "color",
+          "gallery",
+          "institution",
+        ]
+        break
+      case "Fair":
         sortOrder = [
           "sort",
           "medium",

--- a/src/lib/Components/FilterModal.tsx
+++ b/src/lib/Components/FilterModal.tsx
@@ -4,6 +4,7 @@ import {
   FilterDisplayName,
   FilterParamName,
   FilterParams,
+  selectedOption,
 } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
 import { Schema } from "lib/utils/track"
 import { OwnerEntityTypes, PageNames } from "lib/utils/track/schema"
@@ -18,10 +19,10 @@ import {
   AggregationName,
   Aggregations,
   ArtworkFilterContext,
-  FilterData,
   useSelectedOptionsDisplay,
 } from "../utils/ArtworkFiltersStore"
 import { AnimatedBottomButton } from "./AnimatedBottomButton"
+import { ArtistsIFollowOptionsScreen } from "./ArtworkFilterOptions/ArtistsIFollowOptions"
 import { ColorOption, ColorOptionsScreen } from "./ArtworkFilterOptions/ColorOptions"
 import { colorHexMap } from "./ArtworkFilterOptions/ColorSwatch"
 import { GalleryOptionsScreen } from "./ArtworkFilterOptions/GalleryOptions"
@@ -137,7 +138,7 @@ export const FilterModalNavigator: React.FC<FilterModalProps> = (props) => {
   )
 }
 
-type FilterScreen =
+export type FilterScreen =
   | "sort"
   | "waysToBuy"
   | "medium"
@@ -147,6 +148,7 @@ type FilterScreen =
   | "color"
   | "gallery"
   | "institution"
+  | "artistsIFollow"
 
 export interface FilterDisplayConfig {
   filterType: FilterScreen
@@ -174,6 +176,8 @@ export const FilterOptions: React.FC<FilterOptionsProps> = (props) => {
   const { closeModal, navigator, id, slug, mode } = props
 
   const { dispatch, state } = useContext(ArtworkFilterContext)
+
+  const selectedOptions = useSelectedOptionsDisplay()
 
   const navigateToNextFilterScreen = (NextComponent: any /* STRICTNESS_MIGRATION */) => {
     navigator.push({
@@ -241,6 +245,7 @@ export const FilterOptions: React.FC<FilterOptionsProps> = (props) => {
       case "Fair":
         sortOrder = [
           "sort",
+          "artistsIFollow",
           "medium",
           "priceRange",
           "waysToBuy",
@@ -282,34 +287,6 @@ export const FilterOptions: React.FC<FilterOptionsProps> = (props) => {
 
   const handleTappingCloseIcon = () => {
     closeModal()
-  }
-
-  const selectedOptions = useSelectedOptionsDisplay()
-  const multiSelectedOptions = selectedOptions.filter((option) => option.paramValue === true)
-
-  const selectedOption = (filterType: FilterScreen) => {
-    if (filterType === "waysToBuy") {
-      if (multiSelectedOptions.length === 0) {
-        return "All"
-      }
-      return multiSelectionDisplay()
-    } else if (filterType === "gallery" || filterType === "institution") {
-      const displayText = selectedOptions.find((option) => option.filterKey === filterType)?.displayText
-      if (displayText) {
-        return displayText
-      } else {
-        return "All"
-      }
-    }
-    return selectedOptions.find((option) => option.paramName === filterType)?.displayText
-  }
-
-  const multiSelectionDisplay = (): string => {
-    const displayTexts: string[] = []
-    multiSelectedOptions.forEach((f: FilterData) => {
-      displayTexts.push(f.displayText)
-    })
-    return displayTexts.join(", ")
   }
 
   return (
@@ -362,7 +339,10 @@ export const FilterOptions: React.FC<FilterOptionsProps> = (props) => {
                       {item.displayText}
                     </Sans>
                     <Flex flexDirection="row" alignItems="center">
-                      <OptionDetail currentOption={selectedOption(item.filterType)} filterType={item.filterType} />
+                      <OptionDetail
+                        currentOption={selectedOption(selectedOptions, item.filterType)}
+                        filterType={item.filterType}
+                      />
                       <ArrowRightIcon fill="black30" ml="1" />
                     </Flex>
                   </Flex>
@@ -475,6 +455,7 @@ const filterKeyFromAggregation: Record<AggregationName, FilterParamName | string
   MAJOR_PERIOD: FilterParamName.timePeriod,
   MEDIUM: FilterParamName.medium,
   PRICE_RANGE: FilterParamName.priceRange,
+  FOLLOWED_ARTISTS: "artistsIFollow",
 }
 
 // For most cases filter key can simply be FilterParamName, exception
@@ -487,6 +468,7 @@ export const aggregationNameFromFilter: Record<string, AggregationName | undefin
   majorPeriods: "MAJOR_PERIOD",
   medium: "MEDIUM",
   priceRange: "PRICE_RANGE",
+  artistsIFollow: "FOLLOWED_ARTISTS",
 }
 
 export const aggregationForFilter = (filterKey: string, aggregations: Aggregations) => {
@@ -500,6 +482,11 @@ const filterOptionToDisplayConfigMap: Record<string, FilterDisplayConfig> = {
     displayText: FilterDisplayName.sort,
     filterType: "sort",
     ScreenComponent: SortOptionsScreen,
+  },
+  artistsIFollow: {
+    displayText: FilterDisplayName.artistsIFollow,
+    filterType: "artistsIFollow",
+    ScreenComponent: ArtistsIFollowOptionsScreen,
   },
   medium: {
     displayText: FilterDisplayName.medium,

--- a/src/lib/Scenes/Collection/Helpers/FilterArtworksHelpers.ts
+++ b/src/lib/Scenes/Collection/Helpers/FilterArtworksHelpers.ts
@@ -1,3 +1,4 @@
+import { FilterScreen } from "lib/Components/FilterModal"
 import { Aggregations, FilterArray } from "lib/utils/ArtworkFiltersStore"
 import { forOwn } from "lodash"
 
@@ -15,6 +16,7 @@ export enum FilterParamName {
   waysToBuyBid = "atAuction",
   waysToBuyInquire = "inquireableOnly",
   waysToBuyMakeOffer = "offerable",
+  artistsIFollow = "includeArtworksByFollowedArtists",
 }
 
 // Types for the parameters passed to Relay
@@ -32,6 +34,7 @@ export enum FilterDisplayName {
   institution = "Institution",
   timePeriod = "Time period",
   waysToBuy = "Ways to buy",
+  artistsIFollow = "Artist",
 }
 
 export interface InitialState {
@@ -58,6 +61,7 @@ const defaultFilterParams = {
   acquireable: false,
   inquireableOnly: false,
   offerable: false,
+  includeArtworksByFollowedArtists: false,
 } as FilterParams
 
 const paramsFromAppliedFilters = (appliedFilters: FilterArray, filterParams: FilterParams) => {
@@ -95,4 +99,64 @@ export const changedFiltersParams = (currentFilterParams: FilterParams, selected
   })
 
   return changedFilters
+}
+
+export const selectedOption = (selectedOptions: FilterArray, filterType: FilterScreen) => {
+  const multiSelectedOptions = selectedOptions.filter((option) => option.paramValue === true)
+
+  if (filterType === "waysToBuy") {
+    const waysToBuyFilterNames = [
+      FilterParamName.waysToBuyBuy,
+      FilterParamName.waysToBuyMakeOffer,
+      FilterParamName.waysToBuyBid,
+      FilterParamName.waysToBuyInquire,
+    ]
+    const waysToBuyOptions = multiSelectedOptions
+      .filter((value) => waysToBuyFilterNames.includes(value.paramName))
+      .map((option) => option.displayText)
+
+    if (waysToBuyOptions.length === 0) {
+      return "All"
+    }
+    return waysToBuyOptions.join(", ")
+  } else if (filterType === "gallery" || filterType === "institution") {
+    const displayText = selectedOptions.find((option) => option.filterKey === filterType)?.displayText
+    if (displayText) {
+      return displayText
+    } else {
+      return "All"
+    }
+  } else if (filterType === "artistsIFollow") {
+    const displayText = multiSelectedOptions.find((option) => option.paramName === "includeArtworksByFollowedArtists")
+      ?.displayText
+    if (displayText) {
+      return displayText
+    } else {
+      return "All"
+    }
+  }
+  return selectedOptions.find((option) => option.paramName === filterType)?.displayText
+}
+
+export type aggregationsType =
+  | ReadonlyArray<{
+      slice: string
+      counts: Array<{ count: number; value: string; name?: string }>
+    }>
+  | []
+
+export const aggregationsWithFollowedArtists = (
+  followedArtistCount: number,
+  artworkAggregations: aggregationsType
+): aggregationsType => {
+  const followedArtistAggregation =
+    followedArtistCount > 0
+      ? [
+          {
+            slice: "FOLLOWED_ARTISTS",
+            counts: [{ count: followedArtistCount, value: "followed_artists" }],
+          },
+        ]
+      : []
+  return [...artworkAggregations, ...followedArtistAggregation]
 }

--- a/src/lib/Scenes/Collection/Helpers/FilterArtworksHelpers.ts
+++ b/src/lib/Scenes/Collection/Helpers/FilterArtworksHelpers.ts
@@ -61,7 +61,6 @@ const defaultFilterParams = {
   acquireable: false,
   inquireableOnly: false,
   offerable: false,
-  includeArtworksByFollowedArtists: false,
 } as FilterParams
 
 const paramsFromAppliedFilters = (appliedFilters: FilterArray, filterParams: FilterParams) => {

--- a/src/lib/Scenes/Collection/Helpers/__tests__/FilterArtworksHelpers-tests.tsx
+++ b/src/lib/Scenes/Collection/Helpers/__tests__/FilterArtworksHelpers-tests.tsx
@@ -1,5 +1,11 @@
 import { FilterArray } from "lib/utils/ArtworkFiltersStore"
-import { changedFiltersParams, filterArtworksParams, FilterParamName } from "../FilterArtworksHelpers"
+import {
+  aggregationsWithFollowedArtists,
+  changedFiltersParams,
+  filterArtworksParams,
+  FilterParamName,
+  selectedOption,
+} from "../FilterArtworksHelpers"
 
 describe("changedFiltersParams helper", () => {
   it("when a medium selection changed and sort selection unchanged", () => {
@@ -185,6 +191,7 @@ describe("filterArtworksParams helper", () => {
       atAuction: false,
       acquireable: false,
       offerable: false,
+      includeArtworksByFollowedArtists: false,
     })
   })
 
@@ -199,6 +206,7 @@ describe("filterArtworksParams helper", () => {
       atAuction: false,
       acquireable: false,
       offerable: false,
+      includeArtworksByFollowedArtists: false,
     })
   })
 
@@ -219,6 +227,7 @@ describe("filterArtworksParams helper", () => {
       atAuction: false,
       acquireable: false,
       offerable: false,
+      includeArtworksByFollowedArtists: false,
     })
   })
 
@@ -269,6 +278,221 @@ describe("filterArtworksParams helper", () => {
       atAuction: false,
       acquireable: true,
       offerable: false,
+      includeArtworksByFollowedArtists: false,
     })
+  })
+})
+
+describe("selectedOption", () => {
+  describe("waysToBuy", () => {
+    it("returns the correct result when nothing is selected", () => {
+      const selectedOptions = [
+        { paramName: FilterParamName.timePeriod, paramValue: "*-*", displayText: "All" },
+        {
+          paramName: FilterParamName.waysToBuyBuy,
+          paramValue: false,
+          displayText: "Buy now",
+        },
+        {
+          paramName: FilterParamName.waysToBuyInquire,
+          paramValue: false,
+          displayText: "Inquire",
+        },
+        {
+          paramName: FilterParamName.waysToBuyMakeOffer,
+          paramValue: false,
+          displayText: "Make offer",
+        },
+        {
+          paramName: FilterParamName.waysToBuyBid,
+          paramValue: false,
+          displayText: "Bid",
+        },
+      ]
+
+      expect(selectedOption(selectedOptions, "waysToBuy")).toEqual("All")
+    })
+
+    it("returns the correct result when one item is selected", () => {
+      const selectedOptions = [
+        { paramName: FilterParamName.timePeriod, paramValue: "*-*", displayText: "All" },
+        {
+          paramName: FilterParamName.waysToBuyBuy,
+          paramValue: true,
+          displayText: "Buy now",
+        },
+        {
+          paramName: FilterParamName.waysToBuyInquire,
+          paramValue: false,
+          displayText: "Inquire",
+        },
+        {
+          paramName: FilterParamName.waysToBuyMakeOffer,
+          paramValue: false,
+          displayText: "Make offer",
+        },
+        {
+          paramName: FilterParamName.waysToBuyBid,
+          paramValue: false,
+          displayText: "Bid",
+        },
+      ]
+
+      expect(selectedOption(selectedOptions, "waysToBuy")).toEqual("Buy now")
+    })
+    it("returns the correct result when multiple items is selected", () => {
+      const selectedOptions = [
+        { paramName: FilterParamName.timePeriod, paramValue: "*-*", displayText: "All" },
+        {
+          paramName: FilterParamName.waysToBuyBuy,
+          paramValue: true,
+          displayText: "Buy now",
+        },
+        {
+          paramName: FilterParamName.waysToBuyInquire,
+          paramValue: false,
+          displayText: "Inquire",
+        },
+        {
+          paramName: FilterParamName.waysToBuyMakeOffer,
+          paramValue: true,
+          displayText: "Make offer",
+        },
+        {
+          paramName: FilterParamName.waysToBuyBid,
+          paramValue: false,
+          displayText: "Bid",
+        },
+      ]
+
+      expect(selectedOption(selectedOptions, "waysToBuy")).toEqual("Buy now, Make offer")
+    })
+  })
+
+  describe("gallery", () => {
+    it("returns the correct value in the default case", () => {
+      const selectedOptions = [{ paramName: FilterParamName.gallery, displayText: "All" }]
+
+      expect(selectedOption(selectedOptions, "gallery")).toEqual("All")
+    })
+
+    it("returns the correct value when an options is selected", () => {
+      const selectedOptions = [{ paramName: FilterParamName.gallery, displayText: "gallery one", filterKey: "gallery" }]
+
+      expect(selectedOption(selectedOptions, "gallery")).toEqual("gallery one")
+    })
+  })
+
+  describe("artistsIFollow", () => {
+    it("returns the correct value in the default case", () => {
+      const selectedOptions = [
+        {
+          paramName: FilterParamName.artistsIFollow,
+          paramValue: false,
+          displayText: "Artists I follow",
+        },
+      ]
+
+      expect(selectedOption(selectedOptions, "artistsIFollow")).toEqual("All")
+    })
+
+    it("returns the correct value when an options is selected", () => {
+      const selectedOptions = [
+        {
+          paramName: FilterParamName.artistsIFollow,
+          paramValue: true,
+          displayText: "Artists I follow",
+        },
+      ]
+
+      expect(selectedOption(selectedOptions, "artistsIFollow")).toEqual("Artists I follow")
+    })
+  })
+})
+
+describe("aggregationsWithFollowedArtists", () => {
+  it("returns the correct structure if there are followed artists", () => {
+    const existingAggregations = [
+      {
+        slice: "MEDIUM",
+        counts: [
+          {
+            count: 4222,
+            value: "prints",
+            name: "Prints",
+          },
+          {
+            count: 176,
+            value: "work-on-paper",
+            name: "Work on Paper",
+          },
+        ],
+      },
+    ]
+
+    expect(aggregationsWithFollowedArtists(10, existingAggregations)).toEqual([
+      {
+        slice: "MEDIUM",
+        counts: [
+          {
+            count: 4222,
+            value: "prints",
+            name: "Prints",
+          },
+          {
+            count: 176,
+            value: "work-on-paper",
+            name: "Work on Paper",
+          },
+        ],
+      },
+      {
+        slice: "FOLLOWED_ARTISTS",
+        counts: [
+          {
+            count: 10,
+            value: "followed_artists",
+          },
+        ],
+      },
+    ])
+  })
+
+  it("returns the correct structure if there are no followed artists", () => {
+    const existingAggregations = [
+      {
+        slice: "MEDIUM",
+        counts: [
+          {
+            count: 4222,
+            value: "prints",
+            name: "Prints",
+          },
+          {
+            count: 176,
+            value: "work-on-paper",
+            name: "Work on Paper",
+          },
+        ],
+      },
+    ]
+
+    expect(aggregationsWithFollowedArtists(0, existingAggregations)).toEqual([
+      {
+        slice: "MEDIUM",
+        counts: [
+          {
+            count: 4222,
+            value: "prints",
+            name: "Prints",
+          },
+          {
+            count: 176,
+            value: "work-on-paper",
+            name: "Work on Paper",
+          },
+        ],
+      },
+    ])
   })
 })

--- a/src/lib/Scenes/Collection/Helpers/__tests__/FilterArtworksHelpers-tests.tsx
+++ b/src/lib/Scenes/Collection/Helpers/__tests__/FilterArtworksHelpers-tests.tsx
@@ -191,7 +191,6 @@ describe("filterArtworksParams helper", () => {
       atAuction: false,
       acquireable: false,
       offerable: false,
-      includeArtworksByFollowedArtists: false,
     })
   })
 
@@ -206,7 +205,6 @@ describe("filterArtworksParams helper", () => {
       atAuction: false,
       acquireable: false,
       offerable: false,
-      includeArtworksByFollowedArtists: false,
     })
   })
 
@@ -227,7 +225,6 @@ describe("filterArtworksParams helper", () => {
       atAuction: false,
       acquireable: false,
       offerable: false,
-      includeArtworksByFollowedArtists: false,
     })
   })
 
@@ -268,6 +265,11 @@ describe("filterArtworksParams helper", () => {
         paramValue: false,
         paramName: FilterParamName.waysToBuyMakeOffer,
       },
+      {
+        displayText: "Artists I follow",
+        paramValue: true,
+        paramName: FilterParamName.artistsIFollow,
+      },
     ]
     expect(filterArtworksParams(appliedFilters)).toEqual({
       sort: "-partner_updated_at",
@@ -278,7 +280,7 @@ describe("filterArtworksParams helper", () => {
       atAuction: false,
       acquireable: true,
       offerable: false,
-      includeArtworksByFollowedArtists: false,
+      includeArtworksByFollowedArtists: true,
     })
   })
 })

--- a/src/lib/Scenes/Fair2/Components/Fair2Artworks.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2Artworks.tsx
@@ -1,20 +1,66 @@
 import { OwnerType } from "@artsy/cohesion"
 import { Fair2Artworks_fair } from "__generated__/Fair2Artworks_fair.graphql"
+import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
 import { InfiniteScrollArtworksGridContainer } from "lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
-import { Box } from "palette"
-import React from "react"
+import { filterArtworksParams } from "lib/Scenes/Collection/Helpers/FilterArtworksHelpers"
+import { ArtworkFilterContext } from "lib/utils/ArtworkFiltersStore"
+import { Schema } from "lib/utils/track"
+import { Box, Separator, Spacer } from "palette"
+import React, { useContext, useEffect } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
+import { useTracking } from "react-tracking"
 
 interface Fair2ArtworksProps {
   fair: Fair2Artworks_fair
   relay: RelayPaginationProp
 }
 
+const PAGE_SIZE = 20
+
 export const Fair2Artworks: React.FC<Fair2ArtworksProps> = ({ fair, relay }) => {
   const artworks = fair.fairArtworks!
+  const { dispatch, state } = useContext(ArtworkFilterContext)
+  const tracking = useTracking()
+  const filterParams = filterArtworksParams(state.appliedFilters)
+
+  const trackClear = (id: string, slug: string) => {
+    tracking.trackEvent({
+      action_name: "clearFilters",
+      context_screen: Schema.ContextModules.ArtworkGrid,
+      context_screen_owner_type: Schema.OwnerEntityTypes.Fair,
+      context_screen_owner_id: id,
+      context_screen_owner_slug: slug,
+      action_type: Schema.ActionTypes.Tap,
+    })
+  }
+
+  useEffect(() => {
+    if (state.applyFilters) {
+      relay.refetchConnection(
+        PAGE_SIZE,
+        (error) => {
+          if (error) {
+            throw new Error("Fair/FairArtworks filter error: " + error.message)
+          }
+        },
+        filterParams
+      )
+    }
+  }, [state.appliedFilters])
+
+  useEffect(() => {
+    dispatch({
+      type: "setAggregations",
+      payload: artworks?.aggregations,
+    })
+  }, [])
 
   if ((artworks?.counts?.total ?? 0) === 0) {
-    return null
+    return (
+      <Box mb="80px">
+        <FilteredArtworkGridZeroState id={fair.internalID} slug={fair.slug} trackClear={trackClear} />
+      </Box>
+    )
   }
 
   return (
@@ -42,11 +88,43 @@ export const Fair2ArtworksFragmentContainer = createPaginationContainer(
         count: { type: "Int", defaultValue: 20 }
         cursor: { type: "String" }
         sort: { type: "String", defaultValue: "-decayed_merch" }
+        medium: { type: "String", defaultValue: "*" }
+        priceRange: { type: "String" }
+        color: { type: "String" }
+        partnerID: { type: "ID" }
+        dimensionRange: { type: "String", defaultValue: "*-*" }
+        majorPeriods: { type: "[String]" }
+        acquireable: { type: "Boolean" }
+        inquireableOnly: { type: "Boolean" }
+        atAuction: { type: "Boolean" }
+        offerable: { type: "Boolean" }
       ) {
         slug
         internalID
-        fairArtworks: filterArtworksConnection(first: 20, sort: $sort, after: $cursor)
-        @connection(key: "Fair_fairArtworks") {
+        fairArtworks: filterArtworksConnection(
+          first: 20
+          after: $cursor
+          sort: $sort
+          medium: $medium
+          priceRange: $priceRange
+          color: $color
+          partnerID: $partnerID
+          dimensionRange: $dimensionRange
+          majorPeriods: $majorPeriods
+          acquireable: $acquireable
+          inquireableOnly: $inquireableOnly
+          atAuction: $atAuction
+          offerable: $offerable
+          aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]
+        ) @connection(key: "Fair_fairArtworks") {
+          aggregations {
+            slice
+            counts {
+              count
+              name
+              value
+            }
+          }
           edges {
             node {
               id
@@ -81,9 +159,39 @@ export const Fair2ArtworksFragmentContainer = createPaginationContainer(
       }
     },
     query: graphql`
-      query Fair2ArtworksInfiniteScrollGridQuery($id: String!, $count: Int!, $cursor: String, $sort: String) {
+      query Fair2ArtworksInfiniteScrollGridQuery(
+        $id: String!
+        $count: Int!
+        $cursor: String
+        $sort: String
+        $medium: String
+        $priceRange: String
+        $color: String
+        $partnerID: ID
+        $dimensionRange: String
+        $majorPeriods: [String]
+        $acquireable: Boolean
+        $inquireableOnly: Boolean
+        $atAuction: Boolean
+        $offerable: Boolean
+      ) {
         fair(id: $id) {
-          ...Fair2Artworks_fair @arguments(count: $count, cursor: $cursor, sort: $sort)
+          ...Fair2Artworks_fair
+          @arguments(
+            count: $count
+            cursor: $cursor
+            sort: $sort
+            medium: $medium
+            color: $color
+            partnerID: $partnerID
+            priceRange: $priceRange
+            dimensionRange: $dimensionRange
+            majorPeriods: $majorPeriods
+            acquireable: $acquireable
+            inquireableOnly: $inquireableOnly
+            atAuction: $atAuction
+            offerable: $offerable
+          )
         }
       }
     `,

--- a/src/lib/Scenes/Fair2/Components/SimpleTabs.tsx
+++ b/src/lib/Scenes/Fair2/Components/SimpleTabs.tsx
@@ -1,32 +1,11 @@
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { Box, color, Flex, Text } from "palette"
-import React, { Dispatch, ReactElement, SetStateAction } from "react"
+import React, { Dispatch, SetStateAction } from "react"
 import { TouchableOpacity, View } from "react-native"
 
 export type TabsType = Array<{
   label: string
-  component: ReactElement
 }>
-
-interface TabChildContentProps {
-  activeTab: number
-  tabs: TabsType
-}
-
-/**
- * Each "tab" in the "tabs" array is an object containing a label and a
- * component reference. This method returns the component for the currently-active
- * tab.
- */
-export const TabChildContent: React.FC<TabChildContentProps> = ({ activeTab, tabs }) => {
-  const tabToShow = tabs ? tabs[activeTab] : null
-
-  if (!tabToShow) {
-    return null
-  }
-
-  return tabToShow.component
-}
 
 interface TabProps {
   label: string

--- a/src/lib/Scenes/Fair2/__tests__/Fair2Artworks-tests.tsx
+++ b/src/lib/Scenes/Fair2/__tests__/Fair2Artworks-tests.tsx
@@ -4,14 +4,29 @@ import {
 } from "__generated__/Fair2ArtworksTestsQuery.graphql"
 import { InfiniteScrollArtworksGridContainer } from "lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
 import { Fair2ArtworksFragmentContainer } from "lib/Scenes/Fair2/Components/Fair2Artworks"
+import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment } from "relay-test-utils"
+import { extractText } from "lib/tests/extractText"
+import { ArtworkFilterContext, ArtworkFilterContextState } from "lib/utils/ArtworkFiltersStore"
 
 jest.unmock("react-relay")
 
 describe("Fair2Artworks", () => {
+  let state: ArtworkFilterContextState
+
+  beforeEach(() => {
+    state = {
+      selectedFilters: [],
+      appliedFilters: [],
+      previouslyAppliedFilters: [],
+      applyFilters: false,
+      aggregations: [],
+    }
+  })
+
   const getWrapper = (fixture = FAIR_2_ARTWORKS_FIXTURE) => {
     const env = createMockEnvironment()
 
@@ -35,8 +50,11 @@ describe("Fair2Artworks", () => {
           if (!props || !props.fair) {
             return null
           }
-
-          return <Fair2ArtworksFragmentContainer fair={props.fair} />
+          return (
+            <ArtworkFilterContext.Provider value={{ state, dispatch: jest.fn() }}>
+              <Fair2ArtworksFragmentContainer fair={props.fair} />
+            </ArtworkFilterContext.Provider>
+          )
         }}
       />
     )
@@ -66,6 +84,9 @@ describe("Fair2Artworks", () => {
     } as Fair2ArtworksTestsQueryRawResponse)
 
     expect(wrapper.root.findAllByType(InfiniteScrollArtworksGridContainer)).toHaveLength(0)
+    expect(wrapper.root.findAllByType(InfiniteScrollArtworksGridContainer)).toHaveLength(0)
+    expect(wrapper.root.findAllByType(FilteredArtworkGridZeroState)).toHaveLength(1)
+    expect(extractText(wrapper.root)).toContain("Unfortunately, there are no works that meet your criteria.")
   })
 })
 
@@ -84,6 +105,7 @@ const FAIR_2_ARTWORKS_FIXTURE: Fair2ArtworksTestsQueryRawResponse = {
         startCursor: "123",
         endCursor: "abc",
       },
+      aggregations: [],
       edges: [
         {
           node: {

--- a/src/lib/Scenes/Fair2/__tests__/Fair2Artworks-tests.tsx
+++ b/src/lib/Scenes/Fair2/__tests__/Fair2Artworks-tests.tsx
@@ -2,15 +2,15 @@ import {
   Fair2ArtworksTestsQuery,
   Fair2ArtworksTestsQueryRawResponse,
 } from "__generated__/Fair2ArtworksTestsQuery.graphql"
+import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
 import { InfiniteScrollArtworksGridContainer } from "lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
 import { Fair2ArtworksFragmentContainer } from "lib/Scenes/Fair2/Components/Fair2Artworks"
-import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
+import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { ArtworkFilterContext, ArtworkFilterContextState } from "lib/utils/ArtworkFiltersStore"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment } from "relay-test-utils"
-import { extractText } from "lib/tests/extractText"
-import { ArtworkFilterContext, ArtworkFilterContextState } from "lib/utils/ArtworkFiltersStore"
 
 jest.unmock("react-relay")
 
@@ -78,6 +78,7 @@ describe("Fair2Artworks", () => {
           edges: [],
           counts: {
             total: 0,
+            followedArtists: 0,
           },
         },
       },
@@ -99,6 +100,7 @@ const FAIR_2_ARTWORKS_FIXTURE: Fair2ArtworksTestsQueryRawResponse = {
       id: "fa123",
       counts: {
         total: 2,
+        followedArtists: 0,
       },
       pageInfo: {
         hasNextPage: false,

--- a/src/lib/utils/ArtworkFiltersStore.tsx
+++ b/src/lib/utils/ArtworkFiltersStore.tsx
@@ -132,6 +132,7 @@ export const ParamDefaultValues = {
   offerable: false,
   atAuction: false,
   acquireable: false,
+  includeArtworksByFollowedArtists: false,
 }
 
 const defaultFilterOptions: Record<FilterParamName, string | boolean | undefined> = {
@@ -146,6 +147,7 @@ const defaultFilterOptions: Record<FilterParamName, string | boolean | undefined
   offerable: ParamDefaultValues.offerable,
   atAuction: ParamDefaultValues.atAuction,
   acquireable: ParamDefaultValues.acquireable,
+  includeArtworksByFollowedArtists: ParamDefaultValues.includeArtworksByFollowedArtists,
 }
 
 export const useSelectedOptionsDisplay = (): FilterArray => {
@@ -186,6 +188,11 @@ export const useSelectedOptionsDisplay = (): FilterArray => {
       paramName: FilterParamName.waysToBuyBid,
       paramValue: false,
       displayText: "Bid",
+    },
+    {
+      paramName: FilterParamName.artistsIFollow,
+      paramValue: false,
+      displayText: "Artists I follow",
     },
   ]
 
@@ -266,6 +273,7 @@ export type AggregationName =
   | "MAJOR_PERIOD"
   | "MEDIUM"
   | "PRICE_RANGE"
+  | "FOLLOWED_ARTISTS"
 
 export type Aggregations = Array<{
   slice: AggregationName


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-2216]

### Description

This PR adds the ability filter a fair by "Artists I Follow". For the most part, I was able to follow existing patterns but refactored slightly to make it easier to include the new aggregation/filter.

Adding the default filters at this point is trivial boilerplate (the filter button was included in a separate PR).

![followfilter](https://user-images.githubusercontent.com/2081340/94687213-f2e2e380-02f9-11eb-99c0-87917c4aca18.gif)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [X] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [X] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [X] I have documented any follow-up work that this PR will require, or it does not require any.
- [X] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [X] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434
[FX-2216]: https://artsyproduct.atlassian.net/browse/FX-2216