### PR TITLE
fix: Update paging for exhibitors to 30 shows at a time

### DIFF
--- a/src/__generated__/Fair2ExhibitorsTestsQuery.graphql.ts
+++ b/src/__generated__/Fair2ExhibitorsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 010f82aa845678f76f81ef91615693af */
+/* @relayHash cc376be2bdb80d4add6aa87dfe363b44 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -184,7 +184,7 @@ fragment Fair2ExhibitorRail_show on Show {
 fragment Fair2Exhibitors_fair on Fair {
   internalID
   slug
-  exhibitors: showsConnection(first: 15, sort: FEATURED_ASC) {
+  exhibitors: showsConnection(first: 30, sort: FEATURED_ASC) {
     edges {
       node {
         id
@@ -250,7 +250,7 @@ v4 = [
   {
     "kind": "Literal",
     "name": "first",
-    "value": 15
+    "value": 30
   },
   {
     "kind": "Literal",
@@ -655,7 +655,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "showsConnection(first:15,sort:\"FEATURED_ASC\")"
+            "storageKey": "showsConnection(first:30,sort:\"FEATURED_ASC\")"
           },
           {
             "alias": "exhibitors",
@@ -675,7 +675,7 @@ return {
     ]
   },
   "params": {
-    "id": "010f82aa845678f76f81ef91615693af",
+    "id": "cc376be2bdb80d4add6aa87dfe363b44",
     "metadata": {},
     "name": "Fair2ExhibitorsTestsQuery",
     "operationKind": "query",

--- a/src/__generated__/Fair2ExhibitorsTestsQuery.graphql.ts
+++ b/src/__generated__/Fair2ExhibitorsTestsQuery.graphql.ts
@@ -13,94 +13,9 @@ export type Fair2ExhibitorsTestsQueryResponse = {
         readonly " $fragmentRefs": FragmentRefs<"Fair2Exhibitors_fair">;
     } | null;
 };
-export type Fair2ExhibitorsTestsQueryRawResponse = {
-    readonly fair: ({
-        readonly internalID: string;
-        readonly slug: string;
-        readonly exhibitors: ({
-            readonly edges: ReadonlyArray<({
-                readonly node: ({
-                    readonly id: string;
-                    readonly counts: ({
-                        readonly artworks: number | null;
-                    }) | null;
-                    readonly partner: ({
-                        readonly __typename: "Partner";
-                        readonly __isNode: "Partner";
-                        readonly id: string;
-                        readonly name: string | null;
-                    } | {
-                        readonly __typename: "ExternalPartner";
-                        readonly __isNode: "ExternalPartner";
-                        readonly id: string;
-                        readonly name: string | null;
-                    } | {
-                        readonly __typename: string;
-                        readonly __isNode: string;
-                        readonly id: string;
-                    }) | null;
-                    readonly internalID: string;
-                    readonly slug: string;
-                    readonly href: string | null;
-                    readonly fair: ({
-                        readonly internalID: string;
-                        readonly slug: string;
-                        readonly id: string;
-                    }) | null;
-                    readonly artworks: ({
-                        readonly edges: ReadonlyArray<({
-                            readonly node: ({
-                                readonly href: string | null;
-                                readonly artistNames: string | null;
-                                readonly id: string;
-                                readonly image: ({
-                                    readonly imageURL: string | null;
-                                    readonly aspectRatio: number;
-                                }) | null;
-                                readonly saleMessage: string | null;
-                                readonly saleArtwork: ({
-                                    readonly openingBid: ({
-                                        readonly display: string | null;
-                                    }) | null;
-                                    readonly highestBid: ({
-                                        readonly display: string | null;
-                                    }) | null;
-                                    readonly currentBid: ({
-                                        readonly display: string | null;
-                                    }) | null;
-                                    readonly counts: ({
-                                        readonly bidderPositions: number | null;
-                                    }) | null;
-                                    readonly id: string;
-                                }) | null;
-                                readonly sale: ({
-                                    readonly isClosed: boolean | null;
-                                    readonly isAuction: boolean | null;
-                                    readonly endAt: string | null;
-                                    readonly id: string;
-                                }) | null;
-                                readonly title: string | null;
-                                readonly internalID: string;
-                                readonly slug: string;
-                            }) | null;
-                        }) | null> | null;
-                    }) | null;
-                    readonly __typename: "Show";
-                }) | null;
-                readonly cursor: string;
-            }) | null> | null;
-            readonly pageInfo: {
-                readonly endCursor: string | null;
-                readonly hasNextPage: boolean;
-            };
-        }) | null;
-        readonly id: string;
-    }) | null;
-};
 export type Fair2ExhibitorsTestsQuery = {
     readonly response: Fair2ExhibitorsTestsQueryResponse;
     readonly variables: Fair2ExhibitorsTestsQueryVariables;
-    readonly rawResponse: Fair2ExhibitorsTestsQueryRawResponse;
 };
 
 
@@ -297,7 +212,37 @@ v9 = [
     "name": "display",
     "storageKey": null
   }
-];
+],
+v10 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Fair"
+},
+v11 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v12 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v13 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v14 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Boolean"
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -676,12 +621,170 @@ return {
   },
   "params": {
     "id": "cc376be2bdb80d4add6aa87dfe363b44",
-    "metadata": {},
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "fair": (v10/*: any*/),
+        "fair.exhibitors": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ShowConnection"
+        },
+        "fair.exhibitors.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "ShowEdge"
+        },
+        "fair.exhibitors.edges.cursor": (v11/*: any*/),
+        "fair.exhibitors.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Show"
+        },
+        "fair.exhibitors.edges.node.__typename": (v11/*: any*/),
+        "fair.exhibitors.edges.node.artworks": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtworkConnection"
+        },
+        "fair.exhibitors.edges.node.artworks.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "ArtworkEdge"
+        },
+        "fair.exhibitors.edges.node.artworks.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "fair.exhibitors.edges.node.artworks.edges.node.artistNames": (v12/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.href": (v12/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.id": (v13/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.image": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Image"
+        },
+        "fair.exhibitors.edges.node.artworks.edges.node.image.aspectRatio": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Float"
+        },
+        "fair.exhibitors.edges.node.artworks.edges.node.image.imageURL": (v12/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.internalID": (v13/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.sale": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Sale"
+        },
+        "fair.exhibitors.edges.node.artworks.edges.node.sale.endAt": (v12/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.sale.id": (v13/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.sale.isAuction": (v14/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.sale.isClosed": (v14/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtwork"
+        },
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.counts": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkCounts"
+        },
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.counts.bidderPositions": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "FormattedNumber"
+        },
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.currentBid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkCurrentBid"
+        },
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.currentBid.display": (v12/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.highestBid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkHighestBid"
+        },
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.highestBid.display": (v12/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.id": (v13/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.openingBid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkOpeningBid"
+        },
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.openingBid.display": (v12/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleMessage": (v12/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.slug": (v13/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.title": (v12/*: any*/),
+        "fair.exhibitors.edges.node.counts": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ShowCounts"
+        },
+        "fair.exhibitors.edges.node.counts.artworks": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Int"
+        },
+        "fair.exhibitors.edges.node.fair": (v10/*: any*/),
+        "fair.exhibitors.edges.node.fair.id": (v13/*: any*/),
+        "fair.exhibitors.edges.node.fair.internalID": (v13/*: any*/),
+        "fair.exhibitors.edges.node.fair.slug": (v13/*: any*/),
+        "fair.exhibitors.edges.node.href": (v12/*: any*/),
+        "fair.exhibitors.edges.node.id": (v13/*: any*/),
+        "fair.exhibitors.edges.node.internalID": (v13/*: any*/),
+        "fair.exhibitors.edges.node.partner": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "PartnerTypes"
+        },
+        "fair.exhibitors.edges.node.partner.__isNode": (v11/*: any*/),
+        "fair.exhibitors.edges.node.partner.__typename": (v11/*: any*/),
+        "fair.exhibitors.edges.node.partner.id": (v13/*: any*/),
+        "fair.exhibitors.edges.node.partner.name": (v12/*: any*/),
+        "fair.exhibitors.edges.node.slug": (v13/*: any*/),
+        "fair.exhibitors.pageInfo": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "PageInfo"
+        },
+        "fair.exhibitors.pageInfo.endCursor": (v12/*: any*/),
+        "fair.exhibitors.pageInfo.hasNextPage": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Boolean"
+        },
+        "fair.id": (v13/*: any*/),
+        "fair.internalID": (v13/*: any*/),
+        "fair.slug": (v13/*: any*/)
+      }
+    },
     "name": "Fair2ExhibitorsTestsQuery",
     "operationKind": "query",
     "text": null
   }
 };
 })();
-(node as any).hash = '2b9db9ffc7b72e3d1be66a0ccd70eabf';
+(node as any).hash = 'a75bfc1bbe66903e3449675610e34e9f';
 export default node;

--- a/src/__generated__/Fair2Exhibitors_fair.graphql.ts
+++ b/src/__generated__/Fair2Exhibitors_fair.graphql.ts
@@ -50,7 +50,7 @@ return {
       "name": "after"
     },
     {
-      "defaultValue": 15,
+      "defaultValue": 30,
       "kind": "LocalArgument",
       "name": "first"
     }
@@ -214,5 +214,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = 'cbaa7f070b00285140baff4b99695311';
+(node as any).hash = '41646af987ff8e5840fdb94152676184';
 export default node;

--- a/src/__generated__/Fair2Query.graphql.ts
+++ b/src/__generated__/Fair2Query.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 723d62587941c87a195d18cdc946e373 */
+/* @relayHash 15222249e6123989085212dd3013dd76 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -219,7 +219,7 @@ fragment Fair2ExhibitorRail_show on Show {
 fragment Fair2Exhibitors_fair on Fair {
   internalID
   slug
-  exhibitors: showsConnection(first: 15, sort: FEATURED_ASC) {
+  exhibitors: showsConnection(first: 30, sort: FEATURED_ASC) {
     edges {
       node {
         id
@@ -489,7 +489,12 @@ v17 = {
   "name": "endAt",
   "storageKey": null
 },
-v18 = [
+v18 = {
+  "kind": "Literal",
+  "name": "first",
+  "value": 30
+},
+v19 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -510,11 +515,7 @@ v18 = [
     "name": "dimensionRange",
     "value": "*-*"
   },
-  {
-    "kind": "Literal",
-    "name": "first",
-    "value": 30
-  },
+  (v18/*: any*/),
   {
     "kind": "Literal",
     "name": "medium",
@@ -526,14 +527,14 @@ v18 = [
     "value": "-decayed_merch"
   }
 ],
-v19 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v20 = {
+v21 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -558,21 +559,21 @@ v20 = {
   ],
   "storageKey": null
 },
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isAuction",
   "storageKey": null
 },
-v22 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v23 = {
+v24 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCounts",
@@ -590,7 +591,7 @@ v23 = {
   ],
   "storageKey": null
 },
-v24 = [
+v25 = [
   {
     "alias": null,
     "args": null,
@@ -599,17 +600,17 @@ v24 = [
     "storageKey": null
   }
 ],
-v25 = {
+v26 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCurrentBid",
   "kind": "LinkedField",
   "name": "currentBid",
   "plural": false,
-  "selections": (v24/*: any*/),
+  "selections": (v25/*: any*/),
   "storageKey": null
 },
-v26 = {
+v27 = {
   "kind": "InlineFragment",
   "selections": [
     (v5/*: any*/)
@@ -617,19 +618,15 @@ v26 = {
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v27 = [
-  {
-    "kind": "Literal",
-    "name": "first",
-    "value": 15
-  },
+v28 = [
+  (v18/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "FEATURED_ASC"
   }
 ],
-v28 = [
+v29 = [
   (v5/*: any*/),
   (v14/*: any*/)
 ];
@@ -1121,7 +1118,7 @@ return {
           (v17/*: any*/),
           {
             "alias": "fairArtworks",
-            "args": (v18/*: any*/),
+            "args": (v19/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -1192,7 +1189,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v19/*: any*/)
+                  (v20/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -1221,7 +1218,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v20/*: any*/),
+              (v21/*: any*/),
               (v5/*: any*/),
               {
                 "kind": "InlineFragment",
@@ -1307,8 +1304,8 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v21/*: any*/),
                               (v22/*: any*/),
+                              (v23/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1329,8 +1326,8 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v23/*: any*/),
-                              (v25/*: any*/),
+                              (v24/*: any*/),
+                              (v26/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1358,7 +1355,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v26/*: any*/)
+                      (v27/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1371,7 +1368,7 @@ return {
           },
           {
             "alias": "fairArtworks",
-            "args": (v18/*: any*/),
+            "args": (v19/*: any*/),
             "filters": [
               "sort",
               "medium",
@@ -1395,7 +1392,7 @@ return {
           },
           {
             "alias": "exhibitors",
-            "args": (v27/*: any*/),
+            "args": (v28/*: any*/),
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
@@ -1441,17 +1438,17 @@ return {
                           (v4/*: any*/),
                           {
                             "kind": "InlineFragment",
-                            "selections": (v28/*: any*/),
+                            "selections": (v29/*: any*/),
                             "type": "Partner",
                             "abstractKey": null
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v28/*: any*/),
+                            "selections": (v29/*: any*/),
                             "type": "ExternalPartner",
                             "abstractKey": null
                           },
-                          (v26/*: any*/)
+                          (v27/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -1530,7 +1527,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "openingBid",
                                         "plural": false,
-                                        "selections": (v24/*: any*/),
+                                        "selections": (v25/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -1540,11 +1537,11 @@ return {
                                         "kind": "LinkedField",
                                         "name": "highestBid",
                                         "plural": false,
-                                        "selections": (v24/*: any*/),
+                                        "selections": (v25/*: any*/),
                                         "storageKey": null
                                       },
-                                      (v25/*: any*/),
-                                      (v23/*: any*/),
+                                      (v26/*: any*/),
+                                      (v24/*: any*/),
                                       (v5/*: any*/)
                                     ],
                                     "storageKey": null
@@ -1557,8 +1554,8 @@ return {
                                     "name": "sale",
                                     "plural": false,
                                     "selections": [
+                                      (v23/*: any*/),
                                       (v22/*: any*/),
-                                      (v21/*: any*/),
                                       (v17/*: any*/),
                                       (v5/*: any*/)
                                     ],
@@ -1580,17 +1577,17 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v19/*: any*/)
+                  (v20/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v20/*: any*/)
+              (v21/*: any*/)
             ],
-            "storageKey": "showsConnection(first:15,sort:\"FEATURED_ASC\")"
+            "storageKey": "showsConnection(first:30,sort:\"FEATURED_ASC\")"
           },
           {
             "alias": "exhibitors",
-            "args": (v27/*: any*/),
+            "args": (v28/*: any*/),
             "filters": [
               "sort"
             ],
@@ -1606,7 +1603,7 @@ return {
     ]
   },
   "params": {
-    "id": "723d62587941c87a195d18cdc946e373",
+    "id": "15222249e6123989085212dd3013dd76",
     "metadata": {},
     "name": "Fair2Query",
     "operationKind": "query",

--- a/src/__generated__/Fair2TestsQuery.graphql.ts
+++ b/src/__generated__/Fair2TestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash b64b4c86d524bfefca953cd7458107dd */
+/* @relayHash 7888b905e36a492c6b3b9fa51d1fdf3a */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -219,7 +219,7 @@ fragment Fair2ExhibitorRail_show on Show {
 fragment Fair2Exhibitors_fair on Fair {
   internalID
   slug
-  exhibitors: showsConnection(first: 15, sort: FEATURED_ASC) {
+  exhibitors: showsConnection(first: 30, sort: FEATURED_ASC) {
     edges {
       node {
         id
@@ -489,7 +489,12 @@ v17 = {
   "name": "endAt",
   "storageKey": null
 },
-v18 = [
+v18 = {
+  "kind": "Literal",
+  "name": "first",
+  "value": 30
+},
+v19 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -510,11 +515,7 @@ v18 = [
     "name": "dimensionRange",
     "value": "*-*"
   },
-  {
-    "kind": "Literal",
-    "name": "first",
-    "value": 30
-  },
+  (v18/*: any*/),
   {
     "kind": "Literal",
     "name": "medium",
@@ -526,14 +527,14 @@ v18 = [
     "value": "-decayed_merch"
   }
 ],
-v19 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v20 = {
+v21 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -558,21 +559,21 @@ v20 = {
   ],
   "storageKey": null
 },
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isAuction",
   "storageKey": null
 },
-v22 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v23 = {
+v24 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCounts",
@@ -590,7 +591,7 @@ v23 = {
   ],
   "storageKey": null
 },
-v24 = [
+v25 = [
   {
     "alias": null,
     "args": null,
@@ -599,17 +600,17 @@ v24 = [
     "storageKey": null
   }
 ],
-v25 = {
+v26 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCurrentBid",
   "kind": "LinkedField",
   "name": "currentBid",
   "plural": false,
-  "selections": (v24/*: any*/),
+  "selections": (v25/*: any*/),
   "storageKey": null
 },
-v26 = {
+v27 = {
   "kind": "InlineFragment",
   "selections": [
     (v5/*: any*/)
@@ -617,37 +618,27 @@ v26 = {
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v27 = [
-  {
-    "kind": "Literal",
-    "name": "first",
-    "value": 15
-  },
+v28 = [
+  (v18/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "FEATURED_ASC"
   }
 ],
-v28 = [
+v29 = [
   (v5/*: any*/),
   (v14/*: any*/)
 ],
-v29 = {
+v30 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Fair"
 },
-v30 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "String"
-},
 v31 = {
   "enumValues": null,
-  "nullable": false,
+  "nullable": true,
   "plural": false,
   "type": "String"
 },
@@ -655,87 +646,93 @@ v32 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
-  "type": "ID"
+  "type": "String"
 },
 v33 = {
   "enumValues": null,
-  "nullable": true,
+  "nullable": false,
   "plural": false,
-  "type": "Image"
+  "type": "ID"
 },
 v34 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "FormattedNumber"
+  "type": "Image"
 },
 v35 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Artwork"
+  "type": "FormattedNumber"
 },
 v36 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Artwork"
+},
+v37 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Float"
 },
-v37 = {
+v38 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Sale"
 },
-v38 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Boolean"
-},
 v39 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "SaleArtwork"
+  "type": "Boolean"
 },
 v40 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "SaleArtworkCounts"
+  "type": "SaleArtwork"
 },
 v41 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "SaleArtworkCurrentBid"
+  "type": "SaleArtworkCounts"
 },
 v42 = {
   "enumValues": null,
-  "nullable": false,
+  "nullable": true,
   "plural": false,
-  "type": "PageInfo"
+  "type": "SaleArtworkCurrentBid"
 },
 v43 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
-  "type": "Boolean"
+  "type": "PageInfo"
 },
 v44 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Boolean"
+},
+v45 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FilterArtworksConnection"
 },
-v45 = {
+v46 = {
   "enumValues": null,
   "nullable": true,
   "plural": true,
   "type": "FilterArtworksEdge"
 },
-v46 = {
+v47 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -1229,7 +1226,7 @@ return {
           (v17/*: any*/),
           {
             "alias": "fairArtworks",
-            "args": (v18/*: any*/),
+            "args": (v19/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -1300,7 +1297,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v19/*: any*/)
+                  (v20/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -1329,7 +1326,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v20/*: any*/),
+              (v21/*: any*/),
               (v5/*: any*/),
               {
                 "kind": "InlineFragment",
@@ -1415,8 +1412,8 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v21/*: any*/),
                               (v22/*: any*/),
+                              (v23/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1437,8 +1434,8 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v23/*: any*/),
-                              (v25/*: any*/),
+                              (v24/*: any*/),
+                              (v26/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1466,7 +1463,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v26/*: any*/)
+                      (v27/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1479,7 +1476,7 @@ return {
           },
           {
             "alias": "fairArtworks",
-            "args": (v18/*: any*/),
+            "args": (v19/*: any*/),
             "filters": [
               "sort",
               "medium",
@@ -1503,7 +1500,7 @@ return {
           },
           {
             "alias": "exhibitors",
-            "args": (v27/*: any*/),
+            "args": (v28/*: any*/),
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
@@ -1549,17 +1546,17 @@ return {
                           (v4/*: any*/),
                           {
                             "kind": "InlineFragment",
-                            "selections": (v28/*: any*/),
+                            "selections": (v29/*: any*/),
                             "type": "Partner",
                             "abstractKey": null
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v28/*: any*/),
+                            "selections": (v29/*: any*/),
                             "type": "ExternalPartner",
                             "abstractKey": null
                           },
-                          (v26/*: any*/)
+                          (v27/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -1638,7 +1635,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "openingBid",
                                         "plural": false,
-                                        "selections": (v24/*: any*/),
+                                        "selections": (v25/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -1648,11 +1645,11 @@ return {
                                         "kind": "LinkedField",
                                         "name": "highestBid",
                                         "plural": false,
-                                        "selections": (v24/*: any*/),
+                                        "selections": (v25/*: any*/),
                                         "storageKey": null
                                       },
-                                      (v25/*: any*/),
-                                      (v23/*: any*/),
+                                      (v26/*: any*/),
+                                      (v24/*: any*/),
                                       (v5/*: any*/)
                                     ],
                                     "storageKey": null
@@ -1665,8 +1662,8 @@ return {
                                     "name": "sale",
                                     "plural": false,
                                     "selections": [
+                                      (v23/*: any*/),
                                       (v22/*: any*/),
-                                      (v21/*: any*/),
                                       (v17/*: any*/),
                                       (v5/*: any*/)
                                     ],
@@ -1688,17 +1685,17 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v19/*: any*/)
+                  (v20/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v20/*: any*/)
+              (v21/*: any*/)
             ],
-            "storageKey": "showsConnection(first:15,sort:\"FEATURED_ASC\")"
+            "storageKey": "showsConnection(first:30,sort:\"FEATURED_ASC\")"
           },
           {
             "alias": "exhibitors",
-            "args": (v27/*: any*/),
+            "args": (v28/*: any*/),
             "filters": [
               "sort"
             ],
@@ -1714,11 +1711,11 @@ return {
     ]
   },
   "params": {
-    "id": "b64b4c86d524bfefca953cd7458107dd",
+    "id": "7888b905e36a492c6b3b9fa51d1fdf3a",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "fair": (v29/*: any*/),
-        "fair.about": (v30/*: any*/),
+        "fair": (v30/*: any*/),
+        "fair.about": (v31/*: any*/),
         "fair.articles": {
           "enumValues": null,
           "nullable": true,
@@ -1731,31 +1728,31 @@ return {
           "plural": true,
           "type": "ArticleEdge"
         },
-        "fair.articles.edges.__typename": (v31/*: any*/),
+        "fair.articles.edges.__typename": (v32/*: any*/),
         "fair.articles.edges.node": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Article"
         },
-        "fair.articles.edges.node.href": (v30/*: any*/),
-        "fair.articles.edges.node.id": (v32/*: any*/),
-        "fair.articles.edges.node.internalID": (v32/*: any*/),
-        "fair.articles.edges.node.publishedAt": (v30/*: any*/),
-        "fair.articles.edges.node.slug": (v30/*: any*/),
-        "fair.articles.edges.node.thumbnailImage": (v33/*: any*/),
-        "fair.articles.edges.node.thumbnailImage.src": (v30/*: any*/),
-        "fair.articles.edges.node.title": (v30/*: any*/),
+        "fair.articles.edges.node.href": (v31/*: any*/),
+        "fair.articles.edges.node.id": (v33/*: any*/),
+        "fair.articles.edges.node.internalID": (v33/*: any*/),
+        "fair.articles.edges.node.publishedAt": (v31/*: any*/),
+        "fair.articles.edges.node.slug": (v31/*: any*/),
+        "fair.articles.edges.node.thumbnailImage": (v34/*: any*/),
+        "fair.articles.edges.node.thumbnailImage.src": (v31/*: any*/),
+        "fair.articles.edges.node.title": (v31/*: any*/),
         "fair.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FairCounts"
         },
-        "fair.counts.artworks": (v34/*: any*/),
-        "fair.counts.partnerShows": (v34/*: any*/),
-        "fair.endAt": (v30/*: any*/),
-        "fair.exhibitionPeriod": (v30/*: any*/),
+        "fair.counts.artworks": (v35/*: any*/),
+        "fair.counts.partnerShows": (v35/*: any*/),
+        "fair.endAt": (v31/*: any*/),
+        "fair.exhibitionPeriod": (v31/*: any*/),
         "fair.exhibitors": {
           "enumValues": null,
           "nullable": true,
@@ -1768,14 +1765,14 @@ return {
           "plural": true,
           "type": "ShowEdge"
         },
-        "fair.exhibitors.edges.cursor": (v31/*: any*/),
+        "fair.exhibitors.edges.cursor": (v32/*: any*/),
         "fair.exhibitors.edges.node": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Show"
         },
-        "fair.exhibitors.edges.node.__typename": (v31/*: any*/),
+        "fair.exhibitors.edges.node.__typename": (v32/*: any*/),
         "fair.exhibitors.edges.node.artworks": {
           "enumValues": null,
           "nullable": true,
@@ -1788,42 +1785,42 @@ return {
           "plural": true,
           "type": "ArtworkEdge"
         },
-        "fair.exhibitors.edges.node.artworks.edges.node": (v35/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.artistNames": (v30/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.href": (v30/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.id": (v32/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.image": (v33/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.image.aspectRatio": (v36/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.image.imageURL": (v30/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.internalID": (v32/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.sale": (v37/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.sale.endAt": (v30/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.sale.id": (v32/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.sale.isAuction": (v38/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.sale.isClosed": (v38/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork": (v39/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.counts": (v40/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.counts.bidderPositions": (v34/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.currentBid": (v41/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.currentBid.display": (v30/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node": (v36/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.artistNames": (v31/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.href": (v31/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.id": (v33/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.image": (v34/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.image.aspectRatio": (v37/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.image.imageURL": (v31/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.internalID": (v33/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.sale": (v38/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.sale.endAt": (v31/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.sale.id": (v33/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.sale.isAuction": (v39/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.sale.isClosed": (v39/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork": (v40/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.counts": (v41/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.counts.bidderPositions": (v35/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.currentBid": (v42/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.currentBid.display": (v31/*: any*/),
         "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.highestBid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.highestBid.display": (v30/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.id": (v32/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.highestBid.display": (v31/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.id": (v33/*: any*/),
         "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.openingBid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.openingBid.display": (v30/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.saleMessage": (v30/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.slug": (v32/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.title": (v30/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.openingBid.display": (v31/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleMessage": (v31/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.slug": (v33/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.title": (v31/*: any*/),
         "fair.exhibitors.edges.node.counts": {
           "enumValues": null,
           "nullable": true,
@@ -1836,29 +1833,29 @@ return {
           "plural": false,
           "type": "Int"
         },
-        "fair.exhibitors.edges.node.fair": (v29/*: any*/),
-        "fair.exhibitors.edges.node.fair.id": (v32/*: any*/),
-        "fair.exhibitors.edges.node.fair.internalID": (v32/*: any*/),
-        "fair.exhibitors.edges.node.fair.slug": (v32/*: any*/),
-        "fair.exhibitors.edges.node.href": (v30/*: any*/),
-        "fair.exhibitors.edges.node.id": (v32/*: any*/),
-        "fair.exhibitors.edges.node.internalID": (v32/*: any*/),
+        "fair.exhibitors.edges.node.fair": (v30/*: any*/),
+        "fair.exhibitors.edges.node.fair.id": (v33/*: any*/),
+        "fair.exhibitors.edges.node.fair.internalID": (v33/*: any*/),
+        "fair.exhibitors.edges.node.fair.slug": (v33/*: any*/),
+        "fair.exhibitors.edges.node.href": (v31/*: any*/),
+        "fair.exhibitors.edges.node.id": (v33/*: any*/),
+        "fair.exhibitors.edges.node.internalID": (v33/*: any*/),
         "fair.exhibitors.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerTypes"
         },
-        "fair.exhibitors.edges.node.partner.__isNode": (v31/*: any*/),
-        "fair.exhibitors.edges.node.partner.__typename": (v31/*: any*/),
-        "fair.exhibitors.edges.node.partner.id": (v32/*: any*/),
-        "fair.exhibitors.edges.node.partner.name": (v30/*: any*/),
-        "fair.exhibitors.edges.node.slug": (v32/*: any*/),
-        "fair.exhibitors.pageInfo": (v42/*: any*/),
-        "fair.exhibitors.pageInfo.endCursor": (v30/*: any*/),
-        "fair.exhibitors.pageInfo.hasNextPage": (v43/*: any*/),
-        "fair.fairArtworks": (v44/*: any*/),
-        "fair.fairArtworks.__isArtworkConnectionInterface": (v31/*: any*/),
+        "fair.exhibitors.edges.node.partner.__isNode": (v32/*: any*/),
+        "fair.exhibitors.edges.node.partner.__typename": (v32/*: any*/),
+        "fair.exhibitors.edges.node.partner.id": (v33/*: any*/),
+        "fair.exhibitors.edges.node.partner.name": (v31/*: any*/),
+        "fair.exhibitors.edges.node.slug": (v33/*: any*/),
+        "fair.exhibitors.pageInfo": (v43/*: any*/),
+        "fair.exhibitors.pageInfo.endCursor": (v31/*: any*/),
+        "fair.exhibitors.pageInfo.hasNextPage": (v44/*: any*/),
+        "fair.fairArtworks": (v45/*: any*/),
+        "fair.fairArtworks.__isArtworkConnectionInterface": (v32/*: any*/),
         "fair.fairArtworks.aggregations": {
           "enumValues": null,
           "nullable": true,
@@ -1877,8 +1874,8 @@ return {
           "plural": false,
           "type": "Int"
         },
-        "fair.fairArtworks.aggregations.counts.name": (v31/*: any*/),
-        "fair.fairArtworks.aggregations.counts.value": (v31/*: any*/),
+        "fair.fairArtworks.aggregations.counts.name": (v32/*: any*/),
+        "fair.fairArtworks.aggregations.counts.value": (v32/*: any*/),
         "fair.fairArtworks.aggregations.slice": {
           "enumValues": [
             "ARTIST",
@@ -1905,79 +1902,79 @@ return {
           "plural": false,
           "type": "FilterArtworksCounts"
         },
-        "fair.fairArtworks.counts.followedArtists": (v34/*: any*/),
-        "fair.fairArtworks.counts.total": (v34/*: any*/),
+        "fair.fairArtworks.counts.followedArtists": (v35/*: any*/),
+        "fair.fairArtworks.counts.total": (v35/*: any*/),
         "fair.fairArtworks.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "ArtworkEdgeInterface"
         },
-        "fair.fairArtworks.edges.__isNode": (v31/*: any*/),
-        "fair.fairArtworks.edges.__typename": (v31/*: any*/),
-        "fair.fairArtworks.edges.cursor": (v31/*: any*/),
-        "fair.fairArtworks.edges.id": (v32/*: any*/),
-        "fair.fairArtworks.edges.node": (v35/*: any*/),
-        "fair.fairArtworks.edges.node.__typename": (v31/*: any*/),
-        "fair.fairArtworks.edges.node.artistNames": (v30/*: any*/),
-        "fair.fairArtworks.edges.node.date": (v30/*: any*/),
-        "fair.fairArtworks.edges.node.href": (v30/*: any*/),
-        "fair.fairArtworks.edges.node.id": (v32/*: any*/),
-        "fair.fairArtworks.edges.node.image": (v33/*: any*/),
-        "fair.fairArtworks.edges.node.image.aspectRatio": (v36/*: any*/),
-        "fair.fairArtworks.edges.node.image.url": (v30/*: any*/),
-        "fair.fairArtworks.edges.node.internalID": (v32/*: any*/),
+        "fair.fairArtworks.edges.__isNode": (v32/*: any*/),
+        "fair.fairArtworks.edges.__typename": (v32/*: any*/),
+        "fair.fairArtworks.edges.cursor": (v32/*: any*/),
+        "fair.fairArtworks.edges.id": (v33/*: any*/),
+        "fair.fairArtworks.edges.node": (v36/*: any*/),
+        "fair.fairArtworks.edges.node.__typename": (v32/*: any*/),
+        "fair.fairArtworks.edges.node.artistNames": (v31/*: any*/),
+        "fair.fairArtworks.edges.node.date": (v31/*: any*/),
+        "fair.fairArtworks.edges.node.href": (v31/*: any*/),
+        "fair.fairArtworks.edges.node.id": (v33/*: any*/),
+        "fair.fairArtworks.edges.node.image": (v34/*: any*/),
+        "fair.fairArtworks.edges.node.image.aspectRatio": (v37/*: any*/),
+        "fair.fairArtworks.edges.node.image.url": (v31/*: any*/),
+        "fair.fairArtworks.edges.node.internalID": (v33/*: any*/),
         "fair.fairArtworks.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "fair.fairArtworks.edges.node.partner.id": (v32/*: any*/),
-        "fair.fairArtworks.edges.node.partner.name": (v30/*: any*/),
-        "fair.fairArtworks.edges.node.sale": (v37/*: any*/),
-        "fair.fairArtworks.edges.node.sale.displayTimelyAt": (v30/*: any*/),
-        "fair.fairArtworks.edges.node.sale.endAt": (v30/*: any*/),
-        "fair.fairArtworks.edges.node.sale.id": (v32/*: any*/),
-        "fair.fairArtworks.edges.node.sale.isAuction": (v38/*: any*/),
-        "fair.fairArtworks.edges.node.sale.isClosed": (v38/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork": (v39/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork.counts": (v40/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork.counts.bidderPositions": (v34/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork.currentBid": (v41/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork.currentBid.display": (v30/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork.id": (v32/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork.lotLabel": (v30/*: any*/),
-        "fair.fairArtworks.edges.node.saleMessage": (v30/*: any*/),
-        "fair.fairArtworks.edges.node.slug": (v32/*: any*/),
-        "fair.fairArtworks.edges.node.title": (v30/*: any*/),
-        "fair.fairArtworks.id": (v32/*: any*/),
-        "fair.fairArtworks.pageInfo": (v42/*: any*/),
-        "fair.fairArtworks.pageInfo.endCursor": (v30/*: any*/),
-        "fair.fairArtworks.pageInfo.hasNextPage": (v43/*: any*/),
-        "fair.fairArtworks.pageInfo.startCursor": (v30/*: any*/),
-        "fair.fairContact": (v30/*: any*/),
-        "fair.fairHours": (v30/*: any*/),
-        "fair.fairLinks": (v30/*: any*/),
-        "fair.fairTickets": (v30/*: any*/),
-        "fair.followedArtistArtworks": (v44/*: any*/),
-        "fair.followedArtistArtworks.edges": (v45/*: any*/),
-        "fair.followedArtistArtworks.edges.__typename": (v31/*: any*/),
-        "fair.followedArtistArtworks.edges.artwork": (v35/*: any*/),
-        "fair.followedArtistArtworks.edges.artwork.artistNames": (v30/*: any*/),
-        "fair.followedArtistArtworks.edges.artwork.href": (v30/*: any*/),
-        "fair.followedArtistArtworks.edges.artwork.id": (v32/*: any*/),
-        "fair.followedArtistArtworks.edges.artwork.image": (v33/*: any*/),
-        "fair.followedArtistArtworks.edges.artwork.image.imageURL": (v30/*: any*/),
-        "fair.followedArtistArtworks.edges.artwork.internalID": (v32/*: any*/),
-        "fair.followedArtistArtworks.edges.artwork.saleMessage": (v30/*: any*/),
-        "fair.followedArtistArtworks.edges.artwork.slug": (v32/*: any*/),
-        "fair.followedArtistArtworks.id": (v32/*: any*/),
-        "fair.id": (v32/*: any*/),
-        "fair.image": (v33/*: any*/),
-        "fair.image.aspectRatio": (v36/*: any*/),
-        "fair.image.imageUrl": (v30/*: any*/),
-        "fair.internalID": (v32/*: any*/),
+        "fair.fairArtworks.edges.node.partner.id": (v33/*: any*/),
+        "fair.fairArtworks.edges.node.partner.name": (v31/*: any*/),
+        "fair.fairArtworks.edges.node.sale": (v38/*: any*/),
+        "fair.fairArtworks.edges.node.sale.displayTimelyAt": (v31/*: any*/),
+        "fair.fairArtworks.edges.node.sale.endAt": (v31/*: any*/),
+        "fair.fairArtworks.edges.node.sale.id": (v33/*: any*/),
+        "fair.fairArtworks.edges.node.sale.isAuction": (v39/*: any*/),
+        "fair.fairArtworks.edges.node.sale.isClosed": (v39/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork": (v40/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.counts": (v41/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.counts.bidderPositions": (v35/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.currentBid": (v42/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.currentBid.display": (v31/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.id": (v33/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.lotLabel": (v31/*: any*/),
+        "fair.fairArtworks.edges.node.saleMessage": (v31/*: any*/),
+        "fair.fairArtworks.edges.node.slug": (v33/*: any*/),
+        "fair.fairArtworks.edges.node.title": (v31/*: any*/),
+        "fair.fairArtworks.id": (v33/*: any*/),
+        "fair.fairArtworks.pageInfo": (v43/*: any*/),
+        "fair.fairArtworks.pageInfo.endCursor": (v31/*: any*/),
+        "fair.fairArtworks.pageInfo.hasNextPage": (v44/*: any*/),
+        "fair.fairArtworks.pageInfo.startCursor": (v31/*: any*/),
+        "fair.fairContact": (v31/*: any*/),
+        "fair.fairHours": (v31/*: any*/),
+        "fair.fairLinks": (v31/*: any*/),
+        "fair.fairTickets": (v31/*: any*/),
+        "fair.followedArtistArtworks": (v45/*: any*/),
+        "fair.followedArtistArtworks.edges": (v46/*: any*/),
+        "fair.followedArtistArtworks.edges.__typename": (v32/*: any*/),
+        "fair.followedArtistArtworks.edges.artwork": (v36/*: any*/),
+        "fair.followedArtistArtworks.edges.artwork.artistNames": (v31/*: any*/),
+        "fair.followedArtistArtworks.edges.artwork.href": (v31/*: any*/),
+        "fair.followedArtistArtworks.edges.artwork.id": (v33/*: any*/),
+        "fair.followedArtistArtworks.edges.artwork.image": (v34/*: any*/),
+        "fair.followedArtistArtworks.edges.artwork.image.imageURL": (v31/*: any*/),
+        "fair.followedArtistArtworks.edges.artwork.internalID": (v33/*: any*/),
+        "fair.followedArtistArtworks.edges.artwork.saleMessage": (v31/*: any*/),
+        "fair.followedArtistArtworks.edges.artwork.slug": (v33/*: any*/),
+        "fair.followedArtistArtworks.id": (v33/*: any*/),
+        "fair.id": (v33/*: any*/),
+        "fair.image": (v34/*: any*/),
+        "fair.image.aspectRatio": (v37/*: any*/),
+        "fair.image.imageUrl": (v31/*: any*/),
+        "fair.internalID": (v33/*: any*/),
         "fair.location": {
           "enumValues": null,
           "nullable": true,
@@ -1990,51 +1987,51 @@ return {
           "plural": false,
           "type": "LatLng"
         },
-        "fair.location.coordinates.lat": (v46/*: any*/),
-        "fair.location.coordinates.lng": (v46/*: any*/),
-        "fair.location.id": (v32/*: any*/),
-        "fair.location.summary": (v30/*: any*/),
+        "fair.location.coordinates.lat": (v47/*: any*/),
+        "fair.location.coordinates.lng": (v47/*: any*/),
+        "fair.location.id": (v33/*: any*/),
+        "fair.location.summary": (v31/*: any*/),
         "fair.marketingCollections": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "MarketingCollection"
         },
-        "fair.marketingCollections.__typename": (v31/*: any*/),
-        "fair.marketingCollections.artworks": (v44/*: any*/),
-        "fair.marketingCollections.artworks.edges": (v45/*: any*/),
-        "fair.marketingCollections.artworks.edges.node": (v35/*: any*/),
-        "fair.marketingCollections.artworks.edges.node.id": (v32/*: any*/),
-        "fair.marketingCollections.artworks.edges.node.image": (v33/*: any*/),
-        "fair.marketingCollections.artworks.edges.node.image.url": (v30/*: any*/),
-        "fair.marketingCollections.artworks.id": (v32/*: any*/),
-        "fair.marketingCollections.category": (v31/*: any*/),
-        "fair.marketingCollections.id": (v32/*: any*/),
-        "fair.marketingCollections.slug": (v31/*: any*/),
-        "fair.marketingCollections.title": (v31/*: any*/),
-        "fair.name": (v30/*: any*/),
+        "fair.marketingCollections.__typename": (v32/*: any*/),
+        "fair.marketingCollections.artworks": (v45/*: any*/),
+        "fair.marketingCollections.artworks.edges": (v46/*: any*/),
+        "fair.marketingCollections.artworks.edges.node": (v36/*: any*/),
+        "fair.marketingCollections.artworks.edges.node.id": (v33/*: any*/),
+        "fair.marketingCollections.artworks.edges.node.image": (v34/*: any*/),
+        "fair.marketingCollections.artworks.edges.node.image.url": (v31/*: any*/),
+        "fair.marketingCollections.artworks.id": (v33/*: any*/),
+        "fair.marketingCollections.category": (v32/*: any*/),
+        "fair.marketingCollections.id": (v33/*: any*/),
+        "fair.marketingCollections.slug": (v32/*: any*/),
+        "fair.marketingCollections.title": (v32/*: any*/),
+        "fair.name": (v31/*: any*/),
         "fair.profile": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Profile"
         },
-        "fair.profile.icon": (v33/*: any*/),
-        "fair.profile.icon.imageUrl": (v30/*: any*/),
-        "fair.profile.id": (v32/*: any*/),
-        "fair.slug": (v32/*: any*/),
+        "fair.profile.icon": (v34/*: any*/),
+        "fair.profile.icon.imageUrl": (v31/*: any*/),
+        "fair.profile.id": (v33/*: any*/),
+        "fair.slug": (v33/*: any*/),
         "fair.sponsoredContent": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FairSponsoredContent"
         },
-        "fair.sponsoredContent.activationText": (v30/*: any*/),
-        "fair.sponsoredContent.pressReleaseUrl": (v30/*: any*/),
-        "fair.startAt": (v30/*: any*/),
-        "fair.summary": (v30/*: any*/),
-        "fair.tagline": (v30/*: any*/),
-        "fair.ticketsLink": (v30/*: any*/)
+        "fair.sponsoredContent.activationText": (v31/*: any*/),
+        "fair.sponsoredContent.pressReleaseUrl": (v31/*: any*/),
+        "fair.startAt": (v31/*: any*/),
+        "fair.summary": (v31/*: any*/),
+        "fair.tagline": (v31/*: any*/),
+        "fair.ticketsLink": (v31/*: any*/)
       }
     },
     "name": "Fair2TestsQuery",

--- a/src/__generated__/VanityURLEntityQuery.graphql.ts
+++ b/src/__generated__/VanityURLEntityQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash f75f5718f56464d4aec0bf044181a63a */
+/* @relayHash f4a419852a2158567589cfe417fcbcfb */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -241,7 +241,7 @@ fragment Fair2ExhibitorRail_show on Show {
 fragment Fair2Exhibitors_fair on Fair {
   internalID
   slug
-  exhibitors: showsConnection(first: 15, sort: FEATURED_ASC) {
+  exhibitors: showsConnection(first: 30, sort: FEATURED_ASC) {
     edges {
       node {
         id
@@ -963,7 +963,12 @@ v24 = {
   "name": "endAt",
   "storageKey": null
 },
-v25 = [
+v25 = {
+  "kind": "Literal",
+  "name": "first",
+  "value": 30
+},
+v26 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -984,11 +989,7 @@ v25 = [
     "name": "dimensionRange",
     "value": "*-*"
   },
-  {
-    "kind": "Literal",
-    "name": "first",
-    "value": 30
-  },
+  (v25/*: any*/),
   {
     "kind": "Literal",
     "name": "medium",
@@ -1000,14 +1001,14 @@ v25 = [
     "value": "-decayed_merch"
   }
 ],
-v26 = {
+v27 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v27 = [
+v28 = [
   {
     "alias": null,
     "args": null,
@@ -1021,23 +1022,23 @@ v27 = [
     ],
     "storageKey": null
   },
-  (v26/*: any*/)
+  (v27/*: any*/)
 ],
-v28 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endCursor",
   "storageKey": null
 },
-v29 = {
+v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "hasNextPage",
   "storageKey": null
 },
-v30 = {
+v31 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -1045,19 +1046,19 @@ v30 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v28/*: any*/),
-    (v29/*: any*/)
+    (v29/*: any*/),
+    (v30/*: any*/)
   ],
   "storageKey": null
 },
-v31 = {
+v32 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startCursor",
   "storageKey": null
 },
-v32 = {
+v33 = {
   "alias": null,
   "args": [
     {
@@ -1070,28 +1071,28 @@ v32 = {
   "name": "url",
   "storageKey": "url(version:\"large\")"
 },
-v33 = {
+v34 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "date",
   "storageKey": null
 },
-v34 = {
+v35 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isAuction",
   "storageKey": null
 },
-v35 = {
+v36 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v36 = {
+v37 = {
   "alias": null,
   "args": null,
   "concreteType": "Sale",
@@ -1099,8 +1100,8 @@ v36 = {
   "name": "sale",
   "plural": false,
   "selections": [
-    (v34/*: any*/),
     (v35/*: any*/),
+    (v36/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -1113,7 +1114,7 @@ v36 = {
   ],
   "storageKey": null
 },
-v37 = {
+v38 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCounts",
@@ -1131,27 +1132,27 @@ v37 = {
   ],
   "storageKey": null
 },
-v38 = {
+v39 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "display",
   "storageKey": null
 },
-v39 = [
-  (v38/*: any*/)
+v40 = [
+  (v39/*: any*/)
 ],
-v40 = {
+v41 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCurrentBid",
   "kind": "LinkedField",
   "name": "currentBid",
   "plural": false,
-  "selections": (v39/*: any*/),
+  "selections": (v40/*: any*/),
   "storageKey": null
 },
-v41 = {
+v42 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtwork",
@@ -1159,8 +1160,8 @@ v41 = {
   "name": "saleArtwork",
   "plural": false,
   "selections": [
-    (v37/*: any*/),
-    (v40/*: any*/),
+    (v38/*: any*/),
+    (v41/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -1172,7 +1173,7 @@ v41 = {
   ],
   "storageKey": null
 },
-v42 = {
+v43 = {
   "alias": null,
   "args": null,
   "concreteType": "Partner",
@@ -1185,16 +1186,16 @@ v42 = {
   ],
   "storageKey": null
 },
-v43 = [
+v44 = [
   (v6/*: any*/)
 ],
-v44 = {
+v45 = {
   "kind": "InlineFragment",
-  "selections": (v43/*: any*/),
+  "selections": (v44/*: any*/),
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v45 = {
+v46 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -1205,7 +1206,7 @@ v45 = {
       "name": "pageInfo",
       "plural": false,
       "selections": [
-        (v31/*: any*/)
+        (v32/*: any*/)
       ],
       "storageKey": null
     },
@@ -1236,23 +1237,23 @@ v45 = {
               "plural": false,
               "selections": [
                 (v17/*: any*/),
-                (v32/*: any*/)
+                (v33/*: any*/)
               ],
               "storageKey": null
             },
             (v7/*: any*/),
-            (v33/*: any*/),
+            (v34/*: any*/),
             (v14/*: any*/),
             (v4/*: any*/),
             (v12/*: any*/),
             (v8/*: any*/),
-            (v36/*: any*/),
-            (v41/*: any*/),
-            (v42/*: any*/)
+            (v37/*: any*/),
+            (v42/*: any*/),
+            (v43/*: any*/)
           ],
           "storageKey": null
         },
-        (v44/*: any*/)
+        (v45/*: any*/)
       ],
       "storageKey": null
     }
@@ -1260,76 +1261,72 @@ v45 = {
   "type": "ArtworkConnectionInterface",
   "abstractKey": "__isArtworkConnectionInterface"
 },
-v46 = [
-  {
-    "kind": "Literal",
-    "name": "first",
-    "value": 15
-  },
+v47 = [
+  (v25/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "FEATURED_ASC"
   }
 ],
-v47 = [
+v48 = [
   (v10/*: any*/)
 ],
-v48 = {
+v49 = {
   "alias": null,
   "args": null,
   "concreteType": "ShowCounts",
   "kind": "LinkedField",
   "name": "counts",
   "plural": false,
-  "selections": (v47/*: any*/),
+  "selections": (v48/*: any*/),
   "storageKey": null
 },
-v49 = [
+v50 = [
   (v6/*: any*/),
   (v16/*: any*/)
 ],
-v50 = [
+v51 = [
   "sort"
 ],
-v51 = {
+v52 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v52 = [
-  (v51/*: any*/)
+v53 = [
+  (v52/*: any*/)
 ],
-v53 = {
+v54 = {
   "alias": null,
   "args": null,
   "concreteType": "Image",
   "kind": "LinkedField",
   "name": "image",
   "plural": false,
-  "selections": (v52/*: any*/),
+  "selections": (v53/*: any*/),
   "storageKey": null
 },
-v54 = [
+v55 = [
   (v16/*: any*/),
   (v8/*: any*/),
   (v3/*: any*/),
   (v4/*: any*/),
   (v6/*: any*/)
 ],
-v55 = {
+v56 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "hours",
   "storageKey": null
 },
-v56 = [
+v57 = [
   (v5/*: any*/)
 ],
-v57 = {
+v58 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -1337,69 +1334,69 @@ v57 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v29/*: any*/),
-    (v31/*: any*/),
-    (v28/*: any*/)
+    (v30/*: any*/),
+    (v32/*: any*/),
+    (v29/*: any*/)
   ],
   "storageKey": null
 },
-v58 = {
+v59 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isFollowed",
   "storageKey": null
 },
-v59 = {
+v60 = {
   "kind": "InlineFragment",
-  "selections": (v43/*: any*/),
+  "selections": (v44/*: any*/),
   "type": "ExternalPartner",
   "abstractKey": null
 },
-v60 = {
+v61 = {
   "alias": null,
   "args": null,
   "concreteType": "Image",
   "kind": "LinkedField",
   "name": "coverImage",
   "plural": false,
-  "selections": (v52/*: any*/),
+  "selections": (v53/*: any*/),
   "storageKey": null
 },
-v61 = {
+v62 = {
   "kind": "Literal",
   "name": "first",
   "value": 10
 },
-v62 = [
-  (v61/*: any*/),
+v63 = [
+  (v62/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "PARTNER_UPDATED_AT_DESC"
   }
 ],
-v63 = [
-  (v61/*: any*/),
+v64 = [
+  (v62/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "SORTABLE_ID_ASC"
   }
 ],
-v64 = {
+v65 = {
   "kind": "Literal",
   "name": "status",
   "value": "CURRENT"
 },
-v65 = {
+v66 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isDisplayable",
   "storageKey": null
 },
-v66 = [
+v67 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -1416,11 +1413,11 @@ v66 = [
     "value": "CLOSED"
   }
 ],
-v67 = [
+v68 = [
   "status",
   "sort"
 ],
-v68 = [
+v69 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -1431,7 +1428,7 @@ v68 = [
     "name": "sort",
     "value": "END_AT_ASC"
   },
-  (v64/*: any*/)
+  (v65/*: any*/)
 ];
 return {
   "fragment": {
@@ -1882,7 +1879,7 @@ return {
                   (v24/*: any*/),
                   {
                     "alias": "fairArtworks",
-                    "args": (v25/*: any*/),
+                    "args": (v26/*: any*/),
                     "concreteType": "FilterArtworksConnection",
                     "kind": "LinkedField",
                     "name": "filterArtworksConnection",
@@ -1939,7 +1936,7 @@ return {
                         "kind": "LinkedField",
                         "name": "edges",
                         "plural": true,
-                        "selections": (v27/*: any*/),
+                        "selections": (v28/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -1967,15 +1964,15 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v30/*: any*/),
+                      (v31/*: any*/),
                       (v6/*: any*/),
-                      (v45/*: any*/)
+                      (v46/*: any*/)
                     ],
                     "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,medium:\"*\",sort:\"-decayed_merch\")"
                   },
                   {
                     "alias": "fairArtworks",
-                    "args": (v25/*: any*/),
+                    "args": (v26/*: any*/),
                     "filters": [
                       "sort",
                       "medium",
@@ -1999,7 +1996,7 @@ return {
                   },
                   {
                     "alias": "exhibitors",
-                    "args": (v46/*: any*/),
+                    "args": (v47/*: any*/),
                     "concreteType": "ShowConnection",
                     "kind": "LinkedField",
                     "name": "showsConnection",
@@ -2022,7 +2019,7 @@ return {
                             "plural": false,
                             "selections": [
                               (v6/*: any*/),
-                              (v48/*: any*/),
+                              (v49/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -2034,17 +2031,17 @@ return {
                                   (v2/*: any*/),
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v49/*: any*/),
+                                    "selections": (v50/*: any*/),
                                     "type": "Partner",
                                     "abstractKey": null
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v49/*: any*/),
+                                    "selections": (v50/*: any*/),
                                     "type": "ExternalPartner",
                                     "abstractKey": null
                                   },
-                                  (v44/*: any*/)
+                                  (v45/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -2123,7 +2120,7 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "openingBid",
                                                 "plural": false,
-                                                "selections": (v39/*: any*/),
+                                                "selections": (v40/*: any*/),
                                                 "storageKey": null
                                               },
                                               {
@@ -2133,11 +2130,11 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "highestBid",
                                                 "plural": false,
-                                                "selections": (v39/*: any*/),
+                                                "selections": (v40/*: any*/),
                                                 "storageKey": null
                                               },
-                                              (v40/*: any*/),
-                                              (v37/*: any*/),
+                                              (v41/*: any*/),
+                                              (v38/*: any*/),
                                               (v6/*: any*/)
                                             ],
                                             "storageKey": null
@@ -2150,8 +2147,8 @@ return {
                                             "name": "sale",
                                             "plural": false,
                                             "selections": [
+                                              (v36/*: any*/),
                                               (v35/*: any*/),
-                                              (v34/*: any*/),
                                               (v24/*: any*/),
                                               (v6/*: any*/)
                                             ],
@@ -2173,18 +2170,18 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v26/*: any*/)
+                          (v27/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v30/*: any*/)
+                      (v31/*: any*/)
                     ],
-                    "storageKey": "showsConnection(first:15,sort:\"FEATURED_ASC\")"
+                    "storageKey": "showsConnection(first:30,sort:\"FEATURED_ASC\")"
                   },
                   {
                     "alias": "exhibitors",
-                    "args": (v46/*: any*/),
-                    "filters": (v50/*: any*/),
+                    "args": (v47/*: any*/),
+                    "filters": (v51/*: any*/),
                     "handle": "connection",
                     "key": "Fair2ExhibitorsQuery_exhibitors",
                     "kind": "LinkedHandle",
@@ -2227,7 +2224,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v53/*: any*/),
+                  (v54/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2243,7 +2240,7 @@ return {
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
-                        "selections": (v54/*: any*/),
+                        "selections": (v55/*: any*/),
                         "storageKey": null
                       }
                     ],
@@ -2272,7 +2269,7 @@ return {
                             "kind": "LinkedField",
                             "name": "node",
                             "plural": false,
-                            "selections": (v54/*: any*/),
+                            "selections": (v55/*: any*/),
                             "storageKey": null
                           }
                         ],
@@ -2319,7 +2316,7 @@ return {
                     "storageKey": null
                   },
                   (v4/*: any*/),
-                  (v55/*: any*/),
+                  (v56/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2426,7 +2423,7 @@ return {
                                     "name": "days",
                                     "storageKey": null
                                   },
-                                  (v55/*: any*/)
+                                  (v56/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -2488,13 +2485,13 @@ return {
                   },
                   {
                     "alias": "shows",
-                    "args": (v56/*: any*/),
+                    "args": (v57/*: any*/),
                     "concreteType": "ShowConnection",
                     "kind": "LinkedField",
                     "name": "showsConnection",
                     "plural": false,
                     "selections": [
-                      (v57/*: any*/),
+                      (v58/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -2503,7 +2500,7 @@ return {
                         "name": "edges",
                         "plural": true,
                         "selections": [
-                          (v26/*: any*/),
+                          (v27/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -2559,20 +2556,20 @@ return {
                                                 "name": "aspectRatio",
                                                 "storageKey": null
                                               },
-                                              (v32/*: any*/),
+                                              (v33/*: any*/),
                                               (v17/*: any*/)
                                             ],
                                             "storageKey": null
                                           },
                                           (v7/*: any*/),
-                                          (v33/*: any*/),
+                                          (v34/*: any*/),
                                           (v14/*: any*/),
                                           (v4/*: any*/),
                                           (v12/*: any*/),
                                           (v8/*: any*/),
-                                          (v36/*: any*/),
-                                          (v41/*: any*/),
-                                          (v42/*: any*/)
+                                          (v37/*: any*/),
+                                          (v42/*: any*/),
+                                          (v43/*: any*/)
                                         ],
                                         "storageKey": null
                                       }
@@ -2584,7 +2581,7 @@ return {
                               },
                               (v3/*: any*/),
                               (v4/*: any*/),
-                              (v48/*: any*/),
+                              (v49/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -2613,7 +2610,7 @@ return {
                                           (v6/*: any*/),
                                           (v3/*: any*/),
                                           (v4/*: any*/),
-                                          (v58/*: any*/)
+                                          (v59/*: any*/)
                                         ],
                                         "storageKey": null
                                       }
@@ -2621,12 +2618,12 @@ return {
                                     "type": "Partner",
                                     "abstractKey": null
                                   },
-                                  (v44/*: any*/),
-                                  (v59/*: any*/)
+                                  (v45/*: any*/),
+                                  (v60/*: any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v60/*: any*/),
+                              (v61/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -2635,7 +2632,7 @@ return {
                                 "name": "location",
                                 "plural": false,
                                 "selections": [
-                                  (v38/*: any*/),
+                                  (v39/*: any*/),
                                   (v6/*: any*/)
                                 ],
                                 "storageKey": null
@@ -2653,7 +2650,7 @@ return {
                   },
                   {
                     "alias": "shows",
-                    "args": (v56/*: any*/),
+                    "args": (v57/*: any*/),
                     "filters": null,
                     "handle": "connection",
                     "key": "Fair_shows",
@@ -2681,7 +2678,7 @@ return {
                 "plural": false,
                 "selections": [
                   (v6/*: any*/),
-                  (v58/*: any*/),
+                  (v59/*: any*/),
                   (v4/*: any*/),
                   {
                     "alias": null,
@@ -2696,7 +2693,7 @@ return {
               },
               {
                 "alias": "artworks",
-                "args": (v62/*: any*/),
+                "args": (v63/*: any*/),
                 "concreteType": "ArtworkConnection",
                 "kind": "LinkedField",
                 "name": "artworksConnection",
@@ -2709,18 +2706,18 @@ return {
                     "kind": "LinkedField",
                     "name": "edges",
                     "plural": true,
-                    "selections": (v27/*: any*/),
+                    "selections": (v28/*: any*/),
                     "storageKey": null
                   },
-                  (v30/*: any*/),
-                  (v45/*: any*/)
+                  (v31/*: any*/),
+                  (v46/*: any*/)
                 ],
                 "storageKey": "artworksConnection(first:10,sort:\"PARTNER_UPDATED_AT_DESC\")"
               },
               {
                 "alias": "artworks",
-                "args": (v62/*: any*/),
-                "filters": (v50/*: any*/),
+                "args": (v63/*: any*/),
+                "filters": (v51/*: any*/),
                 "handle": "connection",
                 "key": "Partner_artworks",
                 "kind": "LinkedHandle",
@@ -2736,13 +2733,13 @@ return {
               },
               {
                 "alias": "artists",
-                "args": (v63/*: any*/),
+                "args": (v64/*: any*/),
                 "concreteType": "ArtistPartnerConnection",
                 "kind": "LinkedField",
                 "name": "artistsConnection",
                 "plural": false,
                 "selections": [
-                  (v57/*: any*/),
+                  (v58/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2799,7 +2796,7 @@ return {
                             "name": "deathday",
                             "storageKey": null
                           },
-                          (v53/*: any*/),
+                          (v54/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -2807,14 +2804,14 @@ return {
                             "kind": "LinkedField",
                             "name": "counts",
                             "plural": false,
-                            "selections": (v47/*: any*/),
+                            "selections": (v48/*: any*/),
                             "storageKey": null
                           },
                           (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v26/*: any*/),
+                      (v27/*: any*/),
                       (v6/*: any*/)
                     ],
                     "storageKey": null
@@ -2824,8 +2821,8 @@ return {
               },
               {
                 "alias": "artists",
-                "args": (v63/*: any*/),
-                "filters": (v50/*: any*/),
+                "args": (v64/*: any*/),
+                "filters": (v51/*: any*/),
                 "handle": "connection",
                 "key": "Partner_artists",
                 "kind": "LinkedHandle",
@@ -2858,8 +2855,8 @@ return {
               {
                 "alias": "recentShows",
                 "args": [
-                  (v61/*: any*/),
-                  (v64/*: any*/)
+                  (v62/*: any*/),
+                  (v65/*: any*/)
                 ],
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
@@ -2883,7 +2880,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v6/*: any*/),
-                          (v65/*: any*/)
+                          (v66/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -2895,13 +2892,13 @@ return {
               },
               {
                 "alias": "pastShows",
-                "args": (v66/*: any*/),
+                "args": (v67/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": [
-                  (v57/*: any*/),
+                  (v58/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2918,7 +2915,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v65/*: any*/),
+                          (v66/*: any*/),
                           (v6/*: any*/),
                           (v16/*: any*/),
                           (v3/*: any*/),
@@ -2931,7 +2928,7 @@ return {
                             "name": "coverImage",
                             "plural": false,
                             "selections": [
-                              (v51/*: any*/),
+                              (v52/*: any*/),
                               (v17/*: any*/)
                             ],
                             "storageKey": null
@@ -2941,7 +2938,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v26/*: any*/)
+                      (v27/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -2950,8 +2947,8 @@ return {
               },
               {
                 "alias": "pastShows",
-                "args": (v66/*: any*/),
-                "filters": (v67/*: any*/),
+                "args": (v67/*: any*/),
+                "filters": (v68/*: any*/),
                 "handle": "connection",
                 "key": "Partner_pastShows",
                 "kind": "LinkedHandle",
@@ -2959,13 +2956,13 @@ return {
               },
               {
                 "alias": "currentAndUpcomingShows",
-                "args": (v68/*: any*/),
+                "args": (v69/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": [
-                  (v57/*: any*/),
+                  (v58/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2982,7 +2979,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v65/*: any*/),
+                          (v66/*: any*/),
                           (v6/*: any*/),
                           (v4/*: any*/),
                           (v3/*: any*/),
@@ -2996,7 +2993,7 @@ return {
                             "kind": "LinkedField",
                             "name": "images",
                             "plural": true,
-                            "selections": (v52/*: any*/),
+                            "selections": (v53/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -3016,17 +3013,17 @@ return {
                                 "type": "Partner",
                                 "abstractKey": null
                               },
-                              (v44/*: any*/),
-                              (v59/*: any*/)
+                              (v45/*: any*/),
+                              (v60/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v60/*: any*/),
+                          (v61/*: any*/),
                           (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v26/*: any*/)
+                      (v27/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -3035,8 +3032,8 @@ return {
               },
               {
                 "alias": "currentAndUpcomingShows",
-                "args": (v68/*: any*/),
-                "filters": (v67/*: any*/),
+                "args": (v69/*: any*/),
+                "filters": (v68/*: any*/),
                 "handle": "connection",
                 "key": "Partner_currentAndUpcomingShows",
                 "kind": "LinkedHandle",
@@ -3064,14 +3061,14 @@ return {
             "type": "Partner",
             "abstractKey": null
           },
-          (v44/*: any*/)
+          (v45/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "f75f5718f56464d4aec0bf044181a63a",
+    "id": "f4a419852a2158567589cfe417fcbcfb",
     "metadata": {},
     "name": "VanityURLEntityQuery",
     "operationKind": "query",

--- a/src/lib/Scenes/Fair2/Components/Fair2Exhibitors.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2Exhibitors.tsx
@@ -1,6 +1,7 @@
 import { ActionType, ContextModule, OwnerType, TappedShowMore } from "@artsy/cohesion"
 import { Fair2Exhibitors_fair } from "__generated__/Fair2Exhibitors_fair.graphql"
 import { Col } from "lib/Components/Bidding/Elements/Grid"
+import { FAIR2_EXHIBITORS_PAGE_SIZE } from "lib/data/constants"
 import { Row } from "lib/Scenes/Consignments/Components/FormElements"
 import { Box, Button } from "palette"
 import React, { useState } from "react"
@@ -37,7 +38,7 @@ const Fair2Exhibitors: React.FC<Fair2ExhibitorsProps> = ({ fair, relay }) => {
 
     setIsLoading(true)
 
-    relay.loadMore(15, (err) => {
+    relay.loadMore(FAIR2_EXHIBITORS_PAGE_SIZE, (err) => {
       setIsLoading(false)
 
       if (err) {
@@ -84,7 +85,7 @@ export const Fair2ExhibitorsFragmentContainer = createPaginationContainer(
   {
     fair: graphql`
       fragment Fair2Exhibitors_fair on Fair
-      @argumentDefinitions(first: { type: "Int", defaultValue: 15 }, after: { type: "String" }) {
+      @argumentDefinitions(first: { type: "Int", defaultValue: 30 }, after: { type: "String" }) {
         internalID
         slug
         exhibitors: showsConnection(first: $first, after: $after, sort: FEATURED_ASC)

--- a/src/lib/Scenes/Fair2/__tests__/Fair2Exhibitors-tests.tsx
+++ b/src/lib/Scenes/Fair2/__tests__/Fair2Exhibitors-tests.tsx
@@ -1,7 +1,4 @@
-import {
-  Fair2ExhibitorsTestsQuery,
-  Fair2ExhibitorsTestsQueryRawResponse,
-} from "__generated__/Fair2ExhibitorsTestsQuery.graphql"
+import { Fair2ExhibitorsTestsQuery } from "__generated__/Fair2ExhibitorsTestsQuery.graphql"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { Button } from "palette"
@@ -9,7 +6,7 @@ import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { act } from "react-test-renderer"
 import { useTracking } from "react-tracking"
-import { createMockEnvironment } from "relay-test-utils"
+import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { Fair2ExhibitorRailFragmentContainer } from "../Components/Fair2ExhibitorRail"
 import { Fair2ExhibitorsFragmentContainer } from "../Components/Fair2Exhibitors"
 
@@ -17,14 +14,14 @@ jest.unmock("react-relay")
 
 describe("FairExhibitors", () => {
   const trackEvent = useTracking().trackEvent
-  const getWrapper = (fixture = FAIR_2_EXHIBITORS_FIXTURE) => {
+  const getWrapper = (mockResolvers = {}) => {
     const env = createMockEnvironment()
 
     const tree = renderWithWrappers(
       <QueryRenderer<Fair2ExhibitorsTestsQuery>
         environment={env}
         query={graphql`
-          query Fair2ExhibitorsTestsQuery($fairID: String!) @raw_response_type {
+          query Fair2ExhibitorsTestsQuery($fairID: String!) @relay_test_operation {
             fair(id: $fairID) {
               ...Fair2Exhibitors_fair
             }
@@ -46,13 +43,37 @@ describe("FairExhibitors", () => {
       />
     )
 
-    env.mock.resolveMostRecentOperation({ errors: [], data: fixture })
+    env.mock.resolveMostRecentOperation((operation) => MockPayloadGenerator.generate(operation, mockResolvers))
 
     return tree
   }
 
   it("renders the rails from exhibitors that have artworks", () => {
-    const wrapper = getWrapper()
+    const wrapper = getWrapper({
+      Fair: () => ({
+        exhibitors: {
+          edges: [
+            {
+              node: {
+                slug: "exhibitor-1",
+              },
+            },
+            {
+              node: {
+                slug: "exhibitor-2",
+              },
+            },
+            {
+              node: {
+                slug: "exhibitor-3-no-artworks",
+                counts: { artworks: 0 },
+                artworks: null,
+              },
+            },
+          ],
+        },
+      }),
+    })
     expect(wrapper.root.findAllByType(Fair2ExhibitorRailFragmentContainer)).toHaveLength(2)
   })
 
@@ -67,7 +88,12 @@ describe("FairExhibitors", () => {
   })
 
   it("tracks taps on the show more button", () => {
-    const wrapper = getWrapper()
+    const wrapper = getWrapper({
+      Fair: () => ({
+        internalID: "xyz123",
+        slug: "xxx",
+      }),
+    })
     const button = wrapper.root.findAllByType(Button)[0]
     act(() => button.props.onPress())
     expect(trackEvent).toHaveBeenCalledWith({
@@ -80,196 +106,3 @@ describe("FairExhibitors", () => {
     })
   })
 })
-
-const FAIR_2_EXHIBITORS_FIXTURE: Fair2ExhibitorsTestsQueryRawResponse = {
-  fair: {
-    id: "xxx",
-    internalID: "xyz123",
-    slug: "xxx",
-    exhibitors: {
-      pageInfo: {
-        endCursor: "xxx",
-        hasNextPage: false,
-      },
-      edges: [
-        {
-          cursor: "xxx",
-          node: {
-            __typename: "Show",
-            id: "xxx-1",
-            fair: {
-              id: "xxyyzz-123",
-              internalID: "aabbcc-123",
-              slug: "art-basel-hong-kong-2019",
-            },
-            slug: "example-1",
-            internalID: "xxx-1",
-            counts: { artworks: 0 },
-            href: "/show/example-1",
-            partner: {
-              __typename: "ExternalPartner" as "ExternalPartner",
-              __isNode: "ExternalPartner",
-              id: "example-1",
-              name: "Partner Without Artworks",
-            },
-            artworks: null,
-          },
-        },
-        {
-          cursor: "xxx",
-          node: {
-            __typename: "Show",
-            id: "xxx-2",
-            fair: {
-              id: "xxyyzz-123",
-              internalID: "aabbcc-123",
-              slug: "art-basel-hong-kong-2019",
-            },
-            slug: "example-2",
-            internalID: "xxx-2",
-            counts: { artworks: 10 },
-            href: "/show/example-2",
-            partner: {
-              __typename: "ExternalPartner" as "ExternalPartner",
-              __isNode: "ExternalPartner",
-              id: "example-2",
-              name: "First Partner Has Artworks",
-            },
-            artworks: {
-              edges: [
-                {
-                  node: {
-                    href: "/artwork/cool-artwork-1",
-                    artistNames: "Andy Warhol",
-                    id: "abc124",
-                    saleMessage: "For Sale",
-                    image: {
-                      aspectRatio: 1.2,
-                      imageURL: "image.jpg",
-                    },
-                    saleArtwork: null,
-                    sale: null,
-                    title: "Best Artwork Ever",
-                    internalID: "artwork1234",
-                    slug: "cool-artwork-1",
-                  },
-                },
-                {
-                  node: {
-                    href: "/artwork/cool-artwork-1",
-                    artistNames: "Andy Warhol",
-                    id: "abc125",
-                    saleMessage: "For Sale",
-                    image: {
-                      aspectRatio: 1.2,
-                      imageURL: "image.jpg",
-                    },
-                    saleArtwork: null,
-                    sale: null,
-                    title: "Best Artwork Ever",
-                    internalID: "artwork1234",
-                    slug: "cool-artwork-1",
-                  },
-                },
-                {
-                  node: {
-                    href: "/artwork/cool-artwork-1",
-                    artistNames: "Andy Warhol",
-                    id: "abc126",
-                    saleMessage: "For Sale",
-                    image: {
-                      aspectRatio: 1.2,
-                      imageURL: "image.jpg",
-                    },
-                    saleArtwork: null,
-                    sale: null,
-                    title: "Best Artwork Ever",
-                    internalID: "artwork1234",
-                    slug: "cool-artwork-1",
-                  },
-                },
-              ],
-            },
-          },
-        },
-        {
-          cursor: "xxx",
-          node: {
-            __typename: "Show",
-            id: "xxx-3",
-            internalID: "xxx-3",
-            counts: { artworks: 10 },
-            fair: {
-              id: "xxyyzz-123",
-              internalID: "aabbcc-123",
-              slug: "art-basel-hong-kong-2019",
-            },
-            slug: "example-3",
-            href: "/show/example-3",
-            partner: {
-              __typename: "ExternalPartner" as "ExternalPartner",
-              __isNode: "ExternalPartner",
-              id: "example-3",
-              name: "Second Partner Has Artworks",
-            },
-            artworks: {
-              edges: [
-                {
-                  node: {
-                    href: "/artwork/cool-artwork-1",
-                    artistNames: "Andy Warhol",
-                    id: "abc124",
-                    saleMessage: "For Sale",
-                    image: {
-                      aspectRatio: 1.2,
-                      imageURL: "image.jpg",
-                    },
-                    saleArtwork: null,
-                    sale: null,
-                    title: "Best Artwork Ever",
-                    internalID: "artwork1234",
-                    slug: "cool-artwork-1",
-                  },
-                },
-                {
-                  node: {
-                    href: "/artwork/cool-artwork-1",
-                    artistNames: "Andy Warhol",
-                    id: "abc125",
-                    saleMessage: "For Sale",
-                    image: {
-                      aspectRatio: 1.2,
-                      imageURL: "image.jpg",
-                    },
-                    saleArtwork: null,
-                    sale: null,
-                    title: "Best Artwork Ever",
-                    internalID: "artwork1234",
-                    slug: "cool-artwork-1",
-                  },
-                },
-                {
-                  node: {
-                    href: "/artwork/cool-artwork-1",
-                    artistNames: "Andy Warhol",
-                    id: "abc126",
-                    saleMessage: "For Sale",
-                    image: {
-                      aspectRatio: 1.2,
-                      imageURL: "image.jpg",
-                    },
-                    saleArtwork: null,
-                    sale: null,
-                    title: "Best Artwork Ever",
-                    internalID: "artwork1234",
-                    slug: "cool-artwork-1",
-                  },
-                },
-              ],
-            },
-          },
-        },
-      ],
-    },
-  },
-}

--- a/src/lib/data/constants.ts
+++ b/src/lib/data/constants.ts
@@ -1,4 +1,5 @@
 export const PAGE_SIZE = 10
 export const FAIR_SHOW_PAGE_SIZE = 20
 export const FAIR2_ARTWORKS_PAGE_SIZE = 30
+export const FAIR2_EXHIBITORS_PAGE_SIZE = 30
 export const ARTIST_SERIES_PAGE_SIZE = 30


### PR DESCRIPTION
The type of this PR is: **fix**

This PR resolves [FX-2346].

### Description

Updates pagination to show 30 exhibitors at a time instead of 20. Also updates exhibitors test to use new testing pattern.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

<img width="1440" alt="Screen Shot 2020-10-14 at 11 37 10 AM" src="https://user-images.githubusercontent.com/4432348/96022343-b85f6780-0e1e-11eb-947b-a4ba9b85c31b.png">


[FX-2346]: https://artsyproduct.atlassian.net/browse/FX-2346