### PR TITLE
fix: extra padding on single option filters screens

### DIFF
--- a/src/lib/Components/ArtworkFilterOptions/MediumOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/MediumOptions.tsx
@@ -60,6 +60,7 @@ export const MediumOptionsScreen: React.FC<MediumOptionsScreenProps> = ({ naviga
       filterOptions={displayOptions}
       selectedOption={selectedOption}
       navigator={navigator}
+      withExtraPadding
     />
   )
 }

--- a/src/lib/Components/ArtworkFilterOptions/SingleSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/SingleSelectOption.tsx
@@ -13,6 +13,7 @@ interface SingleSelectOptionScreenProps {
   selectedOption: FilterData
   filterOptions: FilterData[]
   ListHeaderComponent?: JSX.Element
+  withExtraPadding?: boolean
 }
 
 export const SingleSelectOptionScreen: React.FC<SingleSelectOptionScreenProps> = ({
@@ -22,6 +23,7 @@ export const SingleSelectOptionScreen: React.FC<SingleSelectOptionScreenProps> =
   filterOptions,
   navigator,
   ListHeaderComponent,
+  withExtraPadding = false,
 }) => {
   const handleBackNavigation = () => {
     navigator.pop()
@@ -38,7 +40,14 @@ export const SingleSelectOptionScreen: React.FC<SingleSelectOptionScreenProps> =
           keyExtractor={(_item, index) => String(index)}
           data={filterOptions}
           ItemSeparatorComponent={() => <Separator />}
-          renderItem={({ item }) => <ListItem item={item} selectedOption={selectedOption} onSelect={onSelect} />}
+          renderItem={({ item }) => (
+            <ListItem
+              item={item}
+              selectedOption={selectedOption}
+              onSelect={onSelect}
+              withExtraPadding={withExtraPadding}
+            />
+          )}
         />
       </Flex>
     </Flex>
@@ -49,14 +58,16 @@ const ListItem = ({
   item,
   onSelect,
   selectedOption,
+  withExtraPadding,
 }: {
   item: FilterData
   onSelect: (any: any) => void
   selectedOption: FilterData
+  withExtraPadding: boolean
 }) => (
   <SingleSelectOptionListItemRow onPress={() => onSelect(item)}>
     <OptionListItem>
-      <InnerOptionListItem px={item.displayText === "All" ? 2 : 3}>
+      <InnerOptionListItem px={withExtraPadding && item.displayText !== "All" ? 3 : 2}>
         <Sans color="black100" size="3t">
           {item.displayText}
           {!!item.count && (


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-796]

### Description
- Add extra padding on single option filters screens

### Screenshots
**Before** 
<img width="330" alt="Screenshot 2020-11-06 at 15 07 40" src="https://user-images.githubusercontent.com/11945712/98375199-1a884280-2042-11eb-85c3-e9488e8e362a.png">
<img width="328" alt="Screenshot 2020-11-06 at 15 07 33" src="https://user-images.githubusercontent.com/11945712/98375206-1c520600-2042-11eb-875c-a89f4a11efa8.png">

____

**After**
<img width="331" alt="Screenshot 2020-11-06 at 15 05 27" src="https://user-images.githubusercontent.com/11945712/98375218-21af5080-2042-11eb-8176-8acc04bcdd50.png">
<img width="326" alt="Screenshot 2020-11-06 at 15 06 26" src="https://user-images.githubusercontent.com/11945712/98375228-25db6e00-2042-11eb-8a43-b325b1f008b6.png">


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-796]: https://artsyproduct.atlassian.net/browse/CX-796