### PR TITLE
bug: Disable sale artworks clear-all-filters button if 0 filters selected

### DIFF
--- a/src/lib/Components/FilterModal/FilterModal.tsx
+++ b/src/lib/Components/FilterModal/FilterModal.tsx
@@ -214,6 +214,8 @@ export const FilterOptions: React.FC<FilterOptionsProps> = (props) => {
 
   const concreteAggregations = state.aggregations ?? []
 
+  const isClearAllButtonEnabled = state.appliedFilters.length > 0
+
   const aggregateFilterOptions: FilterDisplayConfig[] = _.compact(
     concreteAggregations.map((aggregation) => {
       const filterOption = filterKeyFromAggregation[aggregation.slice]
@@ -260,6 +262,7 @@ export const FilterOptions: React.FC<FilterOptionsProps> = (props) => {
           </CloseIconContainer>
         </Flex>
         <ClearAllButton
+          disabled={!isClearAllButtonEnabled}
           onPress={() => {
             switch (mode) {
               case FilterModalMode.Collection:
@@ -279,7 +282,7 @@ export const FilterOptions: React.FC<FilterOptionsProps> = (props) => {
             clearAllFilters()
           }}
         >
-          <Sans mr={2} mt={2} size="4" color="black100">
+          <Sans mr={2} mt={2} size="4" color={isClearAllButtonEnabled ? "black100" : "black30"}>
             Clear all
           </Sans>
         </ClearAllButton>

--- a/src/lib/Components/FilterModal/FilterModal.tsx
+++ b/src/lib/Components/FilterModal/FilterModal.tsx
@@ -214,7 +214,7 @@ export const FilterOptions: React.FC<FilterOptionsProps> = (props) => {
 
   const concreteAggregations = state.aggregations ?? []
 
-  const isClearAllButtonEnabled = state.appliedFilters.length > 0
+  const isClearAllButtonEnabled = state.appliedFilters.length > 0 || state.appliedFilters.length > 0
 
   const aggregateFilterOptions: FilterDisplayConfig[] = _.compact(
     concreteAggregations.map((aggregation) => {

--- a/src/lib/Components/FilterModal/FilterModal.tsx
+++ b/src/lib/Components/FilterModal/FilterModal.tsx
@@ -214,7 +214,7 @@ export const FilterOptions: React.FC<FilterOptionsProps> = (props) => {
 
   const concreteAggregations = state.aggregations ?? []
 
-  const isClearAllButtonEnabled = state.appliedFilters.length > 0 || state.appliedFilters.length > 0
+  const isClearAllButtonEnabled = state.appliedFilters.length > 0 || state.selectedFilters.length > 0
 
   const aggregateFilterOptions: FilterDisplayConfig[] = _.compact(
     concreteAggregations.map((aggregation) => {


### PR DESCRIPTION
The type of this PR is: BUG

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-720]

### Description

<img width="361" alt="Screen Shot 2020-10-26 at 3 51 10 PM" src="https://user-images.githubusercontent.com/19369/97222176-539ff780-17a4-11eb-975f-ef71e1c8d39e.png">

<img width="351" alt="Screen Shot 2020-10-26 at 3 51 30 PM" src="https://user-images.githubusercontent.com/19369/97222177-539ff780-17a4-11eb-9d93-be58df0e7acc.png">


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-720]: https://artsyproduct.atlassian.net/browse/CX-720