### PR TITLE
fix(my collection): set correct keyboard types #trivial

### DIFF
--- a/src/lib/Scenes/MyCollection/Screens/AddArtwork/Components/Dimensions.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/AddArtwork/Components/Dimensions.tsx
@@ -22,6 +22,7 @@ export const Dimensions: React.FC = () => {
       <Flex flexDirection="row">
         <Input
           placeholder="Height"
+          keyboardType="decimal-pad"
           onChangeText={formik.handleChange("height")}
           onBlur={formik.handleBlur("height")}
           defaultValue={formik.values.height}
@@ -29,6 +30,7 @@ export const Dimensions: React.FC = () => {
         />
         <Input
           placeholder="Width"
+          keyboardType="decimal-pad"
           onChangeText={formik.handleChange("width")}
           onBlur={formik.handleBlur("width")}
           defaultValue={formik.values.width}
@@ -36,6 +38,7 @@ export const Dimensions: React.FC = () => {
         />
         <Input
           placeholder="Depth"
+          keyboardType="decimal-pad"
           onChangeText={formik.handleChange("depth")}
           onBlur={formik.handleBlur("depth")}
           defaultValue={formik.values.depth}

--- a/src/lib/Scenes/MyCollection/Screens/AddArtwork/Screens/AdditionalDetails.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/AddArtwork/Screens/AdditionalDetails.tsx
@@ -32,9 +32,9 @@ export const AdditionalDetails = () => {
               defaultValue={formikValues.title}
             />
             <Input
-              title="Date"
-              keyboardType="numbers-and-punctuation"
-              placeholder="Date"
+              title="Year"
+              keyboardType="number-pad"
+              placeholder="Year"
               onChangeText={formik.handleChange("date")}
               onBlur={formik.handleBlur("date")}
               data-test-id="DateInput"

--- a/src/lib/Scenes/MyCollection/Screens/AddArtwork/Screens/AdditionalDetails.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/AddArtwork/Screens/AdditionalDetails.tsx
@@ -33,6 +33,7 @@ export const AdditionalDetails = () => {
             />
             <Input
               title="Date"
+              keyboardType="numbers-and-punctuation"
               placeholder="Date"
               onChangeText={formik.handleChange("date")}
               onBlur={formik.handleBlur("date")}
@@ -55,6 +56,7 @@ export const AdditionalDetails = () => {
               <Flex flexDirection="row">
                 <Input
                   placeholder="Edition number"
+                  keyboardType="number-pad"
                   onChangeText={formik.handleChange("editionNumber")}
                   onBlur={formik.handleBlur("editionNumber")}
                   defaultValue={formikValues.editionNumber!}
@@ -63,6 +65,7 @@ export const AdditionalDetails = () => {
                 />
                 <Input
                   placeholder="Edition size"
+                  keyboardType="number-pad"
                   onChangeText={formik.handleChange("editionSize")}
                   onBlur={formik.handleBlur("editionSize")}
                   data-test-id="EditionSizeInput"
@@ -83,6 +86,7 @@ export const AdditionalDetails = () => {
             <Input
               title="Price paid"
               placeholder="Price paid"
+              keyboardType="decimal-pad"
               onChangeText={formik.handleChange("costMinor")}
               onBlur={formik.handleBlur("costMinor")}
               data-test-id="PricePaidInput"


### PR DESCRIPTION
The type of this PR is: Bugfix

This PR resolves [CX-786]

### Description

This specifies keyboard types for the Add Artwork form:

- Dimensions (height/width/depth): numeric with decimal
- Edition (number/size): numeric
- Price paid: numeric with decimal
- Date: numeric with punctuation

The Date field is not ideal - I wonder whether we should change the label to "Year" and then have a straight numeric keyboard @joanna20 ? Or just leave it as "Date" but use a numeric keyboard?

![image](https://user-images.githubusercontent.com/1815204/97979042-cb86a700-1dce-11eb-8306-7dcc0c556a86.png)
![image](https://user-images.githubusercontent.com/1815204/97979084-dc371d00-1dce-11eb-8581-e8e0641db323.png)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-786]: https://artsyproduct.atlassian.net/browse/CX-786