### PR TITLE
FX-2328: (feat) Adds legacyFairSlugs and legacyProfileSlugs for tailored fair routing #trivial

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -44,6 +44,7 @@
 
 @import Darwin.POSIX.sys.utsname;
 
+
 @implementation ARAppDelegate (Emission)
 
 - (void)setupEmission;
@@ -85,14 +86,14 @@ SOFTWARE.
 */
 - (NSString *)deviceId;
 {
-  struct utsname systemInfo;
-  uname(&systemInfo);
-  NSString* deviceId = [NSString stringWithCString:systemInfo.machine
-                                          encoding:NSUTF8StringEncoding];
-  if ([deviceId isEqualToString:@"i386"] || [deviceId isEqualToString:@"x86_64"] ) {
-    deviceId = [NSString stringWithFormat:@"%s", getenv("SIMULATOR_MODEL_IDENTIFIER")];
-  }
-  return deviceId;
+    struct utsname systemInfo;
+    uname(&systemInfo);
+    NSString *deviceId = [NSString stringWithCString:systemInfo.machine
+                                            encoding:NSUTF8StringEncoding];
+    if ([deviceId isEqualToString:@"i386"] || [deviceId isEqualToString:@"x86_64"]) {
+        deviceId = [NSString stringWithFormat:@"%s", getenv("SIMULATOR_MODEL_IDENTIFIER")];
+    }
+    return deviceId;
 }
 
 - (void)setupSharedEmissionWithPackagerURL:(NSURL *)packagerURL;
@@ -130,26 +131,31 @@ SOFTWARE.
         liveAuctionsURL = @"https://live.artsy.net";
     }
 
+    NSArray *fairSlugs = [aero legacyFairSlugs];
+    NSArray *fairProfileSlugs = [aero legacyFairProfileSlugs];
+
     NSInteger launchCount = [[NSUserDefaults standardUserDefaults] integerForKey:ARAnalyticsAppUsageCountProperty];
     AROnboardingUserProgressStage onboardingState = [[NSUserDefaults standardUserDefaults] integerForKey:AROnboardingUserProgressionStage];
 
     NSDictionary *options = [self getOptionsForEmission:[aero featuresMap] labOptions:[AROptions labOptionsMap]];
 
-    AREmission *emission = [[AREmission alloc] initWithState: @{
-        [ARStateKey userID]: (userID ?: [NSNull null]),
-        [ARStateKey authenticationToken]: (authenticationToken ?: [NSNull null]),
-        [ARStateKey launchCount]: @(launchCount),
-        [ARStateKey onboardingState]: onboardingState == AROnboardingStageDefault ? @"none" : onboardingState == AROnboardingStageOnboarded ? @"complete" : @"incomplete",
-        [ARStateKey sentryDSN]: (sentryDSN ?: [NSNull null]),
-        [ARStateKey stripePublishableKey]: (stripePublishableKey ?: [NSNull null]),
-        [ARStateKey gravityURL]: gravity,
-        [ARStateKey metaphysicsURL]: metaphysics,
-        [ARStateKey predictionURL]: liveAuctionsURL,
-        [ARStateKey webURL]: [[ARRouter baseWebURL] absoluteString],
-        [ARStateKey userAgent]: ARRouter.userAgent,
-        [ARStateKey env]: env,
-        [ARStateKey options]: options,
-        [ARStateKey deviceId]: self.deviceId
+    AREmission *emission = [[AREmission alloc] initWithState:@{
+                                                                 [ARStateKey userID] : (userID ?: [NSNull null]),
+                                                                 [ARStateKey authenticationToken] : (authenticationToken ?: [NSNull null]),
+                                                                 [ARStateKey launchCount] : @(launchCount),
+                                                                 [ARStateKey onboardingState] : onboardingState == AROnboardingStageDefault ? @"none" : onboardingState == AROnboardingStageOnboarded ? @"complete" : @"incomplete",
+                                                                 [ARStateKey sentryDSN] : (sentryDSN ?: [NSNull null]),
+                                                                 [ARStateKey stripePublishableKey] : (stripePublishableKey ?: [NSNull null]),
+                                                                 [ARStateKey gravityURL] : gravity,
+                                                                 [ARStateKey metaphysicsURL] : metaphysics,
+                                                                 [ARStateKey predictionURL] : liveAuctionsURL,
+                                                                 [ARStateKey webURL] : [[ARRouter baseWebURL] absoluteString],
+                                                                 [ARStateKey userAgent] : ARRouter.userAgent,
+                                                                 [ARStateKey env] : env,
+                                                                 [ARStateKey options] : options,
+                                                                 [ARStateKey legacyFairSlugs] : fairSlugs,
+                                                                 [ARStateKey legacyFairProfileSlugs] : fairProfileSlugs,
+                                                                 [ARStateKey deviceId] : self.deviceId
     } packagerURL:packagerURL];
 
     // Disable default React Native dev menu shake motion handler
@@ -211,14 +217,13 @@ SOFTWARE.
             [ARAnalytics pageView:info[@"context_screen"]  withProperties:[properties copy]];
         }
     };
-
 }
 
 - (void)updateEmissionOptions
 {
     ArtsyEcho *aero = [[ArtsyEcho alloc] init];
     [aero setup];
-    [[AREmission sharedInstance] updateState:@{[ARStateKey options]: [self getOptionsForEmission:[aero featuresMap] labOptions:[AROptions labOptionsMap]]}];
+    [[AREmission sharedInstance] updateState:@{[ARStateKey options] : [self getOptionsForEmission:[aero featuresMap] labOptions:[AROptions labOptionsMap]]}];
 }
 
 - (NSDictionary *)getOptionsForEmission:(NSDictionary *)echoFeatures labOptions:(NSDictionary *)labOptions

--- a/Artsy/App/ArtsyEcho.h
+++ b/Artsy/App/ArtsyEcho.h
@@ -1,9 +1,12 @@
 #import <Aerodramus/Aerodramus.h>
 
-@interface ArtsyEcho: Aerodramus
+
+@interface ArtsyEcho : Aerodramus
 
 - (instancetype)init;
 - (NSDictionary *)featuresMap;
 - (BOOL)isFeatureEnabled:(NSString *)featureFlag;
+- (NSArray *)legacyFairSlugs;
+- (NSArray *)legacyFairProfileSlugs;
 
 @end

--- a/Artsy/App/ArtsyEcho.m
+++ b/Artsy/App/ArtsyEcho.m
@@ -5,6 +5,7 @@
 
 #import "ARAppStatus.h"
 
+
 @implementation ArtsyEcho
 
 - (instancetype)init
@@ -41,13 +42,28 @@
     return [mutableOptions copy];
 }
 
-- (BOOL)isFeatureEnabled:(NSString *)featureFlag {
+- (BOOL)isFeatureEnabled:(NSString *)featureFlag
+{
     Feature *currentFeature = self.features[featureFlag];
     if (currentFeature) {
         return currentFeature.state;
     } else {
         return NO;
     }
+}
+
+- (NSArray *)legacyFairSlugs
+{
+    Message *legacyFairMessage = self.messages[@"LegacyFairSlugs"];
+    NSArray *fairSlugs = [legacyFairMessage.content componentsSeparatedByString:@","];
+    return fairSlugs;
+}
+
+- (NSArray *)legacyFairProfileSlugs
+{
+    Message *legacyFairProfileSlugsMessage = self.messages[@"LegacyFairProfileSlugs"];
+    NSArray *fairProfileSlugs = [legacyFairProfileSlugsMessage.content componentsSeparatedByString:@","];
+    return fairProfileSlugs;
 }
 
 @end

--- a/Artsy/App/ArtsyEcho.m
+++ b/Artsy/App/ArtsyEcho.m
@@ -56,14 +56,14 @@
 {
     Message *legacyFairMessage = self.messages[@"LegacyFairSlugs"];
     NSArray *fairSlugs = [legacyFairMessage.content componentsSeparatedByString:@","];
-    return fairSlugs;
+    return fairSlugs ? fairSlugs : @[];
 }
 
 - (NSArray *)legacyFairProfileSlugs
 {
     Message *legacyFairProfileSlugsMessage = self.messages[@"LegacyFairProfileSlugs"];
     NSArray *fairProfileSlugs = [legacyFairProfileSlugsMessage.content componentsSeparatedByString:@","];
-    return fairProfileSlugs;
+    return fairProfileSlugs ? fairProfileSlugs : @[];
 }
 
 @end

--- a/emission/Pod/Classes/EigenCommunications/ARNotificationsManager.h
+++ b/emission/Pod/Classes/EigenCommunications/ARNotificationsManager.h
@@ -1,6 +1,7 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
 
+
 @interface ARStateKey : NSObject
 + (NSString *)selectedTab;
 + (NSString *)userID;
@@ -15,12 +16,16 @@
 + (NSString *)userAgent;
 + (NSString *)options;
 
++ (NSString *)legacyFairSlugs;
++ (NSString *)legacyFairProfileSlugs;
+
 + (NSString *)env;
 + (NSString *)deviceId;
 
 + (NSString *)stripePublishableKey;
 + (NSString *)sentryDSN;
 @end
+
 
 @interface ARNotificationsManager : RCTEventEmitter <RCTBridgeModule>
 

--- a/emission/Pod/Classes/EigenCommunications/ARNotificationsManager.m
+++ b/emission/Pod/Classes/EigenCommunications/ARNotificationsManager.m
@@ -7,6 +7,7 @@
 // Once this class encompasses as much of the strictly-necessary bridging code as possible we can duplicate it in Java
 // for the android build.
 
+
 @implementation ARStateKey
 // These should match the values in src/lib/store/NativeModel.ts
 + (NSString *)selectedTab { return @"selectedTab"; }
@@ -22,12 +23,16 @@
 + (NSString *)userAgent { return @"userAgent"; }
 + (NSString *)options { return @"options"; }
 
++ (NSString *)legacyFairSlugs { return @"legacyFairSlugs"; }
++ (NSString *)legacyFairProfileSlugs { return @"legacyFairProfileSlugs"; }
+
 + (NSString *)env { return @"env"; }
 + (NSString *)deviceId { return @"deviceId"; }
 
 + (NSString *)stripePublishableKey { return @"stripePublishableKey"; }
 + (NSString *)sentryDSN { return @"sentryDSN"; };
 @end
+
 
 @interface ARNotificationsManager ()
 @property (nonatomic, assign, readwrite) BOOL isBeingObserved;
@@ -43,6 +48,7 @@ static const NSString *notificationReceived = @"NOTIFICATION_RECEIVED";
 static const NSString *stateChanged = @"STATE_CHANGED";
 static const NSString *resetState = @"RESET_APP_STATE";
 static const NSString *requestNavigation = @"REQUEST_NAVIGATION";
+
 
 @implementation ARNotificationsManager
 
@@ -70,12 +76,12 @@ RCT_EXPORT_MODULE();
 
 - (NSDictionary *)constantsToExport
 {
-    return @{@"nativeState": self.state};
+    return @{ @"nativeState" : self.state };
 }
 
 - (NSArray<NSString *> *)supportedEvents
 {
-    return @[@"event"];
+    return @[ @"event" ];
 }
 
 - (void)dispatch:(NSString *)eventName data:(NSDictionary *)data
@@ -92,7 +98,8 @@ RCT_EXPORT_MODULE();
 
 - (void)updateState:(NSDictionary *)state
 {
-    @synchronized (self) {
+    @synchronized(self)
+    {
         NSMutableDictionary *nextState = [[self state] mutableCopy];
         [nextState addEntriesFromDictionary:state];
         _state = [[NSDictionary alloc] initWithDictionary:nextState];
@@ -121,16 +128,19 @@ RCT_EXPORT_MODULE();
 }
 
 // Will be called when this module's first listener is added.
-- (void)startObserving {
+- (void)startObserving
+{
     self.isBeingObserved = true;
 }
 
 // Will be called when this module's last listener is removed, or on dealloc.
-- (void)stopObserving {
+- (void)stopObserving
+{
     self.isBeingObserved = false;
 }
 
-- (void)afterBootstrap:(void (^)())completion {
+- (void)afterBootstrap:(void (^)())completion
+{
     if (self.didBootStrap) {
         completion();
     } else {
@@ -138,7 +148,9 @@ RCT_EXPORT_MODULE();
     }
 }
 
-RCT_EXPORT_METHOD(postNotificationName:(nonnull NSString *)notificationName userInfo:(NSDictionary *)userInfo)
+RCT_EXPORT_METHOD(postNotificationName
+                  : (nonnull NSString *)notificationName userInfo
+                  : (NSDictionary *)userInfo)
 {
     [[NSNotificationCenter defaultCenter] postNotificationName:notificationName object:nil userInfo:userInfo];
 }
@@ -156,7 +168,7 @@ RCT_EXPORT_METHOD(didFinishBootstrapping)
 // All notification JS methods occur on the main queue/thread.
 - (dispatch_queue_t)methodQueue
 {
-  return dispatch_get_main_queue();
+    return dispatch_get_main_queue();
 }
 
 

--- a/src/__generated__/VanityURLEntityQuery.graphql.ts
+++ b/src/__generated__/VanityURLEntityQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 47071ff412d9d2d1e9adb31d30f7d7d7 */
+/* @relayHash 99865e28ae0f1aea0fa3cbc85c101a4c */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -751,6 +751,7 @@ fragment VanityURLEntity_fairOrPartner_18FOGk on VanityURLEntityType {
   __isVanityURLEntityType: __typename
   __typename
   ... on Fair {
+    slug
     ...Fair2_fair @include(if: $useNewFairView)
     ...Fair_fair @skip(if: $useNewFairView)
   }
@@ -791,14 +792,14 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "internalID",
+  "name": "slug",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "slug",
+  "name": "internalID",
   "storageKey": null
 },
 v5 = {
@@ -1174,7 +1175,7 @@ v42 = {
           "name": "node",
           "plural": false,
           "selections": [
-            (v4/*: any*/),
+            (v3/*: any*/),
             {
               "alias": null,
               "args": null,
@@ -1191,7 +1192,7 @@ v42 = {
             (v7/*: any*/),
             (v30/*: any*/),
             (v14/*: any*/),
-            (v3/*: any*/),
+            (v4/*: any*/),
             (v12/*: any*/),
             (v8/*: any*/),
             (v33/*: any*/),
@@ -1263,8 +1264,8 @@ v50 = {
 v51 = [
   (v16/*: any*/),
   (v8/*: any*/),
-  (v4/*: any*/),
   (v3/*: any*/),
+  (v4/*: any*/),
   (v6/*: any*/)
 ],
 v52 = {
@@ -1436,12 +1437,12 @@ return {
           {
             "kind": "InlineFragment",
             "selections": [
+              (v3/*: any*/),
               {
                 "condition": "useNewFairView",
                 "kind": "Condition",
                 "passingValue": true,
                 "selections": [
-                  (v3/*: any*/),
                   (v4/*: any*/),
                   {
                     "alias": "articles",
@@ -1476,8 +1477,8 @@ return {
                             "plural": false,
                             "selections": [
                               (v6/*: any*/),
-                              (v3/*: any*/),
                               (v4/*: any*/),
+                              (v3/*: any*/),
                               (v7/*: any*/),
                               (v8/*: any*/),
                               {
@@ -1536,8 +1537,8 @@ return {
                     "selections": [
                       (v2/*: any*/),
                       (v6/*: any*/),
-                      (v3/*: any*/),
                       (v4/*: any*/),
+                      (v3/*: any*/),
                       (v7/*: any*/),
                       {
                         "alias": null,
@@ -1660,8 +1661,8 @@ return {
                             "plural": false,
                             "selections": [
                               (v6/*: any*/),
-                              (v3/*: any*/),
                               (v4/*: any*/),
+                              (v3/*: any*/),
                               (v8/*: any*/),
                               (v12/*: any*/),
                               {
@@ -1982,8 +1983,8 @@ return {
                                 ],
                                 "storageKey": null
                               },
-                              (v3/*: any*/),
                               (v4/*: any*/),
+                              (v3/*: any*/),
                               (v8/*: any*/),
                               {
                                 "alias": null,
@@ -1993,8 +1994,8 @@ return {
                                 "name": "fair",
                                 "plural": false,
                                 "selections": [
-                                  (v3/*: any*/),
                                   (v4/*: any*/),
+                                  (v3/*: any*/),
                                   (v6/*: any*/)
                                 ],
                                 "storageKey": null
@@ -2092,8 +2093,8 @@ return {
                                             "storageKey": null
                                           },
                                           (v7/*: any*/),
-                                          (v3/*: any*/),
-                                          (v4/*: any*/)
+                                          (v4/*: any*/),
+                                          (v3/*: any*/)
                                         ],
                                         "storageKey": null
                                       }
@@ -2132,7 +2133,6 @@ return {
                 "passingValue": false,
                 "selections": [
                   (v6/*: any*/),
-                  (v4/*: any*/),
                   (v16/*: any*/),
                   {
                     "alias": null,
@@ -2253,7 +2253,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v3/*: any*/),
+                  (v4/*: any*/),
                   (v52/*: any*/),
                   {
                     "alias": null,
@@ -2271,7 +2271,7 @@ return {
                     "plural": false,
                     "selections": [
                       (v6/*: any*/),
-                      (v3/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -2513,7 +2513,7 @@ return {
                                         "name": "node",
                                         "plural": false,
                                         "selections": [
-                                          (v4/*: any*/),
+                                          (v3/*: any*/),
                                           (v6/*: any*/),
                                           {
                                             "alias": null,
@@ -2538,7 +2538,7 @@ return {
                                           (v7/*: any*/),
                                           (v30/*: any*/),
                                           (v14/*: any*/),
-                                          (v3/*: any*/),
+                                          (v4/*: any*/),
                                           (v12/*: any*/),
                                           (v8/*: any*/),
                                           (v33/*: any*/),
@@ -2553,8 +2553,8 @@ return {
                                 ],
                                 "storageKey": "artworksConnection(first:4)"
                               },
-                              (v4/*: any*/),
                               (v3/*: any*/),
+                              (v4/*: any*/),
                               (v45/*: any*/),
                               {
                                 "alias": null,
@@ -2570,8 +2570,8 @@ return {
                                     "selections": [
                                       (v16/*: any*/),
                                       (v8/*: any*/),
-                                      (v4/*: any*/),
                                       (v3/*: any*/),
+                                      (v4/*: any*/),
                                       (v6/*: any*/),
                                       {
                                         "alias": null,
@@ -2582,8 +2582,8 @@ return {
                                         "plural": false,
                                         "selections": [
                                           (v6/*: any*/),
-                                          (v4/*: any*/),
                                           (v3/*: any*/),
+                                          (v4/*: any*/),
                                           (v55/*: any*/)
                                         ],
                                         "storageKey": null
@@ -2641,8 +2641,8 @@ return {
             "kind": "InlineFragment",
             "selections": [
               (v6/*: any*/),
-              (v3/*: any*/),
               (v4/*: any*/),
+              (v3/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -2653,7 +2653,7 @@ return {
                 "selections": [
                   (v6/*: any*/),
                   (v55/*: any*/),
-                  (v3/*: any*/),
+                  (v4/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2731,8 +2731,8 @@ return {
                         "plural": false,
                         "selections": [
                           (v6/*: any*/),
-                          (v3/*: any*/),
                           (v4/*: any*/),
+                          (v3/*: any*/),
                           (v16/*: any*/),
                           {
                             "alias": null,
@@ -2892,7 +2892,7 @@ return {
                           (v62/*: any*/),
                           (v6/*: any*/),
                           (v16/*: any*/),
-                          (v4/*: any*/),
+                          (v3/*: any*/),
                           (v19/*: any*/),
                           {
                             "alias": null,
@@ -2955,8 +2955,8 @@ return {
                         "selections": [
                           (v62/*: any*/),
                           (v6/*: any*/),
-                          (v3/*: any*/),
                           (v4/*: any*/),
+                          (v3/*: any*/),
                           (v16/*: any*/),
                           (v19/*: any*/),
                           (v21/*: any*/),
@@ -3042,7 +3042,7 @@ return {
     ]
   },
   "params": {
-    "id": "47071ff412d9d2d1e9adb31d30f7d7d7",
+    "id": "99865e28ae0f1aea0fa3cbc85c101a4c",
     "metadata": {},
     "name": "VanityURLEntityQuery",
     "operationKind": "query",

--- a/src/__generated__/VanityURLEntity_fairOrPartner.graphql.ts
+++ b/src/__generated__/VanityURLEntity_fairOrPartner.graphql.ts
@@ -6,6 +6,7 @@ import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type VanityURLEntity_fairOrPartner = {
     readonly __typename: "Fair";
+    readonly slug: string;
     readonly " $fragmentRefs": FragmentRefs<"Fair2_fair" | "Fair_fair">;
     readonly " $refType": "VanityURLEntity_fairOrPartner";
 } | {
@@ -48,6 +49,13 @@ const node: ReaderFragment = {
     {
       "kind": "InlineFragment",
       "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "slug",
+          "storageKey": null
+        },
         {
           "condition": "useNewFairView",
           "kind": "Condition",
@@ -92,5 +100,5 @@ const node: ReaderFragment = {
   "type": "VanityURLEntityType",
   "abstractKey": "__isVanityURLEntityType"
 };
-(node as any).hash = 'a45efee3a131453bfba982b2610f0ade';
+(node as any).hash = 'd887180404e9d331b968e01d820aa307';
 export default node;

--- a/src/lib/Scenes/VanityURL/__tests__/VanityURLEntity-tests.tsx
+++ b/src/lib/Scenes/VanityURL/__tests__/VanityURLEntity-tests.tsx
@@ -188,6 +188,31 @@ describe("VanityURLEntity", () => {
       expect(fairComponent).toBeDefined()
     })
   })
+
+  it("renders an old fair page when the lab option is enabled and the slug is configured", () => {
+    __appStoreTestUtils__?.injectEmissionOptions({ AROptionsNewFairPage: true })
+    __appStoreTestUtils__?.injectState({
+      native: { sessionState: { legacyFairSlugs: ["sofa-chicago-2018"] } },
+    })
+    __appStoreTestUtils__?.injectState({
+      native: { sessionState: { legacyFairProfileSlugs: ["old-fair-profile"] } },
+    })
+
+    const tree = renderWithWrappers(<TestRenderer entity="fair" slugType="profileID" slug="old-fair-profile" />)
+    expect(env.mock.getMostRecentOperation().request.node.operation.name).toBe("VanityURLEntityQuery")
+    act(() => {
+      env.mock.resolveMostRecentOperation({
+        errors: [],
+        data: {
+          vanityURLEntity: {
+            ...fairFixture,
+          },
+        },
+      })
+    })
+    const fairComponent = tree.root.findByType(FairContainer)
+    expect(fairComponent).toBeDefined()
+  })
 })
 
 const Fair2Fixture = {

--- a/src/lib/navigation/__tests__/routes-tests.tsx
+++ b/src/lib/navigation/__tests__/routes-tests.tsx
@@ -827,161 +827,29 @@ describe("artsy.net routes", () => {
   })
 
   describe("Fair routing", () => {
-    describe("with the new option enabled", () => {
-      beforeEach(() => {
-        __appStoreTestUtils__?.injectEmissionOptions({ AROptionsNewFairPage: true })
-      })
-      it("routes to Fair2", () => {
-        expect(matchRoute("/fair/red")).toMatchInlineSnapshot(`
+    it("routes to FairArtworks", () => {
+      expect(matchRoute("/fair/red/artworks")).toMatchInlineSnapshot(`
       Object {
-        "module": "Fair2",
+        "module": "FairArtworks",
         "params": Object {
           "fairID": "red",
         },
         "type": "match",
       }
     `)
-        expect(matchRoute("/fair/blue")).toMatchInlineSnapshot(`
+      expect(matchRoute("/fair/blue/artworks")).toMatchInlineSnapshot(`
       Object {
-        "module": "Fair2",
+        "module": "FairArtworks",
         "params": Object {
           "fairID": "blue",
         },
         "type": "match",
       }
     `)
-      })
-
-      it("routes to /fair/:id/artworks", () => {
-        expect(matchRoute("/fair/red/artworks")).toMatchInlineSnapshot(`
-      Object {
-        "module": "Fair2",
-        "params": Object {
-          "fairID": "red",
-        },
-        "type": "match",
-      }
-    `)
-        expect(matchRoute("/fair/blue/artworks")).toMatchInlineSnapshot(`
-      Object {
-        "module": "Fair2",
-        "params": Object {
-          "fairID": "blue",
-        },
-        "type": "match",
-      }
-    `)
-      })
-
-      it("routes to /fair/:id/artists", () => {
-        expect(matchRoute("/fair/red/artists")).toMatchInlineSnapshot(`
-      Object {
-        "module": "Fair2",
-        "params": Object {
-          "fairID": "red",
-        },
-        "type": "match",
-      }
-    `)
-        expect(matchRoute("/fair/blue/artists")).toMatchInlineSnapshot(`
-      Object {
-        "module": "Fair2",
-        "params": Object {
-          "fairID": "blue",
-        },
-        "type": "match",
-      }
-    `)
-      })
-
-      it("routes to /fair/:id/exhibitors", () => {
-        expect(matchRoute("/fair/red/exhibitors")).toMatchInlineSnapshot(`
-      Object {
-        "module": "Fair2",
-        "params": Object {
-          "fairID": "red",
-        },
-        "type": "match",
-      }
-    `)
-        expect(matchRoute("/fair/blue/exhibitors")).toMatchInlineSnapshot(`
-      Object {
-        "module": "Fair2",
-        "params": Object {
-          "fairID": "blue",
-        },
-        "type": "match",
-      }
-    `)
-      })
-
-      it("routes to FairBMWArtActivation", () => {
-        expect(matchRoute("/fair/red/bmw-sponsored-content")).toMatchInlineSnapshot(`
-      Object {
-        "module": "FairBMWArtActivation",
-        "params": Object {
-          "fairID": "red",
-        },
-        "type": "match",
-      }
-    `)
-        expect(matchRoute("/fair/blue/bmw-sponsored-content")).toMatchInlineSnapshot(`
-      Object {
-        "module": "FairBMWArtActivation",
-        "params": Object {
-          "fairID": "blue",
-        },
-        "type": "match",
-      }
-    `)
-      })
-
-      it("routes to Fair2MoreInfo", () => {
-        expect(matchRoute("/fair/red/info")).toMatchInlineSnapshot(`
-      Object {
-        "module": "Fair2MoreInfo",
-        "params": Object {
-          "fairID": "red",
-        },
-        "type": "match",
-      }
-    `)
-        expect(matchRoute("/fair/blue/info")).toMatchInlineSnapshot(`
-      Object {
-        "module": "Fair2MoreInfo",
-        "params": Object {
-          "fairID": "blue",
-        },
-        "type": "match",
-      }
-    `)
-      })
     })
 
-    describe("without the option enabled", () => {
-      it("routes to FairArtworks", () => {
-        expect(matchRoute("/fair/red/artworks")).toMatchInlineSnapshot(`
-      Object {
-        "module": "FairArtworks",
-        "params": Object {
-          "fairID": "red",
-        },
-        "type": "match",
-      }
-    `)
-        expect(matchRoute("/fair/blue/artworks")).toMatchInlineSnapshot(`
-      Object {
-        "module": "FairArtworks",
-        "params": Object {
-          "fairID": "blue",
-        },
-        "type": "match",
-      }
-    `)
-      })
-
-      it("routes to Fair", () => {
-        expect(matchRoute("/fair/red")).toMatchInlineSnapshot(`
+    it("routes to Fair", () => {
+      expect(matchRoute("/fair/red")).toMatchInlineSnapshot(`
       Object {
         "module": "Fair",
         "params": Object {
@@ -990,7 +858,7 @@ describe("artsy.net routes", () => {
         "type": "match",
       }
     `)
-        expect(matchRoute("/fair/blue")).toMatchInlineSnapshot(`
+      expect(matchRoute("/fair/blue")).toMatchInlineSnapshot(`
       Object {
         "module": "Fair",
         "params": Object {
@@ -999,10 +867,10 @@ describe("artsy.net routes", () => {
         "type": "match",
       }
     `)
-      })
+    })
 
-      it("routes to FairArtists", () => {
-        expect(matchRoute("/fair/red/artists")).toMatchInlineSnapshot(`
+    it("routes to FairArtists", () => {
+      expect(matchRoute("/fair/red/artists")).toMatchInlineSnapshot(`
       Object {
         "module": "FairArtists",
         "params": Object {
@@ -1011,7 +879,7 @@ describe("artsy.net routes", () => {
         "type": "match",
       }
     `)
-        expect(matchRoute("/fair/blue/artists")).toMatchInlineSnapshot(`
+      expect(matchRoute("/fair/blue/artists")).toMatchInlineSnapshot(`
       Object {
         "module": "FairArtists",
         "params": Object {
@@ -1020,10 +888,10 @@ describe("artsy.net routes", () => {
         "type": "match",
       }
     `)
-      })
+    })
 
-      it("routes to FairExhibitors", () => {
-        expect(matchRoute("/fair/red/exhibitors")).toMatchInlineSnapshot(`
+    it("routes to FairExhibitors", () => {
+      expect(matchRoute("/fair/red/exhibitors")).toMatchInlineSnapshot(`
       Object {
         "module": "FairExhibitors",
         "params": Object {
@@ -1032,7 +900,7 @@ describe("artsy.net routes", () => {
         "type": "match",
       }
     `)
-        expect(matchRoute("/fair/blue/exhibitors")).toMatchInlineSnapshot(`
+      expect(matchRoute("/fair/blue/exhibitors")).toMatchInlineSnapshot(`
       Object {
         "module": "FairExhibitors",
         "params": Object {
@@ -1041,10 +909,10 @@ describe("artsy.net routes", () => {
         "type": "match",
       }
     `)
-      })
+    })
 
-      it("routes to FairBMWArtActivation", () => {
-        expect(matchRoute("/fair/red/bmw-sponsored-content")).toMatchInlineSnapshot(`
+    it("routes to FairBMWArtActivation", () => {
+      expect(matchRoute("/fair/red/bmw-sponsored-content")).toMatchInlineSnapshot(`
       Object {
         "module": "FairBMWArtActivation",
         "params": Object {
@@ -1053,7 +921,7 @@ describe("artsy.net routes", () => {
         "type": "match",
       }
     `)
-        expect(matchRoute("/fair/blue/bmw-sponsored-content")).toMatchInlineSnapshot(`
+      expect(matchRoute("/fair/blue/bmw-sponsored-content")).toMatchInlineSnapshot(`
       Object {
         "module": "FairBMWArtActivation",
         "params": Object {
@@ -1062,7 +930,6 @@ describe("artsy.net routes", () => {
         "type": "match",
       }
     `)
-      })
     })
   })
 

--- a/src/lib/navigation/__tests__/util-tests.ts
+++ b/src/lib/navigation/__tests__/util-tests.ts
@@ -1,0 +1,67 @@
+import { __appStoreTestUtils__ } from "lib/store/AppStore"
+import { handleFairRouting, MatchResult } from "../util"
+
+describe("#handleFairRouting", () => {
+  it("routes to a new fair page if the option is enabled", () => {
+    __appStoreTestUtils__?.injectEmissionOptions({ AROptionsNewFairPage: true })
+    __appStoreTestUtils__?.injectState({
+      native: { sessionState: { legacyFairSlugs: [] } },
+    })
+
+    const newFairMatch: MatchResult = {
+      type: "match",
+      module: "Fair",
+      params: { fairID: "awesome-fair" },
+    }
+
+    expect(handleFairRouting(newFairMatch)).toEqual({
+      type: "match",
+      module: "Fair2",
+      params: { fairID: "awesome-fair" },
+    })
+  })
+
+  it("routes to an old fair page if the option is enabled and fair is part of slug list", () => {
+    __appStoreTestUtils__?.injectEmissionOptions({ AROptionsNewFairPage: true })
+    __appStoreTestUtils__?.injectState({
+      native: { sessionState: { legacyFairSlugs: ["awesome-fair"] } },
+    })
+
+    const newFairMatch: MatchResult = {
+      type: "match",
+      module: "Fair",
+      params: { fairID: "awesome-fair" },
+    }
+
+    expect(handleFairRouting(newFairMatch)).toEqual({
+      type: "match",
+      module: "Fair",
+      params: { fairID: "awesome-fair" },
+    })
+  })
+
+  it("returns same result if module is not part of fair list", () => {
+    __appStoreTestUtils__?.injectEmissionOptions({ AROptionsNewFairPage: true })
+    __appStoreTestUtils__?.injectState({
+      native: { sessionState: { legacyFairSlugs: ["awesome-fair"] } },
+    })
+
+    const newFairMatch: any = {
+      type: "match",
+      module: "FairBlah",
+      params: { fairID: "awesome-fair" },
+    }
+
+    expect(handleFairRouting(newFairMatch)).toEqual(newFairMatch)
+  })
+
+  it("returns same result if option is not enabled", () => {
+    const newFairMatch: MatchResult = {
+      type: "match",
+      module: "FairArtworks",
+      params: { fairID: "awesome-fair" },
+    }
+
+    expect(handleFairRouting(newFairMatch)).toEqual(newFairMatch)
+  })
+})

--- a/src/lib/navigation/navigate.ts
+++ b/src/lib/navigation/navigate.ts
@@ -1,13 +1,22 @@
 import { isNativeModule, modules } from "lib/AppRegistry"
 import { Linking, NativeModules } from "react-native"
 import { matchRoute } from "./routes"
+import { handleFairRouting } from "./util"
 
 export function navigate(url: string, options: { modal?: boolean } = {}) {
-  const result = matchRoute(url)
+  let result = matchRoute(url)
 
   if (result.type === "external_url") {
     Linking.openURL(result.url)
     return
+  }
+
+  // Conditional routing for fairs depends on the `:fairID` param,
+  // so pulled that out into a separate method. Can be removed
+  // when the old fair view is fully deprecated.
+  // @ts-ignore
+  if (result.type === "match" && !!result.params.fairID) {
+    result = handleFairRouting(result)
   }
 
   const module = modules[result.module]

--- a/src/lib/navigation/routes.tsx
+++ b/src/lib/navigation/routes.tsx
@@ -48,24 +48,6 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
     new RouteMatcher("/*", "LiveAuction", (params) => ({ slug: params["*"] })),
   ])
 
-  const fairRoutes = getCurrentEmissionState().options.AROptionsNewFairPage
-    ? [
-        new RouteMatcher("/fair/:fairID", "Fair2"),
-        new RouteMatcher("/fair/:fairID/artworks", "Fair2"),
-        new RouteMatcher("/fair/:fairID/artists", "Fair2"),
-        new RouteMatcher("/fair/:fairID/exhibitors", "Fair2"),
-        new RouteMatcher("/fair/:fairID/info", "Fair2MoreInfo"),
-        new RouteMatcher("/fair/:fairID/bmw-sponsored-content", "FairBMWArtActivation"),
-      ]
-    : [
-        new RouteMatcher("/fair/:fairID", "Fair"),
-        new RouteMatcher("/fair/:fairID/artworks", "FairArtworks"),
-        new RouteMatcher("/fair/:fairID/artists", "FairArtists"),
-        new RouteMatcher("/fair/:fairID/exhibitors", "FairExhibitors"),
-        new RouteMatcher("/fair/:fairID/info", "FairMoreInfo"),
-        new RouteMatcher("/fair/:fairID/bmw-sponsored-content", "FairBMWArtActivation"),
-      ]
-
   const artsyDotNet: RouteMatcher[] = compact([
     new RouteMatcher("/", "Home"),
     new RouteMatcher("/sales", "Sales"),
@@ -134,7 +116,12 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
 
     new RouteMatcher("/partner-locations/:partnerID", "PartnerLocations"),
 
-    ...fairRoutes,
+    new RouteMatcher("/fair/:fairID", "Fair"),
+    new RouteMatcher("/fair/:fairID/artworks", "FairArtworks"),
+    new RouteMatcher("/fair/:fairID/artists", "FairArtists"),
+    new RouteMatcher("/fair/:fairID/exhibitors", "FairExhibitors"),
+    new RouteMatcher("/fair/:fairID/info", "FairMoreInfo"),
+    new RouteMatcher("/fair/:fairID/bmw-sponsored-content", "FairBMWArtActivation"),
 
     new RouteMatcher("/city/:citySlug/:section", "CitySectionList"),
     new RouteMatcher("/city-fair/:citySlug", "CityFairList"),

--- a/src/lib/navigation/util.ts
+++ b/src/lib/navigation/util.ts
@@ -20,7 +20,7 @@ export function handleFairRouting(result: MatchResult): MatchResult {
     FairMoreInfo: "Fair2MoreInfo",
     FairArtists: "Fair2",
     FairExhibitors: "Fair2",
-    FairBMWArtActivation: "Fair2MoreInfo",
+    FairBMWArtActivation: "FairBMWArtActivation",
   }
 
   if (useNewFairView) {

--- a/src/lib/navigation/util.ts
+++ b/src/lib/navigation/util.ts
@@ -1,0 +1,32 @@
+import { AppModule } from "lib/AppRegistry"
+import { getCurrentEmissionState } from "lib/store/AppStore"
+
+export interface MatchResult {
+  type: "match"
+  module: AppModule
+  params: object
+}
+
+export function handleFairRouting(result: MatchResult): MatchResult {
+  const showNewFairViewFeatureEnabled = getCurrentEmissionState().options.AROptionsNewFairPage
+  const fairSlugs = getCurrentEmissionState().legacyFairSlugs
+
+  // @ts-ignore
+  const useNewFairView = showNewFairViewFeatureEnabled && !fairSlugs?.includes(result.params.fairID)
+
+  const fairModuleMapping: Record<any, AppModule> = {
+    Fair: "Fair2",
+    FairArtworks: "Fair2",
+    FairMoreInfo: "Fair2MoreInfo",
+    FairArtists: "Fair2",
+    FairExhibitors: "Fair2",
+    FairBMWArtActivation: "Fair2MoreInfo",
+  }
+
+  if (useNewFairView) {
+    const fairModule = fairModuleMapping[result.module]
+    result.module = fairModule ?? result.module
+  }
+
+  return result
+}

--- a/src/lib/store/NativeModel.ts
+++ b/src/lib/store/NativeModel.ts
@@ -61,6 +61,8 @@ export interface NativeState {
     AROptionsNewShowPage: boolean
     AROptionsNewFairPage: boolean
   }
+  legacyFairSlugs: string[]
+  legacyFairProfileSlugs: string[]
 }
 
 export type EmissionOptions = NativeState["options"]

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -168,6 +168,8 @@ function getNativeModules(): typeof NativeModules {
           AROptionsNewShowPage: false,
           AROptionsNewFairPage: false,
         },
+        legacyFairSlugs: ["some-fairs-slug", "some-other-fair-slug"],
+        legacyFairProfileSlugs: [],
       },
       postNotificationName: jest.fn(),
       didFinishBootstrapping: jest.fn(),


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-2328]

### Description

This PR allows us to continue to show the _old_ fair view for certain fairs (configured via `LegacyFairSlugs` and `LegacyProfileSlugs`). This is necessary so that, when we launch the new view of fairs, any currently-running (or otherwise specified) fairs can continue to use the old view for a period of time.

Some notes:
- We need to route to the new or old view based on whether the `fairID` param is in that configured list. I couldn't find a "nice" way to do that in our new router, but I tried to make it as clean as possible. Will comment inline.
- Aside from the router, we have to include this logic in our `VanityURLEntity` renderer so we can correctly route from search results (and externally, based on `:profileSlug` routing).
- It's frustrating but necessary to include _both_ the profile slug and the fair slug in our config. This is because, from some entry points, we only have the profile slug (vs. others, where we have the fair slug). Both need to be present for a given fair for this to work.

In the example below, `swab-barcelona-2020` and `swab-barcelona` are configured as `legacyFairSlugs` and `legacyProfileSlugs`, respectively.

![fairrouting](https://user-images.githubusercontent.com/2081340/95265333-fcd77b80-07fe-11eb-8e36-09b10677f60f.gif)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [X] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [X] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [X] I have documented any follow-up work that this PR will require, or it does not require any.
- [X] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [X] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[FX-2328]: https://artsyproduct.atlassian.net/browse/FX-2328