### PR TITLE
feat: full artwork details in inquiry modal; improve UI (PURCHASE-2154)

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -24,6 +24,7 @@ upcoming:
     - Add new Show2 view, behind lab option - roop, sarah
     - Adds tracking for Fair2 - will
     - Adds ability to route to new fair view via option - sweir
+    - Include full artwork details in inquiry modal; improve animation - starsirius
   user_facing:
     - Fix navigation bug on Artwork consign button - david
     - Add auction lots rail to the auctions screen - mounir

--- a/src/__generated__/ArtworkAboveTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtworkAboveTheFoldQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 48ee80b12e6c017b8f6d84600eaac61f */
+/* @relayHash 7c7010f22fa8fead5c5fd3c1eaaf70d6 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -229,12 +229,28 @@ fragment CollapsibleArtworkDetails_artwork on Artwork {
   internalID
   title
   date
+  saleMessage
+  attributionClass {
+    name
+    id
+  }
+  category
+  manufacturer
+  publisher
   medium
+  conditionDescription {
+    details
+  }
+  certificateOfAuthenticity {
+    details
+  }
+  framed {
+    details
+  }
   dimensions {
     in
     cm
   }
-  editionOf
   signatureInfo {
     details
   }
@@ -524,7 +540,16 @@ v15 = {
   "kind": "ScalarField",
   "name": "editionOf",
   "storageKey": null
-};
+},
+v16 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "details",
+    "storageKey": null
+  }
+];
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -1143,15 +1168,7 @@ return {
             "kind": "LinkedField",
             "name": "signatureInfo",
             "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "details",
-                "storageKey": null
-              }
-            ],
+            "selections": (v16/*: any*/),
             "storageKey": null
           },
           {
@@ -1162,6 +1179,67 @@ return {
             "name": "artist",
             "plural": false,
             "selections": (v9/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AttributionClass",
+            "kind": "LinkedField",
+            "name": "attributionClass",
+            "plural": false,
+            "selections": (v9/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "category",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "manufacturer",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "publisher",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "conditionDescription",
+            "plural": false,
+            "selections": (v16/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "certificateOfAuthenticity",
+            "plural": false,
+            "selections": (v16/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "framed",
+            "plural": false,
+            "selections": (v16/*: any*/),
             "storageKey": null
           },
           {
@@ -1245,7 +1323,7 @@ return {
     ]
   },
   "params": {
-    "id": "48ee80b12e6c017b8f6d84600eaac61f",
+    "id": "7c7010f22fa8fead5c5fd3c1eaaf70d6",
     "metadata": {},
     "name": "ArtworkAboveTheFoldQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtworkAboveTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtworkAboveTheFoldQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 2e472e6e43d65c33e8430893fee3a6a8 */
+/* @relayHash 48ee80b12e6c017b8f6d84600eaac61f */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -238,10 +238,7 @@ fragment CollapsibleArtworkDetails_artwork on Artwork {
   signatureInfo {
     details
   }
-  artist {
-    name
-    id
-  }
+  artistNames
 }
 
 fragment CommercialButtons_artwork on Artwork {
@@ -1171,6 +1168,13 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "artistNames",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "shippingOrigin",
             "storageKey": null
           },
@@ -1241,7 +1245,7 @@ return {
     ]
   },
   "params": {
-    "id": "2e472e6e43d65c33e8430893fee3a6a8",
+    "id": "48ee80b12e6c017b8f6d84600eaac61f",
     "metadata": {},
     "name": "ArtworkAboveTheFoldQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtworkRefetchQuery.graphql.ts
+++ b/src/__generated__/ArtworkRefetchQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash a2c27a5a938c6980ff60086e94916408 */
+/* @relayHash 430aa6f7d950e7efbaf5240dcd8f1cd0 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -481,10 +481,7 @@ fragment CollapsibleArtworkDetails_artwork on Artwork {
   signatureInfo {
     details
   }
-  artist {
-    name
-    id
-  }
+  artistNames
 }
 
 fragment CommercialButtons_artwork on Artwork {
@@ -1007,10 +1004,17 @@ v31 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "__typename",
+  "name": "artistNames",
   "storageKey": null
 },
 v32 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v33 = {
   "alias": null,
   "args": null,
   "concreteType": "Image",
@@ -1020,25 +1024,18 @@ v32 = {
   "selections": (v12/*: any*/),
   "storageKey": null
 },
-v33 = {
+v34 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "exhibitionPeriod",
   "storageKey": null
 },
-v34 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "aspectRatio",
-  "storageKey": null
-},
 v35 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "artistNames",
+  "name": "aspectRatio",
   "storageKey": null
 },
 v36 = {
@@ -1760,6 +1757,7 @@ return {
             ],
             "storageKey": null
           },
+          (v31/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -1931,7 +1929,7 @@ return {
             "name": "context",
             "plural": false,
             "selections": [
-              (v31/*: any*/),
+              (v32/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -1947,7 +1945,7 @@ return {
                     "name": "formattedStartDateTime",
                     "storageKey": null
                   },
-                  (v32/*: any*/)
+                  (v33/*: any*/)
                 ],
                 "type": "Sale",
                 "abstractKey": null
@@ -1966,7 +1964,7 @@ return {
                   (v2/*: any*/),
                   (v7/*: any*/),
                   (v6/*: any*/),
-                  (v33/*: any*/),
+                  (v34/*: any*/),
                   (v13/*: any*/)
                 ],
                 "type": "Fair",
@@ -1980,7 +1978,7 @@ return {
                   (v4/*: any*/),
                   (v7/*: any*/),
                   (v6/*: any*/),
-                  (v33/*: any*/),
+                  (v34/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1988,7 +1986,7 @@ return {
                     "name": "isFollowed",
                     "storageKey": null
                   },
-                  (v32/*: any*/)
+                  (v33/*: any*/)
                 ],
                 "type": "Show",
                 "abstractKey": null
@@ -2004,7 +2002,7 @@ return {
             "name": "contextGrids",
             "plural": true,
             "selections": [
-              (v31/*: any*/),
+              (v32/*: any*/),
               {
                 "alias": "artworks",
                 "args": [
@@ -2064,7 +2062,7 @@ return {
                                 "name": "url",
                                 "storageKey": "url(version:\"large\")"
                               },
-                              (v34/*: any*/)
+                              (v35/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -2073,7 +2071,7 @@ return {
                           (v28/*: any*/),
                           (v4/*: any*/),
                           (v3/*: any*/),
-                          (v35/*: any*/),
+                          (v31/*: any*/),
                           (v6/*: any*/),
                           {
                             "alias": null,
@@ -2203,7 +2201,7 @@ return {
                                   (v4/*: any*/),
                                   (v3/*: any*/),
                                   (v6/*: any*/),
-                                  (v35/*: any*/),
+                                  (v31/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -2219,7 +2217,7 @@ return {
                                         "name": "imageURL",
                                         "storageKey": null
                                       },
-                                      (v34/*: any*/)
+                                      (v35/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -2283,7 +2281,7 @@ return {
     ]
   },
   "params": {
-    "id": "a2c27a5a938c6980ff60086e94916408",
+    "id": "430aa6f7d950e7efbaf5240dcd8f1cd0",
     "metadata": {},
     "name": "ArtworkRefetchQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtworkRefetchQuery.graphql.ts
+++ b/src/__generated__/ArtworkRefetchQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 430aa6f7d950e7efbaf5240dcd8f1cd0 */
+/* @relayHash b46ddef803d769a301bcbb21eb3d15fa */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -472,12 +472,28 @@ fragment CollapsibleArtworkDetails_artwork on Artwork {
   internalID
   title
   date
+  saleMessage
+  attributionClass {
+    name
+    id
+  }
+  category
+  manufacturer
+  publisher
   medium
+  conditionDescription {
+    details
+  }
+  certificateOfAuthenticity {
+    details
+  }
+  framed {
+    details
+  }
   dimensions {
     in
     cm
   }
-  editionOf
   signatureInfo {
     details
   }
@@ -874,48 +890,49 @@ v19 = {
   "name": "endAt",
   "storageKey": null
 },
-v20 = {
+v20 = [
+  (v7/*: any*/),
+  (v2/*: any*/)
+],
+v21 = {
   "alias": null,
   "args": null,
   "concreteType": "Partner",
   "kind": "LinkedField",
   "name": "partner",
   "plural": false,
-  "selections": [
-    (v7/*: any*/),
-    (v2/*: any*/)
-  ],
-  "storageKey": null
-},
-v21 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "date",
+  "selections": (v20/*: any*/),
   "storageKey": null
 },
 v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "lotLabel",
+  "name": "date",
   "storageKey": null
 },
 v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "cents",
+  "name": "lotLabel",
   "storageKey": null
 },
 v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "display",
+  "name": "cents",
   "storageKey": null
 },
 v25 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "display",
+  "storageKey": null
+},
+v26 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCurrentBid",
@@ -923,11 +940,11 @@ v25 = {
   "name": "currentBid",
   "plural": false,
   "selections": [
-    (v24/*: any*/)
+    (v25/*: any*/)
   ],
   "storageKey": null
 },
-v26 = {
+v27 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCounts",
@@ -945,7 +962,7 @@ v26 = {
   ],
   "storageKey": null
 },
-v27 = {
+v28 = {
   "alias": null,
   "args": null,
   "concreteType": "dimensions",
@@ -970,21 +987,21 @@ v27 = {
   ],
   "storageKey": null
 },
-v28 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "saleMessage",
   "storageKey": null
 },
-v29 = {
+v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "editionOf",
   "storageKey": null
 },
-v30 = [
+v31 = [
   {
     "alias": null,
     "args": null,
@@ -1000,21 +1017,21 @@ v30 = [
     "storageKey": null
   }
 ],
-v31 = {
+v32 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "artistNames",
   "storageKey": null
 },
-v32 = {
+v33 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v33 = {
+v34 = {
   "alias": null,
   "args": null,
   "concreteType": "Image",
@@ -1024,21 +1041,21 @@ v33 = {
   "selections": (v12/*: any*/),
   "storageKey": null
 },
-v34 = {
+v35 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "exhibitionPeriod",
   "storageKey": null
 },
-v35 = {
+v36 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "aspectRatio",
   "storageKey": null
 },
-v36 = {
+v37 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -1248,7 +1265,7 @@ return {
                 "name": "isBenefit",
                 "storageKey": null
               },
-              (v20/*: any*/),
+              (v21/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1294,7 +1311,7 @@ return {
             "name": "medium",
             "storageKey": null
           },
-          (v21/*: any*/),
+          (v22/*: any*/),
           {
             "alias": "cultural_maker",
             "args": null,
@@ -1310,7 +1327,7 @@ return {
             "name": "saleArtwork",
             "plural": false,
             "selections": [
-              (v22/*: any*/),
+              (v23/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1327,7 +1344,7 @@ return {
                 "name": "increments",
                 "plural": true,
                 "selections": [
-                  (v23/*: any*/)
+                  (v24/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -1338,8 +1355,8 @@ return {
                 "name": "reserveMessage",
                 "storageKey": null
               },
-              (v25/*: any*/),
-              (v26/*: any*/)
+              (v26/*: any*/),
+              (v27/*: any*/)
             ],
             "storageKey": null
           },
@@ -1418,7 +1435,7 @@ return {
             ],
             "storageKey": null
           },
-          (v27/*: any*/),
+          (v28/*: any*/),
           {
             "alias": "edition_of",
             "args": null,
@@ -1568,7 +1585,7 @@ return {
             "name": "availability",
             "storageKey": null
           },
-          (v28/*: any*/),
+          (v29/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -1586,9 +1603,9 @@ return {
             "selections": [
               (v2/*: any*/),
               (v3/*: any*/),
-              (v28/*: any*/),
               (v29/*: any*/),
-              (v27/*: any*/)
+              (v30/*: any*/),
+              (v28/*: any*/)
             ],
             "storageKey": null
           },
@@ -1629,8 +1646,8 @@ return {
                     "name": "maxBid",
                     "plural": false,
                     "selections": [
-                      (v23/*: any*/),
-                      (v24/*: any*/)
+                      (v24/*: any*/),
+                      (v25/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -1667,7 +1684,7 @@ return {
             "name": "isPriceHidden",
             "storageKey": null
           },
-          (v29/*: any*/),
+          (v30/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -1675,7 +1692,7 @@ return {
             "kind": "LinkedField",
             "name": "signatureInfo",
             "plural": false,
-            "selections": (v30/*: any*/),
+            "selections": (v31/*: any*/),
             "storageKey": null
           },
           {
@@ -1757,7 +1774,68 @@ return {
             ],
             "storageKey": null
           },
-          (v31/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AttributionClass",
+            "kind": "LinkedField",
+            "name": "attributionClass",
+            "plural": false,
+            "selections": (v20/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "category",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "manufacturer",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "publisher",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "conditionDescription",
+            "plural": false,
+            "selections": (v31/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "certificateOfAuthenticity",
+            "plural": false,
+            "selections": (v31/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "framed",
+            "plural": false,
+            "selections": (v31/*: any*/),
+            "storageKey": null
+          },
+          (v32/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -1846,24 +1924,7 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "category",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
             "name": "canRequestLotConditionsReport",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "ArtworkInfoRow",
-            "kind": "LinkedField",
-            "name": "conditionDescription",
-            "plural": false,
-            "selections": (v30/*: any*/),
             "storageKey": null
           },
           {
@@ -1876,42 +1937,8 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "ArtworkInfoRow",
-            "kind": "LinkedField",
-            "name": "certificateOfAuthenticity",
-            "plural": false,
-            "selections": (v30/*: any*/),
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "ArtworkInfoRow",
-            "kind": "LinkedField",
-            "name": "framed",
-            "plural": false,
-            "selections": (v30/*: any*/),
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
             "kind": "ScalarField",
             "name": "series",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "publisher",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "manufacturer",
             "storageKey": null
           },
           {
@@ -1929,7 +1956,7 @@ return {
             "name": "context",
             "plural": false,
             "selections": [
-              (v32/*: any*/),
+              (v33/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -1945,7 +1972,7 @@ return {
                     "name": "formattedStartDateTime",
                     "storageKey": null
                   },
-                  (v33/*: any*/)
+                  (v34/*: any*/)
                 ],
                 "type": "Sale",
                 "abstractKey": null
@@ -1964,7 +1991,7 @@ return {
                   (v2/*: any*/),
                   (v7/*: any*/),
                   (v6/*: any*/),
-                  (v34/*: any*/),
+                  (v35/*: any*/),
                   (v13/*: any*/)
                 ],
                 "type": "Fair",
@@ -1978,7 +2005,7 @@ return {
                   (v4/*: any*/),
                   (v7/*: any*/),
                   (v6/*: any*/),
-                  (v34/*: any*/),
+                  (v35/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1986,7 +2013,7 @@ return {
                     "name": "isFollowed",
                     "storageKey": null
                   },
-                  (v33/*: any*/)
+                  (v34/*: any*/)
                 ],
                 "type": "Show",
                 "abstractKey": null
@@ -2002,7 +2029,7 @@ return {
             "name": "contextGrids",
             "plural": true,
             "selections": [
-              (v32/*: any*/),
+              (v33/*: any*/),
               {
                 "alias": "artworks",
                 "args": [
@@ -2062,16 +2089,16 @@ return {
                                 "name": "url",
                                 "storageKey": "url(version:\"large\")"
                               },
-                              (v35/*: any*/)
+                              (v36/*: any*/)
                             ],
                             "storageKey": null
                           },
                           (v5/*: any*/),
-                          (v21/*: any*/),
-                          (v28/*: any*/),
+                          (v22/*: any*/),
+                          (v29/*: any*/),
                           (v4/*: any*/),
                           (v3/*: any*/),
-                          (v31/*: any*/),
+                          (v32/*: any*/),
                           (v6/*: any*/),
                           {
                             "alias": null,
@@ -2083,7 +2110,7 @@ return {
                             "selections": [
                               (v16/*: any*/),
                               (v17/*: any*/),
-                              (v36/*: any*/),
+                              (v37/*: any*/),
                               (v19/*: any*/),
                               (v2/*: any*/)
                             ],
@@ -2097,14 +2124,14 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
+                              (v27/*: any*/),
                               (v26/*: any*/),
-                              (v25/*: any*/),
-                              (v22/*: any*/),
+                              (v23/*: any*/),
                               (v2/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v20/*: any*/)
+                          (v21/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -2201,7 +2228,7 @@ return {
                                   (v4/*: any*/),
                                   (v3/*: any*/),
                                   (v6/*: any*/),
-                                  (v31/*: any*/),
+                                  (v32/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -2217,7 +2244,7 @@ return {
                                         "name": "imageURL",
                                         "storageKey": null
                                       },
-                                      (v35/*: any*/)
+                                      (v36/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -2231,7 +2258,7 @@ return {
                                     "selections": [
                                       (v16/*: any*/),
                                       (v17/*: any*/),
-                                      (v36/*: any*/),
+                                      (v37/*: any*/),
                                       (v2/*: any*/)
                                     ],
                                     "storageKey": null
@@ -2244,16 +2271,16 @@ return {
                                     "name": "saleArtwork",
                                     "plural": false,
                                     "selections": [
+                                      (v27/*: any*/),
                                       (v26/*: any*/),
-                                      (v25/*: any*/),
                                       (v2/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
-                                  (v28/*: any*/),
+                                  (v29/*: any*/),
                                   (v5/*: any*/),
-                                  (v21/*: any*/),
-                                  (v20/*: any*/)
+                                  (v22/*: any*/),
+                                  (v21/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -2281,7 +2308,7 @@ return {
     ]
   },
   "params": {
-    "id": "430aa6f7d950e7efbaf5240dcd8f1cd0",
+    "id": "b46ddef803d769a301bcbb21eb3d15fa",
     "metadata": {},
     "name": "ArtworkRefetchQuery",
     "operationKind": "query",

--- a/src/__generated__/CollapsibleArtworkDetailsTestsQuery.graphql.ts
+++ b/src/__generated__/CollapsibleArtworkDetailsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 722738e21ca4461c6ccd0a847e89a70e */
+/* @relayHash d761eeff945579e4683a3915d26544eb */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -35,12 +35,28 @@ fragment CollapsibleArtworkDetails_artwork on Artwork {
   internalID
   title
   date
+  saleMessage
+  attributionClass {
+    name
+    id
+  }
+  category
+  manufacturer
+  publisher
   medium
+  conditionDescription {
+    details
+  }
+  certificateOfAuthenticity {
+    details
+  }
+  framed {
+    details
+  }
   dimensions {
     in
     cm
   }
-  editionOf
   signatureInfo {
     details
   }
@@ -57,18 +73,40 @@ var v0 = [
   }
 ],
 v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "details",
+    "storageKey": null
+  }
+],
+v3 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v2 = {
+v4 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v3 = {
+v5 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "ArtworkInfoRow"
+},
+v6 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -172,7 +210,84 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "saleMessage",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AttributionClass",
+            "kind": "LinkedField",
+            "name": "attributionClass",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              },
+              (v1/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "category",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "manufacturer",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "publisher",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "medium",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "conditionDescription",
+            "plural": false,
+            "selections": (v2/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "certificateOfAuthenticity",
+            "plural": false,
+            "selections": (v2/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "framed",
+            "plural": false,
+            "selections": (v2/*: any*/),
             "storageKey": null
           },
           {
@@ -203,26 +318,11 @@ return {
           {
             "alias": null,
             "args": null,
-            "kind": "ScalarField",
-            "name": "editionOf",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
             "concreteType": "ArtworkInfoRow",
             "kind": "LinkedField",
             "name": "signatureInfo",
             "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "details",
-                "storageKey": null
-              }
-            ],
+            "selections": (v2/*: any*/),
             "storageKey": null
           },
           {
@@ -232,20 +332,14 @@ return {
             "name": "artistNames",
             "storageKey": null
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          }
+          (v1/*: any*/)
         ],
         "storageKey": "artwork(id:\"some-slug\")"
       }
     ]
   },
   "params": {
-    "id": "722738e21ca4461c6ccd0a847e89a70e",
+    "id": "d761eeff945579e4683a3915d26544eb",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artwork": {
@@ -254,37 +348,49 @@ return {
           "plural": false,
           "type": "Artwork"
         },
-        "artwork.artistNames": (v1/*: any*/),
-        "artwork.date": (v1/*: any*/),
+        "artwork.artistNames": (v3/*: any*/),
+        "artwork.attributionClass": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "AttributionClass"
+        },
+        "artwork.attributionClass.id": (v4/*: any*/),
+        "artwork.attributionClass.name": (v3/*: any*/),
+        "artwork.category": (v3/*: any*/),
+        "artwork.certificateOfAuthenticity": (v5/*: any*/),
+        "artwork.certificateOfAuthenticity.details": (v3/*: any*/),
+        "artwork.conditionDescription": (v5/*: any*/),
+        "artwork.conditionDescription.details": (v3/*: any*/),
+        "artwork.date": (v3/*: any*/),
         "artwork.dimensions": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "dimensions"
         },
-        "artwork.dimensions.cm": (v1/*: any*/),
-        "artwork.dimensions.in": (v1/*: any*/),
-        "artwork.editionOf": (v1/*: any*/),
-        "artwork.id": (v2/*: any*/),
+        "artwork.dimensions.cm": (v3/*: any*/),
+        "artwork.dimensions.in": (v3/*: any*/),
+        "artwork.framed": (v5/*: any*/),
+        "artwork.framed.details": (v3/*: any*/),
+        "artwork.id": (v4/*: any*/),
         "artwork.image": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "artwork.image.height": (v3/*: any*/),
-        "artwork.image.url": (v1/*: any*/),
-        "artwork.image.width": (v3/*: any*/),
-        "artwork.internalID": (v2/*: any*/),
-        "artwork.medium": (v1/*: any*/),
-        "artwork.signatureInfo": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ArtworkInfoRow"
-        },
-        "artwork.signatureInfo.details": (v1/*: any*/),
-        "artwork.title": (v1/*: any*/)
+        "artwork.image.height": (v6/*: any*/),
+        "artwork.image.url": (v3/*: any*/),
+        "artwork.image.width": (v6/*: any*/),
+        "artwork.internalID": (v4/*: any*/),
+        "artwork.manufacturer": (v3/*: any*/),
+        "artwork.medium": (v3/*: any*/),
+        "artwork.publisher": (v3/*: any*/),
+        "artwork.saleMessage": (v3/*: any*/),
+        "artwork.signatureInfo": (v5/*: any*/),
+        "artwork.signatureInfo.details": (v3/*: any*/),
+        "artwork.title": (v3/*: any*/)
       }
     },
     "name": "CollapsibleArtworkDetailsTestsQuery",

--- a/src/__generated__/CollapsibleArtworkDetailsTestsQuery.graphql.ts
+++ b/src/__generated__/CollapsibleArtworkDetailsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash ad7757da531ea630b4ec6e9073539f13 */
+/* @relayHash 722738e21ca4461c6ccd0a847e89a70e */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -44,10 +44,7 @@ fragment CollapsibleArtworkDetails_artwork on Artwork {
   signatureInfo {
     details
   }
-  artist {
-    name
-    id
-  }
+  artistNames
 }
 */
 
@@ -60,11 +57,10 @@ var v0 = [
   }
 ],
 v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
 },
 v2 = {
   "enumValues": null,
@@ -73,12 +69,6 @@ v2 = {
   "type": "ID"
 },
 v3 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "String"
-},
-v4 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -238,30 +228,24 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "Artist",
-            "kind": "LinkedField",
-            "name": "artist",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "name",
-                "storageKey": null
-              },
-              (v1/*: any*/)
-            ],
+            "kind": "ScalarField",
+            "name": "artistNames",
             "storageKey": null
           },
-          (v1/*: any*/)
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
         ],
         "storageKey": "artwork(id:\"some-slug\")"
       }
     ]
   },
   "params": {
-    "id": "ad7757da531ea630b4ec6e9073539f13",
+    "id": "722738e21ca4461c6ccd0a847e89a70e",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artwork": {
@@ -270,24 +254,17 @@ return {
           "plural": false,
           "type": "Artwork"
         },
-        "artwork.artist": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Artist"
-        },
-        "artwork.artist.id": (v2/*: any*/),
-        "artwork.artist.name": (v3/*: any*/),
-        "artwork.date": (v3/*: any*/),
+        "artwork.artistNames": (v1/*: any*/),
+        "artwork.date": (v1/*: any*/),
         "artwork.dimensions": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "dimensions"
         },
-        "artwork.dimensions.cm": (v3/*: any*/),
-        "artwork.dimensions.in": (v3/*: any*/),
-        "artwork.editionOf": (v3/*: any*/),
+        "artwork.dimensions.cm": (v1/*: any*/),
+        "artwork.dimensions.in": (v1/*: any*/),
+        "artwork.editionOf": (v1/*: any*/),
         "artwork.id": (v2/*: any*/),
         "artwork.image": {
           "enumValues": null,
@@ -295,19 +272,19 @@ return {
           "plural": false,
           "type": "Image"
         },
-        "artwork.image.height": (v4/*: any*/),
-        "artwork.image.url": (v3/*: any*/),
-        "artwork.image.width": (v4/*: any*/),
+        "artwork.image.height": (v3/*: any*/),
+        "artwork.image.url": (v1/*: any*/),
+        "artwork.image.width": (v3/*: any*/),
         "artwork.internalID": (v2/*: any*/),
-        "artwork.medium": (v3/*: any*/),
+        "artwork.medium": (v1/*: any*/),
         "artwork.signatureInfo": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtworkInfoRow"
         },
-        "artwork.signatureInfo.details": (v3/*: any*/),
-        "artwork.title": (v3/*: any*/)
+        "artwork.signatureInfo.details": (v1/*: any*/),
+        "artwork.title": (v1/*: any*/)
       }
     },
     "name": "CollapsibleArtworkDetailsTestsQuery",

--- a/src/__generated__/CollapsibleArtworkDetails_artwork.graphql.ts
+++ b/src/__generated__/CollapsibleArtworkDetails_artwork.graphql.ts
@@ -22,9 +22,7 @@ export type CollapsibleArtworkDetails_artwork = {
     readonly signatureInfo: {
         readonly details: string | null;
     } | null;
-    readonly artist: {
-        readonly name: string | null;
-    } | null;
+    readonly artistNames: string | null;
     readonly " $refType": "CollapsibleArtworkDetails_artwork";
 };
 export type CollapsibleArtworkDetails_artwork$data = CollapsibleArtworkDetails_artwork;
@@ -154,24 +152,13 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
-      "concreteType": "Artist",
-      "kind": "LinkedField",
-      "name": "artist",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "name",
-          "storageKey": null
-        }
-      ],
+      "kind": "ScalarField",
+      "name": "artistNames",
       "storageKey": null
     }
   ],
   "type": "Artwork",
   "abstractKey": null
 };
-(node as any).hash = '78faf77994e0d624d950f984f7b98876';
+(node as any).hash = 'ea27830e66ce26507000d6a7a74807c1';
 export default node;

--- a/src/__generated__/CollapsibleArtworkDetails_artwork.graphql.ts
+++ b/src/__generated__/CollapsibleArtworkDetails_artwork.graphql.ts
@@ -13,12 +13,27 @@ export type CollapsibleArtworkDetails_artwork = {
     readonly internalID: string;
     readonly title: string | null;
     readonly date: string | null;
+    readonly saleMessage: string | null;
+    readonly attributionClass: {
+        readonly name: string | null;
+    } | null;
+    readonly category: string | null;
+    readonly manufacturer: string | null;
+    readonly publisher: string | null;
     readonly medium: string | null;
+    readonly conditionDescription: {
+        readonly details: string | null;
+    } | null;
+    readonly certificateOfAuthenticity: {
+        readonly details: string | null;
+    } | null;
+    readonly framed: {
+        readonly details: string | null;
+    } | null;
     readonly dimensions: {
         readonly in: string | null;
         readonly cm: string | null;
     } | null;
-    readonly editionOf: string | null;
     readonly signatureInfo: {
         readonly details: string | null;
     } | null;
@@ -33,7 +48,17 @@ export type CollapsibleArtworkDetails_artwork$key = {
 
 
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "details",
+    "storageKey": null
+  }
+];
+return {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
@@ -96,7 +121,83 @@ const node: ReaderFragment = {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
+      "name": "saleMessage",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AttributionClass",
+      "kind": "LinkedField",
+      "name": "attributionClass",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "category",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "manufacturer",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "publisher",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
       "name": "medium",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ArtworkInfoRow",
+      "kind": "LinkedField",
+      "name": "conditionDescription",
+      "plural": false,
+      "selections": (v0/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ArtworkInfoRow",
+      "kind": "LinkedField",
+      "name": "certificateOfAuthenticity",
+      "plural": false,
+      "selections": (v0/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ArtworkInfoRow",
+      "kind": "LinkedField",
+      "name": "framed",
+      "plural": false,
+      "selections": (v0/*: any*/),
       "storageKey": null
     },
     {
@@ -127,26 +228,11 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
-      "kind": "ScalarField",
-      "name": "editionOf",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
       "concreteType": "ArtworkInfoRow",
       "kind": "LinkedField",
       "name": "signatureInfo",
       "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "details",
-          "storageKey": null
-        }
-      ],
+      "selections": (v0/*: any*/),
       "storageKey": null
     },
     {
@@ -160,5 +246,6 @@ const node: ReaderFragment = {
   "type": "Artwork",
   "abstractKey": null
 };
-(node as any).hash = 'ea27830e66ce26507000d6a7a74807c1';
+})();
+(node as any).hash = '0be4180137ff27fdb1133d7e8c323982';
 export default node;

--- a/src/__generated__/CommercialButtonsTestsMutationQuery.graphql.ts
+++ b/src/__generated__/CommercialButtonsTestsMutationQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 7cc7ba155d6b8b5e06fa6f27bddf0626 */
+/* @relayHash cf19fd56ccc7d96fd7c548cc6e0d374f */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -73,6 +73,7 @@ export type CommercialButtonsTestsMutationQueryRawResponse = {
             readonly name: string | null;
             readonly id: string;
         }) | null;
+        readonly artistNames: string | null;
         readonly id: string;
     }) | null;
 };
@@ -146,10 +147,7 @@ fragment CollapsibleArtworkDetails_artwork on Artwork {
   signatureInfo {
     details
   }
-  artist {
-    name
-    id
-  }
+  artistNames
 }
 
 fragment CommercialButtons_artwork on Artwork {
@@ -606,6 +604,13 @@ return {
             ],
             "storageKey": null
           },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "artistNames",
+            "storageKey": null
+          },
           (v2/*: any*/)
         ],
         "storageKey": "artwork(id:\"artworkID\")"
@@ -613,7 +618,7 @@ return {
     ]
   },
   "params": {
-    "id": "7cc7ba155d6b8b5e06fa6f27bddf0626",
+    "id": "cf19fd56ccc7d96fd7c548cc6e0d374f",
     "metadata": {},
     "name": "CommercialButtonsTestsMutationQuery",
     "operationKind": "query",

--- a/src/__generated__/CommercialButtonsTestsMutationQuery.graphql.ts
+++ b/src/__generated__/CommercialButtonsTestsMutationQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash cf19fd56ccc7d96fd7c548cc6e0d374f */
+/* @relayHash 13689a8254c789588af2d63804ae16d8 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -73,6 +73,22 @@ export type CommercialButtonsTestsMutationQueryRawResponse = {
             readonly name: string | null;
             readonly id: string;
         }) | null;
+        readonly attributionClass: ({
+            readonly name: string | null;
+            readonly id: string;
+        }) | null;
+        readonly category: string | null;
+        readonly manufacturer: string | null;
+        readonly publisher: string | null;
+        readonly conditionDescription: ({
+            readonly details: string | null;
+        }) | null;
+        readonly certificateOfAuthenticity: ({
+            readonly details: string | null;
+        }) | null;
+        readonly framed: ({
+            readonly details: string | null;
+        }) | null;
         readonly artistNames: string | null;
         readonly id: string;
     }) | null;
@@ -138,12 +154,28 @@ fragment CollapsibleArtworkDetails_artwork on Artwork {
   internalID
   title
   date
+  saleMessage
+  attributionClass {
+    name
+    id
+  }
+  category
+  manufacturer
+  publisher
   medium
+  conditionDescription {
+    details
+  }
+  certificateOfAuthenticity {
+    details
+  }
+  framed {
+    details
+  }
   dimensions {
     in
     cm
   }
-  editionOf
   signatureInfo {
     details
   }
@@ -236,6 +268,25 @@ v3 = [
     "name": "cents",
     "storageKey": null
   }
+],
+v4 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "details",
+    "storageKey": null
+  }
+],
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "name",
+    "storageKey": null
+  },
+  (v2/*: any*/)
 ];
 return {
   "fragment": {
@@ -574,15 +625,7 @@ return {
             "kind": "LinkedField",
             "name": "signatureInfo",
             "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "details",
-                "storageKey": null
-              }
-            ],
+            "selections": (v4/*: any*/),
             "storageKey": null
           },
           {
@@ -592,16 +635,68 @@ return {
             "kind": "LinkedField",
             "name": "artist",
             "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "name",
-                "storageKey": null
-              },
-              (v2/*: any*/)
-            ],
+            "selections": (v5/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AttributionClass",
+            "kind": "LinkedField",
+            "name": "attributionClass",
+            "plural": false,
+            "selections": (v5/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "category",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "manufacturer",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "publisher",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "conditionDescription",
+            "plural": false,
+            "selections": (v4/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "certificateOfAuthenticity",
+            "plural": false,
+            "selections": (v4/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "framed",
+            "plural": false,
+            "selections": (v4/*: any*/),
             "storageKey": null
           },
           {
@@ -618,7 +713,7 @@ return {
     ]
   },
   "params": {
-    "id": "cf19fd56ccc7d96fd7c548cc6e0d374f",
+    "id": "13689a8254c789588af2d63804ae16d8",
     "metadata": {},
     "name": "CommercialButtonsTestsMutationQuery",
     "operationKind": "query",

--- a/src/__generated__/CommercialButtonsTestsRenderQuery.graphql.ts
+++ b/src/__generated__/CommercialButtonsTestsRenderQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 4cf1c43b5c63363377e081d7298dba43 */
+/* @relayHash cbfb4cd61f1ed450d2c50ac32ac4f13f */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -73,6 +73,7 @@ export type CommercialButtonsTestsRenderQueryRawResponse = {
             readonly name: string | null;
             readonly id: string;
         }) | null;
+        readonly artistNames: string | null;
         readonly id: string;
     }) | null;
 };
@@ -146,10 +147,7 @@ fragment CollapsibleArtworkDetails_artwork on Artwork {
   signatureInfo {
     details
   }
-  artist {
-    name
-    id
-  }
+  artistNames
 }
 
 fragment CommercialButtons_artwork on Artwork {
@@ -606,6 +604,13 @@ return {
             ],
             "storageKey": null
           },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "artistNames",
+            "storageKey": null
+          },
           (v2/*: any*/)
         ],
         "storageKey": "artwork(id:\"artworkID\")"
@@ -613,7 +618,7 @@ return {
     ]
   },
   "params": {
-    "id": "4cf1c43b5c63363377e081d7298dba43",
+    "id": "cbfb4cd61f1ed450d2c50ac32ac4f13f",
     "metadata": {},
     "name": "CommercialButtonsTestsRenderQuery",
     "operationKind": "query",

--- a/src/__generated__/CommercialButtonsTestsRenderQuery.graphql.ts
+++ b/src/__generated__/CommercialButtonsTestsRenderQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash cbfb4cd61f1ed450d2c50ac32ac4f13f */
+/* @relayHash ff1860339be54f65bb2f86d8b3fe8d78 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -73,6 +73,22 @@ export type CommercialButtonsTestsRenderQueryRawResponse = {
             readonly name: string | null;
             readonly id: string;
         }) | null;
+        readonly attributionClass: ({
+            readonly name: string | null;
+            readonly id: string;
+        }) | null;
+        readonly category: string | null;
+        readonly manufacturer: string | null;
+        readonly publisher: string | null;
+        readonly conditionDescription: ({
+            readonly details: string | null;
+        }) | null;
+        readonly certificateOfAuthenticity: ({
+            readonly details: string | null;
+        }) | null;
+        readonly framed: ({
+            readonly details: string | null;
+        }) | null;
         readonly artistNames: string | null;
         readonly id: string;
     }) | null;
@@ -138,12 +154,28 @@ fragment CollapsibleArtworkDetails_artwork on Artwork {
   internalID
   title
   date
+  saleMessage
+  attributionClass {
+    name
+    id
+  }
+  category
+  manufacturer
+  publisher
   medium
+  conditionDescription {
+    details
+  }
+  certificateOfAuthenticity {
+    details
+  }
+  framed {
+    details
+  }
   dimensions {
     in
     cm
   }
-  editionOf
   signatureInfo {
     details
   }
@@ -236,6 +268,25 @@ v3 = [
     "name": "cents",
     "storageKey": null
   }
+],
+v4 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "details",
+    "storageKey": null
+  }
+],
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "name",
+    "storageKey": null
+  },
+  (v2/*: any*/)
 ];
 return {
   "fragment": {
@@ -574,15 +625,7 @@ return {
             "kind": "LinkedField",
             "name": "signatureInfo",
             "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "details",
-                "storageKey": null
-              }
-            ],
+            "selections": (v4/*: any*/),
             "storageKey": null
           },
           {
@@ -592,16 +635,68 @@ return {
             "kind": "LinkedField",
             "name": "artist",
             "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "name",
-                "storageKey": null
-              },
-              (v2/*: any*/)
-            ],
+            "selections": (v5/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AttributionClass",
+            "kind": "LinkedField",
+            "name": "attributionClass",
+            "plural": false,
+            "selections": (v5/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "category",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "manufacturer",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "publisher",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "conditionDescription",
+            "plural": false,
+            "selections": (v4/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "certificateOfAuthenticity",
+            "plural": false,
+            "selections": (v4/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "framed",
+            "plural": false,
+            "selections": (v4/*: any*/),
             "storageKey": null
           },
           {
@@ -618,7 +713,7 @@ return {
     ]
   },
   "params": {
-    "id": "cbfb4cd61f1ed450d2c50ac32ac4f13f",
+    "id": "ff1860339be54f65bb2f86d8b3fe8d78",
     "metadata": {},
     "name": "CommercialButtonsTestsRenderQuery",
     "operationKind": "query",

--- a/src/lib/Scenes/Artwork/Components/ArtworkDetails.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkDetails.tsx
@@ -1,11 +1,10 @@
 import { ArtworkDetails_artwork } from "__generated__/ArtworkDetails_artwork.graphql"
-import { ReadMore } from "lib/Components/ReadMore"
 import { getCurrentEmissionState } from "lib/store/AppStore"
-import { truncatedTextLimit } from "lib/utils/hardware"
 import { Schema } from "lib/utils/track"
 import { Box, Join, Sans, Spacer } from "palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { ArtworkDetailsRow } from "./ArtworkDetailsRow"
 import { RequestConditionReportQueryRenderer } from "./RequestConditionReport"
 
 interface ArtworkDetailsProps {
@@ -48,23 +47,17 @@ export class ArtworkDetails extends React.Component<ArtworkDetailsProps> {
         <Join separator={<Spacer my={1} />}>
           <Sans size="4t">Artwork details</Sans>
           {displayItems.map(({ title, value }, index) => (
-            <React.Fragment key={index}>
-              <Sans size="3t" weight="regular">
-                {title}
-              </Sans>
-              {React.isValidElement(value) ? (
-                value
-              ) : (
-                <ReadMore
-                  content={value as string}
-                  color="black60"
-                  textStyle="sans"
-                  maxChars={truncatedTextLimit()}
-                  trackingFlow={Schema.Flow.ArtworkDetails}
-                  contextModule={Schema.ContextModules.ArtworkDetails}
-                />
-              )}
-            </React.Fragment>
+            <ArtworkDetailsRow
+              key={index.toString()}
+              title={title}
+              value={value}
+              tracking={{
+                readMore: {
+                  flow: Schema.Flow.ArtworkDetails,
+                  contextModule: Schema.ContextModules.ArtworkDetails,
+                },
+              }}
+            />
           ))}
         </Join>
       </Box>

--- a/src/lib/Scenes/Artwork/Components/ArtworkDetailsRow.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkDetailsRow.tsx
@@ -12,7 +12,7 @@ interface Tracking {
 interface ArtworkDetailsRowProps {
   key: string
   title: string
-  value: string | React.ReactElement | null
+  value: string | React.ReactElement | null | undefined
   tracking?: {
     readMore?: Tracking
   }

--- a/src/lib/Scenes/Artwork/Components/ArtworkDetailsRow.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkDetailsRow.tsx
@@ -1,0 +1,41 @@
+import { ReadMore } from "lib/Components/ReadMore"
+import { truncatedTextLimit } from "lib/utils/hardware"
+import { Schema } from "lib/utils/track"
+import { Sans } from "palette"
+import React from "react"
+
+interface Tracking {
+  flow: Schema.Flow
+  contextModule: Schema.ContextModules
+}
+
+interface ArtworkDetailsRowProps {
+  key: string
+  title: string
+  value: string | React.ReactElement | null
+  tracking?: {
+    readMore?: Tracking
+  }
+}
+
+export const ArtworkDetailsRow: React.FC<ArtworkDetailsRowProps> = ({ key, title, value, tracking }) => {
+  return (
+    <React.Fragment key={key}>
+      <Sans size="3t" weight="regular">
+        {title}
+      </Sans>
+      {React.isValidElement(value) ? (
+        value
+      ) : (
+        <ReadMore
+          content={value as string}
+          color="black60"
+          textStyle="sans"
+          maxChars={truncatedTextLimit()}
+          trackingFlow={tracking?.readMore?.flow}
+          contextModule={tracking?.readMore?.contextModule}
+        />
+      )}
+    </React.Fragment>
+  )
+}

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails.tsx
@@ -1,7 +1,8 @@
 import { CollapsibleArtworkDetails_artwork } from "__generated__/CollapsibleArtworkDetails_artwork.graphql"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import ChevronIcon from "lib/Icons/ChevronIcon"
-import { Flex, Separator, Text } from "palette"
+import { ArtworkDetailsRow } from "lib/Scenes/Artwork/Components/ArtworkDetailsRow"
+import { Flex, Join, Separator, Spacer, Text } from "palette"
 import React, { useState } from "react"
 import { LayoutAnimation, TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -10,14 +11,23 @@ export interface CollapsibleArtworkDetailsProps {
   artwork: CollapsibleArtworkDetails_artwork
 }
 
-const makeRow = (name: string, value: string) => (
-  <Flex flexDirection="row" mb={1}>
-    <Text style={{ flex: 1 }}>{name}</Text>
-    <Text color="black60" style={{ flex: 1, flexGrow: 3 }}>
-      {value}
-    </Text>
-  </Flex>
-)
+const artworkDetailItems = (artwork: CollapsibleArtworkDetails_artwork) => {
+  const items = [
+    { title: "Price", value: artwork.saleMessage },
+    { title: "Medium", value: artwork.category },
+    { title: "Manufacturer", value: artwork.manufacturer },
+    { title: "Publisher", value: artwork.publisher },
+    { title: "Materials", value: artwork.medium },
+    { title: "Classification", value: artwork.attributionClass?.name },
+    { title: "Dimensions", value: [artwork.dimensions?.in, artwork.dimensions?.cm].filter((d) => d).join("\n") },
+    { title: "Signature", value: artwork.signatureInfo?.details },
+    { title: "Frame", value: artwork.framed?.details },
+    { title: "Certificate of Authenticity", value: artwork.certificateOfAuthenticity?.details },
+    { title: "Condition", value: artwork.conditionDescription?.details },
+  ]
+
+  return items.filter((i) => i.value != null && i.value !== "")
+}
 
 export const CollapsibleArtworkDetails: React.FC<CollapsibleArtworkDetailsProps> = ({ artwork }) => {
   const [isExpanded, setExpanded] = useState(false)
@@ -28,6 +38,8 @@ export const CollapsibleArtworkDetails: React.FC<CollapsibleArtworkDetailsProps>
     })
     setExpanded(!isExpanded)
   }
+  const detailItems = artworkDetailItems(artwork)
+
   return artwork ? (
     <>
       <TouchableOpacity onPress={() => toggleExpanded()}>
@@ -52,10 +64,11 @@ export const CollapsibleArtworkDetails: React.FC<CollapsibleArtworkDetailsProps>
       </TouchableOpacity>
       {isExpanded && (
         <Flex mx={2} mb={1}>
-          {!!artwork.medium && makeRow("Medium", artwork.medium)}
-          {!!artwork.dimensions && makeRow("Size", artwork.dimensions.in + "\n" + artwork.dimensions.cm)}
-          {!!artwork.editionOf && makeRow("Availability", artwork.editionOf)}
-          {!!artwork.signatureInfo?.details && makeRow("Signature", artwork.signatureInfo.details)}
+          <Join separator={<Spacer my={1} />}>
+            {detailItems.map(({ title, value }, index) => (
+              <ArtworkDetailsRow key={index.toString()} title={title} value={value} />
+            ))}
+          </Join>
         </Flex>
       )}
       <Separator />
@@ -74,12 +87,27 @@ export const CollapsibleArtworkDetailsFragmentContainer = createFragmentContaine
       internalID
       title
       date
+      saleMessage
+      attributionClass {
+        name
+      }
+      category
+      manufacturer
+      publisher
       medium
+      conditionDescription {
+        details
+      }
+      certificateOfAuthenticity {
+        details
+      }
+      framed {
+        details
+      }
       dimensions {
         in
         cm
       }
-      editionOf
       signatureInfo {
         details
       }

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails.tsx
@@ -42,7 +42,7 @@ export const CollapsibleArtworkDetails: React.FC<CollapsibleArtworkDetailsProps>
             />
           )}
           <Flex ml={2} flex="1">
-            <Text>{artwork.artist?.name}</Text>
+            <Text>{artwork.artistNames}</Text>
             <Text color="black60" variant="caption">
               {artwork.title}, {artwork.date}
             </Text>
@@ -83,9 +83,7 @@ export const CollapsibleArtworkDetailsFragmentContainer = createFragmentContaine
       signatureInfo {
         details
       }
-      artist {
-        name
-      }
+      artistNames
     }
   `,
 })

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails.tsx
@@ -41,7 +41,7 @@ export const CollapsibleArtworkDetails: React.FC<CollapsibleArtworkDetailsProps>
               style={{ alignSelf: "center" }}
             />
           )}
-          <Flex ml={2} flex="1">
+          <Flex ml={2} flex={1}>
             <Text>{artwork.artistNames}</Text>
             <Text color="black60" variant="caption">
               {artwork.title}, {artwork.date}

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -1,7 +1,7 @@
 import { InquiryModal_artwork } from "__generated__/InquiryModal_artwork.graphql"
 import { FancyModal } from "lib/Components/FancyModal/FancyModal"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
-import { Text } from "palette"
+import { Flex, Text } from "palette"
 import React from "react"
 import NavigatorIOS from "react-native-navigator-ios"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -25,9 +25,11 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, ...props })
         Contact Gallery
       </FancyModalHeader>
       <CollapsibleArtworkDetailsFragmentContainer artwork={artwork} />
-      <Text m={2} variant="title">
-        More here
-      </Text>
+      <Flex bg="white100" flex={1}>
+        <Text m={2} variant="title">
+          More here
+        </Text>
+      </Flex>
     </FancyModal>
   )
 }

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/CollapsibleArtworkDetails-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/CollapsibleArtworkDetails-tests.tsx
@@ -1,6 +1,7 @@
 import { CollapsibleArtworkDetailsTestsQuery } from "__generated__/CollapsibleArtworkDetailsTestsQuery.graphql"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { __appStoreTestUtils__ } from "lib/store/AppStore"
+import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { Text } from "palette"
 import React from "react"
@@ -48,6 +49,16 @@ describe("CollapsibleArtworkDetails", () => {
     resolveData()
     expect(wrapper.root.findAllByType(OpaqueImageView)).toHaveLength(1)
     expect(wrapper.root.findAllByType(Text)).toHaveLength(2)
+  })
+
+  it("renders artist names", () => {
+    const wrapper = renderWithWrappers(<TestRenderer />)
+    resolveData({
+      Artwork: () => ({
+        artistNames: "Vladimir Petrov, Kristina Kost",
+      }),
+    })
+    expect(extractText(wrapper.root)).toContain("Vladimir Petrov, Kristina Kost")
   })
 
   it("expands component on press", () => {

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/CollapsibleArtworkDetails-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/CollapsibleArtworkDetails-tests.tsx
@@ -1,5 +1,6 @@
 import { CollapsibleArtworkDetailsTestsQuery } from "__generated__/CollapsibleArtworkDetailsTestsQuery.graphql"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
+import { ArtworkDetailsRow } from "lib/Scenes/Artwork/Components/ArtworkDetailsRow"
 import { __appStoreTestUtils__ } from "lib/store/AppStore"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
@@ -49,6 +50,7 @@ describe("CollapsibleArtworkDetails", () => {
     resolveData()
     expect(wrapper.root.findAllByType(OpaqueImageView)).toHaveLength(1)
     expect(wrapper.root.findAllByType(Text)).toHaveLength(2)
+    expect(wrapper.root.findAllByType(ArtworkDetailsRow)).toHaveLength(0)
   })
 
   it("renders artist names", () => {
@@ -66,7 +68,7 @@ describe("CollapsibleArtworkDetails", () => {
     resolveData()
     expect(wrapper.root.findAllByType(Text)).toHaveLength(2)
     wrapper.root.findByType(TouchableOpacity).props.onPress()
-    expect(wrapper.root.findAllByType(Text)).toHaveLength(10)
+    expect(wrapper.root.findAllByType(ArtworkDetailsRow)).toHaveLength(11)
   })
 
   it("doesn't render what it doesn't have", () => {
@@ -79,6 +81,6 @@ describe("CollapsibleArtworkDetails", () => {
       }),
     })
     wrapper.root.findByType(TouchableOpacity).props.onPress()
-    expect(wrapper.root.findAllByType(Text)).toHaveLength(8)
+    expect(wrapper.root.findAllByType(ArtworkDetailsRow)).toHaveLength(10)
   })
 })

--- a/src/lib/__fixtures__/ArtworkFixture.ts
+++ b/src/lib/__fixtures__/ArtworkFixture.ts
@@ -27,6 +27,9 @@ export const ArtworkFixture = {
   category: "Photography",
   date: "2020",
   medium: "photograph",
+  attributionClass: {
+    name: "Unique",
+  },
   editionOf: "",
   image: {
     url: "",
@@ -74,6 +77,7 @@ export const ArtworkFixture = {
       },
     },
   ],
+  artistNames: "Abbas Kiarostami",
   artists: [
     {
       " $refType": null,


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [PURCHASE-2154].

### Description

![Screen Shot 2020-10-08 at 10 24 33 AM](https://user-images.githubusercontent.com/796573/95472006-85196600-0950-11eb-9eff-a04bb7fb4539.png)

Following up on https://github.com/artsy/eigen/pull/3883, this adds the full artwork details in the inquiry modal. I also take this opportunity to improve the expand/collapse animation. More details inline.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[MX-434]: https://artsyproduct.atlassian.net/browse/MX-434

[PURCHASE-2154]: https://artsyproduct.atlassian.net/browse/PURCHASE-2154