### PR TITLE
fix: Add screen tracking for sale screen

### DIFF
--- a/src/lib/Scenes/Sale/Sale.tsx
+++ b/src/lib/Scenes/Sale/Sale.tsx
@@ -13,7 +13,7 @@ import { getCurrentEmissionState } from "lib/store/AppStore"
 import { AboveTheFoldQueryRenderer } from "lib/utils/AboveTheFoldQueryRenderer"
 import { ArtworkFilterContext, ArtworkFilterGlobalStateProvider } from "lib/utils/ArtworkFilter/ArtworkFiltersStore"
 import { PlaceholderBox, PlaceholderText, ProvidePlaceholderContext } from "lib/utils/placeholders"
-import { Schema } from "lib/utils/track"
+import { ProvideScreenTracking, Schema } from "lib/utils/track"
 import { useInterval } from "lib/utils/useInterval"
 import { usePrevious } from "lib/utils/usePrevious"
 import _, { times } from "lodash"
@@ -126,26 +126,12 @@ export const Sale: React.FC<Props> = ({ sale, me, below, relay }) => {
   })
 
   const openFilterArtworksModal = () => {
-    tracking.trackEvent({
-      action_name: "filter",
-      context_screen_owner_type: Schema.OwnerEntityTypes.Auction,
-      context_screen: Schema.PageNames.Auction,
-      context_screen_owner_id: sale.internalID,
-      context_screen_owner_slug: sale.slug,
-      action_type: Schema.ActionTypes.Tap,
-    })
+    tracking.trackEvent(tracks.openFilter(sale.internalID, sale.slug))
     setFilterArtworkModalVisible(true)
   }
 
   const closeFilterArtworksModal = () => {
-    tracking.trackEvent({
-      action_name: "closeFilterWindow",
-      context_screen_owner_type: Schema.OwnerEntityTypes.Auction,
-      context_screen: Schema.PageNames.Auction,
-      context_screen_owner_id: sale.internalID,
-      context_screen_owner_slug: sale.slug,
-      action_type: Schema.ActionTypes.Tap,
-    })
+    tracking.trackEvent(tracks.closeFilter(sale.internalID, sale.slug))
     setFilterArtworkModalVisible(false)
   }
 
@@ -200,7 +186,7 @@ export const Sale: React.FC<Props> = ({ sale, me, below, relay }) => {
     <ArtworkFilterGlobalStateProvider>
       <ArtworkFilterContext.Consumer>
         {() => (
-          <>
+          <ProvideScreenTracking info={tracks.screen(sale.internalID, sale.slug)}>
             <Animated.FlatList
               ref={flatListRef}
               data={saleSectionsData}
@@ -233,11 +219,42 @@ export const Sale: React.FC<Props> = ({ sale, me, below, relay }) => {
               closeModal={closeFilterArtworksModal}
             />
             <AnimatedArtworkFilterButton isVisible={isArtworksGridVisible} onPress={openFilterArtworksModal} />
-          </>
+          </ProvideScreenTracking>
         )}
       </ArtworkFilterContext.Consumer>
     </ArtworkFilterGlobalStateProvider>
   )
+}
+
+export const tracks = {
+  screen: (id: string, slug: string) => {
+    return {
+      context_screen: Schema.PageNames.Auction,
+      context_screen_owner_type: Schema.OwnerEntityTypes.Auction,
+      context_screen_owner_id: id,
+      context_screen_owner_slug: slug,
+    }
+  },
+  openFilter: (id: string, slug: string) => {
+    return {
+      action_name: "filter",
+      context_screen_owner_type: Schema.OwnerEntityTypes.Auction,
+      context_screen: Schema.PageNames.Auction,
+      context_screen_owner_id: id,
+      context_screen_owner_slug: slug,
+      action_type: Schema.ActionTypes.Tap,
+    }
+  },
+  closeFilter: (id: string, slug: string) => {
+    return {
+      action_name: "closeFilterWindow",
+      context_screen_owner_type: Schema.OwnerEntityTypes.Auction,
+      context_screen: Schema.PageNames.Auction,
+      context_screen_owner_id: id,
+      context_screen_owner_slug: slug,
+      action_type: Schema.ActionTypes.Tap,
+    }
+  },
 }
 
 export const SalePlaceholder: React.FC<{}> = () => (


### PR DESCRIPTION
The type of this PR is: Bugfix

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-803]

### Description

- Adds screen tracking for the new sale screen
- Centralizes the tracking code in the Sale component to match the recommendations in [the analytics and tracking docs](https://github.com/artsy/eigen/blob/master/docs/analytics_and_tracking.md#inside-react-components).

Tracked event in action: 

![screen-tracking](https://user-images.githubusercontent.com/1627089/98423065-1f092700-2053-11eb-98eb-fceb7a82898e.gif)

The event details: 

![image](https://user-images.githubusercontent.com/1627089/98423054-131d6500-2053-11eb-8594-37f5cfca936e.png)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-803]: https://artsyproduct.atlassian.net/browse/CX-803