### PR TITLE
fix(types): removed some `any`s

### DIFF
--- a/src/lib/Scenes/MyAccount/Components/MyAccountFieldEditScreen.tsx
+++ b/src/lib/Scenes/MyAccount/Components/MyAccountFieldEditScreen.tsx
@@ -20,11 +20,7 @@ export interface MyAccountFieldEditScreen {
   save(): Promise<void>
 }
 
-type AlertArgs =
-  | [string] // title
-  | [string, string] // title, message
-  | [string, string, AlertButton[]] // title, message, buttons
-  | [string, string, AlertButton[], AlertOptions] // title, message, buttons, options
+export type AlertArgs = [title: string, message?: string, buttons?: AlertButton[], options?: AlertOptions]
 
 export interface MyAccountFieldEditScreenProps {
   title: string
@@ -51,7 +47,7 @@ export const MyAccountFieldEditScreen = React.forwardRef<
     setBehindTheModalDismiss(true)
   }
 
-  const doTheAlert = (...args: AlertArgs) => {
+  const doTheAlert: AlertStatic["alert"] = (...args) => {
     setBehindTheModalAlert(args)
   }
 
@@ -61,7 +57,7 @@ export const MyAccountFieldEditScreen = React.forwardRef<
     }
     try {
       setIsSaving(true)
-      await onSave(doTheDismiss, doTheAlert as any)
+      await onSave(doTheDismiss, doTheAlert)
     } catch (e) {
       console.error(e)
     } finally {
@@ -116,7 +112,7 @@ export const MyAccountFieldEditScreen = React.forwardRef<
                 onDismiss()
               }
               if (behindTheModalAlert !== undefined) {
-                Alert.alert(...(behindTheModalAlert as [any]))
+                Alert.alert(...behindTheModalAlert)
               }
             }}
           />


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-]

### Description

<!-- Implementation description -->

After the last PR #3950 we merged, I found out there is a way to have named items in arrays in ts, so I used that and removed a couple of `any`s introduced in that last PR.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434