### PR TITLE
Use navigate where possible for fairs routing #trivial

### DIFF
--- a/src/lib/NativeModules/SwitchBoard.tsx
+++ b/src/lib/NativeModules/SwitchBoard.tsx
@@ -39,10 +39,6 @@ function presentPartnerViewController(component: React.Component<any, any>, slug
   presentEntityViewController(component, slug, EntityType.Partner, SlugType.ProfileID)
 }
 
-function presentFairViewController(component: React.Component<any, any>, slug: string, slugType?: SlugType) {
-  presentEntityViewController(component, slug, EntityType.Fair, slugType ?? SlugType.FairID)
-}
-
 function presentModalViewController(_component: React.Component<any, any>, route: string) {
   navigate(route, { modal: true })
 }
@@ -59,7 +55,6 @@ export default {
   presentNavigationViewController,
   presentModalViewController,
   presentPartnerViewController,
-  presentFairViewController,
   dismissModalViewController,
   dismissNavigationViewController,
 }

--- a/src/lib/Scenes/City/Components/FairEventSection/Components/FairEventSectionCard.tsx
+++ b/src/lib/Scenes/City/Components/FairEventSection/Components/FairEventSectionCard.tsx
@@ -1,5 +1,5 @@
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
-import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { navigate } from "lib/navigation/navigate"
 import { Fair } from "lib/Scenes/Map/types"
 import { Box, color, Flex, Sans, space } from "palette"
 import React, { Component } from "react"
@@ -12,7 +12,7 @@ interface Props {
 
 export class FairEventSectionCard extends Component<Props> {
   handleTap() {
-    SwitchBoard.presentFairViewController(this, this.props.fair.slug)
+    navigate(`/fair/${this.props.fair.slug}`)
   }
 
   // @TODO: Implement tests for this component https://artsyproduct.atlassian.net/browse/LD-549

--- a/src/lib/Scenes/City/Components/TabFairItemRow/index.tsx
+++ b/src/lib/Scenes/City/Components/TabFairItemRow/index.tsx
@@ -1,5 +1,5 @@
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
-import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { navigate } from "lib/navigation/navigate"
 import { Fair } from "lib/Scenes/Map/types"
 import { Box, Flex, Sans, space } from "palette"
 import React from "react"
@@ -12,7 +12,7 @@ export interface Props {
 
 export class TabFairItemRow extends React.Component<Props> {
   handleTap = (item: Fair) => {
-    SwitchBoard.presentFairViewController(this, item.slug)
+    navigate(`/fair/${item.slug}`)
   }
 
   render() {

--- a/src/lib/Scenes/Home/Components/FairsRail.tsx
+++ b/src/lib/Scenes/Home/Components/FairsRail.tsx
@@ -1,7 +1,6 @@
 import { FairsRail_fairsModule } from "__generated__/FairsRail_fairsModule.graphql"
 import ImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { SectionTitle } from "lib/Components/SectionTitle"
-import Switchboard from "lib/NativeModules/SwitchBoard"
 import { Flex, Sans } from "palette"
 import React, { useImperativeHandle, useRef } from "react"
 import { FlatList, View } from "react-native"
@@ -16,6 +15,7 @@ import {
   CardRailMetadataContainer as MetadataContainer,
 } from "lib/Components/Home/CardRailCard"
 import { CardRailFlatList } from "lib/Components/Home/CardRailFlatList"
+import { navigate } from "lib/navigation/navigate"
 import { extractNodes } from "lib/utils/extractNodes"
 import { concat, take } from "lodash"
 import HomeAnalytics from "../homeAnalytics"
@@ -64,7 +64,7 @@ const FairsRail: React.FC<Props & RailScrollProps> = (props) => {
               onPress={() => {
                 tracking.trackEvent(HomeAnalytics.fairThumbnailTapEvent(result?.internalID, result?.slug, index))
                 if (result?.slug) {
-                  Switchboard.presentFairViewController(navRef.current, result?.slug)
+                  navigate(`/fair/${result?.slug}`)
                 }
               }}
             >

--- a/src/lib/Scenes/Home/Components/__tests__/FairsRail-tests.tsx
+++ b/src/lib/Scenes/Home/Components/__tests__/FairsRail-tests.tsx
@@ -8,6 +8,7 @@ import { extractText } from "lib/tests/extractText"
 import { FairsRailFragmentContainer } from "../FairsRail"
 
 import { CardRailCard } from "lib/Components/Home/CardRailCard"
+import { navigate } from "lib/navigation/navigate"
 import { useTracking } from "react-tracking"
 import HomeAnalytics from "../../homeAnalytics"
 
@@ -101,6 +102,17 @@ describe("location", () => {
     expect(extractText(tree.root.findAllByProps({ "data-test-id": "card-subtitle" })[0])).toMatchInlineSnapshot(
       `"Monday–Friday  •  Canada"`
     )
+  })
+})
+
+describe("navigation", () => {
+  it("navigates to the fair url", () => {
+    const tree = renderWithWrappers(
+      <FairsRailFragmentContainer fairsModule={fairsModule as any} scrollRef={mockScrollRef} />
+    )
+    const cards = tree.root.findAllByType(CardRailCard)
+    cards[0].props.onPress()
+    expect(navigate).toHaveBeenCalledWith("/fair/the-fair")
   })
 })
 

--- a/src/lib/Scenes/Map/Components/ShowCard.tsx
+++ b/src/lib/Scenes/Map/Components/ShowCard.tsx
@@ -1,5 +1,6 @@
 import { ShowItemRow } from "lib/Components/Lists/ShowItemRow"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { navigate } from "lib/navigation/navigate"
 import { TabFairItemRow } from "lib/Scenes/City/Components/TabFairItemRow"
 import { isEqual } from "lodash"
 import { Box, color, Sans, space } from "palette"
@@ -72,7 +73,7 @@ export class ShowCard extends Component<ShowCardProps, ShowCardState> {
     if (item.type === "Show") {
       SwitchBoard.presentNavigationViewController(this, item.href)
     } else {
-      SwitchBoard.presentFairViewController(this, item.node.id)
+      navigate(`/fair/${item.node.id}`)
     }
   }
 

--- a/src/lib/Scenes/Search/SearchResult.tsx
+++ b/src/lib/Scenes/Search/SearchResult.tsx
@@ -1,6 +1,7 @@
 import GraphemeSplitter from "grapheme-splitter"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
-import SwitchBoard, { SlugType } from "lib/NativeModules/SwitchBoard"
+import SwitchBoard, { EntityType, SlugType } from "lib/NativeModules/SwitchBoard"
+import { navigate } from "lib/navigation/navigate"
 import { AppStore } from "lib/store/AppStore"
 import { normalizeText } from "lib/utils/normalizeText"
 import { Schema } from "lib/utils/track"
@@ -106,7 +107,8 @@ function navigateToResult(result: AutosuggestResult, navRef: React.MutableRefObj
   if (result.displayType === "Gallery" || result.displayType === "Institution") {
     SwitchBoard.presentPartnerViewController(navRef.current, result.slug!)
   } else if (result.displayType === "Fair") {
-    SwitchBoard.presentFairViewController(navRef.current, result.slug!, SlugType.ProfileID)
+    const fairProfileUrl = `/${result.slug!}?entity=${EntityType.Fair}&slugType=${SlugType.ProfileID}`
+    navigate(fairProfileUrl)
   } else {
     SwitchBoard.presentNavigationViewController(navRef.current, result.href!)
   }

--- a/src/lib/Scenes/Search/__tests__/SearchResult-tests.tsx
+++ b/src/lib/Scenes/Search/__tests__/SearchResult-tests.tsx
@@ -1,4 +1,5 @@
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { navigate } from "lib/navigation/navigate"
 import { AppStore, AppStoreProvider } from "lib/store/AppStore"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
@@ -21,6 +22,14 @@ const result = {
 
 jest.mock("lib/NativeModules/SwitchBoard", () => ({
   presentNavigationViewController: jest.fn(),
+  EntityType: {
+    Partner: "partner",
+    Fair: "fair",
+  },
+  SlugType: {
+    ProfileID: "profileID",
+    FairID: "fairID",
+  },
 }))
 
 let recentSearchesArray: any[] = []
@@ -141,5 +150,24 @@ describe(SearchResult, () => {
     const tree = renderWithWrappers(<TestWrapper result={result} onResultPress={spy} />)
     tree.root.findByType(TouchableOpacity).props.onPress()
     expect(spy).toHaveBeenCalled()
+  })
+
+  it(`navigates correctly when the item is a fair`, async () => {
+    const tree = renderWithWrappers(
+      <TestWrapper
+        result={{
+          displayLabel: "Art Expo 2020",
+          href: "/art-expo-profile-slug",
+          slug: "art-expo-profile-slug",
+          imageUrl: "blah",
+          displayType: "Fair",
+        }}
+      />
+    )
+    act(() => {
+      tree.root.findByType(TouchableOpacity).props.onPress()
+    })
+    await new Promise((r) => setTimeout(r, 50))
+    expect(navigate).toHaveBeenCalledWith("/art-expo-profile-slug?entity=fair&slugType=profileID")
   })
 })

--- a/src/lib/navigation/__tests__/routes-tests.tsx
+++ b/src/lib/navigation/__tests__/routes-tests.tsx
@@ -861,6 +861,27 @@ describe("artsy.net routes", () => {
     `)
   })
 
+  it("routes to Fair", () => {
+    expect(matchRoute("/fair/red")).toMatchInlineSnapshot(`
+      Object {
+        "module": "Fair",
+        "params": Object {
+          "fairID": "red",
+        },
+        "type": "match",
+      }
+    `)
+    expect(matchRoute("/fair/blue")).toMatchInlineSnapshot(`
+      Object {
+        "module": "Fair",
+        "params": Object {
+          "fairID": "blue",
+        },
+        "type": "match",
+      }
+    `)
+  })
+
   it("routes to FairArtists", () => {
     expect(matchRoute("/fair/red/artists")).toMatchInlineSnapshot(`
       Object {

--- a/src/lib/navigation/routes.tsx
+++ b/src/lib/navigation/routes.tsx
@@ -116,6 +116,7 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
 
     new RouteMatcher("/fair2/:fairID", "Fair2"),
     new RouteMatcher("/fair2/:fairID/info", "Fair2MoreInfo"),
+    new RouteMatcher("/fair/:fairID", "Fair"),
     new RouteMatcher("/fair/:fairID/artworks", "FairArtworks"),
     new RouteMatcher("/fair/:fairID/artists", "FairArtists"),
     new RouteMatcher("/fair/:fairID/exhibitors", "FairExhibitors"),

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -213,7 +213,6 @@ jest.mock("lib/NativeModules/SwitchBoard", () => {
     presentMediaPreviewController: jest.fn(),
     presentModalViewController: jest.fn(),
     presentPartnerViewController: jest.fn(),
-    presentFairViewController: jest.fn(),
     dismissModalViewController: jest.fn(),
     dismissNavigationViewController: jest.fn(),
   }


### PR DESCRIPTION
The type of this PR is: **Enhancement**

### Description

This is part of a series of PRs that will update fairs routing to support the new fair view.

Fairs routing is inherently confusing because:
- Externally (i.e. search results, from web), fairs are linked to via a URL that looks like `/:profileSlug`. This means that for any fair view, we need to be able to support this top-level URL.
- Internally within eigen, we currently use a combination of that top-level URL and routes that are scoped like `/fair/:fairID`.

What this PR does:
- Gets rid of `SwitchBoard.presentFairViewController` in favor of our new `navigate` helper. (I'm guessing/assuming this is desired from a general ecosystem perspective!)
- Adds a new route to our routes file: `/fair/:fairID`, which will route to the main Fair screen. (Previously, the only way to get to this screen was via the vanity URL).
- Updates as many places as I could find to, internally, route us to `/fair/:fairID` instead of the vanity URL.

Why?
- In future PRs, I need to add the following logic:
  - As a user, if I have a `Feature flag enabled` _or_ the fair I'm looking at is not part of a `specified list of fair slugs`, take me to the new fair view. Else, take me to the old one.
- I've already dug into that ☝️ implementation, and it is especially difficult given how many places and ways we render and route to the fair view. The goal of this PR is to simplify the logic in preparation for adding on the additional complexity.

~Note: the changes are pretty innocuous, but I'm having difficulty testing every place as city guide does not work with Xcode 12 😭!~

(Downgraded to Xcode 11 and was able to test!)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [ ] I have documented any follow-up work that this PR will require, or it does not require any.
- [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
