### PR TITLE
fix(my collection): button improvements in add artwork form

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -53,6 +53,7 @@ upcoming:
     - Fix persisting edit form values (my collection) - brian
     - Fix artist name truncation on add/edit artwork page (my collection) - david
     - Fix photo layout in add/edit artwork page (my collection) - adam
+    - Improve buttons in edit artwork page (my collection) - adam
 
 releases:
   - version: 6.6.7

--- a/src/lib/Scenes/MyCollection/Screens/AddArtwork/AddEditArtwork.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/AddArtwork/AddEditArtwork.tsx
@@ -2,6 +2,7 @@ import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
 import { ScreenMargin } from "lib/Scenes/MyCollection/Components/ScreenMargin"
 import { useArtworkForm } from "lib/Scenes/MyCollection/Screens/AddArtwork/Form/useArtworkForm"
 import { AppStore } from "lib/store/AppStore"
+import { isEqualWith } from "lodash"
 import { BorderBox, Box, Button, Flex, Join, Sans, Spacer } from "palette"
 import React, { useState } from "react"
 import { ActivityIndicator, ScrollView } from "react-native"
@@ -55,10 +56,12 @@ export const AddEditArtwork: React.FC = () => {
 
   const isFormDirty = () => {
     // if you fill an empty field then delete it again, it changes from null to ""
-    const replacer = (_: any, value: any) => (value === "" ? null : value)
-    return (
-      JSON.stringify(artworkState.sessionState.dirtyFormCheckValues, replacer) !==
-      JSON.stringify(artworkState.sessionState.formValues, replacer)
+    const customizer = (aVal: any, bVal: any) =>
+      (aVal === "" || aVal === null) && (bVal === "" || bVal === null) ? true : undefined
+    return !isEqualWith(
+      artworkState.sessionState.dirtyFormCheckValues,
+      artworkState.sessionState.formValues,
+      customizer
     )
   }
 

--- a/src/lib/Scenes/MyCollection/Screens/AddArtwork/AddEditArtwork.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/AddArtwork/AddEditArtwork.tsx
@@ -53,6 +53,15 @@ export const AddEditArtwork: React.FC = () => {
     )
   }
 
+  const isFormDirty = () => {
+    // if you fill an empty field then delete it again, it changes from null to ""
+    const replacer = (_, value: any) => (value === "" ? null : value)
+    return (
+      JSON.stringify(artworkState.sessionState.dirtyFormCheckValues, replacer) !==
+      JSON.stringify(artworkState.sessionState.formValues, replacer)
+    )
+  }
+
   return (
     <>
       {showLoading && <LoadingIndicator />}
@@ -86,17 +95,22 @@ export const AddEditArtwork: React.FC = () => {
         <PhotosButton />
         <AdditionalDetailsButton />
 
-        <Spacer my={2} />
+        <Spacer mt={2} mb={1} />
 
         <ScreenMargin>
-          <Button disabled={!formik.isValid} block onPress={submitArtwork} data-test-id="CompleteButton">
-            Complete
+          <Button
+            disabled={!formik.isValid || !isFormDirty()}
+            block
+            onPress={submitArtwork}
+            data-test-id="CompleteButton"
+          >
+            {modalType === "edit" ? "Save changes" : "Complete"}
           </Button>
 
           {modalType === "edit" && (
             <Button
-              mt={2}
-              variant="secondaryGray"
+              mt={1}
+              variant="secondaryOutlineWarning"
               block
               onPress={() =>
                 artworkActions.confirmDeleteArtwork({
@@ -107,7 +121,7 @@ export const AddEditArtwork: React.FC = () => {
               }
               data-test-id="DeleteButton"
             >
-              Delete
+              Delete artwork
             </Button>
           )}
           <Spacer mt={4} />

--- a/src/lib/Scenes/MyCollection/Screens/AddArtwork/AddEditArtwork.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/AddArtwork/AddEditArtwork.tsx
@@ -55,7 +55,7 @@ export const AddEditArtwork: React.FC = () => {
 
   const isFormDirty = () => {
     // if you fill an empty field then delete it again, it changes from null to ""
-    const replacer = (_, value: any) => (value === "" ? null : value)
+    const replacer = (_: any, value: any) => (value === "" ? null : value)
     return (
       JSON.stringify(artworkState.sessionState.dirtyFormCheckValues, replacer) !==
       JSON.stringify(artworkState.sessionState.formValues, replacer)

--- a/src/palette/elements/Button/Button.tsx
+++ b/src/palette/elements/Button/Button.tsx
@@ -11,7 +11,13 @@ import { Spinner } from "../Spinner"
 import { Sans } from "../Typography"
 
 /** Different theme variations */
-export type ButtonVariant = "primaryBlack" | "primaryWhite" | "secondaryGray" | "secondaryOutline" | "noOutline"
+export type ButtonVariant =
+  | "primaryBlack"
+  | "primaryWhite"
+  | "secondaryGray"
+  | "secondaryOutline"
+  | "secondaryOutlineWarning"
+  | "noOutline"
 /** Default button color variant */
 export const defaultVariant: ButtonVariant = "primaryBlack"
 
@@ -63,7 +69,7 @@ export interface ButtonBaseProps extends BoxProps {
  */
 export function getColorsForVariant(variant: ButtonVariant) {
   const {
-    colors: { black100, black10, black30, white100, purple100 },
+    colors: { black100, black10, black30, white100, purple100, red100 },
   } = themeProps
 
   switch (variant) {
@@ -112,6 +118,19 @@ export function getColorsForVariant(variant: ButtonVariant) {
           backgroundColor: white100,
           borderColor: black10,
           color: black100,
+        },
+        hover: {
+          backgroundColor: white100,
+          borderColor: black100,
+          color: black100,
+        },
+      }
+    case "secondaryOutlineWarning":
+      return {
+        default: {
+          backgroundColor: white100,
+          borderColor: black10,
+          color: red100,
         },
         hover: {
           backgroundColor: white100,


### PR DESCRIPTION
The type of this PR is: Enhancement

This PR resolves [CX-772]

### Description

Disables the save button in the _Edit Artwork_ form until the user makes changes. Additionally improves the styling of the delete button. (Does that new variant name look alright to you @ds300 ?)

![image](https://user-images.githubusercontent.com/1815204/98224522-dae32d00-1f53-11eb-9696-9c2dec9bedfa.png)
![image](https://user-images.githubusercontent.com/1815204/98224567-e8001c00-1f53-11eb-820e-1e7d27c8713c.png)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-772]: https://artsyproduct.atlassian.net/browse/CX-772