### PR TITLE
feat(show2): sets up more information route with basic information

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -11,6 +11,7 @@ upcoming:
     - Adds Show2 install shots, behind lab option - damon
     - Link ConversationDetail screen - sepans
     - Fix Vanity URL fallbacks - david
+    - Adds Show2 basic more information route, behind lab option - damon
 
 releases:
   - version: 6.6.5

--- a/src/__generated__/Show2Info_show.graphql.ts
+++ b/src/__generated__/Show2Info_show.graphql.ts
@@ -1,0 +1,45 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type Show2Info_show = {
+    readonly href: string | null;
+    readonly about: string | null;
+    readonly " $refType": "Show2Info_show";
+};
+export type Show2Info_show$data = Show2Info_show;
+export type Show2Info_show$key = {
+    readonly " $data"?: Show2Info_show$data;
+    readonly " $fragmentRefs": FragmentRefs<"Show2Info_show">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "Show2Info_show",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "href",
+      "storageKey": null
+    },
+    {
+      "alias": "about",
+      "args": null,
+      "kind": "ScalarField",
+      "name": "description",
+      "storageKey": null
+    }
+  ],
+  "type": "Show",
+  "abstractKey": null
+};
+(node as any).hash = '38d9f3fc49f2ca8cbe0f243b821f6f90';
+export default node;

--- a/src/__generated__/Show2MoreInfoQuery.graphql.ts
+++ b/src/__generated__/Show2MoreInfoQuery.graphql.ts
@@ -1,0 +1,145 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash 7085ee295953be39ef806eea15c4be3c */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type Show2MoreInfoQueryVariables = {
+    id: string;
+};
+export type Show2MoreInfoQueryResponse = {
+    readonly show: {
+        readonly " $fragmentRefs": FragmentRefs<"Show2MoreInfo_show">;
+    } | null;
+};
+export type Show2MoreInfoQuery = {
+    readonly response: Show2MoreInfoQueryResponse;
+    readonly variables: Show2MoreInfoQueryVariables;
+};
+
+
+
+/*
+query Show2MoreInfoQuery(
+  $id: String!
+) {
+  show(id: $id) {
+    ...Show2MoreInfo_show
+    id
+  }
+}
+
+fragment Show2MoreInfo_show on Show {
+  href
+  about: description
+  pressRelease(format: MARKDOWN)
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "Show2MoreInfoQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Show",
+        "kind": "LinkedField",
+        "name": "show",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "Show2MoreInfo_show"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "Show2MoreInfoQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Show",
+        "kind": "LinkedField",
+        "name": "show",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "href",
+            "storageKey": null
+          },
+          {
+            "alias": "about",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "description",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "format",
+                "value": "MARKDOWN"
+              }
+            ],
+            "kind": "ScalarField",
+            "name": "pressRelease",
+            "storageKey": "pressRelease(format:\"MARKDOWN\")"
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "7085ee295953be39ef806eea15c4be3c",
+    "metadata": {},
+    "name": "Show2MoreInfoQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = '8433502b326dbbb48f8a6b4aaa2e5e30';
+export default node;

--- a/src/__generated__/Show2MoreInfoTestsQuery.graphql.ts
+++ b/src/__generated__/Show2MoreInfoTestsQuery.graphql.ts
@@ -1,0 +1,169 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash e7eecf92a3e2367056f6635215425215 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type Show2MoreInfoTestsQueryVariables = {
+    showID: string;
+};
+export type Show2MoreInfoTestsQueryResponse = {
+    readonly show: {
+        readonly " $fragmentRefs": FragmentRefs<"Show2MoreInfo_show">;
+    } | null;
+};
+export type Show2MoreInfoTestsQuery = {
+    readonly response: Show2MoreInfoTestsQueryResponse;
+    readonly variables: Show2MoreInfoTestsQueryVariables;
+};
+
+
+
+/*
+query Show2MoreInfoTestsQuery(
+  $showID: String!
+) {
+  show(id: $showID) {
+    ...Show2MoreInfo_show
+    id
+  }
+}
+
+fragment Show2MoreInfo_show on Show {
+  href
+  about: description
+  pressRelease(format: MARKDOWN)
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "showID"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "showID"
+  }
+],
+v2 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "Show2MoreInfoTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Show",
+        "kind": "LinkedField",
+        "name": "show",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "Show2MoreInfo_show"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "Show2MoreInfoTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Show",
+        "kind": "LinkedField",
+        "name": "show",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "href",
+            "storageKey": null
+          },
+          {
+            "alias": "about",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "description",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "format",
+                "value": "MARKDOWN"
+              }
+            ],
+            "kind": "ScalarField",
+            "name": "pressRelease",
+            "storageKey": "pressRelease(format:\"MARKDOWN\")"
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "e7eecf92a3e2367056f6635215425215",
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "show": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Show"
+        },
+        "show.about": (v2/*: any*/),
+        "show.href": (v2/*: any*/),
+        "show.id": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "ID"
+        },
+        "show.pressRelease": (v2/*: any*/)
+      }
+    },
+    "name": "Show2MoreInfoTestsQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = '0cf47ddd45705861c2a85ab21e58bcfd';
+export default node;

--- a/src/__generated__/Show2MoreInfo_show.graphql.ts
+++ b/src/__generated__/Show2MoreInfo_show.graphql.ts
@@ -1,0 +1,59 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type Show2MoreInfo_show = {
+    readonly href: string | null;
+    readonly about: string | null;
+    readonly pressRelease: string | null;
+    readonly " $refType": "Show2MoreInfo_show";
+};
+export type Show2MoreInfo_show$data = Show2MoreInfo_show;
+export type Show2MoreInfo_show$key = {
+    readonly " $data"?: Show2MoreInfo_show$data;
+    readonly " $fragmentRefs": FragmentRefs<"Show2MoreInfo_show">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "Show2MoreInfo_show",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "href",
+      "storageKey": null
+    },
+    {
+      "alias": "about",
+      "args": null,
+      "kind": "ScalarField",
+      "name": "description",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "format",
+          "value": "MARKDOWN"
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "pressRelease",
+      "storageKey": "pressRelease(format:\"MARKDOWN\")"
+    }
+  ],
+  "type": "Show",
+  "abstractKey": null
+};
+(node as any).hash = 'fe8c08f507737e110f2297f6650520f1';
+export default node;

--- a/src/__generated__/Show2Query.graphql.ts
+++ b/src/__generated__/Show2Query.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash b90553fb102e8384cfe12cc366c83e86 */
+/* @relayHash 9bff5ece03786421250d6fbfa5b6f6fb */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -52,6 +52,11 @@ fragment Show2Header_show on Show {
   }
 }
 
+fragment Show2Info_show on Show {
+  href
+  about: description
+}
+
 fragment Show2InstallShots_show on Show {
   name
   images {
@@ -68,6 +73,10 @@ fragment Show2InstallShots_show on Show {
 fragment Show2_show on Show {
   ...Show2Header_show
   ...Show2InstallShots_show
+  ...Show2Info_show
+  images {
+    __typename
+  }
 }
 */
 
@@ -94,6 +103,13 @@ v2 = {
   "storageKey": null
 },
 v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -190,13 +206,7 @@ return {
             "name": "partner",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "__typename",
-                "storageKey": null
-              },
+              (v3/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -209,7 +219,7 @@ return {
                 "kind": "InlineFragment",
                 "selections": [
                   (v2/*: any*/),
-                  (v3/*: any*/)
+                  (v4/*: any*/)
                 ],
                 "type": "ExternalPartner",
                 "abstractKey": null
@@ -217,7 +227,7 @@ return {
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v3/*: any*/)
+                  (v4/*: any*/)
                 ],
                 "type": "Node",
                 "abstractKey": "__isNode"
@@ -293,18 +303,33 @@ return {
                   }
                 ],
                 "storageKey": "resized(height:300)"
-              }
+              },
+              (v3/*: any*/)
             ],
             "storageKey": null
           },
-          (v3/*: any*/)
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "href",
+            "storageKey": null
+          },
+          {
+            "alias": "about",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "description",
+            "storageKey": null
+          },
+          (v4/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "b90553fb102e8384cfe12cc366c83e86",
+    "id": "9bff5ece03786421250d6fbfa5b6f6fb",
     "metadata": {},
     "name": "Show2Query",
     "operationKind": "query",

--- a/src/__generated__/Show2TestsQuery.graphql.ts
+++ b/src/__generated__/Show2TestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash d6f92ff7b9230df729d4e3bd1270b735 */
+/* @relayHash 7825f2d268f1539b9feb28abf705042f */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -52,6 +52,11 @@ fragment Show2Header_show on Show {
   }
 }
 
+fragment Show2Info_show on Show {
+  href
+  about: description
+}
+
 fragment Show2InstallShots_show on Show {
   name
   images {
@@ -68,6 +73,10 @@ fragment Show2InstallShots_show on Show {
 fragment Show2_show on Show {
   ...Show2Header_show
   ...Show2InstallShots_show
+  ...Show2Info_show
+  images {
+    __typename
+  }
 }
 */
 
@@ -97,32 +106,39 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "__typename",
   "storageKey": null
 },
 v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v5 = {
+v6 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
-},
-v6 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Int"
 },
 v7 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
+},
+v8 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
 };
 return {
   "fragment": {
@@ -214,13 +230,7 @@ return {
             "name": "partner",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "__typename",
-                "storageKey": null
-              },
+              (v3/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -233,7 +243,7 @@ return {
                 "kind": "InlineFragment",
                 "selections": [
                   (v2/*: any*/),
-                  (v3/*: any*/)
+                  (v4/*: any*/)
                 ],
                 "type": "ExternalPartner",
                 "abstractKey": null
@@ -241,7 +251,7 @@ return {
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v3/*: any*/)
+                  (v4/*: any*/)
                 ],
                 "type": "Node",
                 "abstractKey": "__isNode"
@@ -317,18 +327,33 @@ return {
                   }
                 ],
                 "storageKey": "resized(height:300)"
-              }
+              },
+              (v3/*: any*/)
             ],
             "storageKey": null
           },
-          (v3/*: any*/)
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "href",
+            "storageKey": null
+          },
+          {
+            "alias": "about",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "description",
+            "storageKey": null
+          },
+          (v4/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "d6f92ff7b9230df729d4e3bd1270b735",
+    "id": "7825f2d268f1539b9feb28abf705042f",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "show": {
@@ -337,33 +362,36 @@ return {
           "plural": false,
           "type": "Show"
         },
-        "show.endAt": (v4/*: any*/),
-        "show.formattedEndAt": (v4/*: any*/),
-        "show.formattedStartAt": (v4/*: any*/),
-        "show.id": (v5/*: any*/),
+        "show.about": (v5/*: any*/),
+        "show.endAt": (v5/*: any*/),
+        "show.formattedEndAt": (v5/*: any*/),
+        "show.formattedStartAt": (v5/*: any*/),
+        "show.href": (v5/*: any*/),
+        "show.id": (v6/*: any*/),
         "show.images": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Image"
         },
-        "show.images.caption": (v4/*: any*/),
+        "show.images.__typename": (v7/*: any*/),
+        "show.images.caption": (v5/*: any*/),
         "show.images.dimensions": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ResizedImageUrl"
         },
-        "show.images.dimensions.height": (v6/*: any*/),
-        "show.images.dimensions.width": (v6/*: any*/),
+        "show.images.dimensions.height": (v8/*: any*/),
+        "show.images.dimensions.width": (v8/*: any*/),
         "show.images.internalID": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ID"
         },
-        "show.images.src": (v4/*: any*/),
-        "show.name": (v4/*: any*/),
+        "show.images.src": (v5/*: any*/),
+        "show.name": (v5/*: any*/),
         "show.partner": {
           "enumValues": null,
           "nullable": true,
@@ -372,9 +400,9 @@ return {
         },
         "show.partner.__isNode": (v7/*: any*/),
         "show.partner.__typename": (v7/*: any*/),
-        "show.partner.id": (v5/*: any*/),
-        "show.partner.name": (v4/*: any*/),
-        "show.startAt": (v4/*: any*/)
+        "show.partner.id": (v6/*: any*/),
+        "show.partner.name": (v5/*: any*/),
+        "show.startAt": (v5/*: any*/)
       }
     },
     "name": "Show2TestsQuery",

--- a/src/__generated__/Show2_show.graphql.ts
+++ b/src/__generated__/Show2_show.graphql.ts
@@ -5,7 +5,10 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type Show2_show = {
-    readonly " $fragmentRefs": FragmentRefs<"Show2Header_show" | "Show2InstallShots_show">;
+    readonly images: ReadonlyArray<{
+        readonly __typename: string;
+    } | null> | null;
+    readonly " $fragmentRefs": FragmentRefs<"Show2Header_show" | "Show2InstallShots_show" | "Show2Info_show">;
     readonly " $refType": "Show2_show";
 };
 export type Show2_show$data = Show2_show;
@@ -23,6 +26,24 @@ const node: ReaderFragment = {
   "name": "Show2_show",
   "selections": [
     {
+      "alias": null,
+      "args": null,
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "images",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "__typename",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
       "args": null,
       "kind": "FragmentSpread",
       "name": "Show2Header_show"
@@ -31,10 +52,15 @@ const node: ReaderFragment = {
       "args": null,
       "kind": "FragmentSpread",
       "name": "Show2InstallShots_show"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "Show2Info_show"
     }
   ],
   "type": "Show",
   "abstractKey": null
 };
-(node as any).hash = 'd59ae3175f339dca832a99511606c8d0';
+(node as any).hash = '3e21cb7c7fee76e6a44a60ff2b30c4b7';
 export default node;

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -74,7 +74,7 @@ import { SalesQueryRenderer } from "./Scenes/Sales"
 import { Search } from "./Scenes/Search"
 import { ShowArtistsQueryRenderer, ShowArtworksQueryRenderer, ShowMoreInfoQueryRenderer } from "./Scenes/Show"
 import { ShowQueryRenderer } from "./Scenes/Show/Show"
-import { Show2QueryRenderer } from "./Scenes/Show2/Show2"
+import { Show2MoreInfoQueryRenderer, Show2QueryRenderer } from "./Scenes/Show2"
 import { VanityURLEntityRenderer } from "./Scenes/VanityURL/VanityURLEntity"
 
 import { BottomTabType } from "./Scenes/BottomTabs/BottomTabType"
@@ -438,6 +438,7 @@ export const modules = defineModules({
   Show2: { Component: Show2QueryRenderer, fullBleed: true },
   ShowArtists: { Component: ShowArtists },
   ShowArtworks: { Component: ShowArtworks },
+  Show2MoreInfo: { Component: Show2MoreInfoQueryRenderer, fullBleed: true },
   ShowMoreInfo: { Component: ShowMoreInfo },
   VanityURLEntity: { Component: VanityURLEntityRenderer, fullBleed: true },
   ViewingRoom: { Component: ViewingRoomQueryRenderer, fullBleed: true },

--- a/src/lib/Scenes/Show2/Components/Show2Info.tsx
+++ b/src/lib/Scenes/Show2/Components/Show2Info.tsx
@@ -1,0 +1,38 @@
+import { Show2Info_show } from "__generated__/Show2Info_show.graphql"
+import { navigate } from "lib/navigation/navigate"
+import { Box, BoxProps, ChevronIcon, Text } from "palette"
+import React from "react"
+import { TouchableOpacity } from "react-native"
+import { createFragmentContainer, graphql } from "react-relay"
+
+export interface Show2InfoProps extends BoxProps {
+  show: Show2Info_show
+}
+
+export const Show2Info: React.FC<Show2InfoProps> = ({ show, ...rest }) => {
+  return (
+    <Box {...rest}>
+      {!!show.about && (
+        <Text variant="text" mb={1}>
+          {show.about}
+        </Text>
+      )}
+
+      <TouchableOpacity onPress={() => navigate(`${show.href}/info`)}>
+        <Box flexDirection="row" alignItems="center">
+          <Text variant="mediumText">More info</Text>
+          <ChevronIcon />
+        </Box>
+      </TouchableOpacity>
+    </Box>
+  )
+}
+
+export const Show2InfoFragmentContainer = createFragmentContainer(Show2Info, {
+  show: graphql`
+    fragment Show2Info_show on Show {
+      href
+      about: description
+    }
+  `,
+})

--- a/src/lib/Scenes/Show2/Screens/Show2MoreInfo.tsx
+++ b/src/lib/Scenes/Show2/Screens/Show2MoreInfo.tsx
@@ -1,0 +1,82 @@
+import { Show2MoreInfo_show } from "__generated__/Show2MoreInfo_show.graphql"
+import { Show2MoreInfoQuery } from "__generated__/Show2MoreInfoQuery.graphql"
+import { ReadMore } from "lib/Components/ReadMore"
+import { defaultEnvironment } from "lib/relay/createEnvironment"
+import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
+import { Box, Spacer, Text } from "palette"
+import React from "react"
+import { FlatList } from "react-native"
+import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+
+export interface Show2MoreInfoProps {
+  show: Show2MoreInfo_show
+}
+
+export const Show2MoreInfo: React.FC<Show2MoreInfoProps> = ({ show }) => {
+  const sections = [
+    <Box mx={2}>
+      <Text variant="largeTitle">About</Text>
+    </Box>,
+
+    // TODO: Partner EntityHeader
+
+    ...(!!show.about
+      ? [
+          <Box mx={2}>
+            <Text variant="mediumText">Statement</Text>
+            <Text variant="text">{show.about}</Text>
+          </Box>,
+        ]
+      : []),
+
+    ...(!!show.pressRelease
+      ? [
+          <Box mx={2}>
+            <Text variant="mediumText">Press Release</Text>
+            <ReadMore content={show.pressRelease} textStyle="new" maxChars={500} />
+          </Box>,
+        ]
+      : []),
+
+    // TODO: Hours
+    // TODO: Location
+  ]
+
+  return (
+    <FlatList
+      data={sections}
+      keyExtractor={(_, i) => String(i)}
+      ListHeaderComponent={<Spacer mt={6} pt={2} />}
+      ListFooterComponent={<Spacer my={2} />}
+      ItemSeparatorComponent={() => <Spacer my={15} />}
+      renderItem={({ item }) => item}
+    />
+  )
+}
+
+export const Show2MoreInfoFragmentContainer = createFragmentContainer(Show2MoreInfo, {
+  show: graphql`
+    fragment Show2MoreInfo_show on Show {
+      href
+      about: description
+      pressRelease(format: MARKDOWN)
+    }
+  `,
+})
+
+export const Show2MoreInfoQueryRenderer: React.FC<{ showID: string }> = ({ showID }) => {
+  return (
+    <QueryRenderer<Show2MoreInfoQuery>
+      environment={defaultEnvironment}
+      query={graphql`
+        query Show2MoreInfoQuery($id: String!) {
+          show(id: $id) {
+            ...Show2MoreInfo_show
+          }
+        }
+      `}
+      variables={{ id: showID }}
+      render={renderWithLoadProgress(Show2MoreInfoFragmentContainer)}
+    />
+  )
+}

--- a/src/lib/Scenes/Show2/Show2.tsx
+++ b/src/lib/Scenes/Show2/Show2.tsx
@@ -3,10 +3,12 @@ import { Show2Query } from "__generated__/Show2Query.graphql"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { PlaceholderBox, PlaceholderGrid, PlaceholderText } from "lib/utils/placeholders"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
-import { Box, Flex, Separator, Spacer, Theme } from "palette"
+import { Flex, Separator, Spacer } from "palette"
 import React from "react"
+import { FlatList } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import { Show2HeaderFragmentContainer as ShowHeader } from "./Components/Show2Header"
+import { Show2InfoFragmentContainer as ShowInfo } from "./Components/Show2Info"
 import { Show2InstallShotsFragmentContainer as ShowInstallShots } from "./Components/Show2InstallShots"
 
 interface Show2QueryRendererProps {
@@ -18,13 +20,21 @@ interface Show2Props {
 }
 
 export const Show2: React.FC<Show2Props> = ({ show }) => {
+  const sections = [
+    <ShowHeader show={show} mx={2} />,
+    ...(!!show.images?.length ? [<ShowInstallShots show={show} />] : []),
+    <ShowInfo show={show} mx={2} />,
+  ]
+
   return (
-    <Theme>
-      <Box mt={6}>
-        <ShowHeader show={show} mt={2} mx={2} mb={3} />
-        <ShowInstallShots show={show} mb={3} />
-      </Box>
-    </Theme>
+    <FlatList<typeof sections[number]>
+      data={sections}
+      keyExtractor={(_, i) => String(i)}
+      ListHeaderComponent={<Spacer mt={6} pt={2} />}
+      ListFooterComponent={<Spacer my={2} />}
+      ItemSeparatorComponent={() => <Spacer my={15} />}
+      renderItem={({ item }) => item}
+    />
   )
 }
 
@@ -33,6 +43,10 @@ export const Show2FragmentContainer = createFragmentContainer(Show2, {
     fragment Show2_show on Show {
       ...Show2Header_show
       ...Show2InstallShots_show
+      ...Show2Info_show
+      images {
+        __typename
+      }
     }
   `,
 })

--- a/src/lib/Scenes/Show2/__tests__/Show2MoreInfo-tests.tsx
+++ b/src/lib/Scenes/Show2/__tests__/Show2MoreInfo-tests.tsx
@@ -1,0 +1,68 @@
+import { Show2MoreInfoTestsQuery } from "__generated__/Show2MoreInfoTestsQuery.graphql"
+import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import { act } from "react-test-renderer"
+import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { Show2MoreInfo, Show2MoreInfoFragmentContainer } from "../Screens/Show2MoreInfo"
+
+jest.unmock("react-relay")
+
+describe("Show2MoreInfo", () => {
+  let env: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => {
+    env = createMockEnvironment()
+  })
+
+  const TestRenderer = () => (
+    <QueryRenderer<Show2MoreInfoTestsQuery>
+      environment={env}
+      query={graphql`
+        query Show2MoreInfoTestsQuery($showID: String!) @relay_test_operation {
+          show(id: $showID) {
+            ...Show2MoreInfo_show
+          }
+        }
+      `}
+      variables={{ showID: "the-big-show" }}
+      render={({ props, error }) => {
+        if (props?.show) {
+          return <Show2MoreInfoFragmentContainer show={props.show} />
+        } else if (error) {
+          console.log(error)
+        }
+      }}
+    />
+  )
+
+  const getWrapper = (mockResolvers = {}) => {
+    const tree = renderWithWrappers(<TestRenderer />)
+    act(() => {
+      env.mock.resolveMostRecentOperation((operation) => MockPayloadGenerator.generate(operation, mockResolvers))
+    })
+    return tree
+  }
+
+  it("renders without throwing an error", () => {
+    const wrapper = getWrapper()
+    expect(wrapper.root.findAllByType(Show2MoreInfo)).toHaveLength(1)
+  })
+
+  it("renders basic information", () => {
+    const wrapper = getWrapper({
+      Show: () => ({
+        about: "Basic information about the show",
+        pressRelease: "The press release for the show",
+      }),
+    })
+
+    expect(wrapper.root.findAllByType(Show2MoreInfo)).toHaveLength(1)
+
+    const text = extractText(wrapper.root)
+
+    expect(text).toContain("Basic information about the show")
+    expect(text).toContain("The press release for the show")
+  })
+})

--- a/src/lib/Scenes/Show2/index.ts
+++ b/src/lib/Scenes/Show2/index.ts
@@ -1,0 +1,2 @@
+export { Show2QueryRenderer } from "./Show2"
+export { Show2MoreInfoQueryRenderer } from "./Screens/Show2MoreInfo"

--- a/src/lib/navigation/routes.tsx
+++ b/src/lib/navigation/routes.tsx
@@ -69,12 +69,12 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
       : new RouteMatcher("/auction/:id", "Auction"),
     new RouteMatcher("/auction/:id/bid/:artwork_id", "AuctionBidArtwork"),
     new RouteMatcher("/gene/:geneID", "Gene"),
-    getCurrentEmissionState().options.AROptionsNewShowPage
-      ? new RouteMatcher("/show/:showID", "Show2")
-      : new RouteMatcher("/show/:showID", "Show"),
+    ...(getCurrentEmissionState().options.AROptionsNewShowPage
+      ? [new RouteMatcher("/show/:showID", "Show2"), new RouteMatcher("/show/:showID/info", "Show2MoreInfo")]
+      : [new RouteMatcher("/show/:showID", "Show"), new RouteMatcher("/show/:showID/info", "ShowMoreInfo")]),
     new RouteMatcher("/show/:showID/artworks", "ShowArtworks"),
     new RouteMatcher("/show/:showID/artists", "ShowArtists"),
-    new RouteMatcher("/show/:showID/info", "ShowMoreInfo"),
+
     new RouteMatcher("/inquiry/:artworkID", "Inquiry"),
     new RouteMatcher("/viewing-rooms", "ViewingRooms"),
     new RouteMatcher("/viewing-room/:viewing_room_id", "ViewingRoom"),


### PR DESCRIPTION
The type of this PR is: Feature

This PR resolves [FX-2223]

### Description

Implements a "more information" screen with basic info (about/press release). I'd like us to handle the following as separate tickets as there's some complexity to each sub-task:

* Extract PartnerCard from the artwork and utilize it here
* Display open hours
* Display location with map

![](http://static.damonzucconi.com/_capture/o8azHoJY2dOL.gif)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2223]: https://artsyproduct.atlassian.net/browse/FX-2223