### PR TITLE
fix(fx-2413): handles empty state for shows/booths without artworks

### DIFF
--- a/src/__generated__/Show2ArtworksEmptyStateTestsQuery.graphql.ts
+++ b/src/__generated__/Show2ArtworksEmptyStateTestsQuery.graphql.ts
@@ -1,0 +1,147 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash 67a1bf7675263b3c420297287503b71e */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type Show2ArtworksEmptyStateTestsQueryVariables = {};
+export type Show2ArtworksEmptyStateTestsQueryResponse = {
+    readonly show: {
+        readonly " $fragmentRefs": FragmentRefs<"Show2ArtworksEmptyState_show">;
+    } | null;
+};
+export type Show2ArtworksEmptyStateTestsQuery = {
+    readonly response: Show2ArtworksEmptyStateTestsQueryResponse;
+    readonly variables: Show2ArtworksEmptyStateTestsQueryVariables;
+};
+
+
+
+/*
+query Show2ArtworksEmptyStateTestsQuery {
+  show(id: "example-show-id") {
+    ...Show2ArtworksEmptyState_show
+    id
+  }
+}
+
+fragment Show2ArtworksEmptyState_show on Show {
+  isFairBooth
+  status
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "example-show-id"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "Show2ArtworksEmptyStateTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Show",
+        "kind": "LinkedField",
+        "name": "show",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "Show2ArtworksEmptyState_show"
+          }
+        ],
+        "storageKey": "show(id:\"example-show-id\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "Show2ArtworksEmptyStateTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Show",
+        "kind": "LinkedField",
+        "name": "show",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isFairBooth",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "status",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "show(id:\"example-show-id\")"
+      }
+    ]
+  },
+  "params": {
+    "id": "67a1bf7675263b3c420297287503b71e",
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "show": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Show"
+        },
+        "show.id": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "ID"
+        },
+        "show.isFairBooth": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Boolean"
+        },
+        "show.status": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "String"
+        }
+      }
+    },
+    "name": "Show2ArtworksEmptyStateTestsQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = '8b940312f8c529fd88dfa96fca8dbfce';
+export default node;

--- a/src/__generated__/Show2ArtworksEmptyState_show.graphql.ts
+++ b/src/__generated__/Show2ArtworksEmptyState_show.graphql.ts
@@ -1,0 +1,45 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type Show2ArtworksEmptyState_show = {
+    readonly isFairBooth: boolean | null;
+    readonly status: string | null;
+    readonly " $refType": "Show2ArtworksEmptyState_show";
+};
+export type Show2ArtworksEmptyState_show$data = Show2ArtworksEmptyState_show;
+export type Show2ArtworksEmptyState_show$key = {
+    readonly " $data"?: Show2ArtworksEmptyState_show$data;
+    readonly " $fragmentRefs": FragmentRefs<"Show2ArtworksEmptyState_show">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "Show2ArtworksEmptyState_show",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "isFairBooth",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "status",
+      "storageKey": null
+    }
+  ],
+  "type": "Show",
+  "abstractKey": null
+};
+(node as any).hash = '1d67f8f055857f0df03f343cf787a283';
+export default node;

--- a/src/__generated__/Show2Query.graphql.ts
+++ b/src/__generated__/Show2Query.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 37574088e4833d9e0b0bc4269d06bda1 */
+/* @relayHash 36bc08c680ce6d14036c06a08cec5dfe */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -87,6 +87,11 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
       id
     }
   }
+}
+
+fragment Show2ArtworksEmptyState_show on Show {
+  isFairBooth
+  status
 }
 
 fragment Show2Artworks_show on Show {
@@ -257,6 +262,8 @@ fragment Show2_show on Show {
   ...Show2Info_show
   ...Show2ViewingRoom_show
   ...Show2ContextCard_show
+  ...Show2Artworks_show
+  ...Show2ArtworksEmptyState_show
   viewingRoomIDs
   images(default: false) {
     __typename
@@ -264,7 +271,6 @@ fragment Show2_show on Show {
   counts {
     eligibleArtworks
   }
-  ...Show2Artworks_show
 }
 */
 
@@ -351,14 +357,21 @@ v11 = {
   "name": "title",
   "storageKey": null
 },
-v12 = [
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "status",
+  "storageKey": null
+},
+v13 = [
   {
     "kind": "Literal",
     "name": "short",
     "value": true
   }
 ],
-v13 = [
+v14 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -695,23 +708,17 @@ return {
                       (v2/*: any*/),
                       (v3/*: any*/),
                       (v11/*: any*/),
+                      (v12/*: any*/),
                       {
                         "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "status",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": (v12/*: any*/),
+                        "args": (v13/*: any*/),
                         "kind": "ScalarField",
                         "name": "distanceToOpen",
                         "storageKey": "distanceToOpen(short:true)"
                       },
                       {
                         "alias": null,
-                        "args": (v12/*: any*/),
+                        "args": (v13/*: any*/),
                         "kind": "ScalarField",
                         "name": "distanceToClose",
                         "storageKey": "distanceToClose(short:true)"
@@ -845,33 +852,8 @@ return {
             "storageKey": null
           },
           {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "viewingRoomIDs",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "ShowCounts",
-            "kind": "LinkedField",
-            "name": "counts",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "eligibleArtworks",
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
-          },
-          {
             "alias": "showArtworks",
-            "args": (v13/*: any*/),
+            "args": (v14/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -1205,7 +1187,7 @@ return {
           },
           {
             "alias": "showArtworks",
-            "args": (v13/*: any*/),
+            "args": (v14/*: any*/),
             "filters": [
               "sort",
               "medium",
@@ -1224,6 +1206,32 @@ return {
             "kind": "LinkedHandle",
             "name": "filterArtworksConnection"
           },
+          (v12/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "viewingRoomIDs",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ShowCounts",
+            "kind": "LinkedField",
+            "name": "counts",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "eligibleArtworks",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
           (v7/*: any*/)
         ],
         "storageKey": null
@@ -1231,7 +1239,7 @@ return {
     ]
   },
   "params": {
-    "id": "37574088e4833d9e0b0bc4269d06bda1",
+    "id": "36bc08c680ce6d14036c06a08cec5dfe",
     "metadata": {},
     "name": "Show2Query",
     "operationKind": "query",

--- a/src/__generated__/Show2TestsQuery.graphql.ts
+++ b/src/__generated__/Show2TestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 99e96fed6be5bcfcbb6ee373bbac2f3b */
+/* @relayHash c10effbe015c76838009485a3b6dd3b9 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -87,6 +87,11 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
       id
     }
   }
+}
+
+fragment Show2ArtworksEmptyState_show on Show {
+  isFairBooth
+  status
 }
 
 fragment Show2Artworks_show on Show {
@@ -257,6 +262,8 @@ fragment Show2_show on Show {
   ...Show2Info_show
   ...Show2ViewingRoom_show
   ...Show2ContextCard_show
+  ...Show2Artworks_show
+  ...Show2ArtworksEmptyState_show
   viewingRoomIDs
   images(default: false) {
     __typename
@@ -264,7 +271,6 @@ fragment Show2_show on Show {
   counts {
     eligibleArtworks
   }
-  ...Show2Artworks_show
 }
 */
 
@@ -351,14 +357,21 @@ v11 = {
   "name": "title",
   "storageKey": null
 },
-v12 = [
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "status",
+  "storageKey": null
+},
+v13 = [
   {
     "kind": "Literal",
     "name": "short",
     "value": true
   }
 ],
-v13 = [
+v14 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -391,55 +404,55 @@ v13 = [
     "value": "-decayed_merch"
   }
 ],
-v14 = {
+v15 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v15 = {
+v16 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FormattedNumber"
 },
-v16 = {
+v17 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v17 = {
+v18 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
 },
-v18 = {
+v19 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Profile"
 },
-v19 = {
+v20 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v20 = {
+v21 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v21 = {
+v22 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v22 = {
+v23 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -749,23 +762,17 @@ return {
                       (v2/*: any*/),
                       (v3/*: any*/),
                       (v11/*: any*/),
+                      (v12/*: any*/),
                       {
                         "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "status",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": (v12/*: any*/),
+                        "args": (v13/*: any*/),
                         "kind": "ScalarField",
                         "name": "distanceToOpen",
                         "storageKey": "distanceToOpen(short:true)"
                       },
                       {
                         "alias": null,
-                        "args": (v12/*: any*/),
+                        "args": (v13/*: any*/),
                         "kind": "ScalarField",
                         "name": "distanceToClose",
                         "storageKey": "distanceToClose(short:true)"
@@ -899,33 +906,8 @@ return {
             "storageKey": null
           },
           {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "viewingRoomIDs",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "ShowCounts",
-            "kind": "LinkedField",
-            "name": "counts",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "eligibleArtworks",
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
-          },
-          {
             "alias": "showArtworks",
-            "args": (v13/*: any*/),
+            "args": (v14/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -1259,7 +1241,7 @@ return {
           },
           {
             "alias": "showArtworks",
-            "args": (v13/*: any*/),
+            "args": (v14/*: any*/),
             "filters": [
               "sort",
               "medium",
@@ -1278,6 +1260,32 @@ return {
             "kind": "LinkedHandle",
             "name": "filterArtworksConnection"
           },
+          (v12/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "viewingRoomIDs",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ShowCounts",
+            "kind": "LinkedField",
+            "name": "counts",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "eligibleArtworks",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
           (v7/*: any*/)
         ],
         "storageKey": null
@@ -1285,7 +1293,7 @@ return {
     ]
   },
   "params": {
-    "id": "99e96fed6be5bcfcbb6ee373bbac2f3b",
+    "id": "c10effbe015c76838009485a3b6dd3b9",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "show": {
@@ -1294,70 +1302,70 @@ return {
           "plural": false,
           "type": "Show"
         },
-        "show.about": (v14/*: any*/),
+        "show.about": (v15/*: any*/),
         "show.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ShowCounts"
         },
-        "show.counts.eligibleArtworks": (v15/*: any*/),
-        "show.endAt": (v14/*: any*/),
+        "show.counts.eligibleArtworks": (v16/*: any*/),
+        "show.endAt": (v15/*: any*/),
         "show.fair": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Fair"
         },
-        "show.fair.exhibitionPeriod": (v14/*: any*/),
-        "show.fair.id": (v16/*: any*/),
-        "show.fair.image": (v17/*: any*/),
-        "show.fair.image.imageUrl": (v14/*: any*/),
-        "show.fair.internalID": (v16/*: any*/),
-        "show.fair.name": (v14/*: any*/),
-        "show.fair.profile": (v18/*: any*/),
-        "show.fair.profile.icon": (v17/*: any*/),
-        "show.fair.profile.icon.imageUrl": (v14/*: any*/),
-        "show.fair.profile.id": (v16/*: any*/),
-        "show.fair.slug": (v16/*: any*/),
-        "show.formattedEndAt": (v14/*: any*/),
-        "show.formattedStartAt": (v14/*: any*/),
-        "show.href": (v14/*: any*/),
-        "show.id": (v16/*: any*/),
+        "show.fair.exhibitionPeriod": (v15/*: any*/),
+        "show.fair.id": (v17/*: any*/),
+        "show.fair.image": (v18/*: any*/),
+        "show.fair.image.imageUrl": (v15/*: any*/),
+        "show.fair.internalID": (v17/*: any*/),
+        "show.fair.name": (v15/*: any*/),
+        "show.fair.profile": (v19/*: any*/),
+        "show.fair.profile.icon": (v18/*: any*/),
+        "show.fair.profile.icon.imageUrl": (v15/*: any*/),
+        "show.fair.profile.id": (v17/*: any*/),
+        "show.fair.slug": (v17/*: any*/),
+        "show.formattedEndAt": (v15/*: any*/),
+        "show.formattedStartAt": (v15/*: any*/),
+        "show.href": (v15/*: any*/),
+        "show.id": (v17/*: any*/),
         "show.images": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Image"
         },
-        "show.images.__typename": (v19/*: any*/),
-        "show.images.caption": (v14/*: any*/),
+        "show.images.__typename": (v20/*: any*/),
+        "show.images.caption": (v15/*: any*/),
         "show.images.dimensions": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ResizedImageUrl"
         },
-        "show.images.dimensions.height": (v20/*: any*/),
-        "show.images.dimensions.width": (v20/*: any*/),
+        "show.images.dimensions.height": (v21/*: any*/),
+        "show.images.dimensions.width": (v21/*: any*/),
         "show.images.internalID": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ID"
         },
-        "show.images.src": (v14/*: any*/),
-        "show.internalID": (v16/*: any*/),
-        "show.isFairBooth": (v21/*: any*/),
-        "show.name": (v14/*: any*/),
+        "show.images.src": (v15/*: any*/),
+        "show.internalID": (v17/*: any*/),
+        "show.isFairBooth": (v22/*: any*/),
+        "show.name": (v15/*: any*/),
         "show.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerTypes"
         },
-        "show.partner.__isNode": (v19/*: any*/),
-        "show.partner.__typename": (v19/*: any*/),
+        "show.partner.__isNode": (v20/*: any*/),
+        "show.partner.__typename": (v20/*: any*/),
         "show.partner.artworksConnection": {
           "enumValues": null,
           "nullable": true,
@@ -1370,30 +1378,30 @@ return {
           "plural": true,
           "type": "ArtworkEdge"
         },
-        "show.partner.artworksConnection.edges.node": (v22/*: any*/),
-        "show.partner.artworksConnection.edges.node.id": (v16/*: any*/),
-        "show.partner.artworksConnection.edges.node.image": (v17/*: any*/),
-        "show.partner.artworksConnection.edges.node.image.url": (v14/*: any*/),
+        "show.partner.artworksConnection.edges.node": (v23/*: any*/),
+        "show.partner.artworksConnection.edges.node.id": (v17/*: any*/),
+        "show.partner.artworksConnection.edges.node.image": (v18/*: any*/),
+        "show.partner.artworksConnection.edges.node.image.url": (v15/*: any*/),
         "show.partner.cities": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "String"
         },
-        "show.partner.id": (v16/*: any*/),
-        "show.partner.internalID": (v16/*: any*/),
-        "show.partner.name": (v14/*: any*/),
-        "show.partner.profile": (v18/*: any*/),
-        "show.partner.profile.id": (v16/*: any*/),
-        "show.partner.profile.slug": (v16/*: any*/),
-        "show.partner.slug": (v16/*: any*/),
+        "show.partner.id": (v17/*: any*/),
+        "show.partner.internalID": (v17/*: any*/),
+        "show.partner.name": (v15/*: any*/),
+        "show.partner.profile": (v19/*: any*/),
+        "show.partner.profile.id": (v17/*: any*/),
+        "show.partner.profile.slug": (v17/*: any*/),
+        "show.partner.slug": (v17/*: any*/),
         "show.showArtworks": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FilterArtworksConnection"
         },
-        "show.showArtworks.__isArtworkConnectionInterface": (v19/*: any*/),
+        "show.showArtworks.__isArtworkConnectionInterface": (v20/*: any*/),
         "show.showArtworks.aggregations": {
           "enumValues": null,
           "nullable": true,
@@ -1412,8 +1420,8 @@ return {
           "plural": false,
           "type": "Int"
         },
-        "show.showArtworks.aggregations.counts.name": (v19/*: any*/),
-        "show.showArtworks.aggregations.counts.value": (v19/*: any*/),
+        "show.showArtworks.aggregations.counts.name": (v20/*: any*/),
+        "show.showArtworks.aggregations.counts.value": (v20/*: any*/),
         "show.showArtworks.aggregations.slice": {
           "enumValues": [
             "ARTIST",
@@ -1440,51 +1448,51 @@ return {
           "plural": false,
           "type": "FilterArtworksCounts"
         },
-        "show.showArtworks.counts.total": (v15/*: any*/),
+        "show.showArtworks.counts.total": (v16/*: any*/),
         "show.showArtworks.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "ArtworkEdgeInterface"
         },
-        "show.showArtworks.edges.__isNode": (v19/*: any*/),
-        "show.showArtworks.edges.__typename": (v19/*: any*/),
-        "show.showArtworks.edges.cursor": (v19/*: any*/),
-        "show.showArtworks.edges.id": (v16/*: any*/),
-        "show.showArtworks.edges.node": (v22/*: any*/),
-        "show.showArtworks.edges.node.__typename": (v19/*: any*/),
-        "show.showArtworks.edges.node.artistNames": (v14/*: any*/),
-        "show.showArtworks.edges.node.date": (v14/*: any*/),
-        "show.showArtworks.edges.node.href": (v14/*: any*/),
-        "show.showArtworks.edges.node.id": (v16/*: any*/),
-        "show.showArtworks.edges.node.image": (v17/*: any*/),
+        "show.showArtworks.edges.__isNode": (v20/*: any*/),
+        "show.showArtworks.edges.__typename": (v20/*: any*/),
+        "show.showArtworks.edges.cursor": (v20/*: any*/),
+        "show.showArtworks.edges.id": (v17/*: any*/),
+        "show.showArtworks.edges.node": (v23/*: any*/),
+        "show.showArtworks.edges.node.__typename": (v20/*: any*/),
+        "show.showArtworks.edges.node.artistNames": (v15/*: any*/),
+        "show.showArtworks.edges.node.date": (v15/*: any*/),
+        "show.showArtworks.edges.node.href": (v15/*: any*/),
+        "show.showArtworks.edges.node.id": (v17/*: any*/),
+        "show.showArtworks.edges.node.image": (v18/*: any*/),
         "show.showArtworks.edges.node.image.aspectRatio": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Float"
         },
-        "show.showArtworks.edges.node.image.url": (v14/*: any*/),
-        "show.showArtworks.edges.node.internalID": (v16/*: any*/),
+        "show.showArtworks.edges.node.image.url": (v15/*: any*/),
+        "show.showArtworks.edges.node.internalID": (v17/*: any*/),
         "show.showArtworks.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "show.showArtworks.edges.node.partner.id": (v16/*: any*/),
-        "show.showArtworks.edges.node.partner.name": (v14/*: any*/),
+        "show.showArtworks.edges.node.partner.id": (v17/*: any*/),
+        "show.showArtworks.edges.node.partner.name": (v15/*: any*/),
         "show.showArtworks.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "show.showArtworks.edges.node.sale.displayTimelyAt": (v14/*: any*/),
-        "show.showArtworks.edges.node.sale.endAt": (v14/*: any*/),
-        "show.showArtworks.edges.node.sale.id": (v16/*: any*/),
-        "show.showArtworks.edges.node.sale.isAuction": (v21/*: any*/),
-        "show.showArtworks.edges.node.sale.isClosed": (v21/*: any*/),
+        "show.showArtworks.edges.node.sale.displayTimelyAt": (v15/*: any*/),
+        "show.showArtworks.edges.node.sale.endAt": (v15/*: any*/),
+        "show.showArtworks.edges.node.sale.id": (v17/*: any*/),
+        "show.showArtworks.edges.node.sale.isAuction": (v22/*: any*/),
+        "show.showArtworks.edges.node.sale.isClosed": (v22/*: any*/),
         "show.showArtworks.edges.node.saleArtwork": {
           "enumValues": null,
           "nullable": true,
@@ -1497,36 +1505,37 @@ return {
           "plural": false,
           "type": "SaleArtworkCounts"
         },
-        "show.showArtworks.edges.node.saleArtwork.counts.bidderPositions": (v15/*: any*/),
+        "show.showArtworks.edges.node.saleArtwork.counts.bidderPositions": (v16/*: any*/),
         "show.showArtworks.edges.node.saleArtwork.currentBid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCurrentBid"
         },
-        "show.showArtworks.edges.node.saleArtwork.currentBid.display": (v14/*: any*/),
-        "show.showArtworks.edges.node.saleArtwork.id": (v16/*: any*/),
-        "show.showArtworks.edges.node.saleArtwork.lotLabel": (v14/*: any*/),
-        "show.showArtworks.edges.node.saleMessage": (v14/*: any*/),
-        "show.showArtworks.edges.node.slug": (v16/*: any*/),
-        "show.showArtworks.edges.node.title": (v14/*: any*/),
-        "show.showArtworks.id": (v16/*: any*/),
+        "show.showArtworks.edges.node.saleArtwork.currentBid.display": (v15/*: any*/),
+        "show.showArtworks.edges.node.saleArtwork.id": (v17/*: any*/),
+        "show.showArtworks.edges.node.saleArtwork.lotLabel": (v15/*: any*/),
+        "show.showArtworks.edges.node.saleMessage": (v15/*: any*/),
+        "show.showArtworks.edges.node.slug": (v17/*: any*/),
+        "show.showArtworks.edges.node.title": (v15/*: any*/),
+        "show.showArtworks.id": (v17/*: any*/),
         "show.showArtworks.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "show.showArtworks.pageInfo.endCursor": (v14/*: any*/),
+        "show.showArtworks.pageInfo.endCursor": (v15/*: any*/),
         "show.showArtworks.pageInfo.hasNextPage": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Boolean"
         },
-        "show.showArtworks.pageInfo.startCursor": (v14/*: any*/),
-        "show.slug": (v16/*: any*/),
-        "show.startAt": (v14/*: any*/),
+        "show.showArtworks.pageInfo.startCursor": (v15/*: any*/),
+        "show.slug": (v17/*: any*/),
+        "show.startAt": (v15/*: any*/),
+        "show.status": (v15/*: any*/),
         "show.viewingRoomIDs": {
           "enumValues": null,
           "nullable": false,
@@ -1551,9 +1560,9 @@ return {
           "plural": false,
           "type": "ViewingRoom"
         },
-        "show.viewingRoomsConnection.edges.node.distanceToClose": (v14/*: any*/),
-        "show.viewingRoomsConnection.edges.node.distanceToOpen": (v14/*: any*/),
-        "show.viewingRoomsConnection.edges.node.href": (v14/*: any*/),
+        "show.viewingRoomsConnection.edges.node.distanceToClose": (v15/*: any*/),
+        "show.viewingRoomsConnection.edges.node.distanceToOpen": (v15/*: any*/),
+        "show.viewingRoomsConnection.edges.node.href": (v15/*: any*/),
         "show.viewingRoomsConnection.edges.node.image": {
           "enumValues": null,
           "nullable": true,
@@ -1566,11 +1575,11 @@ return {
           "plural": false,
           "type": "ImageURLs"
         },
-        "show.viewingRoomsConnection.edges.node.image.imageURLs.normalized": (v14/*: any*/),
-        "show.viewingRoomsConnection.edges.node.internalID": (v16/*: any*/),
-        "show.viewingRoomsConnection.edges.node.slug": (v19/*: any*/),
-        "show.viewingRoomsConnection.edges.node.status": (v19/*: any*/),
-        "show.viewingRoomsConnection.edges.node.title": (v19/*: any*/)
+        "show.viewingRoomsConnection.edges.node.image.imageURLs.normalized": (v15/*: any*/),
+        "show.viewingRoomsConnection.edges.node.internalID": (v17/*: any*/),
+        "show.viewingRoomsConnection.edges.node.slug": (v20/*: any*/),
+        "show.viewingRoomsConnection.edges.node.status": (v20/*: any*/),
+        "show.viewingRoomsConnection.edges.node.title": (v20/*: any*/)
       }
     },
     "name": "Show2TestsQuery",

--- a/src/__generated__/Show2_show.graphql.ts
+++ b/src/__generated__/Show2_show.graphql.ts
@@ -14,7 +14,7 @@ export type Show2_show = {
     readonly counts: {
         readonly eligibleArtworks: number | null;
     } | null;
-    readonly " $fragmentRefs": FragmentRefs<"Show2Header_show" | "Show2InstallShots_show" | "Show2Info_show" | "Show2ViewingRoom_show" | "Show2ContextCard_show" | "Show2Artworks_show">;
+    readonly " $fragmentRefs": FragmentRefs<"Show2Header_show" | "Show2InstallShots_show" | "Show2Info_show" | "Show2ViewingRoom_show" | "Show2ContextCard_show" | "Show2Artworks_show" | "Show2ArtworksEmptyState_show">;
     readonly " $refType": "Show2_show";
 };
 export type Show2_show$data = Show2_show;
@@ -123,10 +123,15 @@ const node: ReaderFragment = {
       "args": null,
       "kind": "FragmentSpread",
       "name": "Show2Artworks_show"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "Show2ArtworksEmptyState_show"
     }
   ],
   "type": "Show",
   "abstractKey": null
 };
-(node as any).hash = '742e452e7539388cc883730cb12e96aa';
+(node as any).hash = '61dcfb33719aabba11fa1ffec11ce03a';
 export default node;

--- a/src/lib/Scenes/Show2/Components/Show2ArtworksEmptyState.tsx
+++ b/src/lib/Scenes/Show2/Components/Show2ArtworksEmptyState.tsx
@@ -1,0 +1,33 @@
+import { Show2ArtworksEmptyState_show } from "__generated__/Show2ArtworksEmptyState_show.graphql"
+import { Box, BoxProps, Message } from "palette"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+
+export interface Show2ArtworksEmptyStateProps extends BoxProps {
+  show: Show2ArtworksEmptyState_show
+}
+
+export const Show2ArtworksEmptyState: React.FC<Show2ArtworksEmptyStateProps> = ({ show, ...rest }) => {
+  const message = [
+    `This ${Boolean(show.isFairBooth) ? "fair booth" : "show"} is currently unavailable.`,
+
+    ...(show.status !== "closed"
+      ? [`Please check back closer to the ${Boolean(show.isFairBooth) ? "fair" : "show"} for artworks.`]
+      : []),
+  ].join(" ")
+
+  return (
+    <Box {...rest}>
+      <Message>{message}</Message>
+    </Box>
+  )
+}
+
+export const Show2ArtworksEmptyStateFragmentContainer = createFragmentContainer(Show2ArtworksEmptyState, {
+  show: graphql`
+    fragment Show2ArtworksEmptyState_show on Show {
+      isFairBooth
+      status
+    }
+  `,
+})

--- a/src/lib/Scenes/Show2/Components/Show2ContextCard.tsx
+++ b/src/lib/Scenes/Show2/Components/Show2ContextCard.tsx
@@ -13,10 +13,10 @@ export interface Show2ContextCardProps extends BoxProps {
   show: Show2ContextCard_show
 }
 
-export const Show2ContextCard: React.FC<Show2ContextCardProps> = ({ show }) => {
+export const Show2ContextCard: React.FC<Show2ContextCardProps> = ({ show, ...rest }) => {
   const { isFairBooth, fair, partner } = show
 
-  const { onPress, ...rest } = isFairBooth ? extractPropsFromFair(fair) : extractPropsFromPartner(partner)
+  const { onPress, ...card } = isFairBooth ? extractPropsFromFair(fair) : extractPropsFromPartner(partner)
 
   const tracking = useTracking()
 
@@ -55,6 +55,7 @@ export const Show2ContextCard: React.FC<Show2ContextCardProps> = ({ show }) => {
         tracking.trackEvent(data)
       }
     },
+    ...card,
     ...rest,
   }
 
@@ -81,7 +82,15 @@ interface ContextCardProps {
   onPress: () => void
 }
 
-const ContextCard: React.FC<ContextCardProps> = ({ sectionTitle, imageUrls, iconUrl, title, subtitle, onPress }) => {
+const ContextCard: React.FC<ContextCardProps> = ({
+  sectionTitle,
+  imageUrls,
+  iconUrl,
+  title,
+  subtitle,
+  onPress,
+  ...rest
+}) => {
   const hasMultipleImages = imageUrls.length > 1
 
   const imageElement = hasMultipleImages ? (
@@ -95,43 +104,41 @@ const ContextCard: React.FC<ContextCardProps> = ({ sectionTitle, imageUrls, icon
   )
 
   return (
-    <>
-      <Box m={2}>
-        <SectionTitle title={sectionTitle} onPress={onPress} />
+    <Box {...rest}>
+      <SectionTitle title={sectionTitle} onPress={onPress} />
 
-        <TouchableOpacity onPress={onPress}>
-          <Box position="relative">
-            {imageElement}
+      <TouchableOpacity onPress={onPress}>
+        <Box position="relative">
+          {imageElement}
 
-            {!!iconUrl && (
-              <Flex
-                alignItems="center"
-                justifyContent="center"
-                bg="white100"
-                width={80}
-                height={60}
-                px={1}
-                position="absolute"
-                bottom={0}
-                left={2}
-              >
-                <OpaqueImageView width={60} height={40} imageURL={iconUrl} placeholderBackgroundColor="white" />
-              </Flex>
-            )}
-          </Box>
-
-          <Text variant="mediumText" mt={0.5}>
-            {title}
-          </Text>
-
-          {!!subtitle && (
-            <Text variant="caption" color="black60">
-              {subtitle}
-            </Text>
+          {!!iconUrl && (
+            <Flex
+              alignItems="center"
+              justifyContent="center"
+              bg="white100"
+              width={80}
+              height={60}
+              px={1}
+              position="absolute"
+              bottom={0}
+              left={2}
+            >
+              <OpaqueImageView width={60} height={40} imageURL={iconUrl} placeholderBackgroundColor="white" />
+            </Flex>
           )}
-        </TouchableOpacity>
-      </Box>
-    </>
+        </Box>
+
+        <Text variant="mediumText" mt={0.5}>
+          {title}
+        </Text>
+
+        {!!subtitle && (
+          <Text variant="caption" color="black60">
+            {subtitle}
+          </Text>
+        )}
+      </TouchableOpacity>
+    </Box>
   )
 }
 

--- a/src/lib/Scenes/Show2/Show2.tsx
+++ b/src/lib/Scenes/Show2/Show2.tsx
@@ -5,11 +5,12 @@ import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { ArtworkFilterGlobalStateProvider } from "lib/utils/ArtworkFilter/ArtworkFiltersStore"
 import { PlaceholderBox, PlaceholderGrid, PlaceholderText } from "lib/utils/placeholders"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
-import { Flex, Separator, Spacer } from "palette"
+import { Box, Flex, Separator, Spacer } from "palette"
 import React, { useState } from "react"
 import { FlatList } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import { Show2ArtworksWithNavigation as Show2Artworks } from "./Components/Show2Artworks"
+import { Show2ArtworksEmptyStateFragmentContainer } from "./Components/Show2ArtworksEmptyState"
 import { Show2ContextCardFragmentContainer as ShowContextCard } from "./Components/Show2ContextCard"
 import { Show2HeaderFragmentContainer as ShowHeader } from "./Components/Show2Header"
 import { Show2InfoFragmentContainer as ShowInfo } from "./Components/Show2Info"
@@ -49,11 +50,29 @@ export const Show2: React.FC<Show2Props> = ({ show }) => {
       ? [{ key: "viewing-room", element: <ShowViewingRoom show={show} mx={2} /> }]
       : []),
 
+    {
+      key: "separator-top",
+      element: (
+        <Box mx={2}>
+          <Separator />
+        </Box>
+      ),
+    },
+
     ...(Boolean(show.counts?.eligibleArtworks)
       ? [{ key: "artworks", element: <Show2Artworks {...artworkProps} /> }]
-      : []),
+      : [{ key: "artworks-empty-state", element: <Show2ArtworksEmptyStateFragmentContainer show={show} mx={2} /> }]),
 
-    { key: "context", element: <ShowContextCard show={show} /> },
+    {
+      key: "separator-bottom",
+      element: (
+        <Box mx={2}>
+          <Separator />
+        </Box>
+      ),
+    },
+
+    { key: "context", element: <ShowContextCard show={show} mx={2} /> },
   ]
 
   return (
@@ -83,6 +102,8 @@ export const Show2FragmentContainer = createFragmentContainer(Show2, {
       ...Show2Info_show
       ...Show2ViewingRoom_show
       ...Show2ContextCard_show
+      ...Show2Artworks_show
+      ...Show2ArtworksEmptyState_show
       viewingRoomIDs
       images(default: false) {
         __typename
@@ -90,7 +111,6 @@ export const Show2FragmentContainer = createFragmentContainer(Show2, {
       counts {
         eligibleArtworks
       }
-      ...Show2Artworks_show
     }
   `,
 })

--- a/src/lib/Scenes/Show2/__tests__/Show2ArtworksEmptyState-tests.tsx
+++ b/src/lib/Scenes/Show2/__tests__/Show2ArtworksEmptyState-tests.tsx
@@ -1,0 +1,87 @@
+import { Show2ArtworksEmptyStateTestsQuery } from "__generated__/Show2ArtworksEmptyStateTestsQuery.graphql"
+import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import { act } from "react-test-renderer"
+import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { Show2ArtworksEmptyStateFragmentContainer } from "../Components/Show2ArtworksEmptyState"
+
+jest.unmock("react-relay")
+
+describe("Show2ArtworksEmptyState", () => {
+  let env: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => {
+    env = createMockEnvironment()
+  })
+
+  const TestRenderer = () => (
+    <QueryRenderer<Show2ArtworksEmptyStateTestsQuery>
+      environment={env}
+      query={graphql`
+        query Show2ArtworksEmptyStateTestsQuery @relay_test_operation {
+          show(id: "example-show-id") {
+            ...Show2ArtworksEmptyState_show
+          }
+        }
+      `}
+      variables={{}}
+      render={({ props, error }) => {
+        if (props?.show) {
+          return <Show2ArtworksEmptyStateFragmentContainer show={props.show} />
+        } else if (error) {
+          console.log(error)
+        }
+      }}
+    />
+  )
+
+  const getWrapper = (mockResolvers = {}) => {
+    const tree = renderWithWrappers(<TestRenderer />)
+    act(() => {
+      env.mock.resolveMostRecentOperation((operation) => MockPayloadGenerator.generate(operation, mockResolvers))
+    })
+    return tree
+  }
+
+  describe("fair booth", () => {
+    it("renders the correct message for non-closed fair booths", () => {
+      const wrapper = getWrapper({ Show: () => ({ isFairBooth: true }) })
+      const text = extractText(wrapper.root)
+
+      expect(text).toContain(
+        "This fair booth is currently unavailable. Please check back closer to the fair for artworks."
+      )
+    })
+
+    it("renders the correct message for closed fair booths", () => {
+      const wrapper = getWrapper({
+        Show: () => ({ isFairBooth: true, status: "closed" }),
+      })
+      const text = extractText(wrapper.root)
+
+      expect(text).toContain("This fair booth is currently unavailable.")
+      expect(text).not.toContain("Please check back closer to the fair for artworks.")
+    })
+  })
+
+  describe("show", () => {
+    it("renders the correct message for non-closed shows", () => {
+      const wrapper = getWrapper({ Show: () => ({ isFairBooth: false }) })
+      const text = extractText(wrapper.root)
+
+      expect(text).toContain("This show is currently unavailable. Please check back closer to the show for artworks.")
+    })
+
+    it("renders the correct message for closed shows", () => {
+      const wrapper = getWrapper({
+        Show: () => ({ isFairBooth: false, status: "closed" }),
+      })
+      const text = extractText(wrapper.root)
+
+      expect(text).toContain("This show is currently unavailable.")
+      expect(text).not.toContain("Please check back closer to the show for artworks.")
+    })
+  })
+})


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [FX-2413]

### Description

Pretty much the same implementation as web

![](https://static.damonzucconi.com/_capture/DI8ujWJxIR4Y.png)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2413]: https://artsyproduct.atlassian.net/browse/FX-2413