### PR TITLE
fix: scroll to top after applying filters

### DIFF
--- a/src/lib/Scenes/Sale/Components/SaleLotsList.tsx
+++ b/src/lib/Scenes/Sale/Components/SaleLotsList.tsx
@@ -17,9 +17,10 @@ interface Props {
   relay: RelayPaginationProp
   saleID: string
   saleSlug: string
+  scrollToTop: () => void
 }
 
-export const SaleLotsList: React.FC<Props> = ({ saleArtworksConnection, relay, saleID, saleSlug }) => {
+export const SaleLotsList: React.FC<Props> = ({ saleArtworksConnection, relay, saleID, saleSlug, scrollToTop }) => {
   const { state, dispatch } = useContext(ArtworkFilterContext)
   const [totalCount, setTotalCount] = useState<number | null>(null)
   const tracking = useTracking()
@@ -61,6 +62,7 @@ export const SaleLotsList: React.FC<Props> = ({ saleArtworksConnection, relay, s
           includeArtworksByFollowedArtists: !!filterParams.includeArtworksByFollowedArtists,
         }
       )
+      scrollToTop()
     }
   }, [state.appliedFilters])
 

--- a/src/lib/Scenes/Sale/Components/SaleLotsList.tsx
+++ b/src/lib/Scenes/Sale/Components/SaleLotsList.tsx
@@ -6,11 +6,10 @@ import { ArtworkFilterContext } from "lib/utils/ArtworkFilter/ArtworkFiltersStor
 import { filterArtworksParams, FilterParamName, ViewAsValues } from "lib/utils/ArtworkFilter/FilterArtworksHelpers"
 import { Schema } from "lib/utils/track"
 import { Box, color, Flex, Sans } from "palette"
-import React, { useCallback, useContext, useEffect, useState } from "react"
+import React, { useContext, useEffect, useState } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
-import { FilterParams } from "../../../utils/ArtworkFilter/FilterArtworksHelpers"
 import { SaleArtworkListContainer } from "./SaleArtworkList"
 
 interface Props {
@@ -19,35 +18,6 @@ interface Props {
   saleID: string
   saleSlug: string
   scrollToTop: () => void
-}
-
-export const SaleLotsListSortMode = ({
-  filterParams,
-  filteredTotal,
-  totalCount,
-}: {
-  filterParams: FilterParams
-  filteredTotal: number | null | undefined
-  totalCount: number | null | undefined
-}) => {
-  const getSortDescription = useCallback(() => {
-    const sortMode = OrderedSaleArtworkSorts.find((sort) => sort.paramValue === filterParams?.sort)
-    if (sortMode) {
-      return sortMode.displayText
-    }
-  }, [filterParams])
-
-  return (
-    <Flex px={2} mb={2}>
-      <FilterTitle size="4" ellipsizeMode="tail">
-        Sorted by {getSortDescription()?.toLowerCase()}
-      </FilterTitle>
-
-      {!!filteredTotal && !!totalCount && (
-        <FilterDescription size="3t">{`Showing ${filteredTotal} of ${totalCount}`}</FilterDescription>
-      )}
-    </Flex>
-  )
 }
 
 export const SaleLotsList: React.FC<Props> = ({ saleArtworksConnection, relay, saleID, saleSlug, scrollToTop }) => {
@@ -123,6 +93,13 @@ export const SaleLotsList: React.FC<Props> = ({ saleArtworksConnection, relay, s
     })
   }
 
+  const getSortDescription = () => {
+    const sortMode = OrderedSaleArtworkSorts.find((sort) => sort.paramValue === filterParams?.sort || "position")
+    if (sortMode) {
+      return sortMode.displayText
+    }
+  }
+
   if (!saleArtworksConnection.saleArtworksConnection?.edges?.length) {
     return (
       <Box my="80px">
@@ -133,7 +110,15 @@ export const SaleLotsList: React.FC<Props> = ({ saleArtworksConnection, relay, s
 
   return (
     <Flex flex={1} my={4}>
-      <SaleLotsListSortMode filterParams={filterParams} filteredTotal={counts?.total} totalCount={totalCount} />
+      <Flex px={2} mb={2}>
+        <FilterTitle size="4" ellipsizeMode="tail">
+          Sorted by {getSortDescription()?.toLowerCase()}
+        </FilterTitle>
+
+        {!!counts?.total && !!totalCount && (
+          <FilterDescription size="3t">{`Showing ${counts.total} of ${totalCount}`}</FilterDescription>
+        )}
+      </Flex>
 
       {viewAsFilter?.paramValue === ViewAsValues.List ? (
         <SaleArtworkListContainer

--- a/src/lib/Scenes/Sale/Components/SaleLotsList.tsx
+++ b/src/lib/Scenes/Sale/Components/SaleLotsList.tsx
@@ -6,10 +6,11 @@ import { ArtworkFilterContext } from "lib/utils/ArtworkFilter/ArtworkFiltersStor
 import { filterArtworksParams, FilterParamName, ViewAsValues } from "lib/utils/ArtworkFilter/FilterArtworksHelpers"
 import { Schema } from "lib/utils/track"
 import { Box, color, Flex, Sans } from "palette"
-import React, { useContext, useEffect, useState } from "react"
+import React, { useCallback, useContext, useEffect, useState } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
+import { FilterParams } from "../../../utils/ArtworkFilter/FilterArtworksHelpers"
 import { SaleArtworkListContainer } from "./SaleArtworkList"
 
 interface Props {
@@ -18,6 +19,35 @@ interface Props {
   saleID: string
   saleSlug: string
   scrollToTop: () => void
+}
+
+export const SaleLotsListSortMode = ({
+  filterParams,
+  filteredTotal,
+  totalCount,
+}: {
+  filterParams: FilterParams
+  filteredTotal: number | null | undefined
+  totalCount: number | null | undefined
+}) => {
+  const getSortDescription = useCallback(() => {
+    const sortMode = OrderedSaleArtworkSorts.find((sort) => sort.paramValue === filterParams?.sort)
+    if (sortMode) {
+      return sortMode.displayText
+    }
+  }, [filterParams])
+
+  return (
+    <Flex px={2} mb={2}>
+      <FilterTitle size="4" ellipsizeMode="tail">
+        Sorted by {getSortDescription()?.toLowerCase()}
+      </FilterTitle>
+
+      {!!filteredTotal && !!totalCount && (
+        <FilterDescription size="3t">{`Showing ${filteredTotal} of ${totalCount}`}</FilterDescription>
+      )}
+    </Flex>
+  )
 }
 
 export const SaleLotsList: React.FC<Props> = ({ saleArtworksConnection, relay, saleID, saleSlug, scrollToTop }) => {
@@ -93,13 +123,6 @@ export const SaleLotsList: React.FC<Props> = ({ saleArtworksConnection, relay, s
     })
   }
 
-  const getSortDescription = () => {
-    const sortMode = OrderedSaleArtworkSorts.find((sort) => sort.paramValue === filterParams?.sort || "position")
-    if (sortMode) {
-      return sortMode.displayText
-    }
-  }
-
   if (!saleArtworksConnection.saleArtworksConnection?.edges?.length) {
     return (
       <Box my="80px">
@@ -110,15 +133,7 @@ export const SaleLotsList: React.FC<Props> = ({ saleArtworksConnection, relay, s
 
   return (
     <Flex flex={1} my={4}>
-      <Flex px={2} mb={2}>
-        <FilterTitle size="4" ellipsizeMode="tail">
-          Sorted by {getSortDescription()?.toLowerCase()}
-        </FilterTitle>
-
-        {!!counts?.total && !!totalCount && (
-          <FilterDescription size="3t">{`Showing ${counts.total} of ${totalCount}`}</FilterDescription>
-        )}
-      </Flex>
+      <SaleLotsListSortMode filterParams={filterParams} filteredTotal={counts?.total} totalCount={totalCount} />
 
       {viewAsFilter?.paramValue === ViewAsValues.List ? (
         <SaleArtworkListContainer

--- a/src/lib/Scenes/Sale/Sale.tsx
+++ b/src/lib/Scenes/Sale/Sale.tsx
@@ -134,7 +134,7 @@ export const Sale: React.FC<Props> = ({ queryRes }) => {
   }
 
   const scrollToTop = () => {
-    const saleLotsListIndex = saleSectionsData.map((section) => section.key).indexOf(SALE_LOTS_LIST) || 0
+    const saleLotsListIndex = saleSectionsData.findIndex((section) => section.key === SALE_LOTS_LIST)
     flatListRef.current?.scrollToIndex({ index: saleLotsListIndex, viewOffset: 50 })
   }
 

--- a/src/lib/Scenes/Sale/Sale.tsx
+++ b/src/lib/Scenes/Sale/Sale.tsx
@@ -135,7 +135,7 @@ export const Sale: React.FC<Props> = ({ queryRes }) => {
 
   const scrollToTop = () => {
     const saleLotsListIndex = saleSectionsData.map((section) => section.key).indexOf(SALE_LOTS_LIST) || 0
-    flatListRef.current?.scrollToIndex({ index: saleLotsListIndex })
+    flatListRef.current?.scrollToIndex({ index: saleLotsListIndex, viewOffset: 50 })
   }
 
   const saleSectionsData: SaleSection[] = _.compact([

--- a/src/lib/Scenes/Sale/Sale.tsx
+++ b/src/lib/Scenes/Sale/Sale.tsx
@@ -14,7 +14,7 @@ import _ from "lodash"
 import moment from "moment"
 import { Flex } from "palette"
 import React, { useEffect, useRef, useState } from "react"
-import { Animated } from "react-native"
+import { Animated, FlatList } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
 import { useTracking } from "react-tracking"
 import { RegisterToBidButtonContainer } from "./Components/RegisterToBidButton"
@@ -32,6 +32,12 @@ interface SaleSection {
   content: JSX.Element
 }
 
+const SALE_HEADER = "header"
+const SALE_REGISTER_TO_BID = "registerToBid"
+const SALE_ACTIVE_BIDS = "saleActiveBids"
+const SALE_ARTWORKS_RAIL = "saleArtworksRail"
+const SALE_LOTS_LIST = "saleLotsList"
+
 // Types related to showing filter button on scroll
 export interface ViewableItems {
   viewableItems?: ViewToken[]
@@ -46,6 +52,8 @@ interface ViewToken {
 }
 
 export const Sale: React.FC<Props> = ({ queryRes }) => {
+  const flatListRef = useRef<FlatList<any>>(null)
+
   const sale = queryRes.sale!
   const me = queryRes.me!
   const tracking = useTracking()
@@ -125,15 +133,20 @@ export const Sale: React.FC<Props> = ({ queryRes }) => {
     setFilterArtworkModalVisible(false)
   }
 
+  const scrollToTop = () => {
+    const saleLotsListIndex = saleSectionsData.map((section) => section.key).indexOf(SALE_LOTS_LIST) || 0
+    flatListRef.current?.scrollToIndex({ index: saleLotsListIndex })
+  }
+
   const saleSectionsData: SaleSection[] = _.compact([
     {
-      key: "header",
+      key: SALE_HEADER,
       content: <SaleHeader sale={sale} scrollAnim={scrollAnim} />,
     },
     (sale.endAt === null || moment().isBefore(sale.endAt)) &&
       sale.registrationEndsAt !== null &&
       moment().isBefore(sale.registrationEndsAt) && {
-        key: "registerToBid",
+        key: SALE_REGISTER_TO_BID,
         content: (
           <Flex mx="2" mt={2}>
             <RegisterToBidButtonContainer sale={sale} me={me} />
@@ -141,16 +154,23 @@ export const Sale: React.FC<Props> = ({ queryRes }) => {
         ),
       },
     {
-      key: "saleActiveBids",
+      key: SALE_ACTIVE_BIDS,
       content: <SaleActiveBidsContainer me={me} saleID={sale.internalID} />,
     },
     {
-      key: "saleArtworksRail",
+      key: SALE_ARTWORKS_RAIL,
       content: <SaleArtworksRailContainer me={me} />,
     },
     {
-      key: "saleLotsList",
-      content: <SaleLotsListContainer saleArtworksConnection={queryRes} saleID={sale.slug} saleSlug={sale.slug} />,
+      key: SALE_LOTS_LIST,
+      content: (
+        <SaleLotsListContainer
+          saleArtworksConnection={queryRes}
+          saleID={sale.slug}
+          saleSlug={sale.slug}
+          scrollToTop={scrollToTop}
+        />
+      ),
     },
   ])
 
@@ -160,6 +180,7 @@ export const Sale: React.FC<Props> = ({ queryRes }) => {
         {() => (
           <>
             <Animated.FlatList
+              ref={flatListRef}
               data={saleSectionsData}
               initialNumToRender={4} // Render the infinite scroll list after the rest of the page
               viewabilityConfig={viewConfigRef.current}

--- a/src/lib/Scenes/Sale/__tests__/SaleLotsList-tests.tsx
+++ b/src/lib/Scenes/Sale/__tests__/SaleLotsList-tests.tsx
@@ -9,9 +9,8 @@ import { FilterParamName, ViewAsValues } from "lib/utils/ArtworkFilter/FilterArt
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment } from "relay-test-utils"
-import { FilterParams } from "../../../utils/ArtworkFilter/FilterArtworksHelpers"
 import { SaleArtworkListContainer } from "../Components/SaleArtworkList"
-import { FilterDescription, FilterTitle, SaleLotsListContainer, SaleLotsListSortMode } from "../Components/SaleLotsList"
+import { FilterTitle, SaleLotsListContainer } from "../Components/SaleLotsList"
 
 jest.unmock("react-relay")
 
@@ -121,20 +120,23 @@ describe("SaleLotsListContainer", () => {
 
     expect(tree.root.findAllByType(SaleArtworkListContainer)).toHaveLength(1)
   })
-})
 
-describe("SaleLotsListSortMode", () => {
-  it("renders the right sort mode and count", () => {
-    const tree = renderWithWrappers(
-      <SaleLotsListSortMode
-        filterParams={{ sort: "bidder_positions_count" } as FilterParams}
-        filteredTotal={20}
-        totalCount={100}
-      />
-    )
+  it("Shows the right default sort mode description", () => {
+    const tree = renderWithWrappers(<TestRenderer viewAs={ViewAsValues.List} />)
 
-    expect(extractText(tree.root.findByType(FilterTitle))).toBe("Sorted by most bids")
-    expect(extractText(tree.root.findByType(FilterDescription))).toBe("Showing 20 of 100")
+    const mockProps = {
+      SaleArtworksConnection: () => ({
+        aggregations: [],
+        counts: {
+          total: 1231,
+        },
+        edges: saleArtworksConnectionEdges,
+      }),
+    }
+
+    mockEnvironmentPayload(mockEnvironment, mockProps)
+
+    expect(extractText(tree.root.findByType(FilterTitle))).toBe("Sorted by lot number ascending")
   })
 })
 

--- a/src/lib/Scenes/Sale/__tests__/SaleLotsList-tests.tsx
+++ b/src/lib/Scenes/Sale/__tests__/SaleLotsList-tests.tsx
@@ -9,8 +9,9 @@ import { FilterParamName, ViewAsValues } from "lib/utils/ArtworkFilter/FilterArt
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment } from "relay-test-utils"
+import { FilterParams } from "../../../utils/ArtworkFilter/FilterArtworksHelpers"
 import { SaleArtworkListContainer } from "../Components/SaleArtworkList"
-import { FilterTitle, SaleLotsListContainer } from "../Components/SaleLotsList"
+import { FilterDescription, FilterTitle, SaleLotsListContainer, SaleLotsListSortMode } from "../Components/SaleLotsList"
 
 jest.unmock("react-relay")
 
@@ -120,23 +121,20 @@ describe("SaleLotsListContainer", () => {
 
     expect(tree.root.findAllByType(SaleArtworkListContainer)).toHaveLength(1)
   })
+})
 
-  it("Shows the right default sort mode description", () => {
-    const tree = renderWithWrappers(<TestRenderer viewAs={ViewAsValues.List} />)
+describe("SaleLotsListSortMode", () => {
+  it("renders the right sort mode and count", () => {
+    const tree = renderWithWrappers(
+      <SaleLotsListSortMode
+        filterParams={{ sort: "bidder_positions_count" } as FilterParams}
+        filteredTotal={20}
+        totalCount={100}
+      />
+    )
 
-    const mockProps = {
-      SaleArtworksConnection: () => ({
-        aggregations: [],
-        counts: {
-          total: 1231,
-        },
-        edges: saleArtworksConnectionEdges,
-      }),
-    }
-
-    mockEnvironmentPayload(mockEnvironment, mockProps)
-
-    expect(extractText(tree.root.findByType(FilterTitle))).toBe("Sorted by lot number ascending")
+    expect(extractText(tree.root.findByType(FilterTitle))).toBe("Sorted by most bids")
+    expect(extractText(tree.root.findByType(FilterDescription))).toBe("Showing 20 of 100")
   })
 })
 

--- a/src/lib/Scenes/Sale/__tests__/SaleLotsList-tests.tsx
+++ b/src/lib/Scenes/Sale/__tests__/SaleLotsList-tests.tsx
@@ -31,7 +31,12 @@ describe("SaleLotsListContainer", () => {
         if (props) {
           return (
             <ArtworkFilterContext.Provider value={{ state: getState(viewAs), dispatch: jest.fn() }}>
-              <SaleLotsListContainer saleArtworksConnection={props} saleID="sale-id" saleSlug="sale-slug" />
+              <SaleLotsListContainer
+                saleArtworksConnection={props}
+                saleID="sale-id"
+                saleSlug="sale-slug"
+                scrollToTop={jest.fn()}
+              />
             </ArtworkFilterContext.Provider>
           )
         }


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-733]

### Description
Instead of staying in the same scroll position on the page, we should instantly move users to the top of the list after applying any filtering/sorting

![Screen_Recording_2020-10-26_at_13 10 12](https://user-images.githubusercontent.com/11945712/97170864-b38aa400-178c-11eb-96ea-67aef736b2ed.gif)

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [X] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-733]: https://artsyproduct.atlassian.net/browse/CX-733