### PR TITLE
fix: reverted sale artworks sorting options

### DIFF
--- a/src/lib/Components/ArtworkFilterOptions/SortOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/SortOptions.tsx
@@ -78,22 +78,22 @@ export const OrderedSaleArtworkSorts: FilterData[] = [
   {
     displayText: "Most bids",
     paramName: FilterParamName.sort,
-    paramValue: "bidder_positions_count",
+    paramValue: "-bidder_positions_count",
   },
   {
     displayText: "Least bids",
     paramName: FilterParamName.sort,
-    paramValue: "-bidder_positions_count",
+    paramValue: "bidder_positions_count",
   },
   {
     displayText: "Highest bid",
     paramName: FilterParamName.sort,
-    paramValue: "searchable_estimate",
+    paramValue: "-searchable_estimate",
   },
   {
     displayText: "Lowest bid",
     paramName: FilterParamName.sort,
-    paramValue: "-searchable_estimate",
+    paramValue: "searchable_estimate",
   },
 ]
 

--- a/src/lib/Scenes/Sale/__tests__/SaleLotsList-tests.tsx
+++ b/src/lib/Scenes/Sale/__tests__/SaleLotsList-tests.tsx
@@ -133,7 +133,7 @@ describe("SaleLotsListSortMode", () => {
       />
     )
 
-    expect(extractText(tree.root.findByType(FilterTitle))).toBe("Sorted by most bids")
+    expect(extractText(tree.root.findByType(FilterTitle))).toBe("Sorted by least bids")
     expect(extractText(tree.root.findByType(FilterDescription))).toBe("Showing 20 of 100")
   })
 })


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-793]

### Description

- Fix Reverted sale artworks sorting options.

![Screen_Recording_2020-11-06_at_14 23 19](https://user-images.githubusercontent.com/11945712/98370985-b793ad00-203b-11eb-84f2-20dc105dc112.gif)


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-793]: https://artsyproduct.atlassian.net/browse/CX-793