### PR TITLE
fix(fx-2408): improves guards for rendering hours and locations #trivial

### DIFF
--- a/src/__generated__/Show2MoreInfoQuery.graphql.ts
+++ b/src/__generated__/Show2MoreInfoQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 01882d95fee25c87a42be270fe07cf86 */
+/* @relayHash e462c2b42e7c1db520d3ac534a753d6b */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -153,6 +153,18 @@ fragment Show2MoreInfo_show on Show {
       __typename
       openingHours {
         __typename
+        ... on OpeningHoursArray {
+          schedules {
+            __typename
+          }
+        }
+        ... on OpeningHoursText {
+          text
+        }
+      }
+      coordinates {
+        lat
+        lng
       }
       id
     }
@@ -162,6 +174,18 @@ fragment Show2MoreInfo_show on Show {
     __typename
     openingHours {
       __typename
+      ... on OpeningHoursArray {
+        schedules {
+          __typename
+        }
+      }
+      ... on OpeningHoursText {
+        text
+      }
+    }
+    coordinates {
+      lat
+      lng
     }
     id
   }
@@ -321,7 +345,8 @@ v7 = {
                   "kind": "ScalarField",
                   "name": "hours",
                   "storageKey": null
-                }
+                },
+                (v2/*: any*/)
               ],
               "storageKey": null
             }
@@ -552,7 +577,7 @@ return {
     ]
   },
   "params": {
-    "id": "01882d95fee25c87a42be270fe07cf86",
+    "id": "e462c2b42e7c1db520d3ac534a753d6b",
     "metadata": {},
     "name": "Show2MoreInfoQuery",
     "operationKind": "query",

--- a/src/__generated__/Show2MoreInfoTestsQuery.graphql.ts
+++ b/src/__generated__/Show2MoreInfoTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash f840c45eed996cb7e597eb66b9f926d3 */
+/* @relayHash ed1a6f581100566d78e93c4b0fcd3193 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -153,6 +153,18 @@ fragment Show2MoreInfo_show on Show {
       __typename
       openingHours {
         __typename
+        ... on OpeningHoursArray {
+          schedules {
+            __typename
+          }
+        }
+        ... on OpeningHoursText {
+          text
+        }
+      }
+      coordinates {
+        lat
+        lng
       }
       id
     }
@@ -162,6 +174,18 @@ fragment Show2MoreInfo_show on Show {
     __typename
     openingHours {
       __typename
+      ... on OpeningHoursArray {
+        schedules {
+          __typename
+        }
+      }
+      ... on OpeningHoursText {
+        text
+      }
+    }
+    coordinates {
+      lat
+      lng
     }
     id
   }
@@ -321,7 +345,8 @@ v7 = {
                   "kind": "ScalarField",
                   "name": "hours",
                   "storageKey": null
-                }
+                },
+                (v2/*: any*/)
               ],
               "storageKey": null
             }
@@ -606,7 +631,7 @@ return {
     ]
   },
   "params": {
-    "id": "f840c45eed996cb7e597eb66b9f926d3",
+    "id": "ed1a6f581100566d78e93c4b0fcd3193",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "show": {
@@ -636,6 +661,7 @@ return {
         "show.fair.location.openingHours": (v14/*: any*/),
         "show.fair.location.openingHours.__typename": (v11/*: any*/),
         "show.fair.location.openingHours.schedules": (v15/*: any*/),
+        "show.fair.location.openingHours.schedules.__typename": (v11/*: any*/),
         "show.fair.location.openingHours.schedules.days": (v8/*: any*/),
         "show.fair.location.openingHours.schedules.hours": (v8/*: any*/),
         "show.fair.location.openingHours.text": (v8/*: any*/),
@@ -657,6 +683,7 @@ return {
         "show.location.openingHours": (v14/*: any*/),
         "show.location.openingHours.__typename": (v11/*: any*/),
         "show.location.openingHours.schedules": (v15/*: any*/),
+        "show.location.openingHours.schedules.__typename": (v11/*: any*/),
         "show.location.openingHours.schedules.days": (v8/*: any*/),
         "show.location.openingHours.schedules.hours": (v8/*: any*/),
         "show.location.openingHours.text": (v8/*: any*/),

--- a/src/__generated__/Show2MoreInfo_show.graphql.ts
+++ b/src/__generated__/Show2MoreInfo_show.graphql.ts
@@ -16,15 +16,43 @@ export type Show2MoreInfo_show = {
     readonly fair: {
         readonly location: {
             readonly __typename: string;
-            readonly openingHours: {
-                readonly __typename: string;
+            readonly openingHours: ({
+                readonly __typename: "OpeningHoursArray";
+                readonly schedules: ReadonlyArray<{
+                    readonly __typename: string;
+                } | null> | null;
+            } | {
+                readonly __typename: "OpeningHoursText";
+                readonly text: string | null;
+            } | {
+                /*This will never be '%other', but we need some
+                value in case none of the concrete values match.*/
+                readonly __typename: "%other";
+            }) | null;
+            readonly coordinates: {
+                readonly lat: number | null;
+                readonly lng: number | null;
             } | null;
         } | null;
     } | null;
     readonly location: {
         readonly __typename: string;
-        readonly openingHours: {
-            readonly __typename: string;
+        readonly openingHours: ({
+            readonly __typename: "OpeningHoursArray";
+            readonly schedules: ReadonlyArray<{
+                readonly __typename: string;
+            } | null> | null;
+        } | {
+            readonly __typename: "OpeningHoursText";
+            readonly text: string | null;
+        } | {
+            /*This will never be '%other', but we need some
+            value in case none of the concrete values match.*/
+            readonly __typename: "%other";
+        }) | null;
+        readonly coordinates: {
+            readonly lat: number | null;
+            readonly lng: number | null;
         } | null;
     } | null;
     readonly " $fragmentRefs": FragmentRefs<"Show2Location_show" | "Show2Hours_show">;
@@ -63,7 +91,65 @@ v1 = {
       "name": "openingHours",
       "plural": false,
       "selections": [
-        (v0/*: any*/)
+        (v0/*: any*/),
+        {
+          "kind": "InlineFragment",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "FormattedDaySchedules",
+              "kind": "LinkedField",
+              "name": "schedules",
+              "plural": true,
+              "selections": [
+                (v0/*: any*/)
+              ],
+              "storageKey": null
+            }
+          ],
+          "type": "OpeningHoursArray",
+          "abstractKey": null
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "text",
+              "storageKey": null
+            }
+          ],
+          "type": "OpeningHoursText",
+          "abstractKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "LatLng",
+      "kind": "LinkedField",
+      "name": "coordinates",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "lat",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "lng",
+          "storageKey": null
+        }
       ],
       "storageKey": null
     }
@@ -162,5 +248,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '227f8a4eb40b805cee6d7434f76ea794';
+(node as any).hash = '6a62162619be68eadd94c7f7853682a5';
 export default node;

--- a/src/lib/Scenes/Show2/Components/Show2Hours.tsx
+++ b/src/lib/Scenes/Show2/Components/Show2Hours.tsx
@@ -9,15 +9,13 @@ export interface Show2HoursProps extends BoxProps {
 }
 
 export const Show2Hours: React.FC<Show2HoursProps> = ({ show, ...rest }) => {
-  if (!!show.fair?.location) {
-    return <Show2LocationHours location={show.fair.location} {...rest} />
+  const location = show.location ?? show.fair?.location
+
+  if (!location) {
+    return null
   }
 
-  if (show.location) {
-    return <Show2LocationHours location={show.location} {...rest} />
-  }
-
-  return null
+  return <Show2LocationHours location={location} {...rest} />
 }
 
 export const Show2HoursFragmentContainer = createFragmentContainer(Show2Hours, {

--- a/src/lib/Scenes/Show2/Components/Show2Location.tsx
+++ b/src/lib/Scenes/Show2/Components/Show2Location.tsx
@@ -9,21 +9,23 @@ export interface Show2LocationProps extends BoxProps {
 }
 
 export const Show2Location: React.FC<Show2LocationProps> = ({ show, ...rest }) => {
-  if (!(!!show.location || !!show.fair?.location) || !show.partner) {
+  const location = show.location ?? show.fair?.location
+
+  if (!show.partner || !location) {
     return null
   }
 
   return (
     <Box {...rest}>
       <LocationMap
-        {...(!!show.fair?.location
+        {...(!!show.fair
           ? {
               partnerName: `${show.partner.name} at ${show.fair!.name}`,
-              location: show.fair!.location!,
+              location,
             }
           : {
               partnerName: show.partner.name!,
-              location: show.location!,
+              location,
             })}
       />
     </Box>

--- a/src/lib/Scenes/Show2/Screens/Show2MoreInfo.tsx
+++ b/src/lib/Scenes/Show2/Screens/Show2MoreInfo.tsx
@@ -27,8 +27,13 @@ export interface Show2MoreInfoProps {
 }
 
 export const Show2MoreInfo: React.FC<Show2MoreInfoProps> = ({ show }) => {
-  const shouldDisplayPartnerType = Object.keys(DISPLAYABLE_PARTNER_TYPES).includes(show.partner?.type!)
   const displayablePartnerType = DISPLAYABLE_PARTNER_TYPES[show.partner?.type as keyof typeof DISPLAYABLE_PARTNER_TYPES]
+  const location = show.location ?? show.fair?.location
+  const shouldDisplayPartnerType = Object.keys(DISPLAYABLE_PARTNER_TYPES).includes(show.partner?.type!)
+  const shouldDisplayHours =
+    (location?.openingHours?.__typename === "OpeningHoursArray" && !!location.openingHours.schedules) ||
+    (location?.openingHours?.__typename === "OpeningHoursText" && !!location.openingHours.text)
+  const shouldDisplayLocation = !!show.partner && !!location?.coordinates?.lat && !!location?.coordinates?.lng
 
   const sections: Section[] = [
     {
@@ -90,7 +95,7 @@ export const Show2MoreInfo: React.FC<Show2MoreInfoProps> = ({ show }) => {
         ]
       : []),
 
-    ...(!!show.location?.openingHours || !!show.fair?.location?.openingHours
+    ...(shouldDisplayHours
       ? [
           {
             key: "hours",
@@ -106,7 +111,7 @@ export const Show2MoreInfo: React.FC<Show2MoreInfoProps> = ({ show }) => {
         ]
       : []),
 
-    ...((!!show.location || !!show.fair?.location) && !!show.partner
+    ...(shouldDisplayLocation
       ? [
           {
             key: "location",
@@ -155,6 +160,18 @@ export const Show2MoreInfoFragmentContainer = createFragmentContainer(Show2MoreI
           __typename
           openingHours {
             __typename
+            ... on OpeningHoursArray {
+              schedules {
+                __typename
+              }
+            }
+            ... on OpeningHoursText {
+              text
+            }
+          }
+          coordinates {
+            lat
+            lng
           }
         }
       }
@@ -162,6 +179,18 @@ export const Show2MoreInfoFragmentContainer = createFragmentContainer(Show2MoreI
         __typename
         openingHours {
           __typename
+          ... on OpeningHoursArray {
+            schedules {
+              __typename
+            }
+          }
+          ... on OpeningHoursText {
+            text
+          }
+        }
+        coordinates {
+          lat
+          lng
         }
       }
     }

--- a/src/lib/Scenes/Show2/__tests__/Show2MoreInfo-tests.tsx
+++ b/src/lib/Scenes/Show2/__tests__/Show2MoreInfo-tests.tsx
@@ -5,6 +5,8 @@ import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { act } from "react-test-renderer"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { Show2HoursFragmentContainer } from "../Components/Show2Hours"
+import { Show2LocationFragmentContainer } from "../Components/Show2Location"
 import { Show2MoreInfo, Show2MoreInfoFragmentContainer } from "../Screens/Show2MoreInfo"
 
 jest.unmock("react-relay")
@@ -75,5 +77,25 @@ describe("Show2MoreInfo", () => {
 
     expect(text).toContain("Institution")
     expect(text).not.toContain("Institutional Seller")
+  })
+
+  it("renders the hours", () => {
+    const wrapper = getWrapper()
+    expect(wrapper.root.findAllByType(Show2HoursFragmentContainer)).toHaveLength(1)
+  })
+
+  it("does not render the hours if they are missing from the location", () => {
+    const wrapper = getWrapper({ Location: () => ({ openingHours: null }) })
+    expect(wrapper.root.findAllByType(Show2HoursFragmentContainer)).toHaveLength(0)
+  })
+
+  it("renders the location", () => {
+    const wrapper = getWrapper()
+    expect(wrapper.root.findAllByType(Show2LocationFragmentContainer)).toHaveLength(1)
+  })
+
+  it("does not render the location if the coordinates are missing", () => {
+    const wrapper = getWrapper({ LatLng: () => ({ lat: null }) })
+    expect(wrapper.root.findAllByType(Show2LocationFragmentContainer)).toHaveLength(0)
   })
 })


### PR DESCRIPTION
The type of this PR is: Bugfix

This PR resolves [FX-2408]

### Description

I think this pattern of rendering is very brittle because of the implicit linking between the parent context and the rendered children which may have conditionals that drift. I don't really have any good answers for this. I could imagine some kind of interface where a component contains its own guard for rendering. For now this just syncs them up.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2408]: https://artsyproduct.atlassian.net/browse/FX-2408