### PR TITLE
fix: fix title for add artwork modal #trivial

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -10,6 +10,7 @@ upcoming:
     - Loading plcaeholders on new auction screen - mounir
     - Adds Show2 viewing room - damon
     - Adds auction closed banner - mounir
+    - Fix add artwork modal title (my collection) - brian
 
 releases:
   - version: 6.6.7

--- a/src/lib/Scenes/MyCollection/Screens/AddArtwork/AddEditArtwork.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/AddArtwork/AddEditArtwork.tsx
@@ -20,7 +20,7 @@ export const AddEditArtwork: React.FC = () => {
   const navState = AppStore.useAppState((state) => state.myCollection.navigation)
   const { formik } = useArtworkForm()
   const modalType = navState?.sessionState?.modalType
-  const addOrEditLabel = modalType ? "Edit" : "Add"
+  const addOrEditLabel = modalType === "edit" ? "Edit" : "Add"
 
   /* FIXME: Wire up proper loading modal */
   const submitArtwork = () => {


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [CX-769]

### Description

Updates check to be string comparison rather than existence. 

### Screenshots

![AddArtworkCopy](https://user-images.githubusercontent.com/49686530/97993497-28279900-1db2-11eb-88fa-5cb28837eaff.png)

### PR Checklist (tick all before merging)
- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-769]: https://artsyproduct.atlassian.net/browse/CX-769