### PR TITLE
fix: vanity url fallback handling

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -10,6 +10,7 @@ upcoming:
     - Adds Show2 header, behind lab option - damon
     - Adds Show2 install shots, behind lab option - damon
     - Link ConversationDetail screen - sepans
+    - Fix Vanity URL fallbacks - david
 
 releases:
   - version: 6.6.5

--- a/src/lib/Scenes/VanityURL/VanityURLEntity.tsx
+++ b/src/lib/Scenes/VanityURL/VanityURLEntity.tsx
@@ -82,6 +82,7 @@ export const VanityURLEntityRenderer: React.FC<RendererProps> = ({ entity, slugT
         `}
         variables={{ id: slug, useNewFairView }}
         render={renderWithPlaceholder({
+          renderFallback: () => <VanityURLPossibleRedirect slug={slug} />,
           renderPlaceholder: () => {
             switch (entity) {
               case "fair":
@@ -101,11 +102,7 @@ export const VanityURLEntityRenderer: React.FC<RendererProps> = ({ entity, slugT
             }
           },
           render: (props: any) => {
-            if (props.vanityURLEntity) {
-              return <VanityURLEntityFragmentContainer fairOrPartner={props.vanityURLEntity} originalSlug={slug} />
-            } else {
-              return <VanityURLPossibleRedirect slug={slug} />
-            }
+            return <VanityURLEntityFragmentContainer fairOrPartner={props.vanityURLEntity} originalSlug={slug} />
           },
         })}
       />

--- a/src/lib/Scenes/VanityURL/__tests__/VanityURLEntity-tests.tsx
+++ b/src/lib/Scenes/VanityURL/__tests__/VanityURLEntity-tests.tsx
@@ -6,6 +6,7 @@ import { Fair2FragmentContainer } from "lib/Scenes/Fair2/Fair2"
 import { PartnerContainer } from "lib/Scenes/Partner"
 import { __appStoreTestUtils__ } from "lib/store/AppStore"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { __renderWithPlaceholderTestUtils__ } from "lib/utils/renderWithPlaceholder"
 import { Spinner } from "palette"
 import React from "react"
 import { act } from "react-test-renderer"
@@ -40,6 +41,16 @@ describe("VanityURLEntity", () => {
 
   beforeEach(() => {
     env.mockClear()
+  })
+
+  it("renders a VanityURLPossibleRedirect when 404", () => {
+    if (__renderWithPlaceholderTestUtils__) {
+      __renderWithPlaceholderTestUtils__.allowFallbacksAtTestTime = true
+    }
+    const tree = renderWithWrappers(<TestRenderer entity="unknown" slug={"some-fair"} />)
+    expect(tree.root.findAllByType(VanityURLPossibleRedirect)).toHaveLength(0)
+    env.mock.resolveMostRecentOperation({ data: undefined, errors: [{ message: "404" }] })
+    expect(tree.root.findAllByType(VanityURLPossibleRedirect)).toHaveLength(1)
   })
 
   it("renders a fairQueryRenderer when given a fair id", () => {

--- a/src/lib/utils/renderWithPlaceholder.tsx
+++ b/src/lib/utils/renderWithPlaceholder.tsx
@@ -6,15 +6,19 @@ import { ProvidePlaceholderContext } from "./placeholders"
 
 type ReadyState = Parameters<React.ComponentProps<typeof QueryRenderer>["render"]>[0]
 
+type FallbackRenderer = (args: { retry: null | (() => void) }) => React.ReactElement | null
+
 export function renderWithPlaceholder<Props>({
   Container,
   render,
   renderPlaceholder,
+  renderFallback,
   initialProps = {},
 }: {
   Container?: React.ComponentType<Props>
   render?: (props: Props) => React.ReactChild
   renderPlaceholder: () => React.ReactChild
+  renderFallback?: FallbackRenderer
   initialProps?: object
 }): (readyState: ReadyState) => React.ReactElement | null {
   if (!Container && !render) {
@@ -44,7 +48,9 @@ export function renderWithPlaceholder<Props>({
         console.error("Error data", data)
       }
 
-      if (retrying) {
+      if (renderFallback) {
+        return renderFallback({ retry })
+      } else if (retrying) {
         retrying = false
         // TODO: Even though this code path is reached, the retry button keeps spinning. iirc it _should_ disappear when
         //      `onRetry` on the instance is unset.

--- a/src/lib/utils/renderWithPlaceholder.tsx
+++ b/src/lib/utils/renderWithPlaceholder.tsx
@@ -33,7 +33,9 @@ export function renderWithPlaceholder<Props>({
     if (error) {
       // In tests we want errors to clearly bubble up.
       if (typeof jest !== "undefined") {
-        throw error
+        if (!__renderWithPlaceholderTestUtils__?.allowFallbacksAtTestTime) {
+          throw error
+        }
       } else {
         console.error(error)
       }
@@ -74,4 +76,19 @@ export function renderWithPlaceholder<Props>({
       return <ProvidePlaceholderContext>{renderPlaceholder()}</ProvidePlaceholderContext>
     }
   }
+}
+
+// tslint:disable-next-line:variable-name
+export const __renderWithPlaceholderTestUtils__ = __TEST__
+  ? {
+      allowFallbacksAtTestTime: false,
+    }
+  : undefined
+
+if (__TEST__) {
+  beforeEach(() => {
+    if (__renderWithPlaceholderTestUtils__) {
+      __renderWithPlaceholderTestUtils__.allowFallbacksAtTestTime = false
+    }
+  })
 }


### PR DESCRIPTION
### Description

When #3867 was merged while I was away, it broke the `VanityURLEntity` fallback handling which depended on the old `principalField` behaviour. Here I added a special `renderFallback` option to our `renderWithPlaceholder` utility so that when metaphysics errors out we can show something other than the `LoadFailureView`, in this case we show our `VanityURLPossibleRedirect` fallback component.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
