### PR TITLE
fix: Gallery follow button doesnt follow

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -30,6 +30,7 @@ upcoming:
     - Add auction lots list to the auctions screen - mounir
     - Add LoadFailureView to Viewing Rooms screens for relay errors - pavlos
     - Enable filtering on artist series views - sweir
+    - Fix bug where a gallery can't be followed - pavlos
     - Show up to 50 artist series in the full list of an artist's series - roop
     - Fix layout issue in internal webviews - brian
     - Add about page - mounir

--- a/src/lib/Scenes/Fair/Components/FairBoothHeader.tsx
+++ b/src/lib/Scenes/Fair/Components/FairBoothHeader.tsx
@@ -34,7 +34,7 @@ export class FairBoothHeader extends React.Component<Props, State> {
   @track((props, _, args) => {
     const partnerSlug = args[0]
     const partnerID = args[1]
-    const partnerFollowed = props.show.partner?.profile?.is_followed
+    const partnerFollowed = props.show.partner?.profile?.is_followed!
     const actionName = partnerFollowed ? Schema.ActionNames.GalleryFollow : Schema.ActionNames.GalleryUnfollow
     return {
       action_name: actionName,
@@ -61,7 +61,7 @@ export class FairBoothHeader extends React.Component<Props, State> {
         id: partnerRelayID,
       },
     } = show
-    const { is_followed: partnerFollowed, internalID: profileID } = show.partner?.profile || {}
+    const { is_followed: partnerFollowed, internalID: profileID } = show.partner?.profile ?? {}
 
     if (profileID === undefined || partnerFollowed == null) {
       return
@@ -129,7 +129,7 @@ export class FairBoothHeader extends React.Component<Props, State> {
       location: { display: boothLocation },
       counts,
     } = show
-    const partnerFollowed = show.partner?.profile?.is_followed
+    const partnerFollowed = show.partner?.profile?.is_followed!
     const { isFollowedChanging } = this.state
 
     return (

--- a/src/lib/Scenes/Fair/Components/FairBoothHeader.tsx
+++ b/src/lib/Scenes/Fair/Components/FairBoothHeader.tsx
@@ -63,7 +63,7 @@ export class FairBoothHeader extends React.Component<Props, State> {
     } = show
     const { is_followed: partnerFollowed, internalID: profileID } = show.partner?.profile || {}
 
-    if (!profileID || !partnerFollowed) {
+    if (profileID === undefined || partnerFollowed == null) {
       return
     }
 

--- a/tslint.json
+++ b/tslint.json
@@ -17,6 +17,7 @@
     "ordered-imports": true,
     "switch-default": false,
     "relay-operation-generics": [true, { "artifactDirectory": "__generated__", "makeRelative": false }],
-    "variable-name": [true, "allow-pascal-case", "allow-leading-underscore"]
+    "variable-name": [true, "allow-pascal-case", "allow-leading-underscore"],
+    "strict-boolean-expressions": [true, "ignore-rhs"]
   }
 }


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [MX-535]

### Description

Turns out the error was not from a gallery not being there, it was from a wrong if check.

We were checking on `!partnerFollowed` with `partnerFollowed: boolean | null | undefined`, which means that the above check would get be truthy for `null` (correctly), `undefined` (correctly), and `false` (incorrectly). Basically if the gallery was not followed, then we would not procceed, which would block us from following.

I changed the check from `!partnerFollowed` to `partnerFollowed == null` so it only becomes truthy in the `null` and `undefined` cases. I feel this is a nice way to check but if anyone can think of a better way, I'm open to suggestions.

As an extra thing, I thought I'll add https://palantir.github.io/tslint/rules/strict-boolean-expressions/ to our lint config. When I added it, it showed a warning under the old check, and it's gone with the new check. Feedback for this is welcome as well. The `ignore-rhs` is for jsx cases like
```jsx
{someCheck && <View />} 
```




<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
