### PR TITLE
fix(my collection add/edit artwork): truncate artist name

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -51,6 +51,7 @@ upcoming:
     - Add inquiry questions state to reducer + wire up mutation - christina
     - Fix keyboard touch intercept (my collection) - brian
     - Fix persisting edit form values (my collection) - brian
+    - Fix artist name truncation on add/edit artwork page (my collection) - david
 
 releases:
   - version: 6.6.7

--- a/src/lib/Scenes/MyCollection/Screens/AddArtwork/Components/ArtistSearchResult.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/AddArtwork/Components/ArtistSearchResult.tsx
@@ -1,25 +1,27 @@
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { AutosuggestResult } from "lib/Scenes/Search/AutosuggestResults"
 import { AppStore } from "lib/store/AppStore"
-import { Button, Flex, Sans, Spacer } from "palette"
+import { Button, Flex, Spacer, Text } from "palette"
 import React from "react"
-import { Text, View } from "react-native"
 
 export const ArtistSearchResult: React.FC<{ result: AutosuggestResult }> = ({ result }) => {
   return (
-    <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
-      <Flex flexDirection="row" alignItems="center">
-        <OpaqueImageView
-          imageURL={result.imageUrl}
-          style={{ width: 40, height: 40, borderRadius: 2, overflow: "hidden" }}
-        />
-        <Spacer ml={1} />
-        <View>
-          <Text ellipsizeMode="tail" numberOfLines={1} data-test-id="displayLabel">
-            {result.displayLabel}
-          </Text>
-        </View>
-      </Flex>
+    <Flex flexDirection="row" alignItems="center">
+      <OpaqueImageView
+        imageURL={result.imageUrl}
+        style={{ width: 40, height: 40, borderRadius: 2, overflow: "hidden" }}
+      />
+      <Spacer ml="1" />
+      <Text
+        variant="subtitle"
+        ellipsizeMode="tail"
+        numberOfLines={1}
+        data-test-id="displayLabel"
+        style={{ flexShrink: 1, flexGrow: 1, overflow: "hidden" }}
+      >
+        {result.displayLabel}
+      </Text>
+      <Spacer ml="1" />
       <Button
         variant="secondaryGray"
         size="small"
@@ -27,7 +29,7 @@ export const ArtistSearchResult: React.FC<{ result: AutosuggestResult }> = ({ re
           AppStore.actions.myCollection.artwork.setArtistSearchResult(null)
         }}
       >
-        <Sans size="3">Remove</Sans>
+        Remove
       </Button>
     </Flex>
   )


### PR DESCRIPTION
This PR resolves [CX-780]

### Description

This PR fixes a bug where long artist names would push the 'remove' button off the screen.

✨ **bonus** :sparkles:

- the artist name was in the wrong font (using RN's `Text` component rather than the palette `Text`)
- the remove button had the wrong text size

#### Before

![image](https://user-images.githubusercontent.com/1242537/98116192-dd844a80-1e9f-11eb-8ab2-7ac400f69dbd.png)


#### After

![image](https://user-images.githubusercontent.com/1242537/98116165-d4937900-1e9f-11eb-8964-089021fa3632.png)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-780]: https://artsyproduct.atlassian.net/browse/CX-780