### PR TITLE
fix: fallback to local photo when processing

### DIFF
--- a/src/lib/Scenes/MyCollection/Screens/ArtworkList/MyCollectionArtworkListItem.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkList/MyCollectionArtworkListItem.tsx
@@ -6,6 +6,7 @@ import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { capitalize } from "lodash"
 import { Box, color, Flex, Sans } from "palette"
 import React from "react"
+import { Image as RNImage } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components/native"
 
@@ -24,12 +25,16 @@ const MyCollectionArtworkListItem: React.FC<MyCollectionArtworkListItemProps> = 
 
   const { artist, artistNames, medium, slug, title } = artwork
 
-  const Image = () =>
-    !!imageURL ? (
-      <OpaqueImageView imageURL={imageURL.replace(":version", "square")} width={90} height={90} />
-    ) : (
-      <Box bg={color("black30")} width={90} height={90} />
-    )
+  const lastUploadedPhoto = AppStore.useAppState((state) => state.myCollection.artwork.sessionState.lastUploadedPhoto)
+  const Image = () => {
+    if (!!imageURL) {
+      return <OpaqueImageView imageURL={imageURL.replace(":version", "square")} width={90} height={90} />
+    } else if (lastUploadedPhoto) {
+      return <RNImage style={{ width: 90, height: 90, resizeMode: "cover" }} source={{ uri: lastUploadedPhoto.path }} />
+    } else {
+      return <Box bg={color("black30")} width={90} height={90} />
+    }
+  }
 
   const Medium = () =>
     !!medium ? (

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkList/__tests__/MyCollectionArtworkListItem-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkList/__tests__/MyCollectionArtworkListItem-tests.tsx
@@ -1,8 +1,10 @@
 import { MyCollectionArtworkListItemTestsQuery } from "__generated__/MyCollectionArtworkListItemTestsQuery.graphql"
 import { AppStore } from "lib/store/AppStore"
+import { __appStoreTestUtils__ } from "lib/store/AppStore"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
+import { Image as RNImage } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { MyCollectionArtworkListItemFragmentContainer, tests } from "../MyCollectionArtworkListItem"
@@ -61,5 +63,41 @@ describe("MyCollectionArtworkListItem", () => {
       artworkSlug: "<Artwork-mock-id-5>",
       medium: '<mock-value-for-field-"medium">',
     })
+  })
+
+  it("uses last uploaded image as a fallback when no url is present", () => {
+    const wrapper = renderWithWrappers(<TestRenderer />)
+    __appStoreTestUtils__?.injectState({
+      myCollection: {
+        artwork: {
+          sessionState: {
+            lastUploadedPhoto: {
+              path: "some-local-path",
+              size: 1800,
+              data: "some-data",
+              width: 90,
+              height: 90,
+              mime: "some-mime",
+              exif: {} as any,
+              cropRect: {} as any,
+              filename: "some-file-name",
+              creationDate: "some-creation-date",
+              duration: {} as any,
+            },
+          },
+        },
+      },
+    })
+    mockEnvironment.mock.resolveMostRecentOperation((operation) =>
+      MockPayloadGenerator.generate(operation, {
+        Artwork: () => ({
+          image: {
+            url: null,
+          },
+        }),
+      })
+    )
+    const image = wrapper.root.findByType(RNImage)
+    expect(image.props.source).toEqual({ uri: "some-local-path" })
   })
 })

--- a/src/lib/Scenes/MyCollection/State/MyCollectionArtworkModel.tsx
+++ b/src/lib/Scenes/MyCollection/State/MyCollectionArtworkModel.tsx
@@ -40,7 +40,7 @@ export interface ArtworkFormValues {
   width: string
 }
 
-const initialFormValues: ArtworkFormValues = {
+export const initialFormValues: ArtworkFormValues = {
   artist: "",
   artistIds: [],
   artistSearchResult: null,
@@ -67,6 +67,7 @@ export interface MyCollectionArtworkModel {
     formValues: ArtworkFormValues
     isLoading: boolean
     meGlobalId: string
+    lastUploadedPhoto?: Image
   }
   setFormValues: Action<MyCollectionArtworkModel, ArtworkFormValues>
   setDirtyFormCheckValues: Action<MyCollectionArtworkModel, ArtworkFormValues>
@@ -187,8 +188,10 @@ export const MyCollectionArtworkModel: MyCollectionArtworkModel = {
     )
   }),
 
-  uploadPhotos: thunk(async (actions, photos) => {
+  uploadPhotos: thunk(async (actions, photos, { getState }) => {
     try {
+      const state = getState()
+      state.sessionState.lastUploadedPhoto = photos[0]
       const imagePaths = photos.map((photo) => photo.path)
       const convectionKey = await getConvectionGeminiKey()
       const acl = "private"
@@ -210,6 +213,37 @@ export const MyCollectionArtworkModel: MyCollectionArtworkModel = {
     }
   }),
 
+  takeOrPickPhotos: thunk((actions, _payload) => {
+    ActionSheetIOS.showActionSheetWithOptions(
+      {
+        options: ["Photo Library", "Take Photo", "Cancel"],
+        cancelButtonIndex: 2,
+      },
+      async (buttonIndex) => {
+        try {
+          let photos = null
+
+          if (buttonIndex === 0) {
+            photos = await ImagePicker.openPicker({
+              multiple: true,
+            })
+          }
+          if (buttonIndex === 1) {
+            photos = await ImagePicker.openCamera({
+              mediaType: "photo",
+            })
+          }
+
+          if (photos) {
+            actions.addPhotos(photos as any) // FIXME: any
+          }
+        } catch (error) {
+          // Photo picker closes by throwing error that we need to catch
+        }
+      }
+    )
+  }),
+
   /**
    * TODO: Log to Sentry
    */
@@ -229,6 +263,7 @@ export const MyCollectionArtworkModel: MyCollectionArtworkModel = {
       try {
         const state = getState()
         const input = cleanArtworkPayload(payload) as typeof payload
+        state.sessionState.lastUploadedPhoto = undefined // reset locally stored photo
         const externalImageUrls = await actions.uploadPhotos(photos)
 
         commitMutation<MyCollectionArtworkModelCreateArtworkMutation>(defaultEnvironment, {
@@ -263,7 +298,6 @@ export const MyCollectionArtworkModel: MyCollectionArtworkModel = {
               ...input,
             },
           },
-
           // TODO: Relay v10 introduces a new directive-based mechanism for updating post-mutation.
           // See https://github.com/facebook/relay/releases/tag/v10.0.0.
           updater: (store) => {
@@ -543,36 +577,5 @@ export const MyCollectionArtworkModel: MyCollectionArtworkModel = {
     } else {
       navigationActions.dismissModal()
     }
-  }),
-
-  takeOrPickPhotos: thunk((actions, _payload) => {
-    ActionSheetIOS.showActionSheetWithOptions(
-      {
-        options: ["Photo Library", "Take Photo", "Cancel"],
-        cancelButtonIndex: 2,
-      },
-      async (buttonIndex) => {
-        try {
-          let photos = null
-
-          if (buttonIndex === 0) {
-            photos = await ImagePicker.openPicker({
-              multiple: true,
-            })
-          }
-          if (buttonIndex === 1) {
-            photos = await ImagePicker.openCamera({
-              mediaType: "photo",
-            })
-          }
-
-          if (photos) {
-            actions.addPhotos(photos as any) // FIXME: any
-          }
-        } catch (error) {
-          // Photo picker closes by throwing error that we need to catch
-        }
-      }
-    )
   }),
 }


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [CX-703]

### Description

Use local path to display photo in users collection list while photo is processing. 

- Adds an additional lastPhotoUploaded field to the session state
- When rendering artwork list view use this as a backup if imageURL is not present

Note: I  initially tried to use relay's optimisticResponse for this but ultimately decided against it because it requires recreating an entire fake artwork model object and we only really need the local path to the last uploaded photo. If there is a better way please let me know.

Co-authored with @bhoggard
Co-authored with @damassi 

### Screenshots

#### Before

![photoStateBefore](https://user-images.githubusercontent.com/49686530/96047616-67159f00-0e43-11eb-88a8-98603f5a4bdb.gif)

#### After 
![photoStateAfter](https://user-images.githubusercontent.com/49686530/96047632-6aa92600-0e43-11eb-96c0-60a616511222.gif)


### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-703]: https://artsyproduct.atlassian.net/browse/CX-703