### PR TITLE
fix: show the right filtering subtitle

### DIFF
--- a/src/lib/Scenes/Sale/Components/SaleLotsList.tsx
+++ b/src/lib/Scenes/Sale/Components/SaleLotsList.tsx
@@ -6,10 +6,11 @@ import { ArtworkFilterContext } from "lib/utils/ArtworkFilter/ArtworkFiltersStor
 import { filterArtworksParams, FilterParamName, ViewAsValues } from "lib/utils/ArtworkFilter/FilterArtworksHelpers"
 import { Schema } from "lib/utils/track"
 import { Box, color, Flex, Sans } from "palette"
-import React, { useContext, useEffect, useState } from "react"
+import React, { useCallback, useContext, useEffect, useState } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
+import { FilterParams } from "../../../utils/ArtworkFilter/FilterArtworksHelpers"
 import { SaleArtworkListContainer } from "./SaleArtworkList"
 
 interface Props {
@@ -17,6 +18,35 @@ interface Props {
   relay: RelayPaginationProp
   saleID: string
   saleSlug: string
+}
+
+export const SaleLotsListSortMode = ({
+  filterParams,
+  filteredTotal,
+  totalCount,
+}: {
+  filterParams: FilterParams
+  filteredTotal: number | null | undefined
+  totalCount: number | null | undefined
+}) => {
+  const getSortDescription = useCallback(() => {
+    const sortMode = OrderedSaleArtworkSorts.find((sort) => sort.paramValue === filterParams?.sort)
+    if (sortMode) {
+      return sortMode.displayText
+    }
+  }, [filterParams])
+
+  return (
+    <Flex px={2} mb={2}>
+      <FilterTitle size="4" ellipsizeMode="tail">
+        Sorted by {getSortDescription()?.toLowerCase()}
+      </FilterTitle>
+
+      {!!filteredTotal && !!totalCount && (
+        <FilterDescription size="3t">{`Showing ${filteredTotal} of ${totalCount}`}</FilterDescription>
+      )}
+    </Flex>
+  )
 }
 
 export const SaleLotsList: React.FC<Props> = ({ saleArtworksConnection, relay, saleID, saleSlug }) => {
@@ -91,13 +121,6 @@ export const SaleLotsList: React.FC<Props> = ({ saleArtworksConnection, relay, s
     })
   }
 
-  const getSortDescription = () => {
-    const sortMode = OrderedSaleArtworkSorts.find((sort) => sort.paramValue === filterParams?.sort || "position")
-    if (sortMode) {
-      return sortMode.displayText
-    }
-  }
-
   if (!saleArtworksConnection.saleArtworksConnection?.edges?.length) {
     return (
       <Box my="80px">
@@ -108,15 +131,7 @@ export const SaleLotsList: React.FC<Props> = ({ saleArtworksConnection, relay, s
 
   return (
     <Flex flex={1} my={4}>
-      <Flex px={2} mb={2}>
-        <FilterTitle size="4" ellipsizeMode="tail">
-          Sorted by {getSortDescription()?.toLowerCase()}
-        </FilterTitle>
-
-        {!!counts?.total && !!totalCount && (
-          <FilterDescription size="3t">{`Showing ${counts.total} of ${totalCount}`}</FilterDescription>
-        )}
-      </Flex>
+      <SaleLotsListSortMode filterParams={filterParams} filteredTotal={counts?.total} totalCount={totalCount} />
 
       {viewAsFilter?.paramValue === ViewAsValues.List ? (
         <SaleArtworkListContainer

--- a/src/lib/Scenes/Sale/__tests__/SaleLotsList-tests.tsx
+++ b/src/lib/Scenes/Sale/__tests__/SaleLotsList-tests.tsx
@@ -9,8 +9,9 @@ import { FilterParamName, ViewAsValues } from "lib/utils/ArtworkFilter/FilterArt
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment } from "relay-test-utils"
+import { FilterParams } from "../../../utils/ArtworkFilter/FilterArtworksHelpers"
 import { SaleArtworkListContainer } from "../Components/SaleArtworkList"
-import { FilterTitle, SaleLotsListContainer } from "../Components/SaleLotsList"
+import { FilterDescription, FilterTitle, SaleLotsListContainer, SaleLotsListSortMode } from "../Components/SaleLotsList"
 
 jest.unmock("react-relay")
 
@@ -115,23 +116,20 @@ describe("SaleLotsListContainer", () => {
 
     expect(tree.root.findAllByType(SaleArtworkListContainer)).toHaveLength(1)
   })
+})
 
-  it("Shows the right default sort mode description", () => {
-    const tree = renderWithWrappers(<TestRenderer viewAs={ViewAsValues.List} />)
+describe("SaleLotsListSortMode", () => {
+  it("renders the right sort mode and count", () => {
+    const tree = renderWithWrappers(
+      <SaleLotsListSortMode
+        filterParams={{ sort: "bidder_positions_count" } as FilterParams}
+        filteredTotal={20}
+        totalCount={100}
+      />
+    )
 
-    const mockProps = {
-      SaleArtworksConnection: () => ({
-        aggregations: [],
-        counts: {
-          total: 1231,
-        },
-        edges: saleArtworksConnectionEdges,
-      }),
-    }
-
-    mockEnvironmentPayload(mockEnvironment, mockProps)
-
-    expect(extractText(tree.root.findByType(FilterTitle))).toBe("Sorted by lot number ascending")
+    expect(extractText(tree.root.findByType(FilterTitle))).toBe("Sorted by most bids")
+    expect(extractText(tree.root.findByType(FilterDescription))).toBe("Showing 20 of 100")
   })
 })
 


### PR DESCRIPTION
(cherry picked from commit 53c1e7d94432ba0b8ddaa812f76c3fac24007644)

The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-721]

### Description
When sorting by a different method, we should also change the subtitle above the grid to reflect that method, i.e.
![Screen_Recording_2020-10-26_at_13 29 15](https://user-images.githubusercontent.com/11945712/97174561-8b05a880-1792-11eb-8285-2ddd0a44b414.gif)

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-721]: https://artsyproduct.atlassian.net/browse/CX-721