### PR TITLE
feat(show2): implements show2 installation shot carousel

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -8,6 +8,7 @@ upcoming:
     - Adds ability to filter by artist in a fair - sweir
     - Fix environment variable names for Sentry - starsirius
     - Adds Show2 header, behind lab option - damon
+    - Adds Show2 install shots, behind lab option - damon
 
 releases:
   - version: 6.6.5

--- a/src/__generated__/Show2InstallShots_show.graphql.ts
+++ b/src/__generated__/Show2InstallShots_show.graphql.ts
@@ -1,0 +1,118 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type Show2InstallShots_show = {
+    readonly name: string | null;
+    readonly images: ReadonlyArray<{
+        readonly internalID: string | null;
+        readonly caption: string | null;
+        readonly src: string | null;
+        readonly dimensions: {
+            readonly width: number | null;
+            readonly height: number | null;
+        } | null;
+    } | null> | null;
+    readonly " $refType": "Show2InstallShots_show";
+};
+export type Show2InstallShots_show$data = Show2InstallShots_show;
+export type Show2InstallShots_show$key = {
+    readonly " $data"?: Show2InstallShots_show$data;
+    readonly " $fragmentRefs": FragmentRefs<"Show2InstallShots_show">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "Show2InstallShots_show",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "images",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "internalID",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "caption",
+          "storageKey": null
+        },
+        {
+          "alias": "src",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "version",
+              "value": [
+                "larger",
+                "large"
+              ]
+            }
+          ],
+          "kind": "ScalarField",
+          "name": "url",
+          "storageKey": "url(version:[\"larger\",\"large\"])"
+        },
+        {
+          "alias": "dimensions",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "height",
+              "value": 300
+            }
+          ],
+          "concreteType": "ResizedImageUrl",
+          "kind": "LinkedField",
+          "name": "resized",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "width",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "height",
+              "storageKey": null
+            }
+          ],
+          "storageKey": "resized(height:300)"
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Show",
+  "abstractKey": null
+};
+(node as any).hash = '30932de5ced97f47c97b5353531a31c4';
+export default node;

--- a/src/__generated__/Show2Query.graphql.ts
+++ b/src/__generated__/Show2Query.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 47c88d63a43f2e047a7abf9fe4595b1e */
+/* @relayHash b90553fb102e8384cfe12cc366c83e86 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -52,9 +52,22 @@ fragment Show2Header_show on Show {
   }
 }
 
+fragment Show2InstallShots_show on Show {
+  name
+  images {
+    internalID
+    caption
+    src: url(version: ["larger", "large"])
+    dimensions: resized(height: 300) {
+      width
+      height
+    }
+  }
+}
+
 fragment Show2_show on Show {
   ...Show2Header_show
-  name
+  ...Show2InstallShots_show
 }
 */
 
@@ -212,6 +225,78 @@ return {
             ],
             "storageKey": null
           },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "images",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "internalID",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "caption",
+                "storageKey": null
+              },
+              {
+                "alias": "src",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": [
+                      "larger",
+                      "large"
+                    ]
+                  }
+                ],
+                "kind": "ScalarField",
+                "name": "url",
+                "storageKey": "url(version:[\"larger\",\"large\"])"
+              },
+              {
+                "alias": "dimensions",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 300
+                  }
+                ],
+                "concreteType": "ResizedImageUrl",
+                "kind": "LinkedField",
+                "name": "resized",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "width",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "height",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "resized(height:300)"
+              }
+            ],
+            "storageKey": null
+          },
           (v3/*: any*/)
         ],
         "storageKey": null
@@ -219,7 +304,7 @@ return {
     ]
   },
   "params": {
-    "id": "47c88d63a43f2e047a7abf9fe4595b1e",
+    "id": "b90553fb102e8384cfe12cc366c83e86",
     "metadata": {},
     "name": "Show2Query",
     "operationKind": "query",

--- a/src/__generated__/Show2TestsQuery.graphql.ts
+++ b/src/__generated__/Show2TestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 6b1049723106f34450089c5df8339ada */
+/* @relayHash d6f92ff7b9230df729d4e3bd1270b735 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -52,9 +52,22 @@ fragment Show2Header_show on Show {
   }
 }
 
+fragment Show2InstallShots_show on Show {
+  name
+  images {
+    internalID
+    caption
+    src: url(version: ["larger", "large"])
+    dimensions: resized(height: 300) {
+      width
+      height
+    }
+  }
+}
+
 fragment Show2_show on Show {
   ...Show2Header_show
-  name
+  ...Show2InstallShots_show
 }
 */
 
@@ -100,6 +113,12 @@ v5 = {
   "type": "ID"
 },
 v6 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+},
+v7 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
@@ -230,6 +249,78 @@ return {
             ],
             "storageKey": null
           },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "images",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "internalID",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "caption",
+                "storageKey": null
+              },
+              {
+                "alias": "src",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": [
+                      "larger",
+                      "large"
+                    ]
+                  }
+                ],
+                "kind": "ScalarField",
+                "name": "url",
+                "storageKey": "url(version:[\"larger\",\"large\"])"
+              },
+              {
+                "alias": "dimensions",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 300
+                  }
+                ],
+                "concreteType": "ResizedImageUrl",
+                "kind": "LinkedField",
+                "name": "resized",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "width",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "height",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "resized(height:300)"
+              }
+            ],
+            "storageKey": null
+          },
           (v3/*: any*/)
         ],
         "storageKey": null
@@ -237,7 +328,7 @@ return {
     ]
   },
   "params": {
-    "id": "6b1049723106f34450089c5df8339ada",
+    "id": "d6f92ff7b9230df729d4e3bd1270b735",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "show": {
@@ -250,6 +341,28 @@ return {
         "show.formattedEndAt": (v4/*: any*/),
         "show.formattedStartAt": (v4/*: any*/),
         "show.id": (v5/*: any*/),
+        "show.images": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "Image"
+        },
+        "show.images.caption": (v4/*: any*/),
+        "show.images.dimensions": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ResizedImageUrl"
+        },
+        "show.images.dimensions.height": (v6/*: any*/),
+        "show.images.dimensions.width": (v6/*: any*/),
+        "show.images.internalID": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ID"
+        },
+        "show.images.src": (v4/*: any*/),
         "show.name": (v4/*: any*/),
         "show.partner": {
           "enumValues": null,
@@ -257,8 +370,8 @@ return {
           "plural": false,
           "type": "PartnerTypes"
         },
-        "show.partner.__isNode": (v6/*: any*/),
-        "show.partner.__typename": (v6/*: any*/),
+        "show.partner.__isNode": (v7/*: any*/),
+        "show.partner.__typename": (v7/*: any*/),
         "show.partner.id": (v5/*: any*/),
         "show.partner.name": (v4/*: any*/),
         "show.startAt": (v4/*: any*/)

--- a/src/__generated__/Show2_show.graphql.ts
+++ b/src/__generated__/Show2_show.graphql.ts
@@ -5,8 +5,7 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type Show2_show = {
-    readonly name: string | null;
-    readonly " $fragmentRefs": FragmentRefs<"Show2Header_show">;
+    readonly " $fragmentRefs": FragmentRefs<"Show2Header_show" | "Show2InstallShots_show">;
     readonly " $refType": "Show2_show";
 };
 export type Show2_show$data = Show2_show;
@@ -24,20 +23,18 @@ const node: ReaderFragment = {
   "name": "Show2_show",
   "selections": [
     {
-      "alias": null,
       "args": null,
-      "kind": "ScalarField",
-      "name": "name",
-      "storageKey": null
+      "kind": "FragmentSpread",
+      "name": "Show2Header_show"
     },
     {
       "args": null,
       "kind": "FragmentSpread",
-      "name": "Show2Header_show"
+      "name": "Show2InstallShots_show"
     }
   ],
   "type": "Show",
   "abstractKey": null
 };
-(node as any).hash = '29f9042ba713c3c50787df0c89e87468';
+(node as any).hash = 'd59ae3175f339dca832a99511606c8d0';
 export default node;

--- a/src/lib/Scenes/Show2/Components/Show2InstallShots.tsx
+++ b/src/lib/Scenes/Show2/Components/Show2InstallShots.tsx
@@ -1,0 +1,70 @@
+import { Show2InstallShots_show } from "__generated__/Show2InstallShots_show.graphql"
+import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
+import { compact } from "lodash"
+import { Box, BoxProps, Spacer, Text } from "palette"
+import React from "react"
+import { FlatList } from "react-native"
+import { createFragmentContainer, graphql } from "react-relay"
+
+export interface Show2InstallShotsProps extends BoxProps {
+  show: Show2InstallShots_show
+}
+
+export const Show2InstallShots: React.FC<Show2InstallShotsProps> = ({ show, ...rest }) => {
+  const images = compact(show.images)
+
+  return (
+    <Box {...rest}>
+      <FlatList<typeof images[number]>
+        data={images}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        ListHeaderComponent={<Spacer mx={1} />}
+        ListFooterComponent={<Spacer mx={1} />}
+        ItemSeparatorComponent={() => <Spacer mx={0.5} />}
+        keyExtractor={(image, i) => String(image.internalID || i)}
+        renderItem={({ item: image }) => {
+          if (!image.src || !image.dimensions) {
+            return null
+          }
+
+          return (
+            <Box>
+              <OpaqueImageView width={image.dimensions.width!} height={image.dimensions.height!} imageURL={image.src} />
+
+              {!!image.caption && (
+                <Text
+                  variant="caption"
+                  color="black60"
+                  mt={0.5}
+                  numberOfLines={1}
+                  ellipsizeMode="tail"
+                  style={{ width: image.dimensions.width! }}
+                >
+                  {image.caption}
+                </Text>
+              )}
+            </Box>
+          )
+        }}
+      />
+    </Box>
+  )
+}
+
+export const Show2InstallShotsFragmentContainer = createFragmentContainer(Show2InstallShots, {
+  show: graphql`
+    fragment Show2InstallShots_show on Show {
+      name
+      images {
+        internalID
+        caption
+        src: url(version: ["larger", "large"])
+        dimensions: resized(height: 300) {
+          width
+          height
+        }
+      }
+    }
+  `,
+})

--- a/src/lib/Scenes/Show2/Show2.tsx
+++ b/src/lib/Scenes/Show2/Show2.tsx
@@ -7,6 +7,7 @@ import { Box, Flex, Separator, Spacer, Theme } from "palette"
 import React from "react"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import { Show2HeaderFragmentContainer as ShowHeader } from "./Components/Show2Header"
+import { Show2InstallShotsFragmentContainer as ShowInstallShots } from "./Components/Show2InstallShots"
 
 interface Show2QueryRendererProps {
   showID: string
@@ -19,8 +20,9 @@ interface Show2Props {
 export const Show2: React.FC<Show2Props> = ({ show }) => {
   return (
     <Theme>
-      <Box mt={6} p={2}>
-        <ShowHeader show={show} />
+      <Box mt={6}>
+        <ShowHeader show={show} mt={2} mx={2} mb={3} />
+        <ShowInstallShots show={show} mb={3} />
       </Box>
     </Theme>
   )
@@ -30,7 +32,7 @@ export const Show2FragmentContainer = createFragmentContainer(Show2, {
   show: graphql`
     fragment Show2_show on Show {
       ...Show2Header_show
-      name
+      ...Show2InstallShots_show
     }
   `,
 })

--- a/src/lib/Scenes/Show2/__tests__/Show2-tests.tsx
+++ b/src/lib/Scenes/Show2/__tests__/Show2-tests.tsx
@@ -73,4 +73,17 @@ describe("Show2", () => {
     expect(text).toContain("Closed")
     expect(text).toContain("Example Partner")
   })
+
+  it("renders the installation shots", () => {
+    const wrapper = getWrapper({
+      Show: () => ({
+        images: [{ caption: "First install shot" }, { caption: "Second install shot" }],
+      }),
+    })
+
+    const text = extractText(wrapper.root)
+
+    expect(text).toContain("First install shot")
+    expect(text).toContain("Second install shot")
+  })
 })


### PR DESCRIPTION
The type of this PR is: Feature

This PR resolves [FX-2222]

### Description

Built off https://github.com/artsy/eigen/pull/4010 so once that's merged those SHAs go away here... Will convert to ready once it's merged. cc @sweir27 

There should likely be another issue about what happens if these images are tapped, which isn't clear from the spec.

![](http://static.damonzucconi.com/_capture/wl3AwkpNqh7s.png)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2222]: https://artsyproduct.atlassian.net/browse/FX-2222