### PR TITLE
fix: change Fairs2 artwork grid batch size from 20 to 30

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -41,6 +41,7 @@ upcoming:
     - Add about page - mounir
     - Center filters modal title - mounir
     - Fix UI not responsive after editing profile settings - mounir
+    - Show 30 artworks at a time in Fair2 artworks grid - roop
 
 releases:
   - version: 6.6.4

--- a/src/__generated__/Fair2ArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/Fair2ArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 93f76084880d4b2e4c47b4ae225d1955 */
+/* @relayHash 6264dcca618cec8a4803b514da0c7ac0 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -95,7 +95,7 @@ fragment ArtworkGridItem_artwork on Artwork {
 fragment Fair2Artworks_fair_2dIbwR on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 20, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, includeArtworksByFollowedArtists: $includeArtworksByFollowedArtists, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS]) {
+  fairArtworks: filterArtworksConnection(first: 30, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, includeArtworksByFollowedArtists: $includeArtworksByFollowedArtists, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS]) {
     aggregations {
       slice
       counts {
@@ -333,7 +333,7 @@ v30 = [
   {
     "kind": "Literal",
     "name": "first",
-    "value": 20
+    "value": 30
   },
   (v20/*: any*/),
   (v21/*: any*/),
@@ -862,7 +862,7 @@ return {
     ]
   },
   "params": {
-    "id": "93f76084880d4b2e4c47b4ae225d1955",
+    "id": "6264dcca618cec8a4803b514da0c7ac0",
     "metadata": {},
     "name": "Fair2ArtworksInfiniteScrollGridQuery",
     "operationKind": "query",

--- a/src/__generated__/Fair2ArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/Fair2ArtworksTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash b27bbb5b11f2e29fecea275099a304a0 */
+/* @relayHash 3144a75e3cd82bb109dd6e0eea14d6c2 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -68,7 +68,7 @@ fragment ArtworkGridItem_artwork on Artwork {
 fragment Fair2Artworks_fair on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS]) {
+  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS]) {
     aggregations {
       slice
       counts {
@@ -174,7 +174,7 @@ v4 = [
   {
     "kind": "Literal",
     "name": "first",
-    "value": 20
+    "value": 30
   },
   {
     "kind": "Literal",
@@ -648,7 +648,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\"],dimensionRange:\"*-*\",first:20,medium:\"*\",sort:\"-decayed_merch\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\"],dimensionRange:\"*-*\",first:30,medium:\"*\",sort:\"-decayed_merch\")"
           },
           {
             "alias": "fairArtworks",
@@ -680,7 +680,7 @@ return {
     ]
   },
   "params": {
-    "id": "b27bbb5b11f2e29fecea275099a304a0",
+    "id": "3144a75e3cd82bb109dd6e0eea14d6c2",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "fair": {

--- a/src/__generated__/Fair2Artworks_fair.graphql.ts
+++ b/src/__generated__/Fair2Artworks_fair.graphql.ts
@@ -56,7 +56,7 @@ const node: ReaderFragment = {
       "name": "color"
     },
     {
-      "defaultValue": 20,
+      "defaultValue": 30,
       "kind": "LocalArgument",
       "name": "count"
     },
@@ -378,5 +378,5 @@ const node: ReaderFragment = {
   "type": "Fair",
   "abstractKey": null
 };
-(node as any).hash = '06024cf92938979a780c90b0f06f4c06';
+(node as any).hash = '1d66448a716f1fa88519e9306d6a7d94';
 export default node;

--- a/src/__generated__/Fair2Query.graphql.ts
+++ b/src/__generated__/Fair2Query.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash fd4ef899bf4a646ca96f1d423a95d0ba */
+/* @relayHash 3a05623fe20995a9ad8d9f211aef2158 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -79,7 +79,7 @@ fragment ArtworkTileRailCard_artwork on Artwork {
 fragment Fair2Artworks_fair on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS]) {
+  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS]) {
     aggregations {
       slice
       counts {
@@ -501,7 +501,11 @@ v18 = [
     "name": "dimensionRange",
     "value": "*-*"
   },
-  (v9/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 30
+  },
   {
     "kind": "Literal",
     "name": "medium",
@@ -1304,7 +1308,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\"],dimensionRange:\"*-*\",first:20,medium:\"*\",sort:\"-decayed_merch\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\"],dimensionRange:\"*-*\",first:30,medium:\"*\",sort:\"-decayed_merch\")"
           },
           {
             "alias": "fairArtworks",
@@ -1542,7 +1546,7 @@ return {
     ]
   },
   "params": {
-    "id": "fd4ef899bf4a646ca96f1d423a95d0ba",
+    "id": "3a05623fe20995a9ad8d9f211aef2158",
     "metadata": {},
     "name": "Fair2Query",
     "operationKind": "query",

--- a/src/__generated__/Fair2TestsQuery.graphql.ts
+++ b/src/__generated__/Fair2TestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash c418eb2aaff557128c70ebb42420bdaf */
+/* @relayHash f0f0436de1b48857b4a804c1138fc8de */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -309,7 +309,7 @@ fragment ArtworkTileRailCard_artwork on Artwork {
 fragment Fair2Artworks_fair on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS]) {
+  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS]) {
     aggregations {
       slice
       counts {
@@ -731,7 +731,11 @@ v18 = [
     "name": "dimensionRange",
     "value": "*-*"
   },
-  (v9/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 30
+  },
   {
     "kind": "Literal",
     "name": "medium",
@@ -1534,7 +1538,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\"],dimensionRange:\"*-*\",first:20,medium:\"*\",sort:\"-decayed_merch\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\"],dimensionRange:\"*-*\",first:30,medium:\"*\",sort:\"-decayed_merch\")"
           },
           {
             "alias": "fairArtworks",
@@ -1772,7 +1776,7 @@ return {
     ]
   },
   "params": {
-    "id": "c418eb2aaff557128c70ebb42420bdaf",
+    "id": "f0f0436de1b48857b4a804c1138fc8de",
     "metadata": {},
     "name": "Fair2TestsQuery",
     "operationKind": "query",

--- a/src/__generated__/VanityURLEntityQuery.graphql.ts
+++ b/src/__generated__/VanityURLEntityQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 6c3ccd246870f7f6eac8c31a5ddc7eff */
+/* @relayHash 376558d8d5ac7c511a881ee865c69125 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -101,7 +101,7 @@ fragment ArtworkTileRailCard_artwork on Artwork {
 fragment Fair2Artworks_fair on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS]) {
+  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS]) {
     aggregations {
       slice
       counts {
@@ -936,7 +936,11 @@ v22 = [
     "name": "dimensionRange",
     "value": "*-*"
   },
-  (v11/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 30
+  },
   {
     "kind": "Literal",
     "name": "medium",
@@ -1905,7 +1909,7 @@ return {
                       (v6/*: any*/),
                       (v42/*: any*/)
                     ],
-                    "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\"],dimensionRange:\"*-*\",first:20,medium:\"*\",sort:\"-decayed_merch\")"
+                    "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\"],dimensionRange:\"*-*\",first:30,medium:\"*\",sort:\"-decayed_merch\")"
                   },
                   {
                     "alias": "fairArtworks",
@@ -3040,7 +3044,7 @@ return {
     ]
   },
   "params": {
-    "id": "6c3ccd246870f7f6eac8c31a5ddc7eff",
+    "id": "376558d8d5ac7c511a881ee865c69125",
     "metadata": {},
     "name": "VanityURLEntityQuery",
     "operationKind": "query",

--- a/src/lib/Scenes/Fair2/Components/Fair2Artworks.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2Artworks.tsx
@@ -2,6 +2,7 @@ import { OwnerType } from "@artsy/cohesion"
 import { Fair2Artworks_fair } from "__generated__/Fair2Artworks_fair.graphql"
 import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
 import { InfiniteScrollArtworksGridContainer } from "lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
+import { FAIR2_ARTWORKS_PAGE_SIZE } from "lib/data/constants"
 import { ArtworkFilterContext } from "lib/utils/ArtworkFilter/ArtworkFiltersStore"
 import {
   aggregationsType,
@@ -18,8 +19,6 @@ interface Fair2ArtworksProps {
   fair: Fair2Artworks_fair
   relay: RelayPaginationProp
 }
-
-const PAGE_SIZE = 20
 
 export const Fair2Artworks: React.FC<Fair2ArtworksProps> = ({ fair, relay }) => {
   const artworks = fair.fairArtworks!
@@ -41,7 +40,7 @@ export const Fair2Artworks: React.FC<Fair2ArtworksProps> = ({ fair, relay }) => 
   useEffect(() => {
     if (state.applyFilters) {
       relay.refetchConnection(
-        PAGE_SIZE,
+        FAIR2_ARTWORKS_PAGE_SIZE,
         (error) => {
           if (error) {
             throw new Error("Fair/FairArtworks filter error: " + error.message)
@@ -78,7 +77,7 @@ export const Fair2Artworks: React.FC<Fair2ArtworksProps> = ({ fair, relay }) => 
         loadMore={relay.loadMore}
         hasMore={relay.hasMore}
         autoFetch={false}
-        pageSize={20}
+        pageSize={FAIR2_ARTWORKS_PAGE_SIZE}
         contextScreenOwnerType={OwnerType.fair}
         contextScreenOwnerId={fair.internalID}
         contextScreenOwnerSlug={fair.slug}
@@ -93,7 +92,7 @@ export const Fair2ArtworksFragmentContainer = createPaginationContainer(
     fair: graphql`
       fragment Fair2Artworks_fair on Fair
       @argumentDefinitions(
-        count: { type: "Int", defaultValue: 20 }
+        count: { type: "Int", defaultValue: 30 }
         cursor: { type: "String" }
         sort: { type: "String", defaultValue: "-decayed_merch" }
         medium: { type: "String", defaultValue: "*" }
@@ -111,7 +110,7 @@ export const Fair2ArtworksFragmentContainer = createPaginationContainer(
         slug
         internalID
         fairArtworks: filterArtworksConnection(
-          first: 20
+          first: 30
           after: $cursor
           sort: $sort
           medium: $medium

--- a/src/lib/Scenes/Fair2/__tests__/Fair2Artworks-tests.tsx
+++ b/src/lib/Scenes/Fair2/__tests__/Fair2Artworks-tests.tsx
@@ -66,6 +66,12 @@ describe("Fair2Artworks", () => {
     expect(wrapper.root.findAllByType(InfiniteScrollArtworksGridContainer)).toHaveLength(1)
   })
 
+  it("requests artworks in batches of 30", () => {
+    const wrapper = getWrapper()
+    const artworksGridContainer = wrapper.root.findByType(InfiniteScrollArtworksGridContainer)
+    expect(artworksGridContainer.props).toMatchObject({ pageSize: 30 })
+  })
+
   it("renders null if there are no artworks", () => {
     const wrapper = getWrapper({
       Fair: () => ({

--- a/src/lib/data/constants.ts
+++ b/src/lib/data/constants.ts
@@ -1,3 +1,4 @@
 export const PAGE_SIZE = 10
 export const FAIR_SHOW_PAGE_SIZE = 20
+export const FAIR2_ARTWORKS_PAGE_SIZE = 30
 export const ARTIST_SERIES_PAGE_SIZE = 30

--- a/src/lib/tests/renderWithWrappers.tsx
+++ b/src/lib/tests/renderWithWrappers.tsx
@@ -6,7 +6,6 @@ import { ReactElement } from "simple-markdown"
 
 /**
  * Renders a React Component with our page wrappers
- * only <Theme> for now
  * @param component
  */
 export const renderWithWrappers = (component: ReactElement) => {
@@ -38,7 +37,6 @@ export const renderWithWrappers = (component: ReactElement) => {
 
 /**
  * Returns given component wrapped with our page wrappers
- * only <Theme> for now
  * @param component
  */
 export const componentWithWrappers = (component: ReactElement) => {


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-2346]

### Description

The artwork grid on the Fairs2 screen shows artworks in batches of 20. 

This updates the batch size to 30, per the design spec. The new batch size is effect for show more pagination, as well as for refetching in response to filter changes.

<img width="1124" alt="Screen Shot 2020-10-12 at 3 42 28 PM" src="https://user-images.githubusercontent.com/140521/95784355-aad0a300-0ca1-11eb-855c-4c13f6082b53.png">


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[FX-2346]: https://artsyproduct.atlassian.net/browse/FX-2346