### PR TITLE
fix(SaleHeader): auction closed bug

### DIFF
--- a/src/lib/Scenes/Sale/Components/SaleHeader.tsx
+++ b/src/lib/Scenes/Sale/Components/SaleHeader.tsx
@@ -1,6 +1,7 @@
 import { SaleHeader_sale } from "__generated__/SaleHeader_sale.graphql"
 import { saleTime } from "lib/utils/saleTime"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
+import moment from "moment"
 import { Flex, Text } from "palette"
 import React from "react"
 import { Animated, Dimensions, View } from "react-native"
@@ -20,11 +21,12 @@ interface Props {
   scrollAnim: AnimatedValue
 }
 
-export const SaleHeader: React.FC<Props> = (props) => {
-  const saleTimeDetails = saleTime(props.sale)
+export const SaleHeader: React.FC<Props> = ({ sale, scrollAnim }) => {
+  const saleTimeDetails = saleTime(sale)
+
   return (
     <>
-      {!!props.sale.coverImage?.url && (
+      {!!sale.coverImage?.url && (
         <Animated.View
           style={{
             position: "absolute",
@@ -32,13 +34,13 @@ export const SaleHeader: React.FC<Props> = (props) => {
             left: 0,
             height: COVER_IMAGE_HEIGHT,
             width: "100%",
-            opacity: props.scrollAnim.interpolate({
+            opacity: scrollAnim.interpolate({
               inputRange: [0, COVER_IMAGE_HEIGHT],
               outputRange: [1, 0],
             }),
             transform: [
               {
-                translateY: props.scrollAnim.interpolate({
+                translateY: scrollAnim.interpolate({
                   inputRange: [-1, 0, 1],
                   outputRange: [0, 0, 0.5],
                 }),
@@ -47,37 +49,39 @@ export const SaleHeader: React.FC<Props> = (props) => {
           }}
         >
           <OpaqueImageView
-            imageURL={props.sale.coverImage.url}
+            imageURL={sale.coverImage.url}
             style={{
               width: Dimensions.get("window").width,
               height: COVER_IMAGE_HEIGHT,
             }}
           >
-            <Flex
-              style={{
-                backgroundColor: "rgba(0,0,0,0.5)",
-                width: Dimensions.get("window").width,
-                height: COVER_IMAGE_HEIGHT,
-                justifyContent: "center",
-                alignItems: "center",
-              }}
-            >
-              <Text variant="subtitle" fontWeight="500" color="white">
-                Auction closed
-              </Text>
-            </Flex>
+            {!!sale.endAt && !!moment().isAfter(sale.endAt) && (
+              <Flex
+                style={{
+                  backgroundColor: "rgba(0,0,0,0.5)",
+                  width: Dimensions.get("window").width,
+                  height: COVER_IMAGE_HEIGHT,
+                  justifyContent: "center",
+                  alignItems: "center",
+                }}
+              >
+                <Text variant="subtitle" fontWeight="500" color="white">
+                  Auction closed
+                </Text>
+              </Flex>
+            )}
           </OpaqueImageView>
         </Animated.View>
       )}
       <View
         style={{
           backgroundColor: "white",
-          marginTop: !!props.sale.coverImage?.url ? COVER_IMAGE_HEIGHT : useScreenDimensions().safeAreaInsets.top + 40,
+          marginTop: !!sale.coverImage?.url ? COVER_IMAGE_HEIGHT : useScreenDimensions().safeAreaInsets.top + 40,
         }}
       >
         <Flex mx="2" mt="2">
           <Text variant="largeTitle" testID="saleName">
-            {props.sale.name}
+            {sale.name}
           </Text>
           <Flex my="1">
             {saleTimeDetails.absolute !== null && (
@@ -94,7 +98,7 @@ export const SaleHeader: React.FC<Props> = (props) => {
           <CaretButton
             text="More info about this auction"
             onPress={() => {
-              navigate(`auction/${props.sale.slug}/info`)
+              navigate(`auction/${sale.slug}/info`)
             }}
           />
         </Flex>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

The auction screen now shows "auction is closed" always. It should instead show "auction is closed" only if an auction `endAt` already passed.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434