### PR TITLE
fix(fair2): sticky tabs interactions + UI

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -26,6 +26,7 @@ upcoming:
     - Add Auctions Info screen - mounir
     - Adds Show2 location hours - damon
     - Adds Show2 partner entity header - damon
+    - Fix Fair2 sticky tab UI + interaction - david
 
 releases:
   - version: 6.6.6

--- a/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -80,6 +80,9 @@ export interface Props {
 
   /** Set as true to automatically manage the back button visibility as the user scrolls */
   hideBackButtonOnScroll?: boolean
+
+  /** To avoid layout jank, supply the width of the grid ahead of time. */
+  width?: number
 }
 
 interface PrivateProps {
@@ -106,7 +109,7 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
   }
 
   state = {
-    sectionDimension: 0,
+    sectionDimension: this.getSectionDimension(this.props.width),
     isLoading: false,
   }
 
@@ -148,19 +151,22 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
     // tslint:enable:no-console
   }
 
-  onLayout = (event: LayoutChangeEvent) => {
-    const layout = event.nativeEvent.layout
-    const { shouldAddPadding } = this.props
-    if (layout.width > 0) {
+  getSectionDimension(width: number | null | undefined) {
+    if (width) {
       // This is the sum of all margins in between sections, so do not count to the right of last column.
-      // @ts-ignore STRICTNESS_MIGRATION
-      const sectionMargins = this.props.sectionMargin * (this.props.sectionCount - 1)
+      const sectionMargins = this.props.sectionMargin! * (this.props.sectionCount! - 1)
+      const { shouldAddPadding } = this.props
       const artworkPadding = shouldAddPadding ? space(4) : 0
-      this.setState({
-        // @ts-ignore STRICTNESS_MIGRATION
-        sectionDimension: (layout.width - sectionMargins) / this.props.sectionCount - artworkPadding,
-      })
+
+      return (width - sectionMargins) / (this.props.sectionCount! - artworkPadding)
     }
+    return 0
+  }
+
+  onLayout = (event: LayoutChangeEvent) => {
+    this.setState({
+      sectionDimension: this.getSectionDimension(event.nativeEvent.layout.width),
+    })
   }
 
   sectionedArtworks() {

--- a/src/lib/Scenes/Fair2/Components/Fair2Artworks.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2Artworks.tsx
@@ -10,6 +10,7 @@ import {
   filterArtworksParams,
 } from "lib/utils/ArtworkFilter/FilterArtworksHelpers"
 import { Schema } from "lib/utils/track"
+import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { Box } from "palette"
 import React, { useContext, useEffect } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
@@ -77,6 +78,8 @@ export const Fair2Artworks: React.FC<Fair2ArtworksProps> = ({
     })
   }, [])
 
+  const screenWidth = useScreenDimensions().width
+
   if ((artworks?.counts?.total ?? 0) === 0) {
     return (
       <Box mb="80px">
@@ -96,6 +99,7 @@ export const Fair2Artworks: React.FC<Fair2ArtworksProps> = ({
         contextScreenOwnerType={OwnerType.fair}
         contextScreenOwnerId={fair.internalID}
         contextScreenOwnerSlug={fair.slug}
+        width={screenWidth - 40}
       />
     </Box>
   )

--- a/src/lib/Scenes/Fair2/Components/SimpleTabs.tsx
+++ b/src/lib/Scenes/Fair2/Components/SimpleTabs.tsx
@@ -45,14 +45,22 @@ interface TabsProps {
 export const Tabs: React.FC<TabsProps> = ({ setActiveTab, activeTab, tabs }) => {
   const tabWidth = 100 / tabs.length
   return (
-    <Flex flexDirection="row" backgroundColor="white">
+    <Flex
+      flexDirection="row"
+      backgroundColor="white"
+      borderBottomColor={color("black10")}
+      borderBottomWidth="1px"
+      px="2"
+    >
       {tabs.map(({ label }, index) => {
         const active = activeTab === index
         return (
           <Box
             width={`${tabWidth}%`}
-            borderBottomColor={active ? color("black100") : color("black10")}
-            borderBottomWidth="1px"
+            borderBottomColor={active ? color("black100") : "transparent"}
+            borderBottomWidth="2px"
+            position="relative"
+            bottom="-1px"
             key={label}
           >
             <Tab label={label} onPress={() => setActiveTab(index)} active={active} />

--- a/src/lib/Scenes/Fair2/Fair2.tsx
+++ b/src/lib/Scenes/Fair2/Fair2.tsx
@@ -4,6 +4,7 @@ import { Fair2Query } from "__generated__/Fair2Query.graphql"
 import { AnimatedArtworkFilterButton, FilterModalMode, FilterModalNavigator } from "lib/Components/FilterModal"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { ArtworkFilterContext, ArtworkFilterGlobalStateProvider } from "lib/utils/ArtworkFilter/ArtworkFiltersStore"
+import { hideBackButtonOnScroll } from "lib/utils/hideBackButtonOnScroll"
 import { PlaceholderBox, PlaceholderGrid, PlaceholderText } from "lib/utils/placeholders"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "lib/utils/track"
@@ -192,6 +193,8 @@ export const Fair2: React.FC<Fair2Props> = ({ fair }) => {
                   ItemSeparatorComponent={() => <Spacer mb={3} />}
                   keyExtractor={(_item, index) => String(index)}
                   stickyHeaderIndices={[tabIndex]}
+                  onScroll={hideBackButtonOnScroll}
+                  scrollEventThrottle={100}
                   // @ts-ignore
                   CellRendererComponent={cellItemRenderer}
                   renderItem={({ item }): null | any => {

--- a/src/lib/Scenes/Fair2/Fair2.tsx
+++ b/src/lib/Scenes/Fair2/Fair2.tsx
@@ -250,7 +250,7 @@ export const Fair2: React.FC<Fair2Props> = ({ fair }) => {
 
                         if (tabToShow.label === "Artworks") {
                           return (
-                            <Box px="15px">
+                            <Box px={2}>
                               <Fair2ArtworksFragmentContainer fair={fair} />
                               <FilterModalNavigator
                                 isFilterArtworksModalVisible={isFilterArtworksModalVisible}


### PR DESCRIPTION
This PR resolves [CX-556]

### Description

- Fixes the scroll jump that happened when you switch tab.

   This happened because the `InfiniteScrollArtworkGrid` component needs to know how wide it is to layout its masonry grid manually. By default it needs to wait until it has mounted to have an `onLayout` callback invoked. This causes a single frame to be rendered where the content has no height. To fix that we allow manually specifying a width so that the content can be laid out before first paint. We could also have worked around this issue in this one case by adding a `min-height: screenHeight` style, but I went for the general-purpose solution since we are likely to need it again one day.
- Hides the back button while the user scrolls down. Otherwise the back button obscures one of the sticky tabs.
- Make the sticky tab UI match what we have elsewhere in the app.
- Make the artwork grid have the standard 20px margins

#### Before

![fair2-scroll-bad](https://user-images.githubusercontent.com/1242537/97195244-07a08300-17a3-11eb-9312-1f5ede7e8a20.gif)


#### After

![fair2-scroll-good](https://user-images.githubusercontent.com/1242537/97195000-b2fd0800-17a2-11eb-87ca-47cd1e90e9fa.gif)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.



[CX-556]: https://artsyproduct.atlassian.net/browse/CX-556