### PR TITLE
fix(my collection): photo list layout in add artwork

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -52,6 +52,7 @@ upcoming:
     - Fix keyboard touch intercept (my collection) - brian
     - Fix persisting edit form values (my collection) - brian
     - Fix artist name truncation on add/edit artwork page (my collection) - david
+    - Fix photo layout in add/edit artwork page (my collection) - adam
 
 releases:
   - version: 6.6.7

--- a/src/lib/Scenes/MyCollection/Screens/AddArtwork/Screens/AddPhotos.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/AddArtwork/Screens/AddPhotos.tsx
@@ -27,7 +27,7 @@ export const AddPhotos: React.FC = () => {
             {photos.map((photo, index) => {
               return (
                 <Box key={index}>
-                  <Box m={0.5}>
+                  <Box ml={index % 2 === 0 ? 1 : 0} mb={1}>
                     <Image
                       style={{ width: imageSize, height: imageSize, resizeMode: "cover" }}
                       source={{ uri: photo.path }}
@@ -50,7 +50,7 @@ const AddPhotosButton: React.FC = () => {
 
   return (
     <TouchableOpacity onPress={() => artworkActions.takeOrPickPhotos()}>
-      <BorderBox m={0.5} p={0} bg={color("white100")} width={imageSize} height={imageSize} key="addMorePhotos">
+      <BorderBox mb={1} p={0} bg={color("white100")} width={imageSize} height={imageSize} key="addMorePhotos">
         <Flex flex={1} flexDirection="row" justifyContent="center" alignItems="center">
           <AddIcon width={30} height={30} />
         </Flex>
@@ -76,7 +76,8 @@ const DeletePhotoButton: React.FC<{ photo: ImageProps }> = ({ photo }) => {
 
 const useImageSize = () => {
   const dimensions = useScreenDimensions()
-  const size = Math.round((dimensions.width / 2) * 0.855)
+  const margins = 2 * 20 + 10
+  const size = Math.round((dimensions.width - margins) / 2)
   return size
 }
 

--- a/src/palette/svgs/XCircleIcon.tsx
+++ b/src/palette/svgs/XCircleIcon.tsx
@@ -1,12 +1,12 @@
 import React from "react"
 import { color } from "../helpers"
-import { Icon, IconProps, Path } from "./Icon"
+import { Circle, Icon, IconProps, Path } from "./Icon"
 
 /** XCircleIcon */
 export const XCircleIcon: React.FC<IconProps> = (props) => {
   return (
     <Icon {...props} viewBox="0 0 18 18">
-      <Path d="M0 0H18V18H0V0Z" fill="white" />
+      <Circle cx={9} cy={9} r={9} fill="white" />
       <Path
         fillRule="evenodd"
         clipRule="evenodd"


### PR DESCRIPTION
The type of this PR is: Bugfix

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-779]

### Description

Some layout re-jigging to get the photos to lay themselves out in a grid. Also, I edited the close button SVG to use a white circle background instead of a square, in order to provide the appearance of a 2px white border.

Note that I can't actually get photos to save, so I've illustrated the layout by adding a background color to the photo components in this image:

![image](https://user-images.githubusercontent.com/1815204/98096534-29c58f80-1e8c-11eb-9ef7-b3560d0ebcaf.png)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-779]: https://artsyproduct.atlassian.net/browse/CX-779