### PR TITLE
chore: add utms to share links

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -20,6 +20,7 @@ upcoming:
     - Adds "Artworks by Artists You Follow" rail (visible only to admins) - damon
     - Upgrade Relay to 10 - chris
     - Add share button to viewing rooms - mdole
+    - Add utms to share buttons - mdole
   user_facing:
     - Fix navigation bug on Artwork consign button - david
     - Add auction lots rail to the auctions screen - mounir

--- a/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -41,7 +41,7 @@ export const shareContent = (title: string, href: string, artists: ArtworkAction
     title: computedTitle,
     // @ts-ignore STRICTNESS_MIGRATION
     message: computedTitle,
-    url: `https://artsy.net${href}`,
+    url: `https://artsy.net${href}?utm_content=artwork-share`,
   }
 }
 

--- a/src/lib/Scenes/Artwork/Components/__tests__/ArtworkActions-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/ArtworkActions-tests.tsx
@@ -22,7 +22,7 @@ describe("ArtworkActions", () => {
       ])
       expect(content).toMatchObject({
         title: "Title 1 by Artist 1, Artist 2, Artist 3 on Artsy",
-        url: "https://artsy.net/artwork/title-1",
+        url: "https://artsy.net/artwork/title-1?utm_content=artwork-share",
         message: "Title 1 by Artist 1, Artist 2, Artist 3 on Artsy",
       })
     })
@@ -31,7 +31,7 @@ describe("ArtworkActions", () => {
       const content = shareContent("Title 1", "/artwork/title-1", [{ name: "Artist 1" }])
       expect(content).toMatchObject({
         title: "Title 1 by Artist 1 on Artsy",
-        url: "https://artsy.net/artwork/title-1",
+        url: "https://artsy.net/artwork/title-1?utm_content=artwork-share",
         message: "Title 1 by Artist 1 on Artsy",
       })
     })
@@ -40,7 +40,7 @@ describe("ArtworkActions", () => {
       const content = shareContent("Title 1", "/artwork/title-1", null)
       expect(content).toMatchObject({
         title: "Title 1 on Artsy",
-        url: "https://artsy.net/artwork/title-1",
+        url: "https://artsy.net/artwork/title-1?utm_content=artwork-share",
         message: "Title 1 on Artsy",
       })
     })

--- a/src/lib/Scenes/Artwork/Components/__tests__/ArtworkActions-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/ArtworkActions-tests.tsx
@@ -48,7 +48,7 @@ describe("ArtworkActions", () => {
     it("displays only the URL if no artists or title", async () => {
       const content = shareContent(null as any /* STRICTNESS_MIGRATION */, "/artwork/title-1", null)
       expect(content).toMatchObject({
-        url: "https://artsy.net/artwork/title-1",
+        url: "https://artsy.net/artwork/title-1?utm_content=artwork-share",
       })
       expect(content.message).not.toBeDefined()
       expect(content.title).not.toBeDefined()

--- a/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
@@ -79,7 +79,7 @@ export const ViewingRoom: React.FC<ViewingRoomProps> = (props) => {
       await Share.share({
         title: viewingRoom.title,
         message: `${viewingRoom.title} by ${viewingRoom?.partner?.name} on Artsy`,
-        url: `https://artsy.net/viewing-room/${viewingRoom.slug}`,
+        url: `https://artsy.net/viewing-room/${viewingRoom.slug}?utm_content=viewing-room-share`,
       })
     } catch (error) {
       console.error("ViewingRoom.tsx", error)


### PR DESCRIPTION
The type of this PR is: **enhancement**

### Description

We lacked UTMs on artwork and VR share links - this PR fixes that by adding `utm_content=[artwork|viewing-room]-share`

[Slack discussion](https://artsy.slack.com/archives/C9ZJYFDNF/p1601661871287500)

<details><summary>Screenshots!</summary>
<img src="https://user-images.githubusercontent.com/5361806/94973423-ace47600-04d9-11eb-92c3-401ab420905a.png" />

<img src="https://user-images.githubusercontent.com/5361806/94973424-ace47600-04d9-11eb-91e1-e322b039e69c.png" />

</details>


### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
