### PR TITLE
fix: adjust typography on you're approved to bid

### DIFF
--- a/src/lib/Scenes/Sale/Components/RegisterToBidButton.tsx
+++ b/src/lib/Scenes/Sale/Components/RegisterToBidButton.tsx
@@ -1,6 +1,6 @@
 import { RegisterToBidButton_sale } from "__generated__/RegisterToBidButton_sale.graphql"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
-import { Box, Button, CheckIcon, Flex, Spacer, Text } from "palette"
+import { Box, Button, CheckIcon, Flex, Sans, Spacer, Text } from "palette"
 import React, { useRef } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -60,7 +60,9 @@ const RegisterToBidButtonComp: React.FC<RegisterToBidButtonProps> = (props) => {
     return (
       <Flex flexDirection="row">
         <CheckIcon fill="green100" mr={8} />
-        <Text color="green100">You're approved to bid</Text>
+        <Sans size="3" weight="medium" color="green100">
+          You're approved to bid
+        </Sans>
       </Flex>
     )
   } else {

--- a/src/lib/Scenes/Sale/__tests__/RegisterToBidButton-tests.tsx
+++ b/src/lib/Scenes/Sale/__tests__/RegisterToBidButton-tests.tsx
@@ -1,7 +1,6 @@
 import { RegisterToBidButtonTestsQuery } from "__generated__/RegisterToBidButtonTestsQuery.graphql"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
-import { Button } from "palette"
-import { Text } from "palette"
+import { Button, Sans } from "palette"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
@@ -74,6 +73,6 @@ describe("RegisterToBidButton", () => {
       })
     )
 
-    expect(tree.root.findAllByType(Text)[0].props.children).toMatch("You're approved to bid")
+    expect(tree.root.findAllByType(Sans)[0].props.children).toMatch("You're approved to bid")
   })
 })


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-732]


### Description

- Make "You're approved to bid" copy  in Medium weight text instead of regular weight text

**Before**
<img width="339" alt="Screenshot 2020-10-21 at 15 43 47" src="https://user-images.githubusercontent.com/11945712/96730851-e9a7dc80-13b6-11eb-86d1-a3ea1d00cf4e.png">

**After**
<img width="333" alt="Screenshot 2020-10-21 at 15 43 32" src="https://user-images.githubusercontent.com/11945712/96730864-ec0a3680-13b6-11eb-9ae0-89d2f191ae8a.png">

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-732]: https://artsyproduct.atlassian.net/browse/CX-732