### PR TITLE
fix: reset form when returning to artwork screen

### DIFF
--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -48,9 +48,7 @@ const InquiryQuestionOption: React.FC<{
     }
   }
 
-  React.useLayoutEffect(() => {
-    maybeRegisterAnimation()
-  }, [questionSelected])
+  React.useLayoutEffect(maybeRegisterAnimation, [questionSelected])
 
   return (
     <React.Fragment>

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -4,7 +4,7 @@ import { FancyModal } from "lib/Components/FancyModal/FancyModal"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
 import ChevronIcon from "lib/Icons/ChevronIcon"
 import { ArtworkInquiryContext } from "lib/utils/ArtworkInquiry/ArtworkInquiryStore"
-import { InquiryOptions, InquiryQuestionIDs } from "lib/utils/ArtworkInquiry/ArtworkInquiryTypes"
+import { InquiryQuestionIDs } from "lib/utils/ArtworkInquiry/ArtworkInquiryTypes"
 import { Box, color, Flex, Separator, space, Text } from "palette"
 import React, { useContext, useState } from "react"
 import { LayoutAnimation, TouchableOpacity } from "react-native"
@@ -25,99 +25,115 @@ interface InquiryModalProps {
   relay: RelayProp
 }
 
+const InquiryQuestionOption: React.FC<{
+  id: string
+  question: string
+  setShippingModalVisibility?: (isVisible: boolean) => void
+}> = ({ id, question, setShippingModalVisibility }) => {
+  const { state, dispatch } = useContext(ArtworkInquiryContext)
+  const isShipping = id === InquiryQuestionIDs.Shipping
+
+  const questionSelected = Boolean(
+    state.inquiryQuestions.find((iq) => {
+      return iq.questionID === id
+    })
+  )
+
+  const maybeRegisterAnimation = () => {
+    if (isShipping) {
+      LayoutAnimation.configureNext({
+        ...LayoutAnimation.Presets.linear,
+        duration: 200,
+      })
+    }
+  }
+
+  React.useLayoutEffect(() => {
+    maybeRegisterAnimation()
+  }, [questionSelected])
+
+  return (
+    <React.Fragment>
+      <InquiryField>
+        <Flex flexDirection="row" justifyContent="space-between">
+          <Flex flexDirection="row">
+            <Checkbox
+              data-test-id={`checkbox-${id}`}
+              checked={questionSelected}
+              onPress={() => {
+                dispatch({
+                  type: "selectInquiryQuestion",
+                  payload: {
+                    questionID: id,
+                    details: isShipping ? state.shippingLocation : null,
+                    isChecked: !questionSelected,
+                  },
+                })
+              }}
+            />
+            <Text variant="text">{question}</Text>
+          </Flex>
+        </Flex>
+
+        {!!isShipping && !!questionSelected && (
+          <>
+            <Separator my={2} />
+            <TouchableOpacity
+              data-test-id="toggle-shipping-modal"
+              onPress={() => {
+                if (typeof setShippingModalVisibility === "function") {
+                  setShippingModalVisibility(true)
+                }
+              }}
+            >
+              <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
+                {!state.shippingLocation ? (
+                  <>
+                    <Text variant="text" color="black60">
+                      Add your location
+                    </Text>
+                    <Box mt={0.5}>
+                      <ChevronIcon color="black60" />
+                    </Box>
+                  </>
+                ) : (
+                  <>
+                    <Text variant="text" color="black100" style={{ width: "70%" }}>
+                      {state.shippingLocation}
+                    </Text>
+                    <Text variant="text" color="purple100">
+                      Edit
+                    </Text>
+                  </>
+                )}
+              </Flex>
+            </TouchableOpacity>
+          </>
+        )}
+      </InquiryField>
+    </React.Fragment>
+  )
+}
+
 export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, ...props }) => {
   const { toggleVisibility, modalIsVisible, relay } = props
   const questions = artwork?.inquiryQuestions!
   const { state, dispatch } = useContext(ArtworkInquiryContext)
-  const [locationExpanded, setLocationExpanded] = useState(false)
-  const toggleLocationExpanded = () => {
-    LayoutAnimation.configureNext({
-      ...LayoutAnimation.Presets.linear,
-      duration: 200,
-    })
-    setLocationExpanded(!locationExpanded)
-  }
   const [shippingModalVisibility, setShippingModalVisibility] = useState(false)
+
   const selectShippingLocation = (l: string) => dispatch({ type: "selectShippingLocation", payload: l })
-  const renderInquiryQuestion = (id: string, inquiryQuestion: string): JSX.Element => {
-    // Shipping requires special logic to accomodate dropdown and shipping modal
-    const isShipping = id === InquiryQuestionIDs.Shipping
-    return (
-      <React.Fragment key={inquiryQuestion}>
-        <InquiryField>
-          <Flex flexDirection="row" justifyContent="space-between">
-            <Flex flexDirection="row">
-              <Checkbox
-                data-test-id={`checkbox-${id}`}
-                checked={
-                  state.inquiryType === InquiryOptions.RequestPrice && id === InquiryQuestionIDs.PriceAndAvailability
-                }
-                onPress={() => {
-                  if (isShipping) {
-                    toggleLocationExpanded()
-                  }
 
-                  const shouldBeChecked: boolean = !state.inquiryQuestions.find((question) => {
-                    return question.questionID === id
-                  })
-
-                  dispatch({
-                    type: "selectInquiryQuestion",
-                    payload: {
-                      questionID: id,
-                      details: isShipping ? state.shippingLocation : null,
-                      isChecked: shouldBeChecked,
-                    },
-                  })
-                }}
-              />
-              <Text variant="text">{inquiryQuestion}</Text>
-            </Flex>
-          </Flex>
-
-          {!!isShipping && !!locationExpanded && (
-            <>
-              <Separator my={2} />
-              <TouchableOpacity
-                data-test-id="toggle-shipping-modal"
-                onPress={() => {
-                  setShippingModalVisibility(true)
-                }}
-              >
-                <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
-                  {!state.shippingLocation ? (
-                    <>
-                      <Text variant="text" color="black60">
-                        Add your location
-                      </Text>
-                      <Box mt={0.5}>
-                        <ChevronIcon color="black60" />
-                      </Box>
-                    </>
-                  ) : (
-                    <>
-                      <Text variant="text" color="black100" style={{ width: "70%" }}>
-                        {state.shippingLocation}
-                      </Text>
-                      <Text variant="text" color="purple100">
-                        Edit
-                      </Text>
-                    </>
-                  )}
-                </Flex>
-              </TouchableOpacity>
-            </>
-          )}
-        </InquiryField>
-      </React.Fragment>
-    )
+  const resetAndExit = () => {
+    dispatch({ type: "resetForm", payload: null })
+    toggleVisibility()
   }
-
   return (
-    <FancyModal visible={modalIsVisible} onBackgroundPressed={() => toggleVisibility()}>
+    <FancyModal visible={modalIsVisible} onBackgroundPressed={() => resetAndExit()}>
       <FancyModalHeader
         leftButtonText="Cancel"
-        onLeftButtonPress={() => toggleVisibility()}
+        onLeftButtonPress={() => {
+          resetAndExit()
+        }}
         rightButtonText="Send"
         rightButtonDisabled={state.inquiryQuestions.length === 0}
         onRightButtonPress={() => {
@@ -136,7 +152,16 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, ...props })
               return false
             }
             const { internalID: id, question } = inquiryQuestion
-            return renderInquiryQuestion(id, question)
+            return id === InquiryQuestionIDs.Shipping ? (
+              <InquiryQuestionOption
+                key={id}
+                id={id}
+                question={question}
+                setShippingModalVisibility={setShippingModalVisibility}
+              />
+            ) : (
+              <InquiryQuestionOption key={id} id={id} question={question} />
+            )
           })
         }
       </Box>

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/InquiryModal-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/InquiryModal-tests.tsx
@@ -4,6 +4,7 @@ import { InquiryModalTestsQuery, InquiryModalTestsQueryResponse } from "__genera
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
 import { Input } from "lib/Components/Input/Input"
 import { extractText } from "lib/tests/extractText"
+import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { ArtworkInquiryContext, ArtworkInquiryStateProvider } from "lib/utils/ArtworkInquiry/ArtworkInquiryStore"
 import { queryLocation } from "lib/utils/googleMaps"
@@ -109,6 +110,20 @@ describe("<InquiryModal />", () => {
   it("renders the modal", () => {
     const tree = getWrapper()
     expect(extractText(tree.root)).toContain("What information are you looking for?")
+  })
+
+  it("state resets when exiting and re-entering the modal", async () => {
+    const wrapper = getWrapper()
+    expect(wrapper.root.findByType(InquiryModalFragmentContainer).props.modalIsVisible).toBeTruthy()
+    const checkBox = wrapper.root.findByProps({ "data-test-id": "checkbox-shipping_quote" })
+    checkBox.props.onPress()
+    await flushPromiseQueue()
+    expect(checkBox.props.checked).toBeTruthy()
+    wrapper.root.findByProps({ "data-test-id": "checkbox-shipping_quote" }).props.onPress()
+    await press(wrapper.root, { text: "Cancel" })
+
+    expect(wrapper.root.findByType(InquiryModalFragmentContainer).props.modalIsVisible).toBeFalsy()
+    expect(checkBox.props.checked).toBeFalsy()
   })
 
   describe("user can select 'Price & Availability'", () => {

--- a/src/lib/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
+++ b/src/lib/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
@@ -39,7 +39,7 @@ export const reducer = (
 
     case "selectInquiryQuestion":
       const { isChecked, ...payloadQuestion } = action.payload
-      const { inquiryQuestions } = inquiryState
+      const { inquiryQuestions = [] } = inquiryState
       const newSelection: InquiryQuestionInput[] = isChecked
         ? [...inquiryQuestions, payloadQuestion]
         : inquiryQuestions.filter((q) => q.questionID !== payloadQuestion.questionID)

--- a/src/lib/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
+++ b/src/lib/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
@@ -1,3 +1,4 @@
+import { InquiryQuestionInput } from "__generated__/SubmitInquiryRequestMutation.graphql"
 import {
   ArtworkInquiryActions,
   ArtworkInquiryContextProps,
@@ -5,10 +6,9 @@ import {
   InquiryOptions,
   InquiryQuestionIDs,
 } from "lib/utils/ArtworkInquiry/ArtworkInquiryTypes"
-import { remove } from "lodash"
 import React, { createContext, Reducer, useReducer } from "react"
 
-const artworkInquiryState: ArtworkInquiryContextState = {
+const initialArtworkInquiryState: ArtworkInquiryContextState = {
   shippingLocation: null,
   inquiryType: null,
   inquiryQuestions: [],
@@ -19,6 +19,8 @@ export const reducer = (
   action: ArtworkInquiryActions
 ): ArtworkInquiryContextState => {
   switch (action.type) {
+    case "resetForm":
+      return initialArtworkInquiryState
     case "selectInquiryType":
       return {
         ...inquiryState,
@@ -37,16 +39,14 @@ export const reducer = (
 
     case "selectInquiryQuestion":
       const { isChecked, ...payloadQuestion } = action.payload
-
-      if (isChecked) {
-        inquiryState.inquiryQuestions.push(payloadQuestion)
-      } else {
-        remove(inquiryState.inquiryQuestions, (question) => question.questionID === payloadQuestion.questionID)
-      }
+      const { inquiryQuestions } = inquiryState
+      const newSelection: InquiryQuestionInput[] = isChecked
+        ? [...inquiryQuestions, payloadQuestion]
+        : inquiryQuestions.filter((q) => q.questionID !== payloadQuestion.questionID)
 
       return {
         ...inquiryState,
-        inquiryQuestions: inquiryState.inquiryQuestions,
+        inquiryQuestions: newSelection,
       }
   }
 }
@@ -54,9 +54,8 @@ export const reducer = (
 export const ArtworkInquiryContext = createContext<ArtworkInquiryContextProps>(null as any)
 
 export const ArtworkInquiryStateProvider = ({ children }: any) => {
-  const [state, dispatch] = useReducer<Reducer<ArtworkInquiryContextState, ArtworkInquiryActions>>(
-    reducer,
-    artworkInquiryState
-  )
+  const [state, dispatch] = useReducer<Reducer<ArtworkInquiryContextState, ArtworkInquiryActions>>(reducer, {
+    ...initialArtworkInquiryState,
+  })
   return <ArtworkInquiryContext.Provider value={{ state, dispatch }}>{children}</ArtworkInquiryContext.Provider>
 }

--- a/src/lib/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
+++ b/src/lib/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
@@ -54,8 +54,9 @@ export const reducer = (
 export const ArtworkInquiryContext = createContext<ArtworkInquiryContextProps>(null as any)
 
 export const ArtworkInquiryStateProvider = ({ children }: any) => {
-  const [state, dispatch] = useReducer<Reducer<ArtworkInquiryContextState, ArtworkInquiryActions>>(reducer, {
-    ...initialArtworkInquiryState,
-  })
+  const [state, dispatch] = useReducer<Reducer<ArtworkInquiryContextState, ArtworkInquiryActions>>(
+    reducer,
+    initialArtworkInquiryState
+  )
   return <ArtworkInquiryContext.Provider value={{ state, dispatch }}>{children}</ArtworkInquiryContext.Provider>
 }

--- a/src/lib/utils/ArtworkInquiry/ArtworkInquiryTypes.ts
+++ b/src/lib/utils/ArtworkInquiry/ArtworkInquiryTypes.ts
@@ -1,7 +1,7 @@
 import { InquiryQuestionInput } from "__generated__/SubmitInquiryRequestMutation.graphql"
 import { Dispatch } from "react"
 
-export type ArtworkInquiryActions = SelectInquiryType | SelectLocation | SelectInquiryQuestion
+export type ArtworkInquiryActions = SelectInquiryType | SelectLocation | SelectInquiryQuestion | ResetForm
 
 export interface ArtworkInquiryContextProps {
   state: ArtworkInquiryContextState
@@ -16,6 +16,10 @@ export interface ArtworkInquiryContextState {
 
 export type InquiryTypes = "Inquire on price" | "Contact gallery" | "Inquire to purchase"
 
+interface ResetForm {
+  type: "resetForm"
+  payload: null
+}
 interface SelectInquiryType {
   type: "selectInquiryType"
   payload: InquiryTypes


### PR DESCRIPTION
The type of this PR is: **fix**

This PR resolves a bug found in QA. [PURCHASE-2223](https://artsyproduct.atlassian.net/browse/PURCHASE-2223]) is the one I set out to address (shipping checkbox gets its logic flipped if you exit/enter the form with it checked) but I think this actually will fix another bug where the 'send' button gets similarly messed up. I don't know if that was found in QA since I reported the former and assumed they were the same thing - they are not.

On an implementation level it:
- Extracts the 'inquiry question' checkbox into its own component
- cleans up some logic within the component, moving Animation setup into `useLayoutEffect`
- resets the form when exiting the inquiry modal, which prevents another bug causing the shipping checkbox to get flipped after exiting and re-entering
- removes some reducer code that mutates our starting value, making it possible to wind up in an unsubmittable state after exiting and re-entering

### Description
To see the bug, enter the inquiry form, tick the shipping box, press cancel to exit the form, and then re-enter the form. The form will be in a bad and unactionable state. This PR fixes it by resetting form state when leaving.

![2020-11-08 13 38 34](https://user-images.githubusercontent.com/9088720/98481488-885e7680-21c8-11eb-8f78-fe0ed9e3ff8f.gif)

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
