### PR TITLE
feat: Display BMW art activations link on Fair2MoreInfo

### DIFF
--- a/src/__generated__/Fair2MoreInfoQuery.graphql.ts
+++ b/src/__generated__/Fair2MoreInfoQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 70828ab286cb639b0e50b903fde130f8 */
+/* @relayHash 4f7f386b4ebb6a0ba60c90f0795f37a6 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -48,6 +48,10 @@ fragment Fair2MoreInfo_fair on Fair {
     }
     summary
     id
+  }
+  sponsoredContent {
+    activationText
+    pressReleaseUrl
   }
   ticketsLink
   fairHours: hours(format: MARKDOWN)
@@ -382,6 +386,31 @@ return {
           {
             "alias": null,
             "args": null,
+            "concreteType": "FairSponsoredContent",
+            "kind": "LinkedField",
+            "name": "sponsoredContent",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "activationText",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "pressReleaseUrl",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "kind": "ScalarField",
             "name": "ticketsLink",
             "storageKey": null
@@ -422,7 +451,7 @@ return {
     ]
   },
   "params": {
-    "id": "70828ab286cb639b0e50b903fde130f8",
+    "id": "4f7f386b4ebb6a0ba60c90f0795f37a6",
     "metadata": {},
     "name": "Fair2MoreInfoQuery",
     "operationKind": "query",

--- a/src/__generated__/Fair2MoreInfoTestsQuery.graphql.ts
+++ b/src/__generated__/Fair2MoreInfoTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 453f736d57b8c8a1640243c2bb6d592c */
+/* @relayHash 0eb59dcbabef429d89f7edba3a46a704 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -54,6 +54,10 @@ export type Fair2MoreInfoTestsQueryRawResponse = {
                 readonly __typename: string;
             }) | null;
         }) | null;
+        readonly sponsoredContent: ({
+            readonly activationText: string | null;
+            readonly pressReleaseUrl: string | null;
+        }) | null;
         readonly ticketsLink: string | null;
         readonly fairHours: string | null;
         readonly fairLinks: string | null;
@@ -99,6 +103,10 @@ fragment Fair2MoreInfo_fair on Fair {
     }
     summary
     id
+  }
+  sponsoredContent {
+    activationText
+    pressReleaseUrl
   }
   ticketsLink
   fairHours: hours(format: MARKDOWN)
@@ -433,6 +441,31 @@ return {
           {
             "alias": null,
             "args": null,
+            "concreteType": "FairSponsoredContent",
+            "kind": "LinkedField",
+            "name": "sponsoredContent",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "activationText",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "pressReleaseUrl",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "kind": "ScalarField",
             "name": "ticketsLink",
             "storageKey": null
@@ -473,7 +506,7 @@ return {
     ]
   },
   "params": {
-    "id": "453f736d57b8c8a1640243c2bb6d592c",
+    "id": "0eb59dcbabef429d89f7edba3a46a704",
     "metadata": {},
     "name": "Fair2MoreInfoTestsQuery",
     "operationKind": "query",

--- a/src/__generated__/Fair2MoreInfo_fair.graphql.ts
+++ b/src/__generated__/Fair2MoreInfo_fair.graphql.ts
@@ -21,6 +21,10 @@ export type Fair2MoreInfo_fair = {
         readonly summary: string | null;
         readonly " $fragmentRefs": FragmentRefs<"LocationMap_location">;
     } | null;
+    readonly sponsoredContent: {
+        readonly activationText: string | null;
+        readonly pressReleaseUrl: string | null;
+    } | null;
     readonly ticketsLink: string | null;
     readonly fairHours: string | null;
     readonly fairLinks: string | null;
@@ -151,6 +155,31 @@ return {
     {
       "alias": null,
       "args": null,
+      "concreteType": "FairSponsoredContent",
+      "kind": "LinkedField",
+      "name": "sponsoredContent",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "activationText",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "pressReleaseUrl",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
       "kind": "ScalarField",
       "name": "ticketsLink",
       "storageKey": null
@@ -189,5 +218,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = 'f05269d4df2c04c7acfc166f2bbeefad';
+(node as any).hash = '75ab873fcd1b60fc241dc6c2802dcae6';
 export default node;

--- a/src/lib/Scenes/Fair/Screens/FairBMWArtActivation.tsx
+++ b/src/lib/Scenes/Fair/Screens/FairBMWArtActivation.tsx
@@ -24,11 +24,14 @@ interface State {
 }
 
 interface ShowMoreMetadataForFairs {
-  sponsoredContent?: { pressReleaseUrl?: string; activationText?: string }
+  sponsoredContent:
+    | { pressReleaseUrl: string | undefined | null; activationText?: string | undefined | null }
+    | undefined
+    | null
 }
 
-export const shouldShowFairBMWArtActivationLink = (data: ShowMoreMetadataForFairs) => {
-  return data.sponsoredContent
+export const shouldShowFairBMWArtActivationLink = (data: ShowMoreMetadataForFairs): boolean => {
+  return !!data?.sponsoredContent
 }
 
 const PressReleaseContainer = styled(Flex)`

--- a/src/lib/Scenes/Fair2/Fair2MoreInfo.tsx
+++ b/src/lib/Scenes/Fair2/Fair2MoreInfo.tsx
@@ -5,10 +5,11 @@ import { Markdown } from "lib/Components/Markdown"
 import { LinkText } from "lib/Components/Text/LinkText"
 import { navigate } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
+import { shouldShowFairBMWArtActivationLink } from "lib/Scenes/Fair/Screens/FairBMWArtActivation"
 import { defaultRules } from "lib/utils/renderMarkdown"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import { ProvideScreenTracking, Schema } from "lib/utils/track"
-import { Box, Spacer, Text, Theme } from "palette"
+import { Box, ChevronIcon, Flex, Spacer, Text, Theme } from "palette"
 import React from "react"
 import { ScrollView, TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
@@ -91,6 +92,15 @@ export const Fair2MoreInfo: React.FC<Fair2MoreInfoProps> = ({ fair }) => {
               </>
             )}
 
+            {!!shouldShowFairBMWArtActivationLink(fair) && (
+              <TouchableOpacity onPress={() => navigate(`/fair/${fair.slug}/bmw-sponsored-content`)}>
+                <Flex py={2} flexDirection="row" justifyContent="flex-start">
+                  <Text variant="mediumText">View BMW art activations</Text>
+                  <ChevronIcon mr="-5px" mt="3px" />
+                </Flex>
+              </TouchableOpacity>
+            )}
+
             {!!fair.fairHours && (
               <>
                 <Text variant="mediumText">Hours</Text>
@@ -152,6 +162,10 @@ export const Fair2MoreInfoFragmentContainer = createFragmentContainer(Fair2MoreI
           lng
         }
         summary
+      }
+      sponsoredContent {
+        activationText
+        pressReleaseUrl
       }
       ticketsLink
       fairHours: hours(format: MARKDOWN)

--- a/src/lib/Scenes/Fair2/__tests__/Fair2MoreInfo-tests.tsx
+++ b/src/lib/Scenes/Fair2/__tests__/Fair2MoreInfo-tests.tsx
@@ -35,6 +35,7 @@ describe("Fair2MoreInfo", () => {
     expect(wrapper.text()).toContain("ContactArt Basel Hong Kong")
     expect(wrapper.text()).toContain("Buy Tickets")
     expect(wrapper.text()).toContain("LinksGoogle it")
+    expect(wrapper.text()).toContain("View BMW art activations")
     expect(wrapper.find(LocationMapContainer).length).toBe(1)
   })
 
@@ -51,6 +52,7 @@ describe("Fair2MoreInfo", () => {
         fairTickets: "",
         fairContact: "",
         summary: "",
+        sponsoredContent: null,
       },
     } as Fair2MoreInfoTestsQueryRawResponse
     const wrapper = await getWrapper(Fair2MoreInfoMissingInfo)
@@ -60,6 +62,7 @@ describe("Fair2MoreInfo", () => {
     expect(wrapper.text()).not.toContain("Links")
     expect(wrapper.text()).not.toContain("Tickets")
     expect(wrapper.text()).not.toContain("Contact")
+    expect(wrapper.text()).not.toContain("View BMW art activations")
     expect(wrapper.find(LocationMapContainer).length).toBe(0)
   })
 })
@@ -89,6 +92,10 @@ const Fair2MoreInfoFixture: Fair2MoreInfoTestsQueryRawResponse = {
         __typename: "OpeningHoursText",
         text: null,
       },
+    },
+    sponsoredContent: {
+      activationText: "Some activation text",
+      pressReleaseUrl: "Some press release text",
     },
     profile: {
       id: "abc123",


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR resolves [FX-2231]

### Description

Adds a link to BMW art activations if the fair is sponsored.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

<img width="534" alt="Screen Shot 2020-10-06 at 2 55 58 PM" src="https://user-images.githubusercontent.com/4432348/95254460-eb39a800-07ed-11eb-86c0-cf8988cc455e.png">



[FX-2231]: https://artsyproduct.atlassian.net/browse/FX-2231