### PR TITLE
feat: add new Show2 view, behind a lab option

### DIFF
--- a/Artsy/App/AROptions.h
+++ b/Artsy/App/AROptions.h
@@ -17,6 +17,7 @@ extern NSString *const AROptionsArtistSeries;
 extern NSString *const AROptionsNewSalePage;
 extern NSString *const AROptionsNewFirstInquiry;
 extern NSString *const AROptionsUseReactNativeWebView;
+extern NSString *const AROptionsNewShowPage;
 
 @interface AROptions : NSObject
 

--- a/Artsy/App/AROptions.m
+++ b/Artsy/App/AROptions.m
@@ -15,6 +15,7 @@ NSString *const AROptionsShowMartsyOnScreen = @"AROptionsShowMartsyOnScreen";
 NSString *const AROptionsArtistSeries = @"AROptionsArtistSeries";
 NSString *const AROptionsNewSalePage = @"AROptionsNewSalePage";
 NSString *const AROptionsNewFirstInquiry = @"AROptionsNewFirstInquiry";
+NSString *const AROptionsNewShowPage = @"AROptionsNewShowPage";
 
 // UX changes
 NSString *const AROptionsDisableNativeLiveAuctions = @"AROptionsDisableNativeLiveAuctions";
@@ -47,6 +48,7 @@ NSString *const AROptionsUseReactNativeWebView = @"AROptionsUseReactNativeWebVie
          AROptionsNewSalePage: @"Enable new sale (auction) page",
          AROptionsNewFirstInquiry: @"Enable new first inquiry flow",
          AROptionsUseReactNativeWebView: @"Use react native webviews",
+         AROptionsNewShowPage: @"Enable new show page",
         };
     });
 }

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -21,6 +21,7 @@ upcoming:
     - Upgrade Relay to 10 - chris
     - Add share button to viewing rooms - mdole
     - Add utms to share buttons - mdole
+    - Add new Show2 view, behind lab option - roop, sarah
   user_facing:
     - Fix navigation bug on Artwork consign button - david
     - Add auction lots rail to the auctions screen - mounir

--- a/src/__generated__/Show2Query.graphql.ts
+++ b/src/__generated__/Show2Query.graphql.ts
@@ -1,0 +1,123 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash 207ffadb89e876c48325a5ab1e132905 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type Show2QueryVariables = {
+    showID: string;
+};
+export type Show2QueryResponse = {
+    readonly show: {
+        readonly " $fragmentRefs": FragmentRefs<"Show2_show">;
+    } | null;
+};
+export type Show2Query = {
+    readonly response: Show2QueryResponse;
+    readonly variables: Show2QueryVariables;
+};
+
+
+
+/*
+query Show2Query(
+  $showID: String!
+) {
+  show(id: $showID) @principalField {
+    ...Show2_show
+    id
+  }
+}
+
+fragment Show2_show on Show {
+  name
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "showID"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "showID"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "Show2Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Show",
+        "kind": "LinkedField",
+        "name": "show",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "Show2_show"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "Show2Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Show",
+        "kind": "LinkedField",
+        "name": "show",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "207ffadb89e876c48325a5ab1e132905",
+    "metadata": {},
+    "name": "Show2Query",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = '35f7ce1004b67e044e9811883202ce7c';
+export default node;

--- a/src/__generated__/Show2TestsQuery.graphql.ts
+++ b/src/__generated__/Show2TestsQuery.graphql.ts
@@ -1,0 +1,144 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash 3aa67395999eac5f8e55a6646e7ee361 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type Show2TestsQueryVariables = {
+    showID: string;
+};
+export type Show2TestsQueryResponse = {
+    readonly show: {
+        readonly " $fragmentRefs": FragmentRefs<"Show2_show">;
+    } | null;
+};
+export type Show2TestsQuery = {
+    readonly response: Show2TestsQueryResponse;
+    readonly variables: Show2TestsQueryVariables;
+};
+
+
+
+/*
+query Show2TestsQuery(
+  $showID: String!
+) {
+  show(id: $showID) {
+    ...Show2_show
+    id
+  }
+}
+
+fragment Show2_show on Show {
+  name
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "showID"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "showID"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "Show2TestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Show",
+        "kind": "LinkedField",
+        "name": "show",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "Show2_show"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "Show2TestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Show",
+        "kind": "LinkedField",
+        "name": "show",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "3aa67395999eac5f8e55a6646e7ee361",
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "show": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Show"
+        },
+        "show.id": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "ID"
+        },
+        "show.name": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "String"
+        }
+      }
+    },
+    "name": "Show2TestsQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = 'd6fbb3afb1d102b089523c9a4dbd9c5f';
+export default node;

--- a/src/__generated__/Show2_show.graphql.ts
+++ b/src/__generated__/Show2_show.graphql.ts
@@ -1,0 +1,37 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type Show2_show = {
+    readonly name: string | null;
+    readonly " $refType": "Show2_show";
+};
+export type Show2_show$data = Show2_show;
+export type Show2_show$key = {
+    readonly " $data"?: Show2_show$data;
+    readonly " $fragmentRefs": FragmentRefs<"Show2_show">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "Show2_show",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "Show",
+  "abstractKey": null
+};
+(node as any).hash = 'a1fe9ef4bb3adce2714cc4811f67c1c2';
+export default node;

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -73,6 +73,7 @@ import { SalesQueryRenderer } from "./Scenes/Sales"
 import { Search } from "./Scenes/Search"
 import { ShowArtistsQueryRenderer, ShowArtworksQueryRenderer, ShowMoreInfoQueryRenderer } from "./Scenes/Show"
 import { ShowQueryRenderer } from "./Scenes/Show/Show"
+import { Show2QueryRenderer } from "./Scenes/Show2/Show2"
 import { VanityURLEntityRenderer } from "./Scenes/VanityURL/VanityURLEntity"
 
 import { BottomTabType } from "./Scenes/BottomTabs/BottomTabType"
@@ -432,6 +433,7 @@ export const modules = defineModules({
   Search: { Component: SearchWithTracking, isRootViewForTabName: "search" },
   SellTabApp: { Component: setupMyCollectionScreen(SellTabApp) },
   Show: { Component: ShowQueryRenderer },
+  Show2: { Component: Show2QueryRenderer, fullBleed: true },
   ShowArtists: { Component: ShowArtists },
   ShowArtworks: { Component: ShowArtworks },
   ShowMoreInfo: { Component: ShowMoreInfo },

--- a/src/lib/Scenes/Show2/Show2.tsx
+++ b/src/lib/Scenes/Show2/Show2.tsx
@@ -1,0 +1,76 @@
+import { Show2_show } from "__generated__/Show2_show.graphql"
+import { Show2Query } from "__generated__/Show2Query.graphql"
+import { defaultEnvironment } from "lib/relay/createEnvironment"
+import { PlaceholderBox, PlaceholderGrid, PlaceholderText } from "lib/utils/placeholders"
+import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
+import { Box, Flex, Separator, Spacer, Text, Theme } from "palette"
+import React from "react"
+import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+
+interface Show2QueryRendererProps {
+  showID: string
+}
+
+interface Show2Props {
+  show: Show2_show
+}
+
+export const Show2: React.FC<Show2Props> = ({ show }) => {
+  const { name } = show
+  return (
+    <Theme>
+      <Box p={2}>
+        <Text variant="largeTitle">{name}</Text>
+      </Box>
+    </Theme>
+  )
+}
+
+export const Show2FragmentContainer = createFragmentContainer(Show2, {
+  show: graphql`
+    fragment Show2_show on Show {
+      name
+    }
+  `,
+})
+
+export const Show2QueryRenderer: React.FC<Show2QueryRendererProps> = ({ showID }) => {
+  return (
+    <QueryRenderer<Show2Query>
+      environment={defaultEnvironment}
+      query={graphql`
+        query Show2Query($showID: String!) {
+          show(id: $showID) @principalField {
+            ...Show2_show
+          }
+        }
+      `}
+      variables={{ showID }}
+      render={renderWithPlaceholder({
+        Container: Show2FragmentContainer,
+        renderPlaceholder: () => <Show2Placeholder />,
+      })}
+    />
+  )
+}
+
+export const Show2Placeholder: React.FC = () => (
+  <Flex>
+    <PlaceholderBox height={400} />
+    <Flex flexDirection="row" justifyContent="space-between" alignItems="center" px="2">
+      <Flex>
+        <Spacer mb={2} />
+        {/* Show name */}
+        <PlaceholderText width={220} />
+        {/* Show info */}
+        <PlaceholderText width={190} />
+        <PlaceholderText width={190} />
+      </Flex>
+    </Flex>
+    <Spacer mb={2} />
+    <Separator />
+    <Spacer mb={2} />
+    {/* masonry grid */}
+    <PlaceholderGrid />
+  </Flex>
+)

--- a/src/lib/Scenes/Show2/__tests__/Show2-tests.tsx
+++ b/src/lib/Scenes/Show2/__tests__/Show2-tests.tsx
@@ -1,0 +1,62 @@
+import { Show2TestsQuery } from "__generated__/Show2TestsQuery.graphql"
+import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import { act } from "react-test-renderer"
+import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { Show2, Show2FragmentContainer } from "../Show2"
+
+jest.unmock("react-relay")
+
+describe("Show2", () => {
+  let env: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => {
+    env = createMockEnvironment()
+  })
+
+  const TestRenderer = () => (
+    <QueryRenderer<Show2TestsQuery>
+      environment={env}
+      query={graphql`
+        query Show2TestsQuery($showID: String!) @relay_test_operation {
+          show(id: $showID) {
+            ...Show2_show
+          }
+        }
+      `}
+      variables={{ showID: "the-big-show" }}
+      render={({ props, error }) => {
+        if (props?.show) {
+          return <Show2FragmentContainer show={props.show} />
+        } else if (error) {
+          console.log(error)
+        }
+      }}
+    />
+  )
+
+  const getWrapper = (mockResolvers = {}) => {
+    const tree = renderWithWrappers(<TestRenderer />)
+    act(() => {
+      env.mock.resolveMostRecentOperation((operation) => MockPayloadGenerator.generate(operation, mockResolvers))
+    })
+    return tree
+  }
+
+  it("renders without throwing an error", () => {
+    const wrapper = getWrapper()
+    expect(wrapper.root.findAllByType(Show2)).toHaveLength(1)
+  })
+
+  it("renders a title", () => {
+    const wrapper = getWrapper({
+      Show: () => ({
+        name: "The big show",
+      }),
+    })
+    expect(wrapper.root.findAllByType(Show2)).toHaveLength(1)
+    expect(extractText(wrapper.root)).toContain("The big show")
+  })
+})

--- a/src/lib/navigation/__tests__/routes-tests.tsx
+++ b/src/lib/navigation/__tests__/routes-tests.tsx
@@ -233,25 +233,32 @@ describe("artsy.net routes", () => {
     `)
   })
 
-  it("routes to Show", () => {
-    expect(matchRoute("/show/blue")).toMatchInlineSnapshot(`
-      Object {
-        "module": "Show",
-        "params": Object {
-          "showID": "blue",
-        },
-        "type": "match",
-      }
-    `)
-    expect(matchRoute("/show/pop-art")).toMatchInlineSnapshot(`
-      Object {
-        "module": "Show",
-        "params": Object {
-          "showID": "pop-art",
-        },
-        "type": "match",
-      }
-    `)
+  describe("routes to Show, based on lab option", () => {
+    it("routes to the old Show view when the AROptionsNewShowPage option is false", () => {
+      __appStoreTestUtils__?.injectEmissionOptions({ AROptionsNewShowPage: false })
+      expect(matchRoute("/show/special-show")).toMatchInlineSnapshot(`
+        Object {
+          "module": "Show",
+          "params": Object {
+            "showID": "special-show",
+          },
+          "type": "match",
+        }
+      `)
+    })
+
+    it("routes to the new Show view when the AROptionsNewShowPage option is true", () => {
+      __appStoreTestUtils__?.injectEmissionOptions({ AROptionsNewShowPage: true })
+      expect(matchRoute("/show/special-show")).toMatchInlineSnapshot(`
+        Object {
+          "module": "Show2",
+          "params": Object {
+            "showID": "special-show",
+          },
+          "type": "match",
+        }
+      `)
+    })
   })
 
   it("routes to ShowArtworks", () => {

--- a/src/lib/navigation/routes.tsx
+++ b/src/lib/navigation/routes.tsx
@@ -69,7 +69,9 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
       : new RouteMatcher("/auction/:id", "Auction"),
     new RouteMatcher("/auction/:id/bid/:artwork_id", "AuctionBidArtwork"),
     new RouteMatcher("/gene/:geneID", "Gene"),
-    new RouteMatcher("/show/:showID", "Show"),
+    getCurrentEmissionState().options.AROptionsNewShowPage
+      ? new RouteMatcher("/show/:showID", "Show2")
+      : new RouteMatcher("/show/:showID", "Show"),
     new RouteMatcher("/show/:showID/artworks", "ShowArtworks"),
     new RouteMatcher("/show/:showID/artists", "ShowArtists"),
     new RouteMatcher("/show/:showID/info", "ShowMoreInfo"),

--- a/src/lib/store/NativeModel.ts
+++ b/src/lib/store/NativeModel.ts
@@ -58,6 +58,7 @@ export interface NativeState {
     AROptionsArtistSeries: boolean
     AROptionsNewFirstInquiry: boolean
     AROptionsUseReactNativeWebView: boolean
+    AROptionsNewShowPage: boolean
   }
 }
 

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -165,6 +165,7 @@ function getNativeModules(): typeof NativeModules {
           AREnableNewPartnerView: false,
           AROptionsNewFirstInquiry: false,
           AROptionsUseReactNativeWebView: false,
+          AROptionsNewShowPage: false,
         },
       },
       postNotificationName: jest.fn(),


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[MX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-2220]

### Description

(Collab with @sweir27)

This roughs in the routing and basic component setup for a new Show view. (No real design or data fetching work as of yet.)

It's a beaut!

<img height="600" src="https://user-images.githubusercontent.com/140521/95129050-68024e80-0728-11eb-9113-de239a69e82d.png" /> <img height="600" src="https://user-images.githubusercontent.com/140521/95129716-67b68300-0729-11eb-8f0a-b857e23b6bd0.png" />

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2220]: https://artsyproduct.atlassian.net/browse/FX-2220