### PR TITLE
fix: select correct window in react-image-crop-picker when input window is present

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -15,6 +15,7 @@ upcoming:
     - Adds Show2 basic more information route, behind lab option - damon
     - Add Show2 context card, linking to Fair or Partner - roop
     - Fix filters on Fair2 Works by Artists I follow artwork grid - devon
+    - Fix blank screen bug in My Collection - brian
 
 releases:
   - version: 6.6.6

--- a/HACKS.md
+++ b/HACKS.md
@@ -24,3 +24,11 @@
   There was a case where echo returns 401 when a user asks for the latest echo options. This might be caused by some key misconfiguration, or it might not. Right now we have figured out that the app was storing broken Echo.json when the status was 401, and this caused the app to crash. As the simplest way to get around that we decided to rename the file, so in the next app update we would force all users to grab a new echo json file (this time named EchoNew.json). We have also added code to make sure we don't store broken echo json files locally anymore.
 
   After a few months we should be safe to return to the old name if we want. If we decide to do that, we should make sure to remove the old file that might have been sitting on users' phones.
+
+- react-native-image-crop-picker getRootVC patch
+
+  Remove when we stop swizzling UIWindow via ARWindow or react-native-image-crop-picker provides a more robust way
+  of finding the viewController to present on.
+
+  Context: https://github.com/ivpusic/react-native-image-crop-picker/pull/1354
+  We do some swizzling in our AppDelegate that causes [[UIApplication sharedApplication] delegate] window] to return nil, this is used by image-crop-picker to find the currently presented viewController to present the picker onto. This patch looks for our custom window subclass (ARWindow) instead and uses that to find the presented viewController. Note we cannot reliably use the lastWindow rather than checking for our custom subclass because in some circumstances this is not our window but an apple window for example UIInputWindow used for managing the keyboard.

--- a/patches/react-native-image-crop-picker+0.32.2.patch
+++ b/patches/react-native-image-crop-picker+0.32.2.patch
@@ -1,17 +1,29 @@
 diff --git a/node_modules/react-native-image-crop-picker/ios/.DS_Store b/node_modules/react-native-image-crop-picker/ios/.DS_Store
 new file mode 100644
-index 0000000..5172429
-Binary files /dev/null and b/node_modules/react-native-image-crop-picker/ios/.DS_Store differ
+index 0000000..e69de29
 diff --git a/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m b/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m
-index 25ead1a..3b431c8 100644
+index 25ead1a..ea872d1 100644
 --- a/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m
 +++ b/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m
-@@ -124,7 +124,7 @@ - (void) setConfiguration:(NSDictionary *)options
+@@ -123,8 +123,19 @@ - (void) setConfiguration:(NSDictionary *)options
+     }
  }
  
- - (UIViewController*) getRootVC {
+-- (UIViewController*) getRootVC {
 -    UIViewController *root = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
-+    UIViewController *root = [[[[UIApplication sharedApplication] windows] lastObject] rootViewController];
++- (UIViewController *) getRootVC {
++    UIWindow *presentingWindow;
++    for (UIWindow *window in [[UIApplication sharedApplication] windows]) {
++        if ([window isKindOfClass:NSClassFromString(@"ARWindow")]) {
++            presentingWindow = window;
++        }
++    }
++    if (!presentingWindow) {
++        NSAssert(false, @"Unable to find ARWindow did it get renamed?");
++        presentingWindow = [[[UIApplication sharedApplication] windows] lastObject];
++    }
++
++    UIViewController *root = [presentingWindow rootViewController];
      while (root.presentedViewController != nil) {
          root = root.presentedViewController;
      }


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [CX-711]

### Description

We do some swizzling in the AppDelegate that causes  `[[UIApplication sharedApplication] delegate] window]` to return nil. react-native-image-crop-picker uses this method to find the viewController to present the picker onto so we had a patch that grabbed the last window in the hierarchy to workaround this issue. In the My Collection flow this was returning the wrong window, specifically a UIInputWindow that manages presentation of the keyboard. This PR updates our existing patch for react-native-image-crop-picker to look for our custom window subclass instead which should return the correct window, and falls back to the last window if it can't find the subclass.

#### Before 

![before-image-crop](https://user-images.githubusercontent.com/49686530/96774397-eeb75c80-13b3-11eb-8ad9-79b422d81720.gif)

#### After 

![after-image-crop](https://user-images.githubusercontent.com/49686530/96774408-f0812000-13b3-11eb-9d66-c4eed656afea.gif)

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-711]: https://artsyproduct.atlassian.net/browse/CX-711