### PR TITLE
Adds support for new text styles within Markdown #trivial

### DIFF
--- a/src/lib/Components/Bidding/Screens/RegistrationResult.tsx
+++ b/src/lib/Components/Bidding/Screens/RegistrationResult.tsx
@@ -67,15 +67,18 @@ const registrationNetworkErrorMessage = {
   description: "Please\ncheck your internet connection\nand try again.",
 }
 
-const markdownRules = defaultRules(true, {
-  paragraph: {
-    match: blockRegex(/^((?:[^\n]|\n(?! *\n))+)(?:\n *)/),
-    react: (node, output, state) => {
-      return (
-        <Sans size="4" key={state.key} textAlign="center">
-          {output(node.content, state)}
-        </Sans>
-      )
+const markdownRules = defaultRules({
+  modal: true,
+  ruleOverrides: {
+    paragraph: {
+      match: blockRegex(/^((?:[^\n]|\n(?! *\n))+)(?:\n *)/),
+      react: (node, output, state) => {
+        return (
+          <Sans size="4" key={state.key} textAlign="center">
+            {output(node.content, state)}
+          </Sans>
+        )
+      },
     },
   },
 })

--- a/src/lib/Components/HoursCollapsible.tsx
+++ b/src/lib/Components/HoursCollapsible.tsx
@@ -23,7 +23,7 @@ interface State {
   isExpanded: boolean
 }
 
-const basicRules = defaultRules(true)
+const basicRules = defaultRules({ modal: true })
 const markdownRules = {
   ...basicRules,
   paragraph: {

--- a/src/lib/Components/Markdown.tsx
+++ b/src/lib/Components/Markdown.tsx
@@ -12,7 +12,7 @@ function stringifyChildren(children: any): string {
   return _.isArray(children) ? children.join("") : children
 }
 
-const basicRules = defaultRules(true)
+const basicRules = defaultRules({ modal: true })
 export class Markdown extends React.Component<Props & FlexProps> {
   static defaultProps = {
     rules: basicRules,

--- a/src/lib/Components/ReadMore.tsx
+++ b/src/lib/Components/ReadMore.tsx
@@ -32,7 +32,8 @@ export const ReadMore = React.memo(
   ({ content, maxChars, presentLinksModally, color, trackingFlow, contextModule, textStyle = "serif" }: Props) => {
     const [isExpanded, setIsExpanded] = useState(false)
     const tracking = useTracking()
-    const basicRules = defaultRules(presentLinksModally)
+    const useNewTextStyles = textStyle === "new"
+    const basicRules = defaultRules({ modal: presentLinksModally, useNewTextStyles })
     const TextComponent: React.ComponentType<SansProps | SerifProps | PaletteTextProps> = (textStyle === "new"
       ? PaletteText
       : textStyle === "sans"
@@ -55,6 +56,7 @@ export const ReadMore = React.memo(
         },
       },
     }
+
     const root = renderMarkdown(content, rules)
     // Removes the last empty space in the markdown array
     if (Array.isArray(root)) {

--- a/src/lib/Components/__tests__/Markdown-tests.tsx
+++ b/src/lib/Components/__tests__/Markdown-tests.tsx
@@ -73,7 +73,7 @@ describe("Markdown", () => {
   })
 
   it("accepts a rules prop", () => {
-    const basicRules = defaultRules(true)
+    const basicRules = defaultRules({ modal: true })
     const rules = {
       ...basicRules,
       paragraph: {

--- a/src/lib/Scenes/Collection/Components/CollectionHubsRails/FeaturedCollections/FeaturedCollectionsRail.tsx
+++ b/src/lib/Scenes/Collection/Components/CollectionHubsRails/FeaturedCollections/FeaturedCollectionsRail.tsx
@@ -26,13 +26,16 @@ export const FeaturedCollectionsRail: React.FC<FeaturedCollectionsRailProps> = (
   const collections = collectionGroup?.members ?? []
 
   const handleMarkdown = (markdown: string, titleLength: number) => {
-    const markdownRules = defaultRules(true, {
-      paragraph: {
-        react: (node, output, state) => (
-          <Sans size="3t" color="black100" key={state.key} numberOfLines={titleLength > 32 ? 3 : 4}>
-            {output(node.content, state)}
-          </Sans>
-        ),
+    const markdownRules = defaultRules({
+      modal: true,
+      ruleOverrides: {
+        paragraph: {
+          react: (node, output, state) => (
+            <Sans size="3t" color="black100" key={state.key} numberOfLines={titleLength > 32 ? 3 : 4}>
+              {output(node.content, state)}
+            </Sans>
+          ),
+        },
       },
     })
 

--- a/src/lib/Scenes/Fair2/Components/Fair2Header.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2Header.tsx
@@ -1,6 +1,8 @@
 import { Fair2Header_fair } from "__generated__/Fair2Header_fair.graphql"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
+import { ReadMore } from "lib/Components/ReadMore"
 import { navigate } from "lib/navigation/navigate"
+import { truncatedTextLimit } from "lib/utils/hardware"
 import { Box, ChevronIcon, Flex, Text } from "palette"
 import React from "react"
 import { Dimensions, TouchableOpacity } from "react-native"
@@ -68,7 +70,7 @@ export const Fair2Header: React.FC<Fair2HeaderProps> = ({ fair }) => {
           {name}
         </Text>
         <FairTiming fair={fair} />
-        <Text variant="text">{previewText}</Text>
+        {!!previewText && <ReadMore textStyle="new" content={previewText} maxChars={truncatedTextLimit()} />}
         {!!canShowMoreInfoLink && (
           <TouchableOpacity onPress={() => navigate(`/fair/${slug}/info`)}>
             <Flex py={2} flexDirection="row" justifyContent="flex-start">

--- a/src/lib/Scenes/Fair2/Fair2MoreInfo.tsx
+++ b/src/lib/Scenes/Fair2/Fair2MoreInfo.tsx
@@ -13,7 +13,6 @@ import { Box, ChevronIcon, Flex, Spacer, Text, Theme } from "palette"
 import React from "react"
 import { ScrollView, TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
-import { blockRegex } from "simple-markdown"
 
 interface Fair2MoreInfoQueryRendererProps {
   fairID: string
@@ -23,23 +22,11 @@ interface Fair2MoreInfoProps {
   fair: Fair2MoreInfo_fair
 }
 
-// Default markdown rules center align text, which we don't want.
-const markdownRules = defaultRules(false, {
-  paragraph: {
-    match: blockRegex(/^((?:[^\n]|\n(?! *\n))+)(?:\n *)/),
-    react: (node, output, state) => {
-      return (
-        <Text variant="text" key={state.key} textAlign="left">
-          {output(node.content, state)}
-        </Text>
-      )
-    },
-  },
-})
-
 export const Fair2MoreInfo: React.FC<Fair2MoreInfoProps> = ({ fair }) => {
   const coordinates = fair.location?.coordinates
   const shouldShowLocationMap = coordinates && coordinates?.lat && coordinates?.lng
+
+  const markdownRules = defaultRules({ useNewTextStyles: true })
 
   return (
     <ProvideScreenTracking
@@ -59,13 +46,13 @@ export const Fair2MoreInfo: React.FC<Fair2MoreInfoProps> = ({ fair }) => {
 
             {!!fair.summary && (
               <>
-                <Text variant="text">{fair.summary}</Text>
+                <Markdown rules={markdownRules}>{fair.summary}</Markdown>
                 <Spacer my={1} />
               </>
             )}
             {!!fair.about && (
               <>
-                <Text variant="text">{fair.about}</Text>
+                <Markdown rules={markdownRules}>{fair.about}</Markdown>
                 <Spacer my={1} />
               </>
             )}

--- a/src/lib/Scenes/Feature/components/FeatureMarkdown.tsx
+++ b/src/lib/Scenes/Feature/components/FeatureMarkdown.tsx
@@ -9,15 +9,18 @@ export const FeatureMarkdown: React.FC<{ content: string; sansProps?: Partial<Re
   sansProps,
 }) => {
   const rendered = renderMarkdown(content, {
-    ...defaultRules(false, {
-      paragraph: {
-        match: SimpleMarkdown.blockRegex(/^((?:[^\n]|\n(?! *\n))+)(?:\n *)/),
-        react: (node, output, state) => {
-          return (
-            <Sans size="3" key={state.key} {...sansProps}>
-              {output(node.content, state)}
-            </Sans>
-          )
+    ...defaultRules({
+      modal: false,
+      ruleOverrides: {
+        paragraph: {
+          match: SimpleMarkdown.blockRegex(/^((?:[^\n]|\n(?! *\n))+)(?:\n *)/),
+          react: (node, output, state) => {
+            return (
+              <Sans size="3" key={state.key} {...sansProps}>
+                {output(node.content, state)}
+              </Sans>
+            )
+          },
         },
       },
     }),

--- a/src/lib/utils/__tests__/renderMarkdown-tests.tsx
+++ b/src/lib/utils/__tests__/renderMarkdown-tests.tsx
@@ -1,7 +1,7 @@
 // @ts-ignore STRICTNESS_MIGRATION
 import { mount, shallow } from "enzyme"
 import { LinkText } from "lib/Components/Text/LinkText"
-import { Flex, Sans, Serif, Theme } from "palette"
+import { Flex, Sans, Serif, Text, Theme } from "palette"
 import React from "react"
 import { defaultRules, renderMarkdown } from "../renderMarkdown"
 
@@ -33,6 +33,18 @@ describe("renderMarkdown", () => {
     expect(renderedComponent.find(Sans).at(1).text()).toEqual("This is a second paragraph")
   })
 
+  it("returns markdown with the new style", () => {
+    const componentList = renderMarkdown(
+      "This is a first paragraph\n\nThis is a second paragraph",
+      defaultRules({ useNewTextStyles: true })
+    ) as any
+    expect(componentList.length).toEqual(4)
+
+    const renderedComponent = shallow(<Flex>{componentList}</Flex>)
+    expect(renderedComponent.find(Sans).length).toEqual(0)
+    expect(renderedComponent.find(Text).length).toEqual(2)
+  })
+
   it("returns markdown for multiple paragraphs and links", () => {
     const componentList = renderMarkdown(
       "This is a [first](/artist/first) paragraph\n\nThis is a [second](/gene/second) paragraph"
@@ -53,7 +65,7 @@ describe("renderMarkdown", () => {
   })
 
   it("handles custom rules", () => {
-    const basicRules = defaultRules()
+    const basicRules = defaultRules({})
     const customRules = {
       ...basicRules,
       paragraph: {
@@ -82,7 +94,7 @@ describe("renderMarkdown", () => {
   })
 
   it("opens links modally when specified", () => {
-    const basicRules = defaultRules(true)
+    const basicRules = defaultRules({ modal: true })
     const customRules = {
       ...basicRules,
       paragraph: {
@@ -115,7 +127,7 @@ describe("renderMarkdown", () => {
   })
 
   it("doesn't open links modally when not specified", () => {
-    const basicRules = defaultRules()
+    const basicRules = defaultRules({})
     const customRules = {
       ...basicRules,
       paragraph: {
@@ -148,7 +160,7 @@ describe("renderMarkdown", () => {
   })
 
   it(`renders all the markdown elements`, async () => {
-    const basicRules = defaultRules()
+    const basicRules = defaultRules({})
     const kitchenSink = readFileSync(join(__dirname, "markdown-kitchen-sink.md")).toString()
 
     const tree = renderMarkdown(kitchenSink, basicRules)

--- a/src/lib/utils/renderMarkdown.tsx
+++ b/src/lib/utils/renderMarkdown.tsx
@@ -161,7 +161,7 @@ export function defaultRules({
           }
 
           const listItemText = useNewTextStyles ? (
-            <Text variant="text" key={state.key}>
+            <Text variant="text" key={String(state.key) + 1}>
               {output(node.content, state)}
             </Text>
           ) : (


### PR DESCRIPTION
The type of this PR is: ** Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

I noticed while working on Fairs that we don't yet have great support for our new text styles within the existing `Markdown` component.

This PR takes a stab (using my best guess and existing tokens/variants) at providing support for this.

Within the ReadMore component:
<img width="418" alt="image" src="https://user-images.githubusercontent.com/2081340/95371432-32846f00-08a8-11eb-8bfa-1f339ce16d83.png">

Within the Markdown component:
<img width="417" alt="image" src="https://user-images.githubusercontent.com/2081340/95376158-a75aa780-08ae-11eb-826c-1170797eb27c.png">


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [X] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [X] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [X] I have documented any follow-up work that this PR will require, or it does not require any.
- [X] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [X] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434