### PR TITLE
PURCHASE Add Artwork context provider for passing/persisting modal state

### DIFF
--- a/src/__generated__/ArtworkAboveTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtworkAboveTheFoldQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 7c7010f22fa8fead5c5fd3c1eaaf70d6 */
+/* @relayHash dce15d4e321e68f7db95f017e4a0462c */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -403,6 +403,10 @@ fragment InquiryButtons_artwork on Artwork {
 
 fragment InquiryModal_artwork on Artwork {
   ...CollapsibleArtworkDetails_artwork
+  inquiryQuestions {
+    question
+    id
+  }
 }
 
 fragment MakeOfferButton_artwork on Artwork {
@@ -1252,6 +1256,25 @@ return {
           {
             "alias": null,
             "args": null,
+            "concreteType": "InquiryQuestion",
+            "kind": "LinkedField",
+            "name": "inquiryQuestions",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "question",
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "kind": "ScalarField",
             "name": "shippingOrigin",
             "storageKey": null
@@ -1323,7 +1346,7 @@ return {
     ]
   },
   "params": {
-    "id": "7c7010f22fa8fead5c5fd3c1eaaf70d6",
+    "id": "dce15d4e321e68f7db95f017e4a0462c",
     "metadata": {},
     "name": "ArtworkAboveTheFoldQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtworkRefetchQuery.graphql.ts
+++ b/src/__generated__/ArtworkRefetchQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash b46ddef803d769a301bcbb21eb3d15fa */
+/* @relayHash 7abe1ef292cc1d046ad3deaa27e04578 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -689,6 +689,10 @@ fragment InquiryButtons_artwork on Artwork {
 
 fragment InquiryModal_artwork on Artwork {
   ...CollapsibleArtworkDetails_artwork
+  inquiryQuestions {
+    question
+    id
+  }
 }
 
 fragment MakeOfferButton_artwork on Artwork {
@@ -1839,6 +1843,25 @@ return {
           {
             "alias": null,
             "args": null,
+            "concreteType": "InquiryQuestion",
+            "kind": "LinkedField",
+            "name": "inquiryQuestions",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "question",
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "kind": "ScalarField",
             "name": "shippingOrigin",
             "storageKey": null
@@ -2308,7 +2331,7 @@ return {
     ]
   },
   "params": {
-    "id": "b46ddef803d769a301bcbb21eb3d15fa",
+    "id": "7abe1ef292cc1d046ad3deaa27e04578",
     "metadata": {},
     "name": "ArtworkRefetchQuery",
     "operationKind": "query",

--- a/src/__generated__/CommercialButtonsTestsMutationQuery.graphql.ts
+++ b/src/__generated__/CommercialButtonsTestsMutationQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 13689a8254c789588af2d63804ae16d8 */
+/* @relayHash 13c1f628d39f09e2cb662f3b79d80ca8 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -90,6 +90,10 @@ export type CommercialButtonsTestsMutationQueryRawResponse = {
             readonly details: string | null;
         }) | null;
         readonly artistNames: string | null;
+        readonly inquiryQuestions: ReadonlyArray<({
+            readonly question: string;
+            readonly id: string;
+        }) | null> | null;
         readonly id: string;
     }) | null;
 };
@@ -231,6 +235,10 @@ fragment InquiryButtons_artwork on Artwork {
 
 fragment InquiryModal_artwork on Artwork {
   ...CollapsibleArtworkDetails_artwork
+  inquiryQuestions {
+    question
+    id
+  }
 }
 
 fragment MakeOfferButton_artwork on Artwork {
@@ -706,6 +714,25 @@ return {
             "name": "artistNames",
             "storageKey": null
           },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "InquiryQuestion",
+            "kind": "LinkedField",
+            "name": "inquiryQuestions",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "question",
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          },
           (v2/*: any*/)
         ],
         "storageKey": "artwork(id:\"artworkID\")"
@@ -713,7 +740,7 @@ return {
     ]
   },
   "params": {
-    "id": "13689a8254c789588af2d63804ae16d8",
+    "id": "13c1f628d39f09e2cb662f3b79d80ca8",
     "metadata": {},
     "name": "CommercialButtonsTestsMutationQuery",
     "operationKind": "query",

--- a/src/__generated__/CommercialButtonsTestsRenderQuery.graphql.ts
+++ b/src/__generated__/CommercialButtonsTestsRenderQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash ff1860339be54f65bb2f86d8b3fe8d78 */
+/* @relayHash 7af42aa4c9ea53227bd46b149d2ad598 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -90,6 +90,10 @@ export type CommercialButtonsTestsRenderQueryRawResponse = {
             readonly details: string | null;
         }) | null;
         readonly artistNames: string | null;
+        readonly inquiryQuestions: ReadonlyArray<({
+            readonly question: string;
+            readonly id: string;
+        }) | null> | null;
         readonly id: string;
     }) | null;
 };
@@ -231,6 +235,10 @@ fragment InquiryButtons_artwork on Artwork {
 
 fragment InquiryModal_artwork on Artwork {
   ...CollapsibleArtworkDetails_artwork
+  inquiryQuestions {
+    question
+    id
+  }
 }
 
 fragment MakeOfferButton_artwork on Artwork {
@@ -706,6 +714,25 @@ return {
             "name": "artistNames",
             "storageKey": null
           },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "InquiryQuestion",
+            "kind": "LinkedField",
+            "name": "inquiryQuestions",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "question",
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          },
           (v2/*: any*/)
         ],
         "storageKey": "artwork(id:\"artworkID\")"
@@ -713,7 +740,7 @@ return {
     ]
   },
   "params": {
-    "id": "ff1860339be54f65bb2f86d8b3fe8d78",
+    "id": "7af42aa4c9ea53227bd46b149d2ad598",
     "metadata": {},
     "name": "CommercialButtonsTestsRenderQuery",
     "operationKind": "query",

--- a/src/__generated__/InquiryModal_artwork.graphql.ts
+++ b/src/__generated__/InquiryModal_artwork.graphql.ts
@@ -5,6 +5,9 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type InquiryModal_artwork = {
+    readonly inquiryQuestions: ReadonlyArray<{
+        readonly question: string;
+    } | null> | null;
     readonly " $fragmentRefs": FragmentRefs<"CollapsibleArtworkDetails_artwork">;
     readonly " $refType": "InquiryModal_artwork";
 };
@@ -23,6 +26,24 @@ const node: ReaderFragment = {
   "name": "InquiryModal_artwork",
   "selections": [
     {
+      "alias": null,
+      "args": null,
+      "concreteType": "InquiryQuestion",
+      "kind": "LinkedField",
+      "name": "inquiryQuestions",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "question",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
       "args": null,
       "kind": "FragmentSpread",
       "name": "CollapsibleArtworkDetails_artwork"
@@ -31,5 +52,5 @@ const node: ReaderFragment = {
   "type": "Artwork",
   "abstractKey": null
 };
-(node as any).hash = 'f3a097eb76bed326d3113836754160e0';
+(node as any).hash = 'c798bd5e61a03573cae3e58f61e162e0';
 export default node;

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -10,6 +10,7 @@ import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { ArtistSeriesMoreSeriesFragmentContainer as ArtistSeriesMoreSeries } from "lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
 import { getCurrentEmissionState } from "lib/store/AppStore"
 import { AboveTheFoldQueryRenderer } from "lib/utils/AboveTheFoldQueryRenderer"
+import { ArtworkInquiryContext, ArtworkInquiryStateProvider } from "lib/utils/ArtworkInquiry/ArtworkInquiryStore"
 import {
   PlaceholderBox,
   PlaceholderRaggedText,
@@ -288,17 +289,25 @@ export class Artwork extends React.Component<Props, State> {
 
   render() {
     return (
-      <FlatList<ArtworkPageSection>
-        data={this.sections()}
-        ItemSeparatorComponent={() => (
-          <Box mx={2} my={3}>
-            <Separator />
-          </Box>
-        )}
-        refreshControl={<RefreshControl refreshing={this.state.refreshing} onRefresh={this.onRefresh} />}
-        contentContainerStyle={{ paddingBottom: 40 }}
-        renderItem={({ item }) => (item.excludePadding ? item.element : <Box px={2}>{item.element}</Box>)}
-      />
+      <ArtworkInquiryStateProvider>
+        <ArtworkInquiryContext.Consumer>
+          {(_context) => {
+            return (
+              <FlatList<ArtworkPageSection>
+                data={this.sections()}
+                ItemSeparatorComponent={() => (
+                  <Box mx={2} my={3}>
+                    <Separator />
+                  </Box>
+                )}
+                refreshControl={<RefreshControl refreshing={this.state.refreshing} onRefresh={this.onRefresh} />}
+                contentContainerStyle={{ paddingBottom: 40 }}
+                renderItem={({ item }) => (item.excludePadding ? item.element : <Box px={2}>{item.element}</Box>)}
+              />
+            )
+          }}
+        </ArtworkInquiryContext.Consumer>
+      </ArtworkInquiryStateProvider>
     )
   }
 }

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryButtons.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryButtons.tsx
@@ -1,6 +1,9 @@
 import { InquiryButtons_artwork } from "__generated__/InquiryButtons_artwork.graphql"
+import { ArtworkInquiryContext } from "lib/utils/ArtworkInquiry/ArtworkInquiryStore"
+import { InquiryTypes } from "lib/utils/ArtworkInquiry/ArtworkInquiryTypes"
+import { InquiryOptions } from "lib/utils/ArtworkInquiry/ArtworkInquiryTypes"
 import { Button, ButtonVariant } from "palette"
-import React, { useState } from "react"
+import React, { useContext, useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { InquiryModalFragmentContainer } from "./InquiryModal"
 
@@ -17,21 +20,50 @@ export interface InquiryButtonsState {
 
 export const InquiryButtons: React.FC<InquiryButtonsProps> = ({ artwork, ...props }) => {
   const [modalVisibility, setModalVisibility] = useState(false)
+  const { dispatch } = useContext(ArtworkInquiryContext)
+  const dispatchAction = (buttonText: string) => {
+    dispatch({
+      type: "selectInquiryType",
+      payload: buttonText as InquiryTypes,
+    })
+
+    setModalVisibility(true)
+  }
 
   return (
     <>
       {!!artwork.isPriceHidden && (
-        <Button onPress={() => setModalVisibility(true)} size="large" mb={1} block width={100} variant={props.variant}>
-          Request Price
+        <Button
+          onPress={() => dispatchAction(InquiryOptions.RequestPrice)}
+          size="large"
+          mb={1}
+          block
+          width={100}
+          variant={props.variant}
+        >
+          {InquiryOptions.RequestPrice}
         </Button>
       )}
       {!artwork.isPriceHidden && (
-        <Button onPress={() => setModalVisibility(true)} size="large" mb={1} block width={100} variant={props.variant}>
-          Inquire to Purchase
+        <Button
+          onPress={() => dispatchAction(InquiryOptions.InquireToPurchase)}
+          size="large"
+          mb={1}
+          block
+          width={100}
+          variant={props.variant}
+        >
+          {InquiryOptions.InquireToPurchase}
         </Button>
       )}
-      <Button onPress={() => setModalVisibility(true)} size="large" block width={100} variant="secondaryOutline">
-        Contact Gallery
+      <Button
+        onPress={() => dispatchAction(InquiryOptions.ContactGallery)}
+        size="large"
+        block
+        width={100}
+        variant="secondaryOutline"
+      >
+        {InquiryOptions.ContactGallery}
       </Button>
       <InquiryModalFragmentContainer
         artwork={artwork}

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -6,7 +6,8 @@ import ChevronIcon from "lib/Icons/ChevronIcon"
 import { ArtworkInquiryContext } from "lib/utils/ArtworkInquiry/ArtworkInquiryStore"
 import { InquiryOptions } from "lib/utils/ArtworkInquiry/ArtworkInquiryTypes"
 import { Box, color, Flex, Separator, space, Text } from "palette"
-import React, { useContext } from "react"
+import React, { useContext, useState } from "react"
+import { LayoutAnimation, TouchableOpacity } from "react-native"
 import NavigatorIOS from "react-native-navigator-ios"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components/native"
@@ -25,30 +26,47 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, ...props })
   const { toggleVisibility, modalIsVisible } = props
   const questions = artwork?.inquiryQuestions!
   const { state } = useContext(ArtworkInquiryContext)
+  const [isExpanded, setExpanded] = useState(false)
+  const toggleExpanded = () => {
+    LayoutAnimation.configureNext({
+      ...LayoutAnimation.Presets.linear,
+      duration: 200,
+    })
+    setExpanded(!isExpanded)
+  }
 
   const renderInquiryQuestion = (inquiry: string): JSX.Element => {
     return (
-      <InfoBox key={inquiry}>
-        <Flex flexDirection="row">
-          <Checkbox
-            checked={state.inquiryType === InquiryOptions.RequestPrice && inquiry === InquiryOptions.PriceAvailability}
-          />
-          <Text variant="text">{inquiry}</Text>
-        </Flex>
-        {inquiry === InquiryOptions.Shipping && (
-          <>
-            <Separator my={2} />
-            <Flex flexDirection="row" justifyContent="space-between">
-              <Text variant="text" color="black60">
-                Add your location
-              </Text>
-              <Box mt={0.5}>
-                <ChevronIcon color="black60" />
-              </Box>
+      <TouchableOpacity onPress={() => toggleExpanded()} key={inquiry}>
+        <InquiryField>
+          <Flex flexDirection="row" justifyContent="space-between">
+            <Flex flexDirection="row">
+              <Checkbox
+                checked={
+                  state.inquiryType === InquiryOptions.RequestPrice && inquiry === InquiryOptions.PriceAvailability
+                }
+              />
+              <Text variant="text">{inquiry}</Text>
             </Flex>
-          </>
-        )}
-      </InfoBox>
+            {inquiry === InquiryOptions.Shipping && (
+              <Flex flexDirection="row" mt={0.5}>
+                <ChevronIcon color="black60" expanded={isExpanded} initialDirection="down" />
+              </Flex>
+            )}
+          </Flex>
+
+          {inquiry === InquiryOptions.Shipping && !!isExpanded && (
+            <>
+              <Separator my={2} />
+              <Flex flexDirection="row" justifyContent="space-between">
+                <Text variant="text" color="black60">
+                  Add your location
+                </Text>
+              </Flex>
+            </>
+          )}
+        </InquiryField>
+      </TouchableOpacity>
     )
   }
 
@@ -72,7 +90,7 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, ...props })
   )
 }
 
-const InfoBox = styled(Flex)`
+const InquiryField = styled(Flex)`
   border-radius: 5;
   border: solid 1px ${color("black10")};
   flex-direction: column;

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -1,10 +1,15 @@
 import { InquiryModal_artwork } from "__generated__/InquiryModal_artwork.graphql"
+import { Checkbox } from "lib/Components/Bidding/Components/Checkbox"
 import { FancyModal } from "lib/Components/FancyModal/FancyModal"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
-import { Flex, Text } from "palette"
-import React from "react"
+import ChevronIcon from "lib/Icons/ChevronIcon"
+import { ArtworkInquiryContext } from "lib/utils/ArtworkInquiry/ArtworkInquiryStore"
+import { InquiryOptions } from "lib/utils/ArtworkInquiry/ArtworkInquiryTypes"
+import { Box, color, Flex, Separator, space, Text } from "palette"
+import React, { useContext } from "react"
 import NavigatorIOS from "react-native-navigator-ios"
 import { createFragmentContainer, graphql } from "react-relay"
+import styled from "styled-components/native"
 import { CollapsibleArtworkDetailsFragmentContainer } from "./CollapsibleArtworkDetails"
 
 interface InquiryModalProps {
@@ -18,6 +23,34 @@ interface InquiryModalProps {
 
 export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, ...props }) => {
   const { toggleVisibility, modalIsVisible } = props
+  const questions = artwork?.inquiryQuestions!
+  const { state } = useContext(ArtworkInquiryContext)
+
+  const renderInquiryQuestion = (inquiry: string): JSX.Element => {
+    return (
+      <InfoBox key={inquiry}>
+        <Flex flexDirection="row">
+          <Checkbox
+            checked={state.inquiryType === InquiryOptions.RequestPrice && inquiry === InquiryOptions.PriceAvailability}
+          />
+          <Text variant="text">{inquiry}</Text>
+        </Flex>
+        {inquiry === InquiryOptions.Shipping && (
+          <>
+            <Separator my={2} />
+            <Flex flexDirection="row" justifyContent="space-between">
+              <Text variant="text" color="black60">
+                Add your location
+              </Text>
+              <Box mt={0.5}>
+                <ChevronIcon color="black60" />
+              </Box>
+            </Flex>
+          </>
+        )}
+      </InfoBox>
+    )
+  }
 
   return (
     <FancyModal visible={modalIsVisible} onBackgroundPressed={() => toggleVisibility()}>
@@ -25,19 +58,35 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, ...props })
         Contact Gallery
       </FancyModalHeader>
       <CollapsibleArtworkDetailsFragmentContainer artwork={artwork} />
-      <Flex bg="white100" flex={1}>
-        <Text m={2} variant="title">
-          More here
-        </Text>
-      </Flex>
+      <Box m={2}>
+        <Text variant="mediumText">What information are you looking for?</Text>
+        {
+          // @ts-ignore
+          // NOTE: For now the inquiryQuestions field values are always present and therefore never null, so it is safe to destructure them
+          questions!.map(({ question }: string) => {
+            return renderInquiryQuestion(question)
+          })
+        }
+      </Box>
     </FancyModal>
   )
 }
+
+const InfoBox = styled(Flex)`
+  border-radius: 5;
+  border: solid 1px ${color("black10")};
+  flex-direction: column;
+  margin-top: ${space(1)}px;
+  padding: ${space(2)}px;
+`
 
 export const InquiryModalFragmentContainer = createFragmentContainer(InquiryModal, {
   artwork: graphql`
     fragment InquiryModal_artwork on Artwork {
       ...CollapsibleArtworkDetails_artwork
+      inquiryQuestions {
+        question
+      }
     }
   `,
 })

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/CommercialButtons-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/CommercialButtons-tests.tsx
@@ -7,7 +7,9 @@ import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { __appStoreTestUtils__ } from "lib/store/AppStore"
 import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
 import { renderRelayTree } from "lib/tests/renderRelayTree"
-import { graphql } from "react-relay"
+import { ArtworkInquiryContext } from "lib/utils/ArtworkInquiry/ArtworkInquiryStore"
+import React from "react"
+import { _FragmentRefs, graphql } from "react-relay"
 import { CommercialButtonsFragmentContainer } from "../CommercialButtons"
 
 jest.unmock("react-relay")
@@ -38,10 +40,27 @@ const componentWithQuery = async ({ mockArtworkData, mockOrderMutationResults, m
   })
 }
 
+const state = {
+  shippingLocation: null,
+  inquiryType: null,
+}
+
+const wrapper = (mockArtwork: _FragmentRefs<"CommercialButtons_artwork">): JSX.Element => (
+  <ArtworkInquiryContext.Provider
+    value={{
+      state,
+      dispatch: jest.fn(),
+    }}
+  >
+    {/* @ts-ignore */}
+    <CommercialButtonsFragmentContainer artwork={mockArtwork} />
+  </ArtworkInquiryContext.Provider>
+)
+
 // @ts-ignore STRICTNESS_MIGRATION
 const relayComponent = async ({ artwork }) => {
   return await renderRelayTree({
-    Component: CommercialButtonsFragmentContainer,
+    Component: () => wrapper(artwork),
     query: graphql`
       query CommercialButtonsTestsRenderQuery @raw_response_type {
         artwork(id: "artworkID") {
@@ -85,18 +104,8 @@ describe("CommercialButtons", () => {
     const commercialButtons = await relayComponent({
       artwork,
     })
-    expect(
-      commercialButtons
-        .find(Button)
-        .at(0)
-        .text()
-    ).toContain("Inquire to Purchase")
-    expect(
-      commercialButtons
-        .find(Button)
-        .at(1)
-        .text()
-    ).toContain("Contact Gallery")
+    expect(commercialButtons.find(Button).at(0).text()).toContain("Inquire to Purchase")
+    expect(commercialButtons.find(Button).at(1).text()).toContain("Contact Gallery")
   })
 
   it("renders Inquire on Price button if isInquireable, price is hidden, and lab option is true", async () => {
@@ -115,18 +124,8 @@ describe("CommercialButtons", () => {
       artwork,
     })
 
-    expect(
-      commercialButtons
-        .find(Button)
-        .at(0)
-        .text()
-    ).toContain("Request Price")
-    expect(
-      commercialButtons
-        .find(Button)
-        .at(1)
-        .text()
-    ).toContain("Contact Gallery")
+    expect(commercialButtons.find(Button).at(0).text()).toContain("Request Price")
+    expect(commercialButtons.find(Button).at(1).text()).toContain("Contact Gallery")
   })
 
   it("renders Make Offer button if isOfferable", async () => {

--- a/src/lib/__fixtures__/ArtworkFixture.ts
+++ b/src/lib/__fixtures__/ArtworkFixture.ts
@@ -16,6 +16,11 @@ export const ArtworkFixture = {
   isInquireable: false,
   isInAuction: false,
   isBuyNowable: false,
+  inquiryQuestions: [
+    { question: "Price & Availability" },
+    { question: "Shipping" },
+    { question: "Condition & Provenance" },
+  ],
   editionSets: [],
   saleMessage: null,
   sale: null,

--- a/src/lib/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
+++ b/src/lib/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
@@ -1,0 +1,42 @@
+import {
+  ArtworkInquiryActions,
+  ArtworkInquiryContextProps,
+  ArtworkInquiryContextState,
+} from "lib/utils/ArtworkInquiry/ArtworkInquiryTypes"
+import React, { createContext, Reducer, useReducer } from "react"
+
+const artworkInquiryState: ArtworkInquiryContextState = {
+  shippingLocation: null,
+  inquiryType: null,
+}
+
+// NOTE: We will need to handle clearing the location fields and other CRUD like actions
+// But since we are working this in different streams we'll have to come back to this
+export const reducer = (
+  inquiryState: ArtworkInquiryContextState,
+  action: ArtworkInquiryActions
+): ArtworkInquiryContextState => {
+  switch (action.type) {
+    case "selectInquiryType":
+      return {
+        shippingLocation: inquiryState.shippingLocation,
+        inquiryType: action.payload,
+      }
+
+    case "selectShippingLocation":
+      return {
+        shippingLocation: action.payload,
+        inquiryType: inquiryState.inquiryType,
+      }
+  }
+}
+
+export const ArtworkInquiryContext = createContext<ArtworkInquiryContextProps>(null as any)
+
+export const ArtworkInquiryStateProvider = ({ children }: any) => {
+  const [state, dispatch] = useReducer<Reducer<ArtworkInquiryContextState, ArtworkInquiryActions>>(
+    reducer,
+    artworkInquiryState
+  )
+  return <ArtworkInquiryContext.Provider value={{ state, dispatch }}>{children}</ArtworkInquiryContext.Provider>
+}

--- a/src/lib/utils/ArtworkInquiry/ArtworkInquiryTypes.ts
+++ b/src/lib/utils/ArtworkInquiry/ArtworkInquiryTypes.ts
@@ -1,0 +1,33 @@
+import { Dispatch } from "react"
+
+export type ArtworkInquiryActions = SelectInquiryType | SelectLocation
+
+export interface ArtworkInquiryContextProps {
+  state: ArtworkInquiryContextState
+  dispatch: Dispatch<ArtworkInquiryActions>
+}
+
+export interface ArtworkInquiryContextState {
+  readonly inquiryType: InquiryTypes | null
+  readonly shippingLocation: string | null
+}
+
+export type InquiryTypes = "Request Price" | "Contact Gallery" | "Inquire to Purchase"
+
+interface SelectInquiryType {
+  type: "selectInquiryType"
+  payload: InquiryTypes
+}
+
+interface SelectLocation {
+  type: "selectShippingLocation"
+  payload: string
+}
+
+export enum InquiryOptions {
+  RequestPrice = "Request Price",
+  ContactGallery = "Contact Gallery",
+  InquireToPurchase = "Inquire to Purchase",
+  PriceAvailability = "Price & Availability",
+  Shipping = "Shipping",
+}

--- a/src/lib/utils/ArtworkInquiry/__tests__/ArtworkInquiryStore-tests.tsx
+++ b/src/lib/utils/ArtworkInquiry/__tests__/ArtworkInquiryStore-tests.tsx
@@ -1,0 +1,68 @@
+import { reducer } from "lib/utils/ArtworkInquiry/ArtworkInquiryStore"
+import { ArtworkInquiryActions, ArtworkInquiryContextState } from "lib/utils/ArtworkInquiry/ArtworkInquiryTypes"
+import { InquiryOptions } from "lib/utils/ArtworkInquiry/ArtworkInquiryTypes"
+
+let inquiryState: ArtworkInquiryContextState
+let inquiryAction: ArtworkInquiryActions
+
+describe("selectInquiryType", () => {
+  it("updates the global state when payload is Request Price", () => {
+    inquiryState = {
+      shippingLocation: null,
+      inquiryType: null,
+    }
+
+    inquiryAction = {
+      type: "selectInquiryType",
+      payload: InquiryOptions.RequestPrice,
+    }
+
+    const r = reducer(inquiryState, inquiryAction)
+
+    expect(r).toEqual({
+      shippingLocation: null,
+      inquiryType: "Request Price",
+    })
+  })
+
+  it("updates the global state when payload is Contact Gallery", () => {
+    inquiryState = {
+      shippingLocation: null,
+      inquiryType: null,
+    }
+
+    inquiryAction = {
+      type: "selectInquiryType",
+      payload: InquiryOptions.ContactGallery,
+    }
+
+    const r = reducer(inquiryState, inquiryAction)
+
+    expect(r).toEqual({
+      shippingLocation: null,
+      inquiryType: "Contact Gallery",
+    })
+  })
+
+  it("updates the global state when payload is Inquire to Purchase", () => {
+    inquiryState = {
+      shippingLocation: null,
+      inquiryType: null,
+    }
+
+    inquiryAction = {
+      type: "selectInquiryType",
+      payload: InquiryOptions.InquireToPurchase,
+    }
+
+    const r = reducer(inquiryState, inquiryAction)
+
+    expect(r).toEqual({
+      shippingLocation: null,
+      inquiryType: "Inquire to Purchase",
+    })
+  })
+})
+
+// TODO: Add tests for location reducer
+// describe("selectShippingLocation", () => {})


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [PURCHASE-2096]

### Description

This PR adds a context provider around the Artwork app to enable passing and persisting state between views in the inquiry modal.

This is an initial pass, so we can safely assume the shape of the global data state will evolve.



<!-- Implementation description -->

![Kapture 2020-10-09 at 14 47 47](https://user-images.githubusercontent.com/10385964/95620790-b2444200-0a3e-11eb-8860-2c2f5fc24878.gif)

![Kapture 2020-10-09 at 14 02 57](https://user-images.githubusercontent.com/10385964/95617166-fdf3ed00-0a38-11eb-84ca-7f2495d1bd23.gif)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.



[PURCHASE-2096]: https://artsyproduct.atlassian.net/browse/PURCHASE-2096

[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434