### PR TITLE
fix: add missing prop to above the fold query renderer

### DIFF
--- a/src/lib/utils/AboveTheFoldQueryRenderer.tsx
+++ b/src/lib/utils/AboveTheFoldQueryRenderer.tsx
@@ -94,6 +94,7 @@ export function AboveTheFoldQueryRenderer<AboveQuery extends OperationType, Belo
               })
             : null
         }}
+        cacheConfig={props.cacheConfig || null}
       />
       {aboveArgs?.props && (
         <QueryRenderer
@@ -105,6 +106,7 @@ export function AboveTheFoldQueryRenderer<AboveQuery extends OperationType, Belo
             setBelowArgs(args)
             return null
           }}
+          cacheConfig={props.cacheConfig || null}
         />
       )}
     </>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description
While trying to figure out some caching issues in the new sale screen I realized we are missing the `cacheConfig` as a prop.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434