### PR TITLE
fix: prevent keyboard touch intercept #trivial

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -29,6 +29,7 @@ upcoming:
     - Adds Show2 location map - damon
     - Adds Show2 location hours - damon
     - Add inquiry questions state to reducer + wire up mutation - christina
+    - Fix keyboard touch intercept (my collection) - brian
 
 releases:
   - version: 6.6.7

--- a/src/lib/Scenes/MyCollection/Screens/AddArtwork/AddEditArtwork.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/AddArtwork/AddEditArtwork.tsx
@@ -57,7 +57,11 @@ export const AddEditArtwork: React.FC = () => {
     <>
       {showLoading && <LoadingIndicator />}
       {/* Disable touch events in form while loading */}
-      <ScrollView pointerEvents={showLoading ? "none" : "auto"}>
+      <ScrollView
+        pointerEvents={showLoading ? "none" : "auto"}
+        keyboardDismissMode={"on-drag"}
+        keyboardShouldPersistTaps={"handled"}
+      >
         <FancyModalHeader leftButtonText="Cancel" onLeftButtonPress={() => artworkActions.cancelAddEditArtwork()}>
           {addOrEditLabel} artwork
         </FancyModalHeader>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [CX-768]

### Description

Adds props to scrollview to prevent keyboard intercepting initial tap. Thanks @ds300 for the pointer this would have taken me a while to figure out 🙌 

### Screenshots

![selectArtist](https://user-images.githubusercontent.com/49686530/98029042-ed872600-1ddc-11eb-9df8-15f53fb3ad7a.gif)


### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-768]: https://artsyproduct.atlassian.net/browse/CX-768