### PR TITLE
fix(show2): updates remaining time once per second #trivial

### DIFF
--- a/src/lib/Scenes/Show2/Components/Show2Header.tsx
+++ b/src/lib/Scenes/Show2/Components/Show2Header.tsx
@@ -1,7 +1,8 @@
 import { Show2Header_show } from "__generated__/Show2Header_show.graphql"
 import { useEventTiming } from "lib/utils/useEventTiming"
+import { DateTime } from "luxon"
 import { Box, BoxProps, Text } from "palette"
-import React from "react"
+import React, { useEffect, useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
 export interface Show2HeaderProps extends BoxProps {
@@ -9,7 +10,23 @@ export interface Show2HeaderProps extends BoxProps {
 }
 
 export const Show2Header: React.FC<Show2HeaderProps> = ({ show, ...rest }) => {
-  const { formattedTime } = useEventTiming({ startAt: show.startAt ?? undefined, endAt: show.endAt ?? undefined })
+  const [currentTime, setCurrentTime] = useState(DateTime.local().toString())
+
+  const { formattedTime } = useEventTiming({
+    currentTime,
+    startAt: show.startAt ?? undefined,
+    endAt: show.endAt ?? undefined,
+  })
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrentTime(DateTime.local().toString())
+    }, 1000)
+
+    return () => {
+      clearInterval(interval)
+    }
+  }, [])
 
   return (
     <Box {...rest}>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [FX-2404]

### Description

![](http://static.damonzucconi.com/_capture/LYjYUBaqciMg.gif)

This simply causes the timer to update once per second. We don't need to do any fancy syncing with the server for millisecond offsets or anything since this isn't an auction.

The ticket says to use the same component in viewing rooms. However:

* That component isn't entirely shared. [Part of it lives in viewing rooms and is specific to viewing rooms status.](https://github.com/artsy/eigen/blob/b9caccdd3a487a199095413e5bd9984de7dfe6ea/src/lib/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx#L50-L75)
* We already use this hook on fairs

So rather than use viewing rooms' component: we should settle on a detailed spec for how to format time, update the hook to match that spec, then refactor the viewing rooms header to use the hook. This can/should be a separate ticket.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2404]: https://artsyproduct.atlassian.net/browse/FX-2404