### PR TITLE
chore: Add tracking for View All button on artworks by artists you follow rail #trivial

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "cheerio": "0.22.0"
   },
   "dependencies": {
-    "@artsy/cohesion": "1.40.0",
+    "@artsy/cohesion": "1.42.0",
     "@mapbox/react-native-mapbox-gl": "6.1.3",
     "@react-native-community/async-storage": "1.6.3",
     "@react-native-community/cameraroll": "1.3.0",

--- a/src/lib/Scenes/Fair2/Components/Fair2FollowedArtistsRail.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2FollowedArtistsRail.tsx
@@ -33,6 +33,20 @@ export const Fair2FollowedArtistsRail: React.FC<Fair2FollowedArtistsRailProps> =
     }
     tracking.trackEvent(trackTappedArtworkProps)
   }
+
+  const trackTappedViewAll = () => {
+    const trackTappedArtworkProps: TappedArtworkGroup = {
+      action: ActionType.tappedArtworkGroup,
+      context_module: ContextModule.worksByArtistsYouFollowRail,
+      context_screen_owner_type: OwnerType.fair,
+      context_screen_owner_id: fair.internalID,
+      context_screen_owner_slug: fair.slug,
+      destination_screen_owner_type: OwnerType.fairArtworks,
+      type: "viewAll",
+    }
+    tracking.trackEvent(trackTappedArtworkProps)
+  }
+
   const artworks = compact(fair.followedArtistArtworks.edges)
 
   return (
@@ -40,7 +54,12 @@ export const Fair2FollowedArtistsRail: React.FC<Fair2FollowedArtistsRailProps> =
       <Box flexDirection="row" justifyContent="space-between" mx={2} mb={2}>
         <Text variant="subtitle">Works by artists you follow</Text>
         {artworks.length > 3 && (
-          <TouchableOpacity onPress={() => navigate(`/fair/${fair.slug}/followedArtists`)}>
+          <TouchableOpacity
+            onPress={() => {
+              trackTappedViewAll()
+              navigate(`/fair/${fair.slug}/followedArtists`)
+            }}
+          >
             <Text variant="subtitle" color="black60">
               View all
             </Text>

--- a/src/lib/Scenes/Fair2/__tests__/Fair2FollowedArtistsRail-tests.tsx
+++ b/src/lib/Scenes/Fair2/__tests__/Fair2FollowedArtistsRail-tests.tsx
@@ -155,4 +155,52 @@ describe("Fair2FollowedArtistsRail", () => {
     })
     expect(wrapper.root.findAllByType(TouchableOpacity).length).toBe(0)
   })
+
+  it("tracks taps on the View All button", () => {
+    const wrapper = getWrapper({
+      Fair: () => ({
+        internalID: "xyz123",
+        slug: "art-basel-hong-kong-2019",
+        followedArtistArtworks: {
+          edges: [
+            {
+              artwork: {
+                internalID: "id-1",
+                slug: "some-artwork-1",
+              },
+            },
+            {
+              artwork: {
+                internalID: "id-2",
+                slug: "some-artwork-2",
+              },
+            },
+            {
+              artwork: {
+                internalID: "id-3",
+                slug: "some-artwork-3",
+              },
+            },
+            {
+              artwork: {
+                internalID: "id-4",
+                slug: "some-artwork-4",
+              },
+            },
+          ],
+        },
+      }),
+    })
+    const viewAllButton = wrapper.root.findAllByType(TouchableOpacity)[0]
+    act(() => viewAllButton.props.onPress())
+    expect(trackEvent).toHaveBeenCalledWith({
+      action: "tappedArtworkGroup",
+      context_module: "worksByArtistsYouFollowRail",
+      context_screen_owner_id: "xyz123",
+      context_screen_owner_slug: "art-basel-hong-kong-2019",
+      context_screen_owner_type: "fair",
+      destination_screen_owner_type: "fairArtworks",
+      type: "viewAll",
+    })
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/auto-config/-/auto-config-1.0.2.tgz#b79f6fd0d0bda0c5e0764ced55e014cf58174d6f"
   integrity sha512-mJyuKNDMYZcgc2oLIkvmpVIr1RexklV71JmU+to5qs3Y9pv5dsj4WHl8+wf9g74EQNOyhWH2SYMGBm1JoPYh/Q==
 
-"@artsy/cohesion@1.40.0":
-  version "1.40.0"
-  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-1.40.0.tgz#a7b543d4049f35207da867fc2b562dcd65364b82"
-  integrity sha512-O2AJ6yfTcb/WITDmZWL5vBfF8QT/VNx2AS8pXvtbruuKdybTin0cAG4mWJdRzdv6fEFzbaqjogEYTYq5fq5yKg==
+"@artsy/cohesion@1.42.0":
+  version "1.42.0"
+  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-1.42.0.tgz#af4f6a88dcf51f7963b1c44163e239a10fc7ed09"
+  integrity sha512-25y2PDTJ8D08IGqWTaXIoVpKw53hwKkrzENuelQMIUvJGkYqXGkmk66j4eV/PQZxQ7uppHjHeI/6Cg0XTkAlnQ==
 
 "@artsy/update-repo@0.2.0":
   version "0.2.0"


### PR DESCRIPTION
The type of this PR is: **enhancement**

This PR resolves [FX-2337]

### Description

Updates Cohesion and adds tracking for tapping on `View all` button on `Fair2FollowedArtistsRail`.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

![Screen Shot 2020-10-16 at 2 17 47 PM](https://user-images.githubusercontent.com/4432348/96294569-91d63380-0fba-11eb-9663-ca67d76fed07.png)


[FX-2337]: https://artsyproduct.atlassian.net/browse/FX-2337