### PR TITLE
fix(formatting): Fix register text in auction

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -24,6 +24,7 @@ upcoming:
   user_facing:
     - Fix navigation bug on Artwork consign button - david
     - Add auction lots rail to the auctions screen - mounir
+    - Fix auction display text formatting - pavlos
     - Enable pagination on My Collection artworks screen - ashley
     - Add long email truncation - pavlos
     - Add auction lots grid to the auctions screen - mounir

--- a/src/lib/Scenes/Sales/Components/SaleListItem.tsx
+++ b/src/lib/Scenes/Sales/Components/SaleListItem.tsx
@@ -26,7 +26,9 @@ export class SaleListItem extends React.Component<Props> {
   render() {
     const sale = this.props.sale
     const image = sale.coverImage
-    const timestamp = capitalize(sale.displayTimelyAt?.replace(/M$/, "mo").replace("\n", " "))
+    const timestamp = capitalize(
+      sale.displayTimelyAt?.replace(/M$/, "mo").replace("\n", " ")
+    ).replace(/(jan|feb|mar|apr|may|jun|jul|aug|sept|oct|nov|dec)/, (s) => capitalize(s))
     const containerWidth = this.props.containerWidth
 
     return (

--- a/src/lib/Scenes/Sales/Components/SaleListItem.tsx
+++ b/src/lib/Scenes/Sales/Components/SaleListItem.tsx
@@ -26,7 +26,7 @@ export class SaleListItem extends React.Component<Props> {
   render() {
     const sale = this.props.sale
     const image = sale.coverImage
-    const timestamp = capitalize(sale.displayTimelyAt?.replace(/M$/, "mo").toLowerCase())
+    const timestamp = capitalize(sale.displayTimelyAt?.replace(/M$/, "mo").replace("\n", " "))
     const containerWidth = this.props.containerWidth
 
     return (


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-537] (woop! first CX issue!)

### Description

The text was displayed incorrectly. Now it should be good.
<img width="380" alt="Screenshot 2020-10-05 at 17 19 57" src="https://user-images.githubusercontent.com/100233/95102434-af420c80-0733-11eb-8cab-c4a5f8fae55e.png">
<img width="397" alt="Screenshot 2020-10-05 at 17 45 36" src="https://user-images.githubusercontent.com/100233/95102456-b36e2a00-0733-11eb-88c8-85a2f8ffedac.png">


I basically added two more `replace`s. One is for removing the newline, and the other is for making the months capitalized, since `capitalize` doesn't do it (I guess it cares only about "sentences", and we don't have a full-stop, so it skips the month).

I tried adding tests but it got a bit tricky because I would need to have them at the top level, in the QueryRenderer, and that feels a bit meh? I might add some there..

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-537]: https://artsyproduct.atlassian.net/browse/CX-537