### PR TITLE
Using onDismiss of Modal to pop, once its hidden

### DIFF
--- a/src/lib/Scenes/MyAccount/Components/MyAccountFieldEditScreen.tsx
+++ b/src/lib/Scenes/MyAccount/Components/MyAccountFieldEditScreen.tsx
@@ -20,11 +20,16 @@ export const MyAccountFieldEditScreen = React.forwardRef<
   }>
 >(({ children, canSave, onSave, title, contentContainerStyle }, ref) => {
   const [isSaving, setIsSaving] = useState<boolean>(false)
+  const [behindTheModalDismiss, setBehindTheModalDismiss] = useState(false)
   const scrollViewRef = useRef<ScrollView>(null)
   const screen = useScreenDimensions()
 
   const onDismiss = () => {
     SwitchBoard.dismissNavigationViewController(scrollViewRef.current!)
+  }
+
+  const doTheDismiss = () => {
+    setBehindTheModalDismiss(true)
   }
 
   const handleSave = async () => {
@@ -33,7 +38,7 @@ export const MyAccountFieldEditScreen = React.forwardRef<
     }
     try {
       setIsSaving(true)
-      await onSave(onDismiss)
+      await onSave(doTheDismiss)
     } catch (e) {
       console.error(e)
     } finally {
@@ -81,7 +86,14 @@ export const MyAccountFieldEditScreen = React.forwardRef<
           keyboardDismissMode="on-drag"
           keyboardShouldPersistTaps="handled"
         >
-          <LoadingModal isVisible={isSaving} />
+          <LoadingModal
+            isVisible={isSaving}
+            onDismiss={() => {
+              if (behindTheModalDismiss) {
+                onDismiss()
+              }
+            }}
+          />
           {children}
         </ScrollView>
       </PageWithSimpleHeader>


### PR DESCRIPTION

The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves https://artsy.slack.com/archives/CN8S32FJR/p1601474431112100

### Description

We are keeping the `Modal` until we can work on https://artsyproduct.atlassian.net/browse/CX-681.

In order to make the dismissal on profile work, we need to pass it on to the Modal. When we `setIsSaving` to `false`, that will hide the modal. When the modal is hidden, it will then run the onDismiss to pop one screen back.

Before (doesnt pop to profile):
https://f.p0l.co/file/dropshare-public-pavlos/Screen-Recording-2020-10-08-at-15.45.05.mov

After (pops to profile):
https://f.p0l.co/file/dropshare-public-pavlos/Screen-Recording-2020-10-08-at-15.43.52.mov



Follow-up: bring #3950 up to speed with this PR.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434