### PR TITLE
fix: filter button overlaps artwork grid content

### DIFF
--- a/src/lib/Scenes/Sale/Sale.tsx
+++ b/src/lib/Scenes/Sale/Sale.tsx
@@ -145,6 +145,7 @@ export const Sale: React.FC<Props> = ({ queryRes }) => {
               initialNumToRender={2}
               viewabilityConfig={viewConfigRef.current}
               onViewableItemsChanged={viewableItemsChangedRef.current}
+              contentContainerStyle={{ paddingBottom: 40 }}
               renderItem={({ item }: { item: SaleSection }) => item.content}
               keyExtractor={(item: SaleSection) => item.key}
               onScroll={Animated.event(


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-719]

### Description
- Filter button overlaps artwork grid content when scrolled to the bottom
<img width="1700" alt="Group 2 (1)" src="https://user-images.githubusercontent.com/11945712/96753059-99894400-13cf-11eb-81f4-355ef9942309.png">


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-719]: https://artsyproduct.atlassian.net/browse/CX-719