### PR TITLE
fix: Show More Info link when there is sponsored content or a location map

### DIFF
--- a/src/__generated__/Fair2HeaderTestsQuery.graphql.ts
+++ b/src/__generated__/Fair2HeaderTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 24230eb32eb0adcd4dc9cc1272469c91 */
+/* @relayHash 181067c753c0f544f59b76818bdd8abd */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -32,6 +32,10 @@ export type Fair2HeaderTestsQueryRawResponse = {
         readonly tagline: string | null;
         readonly location: ({
             readonly summary: string | null;
+            readonly coordinates: ({
+                readonly lat: number | null;
+                readonly lng: number | null;
+            }) | null;
             readonly id: string;
         }) | null;
         readonly ticketsLink: string | null;
@@ -85,6 +89,10 @@ fragment Fair2Header_fair on Fair {
   tagline
   location {
     summary
+    coordinates {
+      lat
+      lng
+    }
     id
   }
   ticketsLink
@@ -288,6 +296,31 @@ return {
             "plural": false,
             "selections": [
               (v2/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "LatLng",
+                "kind": "LinkedField",
+                "name": "coordinates",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "lat",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "lng",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
               (v3/*: any*/)
             ],
             "storageKey": null
@@ -380,7 +413,7 @@ return {
     ]
   },
   "params": {
-    "id": "24230eb32eb0adcd4dc9cc1272469c91",
+    "id": "181067c753c0f544f59b76818bdd8abd",
     "metadata": {},
     "name": "Fair2HeaderTestsQuery",
     "operationKind": "query",

--- a/src/__generated__/Fair2HeaderTestsQuery.graphql.ts
+++ b/src/__generated__/Fair2HeaderTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash cdd95d851e593ab919b430f765303fab */
+/* @relayHash 24230eb32eb0adcd4dc9cc1272469c91 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -35,6 +35,10 @@ export type Fair2HeaderTestsQueryRawResponse = {
             readonly id: string;
         }) | null;
         readonly ticketsLink: string | null;
+        readonly sponsoredContent: ({
+            readonly activationText: string | null;
+            readonly pressReleaseUrl: string | null;
+        }) | null;
         readonly fairHours: string | null;
         readonly fairLinks: string | null;
         readonly fairTickets: string | null;
@@ -84,6 +88,10 @@ fragment Fair2Header_fair on Fair {
     id
   }
   ticketsLink
+  sponsoredContent {
+    activationText
+    pressReleaseUrl
+  }
   fairHours: hours(format: MARKDOWN)
   fairLinks: links(format: MARKDOWN)
   fairTickets: tickets(format: MARKDOWN)
@@ -292,6 +300,31 @@ return {
             "storageKey": null
           },
           {
+            "alias": null,
+            "args": null,
+            "concreteType": "FairSponsoredContent",
+            "kind": "LinkedField",
+            "name": "sponsoredContent",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "activationText",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "pressReleaseUrl",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
             "alias": "fairHours",
             "args": (v4/*: any*/),
             "kind": "ScalarField",
@@ -347,7 +380,7 @@ return {
     ]
   },
   "params": {
-    "id": "cdd95d851e593ab919b430f765303fab",
+    "id": "24230eb32eb0adcd4dc9cc1272469c91",
     "metadata": {},
     "name": "Fair2HeaderTestsQuery",
     "operationKind": "query",

--- a/src/__generated__/Fair2Header_fair.graphql.ts
+++ b/src/__generated__/Fair2Header_fair.graphql.ts
@@ -21,6 +21,10 @@ export type Fair2Header_fair = {
     readonly tagline: string | null;
     readonly location: {
         readonly summary: string | null;
+        readonly coordinates: {
+            readonly lat: number | null;
+            readonly lng: number | null;
+        } | null;
     } | null;
     readonly ticketsLink: string | null;
     readonly sponsoredContent: {
@@ -166,7 +170,32 @@ return {
       "name": "location",
       "plural": false,
       "selections": [
-        (v0/*: any*/)
+        (v0/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "LatLng",
+          "kind": "LinkedField",
+          "name": "coordinates",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "lat",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "lng",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
       ],
       "storageKey": null
     },
@@ -240,5 +269,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '43a39dd38204681e5ec48cf9ca2af289';
+(node as any).hash = '6b700a54089e662567c4b708ba2d0a1b';
 export default node;

--- a/src/__generated__/Fair2Header_fair.graphql.ts
+++ b/src/__generated__/Fair2Header_fair.graphql.ts
@@ -23,6 +23,10 @@ export type Fair2Header_fair = {
         readonly summary: string | null;
     } | null;
     readonly ticketsLink: string | null;
+    readonly sponsoredContent: {
+        readonly activationText: string | null;
+        readonly pressReleaseUrl: string | null;
+    } | null;
     readonly fairHours: string | null;
     readonly fairLinks: string | null;
     readonly fairTickets: string | null;
@@ -174,6 +178,31 @@ return {
       "storageKey": null
     },
     {
+      "alias": null,
+      "args": null,
+      "concreteType": "FairSponsoredContent",
+      "kind": "LinkedField",
+      "name": "sponsoredContent",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "activationText",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "pressReleaseUrl",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
       "alias": "fairHours",
       "args": (v1/*: any*/),
       "kind": "ScalarField",
@@ -211,5 +240,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '7f2cde4276d88cbd8a72bcc1847befbf';
+(node as any).hash = '43a39dd38204681e5ec48cf9ca2af289';
 export default node;

--- a/src/__generated__/Fair2Query.graphql.ts
+++ b/src/__generated__/Fair2Query.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash e16d44fa0e5414ef33a40152e392d19d */
+/* @relayHash 52b943612bf7a96d86befa5997f0bdb2 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -288,6 +288,10 @@ fragment Fair2Header_fair on Fair {
     id
   }
   ticketsLink
+  sponsoredContent {
+    activationText
+    pressReleaseUrl
+  }
   fairHours: hours(format: MARKDOWN)
   fairLinks: links(format: MARKDOWN)
   fairTickets: tickets(format: MARKDOWN)
@@ -1019,6 +1023,31 @@ return {
             "storageKey": null
           },
           {
+            "alias": null,
+            "args": null,
+            "concreteType": "FairSponsoredContent",
+            "kind": "LinkedField",
+            "name": "sponsoredContent",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "activationText",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "pressReleaseUrl",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
             "alias": "fairHours",
             "args": (v16/*: any*/),
             "kind": "ScalarField",
@@ -1548,7 +1577,7 @@ return {
     ]
   },
   "params": {
-    "id": "e16d44fa0e5414ef33a40152e392d19d",
+    "id": "52b943612bf7a96d86befa5997f0bdb2",
     "metadata": {},
     "name": "Fair2Query",
     "operationKind": "query",

--- a/src/__generated__/Fair2Query.graphql.ts
+++ b/src/__generated__/Fair2Query.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 52b943612bf7a96d86befa5997f0bdb2 */
+/* @relayHash 723d62587941c87a195d18cdc946e373 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -285,6 +285,10 @@ fragment Fair2Header_fair on Fair {
   tagline
   location {
     summary
+    coordinates {
+      lat
+      lng
+    }
     id
   }
   ticketsLink
@@ -1011,6 +1015,31 @@ return {
             "plural": false,
             "selections": [
               (v13/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "LatLng",
+                "kind": "LinkedField",
+                "name": "coordinates",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "lat",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "lng",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
               (v5/*: any*/)
             ],
             "storageKey": null
@@ -1577,7 +1606,7 @@ return {
     ]
   },
   "params": {
-    "id": "52b943612bf7a96d86befa5997f0bdb2",
+    "id": "723d62587941c87a195d18cdc946e373",
     "metadata": {},
     "name": "Fair2Query",
     "operationKind": "query",

--- a/src/__generated__/Fair2TestsQuery.graphql.ts
+++ b/src/__generated__/Fair2TestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 6b019ae560b86063310e1f0165d26af1 */
+/* @relayHash 75c65458868922d23248d867b04e9d5e */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -92,6 +92,10 @@ export type Fair2TestsQueryRawResponse = {
             readonly id: string;
         }) | null;
         readonly ticketsLink: string | null;
+        readonly sponsoredContent: ({
+            readonly activationText: string | null;
+            readonly pressReleaseUrl: string | null;
+        }) | null;
         readonly fairHours: string | null;
         readonly fairLinks: string | null;
         readonly fairTickets: string | null;
@@ -518,6 +522,10 @@ fragment Fair2Header_fair on Fair {
     id
   }
   ticketsLink
+  sponsoredContent {
+    activationText
+    pressReleaseUrl
+  }
   fairHours: hours(format: MARKDOWN)
   fairLinks: links(format: MARKDOWN)
   fairTickets: tickets(format: MARKDOWN)
@@ -1249,6 +1257,31 @@ return {
             "storageKey": null
           },
           {
+            "alias": null,
+            "args": null,
+            "concreteType": "FairSponsoredContent",
+            "kind": "LinkedField",
+            "name": "sponsoredContent",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "activationText",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "pressReleaseUrl",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
             "alias": "fairHours",
             "args": (v16/*: any*/),
             "kind": "ScalarField",
@@ -1778,7 +1811,7 @@ return {
     ]
   },
   "params": {
-    "id": "6b019ae560b86063310e1f0165d26af1",
+    "id": "75c65458868922d23248d867b04e9d5e",
     "metadata": {},
     "name": "Fair2TestsQuery",
     "operationKind": "query",

--- a/src/__generated__/Fair2TestsQuery.graphql.ts
+++ b/src/__generated__/Fair2TestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 75c65458868922d23248d867b04e9d5e */
+/* @relayHash b64b4c86d524bfefca953cd7458107dd */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -89,6 +89,10 @@ export type Fair2TestsQueryRawResponse = {
         readonly tagline: string | null;
         readonly location: ({
             readonly summary: string | null;
+            readonly coordinates: ({
+                readonly lat: number | null;
+                readonly lng: number | null;
+            }) | null;
             readonly id: string;
         }) | null;
         readonly ticketsLink: string | null;
@@ -519,6 +523,10 @@ fragment Fair2Header_fair on Fair {
   tagline
   location {
     summary
+    coordinates {
+      lat
+      lng
+    }
     id
   }
   ticketsLink
@@ -1245,6 +1253,31 @@ return {
             "plural": false,
             "selections": [
               (v13/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "LatLng",
+                "kind": "LinkedField",
+                "name": "coordinates",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "lat",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "lng",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
               (v5/*: any*/)
             ],
             "storageKey": null
@@ -1811,7 +1844,7 @@ return {
     ]
   },
   "params": {
-    "id": "75c65458868922d23248d867b04e9d5e",
+    "id": "b64b4c86d524bfefca953cd7458107dd",
     "metadata": {},
     "name": "Fair2TestsQuery",
     "operationKind": "query",

--- a/src/__generated__/VanityURLEntityQuery.graphql.ts
+++ b/src/__generated__/VanityURLEntityQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash a10c5d28a4014b73bb4042e222381ce3 */
+/* @relayHash f75f5718f56464d4aec0bf044181a63a */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -307,6 +307,10 @@ fragment Fair2Header_fair on Fair {
   tagline
   location {
     summary
+    coordinates {
+      lat
+      lng
+    }
     id
   }
   ticketsLink
@@ -895,46 +899,71 @@ v17 = {
 v18 = {
   "alias": null,
   "args": null,
-  "kind": "ScalarField",
-  "name": "activationText",
+  "concreteType": "LatLng",
+  "kind": "LinkedField",
+  "name": "coordinates",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "lat",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "lng",
+      "storageKey": null
+    }
+  ],
   "storageKey": null
 },
 v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "activationText",
+  "storageKey": null
+},
+v20 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "pressReleaseUrl",
   "storageKey": null
 },
-v20 = [
+v21 = [
   {
     "kind": "Literal",
     "name": "format",
     "value": "MARKDOWN"
   }
 ],
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "exhibitionPeriod",
   "storageKey": null
 },
-v22 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startAt",
   "storageKey": null
 },
-v23 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v24 = [
+v25 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -971,14 +1000,14 @@ v24 = [
     "value": "-decayed_merch"
   }
 ],
-v25 = {
+v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v26 = [
+v27 = [
   {
     "alias": null,
     "args": null,
@@ -992,23 +1021,23 @@ v26 = [
     ],
     "storageKey": null
   },
-  (v25/*: any*/)
+  (v26/*: any*/)
 ],
-v27 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endCursor",
   "storageKey": null
 },
-v28 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "hasNextPage",
   "storageKey": null
 },
-v29 = {
+v30 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -1016,19 +1045,19 @@ v29 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v27/*: any*/),
-    (v28/*: any*/)
+    (v28/*: any*/),
+    (v29/*: any*/)
   ],
   "storageKey": null
 },
-v30 = {
+v31 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startCursor",
   "storageKey": null
 },
-v31 = {
+v32 = {
   "alias": null,
   "args": [
     {
@@ -1041,28 +1070,28 @@ v31 = {
   "name": "url",
   "storageKey": "url(version:\"large\")"
 },
-v32 = {
+v33 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "date",
   "storageKey": null
 },
-v33 = {
+v34 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isAuction",
   "storageKey": null
 },
-v34 = {
+v35 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v35 = {
+v36 = {
   "alias": null,
   "args": null,
   "concreteType": "Sale",
@@ -1070,8 +1099,8 @@ v35 = {
   "name": "sale",
   "plural": false,
   "selections": [
-    (v33/*: any*/),
     (v34/*: any*/),
+    (v35/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -1079,12 +1108,12 @@ v35 = {
       "name": "displayTimelyAt",
       "storageKey": null
     },
-    (v23/*: any*/),
+    (v24/*: any*/),
     (v6/*: any*/)
   ],
   "storageKey": null
 },
-v36 = {
+v37 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCounts",
@@ -1102,27 +1131,27 @@ v36 = {
   ],
   "storageKey": null
 },
-v37 = {
+v38 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "display",
   "storageKey": null
 },
-v38 = [
-  (v37/*: any*/)
+v39 = [
+  (v38/*: any*/)
 ],
-v39 = {
+v40 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCurrentBid",
   "kind": "LinkedField",
   "name": "currentBid",
   "plural": false,
-  "selections": (v38/*: any*/),
+  "selections": (v39/*: any*/),
   "storageKey": null
 },
-v40 = {
+v41 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtwork",
@@ -1130,8 +1159,8 @@ v40 = {
   "name": "saleArtwork",
   "plural": false,
   "selections": [
-    (v36/*: any*/),
-    (v39/*: any*/),
+    (v37/*: any*/),
+    (v40/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -1143,7 +1172,7 @@ v40 = {
   ],
   "storageKey": null
 },
-v41 = {
+v42 = {
   "alias": null,
   "args": null,
   "concreteType": "Partner",
@@ -1156,16 +1185,16 @@ v41 = {
   ],
   "storageKey": null
 },
-v42 = [
+v43 = [
   (v6/*: any*/)
 ],
-v43 = {
+v44 = {
   "kind": "InlineFragment",
-  "selections": (v42/*: any*/),
+  "selections": (v43/*: any*/),
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v44 = {
+v45 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -1176,7 +1205,7 @@ v44 = {
       "name": "pageInfo",
       "plural": false,
       "selections": [
-        (v30/*: any*/)
+        (v31/*: any*/)
       ],
       "storageKey": null
     },
@@ -1207,23 +1236,23 @@ v44 = {
               "plural": false,
               "selections": [
                 (v17/*: any*/),
-                (v31/*: any*/)
+                (v32/*: any*/)
               ],
               "storageKey": null
             },
             (v7/*: any*/),
-            (v32/*: any*/),
+            (v33/*: any*/),
             (v14/*: any*/),
             (v4/*: any*/),
             (v12/*: any*/),
             (v8/*: any*/),
-            (v35/*: any*/),
-            (v40/*: any*/),
-            (v41/*: any*/)
+            (v36/*: any*/),
+            (v41/*: any*/),
+            (v42/*: any*/)
           ],
           "storageKey": null
         },
-        (v43/*: any*/)
+        (v44/*: any*/)
       ],
       "storageKey": null
     }
@@ -1231,7 +1260,7 @@ v44 = {
   "type": "ArtworkConnectionInterface",
   "abstractKey": "__isArtworkConnectionInterface"
 },
-v45 = [
+v46 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -1243,64 +1272,64 @@ v45 = [
     "value": "FEATURED_ASC"
   }
 ],
-v46 = [
+v47 = [
   (v10/*: any*/)
 ],
-v47 = {
+v48 = {
   "alias": null,
   "args": null,
   "concreteType": "ShowCounts",
   "kind": "LinkedField",
   "name": "counts",
   "plural": false,
-  "selections": (v46/*: any*/),
+  "selections": (v47/*: any*/),
   "storageKey": null
 },
-v48 = [
+v49 = [
   (v6/*: any*/),
   (v16/*: any*/)
 ],
-v49 = [
+v50 = [
   "sort"
 ],
-v50 = {
+v51 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v51 = [
-  (v50/*: any*/)
+v52 = [
+  (v51/*: any*/)
 ],
-v52 = {
+v53 = {
   "alias": null,
   "args": null,
   "concreteType": "Image",
   "kind": "LinkedField",
   "name": "image",
   "plural": false,
-  "selections": (v51/*: any*/),
+  "selections": (v52/*: any*/),
   "storageKey": null
 },
-v53 = [
+v54 = [
   (v16/*: any*/),
   (v8/*: any*/),
   (v3/*: any*/),
   (v4/*: any*/),
   (v6/*: any*/)
 ],
-v54 = {
+v55 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "hours",
   "storageKey": null
 },
-v55 = [
+v56 = [
   (v5/*: any*/)
 ],
-v56 = {
+v57 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -1308,69 +1337,69 @@ v56 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v28/*: any*/),
-    (v30/*: any*/),
-    (v27/*: any*/)
+    (v29/*: any*/),
+    (v31/*: any*/),
+    (v28/*: any*/)
   ],
   "storageKey": null
 },
-v57 = {
+v58 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isFollowed",
   "storageKey": null
 },
-v58 = {
+v59 = {
   "kind": "InlineFragment",
-  "selections": (v42/*: any*/),
+  "selections": (v43/*: any*/),
   "type": "ExternalPartner",
   "abstractKey": null
 },
-v59 = {
+v60 = {
   "alias": null,
   "args": null,
   "concreteType": "Image",
   "kind": "LinkedField",
   "name": "coverImage",
   "plural": false,
-  "selections": (v51/*: any*/),
+  "selections": (v52/*: any*/),
   "storageKey": null
 },
-v60 = {
+v61 = {
   "kind": "Literal",
   "name": "first",
   "value": 10
 },
-v61 = [
-  (v60/*: any*/),
+v62 = [
+  (v61/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "PARTNER_UPDATED_AT_DESC"
   }
 ],
-v62 = [
-  (v60/*: any*/),
+v63 = [
+  (v61/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "SORTABLE_ID_ASC"
   }
 ],
-v63 = {
+v64 = {
   "kind": "Literal",
   "name": "status",
   "value": "CURRENT"
 },
-v64 = {
+v65 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isDisplayable",
   "storageKey": null
 },
-v65 = [
+v66 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -1387,11 +1416,11 @@ v65 = [
     "value": "CLOSED"
   }
 ],
-v66 = [
+v67 = [
   "status",
   "sort"
 ],
-v67 = [
+v68 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -1402,7 +1431,7 @@ v67 = [
     "name": "sort",
     "value": "END_AT_ASC"
   },
-  (v63/*: any*/)
+  (v64/*: any*/)
 ];
 return {
   "fragment": {
@@ -1795,6 +1824,7 @@ return {
                     "plural": false,
                     "selections": [
                       (v15/*: any*/),
+                      (v18/*: any*/),
                       (v6/*: any*/)
                     ],
                     "storageKey": null
@@ -1814,45 +1844,45 @@ return {
                     "name": "sponsoredContent",
                     "plural": false,
                     "selections": [
-                      (v18/*: any*/),
-                      (v19/*: any*/)
+                      (v19/*: any*/),
+                      (v20/*: any*/)
                     ],
                     "storageKey": null
                   },
                   {
                     "alias": "fairHours",
-                    "args": (v20/*: any*/),
+                    "args": (v21/*: any*/),
                     "kind": "ScalarField",
                     "name": "hours",
                     "storageKey": "hours(format:\"MARKDOWN\")"
                   },
                   {
                     "alias": "fairLinks",
-                    "args": (v20/*: any*/),
+                    "args": (v21/*: any*/),
                     "kind": "ScalarField",
                     "name": "links",
                     "storageKey": "links(format:\"MARKDOWN\")"
                   },
                   {
                     "alias": "fairTickets",
-                    "args": (v20/*: any*/),
+                    "args": (v21/*: any*/),
                     "kind": "ScalarField",
                     "name": "tickets",
                     "storageKey": "tickets(format:\"MARKDOWN\")"
                   },
                   {
                     "alias": "fairContact",
-                    "args": (v20/*: any*/),
+                    "args": (v21/*: any*/),
                     "kind": "ScalarField",
                     "name": "contact",
                     "storageKey": "contact(format:\"MARKDOWN\")"
                   },
-                  (v21/*: any*/),
                   (v22/*: any*/),
                   (v23/*: any*/),
+                  (v24/*: any*/),
                   {
                     "alias": "fairArtworks",
-                    "args": (v24/*: any*/),
+                    "args": (v25/*: any*/),
                     "concreteType": "FilterArtworksConnection",
                     "kind": "LinkedField",
                     "name": "filterArtworksConnection",
@@ -1909,7 +1939,7 @@ return {
                         "kind": "LinkedField",
                         "name": "edges",
                         "plural": true,
-                        "selections": (v26/*: any*/),
+                        "selections": (v27/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -1937,15 +1967,15 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v29/*: any*/),
+                      (v30/*: any*/),
                       (v6/*: any*/),
-                      (v44/*: any*/)
+                      (v45/*: any*/)
                     ],
                     "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,medium:\"*\",sort:\"-decayed_merch\")"
                   },
                   {
                     "alias": "fairArtworks",
-                    "args": (v24/*: any*/),
+                    "args": (v25/*: any*/),
                     "filters": [
                       "sort",
                       "medium",
@@ -1969,7 +1999,7 @@ return {
                   },
                   {
                     "alias": "exhibitors",
-                    "args": (v45/*: any*/),
+                    "args": (v46/*: any*/),
                     "concreteType": "ShowConnection",
                     "kind": "LinkedField",
                     "name": "showsConnection",
@@ -1992,7 +2022,7 @@ return {
                             "plural": false,
                             "selections": [
                               (v6/*: any*/),
-                              (v47/*: any*/),
+                              (v48/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -2004,17 +2034,17 @@ return {
                                   (v2/*: any*/),
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v48/*: any*/),
+                                    "selections": (v49/*: any*/),
                                     "type": "Partner",
                                     "abstractKey": null
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v48/*: any*/),
+                                    "selections": (v49/*: any*/),
                                     "type": "ExternalPartner",
                                     "abstractKey": null
                                   },
-                                  (v43/*: any*/)
+                                  (v44/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -2093,7 +2123,7 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "openingBid",
                                                 "plural": false,
-                                                "selections": (v38/*: any*/),
+                                                "selections": (v39/*: any*/),
                                                 "storageKey": null
                                               },
                                               {
@@ -2103,11 +2133,11 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "highestBid",
                                                 "plural": false,
-                                                "selections": (v38/*: any*/),
+                                                "selections": (v39/*: any*/),
                                                 "storageKey": null
                                               },
-                                              (v39/*: any*/),
-                                              (v36/*: any*/),
+                                              (v40/*: any*/),
+                                              (v37/*: any*/),
                                               (v6/*: any*/)
                                             ],
                                             "storageKey": null
@@ -2120,9 +2150,9 @@ return {
                                             "name": "sale",
                                             "plural": false,
                                             "selections": [
+                                              (v35/*: any*/),
                                               (v34/*: any*/),
-                                              (v33/*: any*/),
-                                              (v23/*: any*/),
+                                              (v24/*: any*/),
                                               (v6/*: any*/)
                                             ],
                                             "storageKey": null
@@ -2143,18 +2173,18 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v25/*: any*/)
+                          (v26/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v29/*: any*/)
+                      (v30/*: any*/)
                     ],
                     "storageKey": "showsConnection(first:15,sort:\"FEATURED_ASC\")"
                   },
                   {
                     "alias": "exhibitors",
-                    "args": (v45/*: any*/),
-                    "filters": (v49/*: any*/),
+                    "args": (v46/*: any*/),
+                    "filters": (v50/*: any*/),
                     "handle": "connection",
                     "key": "Fair2ExhibitorsQuery_exhibitors",
                     "kind": "LinkedHandle",
@@ -2176,9 +2206,9 @@ return {
                     "name": "formattedOpeningHours",
                     "storageKey": null
                   },
-                  (v22/*: any*/),
                   (v23/*: any*/),
-                  (v21/*: any*/),
+                  (v24/*: any*/),
+                  (v22/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2197,7 +2227,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v52/*: any*/),
+                  (v53/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2213,7 +2243,7 @@ return {
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
-                        "selections": (v53/*: any*/),
+                        "selections": (v54/*: any*/),
                         "storageKey": null
                       }
                     ],
@@ -2242,7 +2272,7 @@ return {
                             "kind": "LinkedField",
                             "name": "node",
                             "plural": false,
-                            "selections": (v53/*: any*/),
+                            "selections": (v54/*: any*/),
                             "storageKey": null
                           }
                         ],
@@ -2289,7 +2319,7 @@ return {
                     "storageKey": null
                   },
                   (v4/*: any*/),
-                  (v54/*: any*/),
+                  (v55/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2336,31 +2366,7 @@ return {
                         "storageKey": null
                       },
                       (v15/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "LatLng",
-                        "kind": "LinkedField",
-                        "name": "coordinates",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "lat",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "lng",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
+                      (v18/*: any*/),
                       {
                         "alias": "day_schedules",
                         "args": null,
@@ -2420,7 +2426,7 @@ return {
                                     "name": "days",
                                     "storageKey": null
                                   },
-                                  (v54/*: any*/)
+                                  (v55/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -2475,20 +2481,20 @@ return {
                     "name": "sponsoredContent",
                     "plural": false,
                     "selections": [
-                      (v19/*: any*/),
-                      (v18/*: any*/)
+                      (v20/*: any*/),
+                      (v19/*: any*/)
                     ],
                     "storageKey": null
                   },
                   {
                     "alias": "shows",
-                    "args": (v55/*: any*/),
+                    "args": (v56/*: any*/),
                     "concreteType": "ShowConnection",
                     "kind": "LinkedField",
                     "name": "showsConnection",
                     "plural": false,
                     "selections": [
-                      (v56/*: any*/),
+                      (v57/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -2497,7 +2503,7 @@ return {
                         "name": "edges",
                         "plural": true,
                         "selections": [
-                          (v25/*: any*/),
+                          (v26/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -2553,20 +2559,20 @@ return {
                                                 "name": "aspectRatio",
                                                 "storageKey": null
                                               },
-                                              (v31/*: any*/),
+                                              (v32/*: any*/),
                                               (v17/*: any*/)
                                             ],
                                             "storageKey": null
                                           },
                                           (v7/*: any*/),
-                                          (v32/*: any*/),
+                                          (v33/*: any*/),
                                           (v14/*: any*/),
                                           (v4/*: any*/),
                                           (v12/*: any*/),
                                           (v8/*: any*/),
-                                          (v35/*: any*/),
-                                          (v40/*: any*/),
-                                          (v41/*: any*/)
+                                          (v36/*: any*/),
+                                          (v41/*: any*/),
+                                          (v42/*: any*/)
                                         ],
                                         "storageKey": null
                                       }
@@ -2578,7 +2584,7 @@ return {
                               },
                               (v3/*: any*/),
                               (v4/*: any*/),
-                              (v47/*: any*/),
+                              (v48/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -2607,7 +2613,7 @@ return {
                                           (v6/*: any*/),
                                           (v3/*: any*/),
                                           (v4/*: any*/),
-                                          (v57/*: any*/)
+                                          (v58/*: any*/)
                                         ],
                                         "storageKey": null
                                       }
@@ -2615,12 +2621,12 @@ return {
                                     "type": "Partner",
                                     "abstractKey": null
                                   },
-                                  (v43/*: any*/),
-                                  (v58/*: any*/)
+                                  (v44/*: any*/),
+                                  (v59/*: any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v59/*: any*/),
+                              (v60/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -2629,7 +2635,7 @@ return {
                                 "name": "location",
                                 "plural": false,
                                 "selections": [
-                                  (v37/*: any*/),
+                                  (v38/*: any*/),
                                   (v6/*: any*/)
                                 ],
                                 "storageKey": null
@@ -2647,7 +2653,7 @@ return {
                   },
                   {
                     "alias": "shows",
-                    "args": (v55/*: any*/),
+                    "args": (v56/*: any*/),
                     "filters": null,
                     "handle": "connection",
                     "key": "Fair_shows",
@@ -2675,7 +2681,7 @@ return {
                 "plural": false,
                 "selections": [
                   (v6/*: any*/),
-                  (v57/*: any*/),
+                  (v58/*: any*/),
                   (v4/*: any*/),
                   {
                     "alias": null,
@@ -2690,7 +2696,7 @@ return {
               },
               {
                 "alias": "artworks",
-                "args": (v61/*: any*/),
+                "args": (v62/*: any*/),
                 "concreteType": "ArtworkConnection",
                 "kind": "LinkedField",
                 "name": "artworksConnection",
@@ -2703,18 +2709,18 @@ return {
                     "kind": "LinkedField",
                     "name": "edges",
                     "plural": true,
-                    "selections": (v26/*: any*/),
+                    "selections": (v27/*: any*/),
                     "storageKey": null
                   },
-                  (v29/*: any*/),
-                  (v44/*: any*/)
+                  (v30/*: any*/),
+                  (v45/*: any*/)
                 ],
                 "storageKey": "artworksConnection(first:10,sort:\"PARTNER_UPDATED_AT_DESC\")"
               },
               {
                 "alias": "artworks",
-                "args": (v61/*: any*/),
-                "filters": (v49/*: any*/),
+                "args": (v62/*: any*/),
+                "filters": (v50/*: any*/),
                 "handle": "connection",
                 "key": "Partner_artworks",
                 "kind": "LinkedHandle",
@@ -2730,13 +2736,13 @@ return {
               },
               {
                 "alias": "artists",
-                "args": (v62/*: any*/),
+                "args": (v63/*: any*/),
                 "concreteType": "ArtistPartnerConnection",
                 "kind": "LinkedField",
                 "name": "artistsConnection",
                 "plural": false,
                 "selections": [
-                  (v56/*: any*/),
+                  (v57/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2793,7 +2799,7 @@ return {
                             "name": "deathday",
                             "storageKey": null
                           },
-                          (v52/*: any*/),
+                          (v53/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -2801,14 +2807,14 @@ return {
                             "kind": "LinkedField",
                             "name": "counts",
                             "plural": false,
-                            "selections": (v46/*: any*/),
+                            "selections": (v47/*: any*/),
                             "storageKey": null
                           },
                           (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v25/*: any*/),
+                      (v26/*: any*/),
                       (v6/*: any*/)
                     ],
                     "storageKey": null
@@ -2818,8 +2824,8 @@ return {
               },
               {
                 "alias": "artists",
-                "args": (v62/*: any*/),
-                "filters": (v49/*: any*/),
+                "args": (v63/*: any*/),
+                "filters": (v50/*: any*/),
                 "handle": "connection",
                 "key": "Partner_artists",
                 "kind": "LinkedHandle",
@@ -2852,8 +2858,8 @@ return {
               {
                 "alias": "recentShows",
                 "args": [
-                  (v60/*: any*/),
-                  (v63/*: any*/)
+                  (v61/*: any*/),
+                  (v64/*: any*/)
                 ],
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
@@ -2877,7 +2883,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v6/*: any*/),
-                          (v64/*: any*/)
+                          (v65/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -2889,13 +2895,13 @@ return {
               },
               {
                 "alias": "pastShows",
-                "args": (v65/*: any*/),
+                "args": (v66/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": [
-                  (v56/*: any*/),
+                  (v57/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2912,11 +2918,11 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v64/*: any*/),
+                          (v65/*: any*/),
                           (v6/*: any*/),
                           (v16/*: any*/),
                           (v3/*: any*/),
-                          (v21/*: any*/),
+                          (v22/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -2925,7 +2931,7 @@ return {
                             "name": "coverImage",
                             "plural": false,
                             "selections": [
-                              (v50/*: any*/),
+                              (v51/*: any*/),
                               (v17/*: any*/)
                             ],
                             "storageKey": null
@@ -2935,7 +2941,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v25/*: any*/)
+                      (v26/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -2944,8 +2950,8 @@ return {
               },
               {
                 "alias": "pastShows",
-                "args": (v65/*: any*/),
-                "filters": (v66/*: any*/),
+                "args": (v66/*: any*/),
+                "filters": (v67/*: any*/),
                 "handle": "connection",
                 "key": "Partner_pastShows",
                 "kind": "LinkedHandle",
@@ -2953,13 +2959,13 @@ return {
               },
               {
                 "alias": "currentAndUpcomingShows",
-                "args": (v67/*: any*/),
+                "args": (v68/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": [
-                  (v56/*: any*/),
+                  (v57/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2976,13 +2982,13 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v64/*: any*/),
+                          (v65/*: any*/),
                           (v6/*: any*/),
                           (v4/*: any*/),
                           (v3/*: any*/),
                           (v16/*: any*/),
-                          (v21/*: any*/),
-                          (v23/*: any*/),
+                          (v22/*: any*/),
+                          (v24/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -2990,7 +2996,7 @@ return {
                             "kind": "LinkedField",
                             "name": "images",
                             "plural": true,
-                            "selections": (v51/*: any*/),
+                            "selections": (v52/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -3010,17 +3016,17 @@ return {
                                 "type": "Partner",
                                 "abstractKey": null
                               },
-                              (v43/*: any*/),
-                              (v58/*: any*/)
+                              (v44/*: any*/),
+                              (v59/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v59/*: any*/),
+                          (v60/*: any*/),
                           (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v25/*: any*/)
+                      (v26/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -3029,8 +3035,8 @@ return {
               },
               {
                 "alias": "currentAndUpcomingShows",
-                "args": (v67/*: any*/),
-                "filters": (v66/*: any*/),
+                "args": (v68/*: any*/),
+                "filters": (v67/*: any*/),
                 "handle": "connection",
                 "key": "Partner_currentAndUpcomingShows",
                 "kind": "LinkedHandle",
@@ -3058,14 +3064,14 @@ return {
             "type": "Partner",
             "abstractKey": null
           },
-          (v43/*: any*/)
+          (v44/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "a10c5d28a4014b73bb4042e222381ce3",
+    "id": "f75f5718f56464d4aec0bf044181a63a",
     "metadata": {},
     "name": "VanityURLEntityQuery",
     "operationKind": "query",

--- a/src/__generated__/VanityURLEntityQuery.graphql.ts
+++ b/src/__generated__/VanityURLEntityQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 9a16af9beee1b747292e8275dcc50c3f */
+/* @relayHash a10c5d28a4014b73bb4042e222381ce3 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -310,6 +310,10 @@ fragment Fair2Header_fair on Fair {
     id
   }
   ticketsLink
+  sponsoredContent {
+    activationText
+    pressReleaseUrl
+  }
   fairHours: hours(format: MARKDOWN)
   fairLinks: links(format: MARKDOWN)
   fairTickets: tickets(format: MARKDOWN)
@@ -888,35 +892,49 @@ v17 = {
   "name": "aspectRatio",
   "storageKey": null
 },
-v18 = [
+v18 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "activationText",
+  "storageKey": null
+},
+v19 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "pressReleaseUrl",
+  "storageKey": null
+},
+v20 = [
   {
     "kind": "Literal",
     "name": "format",
     "value": "MARKDOWN"
   }
 ],
-v19 = {
+v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "exhibitionPeriod",
   "storageKey": null
 },
-v20 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startAt",
   "storageKey": null
 },
-v21 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v22 = [
+v24 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -953,14 +971,14 @@ v22 = [
     "value": "-decayed_merch"
   }
 ],
-v23 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v24 = [
+v26 = [
   {
     "alias": null,
     "args": null,
@@ -974,23 +992,23 @@ v24 = [
     ],
     "storageKey": null
   },
-  (v23/*: any*/)
+  (v25/*: any*/)
 ],
-v25 = {
+v27 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endCursor",
   "storageKey": null
 },
-v26 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "hasNextPage",
   "storageKey": null
 },
-v27 = {
+v29 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -998,19 +1016,19 @@ v27 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v25/*: any*/),
-    (v26/*: any*/)
+    (v27/*: any*/),
+    (v28/*: any*/)
   ],
   "storageKey": null
 },
-v28 = {
+v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startCursor",
   "storageKey": null
 },
-v29 = {
+v31 = {
   "alias": null,
   "args": [
     {
@@ -1023,28 +1041,28 @@ v29 = {
   "name": "url",
   "storageKey": "url(version:\"large\")"
 },
-v30 = {
+v32 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "date",
   "storageKey": null
 },
-v31 = {
+v33 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isAuction",
   "storageKey": null
 },
-v32 = {
+v34 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v33 = {
+v35 = {
   "alias": null,
   "args": null,
   "concreteType": "Sale",
@@ -1052,8 +1070,8 @@ v33 = {
   "name": "sale",
   "plural": false,
   "selections": [
-    (v31/*: any*/),
-    (v32/*: any*/),
+    (v33/*: any*/),
+    (v34/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -1061,12 +1079,12 @@ v33 = {
       "name": "displayTimelyAt",
       "storageKey": null
     },
-    (v21/*: any*/),
+    (v23/*: any*/),
     (v6/*: any*/)
   ],
   "storageKey": null
 },
-v34 = {
+v36 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCounts",
@@ -1084,27 +1102,27 @@ v34 = {
   ],
   "storageKey": null
 },
-v35 = {
+v37 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "display",
   "storageKey": null
 },
-v36 = [
-  (v35/*: any*/)
+v38 = [
+  (v37/*: any*/)
 ],
-v37 = {
+v39 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCurrentBid",
   "kind": "LinkedField",
   "name": "currentBid",
   "plural": false,
-  "selections": (v36/*: any*/),
+  "selections": (v38/*: any*/),
   "storageKey": null
 },
-v38 = {
+v40 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtwork",
@@ -1112,8 +1130,8 @@ v38 = {
   "name": "saleArtwork",
   "plural": false,
   "selections": [
-    (v34/*: any*/),
-    (v37/*: any*/),
+    (v36/*: any*/),
+    (v39/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -1125,7 +1143,7 @@ v38 = {
   ],
   "storageKey": null
 },
-v39 = {
+v41 = {
   "alias": null,
   "args": null,
   "concreteType": "Partner",
@@ -1138,16 +1156,16 @@ v39 = {
   ],
   "storageKey": null
 },
-v40 = [
+v42 = [
   (v6/*: any*/)
 ],
-v41 = {
+v43 = {
   "kind": "InlineFragment",
-  "selections": (v40/*: any*/),
+  "selections": (v42/*: any*/),
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v42 = {
+v44 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -1158,7 +1176,7 @@ v42 = {
       "name": "pageInfo",
       "plural": false,
       "selections": [
-        (v28/*: any*/)
+        (v30/*: any*/)
       ],
       "storageKey": null
     },
@@ -1189,23 +1207,23 @@ v42 = {
               "plural": false,
               "selections": [
                 (v17/*: any*/),
-                (v29/*: any*/)
+                (v31/*: any*/)
               ],
               "storageKey": null
             },
             (v7/*: any*/),
-            (v30/*: any*/),
+            (v32/*: any*/),
             (v14/*: any*/),
             (v4/*: any*/),
             (v12/*: any*/),
             (v8/*: any*/),
-            (v33/*: any*/),
-            (v38/*: any*/),
-            (v39/*: any*/)
+            (v35/*: any*/),
+            (v40/*: any*/),
+            (v41/*: any*/)
           ],
           "storageKey": null
         },
-        (v41/*: any*/)
+        (v43/*: any*/)
       ],
       "storageKey": null
     }
@@ -1213,7 +1231,7 @@ v42 = {
   "type": "ArtworkConnectionInterface",
   "abstractKey": "__isArtworkConnectionInterface"
 },
-v43 = [
+v45 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -1225,64 +1243,64 @@ v43 = [
     "value": "FEATURED_ASC"
   }
 ],
-v44 = [
+v46 = [
   (v10/*: any*/)
 ],
-v45 = {
+v47 = {
   "alias": null,
   "args": null,
   "concreteType": "ShowCounts",
   "kind": "LinkedField",
   "name": "counts",
   "plural": false,
-  "selections": (v44/*: any*/),
+  "selections": (v46/*: any*/),
   "storageKey": null
 },
-v46 = [
+v48 = [
   (v6/*: any*/),
   (v16/*: any*/)
 ],
-v47 = [
+v49 = [
   "sort"
 ],
-v48 = {
+v50 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v49 = [
-  (v48/*: any*/)
+v51 = [
+  (v50/*: any*/)
 ],
-v50 = {
+v52 = {
   "alias": null,
   "args": null,
   "concreteType": "Image",
   "kind": "LinkedField",
   "name": "image",
   "plural": false,
-  "selections": (v49/*: any*/),
+  "selections": (v51/*: any*/),
   "storageKey": null
 },
-v51 = [
+v53 = [
   (v16/*: any*/),
   (v8/*: any*/),
   (v3/*: any*/),
   (v4/*: any*/),
   (v6/*: any*/)
 ],
-v52 = {
+v54 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "hours",
   "storageKey": null
 },
-v53 = [
+v55 = [
   (v5/*: any*/)
 ],
-v54 = {
+v56 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -1290,69 +1308,69 @@ v54 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v26/*: any*/),
     (v28/*: any*/),
-    (v25/*: any*/)
+    (v30/*: any*/),
+    (v27/*: any*/)
   ],
   "storageKey": null
 },
-v55 = {
+v57 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isFollowed",
   "storageKey": null
 },
-v56 = {
+v58 = {
   "kind": "InlineFragment",
-  "selections": (v40/*: any*/),
+  "selections": (v42/*: any*/),
   "type": "ExternalPartner",
   "abstractKey": null
 },
-v57 = {
+v59 = {
   "alias": null,
   "args": null,
   "concreteType": "Image",
   "kind": "LinkedField",
   "name": "coverImage",
   "plural": false,
-  "selections": (v49/*: any*/),
+  "selections": (v51/*: any*/),
   "storageKey": null
 },
-v58 = {
+v60 = {
   "kind": "Literal",
   "name": "first",
   "value": 10
 },
-v59 = [
-  (v58/*: any*/),
+v61 = [
+  (v60/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "PARTNER_UPDATED_AT_DESC"
   }
 ],
-v60 = [
-  (v58/*: any*/),
+v62 = [
+  (v60/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "SORTABLE_ID_ASC"
   }
 ],
-v61 = {
+v63 = {
   "kind": "Literal",
   "name": "status",
   "value": "CURRENT"
 },
-v62 = {
+v64 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isDisplayable",
   "storageKey": null
 },
-v63 = [
+v65 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -1369,11 +1387,11 @@ v63 = [
     "value": "CLOSED"
   }
 ],
-v64 = [
+v66 = [
   "status",
   "sort"
 ],
-v65 = [
+v67 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -1384,7 +1402,7 @@ v65 = [
     "name": "sort",
     "value": "END_AT_ASC"
   },
-  (v61/*: any*/)
+  (v63/*: any*/)
 ];
 return {
   "fragment": {
@@ -1789,39 +1807,52 @@ return {
                     "storageKey": null
                   },
                   {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "FairSponsoredContent",
+                    "kind": "LinkedField",
+                    "name": "sponsoredContent",
+                    "plural": false,
+                    "selections": [
+                      (v18/*: any*/),
+                      (v19/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
                     "alias": "fairHours",
-                    "args": (v18/*: any*/),
+                    "args": (v20/*: any*/),
                     "kind": "ScalarField",
                     "name": "hours",
                     "storageKey": "hours(format:\"MARKDOWN\")"
                   },
                   {
                     "alias": "fairLinks",
-                    "args": (v18/*: any*/),
+                    "args": (v20/*: any*/),
                     "kind": "ScalarField",
                     "name": "links",
                     "storageKey": "links(format:\"MARKDOWN\")"
                   },
                   {
                     "alias": "fairTickets",
-                    "args": (v18/*: any*/),
+                    "args": (v20/*: any*/),
                     "kind": "ScalarField",
                     "name": "tickets",
                     "storageKey": "tickets(format:\"MARKDOWN\")"
                   },
                   {
                     "alias": "fairContact",
-                    "args": (v18/*: any*/),
+                    "args": (v20/*: any*/),
                     "kind": "ScalarField",
                     "name": "contact",
                     "storageKey": "contact(format:\"MARKDOWN\")"
                   },
-                  (v19/*: any*/),
-                  (v20/*: any*/),
                   (v21/*: any*/),
+                  (v22/*: any*/),
+                  (v23/*: any*/),
                   {
                     "alias": "fairArtworks",
-                    "args": (v22/*: any*/),
+                    "args": (v24/*: any*/),
                     "concreteType": "FilterArtworksConnection",
                     "kind": "LinkedField",
                     "name": "filterArtworksConnection",
@@ -1878,7 +1909,7 @@ return {
                         "kind": "LinkedField",
                         "name": "edges",
                         "plural": true,
-                        "selections": (v24/*: any*/),
+                        "selections": (v26/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -1906,15 +1937,15 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v27/*: any*/),
+                      (v29/*: any*/),
                       (v6/*: any*/),
-                      (v42/*: any*/)
+                      (v44/*: any*/)
                     ],
                     "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,medium:\"*\",sort:\"-decayed_merch\")"
                   },
                   {
                     "alias": "fairArtworks",
-                    "args": (v22/*: any*/),
+                    "args": (v24/*: any*/),
                     "filters": [
                       "sort",
                       "medium",
@@ -1938,7 +1969,7 @@ return {
                   },
                   {
                     "alias": "exhibitors",
-                    "args": (v43/*: any*/),
+                    "args": (v45/*: any*/),
                     "concreteType": "ShowConnection",
                     "kind": "LinkedField",
                     "name": "showsConnection",
@@ -1961,7 +1992,7 @@ return {
                             "plural": false,
                             "selections": [
                               (v6/*: any*/),
-                              (v45/*: any*/),
+                              (v47/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1973,17 +2004,17 @@ return {
                                   (v2/*: any*/),
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v46/*: any*/),
+                                    "selections": (v48/*: any*/),
                                     "type": "Partner",
                                     "abstractKey": null
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v46/*: any*/),
+                                    "selections": (v48/*: any*/),
                                     "type": "ExternalPartner",
                                     "abstractKey": null
                                   },
-                                  (v41/*: any*/)
+                                  (v43/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -2062,7 +2093,7 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "openingBid",
                                                 "plural": false,
-                                                "selections": (v36/*: any*/),
+                                                "selections": (v38/*: any*/),
                                                 "storageKey": null
                                               },
                                               {
@@ -2072,11 +2103,11 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "highestBid",
                                                 "plural": false,
-                                                "selections": (v36/*: any*/),
+                                                "selections": (v38/*: any*/),
                                                 "storageKey": null
                                               },
-                                              (v37/*: any*/),
-                                              (v34/*: any*/),
+                                              (v39/*: any*/),
+                                              (v36/*: any*/),
                                               (v6/*: any*/)
                                             ],
                                             "storageKey": null
@@ -2089,9 +2120,9 @@ return {
                                             "name": "sale",
                                             "plural": false,
                                             "selections": [
-                                              (v32/*: any*/),
-                                              (v31/*: any*/),
-                                              (v21/*: any*/),
+                                              (v34/*: any*/),
+                                              (v33/*: any*/),
+                                              (v23/*: any*/),
                                               (v6/*: any*/)
                                             ],
                                             "storageKey": null
@@ -2112,18 +2143,18 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v23/*: any*/)
+                          (v25/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v27/*: any*/)
+                      (v29/*: any*/)
                     ],
                     "storageKey": "showsConnection(first:15,sort:\"FEATURED_ASC\")"
                   },
                   {
                     "alias": "exhibitors",
-                    "args": (v43/*: any*/),
-                    "filters": (v47/*: any*/),
+                    "args": (v45/*: any*/),
+                    "filters": (v49/*: any*/),
                     "handle": "connection",
                     "key": "Fair2ExhibitorsQuery_exhibitors",
                     "kind": "LinkedHandle",
@@ -2145,9 +2176,9 @@ return {
                     "name": "formattedOpeningHours",
                     "storageKey": null
                   },
-                  (v20/*: any*/),
+                  (v22/*: any*/),
+                  (v23/*: any*/),
                   (v21/*: any*/),
-                  (v19/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2166,7 +2197,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v50/*: any*/),
+                  (v52/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2182,7 +2213,7 @@ return {
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
-                        "selections": (v51/*: any*/),
+                        "selections": (v53/*: any*/),
                         "storageKey": null
                       }
                     ],
@@ -2211,7 +2242,7 @@ return {
                             "kind": "LinkedField",
                             "name": "node",
                             "plural": false,
-                            "selections": (v51/*: any*/),
+                            "selections": (v53/*: any*/),
                             "storageKey": null
                           }
                         ],
@@ -2258,7 +2289,7 @@ return {
                     "storageKey": null
                   },
                   (v4/*: any*/),
-                  (v52/*: any*/),
+                  (v54/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2389,7 +2420,7 @@ return {
                                     "name": "days",
                                     "storageKey": null
                                   },
-                                  (v52/*: any*/)
+                                  (v54/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -2444,32 +2475,20 @@ return {
                     "name": "sponsoredContent",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "pressReleaseUrl",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "activationText",
-                        "storageKey": null
-                      }
+                      (v19/*: any*/),
+                      (v18/*: any*/)
                     ],
                     "storageKey": null
                   },
                   {
                     "alias": "shows",
-                    "args": (v53/*: any*/),
+                    "args": (v55/*: any*/),
                     "concreteType": "ShowConnection",
                     "kind": "LinkedField",
                     "name": "showsConnection",
                     "plural": false,
                     "selections": [
-                      (v54/*: any*/),
+                      (v56/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -2478,7 +2497,7 @@ return {
                         "name": "edges",
                         "plural": true,
                         "selections": [
-                          (v23/*: any*/),
+                          (v25/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -2534,20 +2553,20 @@ return {
                                                 "name": "aspectRatio",
                                                 "storageKey": null
                                               },
-                                              (v29/*: any*/),
+                                              (v31/*: any*/),
                                               (v17/*: any*/)
                                             ],
                                             "storageKey": null
                                           },
                                           (v7/*: any*/),
-                                          (v30/*: any*/),
+                                          (v32/*: any*/),
                                           (v14/*: any*/),
                                           (v4/*: any*/),
                                           (v12/*: any*/),
                                           (v8/*: any*/),
-                                          (v33/*: any*/),
-                                          (v38/*: any*/),
-                                          (v39/*: any*/)
+                                          (v35/*: any*/),
+                                          (v40/*: any*/),
+                                          (v41/*: any*/)
                                         ],
                                         "storageKey": null
                                       }
@@ -2559,7 +2578,7 @@ return {
                               },
                               (v3/*: any*/),
                               (v4/*: any*/),
-                              (v45/*: any*/),
+                              (v47/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -2588,7 +2607,7 @@ return {
                                           (v6/*: any*/),
                                           (v3/*: any*/),
                                           (v4/*: any*/),
-                                          (v55/*: any*/)
+                                          (v57/*: any*/)
                                         ],
                                         "storageKey": null
                                       }
@@ -2596,12 +2615,12 @@ return {
                                     "type": "Partner",
                                     "abstractKey": null
                                   },
-                                  (v41/*: any*/),
-                                  (v56/*: any*/)
+                                  (v43/*: any*/),
+                                  (v58/*: any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v57/*: any*/),
+                              (v59/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -2610,7 +2629,7 @@ return {
                                 "name": "location",
                                 "plural": false,
                                 "selections": [
-                                  (v35/*: any*/),
+                                  (v37/*: any*/),
                                   (v6/*: any*/)
                                 ],
                                 "storageKey": null
@@ -2628,7 +2647,7 @@ return {
                   },
                   {
                     "alias": "shows",
-                    "args": (v53/*: any*/),
+                    "args": (v55/*: any*/),
                     "filters": null,
                     "handle": "connection",
                     "key": "Fair_shows",
@@ -2656,7 +2675,7 @@ return {
                 "plural": false,
                 "selections": [
                   (v6/*: any*/),
-                  (v55/*: any*/),
+                  (v57/*: any*/),
                   (v4/*: any*/),
                   {
                     "alias": null,
@@ -2671,7 +2690,7 @@ return {
               },
               {
                 "alias": "artworks",
-                "args": (v59/*: any*/),
+                "args": (v61/*: any*/),
                 "concreteType": "ArtworkConnection",
                 "kind": "LinkedField",
                 "name": "artworksConnection",
@@ -2684,18 +2703,18 @@ return {
                     "kind": "LinkedField",
                     "name": "edges",
                     "plural": true,
-                    "selections": (v24/*: any*/),
+                    "selections": (v26/*: any*/),
                     "storageKey": null
                   },
-                  (v27/*: any*/),
-                  (v42/*: any*/)
+                  (v29/*: any*/),
+                  (v44/*: any*/)
                 ],
                 "storageKey": "artworksConnection(first:10,sort:\"PARTNER_UPDATED_AT_DESC\")"
               },
               {
                 "alias": "artworks",
-                "args": (v59/*: any*/),
-                "filters": (v47/*: any*/),
+                "args": (v61/*: any*/),
+                "filters": (v49/*: any*/),
                 "handle": "connection",
                 "key": "Partner_artworks",
                 "kind": "LinkedHandle",
@@ -2711,13 +2730,13 @@ return {
               },
               {
                 "alias": "artists",
-                "args": (v60/*: any*/),
+                "args": (v62/*: any*/),
                 "concreteType": "ArtistPartnerConnection",
                 "kind": "LinkedField",
                 "name": "artistsConnection",
                 "plural": false,
                 "selections": [
-                  (v54/*: any*/),
+                  (v56/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2774,7 +2793,7 @@ return {
                             "name": "deathday",
                             "storageKey": null
                           },
-                          (v50/*: any*/),
+                          (v52/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -2782,14 +2801,14 @@ return {
                             "kind": "LinkedField",
                             "name": "counts",
                             "plural": false,
-                            "selections": (v44/*: any*/),
+                            "selections": (v46/*: any*/),
                             "storageKey": null
                           },
                           (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v23/*: any*/),
+                      (v25/*: any*/),
                       (v6/*: any*/)
                     ],
                     "storageKey": null
@@ -2799,8 +2818,8 @@ return {
               },
               {
                 "alias": "artists",
-                "args": (v60/*: any*/),
-                "filters": (v47/*: any*/),
+                "args": (v62/*: any*/),
+                "filters": (v49/*: any*/),
                 "handle": "connection",
                 "key": "Partner_artists",
                 "kind": "LinkedHandle",
@@ -2833,8 +2852,8 @@ return {
               {
                 "alias": "recentShows",
                 "args": [
-                  (v58/*: any*/),
-                  (v61/*: any*/)
+                  (v60/*: any*/),
+                  (v63/*: any*/)
                 ],
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
@@ -2858,7 +2877,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v6/*: any*/),
-                          (v62/*: any*/)
+                          (v64/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -2870,13 +2889,13 @@ return {
               },
               {
                 "alias": "pastShows",
-                "args": (v63/*: any*/),
+                "args": (v65/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": [
-                  (v54/*: any*/),
+                  (v56/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2893,11 +2912,11 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v62/*: any*/),
+                          (v64/*: any*/),
                           (v6/*: any*/),
                           (v16/*: any*/),
                           (v3/*: any*/),
-                          (v19/*: any*/),
+                          (v21/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -2906,7 +2925,7 @@ return {
                             "name": "coverImage",
                             "plural": false,
                             "selections": [
-                              (v48/*: any*/),
+                              (v50/*: any*/),
                               (v17/*: any*/)
                             ],
                             "storageKey": null
@@ -2916,7 +2935,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v23/*: any*/)
+                      (v25/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -2925,8 +2944,8 @@ return {
               },
               {
                 "alias": "pastShows",
-                "args": (v63/*: any*/),
-                "filters": (v64/*: any*/),
+                "args": (v65/*: any*/),
+                "filters": (v66/*: any*/),
                 "handle": "connection",
                 "key": "Partner_pastShows",
                 "kind": "LinkedHandle",
@@ -2934,13 +2953,13 @@ return {
               },
               {
                 "alias": "currentAndUpcomingShows",
-                "args": (v65/*: any*/),
+                "args": (v67/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": [
-                  (v54/*: any*/),
+                  (v56/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2957,13 +2976,13 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v62/*: any*/),
+                          (v64/*: any*/),
                           (v6/*: any*/),
                           (v4/*: any*/),
                           (v3/*: any*/),
                           (v16/*: any*/),
-                          (v19/*: any*/),
                           (v21/*: any*/),
+                          (v23/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -2971,7 +2990,7 @@ return {
                             "kind": "LinkedField",
                             "name": "images",
                             "plural": true,
-                            "selections": (v49/*: any*/),
+                            "selections": (v51/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -2991,17 +3010,17 @@ return {
                                 "type": "Partner",
                                 "abstractKey": null
                               },
-                              (v41/*: any*/),
-                              (v56/*: any*/)
+                              (v43/*: any*/),
+                              (v58/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v57/*: any*/),
+                          (v59/*: any*/),
                           (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v23/*: any*/)
+                      (v25/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -3010,8 +3029,8 @@ return {
               },
               {
                 "alias": "currentAndUpcomingShows",
-                "args": (v65/*: any*/),
-                "filters": (v64/*: any*/),
+                "args": (v67/*: any*/),
+                "filters": (v66/*: any*/),
                 "handle": "connection",
                 "key": "Partner_currentAndUpcomingShows",
                 "kind": "LinkedHandle",
@@ -3039,14 +3058,14 @@ return {
             "type": "Partner",
             "abstractKey": null
           },
-          (v41/*: any*/)
+          (v43/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "9a16af9beee1b747292e8275dcc50c3f",
+    "id": "a10c5d28a4014b73bb4042e222381ce3",
     "metadata": {},
     "name": "VanityURLEntityQuery",
     "operationKind": "query",

--- a/src/lib/Scenes/Fair2/Components/Fair2Header.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2Header.tsx
@@ -3,6 +3,7 @@ import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { ReadMore } from "lib/Components/ReadMore"
 import { navigate } from "lib/navigation/navigate"
 import { shouldShowFairBMWArtActivationLink } from "lib/Scenes/Fair/Screens/FairBMWArtActivation"
+import { shouldShowLocationMap } from "lib/Scenes/Fair2/Fair2MoreInfo"
 import { truncatedTextLimit } from "lib/utils/hardware"
 import { Box, ChevronIcon, Flex, Text } from "palette"
 import React from "react"
@@ -38,6 +39,7 @@ export const Fair2Header: React.FC<Fair2HeaderProps> = ({ fair }) => {
     !!about ||
     !!tagline ||
     !!location?.summary ||
+    !!shouldShowLocationMap(location?.coordinates) ||
     !!ticketsLink ||
     !!fairHours ||
     !!fairLinks ||
@@ -107,6 +109,10 @@ export const Fair2HeaderFragmentContainer = createFragmentContainer(Fair2Header,
       tagline
       location {
         summary
+        coordinates {
+          lat
+          lng
+        }
       }
       ticketsLink
       sponsoredContent {

--- a/src/lib/Scenes/Fair2/Components/Fair2Header.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2Header.tsx
@@ -2,6 +2,7 @@ import { Fair2Header_fair } from "__generated__/Fair2Header_fair.graphql"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { ReadMore } from "lib/Components/ReadMore"
 import { navigate } from "lib/navigation/navigate"
+import { shouldShowFairBMWArtActivationLink } from "lib/Scenes/Fair/Screens/FairBMWArtActivation"
 import { truncatedTextLimit } from "lib/utils/hardware"
 import { Box, ChevronIcon, Flex, Text } from "palette"
 import React from "react"
@@ -27,6 +28,7 @@ export const Fair2Header: React.FC<Fair2HeaderProps> = ({ fair }) => {
     fairContact,
     summary,
     fairTickets,
+    sponsoredContent,
   } = fair
   const screenWidth = Dimensions.get("screen").width
   const profileImageUrl = fair?.profile?.icon?.imageUrl
@@ -41,7 +43,8 @@ export const Fair2Header: React.FC<Fair2HeaderProps> = ({ fair }) => {
     !!fairLinks ||
     !!fairContact ||
     !!summary ||
-    !!fairTickets
+    !!fairTickets ||
+    shouldShowFairBMWArtActivationLink({ sponsoredContent })
 
   return (
     <Box>
@@ -106,6 +109,10 @@ export const Fair2HeaderFragmentContainer = createFragmentContainer(Fair2Header,
         summary
       }
       ticketsLink
+      sponsoredContent {
+        activationText
+        pressReleaseUrl
+      }
       fairHours: hours(format: MARKDOWN) # aliased to avoid conflicts in the VanityURLQueryRenderer
       fairLinks: links(format: MARKDOWN) # aliased to avoid conflicts in the VanityURLQueryRenderer
       fairTickets: tickets(format: MARKDOWN) # aliased to avoid conflicts in the VanityURLQueryRenderer

--- a/src/lib/Scenes/Fair2/Components/Fair2Header.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2Header.tsx
@@ -39,7 +39,7 @@ export const Fair2Header: React.FC<Fair2HeaderProps> = ({ fair }) => {
     !!about ||
     !!tagline ||
     !!location?.summary ||
-    !!shouldShowLocationMap(location?.coordinates) ||
+    shouldShowLocationMap(location?.coordinates) ||
     !!ticketsLink ||
     !!fairHours ||
     !!fairLinks ||

--- a/src/lib/Scenes/Fair2/Fair2MoreInfo.tsx
+++ b/src/lib/Scenes/Fair2/Fair2MoreInfo.tsx
@@ -22,10 +22,16 @@ interface Fair2MoreInfoProps {
   fair: Fair2MoreInfo_fair
 }
 
-export const Fair2MoreInfo: React.FC<Fair2MoreInfoProps> = ({ fair }) => {
-  const coordinates = fair.location?.coordinates
-  const shouldShowLocationMap = coordinates && coordinates?.lat && coordinates?.lng
+interface LocationCoordinates {
+  lat: number | null
+  lng: number | null
+}
 
+export const shouldShowLocationMap = (coordinates: LocationCoordinates | null | undefined): boolean => {
+  return !!(coordinates && coordinates?.lat && coordinates?.lng)
+}
+
+export const Fair2MoreInfo: React.FC<Fair2MoreInfoProps> = ({ fair }) => {
   const markdownRules = defaultRules({ useNewTextStyles: true })
 
   return (
@@ -68,7 +74,7 @@ export const Fair2MoreInfo: React.FC<Fair2MoreInfoProps> = ({ fair }) => {
               <>
                 <Text variant="mediumText">Location</Text>
                 {!!fair.location?.summary && <Text variant="text">{fair.location?.summary}</Text>}
-                {!!shouldShowLocationMap && (
+                {!!shouldShowLocationMap(fair.location?.coordinates) && (
                   <LocationMapContainer
                     location={fair.location}
                     partnerType={PartnerType.fair}

--- a/src/lib/Scenes/Fair2/__tests__/Fair2-tests.tsx
+++ b/src/lib/Scenes/Fair2/__tests__/Fair2-tests.tsx
@@ -247,6 +247,10 @@ const FAIR_2_FIXTURE: Fair2TestsQueryRawResponse = {
     location: {
       id: "cde123",
       summary: null,
+      coordinates: {
+        lat: 1,
+        lng: 1,
+      },
     },
     profile: {
       id: "abc123",
@@ -272,5 +276,9 @@ const FAIR_2_FIXTURE: Fair2TestsQueryRawResponse = {
     startAt: "2020-08-19T08:00:00+00:00",
     endAt: "2020-09-19T08:00:00+00:00",
     followedArtistArtworks: null,
+    sponsoredContent: {
+      activationText: "This is some activation text",
+      pressReleaseUrl: "https://testing.artsy.net/press",
+    },
   },
 }

--- a/src/lib/Scenes/Fair2/__tests__/Fair2Header-tests.tsx
+++ b/src/lib/Scenes/Fair2/__tests__/Fair2Header-tests.tsx
@@ -133,6 +133,10 @@ const Fair2HeaderFixture: Fair2HeaderTestsQueryRawResponse = {
     fairHours: null,
     fairTickets: null,
     ticketsLink: "",
+    sponsoredContent: {
+      activationText: "This is some activation text",
+      pressReleaseUrl: "https://testing.artsy.net/press",
+    },
     exhibitionPeriod: "Aug 19 - Sep 19",
     startAt: "2020-08-19T08:00:00+00:00",
     endAt: "2020-09-19T08:00:00+00:00",
@@ -151,5 +155,6 @@ const Fair2HeaderFixtureNoAdditionalInfo = {
     ...Fair2HeaderFixture.fair,
     about: "",
     summary: "",
+    sponsoredContent: null,
   },
 } as Fair2HeaderTestsQueryRawResponse

--- a/src/lib/Scenes/Fair2/__tests__/Fair2Header-tests.tsx
+++ b/src/lib/Scenes/Fair2/__tests__/Fair2Header-tests.tsx
@@ -119,7 +119,11 @@ const Fair2HeaderFixture: Fair2HeaderTestsQueryRawResponse = {
     },
     location: {
       id: "cde123",
-      summary: null,
+      summary: "this is a location summary",
+      coordinates: {
+        lat: 1,
+        lng: 1,
+      },
     },
     profile: {
       id: "abc123",
@@ -156,5 +160,6 @@ const Fair2HeaderFixtureNoAdditionalInfo = {
     about: "",
     summary: "",
     sponsoredContent: null,
+    location: null,
   },
 } as Fair2HeaderTestsQueryRawResponse


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [FX-2351]

### Description

Adds checks for fair sponsored content or fair coordinates and renders the "More Info" link if the fair has either.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

Previously this fair did not show a "More Info" link and now it does:

![Screen Shot 2020-10-12 at 4 27 52 PM](https://user-images.githubusercontent.com/4432348/95909068-e3d54a00-0d6b-11eb-9c97-4125f91f5f43.png)


![Screen Shot 2020-10-12 at 4 39 53 PM](https://user-images.githubusercontent.com/4432348/95909051-de77ff80-0d6b-11eb-9a54-46e2d1eb093f.png)



[FX-2351]: https://artsyproduct.atlassian.net/browse/FX-2351