### PR TITLE
Upload photos to S3 and pass off urls to MP

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -7181,6 +7181,7 @@ input MyCollectionCreateArtworkInput {
   depth: String
   editionNumber: String
   editionSize: String
+  externalImageUrls: [String]
   height: String
   medium: String!
   metric: String

--- a/src/__generated__/MyCollectionArtworkModelCreateArtworkMutation.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkModelCreateArtworkMutation.graphql.ts
@@ -1,6 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
-/* @relayHash 55d94b960bf6042d4cf8df0e06a60184 */
+/* @relayHash e64300af8f7059b3c6ee8c860498e14e */
 
 import { ConcreteRequest } from "relay-runtime";
 export type MyCollectionCreateArtworkInput = {
@@ -13,6 +13,7 @@ export type MyCollectionCreateArtworkInput = {
     depth?: string | null;
     editionNumber?: string | null;
     editionSize?: string | null;
+    externalImageUrls?: Array<string | null> | null;
     height?: string | null;
     medium: string;
     metric?: string | null;


### PR DESCRIPTION
Note: This PR relies on https://github.com/artsy/metaphysics/pull/2742 and the update to the schema that it adds.

The purpose of this PR is to begin supporting the uploading of My Collection artwork images. I worked down the stack to support this behavior so it is now possible. For the UX in the app I did the dumbest thing possible: block sending the mutation until all the photos have been uploaded and don't start uploading until the "Create" button is pressed.

This is almost certainly NOT what we'll end up shipping to end users, but it's a start! And it moves us from zero support for images to one that is naive but possible. I hope to demonstrate how this works today and then get feedback and improve things.