### PR TITLE
fix: deep link handling

### DIFF
--- a/Artsy/App/ARScreenPresenterModule.m
+++ b/Artsy/App/ARScreenPresenterModule.m
@@ -91,23 +91,28 @@ RCT_EXPORT_METHOD(presentReactScreen:(nonnull NSString *)moduleName props:(nonnu
     [self presentViewController:vc modalPresentationStyle:modalPresentationStyle];
 }
 
-- (void)presentViewController:(UIViewController *)vc modalPresentationStyle:(UIModalPresentationStyle)modalPresentationStyle
+- (void)presentViewController:(UIViewController *)vc modalPresentationStyle:( UIModalPresentationStyle)_modalPresentationStyle
 {
-    UIViewController *currentVC = [self currentlyPresentedVC];
-    if (![currentVC isKindOfClass:UINavigationController.class]) {
-        modalPresentationStyle = UIModalPresentationFullScreen;
-    }
-    if (modalPresentationStyle != -1) {
-        vc.modalPresentationStyle = modalPresentationStyle;
-        UIViewController *presentingVC = [ARTopMenuViewController sharedController];
-
-        while ([presentingVC presentedViewController]) {
-            presentingVC = [presentingVC presentedViewController];
+    __weak typeof (self) wself = self;
+    [[ARTopMenuViewController sharedController] afterBootstrap:^() {
+        __strong typeof (wself) sself = wself;
+        UIModalPresentationStyle modalPresentationStyle = _modalPresentationStyle;
+        UIViewController *currentVC = [sself currentlyPresentedVC];
+        if (![currentVC isKindOfClass:UINavigationController.class]) {
+            modalPresentationStyle = UIModalPresentationFullScreen;
         }
-        [presentingVC presentViewController:vc animated:YES completion:nil];
-    } else {
-        [(UINavigationController *)currentVC pushViewController:vc animated:YES];
-    }
+        if (modalPresentationStyle != -1) {
+            vc.modalPresentationStyle = modalPresentationStyle;
+            UIViewController *presentingVC = [ARTopMenuViewController sharedController];
+
+            while ([presentingVC presentedViewController]) {
+                presentingVC = [presentingVC presentedViewController];
+            }
+            [presentingVC presentViewController:vc animated:YES completion:nil];
+        } else {
+            [(UINavigationController *)currentVC pushViewController:vc animated:YES];
+        }
+    }];
 }
 
 // This returns either the topmost modal or the current root navigation controller.

--- a/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.h
+++ b/Artsy/View_Controllers/App_Navigation/ARTopMenuViewController.h
@@ -55,6 +55,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns the root navigation controller for specified tab
 - (ARNavigationController *)rootNavigationControllerAtTab:(NSString *)tab;
 
+- (void)afterBootstrap:(void (^)(void))completion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -10,6 +10,7 @@ upcoming:
     - Adds Show2 header, behind lab option - damon
     - Adds Show2 install shots, behind lab option - damon
     - Link ConversationDetail screen - sepans
+    - Fix deep link handling when application is closed - david
 
 releases:
   - version: 6.6.5


### PR DESCRIPTION
### Description

#3771 introduced a regression for deep link handling when the app is closed. The app would open to the home screen. See slack context: https://artsy.slack.com/archives/C9EK04NV6/p1602799492003700

The problem was that the `ARScreenPresenterModule` was asking the `ARTopMenuViewController` to present a screen before it had fully initialized. This PR makes it wait until everybody's ready.

Note that this code is extremely temporary and will be refactored away in my next android PR.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
