### PR TITLE
fix: Fixes sticky tab spacing and a few other QA items for Fairs #trivial

### DIFF
--- a/src/__generated__/Fair2EditorialTestsQuery.graphql.ts
+++ b/src/__generated__/Fair2EditorialTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash b15df5b7cba8e98bc063d427981fef56 */
+/* @relayHash 39b97b79fdcc32cc24ddeca3599b78e0 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -64,7 +64,7 @@ fragment Fair2Editorial_fair on Fair {
         slug
         title
         href
-        publishedAt(format: "MMM Do, YY")
+        publishedAt(format: "MMM Do, YYYY")
         thumbnailImage {
           src: imageURL
         }
@@ -211,12 +211,12 @@ return {
                           {
                             "kind": "Literal",
                             "name": "format",
-                            "value": "MMM Do, YY"
+                            "value": "MMM Do, YYYY"
                           }
                         ],
                         "kind": "ScalarField",
                         "name": "publishedAt",
-                        "storageKey": "publishedAt(format:\"MMM Do, YY\")"
+                        "storageKey": "publishedAt(format:\"MMM Do, YYYY\")"
                       },
                       {
                         "alias": null,
@@ -252,7 +252,7 @@ return {
     ]
   },
   "params": {
-    "id": "b15df5b7cba8e98bc063d427981fef56",
+    "id": "39b97b79fdcc32cc24ddeca3599b78e0",
     "metadata": {},
     "name": "Fair2EditorialTestsQuery",
     "operationKind": "query",

--- a/src/__generated__/Fair2Editorial_fair.graphql.ts
+++ b/src/__generated__/Fair2Editorial_fair.graphql.ts
@@ -119,12 +119,12 @@ return {
                     {
                       "kind": "Literal",
                       "name": "format",
-                      "value": "MMM Do, YY"
+                      "value": "MMM Do, YYYY"
                     }
                   ],
                   "kind": "ScalarField",
                   "name": "publishedAt",
-                  "storageKey": "publishedAt(format:\"MMM Do, YY\")"
+                  "storageKey": "publishedAt(format:\"MMM Do, YYYY\")"
                 },
                 {
                   "alias": null,
@@ -158,5 +158,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '683a5120c185a0328f6bd09ca329d21c';
+(node as any).hash = 'd47cd5b9abff86ad81dc2d90c8c865fa';
 export default node;

--- a/src/__generated__/Fair2Query.graphql.ts
+++ b/src/__generated__/Fair2Query.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 52fa5760842d611294681af039eed0ef */
+/* @relayHash 05617269717f2840213bd93c46cb089b */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -142,7 +142,7 @@ fragment Fair2Editorial_fair on Fair {
         slug
         title
         href
-        publishedAt(format: "MMM Do, YY")
+        publishedAt(format: "MMM Do, YYYY")
         thumbnailImage {
           src: imageURL
         }
@@ -711,12 +711,12 @@ return {
                           {
                             "kind": "Literal",
                             "name": "format",
-                            "value": "MMM Do, YY"
+                            "value": "MMM Do, YYYY"
                           }
                         ],
                         "kind": "ScalarField",
                         "name": "publishedAt",
-                        "storageKey": "publishedAt(format:\"MMM Do, YY\")"
+                        "storageKey": "publishedAt(format:\"MMM Do, YYYY\")"
                       },
                       {
                         "alias": null,
@@ -1544,7 +1544,7 @@ return {
     ]
   },
   "params": {
-    "id": "52fa5760842d611294681af039eed0ef",
+    "id": "05617269717f2840213bd93c46cb089b",
     "metadata": {},
     "name": "Fair2Query",
     "operationKind": "query",

--- a/src/__generated__/Fair2TestsQuery.graphql.ts
+++ b/src/__generated__/Fair2TestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 0ae67ed58f477527546b20593316e62d */
+/* @relayHash 4f92128db8256de835ae80c4c6d62015 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -373,7 +373,7 @@ fragment Fair2Editorial_fair on Fair {
         slug
         title
         href
-        publishedAt(format: "MMM Do, YY")
+        publishedAt(format: "MMM Do, YYYY")
         thumbnailImage {
           src: imageURL
         }
@@ -942,12 +942,12 @@ return {
                           {
                             "kind": "Literal",
                             "name": "format",
-                            "value": "MMM Do, YY"
+                            "value": "MMM Do, YYYY"
                           }
                         ],
                         "kind": "ScalarField",
                         "name": "publishedAt",
-                        "storageKey": "publishedAt(format:\"MMM Do, YY\")"
+                        "storageKey": "publishedAt(format:\"MMM Do, YYYY\")"
                       },
                       {
                         "alias": null,
@@ -1775,7 +1775,7 @@ return {
     ]
   },
   "params": {
-    "id": "0ae67ed58f477527546b20593316e62d",
+    "id": "4f92128db8256de835ae80c4c6d62015",
     "metadata": {},
     "name": "Fair2TestsQuery",
     "operationKind": "query",

--- a/src/__generated__/VanityURLEntityQuery.graphql.ts
+++ b/src/__generated__/VanityURLEntityQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 99865e28ae0f1aea0fa3cbc85c101a4c */
+/* @relayHash aad531637f41a78b86b9bd8221ed1804 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -164,7 +164,7 @@ fragment Fair2Editorial_fair on Fair {
         slug
         title
         href
-        publishedAt(format: "MMM Do, YY")
+        publishedAt(format: "MMM Do, YYYY")
         thumbnailImage {
           src: imageURL
         }
@@ -1487,12 +1487,12 @@ return {
                                   {
                                     "kind": "Literal",
                                     "name": "format",
-                                    "value": "MMM Do, YY"
+                                    "value": "MMM Do, YYYY"
                                   }
                                 ],
                                 "kind": "ScalarField",
                                 "name": "publishedAt",
-                                "storageKey": "publishedAt(format:\"MMM Do, YY\")"
+                                "storageKey": "publishedAt(format:\"MMM Do, YYYY\")"
                               },
                               {
                                 "alias": null,
@@ -3042,7 +3042,7 @@ return {
     ]
   },
   "params": {
-    "id": "99865e28ae0f1aea0fa3cbc85c101a4c",
+    "id": "aad531637f41a78b86b9bd8221ed1804",
     "metadata": {},
     "name": "VanityURLEntityQuery",
     "operationKind": "query",

--- a/src/lib/Scenes/Fair2/Components/Fair2Editorial.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2Editorial.tsx
@@ -87,7 +87,7 @@ export const Fair2EditorialFragmentContainer = createFragmentContainer(Fair2Edit
             slug
             title
             href
-            publishedAt(format: "MMM Do, YY")
+            publishedAt(format: "MMM Do, YYYY")
             thumbnailImage {
               src: imageURL
             }

--- a/src/lib/Scenes/Fair2/Components/Fair2ExhibitorRail.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2ExhibitorRail.tsx
@@ -59,7 +59,7 @@ const Fair2ExhibitorRail: React.FC<Fair2ExhibitorRailProps> = ({ show }) => {
 
   return (
     <>
-      <Box px={2} pb={1}>
+      <Box px={2}>
         <SectionTitle
           title={partnerName}
           subtitle={`${count} works`}

--- a/src/lib/Scenes/Fair2/Components/Fair2Header.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2Header.tsx
@@ -71,7 +71,7 @@ export const Fair2Header: React.FC<Fair2HeaderProps> = ({ fair }) => {
         <Text variant="text">{previewText}</Text>
         {!!canShowMoreInfoLink && (
           <TouchableOpacity onPress={() => navigate(`/fair/${slug}/info`)}>
-            <Flex py={2} flexDirection="row" justifyContent="flex-start">
+            <Flex pt={2} flexDirection="row" justifyContent="flex-start">
               <Text variant="mediumText">More info</Text>
               <ChevronIcon mr="-5px" mt="2px" />
             </Flex>

--- a/src/lib/Scenes/Fair2/Components/SimpleTabs.tsx
+++ b/src/lib/Scenes/Fair2/Components/SimpleTabs.tsx
@@ -1,4 +1,3 @@
-import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { Box, color, Flex, Text } from "palette"
 import React, { Dispatch, SetStateAction } from "react"
 import { TouchableOpacity, View } from "react-native"
@@ -18,12 +17,10 @@ interface TabProps {
  * active tab.
  */
 export const Tab: React.FC<TabProps> = ({ label, active, onPress }) => {
-  const { safeAreaInsets } = useScreenDimensions()
   return (
     <TouchableOpacity onPress={onPress}>
       <View
         style={{
-          marginTop: safeAreaInsets.top,
           height: 55,
           alignItems: "center",
           justifyContent: "center",
@@ -56,6 +53,7 @@ export const Tabs: React.FC<TabsProps> = ({ setActiveTab, activeTab, tabs }) => 
             width={`${tabWidth}%`}
             borderBottomColor={active ? color("black100") : color("black10")}
             borderBottomWidth="1px"
+            key={label}
           >
             <Tab label={label} onPress={() => setActiveTab(index)} active={active} />
           </Box>


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-2310], [FX-2322]

### Description

This PR addresses some general spacing issues on the Fair view. The main change is to fix the way we handle spacing around our tab component. It's slightly tricky because:
- We want there to be a `safeAreaInsets.top` amount of padding on top of the tabs when they are stuck, so that we don't overlap with the top of the phone.
- zIndexes have questionable support in `FlatList`s 😅.

There's more description in-code. Many thanks to @pvinis for tackling this tricky one with me!

![stickyyay](https://user-images.githubusercontent.com/2081340/95384520-bcd5ce80-08ba-11eb-8f6b-362e782e7774.gif)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [X] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [X] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [X] I have documented any follow-up work that this PR will require, or it does not require any.
- [X] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [X] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[FX-2310]: https://artsyproduct.atlassian.net/browse/FX-2310
[FX-2322]: https://artsyproduct.atlassian.net/browse/FX-2322