### PR TITLE
Ensure the modal has the correct title based on the CTA clicked

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -13,6 +13,7 @@ upcoming:
     - Handle artist page subroutes natively by default - david
     - Fix Vanity URL fallbacks - david
     - Adds Show2 basic more information route, behind lab option - damon
+    - Adds header text to new inquiry modal - lily
 
 releases:
   - version: 6.6.6

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryButtons.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryButtons.tsx
@@ -20,21 +20,28 @@ export interface InquiryButtonsState {
 
 export const InquiryButtons: React.FC<InquiryButtonsProps> = ({ artwork, ...props }) => {
   const [modalVisibility, setModalVisibility] = useState(false)
+  const [modalHeaderText, setModalHeaderText] = useState("Contact gallery")
+
   const { dispatch } = useContext(ArtworkInquiryContext)
-  const dispatchAction = (buttonText: string) => {
+  const dispatchAction = (buttonText: string, headerText: string) => {
     dispatch({
       type: "selectInquiryType",
       payload: buttonText as InquiryTypes,
     })
 
+    setModalHeaderText(headerText)
     setModalVisibility(true)
+  }
+
+  const getModalHeaderText = () => {
+    return modalHeaderText
   }
 
   return (
     <>
       {!!artwork.isPriceHidden && (
         <Button
-          onPress={() => dispatchAction(InquiryOptions.RequestPrice)}
+          onPress={() => dispatchAction(InquiryOptions.RequestPrice, "Inquire on price")}
           size="large"
           mb={1}
           block
@@ -46,7 +53,7 @@ export const InquiryButtons: React.FC<InquiryButtonsProps> = ({ artwork, ...prop
       )}
       {!artwork.isPriceHidden && (
         <Button
-          onPress={() => dispatchAction(InquiryOptions.InquireToPurchase)}
+          onPress={() => dispatchAction(InquiryOptions.InquireToPurchase, "Inquire to purchase")}
           size="large"
           mb={1}
           block
@@ -57,7 +64,7 @@ export const InquiryButtons: React.FC<InquiryButtonsProps> = ({ artwork, ...prop
         </Button>
       )}
       <Button
-        onPress={() => dispatchAction(InquiryOptions.ContactGallery)}
+        onPress={() => dispatchAction(InquiryOptions.ContactGallery, "Contact gallery")}
         size="large"
         block
         width={100}
@@ -69,6 +76,7 @@ export const InquiryButtons: React.FC<InquiryButtonsProps> = ({ artwork, ...prop
         artwork={artwork}
         modalIsVisible={modalVisibility}
         toggleVisibility={() => setModalVisibility(!modalVisibility)}
+        modalHeaderText={modalHeaderText}
       />
     </>
   )

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryButtons.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryButtons.tsx
@@ -33,10 +33,6 @@ export const InquiryButtons: React.FC<InquiryButtonsProps> = ({ artwork, ...prop
     setModalVisibility(true)
   }
 
-  const getModalHeaderText = () => {
-    return modalHeaderText
-  }
-
   return (
     <>
       {!!artwork.isPriceHidden && (

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -21,10 +21,11 @@ interface InquiryModalProps {
   toggleVisibility: () => void
   navigator?: NavigatorIOS
   modalIsVisible: boolean
+  modalHeaderText?: string
 }
 
 export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, ...props }) => {
-  const { toggleVisibility, modalIsVisible } = props
+  const { toggleVisibility, modalIsVisible, modalHeaderText } = props
   const questions = artwork?.inquiryQuestions!
   const { state, dispatch } = useContext(ArtworkInquiryContext)
   const [locationExpanded, setLocationExpanded] = useState(false)
@@ -99,7 +100,7 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, ...props })
   return (
     <FancyModal visible={modalIsVisible} onBackgroundPressed={() => toggleVisibility()}>
       <FancyModalHeader leftButtonText="Cancel" onLeftButtonPress={() => toggleVisibility()}>
-        Contact Gallery
+        {modalHeaderText}
       </FancyModalHeader>
       <CollapsibleArtworkDetailsFragmentContainer artwork={artwork} />
       <Box m={2}>

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -100,7 +100,7 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, ...props })
   return (
     <FancyModal visible={modalIsVisible} onBackgroundPressed={() => toggleVisibility()}>
       <FancyModalHeader leftButtonText="Cancel" onLeftButtonPress={() => toggleVisibility()}>
-        {modalHeaderText}
+        {modalHeaderText ?? "Contact gallery"}
       </FancyModalHeader>
       <CollapsibleArtworkDetailsFragmentContainer artwork={artwork} />
       <Box m={2}>

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/InquiryModal-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/InquiryModal-tests.tsx
@@ -23,6 +23,7 @@ let env: ReturnType<typeof createMockEnvironment>
 const modalProps = {
   modalIsVisible: true,
   toggleVisibility: jest.fn(),
+  modalHeaderText: "Inquire on price",
 }
 
 const TestRenderer = () => (
@@ -75,6 +76,11 @@ beforeEach(() => {
 })
 
 describe("<InquiryModal />", () => {
+  it("renders the correct modal header", () => {
+    const tree = getWrapper()
+    expect(extractText(tree.root)).toContain("Inquire on price")
+  })
+
   it("renders the modal", () => {
     const tree = getWrapper()
     expect(extractText(tree.root)).toContain("What information are you looking for?")


### PR DESCRIPTION
# [PURCHASE-2147]

Updates modal header text to match the call to action.

__Before:__
<img width="390" alt="Screen Shot 2020-10-19 at 12 45 42 PM" src="https://user-images.githubusercontent.com/5643895/96504052-056d8000-1209-11eb-852e-7c39310e1859.png">

__After:__
<img width="392" alt="Screen Shot 2020-10-19 at 12 24 32 PM" src="https://user-images.githubusercontent.com/5643895/96502650-f259b080-1206-11eb-964a-099393ae9c15.png">
<img width="377" alt="Screen Shot 2020-10-19 at 12 24 43 PM" src="https://user-images.githubusercontent.com/5643895/96502654-f554a100-1206-11eb-8d8d-1b5fa75e5d3f.png">
<img width="375" alt="Screen Shot 2020-10-19 at 12 25 38 PM" src="https://user-images.githubusercontent.com/5643895/96502659-f7b6fb00-1206-11eb-8ae5-7002a0ec8c73.png">


[PURCHASE-2147]: https://artsyproduct.atlassian.net/browse/PURCHASE-2147