### PR TITLE
fix: add artist names to filtermodal

### DIFF
--- a/src/lib/Components/FilterModal/FilterModal.tsx
+++ b/src/lib/Components/FilterModal/FilterModal.tsx
@@ -300,7 +300,12 @@ export const FilterOptions: React.FC<FilterOptionsProps> = (props) => {
                     </Sans>
                     <Flex flexDirection="row" alignItems="center">
                       <OptionDetail
-                        currentOption={selectedOption(selectedOptions, item.filterType, state.filterType)}
+                        currentOption={selectedOption({
+                          selectedOptions,
+                          filterScreen: item.filterType,
+                          filterType: state.filterType,
+                          aggregations: state.aggregations,
+                        })}
                         filterType={item.filterType}
                       />
                       <ArrowRightIcon fill="black30" ml="1" />

--- a/src/lib/utils/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
+++ b/src/lib/utils/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
@@ -1,4 +1,4 @@
-import { FilterArray } from "lib/utils/ArtworkFilter/ArtworkFiltersStore"
+import { Aggregations, FilterArray } from "lib/utils/ArtworkFilter/ArtworkFiltersStore"
 import {
   aggregationsWithFollowedArtists,
   changedFiltersParams,
@@ -375,7 +375,7 @@ describe("selectedOption", () => {
         },
       ]
 
-      expect(selectedOption(selectedOptions, "waysToBuy")).toEqual("All")
+      expect(selectedOption({ selectedOptions, filterScreen: "waysToBuy", aggregations: [] })).toEqual("All")
     })
 
     it("returns the correct result when one item is selected", () => {
@@ -403,7 +403,7 @@ describe("selectedOption", () => {
         },
       ]
 
-      expect(selectedOption(selectedOptions, "waysToBuy")).toEqual("Buy now")
+      expect(selectedOption({ selectedOptions, filterScreen: "waysToBuy", aggregations: [] })).toEqual("Buy now")
     })
     it("returns the correct result when multiple items is selected", () => {
       const selectedOptions = [
@@ -430,7 +430,9 @@ describe("selectedOption", () => {
         },
       ]
 
-      expect(selectedOption(selectedOptions, "waysToBuy")).toEqual("Buy now, Make offer")
+      expect(selectedOption({ selectedOptions, filterScreen: "waysToBuy", aggregations: [] })).toEqual(
+        "Buy now, Make offer"
+      )
     })
   })
 
@@ -438,13 +440,13 @@ describe("selectedOption", () => {
     it("returns the correct value in the default case", () => {
       const selectedOptions = [{ paramName: FilterParamName.gallery, displayText: "All" }]
 
-      expect(selectedOption(selectedOptions, "gallery")).toEqual("All")
+      expect(selectedOption({ selectedOptions, filterScreen: "gallery", aggregations: [] })).toEqual("All")
     })
 
     it("returns the correct value when an options is selected", () => {
       const selectedOptions = [{ paramName: FilterParamName.gallery, displayText: "gallery one", filterKey: "gallery" }]
 
-      expect(selectedOption(selectedOptions, "gallery")).toEqual("gallery one")
+      expect(selectedOption({ selectedOptions, filterScreen: "gallery", aggregations: [] })).toEqual("gallery one")
     })
   })
 
@@ -453,7 +455,7 @@ describe("selectedOption", () => {
       it("returns the correct value in the default case", () => {
         const selectedOptions = [] as FilterArray
 
-        expect(selectedOption(selectedOptions, "artistIDs")).toEqual("All")
+        expect(selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations: [] })).toEqual("All")
       })
 
       it("returns the correct value when one artist is selected", () => {
@@ -465,7 +467,7 @@ describe("selectedOption", () => {
           },
         ]
 
-        expect(selectedOption(selectedOptions, "artistIDs")).toEqual("Artist 1")
+        expect(selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations: [] })).toEqual("Artist 1")
       })
 
       it("returns the correct value when multiple artists are selected", () => {
@@ -482,7 +484,9 @@ describe("selectedOption", () => {
           },
         ]
 
-        expect(selectedOption(selectedOptions, "artistIDs")).toEqual("Artist 2, 1 more")
+        expect(selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations: [] })).toEqual(
+          "Artist 2, 1 more"
+        )
       })
 
       it("returns the correct value when multiple artists and Artist I follow are selected", () => {
@@ -504,61 +508,57 @@ describe("selectedOption", () => {
           },
         ]
 
-        expect(selectedOption(selectedOptions, "artistIDs")).toEqual("All artists I follow, 2 more")
+        expect(selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations: [] })).toEqual(
+          "All artists I follow, 2 more"
+        )
       })
     })
 
     describe("saleArtworks", () => {
+      const aggregations: Aggregations = [
+        {
+          slice: "ARTIST",
+          counts: [
+            { count: 21, name: "Banksy", value: "banksy" },
+            { count: 21, name: "Andy Warhol", value: "andy-warhol" },
+          ],
+        },
+        { slice: "MEDIUM", counts: [{ count: 21, name: "Prints", value: "prints" }] },
+      ]
       it("returns the correct value in the default case", () => {
         const selectedOptions = [] as FilterArray
 
-        expect(selectedOption(selectedOptions, "artistIDs")).toEqual("All")
+        expect(
+          selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations, filterType: "saleArtwork" })
+        ).toEqual("All")
       })
 
       it("returns the correct value when one artist is selected", () => {
         const selectedOptions = [
           {
             paramName: FilterParamName.artistIDs,
-            paramValue: ["artist-1"],
+            paramValue: ["banksy"],
             displayText: "Artists",
           },
         ]
 
-        expect(selectedOption(selectedOptions, "artistIDs")).toEqual("Artists")
+        expect(
+          selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations, filterType: "saleArtwork" })
+        ).toEqual("Banksy")
       })
 
       it("returns the correct value when multiple artists are selected", () => {
         const selectedOptions = [
           {
             paramName: FilterParamName.artistIDs,
-            paramValue: ["artist-1", "artist-2"],
+            paramValue: ["banksy", "andy-warhol"],
             displayText: "Artists",
           },
         ]
 
-        expect(selectedOption(selectedOptions, "artistIDs")).toEqual("Artists")
-      })
-
-      it("returns the correct value when multiple artists and Artist I follow are selected", () => {
-        const selectedOptions = [
-          {
-            paramName: FilterParamName.artistIDs,
-            paramValue: ["artist-1"],
-            displayText: "Artists",
-          },
-          {
-            paramName: FilterParamName.artistIDs,
-            paramValue: ["artist-2"],
-            displayText: "Artists",
-          },
-          {
-            paramName: FilterParamName.artistsIFollow,
-            paramValue: true,
-            displayText: "Artists",
-          },
-        ]
-
-        expect(selectedOption(selectedOptions, "artistIDs")).toEqual("All artists I follow, 2 more")
+        expect(
+          selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations, filterType: "saleArtwork" })
+        ).toEqual("Andy Warhol, 1 more")
       })
     })
   })


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-718]

### Description
- If you filter for an artist, the top-level filter modal shows the artist-slug instead of the artist name
___
**Before the changes**
![Screen_Recording_2020-10-27_at_13 05 10](https://user-images.githubusercontent.com/11945712/97299462-44c54d80-1855-11eb-8112-9c1674754f37.gif)


**After the changes**
![Screen_Recording_2020-10-27_at_13 03 43](https://user-images.githubusercontent.com/11945712/97299471-47c03e00-1855-11eb-85e9-275f4f3b8d05.gif)


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-718]: https://artsyproduct.atlassian.net/browse/CX-718