### PR TITLE
Fix: [My Collection] reset form on delete; auction list click

### DIFF
--- a/src/lib/Scenes/MyCollection/Screens/AddArtwork/AddEditArtwork.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/AddArtwork/AddEditArtwork.tsx
@@ -102,9 +102,6 @@ const PhotosButton: React.FC = () => {
             <Sans size="3" weight="medium">
               Photos
             </Sans>
-            <Sans size="3" ml="2px">
-              (optional)
-            </Sans>
           </Flex>
           {photos.length > 0 && (
             <>

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/ArtworkInsights/MyCollectionArtworkArtistAuctionResults.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/ArtworkInsights/MyCollectionArtworkArtistAuctionResults.tsx
@@ -8,7 +8,7 @@ import { extractNodes } from "lib/utils/extractNodes"
 import { DateTime } from "luxon"
 import { Box, Flex, Spacer, Text } from "palette"
 import React from "react"
-import { View } from "react-native"
+import { TouchableWithoutFeedback, View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { InfoButton } from "./InfoButton"
 
@@ -31,36 +31,43 @@ const MyCollectionArtworkArtistAuctionResults: React.FC<MyCollectionArtworkArtis
 
         <Spacer my={0.5} />
 
-        {results.map(({ title, saleDate, priceRealized, internalID, images }) => {
-          const dateOfSale = DateTime.fromISO(saleDate as string).toLocaleString(DateTime.DATE_MED)
-          const salePrice = priceRealized?.centsUSD === 0 ? null : priceRealized?.display
+        <TouchableWithoutFeedback
+          onPress={() => navActions.navigateToAllAuctions(props?.artwork?.artist?.slug!)}
+          data-test-id="AuctionsResultsButton"
+        >
+          <Box>
+            {results.map(({ title, saleDate, priceRealized, internalID, images }) => {
+              const dateOfSale = DateTime.fromISO(saleDate as string).toLocaleString(DateTime.DATE_MED)
+              const salePrice = priceRealized?.centsUSD === 0 ? null : priceRealized?.display
 
-          return (
-            <Box my={0.5} key={internalID}>
-              <Box my={0.5}>
-                <Flex flexDirection="row">
-                  <Box pr={1}>
-                    <OpaqueImageView imageURL={images?.thumbnail?.url} width={80} height={60} />
-                  </Box>
-                  <Box pr={1} maxWidth="80%">
+              return (
+                <Box my={0.5} key={internalID}>
+                  <Box my={0.5}>
                     <Flex flexDirection="row">
-                      <Text style={{ flexShrink: 1 }}>{title}</Text>
-                    </Flex>
-                    <Text color="black60" my={0.5}>
-                      Sold {dateOfSale}
-                    </Text>
-
-                    {!!salePrice && (
-                      <Box>
-                        <Text>{salePrice}</Text>
+                      <Box pr={1}>
+                        <OpaqueImageView imageURL={images?.thumbnail?.url} width={80} height={60} />
                       </Box>
-                    )}
+                      <Box pr={1} maxWidth="80%">
+                        <Flex flexDirection="row">
+                          <Text style={{ flexShrink: 1 }}>{title}</Text>
+                        </Flex>
+                        <Text color="black60" my={0.5}>
+                          Sold {dateOfSale}
+                        </Text>
+
+                        {!!salePrice && (
+                          <Box>
+                            <Text>{salePrice}</Text>
+                          </Box>
+                        )}
+                      </Box>
+                    </Flex>
                   </Box>
-                </Flex>
-              </Box>
-            </Box>
-          )
-        })}
+                </Box>
+              )
+            })}
+          </Box>
+        </TouchableWithoutFeedback>
 
         <Spacer my={1} />
 

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/ArtworkInsights/MyCollectionArtworkArtistMarket.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/ArtworkInsights/MyCollectionArtworkArtistMarket.tsx
@@ -64,7 +64,7 @@ const MyCollectionArtworkArtistMarket: React.FC<MyCollectionArtworkArtistMarketP
     <ScreenMargin>
       <InfoButton
         title="Artist market"
-        subTitle={`Based on ${"TODO"} months of auction data`}
+        subTitle="Based on the last 36 months of auction data"
         onPress={() => navActions.showInfoModal("artistMarket")}
       />
 

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/ArtworkInsights/__tests__/MyCollectionArtworkArtistAuctionResults-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/ArtworkInsights/__tests__/MyCollectionArtworkArtistAuctionResults-tests.tsx
@@ -71,6 +71,21 @@ describe("MyCollectionArtworkArtistAuctionResults", () => {
     expect(text).toContain("Explore auction results")
   })
 
+  it("navigates to all auction results when user clicks auctions results items", () => {
+    const spy = jest.fn()
+    AppStore.actions.myCollection.navigation.navigateToAllAuctions = spy as any
+    const wrapper = renderWithWrappers(<TestRenderer />)
+    resolveData({
+      Artwork: () => ({
+        artist: {
+          slug: "artist-slug",
+        },
+      }),
+    })
+    wrapper.root.findByProps({ "data-test-id": "AuctionsResultsButton" }).props.onPress()
+    expect(spy).toHaveBeenCalledWith("artist-slug")
+  })
+
   it("navigates to all auction results on click", () => {
     const spy = jest.fn()
     AppStore.actions.myCollection.navigation.navigateToAllAuctions = spy as any

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/ArtworkInsights/__tests__/MyCollectionArtworkArtistMarket-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/ArtworkInsights/__tests__/MyCollectionArtworkArtistMarket-tests.tsx
@@ -56,7 +56,7 @@ describe("MyCollectionArtworkArtistMarket", () => {
     expect(wrapper.root.findByType(InfoButton)).toBeDefined()
     const text = extractText(wrapper.root)
     expect(text).toContain("Artist market")
-    expect(text).toContain("Based on TODO months of auction data")
+    expect(text).toContain("Based on the last 36 months of auction data")
     expect(text).toContain("Avg. Annual Lots Sold")
     expect(text).toContain("Sell-through Rate")
 

--- a/src/lib/Scenes/MyCollection/State/MyCollectionArtworkModel.tsx
+++ b/src/lib/Scenes/MyCollection/State/MyCollectionArtworkModel.tsx
@@ -109,7 +109,7 @@ export interface MyCollectionArtworkModel {
     AppStoreModel
   >
   deleteArtwork: Thunk<MyCollectionArtworkModel, { artworkId: string; artworkGlobalId: string }, {}, AppStoreModel>
-  deleteArtworkComplete: Action<MyCollectionArtworkModel, any>
+  deleteArtworkComplete: Thunk<MyCollectionArtworkModel>
   deleteArtworkError: Action<MyCollectionArtworkModel, any>
 
   cancelAddEditArtwork: Thunk<MyCollectionArtworkModel, any, {}, AppStoreModel>
@@ -498,7 +498,7 @@ export const MyCollectionArtworkModel: MyCollectionArtworkModel = {
             }
           }
         },
-        onCompleted: actions.deleteArtworkComplete,
+        onCompleted: () => actions.deleteArtworkComplete(),
         onError: actions.deleteArtworkError,
       })
     } catch (error) {
@@ -507,8 +507,9 @@ export const MyCollectionArtworkModel: MyCollectionArtworkModel = {
     }
   }),
 
-  deleteArtworkComplete: action((state) => {
-    state.sessionState.isLoading = false
+  deleteArtworkComplete: thunk((actions) => {
+    actions.setIsLoading(false)
+    actions.resetForm()
   }),
 
   /**


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves 
- https://artsyproduct.atlassian.net/browse/CX-701
- https://artsyproduct.atlassian.net/browse/CX-700

### Description

This fixes an issue where on artwork delete, the form is still populated. This is because we "load" the form on edit button click, but then don't reset the form on delete (which happens from the edit screen). When a user goes to add a new work, the form appears populated with the work that was just deleted. This fixes that. 

Also makes it so that the entire auctions section is clickable, taking the user to `/artist/id/auction-results`, and removes the "optional" text around photo addition (since we require 1 photo before a work can be submitted). 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
