### PR TITLE
fix: provide complete filter options for Works by Artists I Follow grid

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -14,6 +14,7 @@ upcoming:
     - Fix Vanity URL fallbacks - david
     - Adds Show2 basic more information route, behind lab option - damon
     - Add Show2 context card, linking to Fair or Partner - roop
+    - Fix filters on Fair2 Works by Artists I follow artwork grid - devon
 
 releases:
   - version: 6.6.6

--- a/src/__generated__/Fair2AllFollowedArtistsQuery.graphql.ts
+++ b/src/__generated__/Fair2AllFollowedArtistsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 6a8246ecb471e6780d5973f6ab81bfe7 */
+/* @relayHash 4585a24331a8f495a28b24618d538783 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -11,6 +11,9 @@ export type Fair2AllFollowedArtistsQueryVariables = {
 export type Fair2AllFollowedArtistsQueryResponse = {
     readonly fair: {
         readonly " $fragmentRefs": FragmentRefs<"Fair2AllFollowedArtists_fair">;
+    } | null;
+    readonly fairForFilters: {
+        readonly " $fragmentRefs": FragmentRefs<"Fair2AllFollowedArtists_fairForFilters">;
     } | null;
 };
 export type Fair2AllFollowedArtistsQuery = {
@@ -26,6 +29,10 @@ query Fair2AllFollowedArtistsQuery(
 ) {
   fair(id: $fairID) @principalField {
     ...Fair2AllFollowedArtists_fair
+    id
+  }
+  fairForFilters: fair(id: $fairID) {
+    ...Fair2AllFollowedArtists_fairForFilters
     id
   }
 }
@@ -69,6 +76,23 @@ fragment Fair2AllFollowedArtists_fair on Fair {
   internalID
   slug
   ...Fair2Artworks_fair_485l1x
+}
+
+fragment Fair2AllFollowedArtists_fairForFilters on Fair {
+  filterArtworksConnection(first: 0, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
+    counts {
+      followedArtists
+    }
+    id
+  }
 }
 
 fragment Fair2Artworks_fair_485l1x on Fair {
@@ -157,22 +181,23 @@ v3 = {
   "name": "slug",
   "storageKey": null
 },
-v4 = [
-  {
-    "kind": "Literal",
-    "name": "aggregations",
-    "value": [
-      "COLOR",
-      "DIMENSION_RANGE",
-      "GALLERY",
-      "INSTITUTION",
-      "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
-      "FOLLOWED_ARTISTS",
-      "ARTIST"
-    ]
-  },
+v4 = {
+  "kind": "Literal",
+  "name": "aggregations",
+  "value": [
+    "COLOR",
+    "DIMENSION_RANGE",
+    "GALLERY",
+    "INSTITUTION",
+    "MAJOR_PERIOD",
+    "MEDIUM",
+    "PRICE_RANGE",
+    "FOLLOWED_ARTISTS",
+    "ARTIST"
+  ]
+},
+v5 = [
+  (v4/*: any*/),
   {
     "kind": "Literal",
     "name": "dimensionRange",
@@ -199,25 +224,76 @@ v4 = [
     "value": "-decayed_merch"
   }
 ],
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v6 = {
+v7 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ArtworksAggregationResults",
+  "kind": "LinkedField",
+  "name": "aggregations",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slice",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AggregationCount",
+      "kind": "LinkedField",
+      "name": "counts",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "count",
+          "storageKey": null
+        },
+        (v6/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "value",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "followedArtists",
   "storageKey": null
 };
 return {
@@ -239,6 +315,22 @@ return {
             "args": null,
             "kind": "FragmentSpread",
             "name": "Fair2AllFollowedArtists_fair"
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": "fairForFilters",
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "Fair2AllFollowedArtists_fairForFilters"
           }
         ],
         "storageKey": null
@@ -265,56 +357,13 @@ return {
           (v3/*: any*/),
           {
             "alias": "fairArtworks",
-            "args": (v4/*: any*/),
+            "args": (v5/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "ArtworksAggregationResults",
-                "kind": "LinkedField",
-                "name": "aggregations",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "slice",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "AggregationCount",
-                    "kind": "LinkedField",
-                    "name": "counts",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "count",
-                        "storageKey": null
-                      },
-                      (v5/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "value",
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
+              (v7/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -331,8 +380,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
-                      (v7/*: any*/)
+                      (v8/*: any*/),
+                      (v9/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -361,13 +410,7 @@ return {
                     "name": "total",
                     "storageKey": null
                   },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "followedArtists",
-                    "storageKey": null
-                  }
+                  (v10/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -396,7 +439,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v6/*: any*/),
+              (v8/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -426,7 +469,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v7/*: any*/),
+                      (v9/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -539,7 +582,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v6/*: any*/)
+                              (v8/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -594,7 +637,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v6/*: any*/)
+                              (v8/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -606,8 +649,8 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v5/*: any*/),
-                              (v6/*: any*/)
+                              (v6/*: any*/),
+                              (v8/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -617,7 +660,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v6/*: any*/)
+                          (v8/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -634,7 +677,7 @@ return {
           },
           {
             "alias": "fairArtworks",
-            "args": (v4/*: any*/),
+            "args": (v5/*: any*/),
             "filters": [
               "sort",
               "medium",
@@ -656,14 +699,58 @@ return {
             "kind": "LinkedHandle",
             "name": "filterArtworksConnection"
           },
-          (v6/*: any*/)
+          (v8/*: any*/)
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": "fairForFilters",
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              (v4/*: any*/),
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 0
+              }
+            ],
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              (v7/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FilterArtworksCounts",
+                "kind": "LinkedField",
+                "name": "counts",
+                "plural": false,
+                "selections": [
+                  (v10/*: any*/)
+                ],
+                "storageKey": null
+              },
+              (v8/*: any*/)
+            ],
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:0)"
+          },
+          (v8/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "6a8246ecb471e6780d5973f6ab81bfe7",
+    "id": "4585a24331a8f495a28b24618d538783",
     "metadata": {},
     "name": "Fair2AllFollowedArtistsQuery",
     "operationKind": "query",
@@ -671,5 +758,5 @@ return {
   }
 };
 })();
-(node as any).hash = '75ab8d0315a0c3772940f6dcafff8609';
+(node as any).hash = 'ad6eb59e6b112d0b205ed7bfe4d58f62';
 export default node;

--- a/src/__generated__/Fair2AllFollowedArtistsTestsQuery.graphql.ts
+++ b/src/__generated__/Fair2AllFollowedArtistsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 0a6a300f2f1fb0b6ed5f56725bed601c */
+/* @relayHash 8d1ed68eede33877b4cf95611455203e */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -11,6 +11,9 @@ export type Fair2AllFollowedArtistsTestsQueryVariables = {
 export type Fair2AllFollowedArtistsTestsQueryResponse = {
     readonly fair: {
         readonly " $fragmentRefs": FragmentRefs<"Fair2AllFollowedArtists_fair">;
+    } | null;
+    readonly fairForFilters: {
+        readonly " $fragmentRefs": FragmentRefs<"Fair2AllFollowedArtists_fairForFilters">;
     } | null;
 };
 export type Fair2AllFollowedArtistsTestsQuery = {
@@ -26,6 +29,10 @@ query Fair2AllFollowedArtistsTestsQuery(
 ) {
   fair(id: $fairID) {
     ...Fair2AllFollowedArtists_fair
+    id
+  }
+  fairForFilters: fair(id: $fairID) {
+    ...Fair2AllFollowedArtists_fairForFilters
     id
   }
 }
@@ -69,6 +76,23 @@ fragment Fair2AllFollowedArtists_fair on Fair {
   internalID
   slug
   ...Fair2Artworks_fair_485l1x
+}
+
+fragment Fair2AllFollowedArtists_fairForFilters on Fair {
+  filterArtworksConnection(first: 0, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
+    counts {
+      followedArtists
+    }
+    id
+  }
 }
 
 fragment Fair2Artworks_fair_485l1x on Fair {
@@ -157,22 +181,23 @@ v3 = {
   "name": "slug",
   "storageKey": null
 },
-v4 = [
-  {
-    "kind": "Literal",
-    "name": "aggregations",
-    "value": [
-      "COLOR",
-      "DIMENSION_RANGE",
-      "GALLERY",
-      "INSTITUTION",
-      "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
-      "FOLLOWED_ARTISTS",
-      "ARTIST"
-    ]
-  },
+v4 = {
+  "kind": "Literal",
+  "name": "aggregations",
+  "value": [
+    "COLOR",
+    "DIMENSION_RANGE",
+    "GALLERY",
+    "INSTITUTION",
+    "MAJOR_PERIOD",
+    "MEDIUM",
+    "PRICE_RANGE",
+    "FOLLOWED_ARTISTS",
+    "ARTIST"
+  ]
+},
+v5 = [
+  (v4/*: any*/),
   {
     "kind": "Literal",
     "name": "dimensionRange",
@@ -199,52 +224,159 @@ v4 = [
     "value": "-decayed_merch"
   }
 ],
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v6 = {
+v7 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ArtworksAggregationResults",
+  "kind": "LinkedField",
+  "name": "aggregations",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slice",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AggregationCount",
+      "kind": "LinkedField",
+      "name": "counts",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "count",
+          "storageKey": null
+        },
+        (v6/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "value",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v8 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "String"
-},
-v9 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "FormattedNumber"
-},
 v10 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "ID"
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "followedArtists",
+  "storageKey": null
 },
 v11 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "String"
+  "type": "Fair"
 },
 v12 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "FilterArtworksConnection"
+},
+v13 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v14 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": true,
+  "type": "ArtworksAggregationResults"
+},
+v15 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": true,
+  "type": "AggregationCount"
+},
+v16 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Int"
+},
+v17 = {
+  "enumValues": [
+    "ARTIST",
+    "COLOR",
+    "DIMENSION_RANGE",
+    "FOLLOWED_ARTISTS",
+    "GALLERY",
+    "INSTITUTION",
+    "MAJOR_PERIOD",
+    "MEDIUM",
+    "MERCHANDISABLE_ARTISTS",
+    "PARTNER_CITY",
+    "PERIOD",
+    "PRICE_RANGE",
+    "TOTAL"
+  ],
+  "nullable": true,
+  "plural": false,
+  "type": "ArtworkAggregation"
+},
+v18 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "FilterArtworksCounts"
+},
+v19 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "FormattedNumber"
+},
+v20 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v21 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v22 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -272,6 +404,22 @@ return {
           }
         ],
         "storageKey": null
+      },
+      {
+        "alias": "fairForFilters",
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "Fair2AllFollowedArtists_fairForFilters"
+          }
+        ],
+        "storageKey": null
       }
     ],
     "type": "Query",
@@ -295,56 +443,13 @@ return {
           (v3/*: any*/),
           {
             "alias": "fairArtworks",
-            "args": (v4/*: any*/),
+            "args": (v5/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "ArtworksAggregationResults",
-                "kind": "LinkedField",
-                "name": "aggregations",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "slice",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "AggregationCount",
-                    "kind": "LinkedField",
-                    "name": "counts",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "count",
-                        "storageKey": null
-                      },
-                      (v5/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "value",
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
+              (v7/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -361,8 +466,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
-                      (v7/*: any*/)
+                      (v8/*: any*/),
+                      (v9/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -391,13 +496,7 @@ return {
                     "name": "total",
                     "storageKey": null
                   },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "followedArtists",
-                    "storageKey": null
-                  }
+                  (v10/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -426,7 +525,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v6/*: any*/),
+              (v8/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -456,7 +555,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v7/*: any*/),
+                      (v9/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -569,7 +668,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v6/*: any*/)
+                              (v8/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -624,7 +723,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v6/*: any*/)
+                              (v8/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -636,8 +735,8 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v5/*: any*/),
-                              (v6/*: any*/)
+                              (v6/*: any*/),
+                              (v8/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -647,7 +746,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v6/*: any*/)
+                          (v8/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -664,7 +763,7 @@ return {
           },
           {
             "alias": "fairArtworks",
-            "args": (v4/*: any*/),
+            "args": (v5/*: any*/),
             "filters": [
               "sort",
               "medium",
@@ -686,98 +785,93 @@ return {
             "kind": "LinkedHandle",
             "name": "filterArtworksConnection"
           },
-          (v6/*: any*/)
+          (v8/*: any*/)
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": "fairForFilters",
+        "args": (v1/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": [
+              (v4/*: any*/),
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 0
+              }
+            ],
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              (v7/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FilterArtworksCounts",
+                "kind": "LinkedField",
+                "name": "counts",
+                "plural": false,
+                "selections": [
+                  (v10/*: any*/)
+                ],
+                "storageKey": null
+              },
+              (v8/*: any*/)
+            ],
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:0)"
+          },
+          (v8/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "0a6a300f2f1fb0b6ed5f56725bed601c",
+    "id": "8d1ed68eede33877b4cf95611455203e",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "fair": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Fair"
-        },
-        "fair.fairArtworks": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "FilterArtworksConnection"
-        },
-        "fair.fairArtworks.__isArtworkConnectionInterface": (v8/*: any*/),
-        "fair.fairArtworks.aggregations": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "ArtworksAggregationResults"
-        },
-        "fair.fairArtworks.aggregations.counts": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "AggregationCount"
-        },
-        "fair.fairArtworks.aggregations.counts.count": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "Int"
-        },
-        "fair.fairArtworks.aggregations.counts.name": (v8/*: any*/),
-        "fair.fairArtworks.aggregations.counts.value": (v8/*: any*/),
-        "fair.fairArtworks.aggregations.slice": {
-          "enumValues": [
-            "ARTIST",
-            "COLOR",
-            "DIMENSION_RANGE",
-            "FOLLOWED_ARTISTS",
-            "GALLERY",
-            "INSTITUTION",
-            "MAJOR_PERIOD",
-            "MEDIUM",
-            "MERCHANDISABLE_ARTISTS",
-            "PARTNER_CITY",
-            "PERIOD",
-            "PRICE_RANGE",
-            "TOTAL"
-          ],
-          "nullable": true,
-          "plural": false,
-          "type": "ArtworkAggregation"
-        },
-        "fair.fairArtworks.counts": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "FilterArtworksCounts"
-        },
-        "fair.fairArtworks.counts.followedArtists": (v9/*: any*/),
-        "fair.fairArtworks.counts.total": (v9/*: any*/),
+        "fair": (v11/*: any*/),
+        "fair.fairArtworks": (v12/*: any*/),
+        "fair.fairArtworks.__isArtworkConnectionInterface": (v13/*: any*/),
+        "fair.fairArtworks.aggregations": (v14/*: any*/),
+        "fair.fairArtworks.aggregations.counts": (v15/*: any*/),
+        "fair.fairArtworks.aggregations.counts.count": (v16/*: any*/),
+        "fair.fairArtworks.aggregations.counts.name": (v13/*: any*/),
+        "fair.fairArtworks.aggregations.counts.value": (v13/*: any*/),
+        "fair.fairArtworks.aggregations.slice": (v17/*: any*/),
+        "fair.fairArtworks.counts": (v18/*: any*/),
+        "fair.fairArtworks.counts.followedArtists": (v19/*: any*/),
+        "fair.fairArtworks.counts.total": (v19/*: any*/),
         "fair.fairArtworks.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "ArtworkEdgeInterface"
         },
-        "fair.fairArtworks.edges.__isNode": (v8/*: any*/),
-        "fair.fairArtworks.edges.__typename": (v8/*: any*/),
-        "fair.fairArtworks.edges.cursor": (v8/*: any*/),
-        "fair.fairArtworks.edges.id": (v10/*: any*/),
+        "fair.fairArtworks.edges.__isNode": (v13/*: any*/),
+        "fair.fairArtworks.edges.__typename": (v13/*: any*/),
+        "fair.fairArtworks.edges.cursor": (v13/*: any*/),
+        "fair.fairArtworks.edges.id": (v20/*: any*/),
         "fair.fairArtworks.edges.node": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Artwork"
         },
-        "fair.fairArtworks.edges.node.__typename": (v8/*: any*/),
-        "fair.fairArtworks.edges.node.artistNames": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.date": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.href": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.id": (v10/*: any*/),
+        "fair.fairArtworks.edges.node.__typename": (v13/*: any*/),
+        "fair.fairArtworks.edges.node.artistNames": (v21/*: any*/),
+        "fair.fairArtworks.edges.node.date": (v21/*: any*/),
+        "fair.fairArtworks.edges.node.href": (v21/*: any*/),
+        "fair.fairArtworks.edges.node.id": (v20/*: any*/),
         "fair.fairArtworks.edges.node.image": {
           "enumValues": null,
           "nullable": true,
@@ -790,27 +884,27 @@ return {
           "plural": false,
           "type": "Float"
         },
-        "fair.fairArtworks.edges.node.image.url": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.internalID": (v10/*: any*/),
+        "fair.fairArtworks.edges.node.image.url": (v21/*: any*/),
+        "fair.fairArtworks.edges.node.internalID": (v20/*: any*/),
         "fair.fairArtworks.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "fair.fairArtworks.edges.node.partner.id": (v10/*: any*/),
-        "fair.fairArtworks.edges.node.partner.name": (v11/*: any*/),
+        "fair.fairArtworks.edges.node.partner.id": (v20/*: any*/),
+        "fair.fairArtworks.edges.node.partner.name": (v21/*: any*/),
         "fair.fairArtworks.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "fair.fairArtworks.edges.node.sale.displayTimelyAt": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.sale.endAt": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.sale.id": (v10/*: any*/),
-        "fair.fairArtworks.edges.node.sale.isAuction": (v12/*: any*/),
-        "fair.fairArtworks.edges.node.sale.isClosed": (v12/*: any*/),
+        "fair.fairArtworks.edges.node.sale.displayTimelyAt": (v21/*: any*/),
+        "fair.fairArtworks.edges.node.sale.endAt": (v21/*: any*/),
+        "fair.fairArtworks.edges.node.sale.id": (v20/*: any*/),
+        "fair.fairArtworks.edges.node.sale.isAuction": (v22/*: any*/),
+        "fair.fairArtworks.edges.node.sale.isClosed": (v22/*: any*/),
         "fair.fairArtworks.edges.node.saleArtwork": {
           "enumValues": null,
           "nullable": true,
@@ -823,37 +917,49 @@ return {
           "plural": false,
           "type": "SaleArtworkCounts"
         },
-        "fair.fairArtworks.edges.node.saleArtwork.counts.bidderPositions": (v9/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.counts.bidderPositions": (v19/*: any*/),
         "fair.fairArtworks.edges.node.saleArtwork.currentBid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCurrentBid"
         },
-        "fair.fairArtworks.edges.node.saleArtwork.currentBid.display": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork.id": (v10/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork.lotLabel": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.saleMessage": (v11/*: any*/),
-        "fair.fairArtworks.edges.node.slug": (v10/*: any*/),
-        "fair.fairArtworks.edges.node.title": (v11/*: any*/),
-        "fair.fairArtworks.id": (v10/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.currentBid.display": (v21/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.id": (v20/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.lotLabel": (v21/*: any*/),
+        "fair.fairArtworks.edges.node.saleMessage": (v21/*: any*/),
+        "fair.fairArtworks.edges.node.slug": (v20/*: any*/),
+        "fair.fairArtworks.edges.node.title": (v21/*: any*/),
+        "fair.fairArtworks.id": (v20/*: any*/),
         "fair.fairArtworks.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "fair.fairArtworks.pageInfo.endCursor": (v11/*: any*/),
+        "fair.fairArtworks.pageInfo.endCursor": (v21/*: any*/),
         "fair.fairArtworks.pageInfo.hasNextPage": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Boolean"
         },
-        "fair.fairArtworks.pageInfo.startCursor": (v11/*: any*/),
-        "fair.id": (v10/*: any*/),
-        "fair.internalID": (v10/*: any*/),
-        "fair.slug": (v10/*: any*/)
+        "fair.fairArtworks.pageInfo.startCursor": (v21/*: any*/),
+        "fair.id": (v20/*: any*/),
+        "fair.internalID": (v20/*: any*/),
+        "fair.slug": (v20/*: any*/),
+        "fairForFilters": (v11/*: any*/),
+        "fairForFilters.filterArtworksConnection": (v12/*: any*/),
+        "fairForFilters.filterArtworksConnection.aggregations": (v14/*: any*/),
+        "fairForFilters.filterArtworksConnection.aggregations.counts": (v15/*: any*/),
+        "fairForFilters.filterArtworksConnection.aggregations.counts.count": (v16/*: any*/),
+        "fairForFilters.filterArtworksConnection.aggregations.counts.name": (v13/*: any*/),
+        "fairForFilters.filterArtworksConnection.aggregations.counts.value": (v13/*: any*/),
+        "fairForFilters.filterArtworksConnection.aggregations.slice": (v17/*: any*/),
+        "fairForFilters.filterArtworksConnection.counts": (v18/*: any*/),
+        "fairForFilters.filterArtworksConnection.counts.followedArtists": (v19/*: any*/),
+        "fairForFilters.filterArtworksConnection.id": (v20/*: any*/),
+        "fairForFilters.id": (v20/*: any*/)
       }
     },
     "name": "Fair2AllFollowedArtistsTestsQuery",
@@ -862,5 +968,5 @@ return {
   }
 };
 })();
-(node as any).hash = '0b10b1fd7ad663017a8cbc2ef3af966d';
+(node as any).hash = '463cb04d872f462dd14c5f4c70720094';
 export default node;

--- a/src/__generated__/Fair2AllFollowedArtists_fairForFilters.graphql.ts
+++ b/src/__generated__/Fair2AllFollowedArtists_fairForFilters.graphql.ts
@@ -1,0 +1,143 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "ARTIST" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
+export type Fair2AllFollowedArtists_fairForFilters = {
+    readonly filterArtworksConnection: {
+        readonly aggregations: ReadonlyArray<{
+            readonly slice: ArtworkAggregation | null;
+            readonly counts: ReadonlyArray<{
+                readonly count: number;
+                readonly name: string;
+                readonly value: string;
+            } | null> | null;
+        } | null> | null;
+        readonly counts: {
+            readonly followedArtists: number | null;
+        } | null;
+    } | null;
+    readonly " $refType": "Fair2AllFollowedArtists_fairForFilters";
+};
+export type Fair2AllFollowedArtists_fairForFilters$data = Fair2AllFollowedArtists_fairForFilters;
+export type Fair2AllFollowedArtists_fairForFilters$key = {
+    readonly " $data"?: Fair2AllFollowedArtists_fairForFilters$data;
+    readonly " $fragmentRefs": FragmentRefs<"Fair2AllFollowedArtists_fairForFilters">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "Fair2AllFollowedArtists_fairForFilters",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "aggregations",
+          "value": [
+            "COLOR",
+            "DIMENSION_RANGE",
+            "GALLERY",
+            "INSTITUTION",
+            "MAJOR_PERIOD",
+            "MEDIUM",
+            "PRICE_RANGE",
+            "FOLLOWED_ARTISTS",
+            "ARTIST"
+          ]
+        },
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 0
+        }
+      ],
+      "concreteType": "FilterArtworksConnection",
+      "kind": "LinkedField",
+      "name": "filterArtworksConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ArtworksAggregationResults",
+          "kind": "LinkedField",
+          "name": "aggregations",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "slice",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "AggregationCount",
+              "kind": "LinkedField",
+              "name": "counts",
+              "plural": true,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "count",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "name",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "value",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "FilterArtworksCounts",
+          "kind": "LinkedField",
+          "name": "counts",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "followedArtists",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:0)"
+    }
+  ],
+  "type": "Fair",
+  "abstractKey": null
+};
+(node as any).hash = '14d26078c5eab34115831f864fa04f30';
+export default node;

--- a/src/lib/Scenes/Fair2/Components/Fair2Artworks.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2Artworks.tsx
@@ -19,10 +19,17 @@ interface Fair2ArtworksProps {
   fair: Fair2Artworks_fair
   relay: RelayPaginationProp
   initiallyAppliedFilter?: FilterArray
+  aggregations?: aggregationsType
+  followedArtistCount?: number | null | undefined
 }
 
-export const Fair2Artworks: React.FC<Fair2ArtworksProps> = ({ fair, relay, initiallyAppliedFilter }) => {
-
+export const Fair2Artworks: React.FC<Fair2ArtworksProps> = ({
+  fair,
+  relay,
+  initiallyAppliedFilter,
+  aggregations,
+  followedArtistCount,
+}) => {
   const artworks = fair.fairArtworks!
   const { dispatch, state } = useContext(ArtworkFilterContext)
   const tracking = useTracking()
@@ -59,14 +66,14 @@ export const Fair2Artworks: React.FC<Fair2ArtworksProps> = ({ fair, relay, initi
     }
   }, [state.appliedFilters])
 
-  const followedArtistCount = artworks?.counts?.followedArtists ?? 0
-  const artworkAggregations = (artworks?.aggregations ?? []) as aggregationsType
-  const aggregations = aggregationsWithFollowedArtists(followedArtistCount, artworkAggregations)
+  const dispatchFollowedArtistCount = (followedArtistCount || artworks?.counts?.followedArtists) ?? 0
+  const artworkAggregations = ((aggregations || artworks?.aggregations) ?? []) as aggregationsType
+  const dispatchAggregations = aggregationsWithFollowedArtists(dispatchFollowedArtistCount, artworkAggregations)
 
   useEffect(() => {
     dispatch({
       type: "setAggregations",
-      payload: aggregations,
+      payload: dispatchAggregations,
     })
   }, [])
 

--- a/src/lib/Scenes/Fair2/Fair2AllFollowedArtists.tsx
+++ b/src/lib/Scenes/Fair2/Fair2AllFollowedArtists.tsx
@@ -1,8 +1,10 @@
 import { Fair2AllFollowedArtists_fair } from "__generated__/Fair2AllFollowedArtists_fair.graphql"
+import { Fair2AllFollowedArtists_fairForFilters } from "__generated__/Fair2AllFollowedArtists_fairForFilters.graphql"
 import { Fair2AllFollowedArtistsQuery } from "__generated__/Fair2AllFollowedArtistsQuery.graphql"
 import { AnimatedArtworkFilterButton, FilterModalMode, FilterModalNavigator } from "lib/Components/FilterModal"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import {
+  Aggregations,
   ArtworkFilterContext,
   ArtworkFilterGlobalStateProvider,
   FilterArray,
@@ -18,9 +20,10 @@ import { Fair2ArtworksFragmentContainer } from "./Components/Fair2Artworks"
 
 interface Fair2AllFollowedArtistsProps {
   fair: Fair2AllFollowedArtists_fair
+  fairForFilters: Fair2AllFollowedArtists_fairForFilters
 }
 
-export const Fair2AllFollowedArtists: React.FC<Fair2AllFollowedArtistsProps> = ({ fair }) => {
+export const Fair2AllFollowedArtists: React.FC<Fair2AllFollowedArtistsProps> = ({ fair, fairForFilters }) => {
   const [isFilterArtworksModalVisible, setFilterArtworkModalVisible] = useState(false)
   const handleFilterArtworksModal = () => {
     setFilterArtworkModalVisible(!isFilterArtworksModalVisible)
@@ -48,7 +51,12 @@ export const Fair2AllFollowedArtists: React.FC<Fair2AllFollowedArtistsProps> = (
                   <Separator />
                   <Spacer mb={2} />
                   <Box px="15px">
-                    <Fair2ArtworksFragmentContainer fair={fair} initiallyAppliedFilter={initialFilter} />
+                    <Fair2ArtworksFragmentContainer
+                      fair={fair}
+                      initiallyAppliedFilter={initialFilter}
+                      aggregations={fairForFilters.filterArtworksConnection?.aggregations as Aggregations}
+                      followedArtistCount={fairForFilters.filterArtworksConnection?.counts?.followedArtists}
+                    />
                     <FilterModalNavigator
                       isFilterArtworksModalVisible={isFilterArtworksModalVisible}
                       id={fair.internalID}
@@ -81,6 +89,45 @@ export const Fair2AllFollowedArtistsFragmentContainer = createFragmentContainer(
       ...Fair2Artworks_fair @arguments(includeArtworksByFollowedArtists: true)
     }
   `,
+  /**
+   * Filter aggregations are normally dynamic according to applied filters.
+   * Because of the `includeArtworksByFollowedArtists` argument used above, the artwork grid is intially scoped to only
+   * include works by followed artists.
+   * The filter options become incomplete if that option is later disabled in the filter menu.
+   * To compensate, we are querying for the complete set below without the `includeArtworksByFollowedArtists`
+   * argument so that the complete set of filters is available.
+   */
+  fairForFilters: graphql`
+    fragment Fair2AllFollowedArtists_fairForFilters on Fair {
+      filterArtworksConnection(
+        first: 0
+        aggregations: [
+          COLOR
+          DIMENSION_RANGE
+          GALLERY
+          INSTITUTION
+          MAJOR_PERIOD
+          MEDIUM
+          PRICE_RANGE
+          FOLLOWED_ARTISTS
+          ARTIST
+        ]
+      ) {
+        aggregations {
+          slice
+          counts {
+            count
+            name
+            value
+          }
+        }
+
+        counts {
+          followedArtists
+        }
+      }
+    }
+  `,
 })
 
 export const Fair2AllFollowedArtistsQueryRenderer: React.FC<{ fairID: string }> = ({ fairID }) => {
@@ -91,6 +138,10 @@ export const Fair2AllFollowedArtistsQueryRenderer: React.FC<{ fairID: string }> 
         query Fair2AllFollowedArtistsQuery($fairID: String!) {
           fair(id: $fairID) @principalField {
             ...Fair2AllFollowedArtists_fair
+          }
+
+          fairForFilters: fair(id: $fairID) {
+            ...Fair2AllFollowedArtists_fairForFilters
           }
         }
       `}

--- a/src/lib/Scenes/Fair2/__tests__/Fair2AllFollowedArtists-tests.tsx
+++ b/src/lib/Scenes/Fair2/__tests__/Fair2AllFollowedArtists-tests.tsx
@@ -24,12 +24,15 @@ describe("Fair2AllFollowedArtists", () => {
           fair(id: $fairID) {
             ...Fair2AllFollowedArtists_fair
           }
+          fairForFilters: fair(id: $fairID) {
+            ...Fair2AllFollowedArtists_fairForFilters
+          }
         }
       `}
       variables={{ fairID: "art-basel-hong-kong-2019" }}
       render={({ props, error }) => {
-        if (props?.fair) {
-          return <Fair2AllFollowedArtistsFragmentContainer fair={props.fair} />
+        if (props?.fair && props?.fairForFilters) {
+          return <Fair2AllFollowedArtistsFragmentContainer fair={props.fair} fairForFilters={props.fairForFilters} />
         } else if (error) {
           console.log(error)
         }


### PR DESCRIPTION
The type of this PR is: Bugfix

This PR resolves [FX-2358]

cc/ @sweir27 

## Description

When navigating from the new fair screen to the "Works by Artists I Follow" artwork grid, we set an initial filter. This initial filter causes the filter options (backed by aggregations) to also be scoped to the initial filter. A user can disable the initial filter, but the aggregations will not update to reflect the complete set of available filters for the unscoped artworks.

This commit prefetches the artwork aggregations and passes them into the artwork grid component.
## PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [X] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [X] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [X] I have documented any follow-up work that this PR will require, or it does not require any.
- [X] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [X] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

## Screen Recordings

### Before

_Note fewer mediums available to filter by._

<img src="https://user-images.githubusercontent.com/123595/96614698-6ad77480-12ce-11eb-8ace-febf5852be11.gif" width="360">

### After

<img src="https://user-images.githubusercontent.com/123595/96614724-7165ec00-12ce-11eb-90af-59dd7fef0957.gif" width="360">

[FX-2358]: https://artsyproduct.atlassian.net/browse/FX-2358