### PR TITLE
fix: hide lots artists if the user has no follows

### DIFF
--- a/src/lib/Scenes/Sale/Components/SaleArtworksRail.tsx
+++ b/src/lib/Scenes/Sale/Components/SaleArtworksRail.tsx
@@ -19,6 +19,10 @@ export const SaleArtworksRail: React.FC<Props> = ({ me }) => {
 
   const artworks = extractNodes(me?.lotsByFollowedArtistsConnection)
 
+  if (!artworks?.length) {
+    return null
+  }
+
   return (
     <Flex mt={3} ref={navRef}>
       <Flex mx={2}>

--- a/src/lib/Scenes/Sale/__tests__/SaleArtworksRail-tests.tsx
+++ b/src/lib/Scenes/Sale/__tests__/SaleArtworksRail-tests.tsx
@@ -1,7 +1,9 @@
 import { SaleArtworksRailTestsQuery } from "__generated__/SaleArtworksRailTestsQuery.graphql"
 import { SaleArtworkTileRailCardContainer } from "lib/Components/SaleArtworkTileRailCard"
+import { SectionTitle } from "lib/Components/SectionTitle"
 import { mockEnvironmentPayload } from "lib/tests/mockEnvironmentPayload"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { Flex } from "palette"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment } from "relay-test-utils"
@@ -41,7 +43,23 @@ describe("SaleArtworksRail", () => {
 
     mockEnvironmentPayload(mockEnvironment, mockProps)
 
+    expect(tree.root.findAllByType(SectionTitle)[0].props.title).toEqual("Lots by artists you follow")
     expect(tree.root.findAllByType(SaleArtworkTileRailCardContainer)).toHaveLength(INITIAL_NUMBER_TO_RENDER)
+  })
+
+  it("returns null if there are no artworks", () => {
+    const tree = renderWithWrappers(<TestRenderer />)
+
+    const noArtworksProps = {
+      Me: () => ({
+        lotsByFollowedArtistsConnection: {
+          edges: [],
+        },
+      }),
+    }
+    mockEnvironmentPayload(mockEnvironment, noArtworksProps)
+    // React-test-renderer has no isEmptyComponent or isNullComponent therefore I am testing for the container
+    expect(tree.root.findAllByType(Flex)).toHaveLength(0)
   })
 })
 


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-716]

### Description

- Fix: If there are no lots by artists that the user follows, hide this section
- I also added a regression test to avoid this in the future

_When the user **has lots** from artists he's following_
<img width="335" alt="Screenshot 2020-10-21 at 15 28 44" src="https://user-images.githubusercontent.com/11945712/96726653-79975780-13b2-11eb-8db1-800092867c86.png">

_When the user **has no lots** from artists he's following_ 
<img width="337" alt="Screenshot 2020-10-21 at 15 29 00" src="https://user-images.githubusercontent.com/11945712/96726663-7e5c0b80-13b2-11eb-8d21-45d844855dd2.png">


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one. 




[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-716]: https://artsyproduct.atlassian.net/browse/CX-716