### PR TITLE
Display error message when an inquiry is unable to be sent

### DIFF
--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -25,6 +25,13 @@ interface InquiryModalProps {
   relay: RelayProp
 }
 
+const ErrorMessageFlex = styled(Flex)`
+  position: absolute;
+  top: 60px;
+  width: 100%;
+  z-index: 5;
+`
+
 const InquiryQuestionOption: React.FC<{
   id: string
   question: string
@@ -118,7 +125,7 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, ...props })
   const questions = artwork?.inquiryQuestions!
   const { state, dispatch } = useContext(ArtworkInquiryContext)
   const [shippingModalVisibility, setShippingModalVisibility] = useState(false)
-
+  const [errorMessageVisibility, setErrorMessageVisibility] = useState(false)
   const selectShippingLocation = (l: string) => dispatch({ type: "selectShippingLocation", payload: l })
 
   const resetAndExit = () => {
@@ -135,11 +142,18 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, ...props })
         rightButtonText="Send"
         rightButtonDisabled={state.inquiryQuestions.length === 0}
         onRightButtonPress={() => {
-          SubmitInquiryRequest(relay.environment, artwork, state)
+          SubmitInquiryRequest(relay.environment, artwork, state, setErrorMessageVisibility)
         }}
       >
         {state.inquiryType}
       </FancyModalHeader>
+      {!!errorMessageVisibility && (
+        <ErrorMessageFlex bg="red100" py={1} alignItems="center">
+          <Text variant="small" color="white">
+            Sorry, we were unable to send this message. Please try again.
+          </Text>
+        </ErrorMessageFlex>
+      )}
       <CollapsibleArtworkDetailsFragmentContainer artwork={artwork} />
       <Box m={2}>
         <Text variant="mediumText">What information are you looking for?</Text>

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/InquiryModal-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/InquiryModal-tests.tsx
@@ -165,7 +165,7 @@ describe("<InquiryModal />", () => {
   describe("when submiting an inquiry", () => {
     it("it shows error message on failed inquiry", async () => {
       const wrapper = getWrapper()
-      wrapper.root.findByProps({ "data-test-id": "checkbox-Shipping" }).props.onPress()
+      wrapper.root.findByProps({ "data-test-id": "checkbox-shipping_quote" }).props.onPress()
       press(wrapper.root, { text: "Send" })
       env.mock.rejectMostRecentOperation(new Error())
       await flushPromiseQueue()

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/InquiryModal-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/InquiryModal-tests.tsx
@@ -162,6 +162,17 @@ describe("<InquiryModal />", () => {
     })
   })
 
+  describe("when submiting an inquiry", () => {
+    it("it shows error message on failed inquiry", async () => {
+      const wrapper = getWrapper()
+      wrapper.root.findByProps({ "data-test-id": "checkbox-Shipping" }).props.onPress()
+      press(wrapper.root, { text: "Send" })
+      env.mock.rejectMostRecentOperation(new Error())
+      await flushPromiseQueue()
+      expect(extractText(wrapper.root)).toContain("Sorry, we were unable to send this message")
+    })
+  })
+
   describe("user can select Shipping", () => {
     it("user selecting shipping exposes the 'Add your location' CTA", () => {
       const wrapper = getWrapper()

--- a/src/lib/Scenes/Artwork/Components/Mutation/SubmitInquiryRequest.ts
+++ b/src/lib/Scenes/Artwork/Components/Mutation/SubmitInquiryRequest.ts
@@ -1,10 +1,16 @@
 import { SubmitInquiryRequestMutation } from "__generated__/SubmitInquiryRequestMutation.graphql"
 import { commitMutation, Environment, graphql } from "relay-runtime"
 
-export const SubmitInquiryRequest = (environment: Environment, inquireable: any, payload: any) => {
+export const SubmitInquiryRequest = (
+  environment: Environment,
+  inquireable: any,
+  payload: any,
+  showErrorMessage?: any
+) => {
   return commitMutation<SubmitInquiryRequestMutation>(environment, {
     onError: () => {
       // Show error state
+      showErrorMessage(true)
     },
     onCompleted: () => {
       // Show delayed comfirmation notification


### PR DESCRIPTION
[PURCHASE-2181] 

Adds an error message to the modal view when the `SubmitInquiryRequest` mutation errors out

paired with @erikdstock on tests

Error message is dismissed on modal close or successful send

<img width="393" alt="Screen Shot 2020-11-06 at 1 09 25 PM" src="https://user-images.githubusercontent.com/5643895/98418397-a6e13800-2037-11eb-861b-c9083fa2e01c.png">



[PURCHASE-2181]: https://artsyproduct.atlassian.net/browse/PURCHASE-2181