### PR TITLE
fix: add keyboard type for phone number on billing address

### DIFF
--- a/src/lib/Components/Bidding/Screens/BillingAddress.tsx
+++ b/src/lib/Components/Bidding/Screens/BillingAddress.tsx
@@ -297,6 +297,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 {...this.defaultPropsForInput("phoneNumber")}
                 label="Phone"
                 placeholder="Add your phone number"
+                keyboardType="phone-pad"
                 textContentType="telephoneNumber"
                 onSubmitEditing={() => this.presentSelectCountry()}
                 onLayout={({ nativeEvent }) => (this.phoneNumberLayout = nativeEvent.layout)}


### PR DESCRIPTION
The type of this PR is: **TYPE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-801]

### Description
Switch the keyboard for Phone # to the numeric keyboard on Billing Address.
<img width="325" alt="Screenshot 2020-11-06 at 17 14 39" src="https://user-images.githubusercontent.com/11945712/98389077-de5ddd80-2053-11eb-81de-6320244a5de1.png">


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-801]: https://artsyproduct.atlassian.net/browse/CX-801