### PR TITLE
fix: fix upper limit label of demand rank #trivial

### DIFF
--- a/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/ArtworkInsights/MyCollectionArtworkDemandIndex.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/ArtworkInsights/MyCollectionArtworkDemandIndex.tsx
@@ -91,7 +91,7 @@ const DemandRankScale: React.FC<{ demandRank: number }> = ({ demandRank }) => {
       <Spacer my={0.3} />
       <Flex flexDirection="row" justifyContent="space-between">
         <Text>0.0</Text>
-        <Text>{demandRank}</Text>
+        <Text>10.0</Text>
       </Flex>
     </>
   )

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/ArtworkInsights/MyCollectionArtworkDemandIndex.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/ArtworkInsights/MyCollectionArtworkDemandIndex.tsx
@@ -44,7 +44,7 @@ const DemandRankDetails: React.FC<{ demandRank: number }> = ({ demandRank }) => 
       case demandRank >= 9: {
         return (
           <Bubble
-            title="Very Strong Demand (> 0.9)"
+            title="Very Strong Demand (> 9.0)"
             subTitle="This is a great time to sell. Works like these are [the most popular] [highly sought after]"
           />
         )
@@ -52,18 +52,18 @@ const DemandRankDetails: React.FC<{ demandRank: number }> = ({ demandRank }) => 
       case demandRank >= 7 && demandRank < 9: {
         return (
           <Bubble
-            title="Strong Demand (0.7 – 0.9)"
+            title="Strong Demand (7.0 – 9.0)"
             subTitle="There are more collectors looking to buy works like these than [there are for sale] [works available]"
           />
         )
       }
       case demandRank >= 4 && demandRank < 7: {
-        return <Bubble title="Stable Market (0.4 – 0.7)" subTitle="The market is neutral for buying and selling." />
+        return <Bubble title="Stable Market (4.0 – 7.0)" subTitle="The market is neutral for buying and selling." />
       }
       case demandRank < 4: {
         return (
           <Bubble
-            title="Less Active Market  (<0.4)"
+            title="Less Active Market  (<4.0)"
             subTitle="The market for selling isn’t very active yet. We will notify you when the market changes"
           />
         )

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/ArtworkInsights/MyCollectionArtworkDemandIndex.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/ArtworkInsights/MyCollectionArtworkDemandIndex.tsx
@@ -84,14 +84,14 @@ const DemandRankScale: React.FC<{ demandRank: number }> = ({ demandRank }) => {
     <>
       <Box>
         <Text variant="largeTitle" color="purple100">
-          {demandRank}
+          {demandRank.toFixed(1)}
         </Text>
       </Box>
       <ProgressBar width={width} />
       <Spacer my={0.3} />
       <Flex flexDirection="row" justifyContent="space-between">
-        <Text>0.0</Text>
-        <Text>10.0</Text>
+        <Text>0</Text>
+        <Text>10</Text>
       </Flex>
     </>
   )

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/ArtworkInsights/__tests__/MyCollectionArtworkDemandIndex-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/ArtworkInsights/__tests__/MyCollectionArtworkDemandIndex-tests.tsx
@@ -54,8 +54,8 @@ describe("MyCollectionArtworkDemandIndex", () => {
     expect(wrapper.root.findByType(tests.DemandRankDetails)).toBeDefined()
     const text = extractText(wrapper.root)
     expect(text).toContain("Demand index")
-    expect(text).toContain("800.080")
-    expect(text).toContain("Very Strong Demand (> 0.9)")
+    expect(text).toContain("800.010.0")
+    expect(text).toContain("Very Strong Demand (> 9.0)")
   })
 
   // TODO: Figure out why it can't find InfoButton

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/ArtworkInsights/__tests__/MyCollectionArtworkDemandIndex-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkDetail/Components/ArtworkInsights/__tests__/MyCollectionArtworkDemandIndex-tests.tsx
@@ -54,7 +54,7 @@ describe("MyCollectionArtworkDemandIndex", () => {
     expect(wrapper.root.findByType(tests.DemandRankDetails)).toBeDefined()
     const text = extractText(wrapper.root)
     expect(text).toContain("Demand index")
-    expect(text).toContain("800.010.0")
+    expect(text).toContain("80.0010")
     expect(text).toContain("Very Strong Demand (> 9.0)")
   })
 


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [CX-783]

### Description

Update upper limit label for demand index progress bar.

### Screenshots 

![DemandRankUpdatedAgain](https://user-images.githubusercontent.com/49686530/98409754-671f4e00-2041-11eb-8320-d56272f20315.png)


### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-783]: https://artsyproduct.atlassian.net/browse/CX-783