### PR TITLE
fix: reset form when leaving edit modal

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -29,6 +29,7 @@ upcoming:
     - Adds Show2 location map - damon
     - Adds Show2 location hours - damon
     - Add inquiry questions state to reducer + wire up mutation - christina
+    - Fix persisting edit form values (my collection) - brian
 
 releases:
   - version: 6.6.7

--- a/src/lib/Scenes/MyCollection/State/MyCollectionArtworkModel.tsx
+++ b/src/lib/Scenes/MyCollection/State/MyCollectionArtworkModel.tsx
@@ -555,7 +555,8 @@ export const MyCollectionArtworkModel: MyCollectionArtworkModel = {
     Alert.alert("Error deleting artwork", "TODO add better message")
   }),
 
-  cancelAddEditArtwork: thunk((actions, _payload, { getState, getStoreActions }) => {
+  cancelAddEditArtwork: thunk((actions, _payload, { getState, getStoreActions, getStoreState }) => {
+    const modalType = getStoreState().myCollection.navigation.sessionState.modalType
     const navigationActions = getStoreActions().myCollection.navigation
     const formIsDirty = !isEqual(getState().sessionState.formValues, getState().sessionState.dirtyFormCheckValues)
 
@@ -575,6 +576,10 @@ export const MyCollectionArtworkModel: MyCollectionArtworkModel = {
         }
       )
     } else {
+      // avoid edit form values leaking into add artwork forms
+      if (modalType === "edit") {
+        actions.resetForm()
+      }
       navigationActions.dismissModal()
     }
   }),


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [CX-785]

### Description

I couldn't reproduce the exact behavior described in the ticket but I am assuming this is the bug, when starting to edit an artwork in your collection and dismissing the modal and then adding an artwork, the details of the edited artwork appear in the form. Fixed by resetting the form in the cancelAddOrEditArtwork action when editing. 


### Screenshots

#### Before

![beforePersist](https://user-images.githubusercontent.com/49686530/98037097-14e3f000-1de9-11eb-9c1a-25075d0a2446.gif)

#### After 
![afterPersist](https://user-images.githubusercontent.com/49686530/98036900-c898b000-1de8-11eb-93f5-f1f0d08ba8ba.gif)


### Follow-ups

Found another bug while fixing this one that is visible in gif above, the text is updating to the "Add" artwork copy when dismissing the edit modal. Bug filed here: https://artsyproduct.atlassian.net/browse/CX-790
 
### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-785]: https://artsyproduct.atlassian.net/browse/CX-785