### PR TITLE
fix(my collection): artwork list empty state alignment #trivial

### DIFF
--- a/src/lib/Components/States/ZeroState.tsx
+++ b/src/lib/Components/States/ZeroState.tsx
@@ -11,14 +11,18 @@ interface ZeroStateProps {
 
 export const ZeroState = (props: ZeroStateProps) => (
   <Flex py="4" px="2" alignItems="center" justifyContent="center" style={{ height: "100%" }}>
-    <Sans size="6" textAlign="center" maxWidth="80%">
-      {props.title}
-    </Sans>
-    <Spacer mb={3} />
+    {!!props.title && (
+      <>
+        <Sans size="6" textAlign="center" maxWidth="80%">
+          {props.title}
+        </Sans>
+        <Spacer mb={3} />
+      </>
+    )}
 
     {!!props.subtitle && (
       <>
-        <Sans size="4" textAlign="center" maxWidth={!!props.title ? "100%" : "80%"}>
+        <Sans size="4" textAlign="center" maxWidth={props.title ? "100%" : "80%"}>
           {props.subtitle}
         </Sans>
         <Spacer mb={3} />

--- a/src/lib/Components/States/ZeroState.tsx
+++ b/src/lib/Components/States/ZeroState.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import { Flex, Sans, Spacer } from "palette"
 
 interface ZeroStateProps {
-  title: string
+  title?: string
   subtitle?: string
   separators?: boolean
   callToAction?: JSX.Element
@@ -18,7 +18,7 @@ export const ZeroState = (props: ZeroStateProps) => (
 
     {!!props.subtitle && (
       <>
-        <Sans size="4" textAlign="center">
+        <Sans size="4" textAlign="center" maxWidth={!!props.title ? "100%" : "80%"}>
           {props.subtitle}
         </Sans>
         <Spacer mb={3} />

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkList/MyCollectionArtworkList.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkList/MyCollectionArtworkList.tsx
@@ -57,10 +57,12 @@ export const MyCollectionArtworkList: React.FC<MyCollectionArtworkListProps> = (
         My Collection
       </Text>
       {artworks.length === 0 ? (
-        <ZeroState
-          title="Add a work from your collection to access price and market insights."
-          callToAction={<Button onPress={addArtwork}>Add artwork</Button>}
-        />
+        <Flex pb="200">
+          <ZeroState
+            subtitle="Add a work from your collection to access price and market insights."
+            callToAction={<Button onPress={addArtwork}>Add artwork</Button>}
+          />
+        </Flex>
       ) : (
         <FlatList
           data={artworks}

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkList/MyCollectionArtworkList.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkList/MyCollectionArtworkList.tsx
@@ -57,7 +57,7 @@ export const MyCollectionArtworkList: React.FC<MyCollectionArtworkListProps> = (
         My Collection
       </Text>
       {artworks.length === 0 ? (
-        <Flex pb="240">
+        <Flex pb="200">
           <ZeroState
             subtitle="Add a work from your collection to access price and market insights."
             callToAction={<Button onPress={addArtwork}>Add artwork</Button>}

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkList/MyCollectionArtworkList.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkList/MyCollectionArtworkList.tsx
@@ -57,7 +57,7 @@ export const MyCollectionArtworkList: React.FC<MyCollectionArtworkListProps> = (
         My Collection
       </Text>
       {artworks.length === 0 ? (
-        <Flex pb="200">
+        <Flex pb="240">
           <ZeroState
             subtitle="Add a work from your collection to access price and market insights."
             callToAction={<Button onPress={addArtwork}>Add artwork</Button>}


### PR DESCRIPTION
The type of this PR is: Bugfix

This PR resolves [CX-767]

### Description

Moves the zero state component to the centre of the screen. Also reduces the font size.

![image](https://user-images.githubusercontent.com/1815204/97982815-9c733400-1dd4-11eb-9058-5ed967b379b5.png)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-767]: https://artsyproduct.atlassian.net/browse/CX-767