### PR TITLE
[Purchase-2169] SVG bugfix on closed/won auction star icons

### DIFF
--- a/src/palette/svgs/sf/StarCircleFill.tsx
+++ b/src/palette/svgs/sf/StarCircleFill.tsx
@@ -1,10 +1,10 @@
 import React from "react"
 import { EMaskUnits } from "react-native-svg"
 import { color } from "../../helpers"
-import { Icon, IconProps, Mask, Path, Rect } from "../Icon"
+import { Circle, Icon, IconProps, Mask, Path, Rect } from "../Icon"
 
 /** StarCircleFill */
-export const StarCircleFill: React.FC<IconProps> = props => {
+export const StarCircleFill: React.FC<IconProps> = (props) => {
   return (
     <Icon {...props} viewBox="0 0 20 20">
       <Mask
@@ -23,6 +23,7 @@ export const StarCircleFill: React.FC<IconProps> = props => {
           d="M10 18C14.4183 18 18 14.4183 18 10C18 5.58172 14.4183 2 10 2C5.58172 2 2 5.58172 2 10C2 14.4183 5.58172 18 10 18ZM9.65332 10.6357H7.16602C6.98145 10.6357 6.84961 10.5082 6.84961 10.3369C6.84961 10.2402 6.89355 10.1523 6.96826 10.0556L10.9585 5.06782C11.2573 4.69428 11.7231 4.93598 11.5562 5.38862L10.2422 8.94819H12.7295C12.9141 8.94819 13.0415 9.08002 13.0415 9.24702C13.0415 9.34809 13.002 9.43598 12.9272 9.52827L8.93701 14.5205C8.63818 14.8896 8.16797 14.6479 8.33936 14.1953L9.65332 10.6357Z"
         />
       </Mask>
+      <Circle cx="10" cy="10" r="5" fill={color("white100")} />
       <Path
         fillRule="evenodd"
         clipRule="evenodd"


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [PURCH-2169]

cc @artsy/purchase-devs 

### Description

Fixes a small SVG bug where won lots under the My Bids closed tabs showed the artwork through the icon.

Before:
<img width="376" alt="Screen Shot 2020-10-29 at 5 10 42 PM" src="https://user-images.githubusercontent.com/10385964/97632952-adedc200-1a09-11eb-9580-85cb900d9c80.png">


After:
<img width="375" alt="Screen Shot 2020-10-29 at 5 07 31 PM" src="https://user-images.githubusercontent.com/10385964/97632964-b514d000-1a09-11eb-9c00-9571121919f5.png">


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434