### PR TITLE
fix: Use aggregations for all fair artworks in filter options

### DIFF
--- a/src/__generated__/Fair2AllFollowedArtistsQuery.graphql.ts
+++ b/src/__generated__/Fair2AllFollowedArtistsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 6a8246ecb471e6780d5973f6ab81bfe7 */
+/* @relayHash 40d01e730aad300a808356d168fca851 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -74,6 +74,17 @@ fragment Fair2AllFollowedArtists_fair on Fair {
 fragment Fair2Artworks_fair_485l1x on Fair {
   slug
   internalID
+  fairArtworksForAggregation: filterArtworksConnection(first: 0, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
+    id
+  }
   fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", includeArtworksByFollowedArtists: true, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
     aggregations {
       slice
@@ -157,22 +168,81 @@ v3 = {
   "name": "slug",
   "storageKey": null
 },
-v4 = [
-  {
-    "kind": "Literal",
-    "name": "aggregations",
-    "value": [
-      "COLOR",
-      "DIMENSION_RANGE",
-      "GALLERY",
-      "INSTITUTION",
-      "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
-      "FOLLOWED_ARTISTS",
-      "ARTIST"
-    ]
-  },
+v4 = {
+  "kind": "Literal",
+  "name": "aggregations",
+  "value": [
+    "COLOR",
+    "DIMENSION_RANGE",
+    "GALLERY",
+    "INSTITUTION",
+    "MAJOR_PERIOD",
+    "MEDIUM",
+    "PRICE_RANGE",
+    "FOLLOWED_ARTISTS",
+    "ARTIST"
+  ]
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ArtworksAggregationResults",
+  "kind": "LinkedField",
+  "name": "aggregations",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slice",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AggregationCount",
+      "kind": "LinkedField",
+      "name": "counts",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "count",
+          "storageKey": null
+        },
+        (v5/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "value",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v8 = [
+  (v4/*: any*/),
   {
     "kind": "Literal",
     "name": "dimensionRange",
@@ -199,21 +269,7 @@ v4 = [
     "value": "-decayed_merch"
   }
 ],
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v7 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -264,57 +320,34 @@ return {
           (v2/*: any*/),
           (v3/*: any*/),
           {
-            "alias": "fairArtworks",
-            "args": (v4/*: any*/),
+            "alias": "fairArtworksForAggregation",
+            "args": [
+              (v4/*: any*/),
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 0
+              }
+            ],
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "ArtworksAggregationResults",
-                "kind": "LinkedField",
-                "name": "aggregations",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "slice",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "AggregationCount",
-                    "kind": "LinkedField",
-                    "name": "counts",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "count",
-                        "storageKey": null
-                      },
-                      (v5/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "value",
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
+              (v6/*: any*/),
+              (v7/*: any*/)
+            ],
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:0)"
+          },
+          {
+            "alias": "fairArtworks",
+            "args": (v8/*: any*/),
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              (v6/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -331,8 +364,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
-                      (v7/*: any*/)
+                      (v7/*: any*/),
+                      (v9/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -396,7 +429,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v6/*: any*/),
+              (v7/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -426,7 +459,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v7/*: any*/),
+                      (v9/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -539,7 +572,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v6/*: any*/)
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -594,7 +627,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v6/*: any*/)
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -607,7 +640,7 @@ return {
                             "plural": false,
                             "selections": [
                               (v5/*: any*/),
-                              (v6/*: any*/)
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -617,7 +650,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v6/*: any*/)
+                          (v7/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -634,7 +667,7 @@ return {
           },
           {
             "alias": "fairArtworks",
-            "args": (v4/*: any*/),
+            "args": (v8/*: any*/),
             "filters": [
               "sort",
               "medium",
@@ -656,14 +689,14 @@ return {
             "kind": "LinkedHandle",
             "name": "filterArtworksConnection"
           },
-          (v6/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "6a8246ecb471e6780d5973f6ab81bfe7",
+    "id": "40d01e730aad300a808356d168fca851",
     "metadata": {},
     "name": "Fair2AllFollowedArtistsQuery",
     "operationKind": "query",

--- a/src/__generated__/Fair2AllFollowedArtistsTestsQuery.graphql.ts
+++ b/src/__generated__/Fair2AllFollowedArtistsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 0a6a300f2f1fb0b6ed5f56725bed601c */
+/* @relayHash c1e7ffaeb00be8e0c9f479e4d19eb5ca */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -74,6 +74,17 @@ fragment Fair2AllFollowedArtists_fair on Fair {
 fragment Fair2Artworks_fair_485l1x on Fair {
   slug
   internalID
+  fairArtworksForAggregation: filterArtworksConnection(first: 0, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
+    id
+  }
   fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", includeArtworksByFollowedArtists: true, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
     aggregations {
       slice
@@ -157,22 +168,81 @@ v3 = {
   "name": "slug",
   "storageKey": null
 },
-v4 = [
-  {
-    "kind": "Literal",
-    "name": "aggregations",
-    "value": [
-      "COLOR",
-      "DIMENSION_RANGE",
-      "GALLERY",
-      "INSTITUTION",
-      "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
-      "FOLLOWED_ARTISTS",
-      "ARTIST"
-    ]
-  },
+v4 = {
+  "kind": "Literal",
+  "name": "aggregations",
+  "value": [
+    "COLOR",
+    "DIMENSION_RANGE",
+    "GALLERY",
+    "INSTITUTION",
+    "MAJOR_PERIOD",
+    "MEDIUM",
+    "PRICE_RANGE",
+    "FOLLOWED_ARTISTS",
+    "ARTIST"
+  ]
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ArtworksAggregationResults",
+  "kind": "LinkedField",
+  "name": "aggregations",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slice",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AggregationCount",
+      "kind": "LinkedField",
+      "name": "counts",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "count",
+          "storageKey": null
+        },
+        (v5/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "value",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v8 = [
+  (v4/*: any*/),
   {
     "kind": "Literal",
     "name": "dimensionRange",
@@ -199,52 +269,82 @@ v4 = [
     "value": "-decayed_merch"
   }
 ],
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v7 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v8 = {
+v10 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "FilterArtworksConnection"
+},
+v11 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v9 = {
+v12 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": true,
+  "type": "ArtworksAggregationResults"
+},
+v13 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": true,
+  "type": "AggregationCount"
+},
+v14 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Int"
+},
+v15 = {
+  "enumValues": [
+    "ARTIST",
+    "COLOR",
+    "DIMENSION_RANGE",
+    "FOLLOWED_ARTISTS",
+    "GALLERY",
+    "INSTITUTION",
+    "MAJOR_PERIOD",
+    "MEDIUM",
+    "MERCHANDISABLE_ARTISTS",
+    "PARTNER_CITY",
+    "PERIOD",
+    "PRICE_RANGE",
+    "TOTAL"
+  ],
+  "nullable": true,
+  "plural": false,
+  "type": "ArtworkAggregation"
+},
+v16 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FormattedNumber"
 },
-v10 = {
+v17 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v11 = {
+v18 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v12 = {
+v19 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -294,57 +394,34 @@ return {
           (v2/*: any*/),
           (v3/*: any*/),
           {
-            "alias": "fairArtworks",
-            "args": (v4/*: any*/),
+            "alias": "fairArtworksForAggregation",
+            "args": [
+              (v4/*: any*/),
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 0
+              }
+            ],
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "ArtworksAggregationResults",
-                "kind": "LinkedField",
-                "name": "aggregations",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "slice",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "AggregationCount",
-                    "kind": "LinkedField",
-                    "name": "counts",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "count",
-                        "storageKey": null
-                      },
-                      (v5/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "value",
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
+              (v6/*: any*/),
+              (v7/*: any*/)
+            ],
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:0)"
+          },
+          {
+            "alias": "fairArtworks",
+            "args": (v8/*: any*/),
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              (v6/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -361,8 +438,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
-                      (v7/*: any*/)
+                      (v7/*: any*/),
+                      (v9/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -426,7 +503,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v6/*: any*/),
+              (v7/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -456,7 +533,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v7/*: any*/),
+                      (v9/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -569,7 +646,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v6/*: any*/)
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -624,7 +701,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v6/*: any*/)
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -637,7 +714,7 @@ return {
                             "plural": false,
                             "selections": [
                               (v5/*: any*/),
-                              (v6/*: any*/)
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -647,7 +724,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v6/*: any*/)
+                          (v7/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -664,7 +741,7 @@ return {
           },
           {
             "alias": "fairArtworks",
-            "args": (v4/*: any*/),
+            "args": (v8/*: any*/),
             "filters": [
               "sort",
               "medium",
@@ -686,14 +763,14 @@ return {
             "kind": "LinkedHandle",
             "name": "filterArtworksConnection"
           },
-          (v6/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "0a6a300f2f1fb0b6ed5f56725bed601c",
+    "id": "c1e7ffaeb00be8e0c9f479e4d19eb5ca",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "fair": {
@@ -702,82 +779,43 @@ return {
           "plural": false,
           "type": "Fair"
         },
-        "fair.fairArtworks": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "FilterArtworksConnection"
-        },
-        "fair.fairArtworks.__isArtworkConnectionInterface": (v8/*: any*/),
-        "fair.fairArtworks.aggregations": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "ArtworksAggregationResults"
-        },
-        "fair.fairArtworks.aggregations.counts": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "AggregationCount"
-        },
-        "fair.fairArtworks.aggregations.counts.count": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Int"
-        },
-        "fair.fairArtworks.aggregations.counts.name": (v8/*: any*/),
-        "fair.fairArtworks.aggregations.counts.value": (v8/*: any*/),
-        "fair.fairArtworks.aggregations.slice": {
-          "enumValues": [
-            "ARTIST",
-            "COLOR",
-            "DIMENSION_RANGE",
-            "FOLLOWED_ARTISTS",
-            "GALLERY",
-            "INSTITUTION",
-            "MAJOR_PERIOD",
-            "MEDIUM",
-            "MERCHANDISABLE_ARTISTS",
-            "PARTNER_CITY",
-            "PERIOD",
-            "PRICE_RANGE",
-            "TOTAL"
-          ],
-          "nullable": true,
-          "plural": false,
-          "type": "ArtworkAggregation"
-        },
+        "fair.fairArtworks": (v10/*: any*/),
+        "fair.fairArtworks.__isArtworkConnectionInterface": (v11/*: any*/),
+        "fair.fairArtworks.aggregations": (v12/*: any*/),
+        "fair.fairArtworks.aggregations.counts": (v13/*: any*/),
+        "fair.fairArtworks.aggregations.counts.count": (v14/*: any*/),
+        "fair.fairArtworks.aggregations.counts.name": (v11/*: any*/),
+        "fair.fairArtworks.aggregations.counts.value": (v11/*: any*/),
+        "fair.fairArtworks.aggregations.slice": (v15/*: any*/),
         "fair.fairArtworks.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FilterArtworksCounts"
         },
-        "fair.fairArtworks.counts.followedArtists": (v9/*: any*/),
-        "fair.fairArtworks.counts.total": (v9/*: any*/),
+        "fair.fairArtworks.counts.followedArtists": (v16/*: any*/),
+        "fair.fairArtworks.counts.total": (v16/*: any*/),
         "fair.fairArtworks.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "ArtworkEdgeInterface"
         },
-        "fair.fairArtworks.edges.__isNode": (v8/*: any*/),
-        "fair.fairArtworks.edges.__typename": (v8/*: any*/),
-        "fair.fairArtworks.edges.cursor": (v8/*: any*/),
-        "fair.fairArtworks.edges.id": (v10/*: any*/),
+        "fair.fairArtworks.edges.__isNode": (v11/*: any*/),
+        "fair.fairArtworks.edges.__typename": (v11/*: any*/),
+        "fair.fairArtworks.edges.cursor": (v11/*: any*/),
+        "fair.fairArtworks.edges.id": (v17/*: any*/),
         "fair.fairArtworks.edges.node": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Artwork"
         },
-        "fair.fairArtworks.edges.node.__typename": (v8/*: any*/),
-        "fair.fairArtworks.edges.node.artistNames": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.date": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.href": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.id": (v10/*: any*/),
+        "fair.fairArtworks.edges.node.__typename": (v11/*: any*/),
+        "fair.fairArtworks.edges.node.artistNames": (v18/*: any*/),
+        "fair.fairArtworks.edges.node.date": (v18/*: any*/),
+        "fair.fairArtworks.edges.node.href": (v18/*: any*/),
+        "fair.fairArtworks.edges.node.id": (v17/*: any*/),
         "fair.fairArtworks.edges.node.image": {
           "enumValues": null,
           "nullable": true,
@@ -790,27 +828,27 @@ return {
           "plural": false,
           "type": "Float"
         },
-        "fair.fairArtworks.edges.node.image.url": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.internalID": (v10/*: any*/),
+        "fair.fairArtworks.edges.node.image.url": (v18/*: any*/),
+        "fair.fairArtworks.edges.node.internalID": (v17/*: any*/),
         "fair.fairArtworks.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "fair.fairArtworks.edges.node.partner.id": (v10/*: any*/),
-        "fair.fairArtworks.edges.node.partner.name": (v11/*: any*/),
+        "fair.fairArtworks.edges.node.partner.id": (v17/*: any*/),
+        "fair.fairArtworks.edges.node.partner.name": (v18/*: any*/),
         "fair.fairArtworks.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "fair.fairArtworks.edges.node.sale.displayTimelyAt": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.sale.endAt": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.sale.id": (v10/*: any*/),
-        "fair.fairArtworks.edges.node.sale.isAuction": (v12/*: any*/),
-        "fair.fairArtworks.edges.node.sale.isClosed": (v12/*: any*/),
+        "fair.fairArtworks.edges.node.sale.displayTimelyAt": (v18/*: any*/),
+        "fair.fairArtworks.edges.node.sale.endAt": (v18/*: any*/),
+        "fair.fairArtworks.edges.node.sale.id": (v17/*: any*/),
+        "fair.fairArtworks.edges.node.sale.isAuction": (v19/*: any*/),
+        "fair.fairArtworks.edges.node.sale.isClosed": (v19/*: any*/),
         "fair.fairArtworks.edges.node.saleArtwork": {
           "enumValues": null,
           "nullable": true,
@@ -823,37 +861,45 @@ return {
           "plural": false,
           "type": "SaleArtworkCounts"
         },
-        "fair.fairArtworks.edges.node.saleArtwork.counts.bidderPositions": (v9/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.counts.bidderPositions": (v16/*: any*/),
         "fair.fairArtworks.edges.node.saleArtwork.currentBid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCurrentBid"
         },
-        "fair.fairArtworks.edges.node.saleArtwork.currentBid.display": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork.id": (v10/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork.lotLabel": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.saleMessage": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.slug": (v10/*: any*/),
-        "fair.fairArtworks.edges.node.title": (v11/*: any*/),
-        "fair.fairArtworks.id": (v10/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.currentBid.display": (v18/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.id": (v17/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.lotLabel": (v18/*: any*/),
+        "fair.fairArtworks.edges.node.saleMessage": (v18/*: any*/),
+        "fair.fairArtworks.edges.node.slug": (v17/*: any*/),
+        "fair.fairArtworks.edges.node.title": (v18/*: any*/),
+        "fair.fairArtworks.id": (v17/*: any*/),
         "fair.fairArtworks.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "fair.fairArtworks.pageInfo.endCursor": (v11/*: any*/),
+        "fair.fairArtworks.pageInfo.endCursor": (v18/*: any*/),
         "fair.fairArtworks.pageInfo.hasNextPage": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Boolean"
         },
-        "fair.fairArtworks.pageInfo.startCursor": (v11/*: any*/),
-        "fair.id": (v10/*: any*/),
-        "fair.internalID": (v10/*: any*/),
-        "fair.slug": (v10/*: any*/)
+        "fair.fairArtworks.pageInfo.startCursor": (v18/*: any*/),
+        "fair.fairArtworksForAggregation": (v10/*: any*/),
+        "fair.fairArtworksForAggregation.aggregations": (v12/*: any*/),
+        "fair.fairArtworksForAggregation.aggregations.counts": (v13/*: any*/),
+        "fair.fairArtworksForAggregation.aggregations.counts.count": (v14/*: any*/),
+        "fair.fairArtworksForAggregation.aggregations.counts.name": (v11/*: any*/),
+        "fair.fairArtworksForAggregation.aggregations.counts.value": (v11/*: any*/),
+        "fair.fairArtworksForAggregation.aggregations.slice": (v15/*: any*/),
+        "fair.fairArtworksForAggregation.id": (v17/*: any*/),
+        "fair.id": (v17/*: any*/),
+        "fair.internalID": (v17/*: any*/),
+        "fair.slug": (v17/*: any*/)
       }
     },
     "name": "Fair2AllFollowedArtistsTestsQuery",

--- a/src/__generated__/Fair2ArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/Fair2ArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 9f966c9312be9746fb8988576efc9dde */
+/* @relayHash 0cf010794b13e7f1711fdf2ef35d29b0 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -97,6 +97,17 @@ fragment ArtworkGridItem_artwork on Artwork {
 fragment Fair2Artworks_fair_17LhbE on Fair {
   slug
   internalID
+  fairArtworksForAggregation: filterArtworksConnection(first: 0, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
+    id
+  }
   fairArtworks: filterArtworksConnection(first: 30, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, includeArtworksByFollowedArtists: $includeArtworksByFollowedArtists, artistIDs: $artistIDs, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
     aggregations {
       slice
@@ -318,28 +329,87 @@ v31 = {
   "name": "internalID",
   "storageKey": null
 },
-v32 = [
+v32 = {
+  "kind": "Literal",
+  "name": "aggregations",
+  "value": [
+    "COLOR",
+    "DIMENSION_RANGE",
+    "GALLERY",
+    "INSTITUTION",
+    "MAJOR_PERIOD",
+    "MEDIUM",
+    "PRICE_RANGE",
+    "FOLLOWED_ARTISTS",
+    "ARTIST"
+  ]
+},
+v33 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v34 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ArtworksAggregationResults",
+  "kind": "LinkedField",
+  "name": "aggregations",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slice",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AggregationCount",
+      "kind": "LinkedField",
+      "name": "counts",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "count",
+          "storageKey": null
+        },
+        (v33/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "value",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v35 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v36 = [
   (v17/*: any*/),
   {
     "kind": "Variable",
     "name": "after",
     "variableName": "cursor"
   },
-  {
-    "kind": "Literal",
-    "name": "aggregations",
-    "value": [
-      "COLOR",
-      "DIMENSION_RANGE",
-      "GALLERY",
-      "INSTITUTION",
-      "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
-      "FOLLOWED_ARTISTS",
-      "ARTIST"
-    ]
-  },
+  (v32/*: any*/),
   (v18/*: any*/),
   (v19/*: any*/),
   (v20/*: any*/),
@@ -358,21 +428,7 @@ v32 = [
   (v28/*: any*/),
   (v29/*: any*/)
 ],
-v33 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v34 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v35 = {
+v37 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -481,57 +537,34 @@ return {
           (v30/*: any*/),
           (v31/*: any*/),
           {
-            "alias": "fairArtworks",
-            "args": (v32/*: any*/),
+            "alias": "fairArtworksForAggregation",
+            "args": [
+              (v32/*: any*/),
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 0
+              }
+            ],
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "ArtworksAggregationResults",
-                "kind": "LinkedField",
-                "name": "aggregations",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "slice",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "AggregationCount",
-                    "kind": "LinkedField",
-                    "name": "counts",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "count",
-                        "storageKey": null
-                      },
-                      (v33/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "value",
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
+              (v34/*: any*/),
+              (v35/*: any*/)
+            ],
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:0)"
+          },
+          {
+            "alias": "fairArtworks",
+            "args": (v36/*: any*/),
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              (v34/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -548,8 +581,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v34/*: any*/),
-                      (v35/*: any*/)
+                      (v35/*: any*/),
+                      (v37/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -613,7 +646,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v34/*: any*/),
+              (v35/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -643,7 +676,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v35/*: any*/),
+                      (v37/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -756,7 +789,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v34/*: any*/)
+                              (v35/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -811,7 +844,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v34/*: any*/)
+                              (v35/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -824,7 +857,7 @@ return {
                             "plural": false,
                             "selections": [
                               (v33/*: any*/),
-                              (v34/*: any*/)
+                              (v35/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -834,7 +867,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v34/*: any*/)
+                          (v35/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -851,7 +884,7 @@ return {
           },
           {
             "alias": "fairArtworks",
-            "args": (v32/*: any*/),
+            "args": (v36/*: any*/),
             "filters": [
               "sort",
               "medium",
@@ -873,14 +906,14 @@ return {
             "kind": "LinkedHandle",
             "name": "filterArtworksConnection"
           },
-          (v34/*: any*/)
+          (v35/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "9f966c9312be9746fb8988576efc9dde",
+    "id": "0cf010794b13e7f1711fdf2ef35d29b0",
     "metadata": {},
     "name": "Fair2ArtworksInfiniteScrollGridQuery",
     "operationKind": "query",

--- a/src/__generated__/Fair2ArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/Fair2ArtworksTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 8d11899e75851010b7c3e8eaf815ee38 */
+/* @relayHash e19946e47a89a3179c26f3465a5f1c42 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -68,6 +68,17 @@ fragment ArtworkGridItem_artwork on Artwork {
 fragment Fair2Artworks_fair on Fair {
   slug
   internalID
+  fairArtworksForAggregation: filterArtworksConnection(first: 0, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
+    id
+  }
   fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
     aggregations {
       slice
@@ -151,22 +162,81 @@ v3 = {
   "name": "internalID",
   "storageKey": null
 },
-v4 = [
-  {
-    "kind": "Literal",
-    "name": "aggregations",
-    "value": [
-      "COLOR",
-      "DIMENSION_RANGE",
-      "GALLERY",
-      "INSTITUTION",
-      "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
-      "FOLLOWED_ARTISTS",
-      "ARTIST"
-    ]
-  },
+v4 = {
+  "kind": "Literal",
+  "name": "aggregations",
+  "value": [
+    "COLOR",
+    "DIMENSION_RANGE",
+    "GALLERY",
+    "INSTITUTION",
+    "MAJOR_PERIOD",
+    "MEDIUM",
+    "PRICE_RANGE",
+    "FOLLOWED_ARTISTS",
+    "ARTIST"
+  ]
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ArtworksAggregationResults",
+  "kind": "LinkedField",
+  "name": "aggregations",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slice",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AggregationCount",
+      "kind": "LinkedField",
+      "name": "counts",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "count",
+          "storageKey": null
+        },
+        (v5/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "value",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v8 = [
+  (v4/*: any*/),
   {
     "kind": "Literal",
     "name": "dimensionRange",
@@ -188,52 +258,82 @@ v4 = [
     "value": "-decayed_merch"
   }
 ],
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v7 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v8 = {
+v10 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "FilterArtworksConnection"
+},
+v11 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v9 = {
+v12 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": true,
+  "type": "ArtworksAggregationResults"
+},
+v13 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": true,
+  "type": "AggregationCount"
+},
+v14 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Int"
+},
+v15 = {
+  "enumValues": [
+    "ARTIST",
+    "COLOR",
+    "DIMENSION_RANGE",
+    "FOLLOWED_ARTISTS",
+    "GALLERY",
+    "INSTITUTION",
+    "MAJOR_PERIOD",
+    "MEDIUM",
+    "MERCHANDISABLE_ARTISTS",
+    "PARTNER_CITY",
+    "PERIOD",
+    "PRICE_RANGE",
+    "TOTAL"
+  ],
+  "nullable": true,
+  "plural": false,
+  "type": "ArtworkAggregation"
+},
+v16 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FormattedNumber"
 },
-v10 = {
+v17 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v11 = {
+v18 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v12 = {
+v19 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -283,57 +383,34 @@ return {
           (v2/*: any*/),
           (v3/*: any*/),
           {
-            "alias": "fairArtworks",
-            "args": (v4/*: any*/),
+            "alias": "fairArtworksForAggregation",
+            "args": [
+              (v4/*: any*/),
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 0
+              }
+            ],
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "ArtworksAggregationResults",
-                "kind": "LinkedField",
-                "name": "aggregations",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "slice",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "AggregationCount",
-                    "kind": "LinkedField",
-                    "name": "counts",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "count",
-                        "storageKey": null
-                      },
-                      (v5/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "value",
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
+              (v6/*: any*/),
+              (v7/*: any*/)
+            ],
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:0)"
+          },
+          {
+            "alias": "fairArtworks",
+            "args": (v8/*: any*/),
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              (v6/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -350,8 +427,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
-                      (v7/*: any*/)
+                      (v7/*: any*/),
+                      (v9/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -415,7 +492,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v6/*: any*/),
+              (v7/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -445,7 +522,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v7/*: any*/),
+                      (v9/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -558,7 +635,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v6/*: any*/)
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -613,7 +690,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v6/*: any*/)
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -626,7 +703,7 @@ return {
                             "plural": false,
                             "selections": [
                               (v5/*: any*/),
-                              (v6/*: any*/)
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -636,7 +713,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v6/*: any*/)
+                          (v7/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -653,7 +730,7 @@ return {
           },
           {
             "alias": "fairArtworks",
-            "args": (v4/*: any*/),
+            "args": (v8/*: any*/),
             "filters": [
               "sort",
               "medium",
@@ -675,14 +752,14 @@ return {
             "kind": "LinkedHandle",
             "name": "filterArtworksConnection"
           },
-          (v6/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "8d11899e75851010b7c3e8eaf815ee38",
+    "id": "e19946e47a89a3179c26f3465a5f1c42",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "fair": {
@@ -691,82 +768,43 @@ return {
           "plural": false,
           "type": "Fair"
         },
-        "fair.fairArtworks": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "FilterArtworksConnection"
-        },
-        "fair.fairArtworks.__isArtworkConnectionInterface": (v8/*: any*/),
-        "fair.fairArtworks.aggregations": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "ArtworksAggregationResults"
-        },
-        "fair.fairArtworks.aggregations.counts": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "AggregationCount"
-        },
-        "fair.fairArtworks.aggregations.counts.count": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Int"
-        },
-        "fair.fairArtworks.aggregations.counts.name": (v8/*: any*/),
-        "fair.fairArtworks.aggregations.counts.value": (v8/*: any*/),
-        "fair.fairArtworks.aggregations.slice": {
-          "enumValues": [
-            "ARTIST",
-            "COLOR",
-            "DIMENSION_RANGE",
-            "FOLLOWED_ARTISTS",
-            "GALLERY",
-            "INSTITUTION",
-            "MAJOR_PERIOD",
-            "MEDIUM",
-            "MERCHANDISABLE_ARTISTS",
-            "PARTNER_CITY",
-            "PERIOD",
-            "PRICE_RANGE",
-            "TOTAL"
-          ],
-          "nullable": true,
-          "plural": false,
-          "type": "ArtworkAggregation"
-        },
+        "fair.fairArtworks": (v10/*: any*/),
+        "fair.fairArtworks.__isArtworkConnectionInterface": (v11/*: any*/),
+        "fair.fairArtworks.aggregations": (v12/*: any*/),
+        "fair.fairArtworks.aggregations.counts": (v13/*: any*/),
+        "fair.fairArtworks.aggregations.counts.count": (v14/*: any*/),
+        "fair.fairArtworks.aggregations.counts.name": (v11/*: any*/),
+        "fair.fairArtworks.aggregations.counts.value": (v11/*: any*/),
+        "fair.fairArtworks.aggregations.slice": (v15/*: any*/),
         "fair.fairArtworks.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FilterArtworksCounts"
         },
-        "fair.fairArtworks.counts.followedArtists": (v9/*: any*/),
-        "fair.fairArtworks.counts.total": (v9/*: any*/),
+        "fair.fairArtworks.counts.followedArtists": (v16/*: any*/),
+        "fair.fairArtworks.counts.total": (v16/*: any*/),
         "fair.fairArtworks.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "ArtworkEdgeInterface"
         },
-        "fair.fairArtworks.edges.__isNode": (v8/*: any*/),
-        "fair.fairArtworks.edges.__typename": (v8/*: any*/),
-        "fair.fairArtworks.edges.cursor": (v8/*: any*/),
-        "fair.fairArtworks.edges.id": (v10/*: any*/),
+        "fair.fairArtworks.edges.__isNode": (v11/*: any*/),
+        "fair.fairArtworks.edges.__typename": (v11/*: any*/),
+        "fair.fairArtworks.edges.cursor": (v11/*: any*/),
+        "fair.fairArtworks.edges.id": (v17/*: any*/),
         "fair.fairArtworks.edges.node": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Artwork"
         },
-        "fair.fairArtworks.edges.node.__typename": (v8/*: any*/),
-        "fair.fairArtworks.edges.node.artistNames": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.date": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.href": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.id": (v10/*: any*/),
+        "fair.fairArtworks.edges.node.__typename": (v11/*: any*/),
+        "fair.fairArtworks.edges.node.artistNames": (v18/*: any*/),
+        "fair.fairArtworks.edges.node.date": (v18/*: any*/),
+        "fair.fairArtworks.edges.node.href": (v18/*: any*/),
+        "fair.fairArtworks.edges.node.id": (v17/*: any*/),
         "fair.fairArtworks.edges.node.image": {
           "enumValues": null,
           "nullable": true,
@@ -779,27 +817,27 @@ return {
           "plural": false,
           "type": "Float"
         },
-        "fair.fairArtworks.edges.node.image.url": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.internalID": (v10/*: any*/),
+        "fair.fairArtworks.edges.node.image.url": (v18/*: any*/),
+        "fair.fairArtworks.edges.node.internalID": (v17/*: any*/),
         "fair.fairArtworks.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "fair.fairArtworks.edges.node.partner.id": (v10/*: any*/),
-        "fair.fairArtworks.edges.node.partner.name": (v11/*: any*/),
+        "fair.fairArtworks.edges.node.partner.id": (v17/*: any*/),
+        "fair.fairArtworks.edges.node.partner.name": (v18/*: any*/),
         "fair.fairArtworks.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "fair.fairArtworks.edges.node.sale.displayTimelyAt": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.sale.endAt": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.sale.id": (v10/*: any*/),
-        "fair.fairArtworks.edges.node.sale.isAuction": (v12/*: any*/),
-        "fair.fairArtworks.edges.node.sale.isClosed": (v12/*: any*/),
+        "fair.fairArtworks.edges.node.sale.displayTimelyAt": (v18/*: any*/),
+        "fair.fairArtworks.edges.node.sale.endAt": (v18/*: any*/),
+        "fair.fairArtworks.edges.node.sale.id": (v17/*: any*/),
+        "fair.fairArtworks.edges.node.sale.isAuction": (v19/*: any*/),
+        "fair.fairArtworks.edges.node.sale.isClosed": (v19/*: any*/),
         "fair.fairArtworks.edges.node.saleArtwork": {
           "enumValues": null,
           "nullable": true,
@@ -812,37 +850,45 @@ return {
           "plural": false,
           "type": "SaleArtworkCounts"
         },
-        "fair.fairArtworks.edges.node.saleArtwork.counts.bidderPositions": (v9/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.counts.bidderPositions": (v16/*: any*/),
         "fair.fairArtworks.edges.node.saleArtwork.currentBid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCurrentBid"
         },
-        "fair.fairArtworks.edges.node.saleArtwork.currentBid.display": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork.id": (v10/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork.lotLabel": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.saleMessage": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.slug": (v10/*: any*/),
-        "fair.fairArtworks.edges.node.title": (v11/*: any*/),
-        "fair.fairArtworks.id": (v10/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.currentBid.display": (v18/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.id": (v17/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.lotLabel": (v18/*: any*/),
+        "fair.fairArtworks.edges.node.saleMessage": (v18/*: any*/),
+        "fair.fairArtworks.edges.node.slug": (v17/*: any*/),
+        "fair.fairArtworks.edges.node.title": (v18/*: any*/),
+        "fair.fairArtworks.id": (v17/*: any*/),
         "fair.fairArtworks.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "fair.fairArtworks.pageInfo.endCursor": (v11/*: any*/),
+        "fair.fairArtworks.pageInfo.endCursor": (v18/*: any*/),
         "fair.fairArtworks.pageInfo.hasNextPage": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Boolean"
         },
-        "fair.fairArtworks.pageInfo.startCursor": (v11/*: any*/),
-        "fair.id": (v10/*: any*/),
-        "fair.internalID": (v10/*: any*/),
-        "fair.slug": (v10/*: any*/)
+        "fair.fairArtworks.pageInfo.startCursor": (v18/*: any*/),
+        "fair.fairArtworksForAggregation": (v10/*: any*/),
+        "fair.fairArtworksForAggregation.aggregations": (v12/*: any*/),
+        "fair.fairArtworksForAggregation.aggregations.counts": (v13/*: any*/),
+        "fair.fairArtworksForAggregation.aggregations.counts.count": (v14/*: any*/),
+        "fair.fairArtworksForAggregation.aggregations.counts.name": (v11/*: any*/),
+        "fair.fairArtworksForAggregation.aggregations.counts.value": (v11/*: any*/),
+        "fair.fairArtworksForAggregation.aggregations.slice": (v15/*: any*/),
+        "fair.fairArtworksForAggregation.id": (v17/*: any*/),
+        "fair.id": (v17/*: any*/),
+        "fair.internalID": (v17/*: any*/),
+        "fair.slug": (v17/*: any*/)
       }
     },
     "name": "Fair2ArtworksTestsQuery",

--- a/src/__generated__/Fair2Artworks_fair.graphql.ts
+++ b/src/__generated__/Fair2Artworks_fair.graphql.ts
@@ -8,6 +8,16 @@ export type ArtworkAggregation = "ARTIST" | "COLOR" | "DIMENSION_RANGE" | "FOLLO
 export type Fair2Artworks_fair = {
     readonly slug: string;
     readonly internalID: string;
+    readonly fairArtworksForAggregation: {
+        readonly aggregations: ReadonlyArray<{
+            readonly slice: ArtworkAggregation | null;
+            readonly counts: ReadonlyArray<{
+                readonly count: number;
+                readonly name: string;
+                readonly value: string;
+            } | null> | null;
+        } | null> | null;
+    } | null;
     readonly fairArtworks: {
         readonly aggregations: ReadonlyArray<{
             readonly slice: ArtworkAggregation | null;
@@ -38,7 +48,73 @@ export type Fair2Artworks_fair$key = {
 
 
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = {
+  "kind": "Literal",
+  "name": "aggregations",
+  "value": [
+    "COLOR",
+    "DIMENSION_RANGE",
+    "GALLERY",
+    "INSTITUTION",
+    "MAJOR_PERIOD",
+    "MEDIUM",
+    "PRICE_RANGE",
+    "FOLLOWED_ARTISTS",
+    "ARTIST"
+  ]
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ArtworksAggregationResults",
+  "kind": "LinkedField",
+  "name": "aggregations",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slice",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AggregationCount",
+      "kind": "LinkedField",
+      "name": "counts",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "count",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "value",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
   "argumentDefinitions": [
     {
       "defaultValue": null,
@@ -146,6 +222,25 @@ const node: ReaderFragment = {
       "storageKey": null
     },
     {
+      "alias": "fairArtworksForAggregation",
+      "args": [
+        (v0/*: any*/),
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 0
+        }
+      ],
+      "concreteType": "FilterArtworksConnection",
+      "kind": "LinkedField",
+      "name": "filterArtworksConnection",
+      "plural": false,
+      "selections": [
+        (v1/*: any*/)
+      ],
+      "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:0)"
+    },
+    {
       "alias": "fairArtworks",
       "args": [
         {
@@ -153,21 +248,7 @@ const node: ReaderFragment = {
           "name": "acquireable",
           "variableName": "acquireable"
         },
-        {
-          "kind": "Literal",
-          "name": "aggregations",
-          "value": [
-            "COLOR",
-            "DIMENSION_RANGE",
-            "GALLERY",
-            "INSTITUTION",
-            "MAJOR_PERIOD",
-            "MEDIUM",
-            "PRICE_RANGE",
-            "FOLLOWED_ARTISTS",
-            "ARTIST"
-          ]
-        },
+        (v0/*: any*/),
         {
           "kind": "Variable",
           "name": "artistIDs",
@@ -234,56 +315,7 @@ const node: ReaderFragment = {
       "name": "__Fair_fairArtworks_connection",
       "plural": false,
       "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "ArtworksAggregationResults",
-          "kind": "LinkedField",
-          "name": "aggregations",
-          "plural": true,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "slice",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "concreteType": "AggregationCount",
-              "kind": "LinkedField",
-              "name": "counts",
-              "plural": true,
-              "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "count",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "name",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "value",
-                  "storageKey": null
-                }
-              ],
-              "storageKey": null
-            }
-          ],
-          "storageKey": null
-        },
+        (v1/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -389,5 +421,6 @@ const node: ReaderFragment = {
   "type": "Fair",
   "abstractKey": null
 };
-(node as any).hash = '59228d2f0ab1eda622f6cb4228860f18';
+})();
+(node as any).hash = '51e8633daecb312941181893d06d11b5';
 export default node;

--- a/src/__generated__/Fair2Query.graphql.ts
+++ b/src/__generated__/Fair2Query.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 9f4bb99a693f864b561e9fbf93b48e31 */
+/* @relayHash 99c8422411c6b5036cf099258ea51b90 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -79,6 +79,17 @@ fragment ArtworkTileRailCard_artwork on Artwork {
 fragment Fair2Artworks_fair on Fair {
   slug
   internalID
+  fairArtworksForAggregation: filterArtworksConnection(first: 0, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
+    id
+  }
   fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
     aggregations {
       slice
@@ -492,31 +503,76 @@ v17 = {
 },
 v18 = {
   "kind": "Literal",
+  "name": "aggregations",
+  "value": [
+    "COLOR",
+    "DIMENSION_RANGE",
+    "GALLERY",
+    "INSTITUTION",
+    "MAJOR_PERIOD",
+    "MEDIUM",
+    "PRICE_RANGE",
+    "FOLLOWED_ARTISTS",
+    "ARTIST"
+  ]
+},
+v19 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ArtworksAggregationResults",
+  "kind": "LinkedField",
+  "name": "aggregations",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slice",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AggregationCount",
+      "kind": "LinkedField",
+      "name": "counts",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "count",
+          "storageKey": null
+        },
+        (v14/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "value",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v20 = {
+  "kind": "Literal",
   "name": "first",
   "value": 30
 },
-v19 = [
-  {
-    "kind": "Literal",
-    "name": "aggregations",
-    "value": [
-      "COLOR",
-      "DIMENSION_RANGE",
-      "GALLERY",
-      "INSTITUTION",
-      "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
-      "FOLLOWED_ARTISTS",
-      "ARTIST"
-    ]
-  },
+v21 = [
+  (v18/*: any*/),
   {
     "kind": "Literal",
     "name": "dimensionRange",
     "value": "*-*"
   },
-  (v18/*: any*/),
+  (v20/*: any*/),
   {
     "kind": "Literal",
     "name": "medium",
@@ -528,14 +584,14 @@ v19 = [
     "value": "-decayed_merch"
   }
 ],
-v20 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v21 = {
+v23 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -560,21 +616,21 @@ v21 = {
   ],
   "storageKey": null
 },
-v22 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isAuction",
   "storageKey": null
 },
-v23 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v24 = {
+v26 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCounts",
@@ -592,7 +648,7 @@ v24 = {
   ],
   "storageKey": null
 },
-v25 = [
+v27 = [
   {
     "alias": null,
     "args": null,
@@ -601,17 +657,17 @@ v25 = [
     "storageKey": null
   }
 ],
-v26 = {
+v28 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCurrentBid",
   "kind": "LinkedField",
   "name": "currentBid",
   "plural": false,
-  "selections": (v25/*: any*/),
+  "selections": (v27/*: any*/),
   "storageKey": null
 },
-v27 = {
+v29 = {
   "kind": "InlineFragment",
   "selections": [
     (v5/*: any*/)
@@ -619,15 +675,15 @@ v27 = {
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v28 = [
-  (v18/*: any*/),
+v30 = [
+  (v20/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "FEATURED_ASC"
   }
 ],
-v29 = [
+v31 = [
   (v5/*: any*/),
   (v14/*: any*/)
 ];
@@ -1125,57 +1181,34 @@ return {
           },
           (v17/*: any*/),
           {
-            "alias": "fairArtworks",
-            "args": (v19/*: any*/),
+            "alias": "fairArtworksForAggregation",
+            "args": [
+              (v18/*: any*/),
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 0
+              }
+            ],
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "ArtworksAggregationResults",
-                "kind": "LinkedField",
-                "name": "aggregations",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "slice",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "AggregationCount",
-                    "kind": "LinkedField",
-                    "name": "counts",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "count",
-                        "storageKey": null
-                      },
-                      (v14/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "value",
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
+              (v19/*: any*/),
+              (v5/*: any*/)
+            ],
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:0)"
+          },
+          {
+            "alias": "fairArtworks",
+            "args": (v21/*: any*/),
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              (v19/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1197,7 +1230,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v20/*: any*/)
+                  (v22/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -1226,7 +1259,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v21/*: any*/),
+              (v23/*: any*/),
               (v5/*: any*/),
               {
                 "kind": "InlineFragment",
@@ -1312,8 +1345,8 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v22/*: any*/),
-                              (v23/*: any*/),
+                              (v24/*: any*/),
+                              (v25/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1334,8 +1367,8 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v24/*: any*/),
                               (v26/*: any*/),
+                              (v28/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1363,7 +1396,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v27/*: any*/)
+                      (v29/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1376,7 +1409,7 @@ return {
           },
           {
             "alias": "fairArtworks",
-            "args": (v19/*: any*/),
+            "args": (v21/*: any*/),
             "filters": [
               "sort",
               "medium",
@@ -1400,7 +1433,7 @@ return {
           },
           {
             "alias": "exhibitors",
-            "args": (v28/*: any*/),
+            "args": (v30/*: any*/),
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
@@ -1446,17 +1479,17 @@ return {
                           (v4/*: any*/),
                           {
                             "kind": "InlineFragment",
-                            "selections": (v29/*: any*/),
+                            "selections": (v31/*: any*/),
                             "type": "Partner",
                             "abstractKey": null
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v29/*: any*/),
+                            "selections": (v31/*: any*/),
                             "type": "ExternalPartner",
                             "abstractKey": null
                           },
-                          (v27/*: any*/)
+                          (v29/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -1535,7 +1568,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "openingBid",
                                         "plural": false,
-                                        "selections": (v25/*: any*/),
+                                        "selections": (v27/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -1545,11 +1578,11 @@ return {
                                         "kind": "LinkedField",
                                         "name": "highestBid",
                                         "plural": false,
-                                        "selections": (v25/*: any*/),
+                                        "selections": (v27/*: any*/),
                                         "storageKey": null
                                       },
+                                      (v28/*: any*/),
                                       (v26/*: any*/),
-                                      (v24/*: any*/),
                                       (v5/*: any*/)
                                     ],
                                     "storageKey": null
@@ -1562,8 +1595,8 @@ return {
                                     "name": "sale",
                                     "plural": false,
                                     "selections": [
-                                      (v23/*: any*/),
-                                      (v22/*: any*/),
+                                      (v25/*: any*/),
+                                      (v24/*: any*/),
                                       (v17/*: any*/),
                                       (v5/*: any*/)
                                     ],
@@ -1585,17 +1618,17 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v20/*: any*/)
+                  (v22/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v21/*: any*/)
+              (v23/*: any*/)
             ],
             "storageKey": "showsConnection(first:30,sort:\"FEATURED_ASC\")"
           },
           {
             "alias": "exhibitors",
-            "args": (v28/*: any*/),
+            "args": (v30/*: any*/),
             "filters": [
               "sort"
             ],
@@ -1611,7 +1644,7 @@ return {
     ]
   },
   "params": {
-    "id": "9f4bb99a693f864b561e9fbf93b48e31",
+    "id": "99c8422411c6b5036cf099258ea51b90",
     "metadata": {},
     "name": "Fair2Query",
     "operationKind": "query",

--- a/src/__generated__/Fair2TestsQuery.graphql.ts
+++ b/src/__generated__/Fair2TestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 5c7798badce879b2a9e99ea2bb1cffa6 */
+/* @relayHash 40efdd665182cc0a94a01848f79dca8f */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -79,6 +79,17 @@ fragment ArtworkTileRailCard_artwork on Artwork {
 fragment Fair2Artworks_fair on Fair {
   slug
   internalID
+  fairArtworksForAggregation: filterArtworksConnection(first: 0, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
+    id
+  }
   fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
     aggregations {
       slice
@@ -492,31 +503,76 @@ v17 = {
 },
 v18 = {
   "kind": "Literal",
+  "name": "aggregations",
+  "value": [
+    "COLOR",
+    "DIMENSION_RANGE",
+    "GALLERY",
+    "INSTITUTION",
+    "MAJOR_PERIOD",
+    "MEDIUM",
+    "PRICE_RANGE",
+    "FOLLOWED_ARTISTS",
+    "ARTIST"
+  ]
+},
+v19 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ArtworksAggregationResults",
+  "kind": "LinkedField",
+  "name": "aggregations",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slice",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AggregationCount",
+      "kind": "LinkedField",
+      "name": "counts",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "count",
+          "storageKey": null
+        },
+        (v14/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "value",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v20 = {
+  "kind": "Literal",
   "name": "first",
   "value": 30
 },
-v19 = [
-  {
-    "kind": "Literal",
-    "name": "aggregations",
-    "value": [
-      "COLOR",
-      "DIMENSION_RANGE",
-      "GALLERY",
-      "INSTITUTION",
-      "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
-      "FOLLOWED_ARTISTS",
-      "ARTIST"
-    ]
-  },
+v21 = [
+  (v18/*: any*/),
   {
     "kind": "Literal",
     "name": "dimensionRange",
     "value": "*-*"
   },
-  (v18/*: any*/),
+  (v20/*: any*/),
   {
     "kind": "Literal",
     "name": "medium",
@@ -528,14 +584,14 @@ v19 = [
     "value": "-decayed_merch"
   }
 ],
-v20 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v21 = {
+v23 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -560,21 +616,21 @@ v21 = {
   ],
   "storageKey": null
 },
-v22 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isAuction",
   "storageKey": null
 },
-v23 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v24 = {
+v26 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCounts",
@@ -592,7 +648,7 @@ v24 = {
   ],
   "storageKey": null
 },
-v25 = [
+v27 = [
   {
     "alias": null,
     "args": null,
@@ -601,17 +657,17 @@ v25 = [
     "storageKey": null
   }
 ],
-v26 = {
+v28 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCurrentBid",
   "kind": "LinkedField",
   "name": "currentBid",
   "plural": false,
-  "selections": (v25/*: any*/),
+  "selections": (v27/*: any*/),
   "storageKey": null
 },
-v27 = {
+v29 = {
   "kind": "InlineFragment",
   "selections": [
     (v5/*: any*/)
@@ -619,121 +675,159 @@ v27 = {
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v28 = [
-  (v18/*: any*/),
+v30 = [
+  (v20/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "FEATURED_ASC"
   }
 ],
-v29 = [
+v31 = [
   (v5/*: any*/),
   (v14/*: any*/)
 ],
-v30 = {
+v32 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Fair"
 },
-v31 = {
+v33 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v32 = {
+v34 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v33 = {
+v35 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v34 = {
+v36 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
 },
-v35 = {
+v37 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FormattedNumber"
 },
-v36 = {
+v38 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Artwork"
 },
-v37 = {
+v39 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Float"
 },
-v38 = {
+v40 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Sale"
 },
-v39 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Boolean"
-},
-v40 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "SaleArtwork"
-},
 v41 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "SaleArtworkCounts"
+  "type": "Boolean"
 },
 v42 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "SaleArtworkCurrentBid"
+  "type": "SaleArtwork"
 },
 v43 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "SaleArtworkCounts"
+},
+v44 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "SaleArtworkCurrentBid"
+},
+v45 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "PageInfo"
 },
-v44 = {
+v46 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Boolean"
 },
-v45 = {
+v47 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FilterArtworksConnection"
 },
-v46 = {
+v48 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": true,
+  "type": "ArtworksAggregationResults"
+},
+v49 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": true,
+  "type": "AggregationCount"
+},
+v50 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Int"
+},
+v51 = {
+  "enumValues": [
+    "ARTIST",
+    "COLOR",
+    "DIMENSION_RANGE",
+    "FOLLOWED_ARTISTS",
+    "GALLERY",
+    "INSTITUTION",
+    "MAJOR_PERIOD",
+    "MEDIUM",
+    "MERCHANDISABLE_ARTISTS",
+    "PARTNER_CITY",
+    "PERIOD",
+    "PRICE_RANGE",
+    "TOTAL"
+  ],
+  "nullable": true,
+  "plural": false,
+  "type": "ArtworkAggregation"
+},
+v52 = {
   "enumValues": null,
   "nullable": true,
   "plural": true,
   "type": "FilterArtworksEdge"
 },
-v47 = {
+v53 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -1233,57 +1327,34 @@ return {
           },
           (v17/*: any*/),
           {
-            "alias": "fairArtworks",
-            "args": (v19/*: any*/),
+            "alias": "fairArtworksForAggregation",
+            "args": [
+              (v18/*: any*/),
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 0
+              }
+            ],
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "ArtworksAggregationResults",
-                "kind": "LinkedField",
-                "name": "aggregations",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "slice",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "AggregationCount",
-                    "kind": "LinkedField",
-                    "name": "counts",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "count",
-                        "storageKey": null
-                      },
-                      (v14/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "value",
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
+              (v19/*: any*/),
+              (v5/*: any*/)
+            ],
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:0)"
+          },
+          {
+            "alias": "fairArtworks",
+            "args": (v21/*: any*/),
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              (v19/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1305,7 +1376,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v20/*: any*/)
+                  (v22/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -1334,7 +1405,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v21/*: any*/),
+              (v23/*: any*/),
               (v5/*: any*/),
               {
                 "kind": "InlineFragment",
@@ -1420,8 +1491,8 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v22/*: any*/),
-                              (v23/*: any*/),
+                              (v24/*: any*/),
+                              (v25/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1442,8 +1513,8 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v24/*: any*/),
                               (v26/*: any*/),
+                              (v28/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1471,7 +1542,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v27/*: any*/)
+                      (v29/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1484,7 +1555,7 @@ return {
           },
           {
             "alias": "fairArtworks",
-            "args": (v19/*: any*/),
+            "args": (v21/*: any*/),
             "filters": [
               "sort",
               "medium",
@@ -1508,7 +1579,7 @@ return {
           },
           {
             "alias": "exhibitors",
-            "args": (v28/*: any*/),
+            "args": (v30/*: any*/),
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
@@ -1554,17 +1625,17 @@ return {
                           (v4/*: any*/),
                           {
                             "kind": "InlineFragment",
-                            "selections": (v29/*: any*/),
+                            "selections": (v31/*: any*/),
                             "type": "Partner",
                             "abstractKey": null
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v29/*: any*/),
+                            "selections": (v31/*: any*/),
                             "type": "ExternalPartner",
                             "abstractKey": null
                           },
-                          (v27/*: any*/)
+                          (v29/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -1643,7 +1714,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "openingBid",
                                         "plural": false,
-                                        "selections": (v25/*: any*/),
+                                        "selections": (v27/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -1653,11 +1724,11 @@ return {
                                         "kind": "LinkedField",
                                         "name": "highestBid",
                                         "plural": false,
-                                        "selections": (v25/*: any*/),
+                                        "selections": (v27/*: any*/),
                                         "storageKey": null
                                       },
+                                      (v28/*: any*/),
                                       (v26/*: any*/),
-                                      (v24/*: any*/),
                                       (v5/*: any*/)
                                     ],
                                     "storageKey": null
@@ -1670,8 +1741,8 @@ return {
                                     "name": "sale",
                                     "plural": false,
                                     "selections": [
-                                      (v23/*: any*/),
-                                      (v22/*: any*/),
+                                      (v25/*: any*/),
+                                      (v24/*: any*/),
                                       (v17/*: any*/),
                                       (v5/*: any*/)
                                     ],
@@ -1693,17 +1764,17 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v20/*: any*/)
+                  (v22/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v21/*: any*/)
+              (v23/*: any*/)
             ],
             "storageKey": "showsConnection(first:30,sort:\"FEATURED_ASC\")"
           },
           {
             "alias": "exhibitors",
-            "args": (v28/*: any*/),
+            "args": (v30/*: any*/),
             "filters": [
               "sort"
             ],
@@ -1719,11 +1790,11 @@ return {
     ]
   },
   "params": {
-    "id": "5c7798badce879b2a9e99ea2bb1cffa6",
+    "id": "40efdd665182cc0a94a01848f79dca8f",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "fair": (v30/*: any*/),
-        "fair.about": (v31/*: any*/),
+        "fair": (v32/*: any*/),
+        "fair.about": (v33/*: any*/),
         "fair.articles": {
           "enumValues": null,
           "nullable": true,
@@ -1736,31 +1807,31 @@ return {
           "plural": true,
           "type": "ArticleEdge"
         },
-        "fair.articles.edges.__typename": (v32/*: any*/),
+        "fair.articles.edges.__typename": (v34/*: any*/),
         "fair.articles.edges.node": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Article"
         },
-        "fair.articles.edges.node.href": (v31/*: any*/),
-        "fair.articles.edges.node.id": (v33/*: any*/),
-        "fair.articles.edges.node.internalID": (v33/*: any*/),
-        "fair.articles.edges.node.publishedAt": (v31/*: any*/),
-        "fair.articles.edges.node.slug": (v31/*: any*/),
-        "fair.articles.edges.node.thumbnailImage": (v34/*: any*/),
-        "fair.articles.edges.node.thumbnailImage.src": (v31/*: any*/),
-        "fair.articles.edges.node.title": (v31/*: any*/),
+        "fair.articles.edges.node.href": (v33/*: any*/),
+        "fair.articles.edges.node.id": (v35/*: any*/),
+        "fair.articles.edges.node.internalID": (v35/*: any*/),
+        "fair.articles.edges.node.publishedAt": (v33/*: any*/),
+        "fair.articles.edges.node.slug": (v33/*: any*/),
+        "fair.articles.edges.node.thumbnailImage": (v36/*: any*/),
+        "fair.articles.edges.node.thumbnailImage.src": (v33/*: any*/),
+        "fair.articles.edges.node.title": (v33/*: any*/),
         "fair.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FairCounts"
         },
-        "fair.counts.artworks": (v35/*: any*/),
-        "fair.counts.partnerShows": (v35/*: any*/),
-        "fair.endAt": (v31/*: any*/),
-        "fair.exhibitionPeriod": (v31/*: any*/),
+        "fair.counts.artworks": (v37/*: any*/),
+        "fair.counts.partnerShows": (v37/*: any*/),
+        "fair.endAt": (v33/*: any*/),
+        "fair.exhibitionPeriod": (v33/*: any*/),
         "fair.exhibitors": {
           "enumValues": null,
           "nullable": true,
@@ -1773,14 +1844,14 @@ return {
           "plural": true,
           "type": "ShowEdge"
         },
-        "fair.exhibitors.edges.cursor": (v32/*: any*/),
+        "fair.exhibitors.edges.cursor": (v34/*: any*/),
         "fair.exhibitors.edges.node": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Show"
         },
-        "fair.exhibitors.edges.node.__typename": (v32/*: any*/),
+        "fair.exhibitors.edges.node.__typename": (v34/*: any*/),
         "fair.exhibitors.edges.node.artworks": {
           "enumValues": null,
           "nullable": true,
@@ -1793,42 +1864,42 @@ return {
           "plural": true,
           "type": "ArtworkEdge"
         },
-        "fair.exhibitors.edges.node.artworks.edges.node": (v36/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.artistNames": (v31/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.href": (v31/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.id": (v33/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.image": (v34/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.image.aspectRatio": (v37/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.image.imageURL": (v31/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.internalID": (v33/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.sale": (v38/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.sale.endAt": (v31/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.sale.id": (v33/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.sale.isAuction": (v39/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.sale.isClosed": (v39/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork": (v40/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.counts": (v41/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.counts.bidderPositions": (v35/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.currentBid": (v42/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.currentBid.display": (v31/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node": (v38/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.artistNames": (v33/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.href": (v33/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.id": (v35/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.image": (v36/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.image.aspectRatio": (v39/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.image.imageURL": (v33/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.internalID": (v35/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.sale": (v40/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.sale.endAt": (v33/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.sale.id": (v35/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.sale.isAuction": (v41/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.sale.isClosed": (v41/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork": (v42/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.counts": (v43/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.counts.bidderPositions": (v37/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.currentBid": (v44/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.currentBid.display": (v33/*: any*/),
         "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.highestBid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.highestBid.display": (v31/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.id": (v33/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.highestBid.display": (v33/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.id": (v35/*: any*/),
         "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.openingBid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.openingBid.display": (v31/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.saleMessage": (v31/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.slug": (v33/*: any*/),
-        "fair.exhibitors.edges.node.artworks.edges.node.title": (v31/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleArtwork.openingBid.display": (v33/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.saleMessage": (v33/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.slug": (v35/*: any*/),
+        "fair.exhibitors.edges.node.artworks.edges.node.title": (v33/*: any*/),
         "fair.exhibitors.edges.node.counts": {
           "enumValues": null,
           "nullable": true,
@@ -1841,149 +1912,123 @@ return {
           "plural": false,
           "type": "Int"
         },
-        "fair.exhibitors.edges.node.fair": (v30/*: any*/),
-        "fair.exhibitors.edges.node.fair.id": (v33/*: any*/),
-        "fair.exhibitors.edges.node.fair.internalID": (v33/*: any*/),
-        "fair.exhibitors.edges.node.fair.slug": (v33/*: any*/),
-        "fair.exhibitors.edges.node.href": (v31/*: any*/),
-        "fair.exhibitors.edges.node.id": (v33/*: any*/),
-        "fair.exhibitors.edges.node.internalID": (v33/*: any*/),
+        "fair.exhibitors.edges.node.fair": (v32/*: any*/),
+        "fair.exhibitors.edges.node.fair.id": (v35/*: any*/),
+        "fair.exhibitors.edges.node.fair.internalID": (v35/*: any*/),
+        "fair.exhibitors.edges.node.fair.slug": (v35/*: any*/),
+        "fair.exhibitors.edges.node.href": (v33/*: any*/),
+        "fair.exhibitors.edges.node.id": (v35/*: any*/),
+        "fair.exhibitors.edges.node.internalID": (v35/*: any*/),
         "fair.exhibitors.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerTypes"
         },
-        "fair.exhibitors.edges.node.partner.__isNode": (v32/*: any*/),
-        "fair.exhibitors.edges.node.partner.__typename": (v32/*: any*/),
-        "fair.exhibitors.edges.node.partner.id": (v33/*: any*/),
-        "fair.exhibitors.edges.node.partner.name": (v31/*: any*/),
-        "fair.exhibitors.edges.node.slug": (v33/*: any*/),
-        "fair.exhibitors.pageInfo": (v43/*: any*/),
-        "fair.exhibitors.pageInfo.endCursor": (v31/*: any*/),
-        "fair.exhibitors.pageInfo.hasNextPage": (v44/*: any*/),
-        "fair.fairArtworks": (v45/*: any*/),
-        "fair.fairArtworks.__isArtworkConnectionInterface": (v32/*: any*/),
-        "fair.fairArtworks.aggregations": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "ArtworksAggregationResults"
-        },
-        "fair.fairArtworks.aggregations.counts": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "AggregationCount"
-        },
-        "fair.fairArtworks.aggregations.counts.count": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Int"
-        },
-        "fair.fairArtworks.aggregations.counts.name": (v32/*: any*/),
-        "fair.fairArtworks.aggregations.counts.value": (v32/*: any*/),
-        "fair.fairArtworks.aggregations.slice": {
-          "enumValues": [
-            "ARTIST",
-            "COLOR",
-            "DIMENSION_RANGE",
-            "FOLLOWED_ARTISTS",
-            "GALLERY",
-            "INSTITUTION",
-            "MAJOR_PERIOD",
-            "MEDIUM",
-            "MERCHANDISABLE_ARTISTS",
-            "PARTNER_CITY",
-            "PERIOD",
-            "PRICE_RANGE",
-            "TOTAL"
-          ],
-          "nullable": true,
-          "plural": false,
-          "type": "ArtworkAggregation"
-        },
+        "fair.exhibitors.edges.node.partner.__isNode": (v34/*: any*/),
+        "fair.exhibitors.edges.node.partner.__typename": (v34/*: any*/),
+        "fair.exhibitors.edges.node.partner.id": (v35/*: any*/),
+        "fair.exhibitors.edges.node.partner.name": (v33/*: any*/),
+        "fair.exhibitors.edges.node.slug": (v35/*: any*/),
+        "fair.exhibitors.pageInfo": (v45/*: any*/),
+        "fair.exhibitors.pageInfo.endCursor": (v33/*: any*/),
+        "fair.exhibitors.pageInfo.hasNextPage": (v46/*: any*/),
+        "fair.fairArtworks": (v47/*: any*/),
+        "fair.fairArtworks.__isArtworkConnectionInterface": (v34/*: any*/),
+        "fair.fairArtworks.aggregations": (v48/*: any*/),
+        "fair.fairArtworks.aggregations.counts": (v49/*: any*/),
+        "fair.fairArtworks.aggregations.counts.count": (v50/*: any*/),
+        "fair.fairArtworks.aggregations.counts.name": (v34/*: any*/),
+        "fair.fairArtworks.aggregations.counts.value": (v34/*: any*/),
+        "fair.fairArtworks.aggregations.slice": (v51/*: any*/),
         "fair.fairArtworks.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FilterArtworksCounts"
         },
-        "fair.fairArtworks.counts.followedArtists": (v35/*: any*/),
-        "fair.fairArtworks.counts.total": (v35/*: any*/),
+        "fair.fairArtworks.counts.followedArtists": (v37/*: any*/),
+        "fair.fairArtworks.counts.total": (v37/*: any*/),
         "fair.fairArtworks.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "ArtworkEdgeInterface"
         },
-        "fair.fairArtworks.edges.__isNode": (v32/*: any*/),
-        "fair.fairArtworks.edges.__typename": (v32/*: any*/),
-        "fair.fairArtworks.edges.cursor": (v32/*: any*/),
-        "fair.fairArtworks.edges.id": (v33/*: any*/),
-        "fair.fairArtworks.edges.node": (v36/*: any*/),
-        "fair.fairArtworks.edges.node.__typename": (v32/*: any*/),
-        "fair.fairArtworks.edges.node.artistNames": (v31/*: any*/),
-        "fair.fairArtworks.edges.node.date": (v31/*: any*/),
-        "fair.fairArtworks.edges.node.href": (v31/*: any*/),
-        "fair.fairArtworks.edges.node.id": (v33/*: any*/),
-        "fair.fairArtworks.edges.node.image": (v34/*: any*/),
-        "fair.fairArtworks.edges.node.image.aspectRatio": (v37/*: any*/),
-        "fair.fairArtworks.edges.node.image.url": (v31/*: any*/),
-        "fair.fairArtworks.edges.node.internalID": (v33/*: any*/),
+        "fair.fairArtworks.edges.__isNode": (v34/*: any*/),
+        "fair.fairArtworks.edges.__typename": (v34/*: any*/),
+        "fair.fairArtworks.edges.cursor": (v34/*: any*/),
+        "fair.fairArtworks.edges.id": (v35/*: any*/),
+        "fair.fairArtworks.edges.node": (v38/*: any*/),
+        "fair.fairArtworks.edges.node.__typename": (v34/*: any*/),
+        "fair.fairArtworks.edges.node.artistNames": (v33/*: any*/),
+        "fair.fairArtworks.edges.node.date": (v33/*: any*/),
+        "fair.fairArtworks.edges.node.href": (v33/*: any*/),
+        "fair.fairArtworks.edges.node.id": (v35/*: any*/),
+        "fair.fairArtworks.edges.node.image": (v36/*: any*/),
+        "fair.fairArtworks.edges.node.image.aspectRatio": (v39/*: any*/),
+        "fair.fairArtworks.edges.node.image.url": (v33/*: any*/),
+        "fair.fairArtworks.edges.node.internalID": (v35/*: any*/),
         "fair.fairArtworks.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "fair.fairArtworks.edges.node.partner.id": (v33/*: any*/),
-        "fair.fairArtworks.edges.node.partner.name": (v31/*: any*/),
-        "fair.fairArtworks.edges.node.sale": (v38/*: any*/),
-        "fair.fairArtworks.edges.node.sale.displayTimelyAt": (v31/*: any*/),
-        "fair.fairArtworks.edges.node.sale.endAt": (v31/*: any*/),
-        "fair.fairArtworks.edges.node.sale.id": (v33/*: any*/),
-        "fair.fairArtworks.edges.node.sale.isAuction": (v39/*: any*/),
-        "fair.fairArtworks.edges.node.sale.isClosed": (v39/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork": (v40/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork.counts": (v41/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork.counts.bidderPositions": (v35/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork.currentBid": (v42/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork.currentBid.display": (v31/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork.id": (v33/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork.lotLabel": (v31/*: any*/),
-        "fair.fairArtworks.edges.node.saleMessage": (v31/*: any*/),
-        "fair.fairArtworks.edges.node.slug": (v33/*: any*/),
-        "fair.fairArtworks.edges.node.title": (v31/*: any*/),
-        "fair.fairArtworks.id": (v33/*: any*/),
-        "fair.fairArtworks.pageInfo": (v43/*: any*/),
-        "fair.fairArtworks.pageInfo.endCursor": (v31/*: any*/),
-        "fair.fairArtworks.pageInfo.hasNextPage": (v44/*: any*/),
-        "fair.fairArtworks.pageInfo.startCursor": (v31/*: any*/),
-        "fair.fairContact": (v31/*: any*/),
-        "fair.fairHours": (v31/*: any*/),
-        "fair.fairLinks": (v31/*: any*/),
-        "fair.fairTickets": (v31/*: any*/),
-        "fair.followedArtistArtworks": (v45/*: any*/),
-        "fair.followedArtistArtworks.edges": (v46/*: any*/),
-        "fair.followedArtistArtworks.edges.__typename": (v32/*: any*/),
-        "fair.followedArtistArtworks.edges.artwork": (v36/*: any*/),
-        "fair.followedArtistArtworks.edges.artwork.artistNames": (v31/*: any*/),
-        "fair.followedArtistArtworks.edges.artwork.href": (v31/*: any*/),
-        "fair.followedArtistArtworks.edges.artwork.id": (v33/*: any*/),
-        "fair.followedArtistArtworks.edges.artwork.image": (v34/*: any*/),
-        "fair.followedArtistArtworks.edges.artwork.image.imageURL": (v31/*: any*/),
-        "fair.followedArtistArtworks.edges.artwork.internalID": (v33/*: any*/),
-        "fair.followedArtistArtworks.edges.artwork.saleMessage": (v31/*: any*/),
-        "fair.followedArtistArtworks.edges.artwork.slug": (v33/*: any*/),
-        "fair.followedArtistArtworks.id": (v33/*: any*/),
-        "fair.id": (v33/*: any*/),
-        "fair.image": (v34/*: any*/),
-        "fair.image.aspectRatio": (v37/*: any*/),
-        "fair.image.imageUrl": (v31/*: any*/),
-        "fair.internalID": (v33/*: any*/),
-        "fair.isActive": (v39/*: any*/),
+        "fair.fairArtworks.edges.node.partner.id": (v35/*: any*/),
+        "fair.fairArtworks.edges.node.partner.name": (v33/*: any*/),
+        "fair.fairArtworks.edges.node.sale": (v40/*: any*/),
+        "fair.fairArtworks.edges.node.sale.displayTimelyAt": (v33/*: any*/),
+        "fair.fairArtworks.edges.node.sale.endAt": (v33/*: any*/),
+        "fair.fairArtworks.edges.node.sale.id": (v35/*: any*/),
+        "fair.fairArtworks.edges.node.sale.isAuction": (v41/*: any*/),
+        "fair.fairArtworks.edges.node.sale.isClosed": (v41/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork": (v42/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.counts": (v43/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.counts.bidderPositions": (v37/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.currentBid": (v44/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.currentBid.display": (v33/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.id": (v35/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.lotLabel": (v33/*: any*/),
+        "fair.fairArtworks.edges.node.saleMessage": (v33/*: any*/),
+        "fair.fairArtworks.edges.node.slug": (v35/*: any*/),
+        "fair.fairArtworks.edges.node.title": (v33/*: any*/),
+        "fair.fairArtworks.id": (v35/*: any*/),
+        "fair.fairArtworks.pageInfo": (v45/*: any*/),
+        "fair.fairArtworks.pageInfo.endCursor": (v33/*: any*/),
+        "fair.fairArtworks.pageInfo.hasNextPage": (v46/*: any*/),
+        "fair.fairArtworks.pageInfo.startCursor": (v33/*: any*/),
+        "fair.fairArtworksForAggregation": (v47/*: any*/),
+        "fair.fairArtworksForAggregation.aggregations": (v48/*: any*/),
+        "fair.fairArtworksForAggregation.aggregations.counts": (v49/*: any*/),
+        "fair.fairArtworksForAggregation.aggregations.counts.count": (v50/*: any*/),
+        "fair.fairArtworksForAggregation.aggregations.counts.name": (v34/*: any*/),
+        "fair.fairArtworksForAggregation.aggregations.counts.value": (v34/*: any*/),
+        "fair.fairArtworksForAggregation.aggregations.slice": (v51/*: any*/),
+        "fair.fairArtworksForAggregation.id": (v35/*: any*/),
+        "fair.fairContact": (v33/*: any*/),
+        "fair.fairHours": (v33/*: any*/),
+        "fair.fairLinks": (v33/*: any*/),
+        "fair.fairTickets": (v33/*: any*/),
+        "fair.followedArtistArtworks": (v47/*: any*/),
+        "fair.followedArtistArtworks.edges": (v52/*: any*/),
+        "fair.followedArtistArtworks.edges.__typename": (v34/*: any*/),
+        "fair.followedArtistArtworks.edges.artwork": (v38/*: any*/),
+        "fair.followedArtistArtworks.edges.artwork.artistNames": (v33/*: any*/),
+        "fair.followedArtistArtworks.edges.artwork.href": (v33/*: any*/),
+        "fair.followedArtistArtworks.edges.artwork.id": (v35/*: any*/),
+        "fair.followedArtistArtworks.edges.artwork.image": (v36/*: any*/),
+        "fair.followedArtistArtworks.edges.artwork.image.imageURL": (v33/*: any*/),
+        "fair.followedArtistArtworks.edges.artwork.internalID": (v35/*: any*/),
+        "fair.followedArtistArtworks.edges.artwork.saleMessage": (v33/*: any*/),
+        "fair.followedArtistArtworks.edges.artwork.slug": (v35/*: any*/),
+        "fair.followedArtistArtworks.id": (v35/*: any*/),
+        "fair.id": (v35/*: any*/),
+        "fair.image": (v36/*: any*/),
+        "fair.image.aspectRatio": (v39/*: any*/),
+        "fair.image.imageUrl": (v33/*: any*/),
+        "fair.internalID": (v35/*: any*/),
+        "fair.isActive": (v41/*: any*/),
         "fair.location": {
           "enumValues": null,
           "nullable": true,
@@ -1996,51 +2041,51 @@ return {
           "plural": false,
           "type": "LatLng"
         },
-        "fair.location.coordinates.lat": (v47/*: any*/),
-        "fair.location.coordinates.lng": (v47/*: any*/),
-        "fair.location.id": (v33/*: any*/),
-        "fair.location.summary": (v31/*: any*/),
+        "fair.location.coordinates.lat": (v53/*: any*/),
+        "fair.location.coordinates.lng": (v53/*: any*/),
+        "fair.location.id": (v35/*: any*/),
+        "fair.location.summary": (v33/*: any*/),
         "fair.marketingCollections": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "MarketingCollection"
         },
-        "fair.marketingCollections.__typename": (v32/*: any*/),
-        "fair.marketingCollections.artworks": (v45/*: any*/),
-        "fair.marketingCollections.artworks.edges": (v46/*: any*/),
-        "fair.marketingCollections.artworks.edges.node": (v36/*: any*/),
-        "fair.marketingCollections.artworks.edges.node.id": (v33/*: any*/),
-        "fair.marketingCollections.artworks.edges.node.image": (v34/*: any*/),
-        "fair.marketingCollections.artworks.edges.node.image.url": (v31/*: any*/),
-        "fair.marketingCollections.artworks.id": (v33/*: any*/),
-        "fair.marketingCollections.category": (v32/*: any*/),
-        "fair.marketingCollections.id": (v33/*: any*/),
-        "fair.marketingCollections.slug": (v32/*: any*/),
-        "fair.marketingCollections.title": (v32/*: any*/),
-        "fair.name": (v31/*: any*/),
+        "fair.marketingCollections.__typename": (v34/*: any*/),
+        "fair.marketingCollections.artworks": (v47/*: any*/),
+        "fair.marketingCollections.artworks.edges": (v52/*: any*/),
+        "fair.marketingCollections.artworks.edges.node": (v38/*: any*/),
+        "fair.marketingCollections.artworks.edges.node.id": (v35/*: any*/),
+        "fair.marketingCollections.artworks.edges.node.image": (v36/*: any*/),
+        "fair.marketingCollections.artworks.edges.node.image.url": (v33/*: any*/),
+        "fair.marketingCollections.artworks.id": (v35/*: any*/),
+        "fair.marketingCollections.category": (v34/*: any*/),
+        "fair.marketingCollections.id": (v35/*: any*/),
+        "fair.marketingCollections.slug": (v34/*: any*/),
+        "fair.marketingCollections.title": (v34/*: any*/),
+        "fair.name": (v33/*: any*/),
         "fair.profile": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Profile"
         },
-        "fair.profile.icon": (v34/*: any*/),
-        "fair.profile.icon.imageUrl": (v31/*: any*/),
-        "fair.profile.id": (v33/*: any*/),
-        "fair.slug": (v33/*: any*/),
+        "fair.profile.icon": (v36/*: any*/),
+        "fair.profile.icon.imageUrl": (v33/*: any*/),
+        "fair.profile.id": (v35/*: any*/),
+        "fair.slug": (v35/*: any*/),
         "fair.sponsoredContent": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FairSponsoredContent"
         },
-        "fair.sponsoredContent.activationText": (v31/*: any*/),
-        "fair.sponsoredContent.pressReleaseUrl": (v31/*: any*/),
-        "fair.startAt": (v31/*: any*/),
-        "fair.summary": (v31/*: any*/),
-        "fair.tagline": (v31/*: any*/),
-        "fair.ticketsLink": (v31/*: any*/)
+        "fair.sponsoredContent.activationText": (v33/*: any*/),
+        "fair.sponsoredContent.pressReleaseUrl": (v33/*: any*/),
+        "fair.startAt": (v33/*: any*/),
+        "fair.summary": (v33/*: any*/),
+        "fair.tagline": (v33/*: any*/),
+        "fair.ticketsLink": (v33/*: any*/)
       }
     },
     "name": "Fair2TestsQuery",

--- a/src/__generated__/VanityURLEntityQuery.graphql.ts
+++ b/src/__generated__/VanityURLEntityQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 9d7b50130cd93ab8ab8e995e453a2508 */
+/* @relayHash 13aeccb33dbce7c87c52daa75c88405c */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -101,6 +101,17 @@ fragment ArtworkTileRailCard_artwork on Artwork {
 fragment Fair2Artworks_fair on Fair {
   slug
   internalID
+  fairArtworksForAggregation: filterArtworksConnection(first: 0, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
+    id
+  }
   fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
     aggregations {
       slice
@@ -973,31 +984,81 @@ v25 = {
 },
 v26 = {
   "kind": "Literal",
+  "name": "aggregations",
+  "value": [
+    "COLOR",
+    "DIMENSION_RANGE",
+    "GALLERY",
+    "INSTITUTION",
+    "MAJOR_PERIOD",
+    "MEDIUM",
+    "PRICE_RANGE",
+    "FOLLOWED_ARTISTS",
+    "ARTIST"
+  ]
+},
+v27 = {
+  "kind": "Literal",
+  "name": "first",
+  "value": 0
+},
+v28 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ArtworksAggregationResults",
+  "kind": "LinkedField",
+  "name": "aggregations",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slice",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AggregationCount",
+      "kind": "LinkedField",
+      "name": "counts",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "count",
+          "storageKey": null
+        },
+        (v17/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "value",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v29 = {
+  "kind": "Literal",
   "name": "first",
   "value": 30
 },
-v27 = [
-  {
-    "kind": "Literal",
-    "name": "aggregations",
-    "value": [
-      "COLOR",
-      "DIMENSION_RANGE",
-      "GALLERY",
-      "INSTITUTION",
-      "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
-      "FOLLOWED_ARTISTS",
-      "ARTIST"
-    ]
-  },
+v30 = [
+  (v26/*: any*/),
   {
     "kind": "Literal",
     "name": "dimensionRange",
     "value": "*-*"
   },
-  (v26/*: any*/),
+  (v29/*: any*/),
   {
     "kind": "Literal",
     "name": "medium",
@@ -1009,14 +1070,14 @@ v27 = [
     "value": "-decayed_merch"
   }
 ],
-v28 = {
+v31 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v29 = [
+v32 = [
   {
     "alias": null,
     "args": null,
@@ -1030,23 +1091,23 @@ v29 = [
     ],
     "storageKey": null
   },
-  (v28/*: any*/)
+  (v31/*: any*/)
 ],
-v30 = {
+v33 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endCursor",
   "storageKey": null
 },
-v31 = {
+v34 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "hasNextPage",
   "storageKey": null
 },
-v32 = {
+v35 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -1054,19 +1115,19 @@ v32 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v30/*: any*/),
-    (v31/*: any*/)
+    (v33/*: any*/),
+    (v34/*: any*/)
   ],
   "storageKey": null
 },
-v33 = {
+v36 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startCursor",
   "storageKey": null
 },
-v34 = {
+v37 = {
   "alias": null,
   "args": [
     {
@@ -1079,28 +1140,28 @@ v34 = {
   "name": "url",
   "storageKey": "url(version:\"large\")"
 },
-v35 = {
+v38 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "date",
   "storageKey": null
 },
-v36 = {
+v39 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isAuction",
   "storageKey": null
 },
-v37 = {
+v40 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v38 = {
+v41 = {
   "alias": null,
   "args": null,
   "concreteType": "Sale",
@@ -1108,8 +1169,8 @@ v38 = {
   "name": "sale",
   "plural": false,
   "selections": [
-    (v36/*: any*/),
-    (v37/*: any*/),
+    (v39/*: any*/),
+    (v40/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -1122,7 +1183,7 @@ v38 = {
   ],
   "storageKey": null
 },
-v39 = {
+v42 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCounts",
@@ -1140,27 +1201,27 @@ v39 = {
   ],
   "storageKey": null
 },
-v40 = {
+v43 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "display",
   "storageKey": null
 },
-v41 = [
-  (v40/*: any*/)
+v44 = [
+  (v43/*: any*/)
 ],
-v42 = {
+v45 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCurrentBid",
   "kind": "LinkedField",
   "name": "currentBid",
   "plural": false,
-  "selections": (v41/*: any*/),
+  "selections": (v44/*: any*/),
   "storageKey": null
 },
-v43 = {
+v46 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtwork",
@@ -1168,8 +1229,8 @@ v43 = {
   "name": "saleArtwork",
   "plural": false,
   "selections": [
-    (v39/*: any*/),
     (v42/*: any*/),
+    (v45/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -1181,7 +1242,7 @@ v43 = {
   ],
   "storageKey": null
 },
-v44 = {
+v47 = {
   "alias": null,
   "args": null,
   "concreteType": "Partner",
@@ -1194,16 +1255,16 @@ v44 = {
   ],
   "storageKey": null
 },
-v45 = [
+v48 = [
   (v7/*: any*/)
 ],
-v46 = {
+v49 = {
   "kind": "InlineFragment",
-  "selections": (v45/*: any*/),
+  "selections": (v48/*: any*/),
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v47 = {
+v50 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -1214,7 +1275,7 @@ v47 = {
       "name": "pageInfo",
       "plural": false,
       "selections": [
-        (v33/*: any*/)
+        (v36/*: any*/)
       ],
       "storageKey": null
     },
@@ -1245,23 +1306,23 @@ v47 = {
               "plural": false,
               "selections": [
                 (v18/*: any*/),
-                (v34/*: any*/)
+                (v37/*: any*/)
               ],
               "storageKey": null
             },
             (v8/*: any*/),
-            (v35/*: any*/),
+            (v38/*: any*/),
             (v15/*: any*/),
             (v4/*: any*/),
             (v13/*: any*/),
             (v9/*: any*/),
-            (v38/*: any*/),
-            (v43/*: any*/),
-            (v44/*: any*/)
+            (v41/*: any*/),
+            (v46/*: any*/),
+            (v47/*: any*/)
           ],
           "storageKey": null
         },
-        (v46/*: any*/)
+        (v49/*: any*/)
       ],
       "storageKey": null
     }
@@ -1269,72 +1330,72 @@ v47 = {
   "type": "ArtworkConnectionInterface",
   "abstractKey": "__isArtworkConnectionInterface"
 },
-v48 = [
-  (v26/*: any*/),
+v51 = [
+  (v29/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "FEATURED_ASC"
   }
 ],
-v49 = [
+v52 = [
   (v11/*: any*/)
 ],
-v50 = {
+v53 = {
   "alias": null,
   "args": null,
   "concreteType": "ShowCounts",
   "kind": "LinkedField",
   "name": "counts",
   "plural": false,
-  "selections": (v49/*: any*/),
+  "selections": (v52/*: any*/),
   "storageKey": null
 },
-v51 = [
+v54 = [
   (v7/*: any*/),
   (v17/*: any*/)
 ],
-v52 = [
+v55 = [
   "sort"
 ],
-v53 = {
+v56 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v54 = [
-  (v53/*: any*/)
+v57 = [
+  (v56/*: any*/)
 ],
-v55 = {
+v58 = {
   "alias": null,
   "args": null,
   "concreteType": "Image",
   "kind": "LinkedField",
   "name": "image",
   "plural": false,
-  "selections": (v54/*: any*/),
+  "selections": (v57/*: any*/),
   "storageKey": null
 },
-v56 = [
+v59 = [
   (v17/*: any*/),
   (v9/*: any*/),
   (v3/*: any*/),
   (v4/*: any*/),
   (v7/*: any*/)
 ],
-v57 = {
+v60 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "hours",
   "storageKey": null
 },
-v58 = [
+v61 = [
   (v6/*: any*/)
 ],
-v59 = {
+v62 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -1342,69 +1403,69 @@ v59 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v31/*: any*/),
-    (v33/*: any*/),
-    (v30/*: any*/)
+    (v34/*: any*/),
+    (v36/*: any*/),
+    (v33/*: any*/)
   ],
   "storageKey": null
 },
-v60 = {
+v63 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isFollowed",
   "storageKey": null
 },
-v61 = {
+v64 = {
   "kind": "InlineFragment",
-  "selections": (v45/*: any*/),
+  "selections": (v48/*: any*/),
   "type": "ExternalPartner",
   "abstractKey": null
 },
-v62 = {
+v65 = {
   "alias": null,
   "args": null,
   "concreteType": "Image",
   "kind": "LinkedField",
   "name": "coverImage",
   "plural": false,
-  "selections": (v54/*: any*/),
+  "selections": (v57/*: any*/),
   "storageKey": null
 },
-v63 = {
+v66 = {
   "kind": "Literal",
   "name": "first",
   "value": 10
 },
-v64 = [
-  (v63/*: any*/),
+v67 = [
+  (v66/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "PARTNER_UPDATED_AT_DESC"
   }
 ],
-v65 = [
-  (v63/*: any*/),
+v68 = [
+  (v66/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "SORTABLE_ID_ASC"
   }
 ],
-v66 = {
+v69 = {
   "kind": "Literal",
   "name": "status",
   "value": "CURRENT"
 },
-v67 = {
+v70 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isDisplayable",
   "storageKey": null
 },
-v68 = [
+v71 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -1421,11 +1482,11 @@ v68 = [
     "value": "CLOSED"
   }
 ],
-v69 = [
+v72 = [
   "status",
   "sort"
 ],
-v70 = [
+v73 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -1436,7 +1497,7 @@ v70 = [
     "name": "sort",
     "value": "END_AT_ASC"
   },
-  (v66/*: any*/)
+  (v69/*: any*/)
 ];
 return {
   "fragment": {
@@ -1887,57 +1948,30 @@ return {
                   (v24/*: any*/),
                   (v25/*: any*/),
                   {
-                    "alias": "fairArtworks",
-                    "args": (v27/*: any*/),
+                    "alias": "fairArtworksForAggregation",
+                    "args": [
+                      (v26/*: any*/),
+                      (v27/*: any*/)
+                    ],
                     "concreteType": "FilterArtworksConnection",
                     "kind": "LinkedField",
                     "name": "filterArtworksConnection",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "ArtworksAggregationResults",
-                        "kind": "LinkedField",
-                        "name": "aggregations",
-                        "plural": true,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "slice",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "AggregationCount",
-                            "kind": "LinkedField",
-                            "name": "counts",
-                            "plural": true,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "count",
-                                "storageKey": null
-                              },
-                              (v17/*: any*/),
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "value",
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
+                      (v28/*: any*/),
+                      (v7/*: any*/)
+                    ],
+                    "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:0)"
+                  },
+                  {
+                    "alias": "fairArtworks",
+                    "args": (v30/*: any*/),
+                    "concreteType": "FilterArtworksConnection",
+                    "kind": "LinkedField",
+                    "name": "filterArtworksConnection",
+                    "plural": false,
+                    "selections": [
+                      (v28/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1945,7 +1979,7 @@ return {
                         "kind": "LinkedField",
                         "name": "edges",
                         "plural": true,
-                        "selections": (v29/*: any*/),
+                        "selections": (v32/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -1973,15 +2007,15 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v32/*: any*/),
+                      (v35/*: any*/),
                       (v7/*: any*/),
-                      (v47/*: any*/)
+                      (v50/*: any*/)
                     ],
                     "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,medium:\"*\",sort:\"-decayed_merch\")"
                   },
                   {
                     "alias": "fairArtworks",
-                    "args": (v27/*: any*/),
+                    "args": (v30/*: any*/),
                     "filters": [
                       "sort",
                       "medium",
@@ -2005,7 +2039,7 @@ return {
                   },
                   {
                     "alias": "exhibitors",
-                    "args": (v48/*: any*/),
+                    "args": (v51/*: any*/),
                     "concreteType": "ShowConnection",
                     "kind": "LinkedField",
                     "name": "showsConnection",
@@ -2028,7 +2062,7 @@ return {
                             "plural": false,
                             "selections": [
                               (v7/*: any*/),
-                              (v50/*: any*/),
+                              (v53/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -2040,17 +2074,17 @@ return {
                                   (v2/*: any*/),
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v51/*: any*/),
+                                    "selections": (v54/*: any*/),
                                     "type": "Partner",
                                     "abstractKey": null
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v51/*: any*/),
+                                    "selections": (v54/*: any*/),
                                     "type": "ExternalPartner",
                                     "abstractKey": null
                                   },
-                                  (v46/*: any*/)
+                                  (v49/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -2129,7 +2163,7 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "openingBid",
                                                 "plural": false,
-                                                "selections": (v41/*: any*/),
+                                                "selections": (v44/*: any*/),
                                                 "storageKey": null
                                               },
                                               {
@@ -2139,11 +2173,11 @@ return {
                                                 "kind": "LinkedField",
                                                 "name": "highestBid",
                                                 "plural": false,
-                                                "selections": (v41/*: any*/),
+                                                "selections": (v44/*: any*/),
                                                 "storageKey": null
                                               },
+                                              (v45/*: any*/),
                                               (v42/*: any*/),
-                                              (v39/*: any*/),
                                               (v7/*: any*/)
                                             ],
                                             "storageKey": null
@@ -2156,8 +2190,8 @@ return {
                                             "name": "sale",
                                             "plural": false,
                                             "selections": [
-                                              (v37/*: any*/),
-                                              (v36/*: any*/),
+                                              (v40/*: any*/),
+                                              (v39/*: any*/),
                                               (v25/*: any*/),
                                               (v7/*: any*/)
                                             ],
@@ -2179,18 +2213,18 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v28/*: any*/)
+                          (v31/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v32/*: any*/)
+                      (v35/*: any*/)
                     ],
                     "storageKey": "showsConnection(first:30,sort:\"FEATURED_ASC\")"
                   },
                   {
                     "alias": "exhibitors",
-                    "args": (v48/*: any*/),
-                    "filters": (v52/*: any*/),
+                    "args": (v51/*: any*/),
+                    "filters": (v55/*: any*/),
                     "handle": "connection",
                     "key": "Fair2ExhibitorsQuery_exhibitors",
                     "kind": "LinkedHandle",
@@ -2233,7 +2267,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v55/*: any*/),
+                  (v58/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2249,7 +2283,7 @@ return {
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
-                        "selections": (v56/*: any*/),
+                        "selections": (v59/*: any*/),
                         "storageKey": null
                       }
                     ],
@@ -2278,7 +2312,7 @@ return {
                             "kind": "LinkedField",
                             "name": "node",
                             "plural": false,
-                            "selections": (v56/*: any*/),
+                            "selections": (v59/*: any*/),
                             "storageKey": null
                           }
                         ],
@@ -2325,7 +2359,7 @@ return {
                     "storageKey": null
                   },
                   (v4/*: any*/),
-                  (v57/*: any*/),
+                  (v60/*: any*/),
                   (v5/*: any*/),
                   {
                     "alias": null,
@@ -2426,7 +2460,7 @@ return {
                                     "name": "days",
                                     "storageKey": null
                                   },
-                                  (v57/*: any*/)
+                                  (v60/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -2488,13 +2522,13 @@ return {
                   },
                   {
                     "alias": "shows",
-                    "args": (v58/*: any*/),
+                    "args": (v61/*: any*/),
                     "concreteType": "ShowConnection",
                     "kind": "LinkedField",
                     "name": "showsConnection",
                     "plural": false,
                     "selections": [
-                      (v59/*: any*/),
+                      (v62/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -2503,7 +2537,7 @@ return {
                         "name": "edges",
                         "plural": true,
                         "selections": [
-                          (v28/*: any*/),
+                          (v31/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -2559,20 +2593,20 @@ return {
                                                 "name": "aspectRatio",
                                                 "storageKey": null
                                               },
-                                              (v34/*: any*/),
+                                              (v37/*: any*/),
                                               (v18/*: any*/)
                                             ],
                                             "storageKey": null
                                           },
                                           (v8/*: any*/),
-                                          (v35/*: any*/),
+                                          (v38/*: any*/),
                                           (v15/*: any*/),
                                           (v4/*: any*/),
                                           (v13/*: any*/),
                                           (v9/*: any*/),
-                                          (v38/*: any*/),
-                                          (v43/*: any*/),
-                                          (v44/*: any*/)
+                                          (v41/*: any*/),
+                                          (v46/*: any*/),
+                                          (v47/*: any*/)
                                         ],
                                         "storageKey": null
                                       }
@@ -2584,7 +2618,7 @@ return {
                               },
                               (v3/*: any*/),
                               (v4/*: any*/),
-                              (v50/*: any*/),
+                              (v53/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -2613,7 +2647,7 @@ return {
                                           (v7/*: any*/),
                                           (v3/*: any*/),
                                           (v4/*: any*/),
-                                          (v60/*: any*/)
+                                          (v63/*: any*/)
                                         ],
                                         "storageKey": null
                                       }
@@ -2621,12 +2655,12 @@ return {
                                     "type": "Partner",
                                     "abstractKey": null
                                   },
-                                  (v46/*: any*/),
-                                  (v61/*: any*/)
+                                  (v49/*: any*/),
+                                  (v64/*: any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v62/*: any*/),
+                              (v65/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -2635,7 +2669,7 @@ return {
                                 "name": "location",
                                 "plural": false,
                                 "selections": [
-                                  (v40/*: any*/),
+                                  (v43/*: any*/),
                                   (v7/*: any*/)
                                 ],
                                 "storageKey": null
@@ -2653,7 +2687,7 @@ return {
                   },
                   {
                     "alias": "shows",
-                    "args": (v58/*: any*/),
+                    "args": (v61/*: any*/),
                     "filters": null,
                     "handle": "connection",
                     "key": "Fair_shows",
@@ -2681,7 +2715,7 @@ return {
                 "plural": false,
                 "selections": [
                   (v7/*: any*/),
-                  (v60/*: any*/),
+                  (v63/*: any*/),
                   (v4/*: any*/),
                   {
                     "alias": null,
@@ -2696,7 +2730,7 @@ return {
               },
               {
                 "alias": "artworks",
-                "args": (v64/*: any*/),
+                "args": (v67/*: any*/),
                 "concreteType": "ArtworkConnection",
                 "kind": "LinkedField",
                 "name": "artworksConnection",
@@ -2709,18 +2743,18 @@ return {
                     "kind": "LinkedField",
                     "name": "edges",
                     "plural": true,
-                    "selections": (v29/*: any*/),
+                    "selections": (v32/*: any*/),
                     "storageKey": null
                   },
-                  (v32/*: any*/),
-                  (v47/*: any*/)
+                  (v35/*: any*/),
+                  (v50/*: any*/)
                 ],
                 "storageKey": "artworksConnection(first:10,sort:\"PARTNER_UPDATED_AT_DESC\")"
               },
               {
                 "alias": "artworks",
-                "args": (v64/*: any*/),
-                "filters": (v52/*: any*/),
+                "args": (v67/*: any*/),
+                "filters": (v55/*: any*/),
                 "handle": "connection",
                 "key": "Partner_artworks",
                 "kind": "LinkedHandle",
@@ -2736,13 +2770,13 @@ return {
               },
               {
                 "alias": "artists",
-                "args": (v65/*: any*/),
+                "args": (v68/*: any*/),
                 "concreteType": "ArtistPartnerConnection",
                 "kind": "LinkedField",
                 "name": "artistsConnection",
                 "plural": false,
                 "selections": [
-                  (v59/*: any*/),
+                  (v62/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2799,7 +2833,7 @@ return {
                             "name": "deathday",
                             "storageKey": null
                           },
-                          (v55/*: any*/),
+                          (v58/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -2807,14 +2841,14 @@ return {
                             "kind": "LinkedField",
                             "name": "counts",
                             "plural": false,
-                            "selections": (v49/*: any*/),
+                            "selections": (v52/*: any*/),
                             "storageKey": null
                           },
                           (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v28/*: any*/),
+                      (v31/*: any*/),
                       (v7/*: any*/)
                     ],
                     "storageKey": null
@@ -2824,8 +2858,8 @@ return {
               },
               {
                 "alias": "artists",
-                "args": (v65/*: any*/),
-                "filters": (v52/*: any*/),
+                "args": (v68/*: any*/),
+                "filters": (v55/*: any*/),
                 "handle": "connection",
                 "key": "Partner_artists",
                 "kind": "LinkedHandle",
@@ -2834,11 +2868,7 @@ return {
               {
                 "alias": "locations",
                 "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "first",
-                    "value": 0
-                  }
+                  (v27/*: any*/)
                 ],
                 "concreteType": "LocationConnection",
                 "kind": "LinkedField",
@@ -2858,8 +2888,8 @@ return {
               {
                 "alias": "recentShows",
                 "args": [
-                  (v63/*: any*/),
-                  (v66/*: any*/)
+                  (v66/*: any*/),
+                  (v69/*: any*/)
                 ],
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
@@ -2883,7 +2913,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v7/*: any*/),
-                          (v67/*: any*/)
+                          (v70/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -2895,13 +2925,13 @@ return {
               },
               {
                 "alias": "pastShows",
-                "args": (v68/*: any*/),
+                "args": (v71/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": [
-                  (v59/*: any*/),
+                  (v62/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2918,7 +2948,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v67/*: any*/),
+                          (v70/*: any*/),
                           (v7/*: any*/),
                           (v17/*: any*/),
                           (v3/*: any*/),
@@ -2931,7 +2961,7 @@ return {
                             "name": "coverImage",
                             "plural": false,
                             "selections": [
-                              (v53/*: any*/),
+                              (v56/*: any*/),
                               (v18/*: any*/)
                             ],
                             "storageKey": null
@@ -2941,7 +2971,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v28/*: any*/)
+                      (v31/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -2950,8 +2980,8 @@ return {
               },
               {
                 "alias": "pastShows",
-                "args": (v68/*: any*/),
-                "filters": (v69/*: any*/),
+                "args": (v71/*: any*/),
+                "filters": (v72/*: any*/),
                 "handle": "connection",
                 "key": "Partner_pastShows",
                 "kind": "LinkedHandle",
@@ -2959,13 +2989,13 @@ return {
               },
               {
                 "alias": "currentAndUpcomingShows",
-                "args": (v70/*: any*/),
+                "args": (v73/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": [
-                  (v59/*: any*/),
+                  (v62/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2982,7 +3012,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v67/*: any*/),
+                          (v70/*: any*/),
                           (v7/*: any*/),
                           (v4/*: any*/),
                           (v3/*: any*/),
@@ -2996,7 +3026,7 @@ return {
                             "kind": "LinkedField",
                             "name": "images",
                             "plural": true,
-                            "selections": (v54/*: any*/),
+                            "selections": (v57/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -3016,17 +3046,17 @@ return {
                                 "type": "Partner",
                                 "abstractKey": null
                               },
-                              (v46/*: any*/),
-                              (v61/*: any*/)
+                              (v49/*: any*/),
+                              (v64/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v62/*: any*/),
+                          (v65/*: any*/),
                           (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v28/*: any*/)
+                      (v31/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -3035,8 +3065,8 @@ return {
               },
               {
                 "alias": "currentAndUpcomingShows",
-                "args": (v70/*: any*/),
-                "filters": (v69/*: any*/),
+                "args": (v73/*: any*/),
+                "filters": (v72/*: any*/),
                 "handle": "connection",
                 "key": "Partner_currentAndUpcomingShows",
                 "kind": "LinkedHandle",
@@ -3064,14 +3094,14 @@ return {
             "type": "Partner",
             "abstractKey": null
           },
-          (v46/*: any*/)
+          (v49/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "9d7b50130cd93ab8ab8e995e453a2508",
+    "id": "13aeccb33dbce7c87c52daa75c88405c",
     "metadata": {},
     "name": "VanityURLEntityQuery",
     "operationKind": "query",

--- a/src/lib/Scenes/Fair2/Components/Fair2Artworks.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2Artworks.tsx
@@ -22,7 +22,6 @@ interface Fair2ArtworksProps {
 }
 
 export const Fair2Artworks: React.FC<Fair2ArtworksProps> = ({ fair, relay, initiallyAppliedFilter }) => {
-
   const artworks = fair.fairArtworks!
   const { dispatch, state } = useContext(ArtworkFilterContext)
   const tracking = useTracking()
@@ -60,7 +59,7 @@ export const Fair2Artworks: React.FC<Fair2ArtworksProps> = ({ fair, relay, initi
   }, [state.appliedFilters])
 
   const followedArtistCount = artworks?.counts?.followedArtists ?? 0
-  const artworkAggregations = (artworks?.aggregations ?? []) as aggregationsType
+  const artworkAggregations = (fair.fairArtworksForAggregation?.aggregations ?? []) as aggregationsType
   const aggregations = aggregationsWithFollowedArtists(followedArtistCount, artworkAggregations)
 
   useEffect(() => {
@@ -118,6 +117,29 @@ export const Fair2ArtworksFragmentContainer = createPaginationContainer(
       ) {
         slug
         internalID
+        fairArtworksForAggregation: filterArtworksConnection(
+          first: 0
+          aggregations: [
+            COLOR
+            DIMENSION_RANGE
+            GALLERY
+            INSTITUTION
+            MAJOR_PERIOD
+            MEDIUM
+            PRICE_RANGE
+            FOLLOWED_ARTISTS
+            ARTIST
+          ]
+        ) {
+          aggregations {
+            slice
+            counts {
+              count
+              name
+              value
+            }
+          }
+        }
         fairArtworks: filterArtworksConnection(
           first: 30
           after: $cursor


### PR DESCRIPTION
The type of this PR is: Bugfix
This PR resolves [FX-2358]

### Description

When a collector views "Artworks by Artists You Follow", the filter options become pinned to the aggregations calculated for that scoped set. Even if the toggle for "by Artists you Follow" is disabled, the aggregations are not recalculated and still pinned to that initial set of artworks.

This commit adds a query for the aggregations of the full artwork set in the fair. This does result in a second request to our API.

When pairing, we touched on conditionally including this field with a GraphQL directive so that it's not always triggered or optimizing some other way.

### PR Checklist (tick all before merging)

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [ ] I have documented any follow-up work that this PR will require, or it does not require any.
- [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2358]: https://artsyproduct.atlassian.net/browse/FX-2358