### PR TITLE
chore: fix Sentry CLI installation on beta deploys #trivial

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ certs:
 
 distribute: change_version_to_date set_git_properties setup_fastlane_env
 	brew update
-	brew install getsentry/tools/sentry-cli
+	brew tap getsentry/tools
+	brew install sentry-cli
 	bundle exec fastlane update_plugins
 	bundle exec fastlane ship_beta
 


### PR DESCRIPTION
The type of this PR is: **bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

<!-- Implementation description -->

Deploys on Circle CI started failing a few days ago:

```
brew install getsentry/tools/sentry-cli
v12.16.2 is already installed.
Now using node v12.16.2 (npm v6.14.4)
default -> v12.16.2 *
Warning: Permanently added the RSA host key for IP address '140.82.113.3' to the list of known hosts.
==> Tapping getsentry/tools
Cloning into '/usr/local/Homebrew/Library/Taps/getsentry/homebrew-tools'...
remote: Enumerating objects: 20, done.        
remote: Counting objects: 100% (20/20), done.        
remote: Compressing objects: 100% (15/15), done.        
remote: Total 516 (delta 4), reused 0 (delta 0), pack-reused 496        
Receiving objects: 100% (516/516), 58.49 KiB | 4.87 MiB/s, done.
Resolving deltas: 100% (183/183), done.
Tapped 1 formula (28 files, 97.5KB).
Error: No available formula or cask with the name "getsentry/tools/sentry-cli".
==> Searching for similarly named formulae...
This similarly named formula was found:
sentry-cli
```

The solution was to tap `getsentry/tools` first and then use a less-qualified `sentry-cli` formula for Homebrew.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434