### PR TITLE
Feature: [MyCollection] Add global loading / error handing

### DIFF
--- a/src/__generated__/MyCollectionArtworkModelUpdateArtworkMutation.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkModelUpdateArtworkMutation.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 0e0c3a680a72c2f75ecca7832765bbe5 */
+/* @relayHash e7dde358f51cb0d458b0608580fc8b46 */
 
 import { ConcreteRequest } from "relay-runtime";
 export type MyCollectionUpdateArtworkInput = {
@@ -51,6 +51,9 @@ export type MyCollectionArtworkModelUpdateArtworkMutationResponse = {
                 readonly title: string | null;
                 readonly width: string | null;
             } | null;
+            readonly mutationError?: {
+                readonly message: string | null;
+            } | null;
         } | null;
     } | null;
 };
@@ -93,6 +96,11 @@ mutation MyCollectionArtworkModelUpdateArtworkMutation(
           slug
           title
           width
+        }
+      }
+      ... on MyCollectionArtworkMutationFailure {
+        mutationError {
+          message
         }
       }
     }
@@ -244,6 +252,31 @@ v18 = {
   "kind": "ScalarField",
   "name": "width",
   "storageKey": null
+},
+v19 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "GravityMutationError",
+      "kind": "LinkedField",
+      "name": "mutationError",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "message",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "MyCollectionArtworkMutationFailure",
+  "abstractKey": null
 };
 return {
   "fragment": {
@@ -314,7 +347,8 @@ return {
                 ],
                 "type": "MyCollectionArtworkMutationSuccess",
                 "abstractKey": null
-              }
+              },
+              (v19/*: any*/)
             ],
             "storageKey": null
           }
@@ -401,7 +435,8 @@ return {
                 ],
                 "type": "MyCollectionArtworkMutationSuccess",
                 "abstractKey": null
-              }
+              },
+              (v19/*: any*/)
             ],
             "storageKey": null
           }
@@ -411,7 +446,7 @@ return {
     ]
   },
   "params": {
-    "id": "0e0c3a680a72c2f75ecca7832765bbe5",
+    "id": "e7dde358f51cb0d458b0608580fc8b46",
     "metadata": {},
     "name": "MyCollectionArtworkModelUpdateArtworkMutation",
     "operationKind": "mutation",
@@ -419,5 +454,5 @@ return {
   }
 };
 })();
-(node as any).hash = '1b765af296c64ca91d4e2619f95ae676';
+(node as any).hash = 'a5ec4708da17ae5f05ad792a1e16e6ff';
 export default node;

--- a/src/lib/Scenes/MyCollection/Boot.tsx
+++ b/src/lib/Scenes/MyCollection/Boot.tsx
@@ -1,8 +1,8 @@
 import { FormikProvider, useFormik } from "formik"
+import { AddEditModal } from "lib/Scenes/MyCollection/Screens/AddArtwork/Components/AddEditModal"
 import { AppStore } from "lib/store/AppStore"
 import React, { useEffect, useRef } from "react"
 import { View } from "react-native"
-import { Modal } from "./Components/Modal"
 import { Navigator } from "./Components/Navigator"
 import { artworkSchema, validateArtworkSchema } from "./Screens/AddArtwork/Form/artworkSchema"
 import { ArtworkFormValues } from "./State/MyCollectionArtworkModel"
@@ -43,7 +43,9 @@ const Boot: React.FC<{ Component: React.ComponentType<any>; passProps: any }> = 
         <Navigator name="main">
           <Component {...passProps} />
         </Navigator>
-        <Modal />
+
+        {/* Varous modals used in app go here */}
+        <AddEditModal />
       </FormikProvider>
     </View>
   )

--- a/src/lib/Scenes/MyCollection/Screens/AddArtwork/AddEditArtwork.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/AddArtwork/AddEditArtwork.tsx
@@ -2,7 +2,7 @@ import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
 import { ScreenMargin } from "lib/Scenes/MyCollection/Components/ScreenMargin"
 import { useArtworkForm } from "lib/Scenes/MyCollection/Screens/AddArtwork/Form/useArtworkForm"
 import { AppStore } from "lib/store/AppStore"
-import { BorderBox, Box, Button, Flex, Join, Sans, Spacer } from "palette"
+import { BorderBox, Box, Button, Flex, Join, Sans, Spacer, Text } from "palette"
 import React from "react"
 import { ScrollView } from "react-native"
 import { ArrowButton } from "./Components/ArrowButton"
@@ -28,6 +28,9 @@ export const AddEditArtwork: React.FC = () => {
       </FancyModalHeader>
 
       <Spacer my={1} />
+
+      {/* FIXME: Wire up proper loading modal */}
+      {!!artworkState.sessionState.isLoading && <Text variant="title">Loading</Text>}
 
       <Sans size="4" textAlign="center">
         {addOrEditLabel} details about your work for a price {"\n"}
@@ -61,7 +64,7 @@ export const AddEditArtwork: React.FC = () => {
             variant="secondaryGray"
             block
             onPress={() =>
-              artworkActions.deleteArtwork({
+              artworkActions.confirmDeleteArtwork({
                 artworkId: artworkState.sessionState.artworkId,
                 artworkGlobalId: artworkState.sessionState.artworkGlobalId,
               })

--- a/src/lib/Scenes/MyCollection/Screens/AddArtwork/Components/AddEditModal.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/AddArtwork/Components/AddEditModal.tsx
@@ -1,10 +1,10 @@
 import { FancyModal } from "lib/Components/FancyModal/FancyModal"
+import { Navigator } from "lib/Scenes/MyCollection/Components/Navigator"
+import { AddEditArtwork } from "lib/Scenes/MyCollection/Screens/AddArtwork/AddEditArtwork"
 import { AppStore } from "lib/store/AppStore"
 import React from "react"
-import { AddEditArtwork } from "../Screens/AddArtwork/AddEditArtwork"
-import { Navigator } from "./Navigator"
 
-export const Modal: React.FC = () => {
+export const AddEditModal: React.FC = () => {
   const modalType = AppStore.useAppState((state) => state.myCollection.navigation.sessionState.modalType)
   const artworkActions = AppStore.actions.myCollection.artwork
 

--- a/src/lib/Scenes/MyCollection/Screens/AddArtwork/Components/__tests__/AddEditModal-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/AddArtwork/Components/__tests__/AddEditModal-tests.tsx
@@ -4,16 +4,16 @@ import { __appStoreTestUtils__, AppStore } from "lib/store/AppStore"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { act } from "react-test-renderer"
-import { Modal } from "../Modal"
+import { AddEditModal } from "../AddEditModal"
 
 jest.mock("lib/Scenes/MyCollection/Screens/AddArtwork/AddEditArtwork", () => ({
   AddEditArtwork: () => null,
 }))
 
-describe("Modal", () => {
+describe("AddEditModal", () => {
   it("injects correct navigator", (done) => {
     __appStoreTestUtils__?.injectState({ myCollection: { navigation: { sessionState: { modalType: "add" } } } })
-    renderWithWrappers(<Modal />)
+    renderWithWrappers(<AddEditModal />)
     act(() => {
       setImmediate(() => {
         expect(
@@ -26,7 +26,7 @@ describe("Modal", () => {
 
   it("renders AddEditArtwork component with visible=true", () => {
     __appStoreTestUtils__?.injectState({ myCollection: { navigation: { sessionState: { modalType: "add" } } } })
-    const wrapper = renderWithWrappers(<Modal />)
+    const wrapper = renderWithWrappers(<AddEditModal />)
     expect(wrapper.root.findAllByType(AddEditArtwork)).toBeDefined()
   })
 
@@ -34,7 +34,7 @@ describe("Modal", () => {
     const spy = jest.fn()
     AppStore.actions.myCollection.artwork.cancelAddEditArtwork = spy as any
     __appStoreTestUtils__?.injectState({ myCollection: { navigation: { sessionState: { modalType: "add" } } } })
-    const wrapper = renderWithWrappers(<Modal />)
+    const wrapper = renderWithWrappers(<AddEditModal />)
     wrapper.root.findByType(FancyModal).props.onBackgroundPressed()
     expect(spy).toHaveBeenCalled()
   })

--- a/src/lib/Scenes/MyCollection/Screens/AddArtwork/Form/artworkSchema.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/AddArtwork/Form/artworkSchema.tsx
@@ -5,8 +5,16 @@ import * as Yup from "yup"
 export const artworkSchema = Yup.object().shape({
   artistSearchResult: Yup.object()
     .nullable()
-    .test("artistSearchResult", "Artist search result required", value => value !== null),
-  medium: Yup.string().test("medium", "Medium required", value => value !== ""),
+    .test("artistSearchResult", "Artist search result required", (value) => value !== null),
+  medium: Yup.string().test("medium", "Medium required", (value) => value !== ""),
+  photos: Yup.string().test("photos", "Photos required", (value) => {
+    // Allow us to bypass adding photos in DEV
+    if (__DEV__) {
+      return true
+    }
+
+    return value.length > 0
+  }),
 })
 
 export function validateArtworkSchema(values: ArtworkFormValues) {

--- a/src/lib/Scenes/MyCollection/Screens/AddArtwork/Form/artworkSchema.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/AddArtwork/Form/artworkSchema.tsx
@@ -7,7 +7,7 @@ export const artworkSchema = Yup.object().shape({
     .nullable()
     .test("artistSearchResult", "Artist search result required", (value) => value !== null),
   medium: Yup.string().test("medium", "Medium required", (value) => value !== ""),
-  photos: Yup.string().test("photos", "Photos required", (value) => {
+  photos: Yup.array().test("photos", "Photos required", (value) => {
     // Allow us to bypass adding photos in DEV
     if (__DEV__) {
       return true

--- a/src/lib/Scenes/MyCollection/Screens/AddArtwork/__tests__/AddEditArtwork-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/AddArtwork/__tests__/AddEditArtwork-tests.tsx
@@ -120,7 +120,7 @@ describe("AddEditArtwork", () => {
     })
 
     const spy = jest.fn()
-    AppStore.actions.myCollection.artwork.deleteArtwork = spy as any
+    AppStore.actions.myCollection.artwork.confirmDeleteArtwork = spy as any
     const wrapper = renderWithWrappers(<AddEditArtwork />)
     const deleteButton = wrapper.root.findByProps({ "data-test-id": "DeleteButton" })
     deleteButton.props.onPress()

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkList/MyCollectionArtworkList.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkList/MyCollectionArtworkList.tsx
@@ -132,7 +132,7 @@ export const MyCollectionArtworkListQueryRenderer: React.FC = () => {
 const LoadingSkeleton = () => {
   return (
     <>
-      <Text variant="largeTitle" ml={2} mb={2}>
+      <Text variant="largeTitle" ml={2} mb={2} mt={6}>
         Artwork Insights
       </Text>
 

--- a/src/lib/Scenes/MyCollection/State/MyCollectionNavigationModel.tsx
+++ b/src/lib/Scenes/MyCollection/State/MyCollectionNavigationModel.tsx
@@ -18,8 +18,8 @@ export type InfoModalType = "demandIndex" | "priceEstimate" | "artistMarket" | "
 
 export interface MyCollectionNavigationModel {
   sessionState: {
-    modalType: ModalType
     infoModalType: InfoModalType
+    modalType: ModalType
     navViewRef: RefObject<any>
     navigators: {
       [key: string]: NavigatorProps
@@ -74,8 +74,8 @@ export interface MyCollectionNavigationModel {
 
 export const MyCollectionNavigationModel: MyCollectionNavigationModel = {
   sessionState: {
-    modalType: null,
     infoModalType: null,
+    modalType: null,
     navViewRef: { current: null },
     navigators: {},
   },
@@ -98,6 +98,10 @@ export const MyCollectionNavigationModel: MyCollectionNavigationModel = {
   goBack: action((state) => {
     getNavigatorIOS(state.sessionState, "main").pop()
   }),
+
+  /**
+   * Modals
+   */
 
   goBackInModal: action((state) => {
     getNavigatorIOS(state.sessionState, "modal").pop()


### PR DESCRIPTION
The type of this PR is: **Feature**

### Description

This PR roughs in some patterns around global loading and error handling while performing different mutation operations on MyCollection. 

The flow:

- The navigation model listens for various artwork actions (add / edit / delete) and toggles `isLoading` to true
- Views can then tap into the `isLoading` state and display a loading indicator, etc

Note that I tried to take advantage of the `LoadingModal` component in Eigen but ran into a hard blocker -- since most of our operations take place modally, from within the FancyModal component, we can't display the `LoadingModal` because of a hard iOS limitation around displaying only **one** modal at a time.  (cc @pvinis and @MounirDhahri)

In place of this limitation I'm just displaying "loading" text in the form for now. We can style it later. 

See [this slack thread](https://artsy.slack.com/archives/C02BAQ5K7/p1602109961092000) for more info. 

> ⚠️   Also note I'm going to start tagging CX devs on these MyCollection PRs to help spead knowledge while I transition off of the team and hand over code. 
 
![loading-alert](https://user-images.githubusercontent.com/236943/95400609-db8a9400-08bf-11eb-869c-a553d841aeb9.gif)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
