### PR TITLE
fix: avoid needless show artwork grid refresh as views change

### DIFF
--- a/src/lib/Scenes/Show2/Components/Show2Artworks.tsx
+++ b/src/lib/Scenes/Show2/Components/Show2Artworks.tsx
@@ -1,5 +1,8 @@
+import { Show2_show } from "__generated__/Show2_show.graphql"
 import { Show2Artworks_show } from "__generated__/Show2Artworks_show.graphql"
+import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
 import { InfiniteScrollArtworksGridContainer } from "lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
+import { FilterModalMode, FilterModalNavigator } from "lib/Components/FilterModal"
 import { SHOW2_ARTWORKS_PAGE_SIZE } from "lib/data/constants"
 import { ArtworkFilterContext, FilterArray } from "lib/utils/ArtworkFilter/ArtworkFiltersStore"
 import { aggregationsType, filterArtworksParams } from "lib/utils/ArtworkFilter/FilterArtworksHelpers"
@@ -13,8 +16,32 @@ interface Props {
   initiallyAppliedFilter?: FilterArray
 }
 
-export const Show2Artworks: React.FC<Props> = ({ show, relay, initiallyAppliedFilter }) => {
+interface ArtworkProps {
+  show: Show2_show
+  isFilterArtworksModalVisible: boolean
+  toggleFilterArtworksModal: () => void
+}
+
+export const Show2ArtworksWithNavigation = (props: ArtworkProps) => {
+  const { show, isFilterArtworksModalVisible, toggleFilterArtworksModal } = props
+  return (
+    <Box px={2}>
+      <Show2ArtworksPaginationContainer show={show} />
+      <FilterModalNavigator
+        isFilterArtworksModalVisible={isFilterArtworksModalVisible}
+        id={show.internalID}
+        slug={show.slug}
+        mode={FilterModalMode.Show}
+        exitModal={toggleFilterArtworksModal}
+        closeModal={toggleFilterArtworksModal}
+      />
+    </Box>
+  )
+}
+
+const Show2Artworks: React.FC<Props> = ({ show, relay, initiallyAppliedFilter }) => {
   const artworks = show.showArtworks!
+  const { internalID, slug } = show
   const { dispatch, state } = useContext(ArtworkFilterContext)
   const filterParams = filterArtworksParams(state.appliedFilters)
 
@@ -48,7 +75,7 @@ export const Show2Artworks: React.FC<Props> = ({ show, relay, initiallyAppliedFi
   }, [])
 
   if ((artworks?.counts?.total ?? 0) === 0) {
-    return null
+    return <FilteredArtworkGridZeroState id={internalID} slug={slug} />
   }
 
   return (

--- a/src/lib/Scenes/Show2/Show2.tsx
+++ b/src/lib/Scenes/Show2/Show2.tsx
@@ -1,15 +1,15 @@
 import { Show2_show } from "__generated__/Show2_show.graphql"
 import { Show2Query } from "__generated__/Show2Query.graphql"
-import { AnimatedArtworkFilterButton, FilterModalMode, FilterModalNavigator } from "lib/Components/FilterModal"
+import { AnimatedArtworkFilterButton } from "lib/Components/FilterModal"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { ArtworkFilterGlobalStateProvider } from "lib/utils/ArtworkFilter/ArtworkFiltersStore"
 import { PlaceholderBox, PlaceholderGrid, PlaceholderText } from "lib/utils/placeholders"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
-import { Box, Flex, Separator, Spacer } from "palette"
+import { Flex, Separator, Spacer } from "palette"
 import React, { useState } from "react"
 import { FlatList } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
-import { Show2ArtworksPaginationContainer as Show2Artworks } from "./Components/Show2Artworks"
+import { Show2ArtworksWithNavigation as Show2Artworks } from "./Components/Show2Artworks"
 import { Show2ContextCardFragmentContainer as ShowContextCard } from "./Components/Show2ContextCard"
 import { Show2HeaderFragmentContainer as ShowHeader } from "./Components/Show2Header"
 import { Show2InfoFragmentContainer as ShowInfo } from "./Components/Show2Info"
@@ -30,27 +30,13 @@ export const Show2: React.FC<Show2Props> = ({ show }) => {
     setFilterArtworkModalVisible(!isFilterArtworksModalVisible)
   }
 
-  const Artworks = () => {
-    return (
-      <Box px={2}>
-        <Show2Artworks show={show} />
-        <FilterModalNavigator
-          isFilterArtworksModalVisible={isFilterArtworksModalVisible}
-          id={show.internalID}
-          slug={show.slug}
-          mode={FilterModalMode.Show}
-          exitModal={toggleFilterArtworksModal}
-          closeModal={toggleFilterArtworksModal}
-        />
-      </Box>
-    )
-  }
+  const artworkProps = { show, isFilterArtworksModalVisible, toggleFilterArtworksModal }
 
   const sections = [
     <ShowHeader show={show} mx={2} />,
     ...(!!show.images?.length ? [<ShowInstallShots show={show} />] : []),
     <ShowInfo show={show} mx={2} />,
-    ...(show.counts?.eligibleArtworks ? [<Artworks />] : []),
+    ...(show.counts?.eligibleArtworks ? [<Show2Artworks {...artworkProps} />] : []),
     <ShowContextCard show={show} />,
   ]
 


### PR DESCRIPTION
The type of this PR is: **FIX**

### Description

- Moves component out of container to avoid refresh when changing iews
- Restores zero state for filter

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
