### PR TITLE
fix: center text items withing the sale artwrorks items

### DIFF
--- a/src/lib/Scenes/Sale/Components/SaleArtworkListItem.tsx
+++ b/src/lib/Scenes/Sale/Components/SaleArtworkListItem.tsx
@@ -37,7 +37,7 @@ export const SaleArtworkListItem: React.FC<Props> = ({ artwork }) => {
           </Flex>
         )}
 
-        <Flex ml={2} height={100} flex={1}>
+        <Flex ml={2} height={100} flex={1} justifyContent="center">
           {!!artwork.saleArtwork?.lotLabel && (
             <Sans size="3t" color="black60" numberOfLines={1}>
               Lot {artwork.saleArtwork.lotLabel}


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves Sam's comment here: https://artsyproduct.atlassian.net/browse/CX-519

### Description
- Center the text items within the saleArtworks

<img width="309" alt="Screenshot 2020-10-12 at 19 43 23" src="https://user-images.githubusercontent.com/11945712/95775725-37d82400-0cc3-11eb-844d-c05d1a211c21.png">

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434