### PR TITLE
feat(fair): show up to 5 marketing collections on fair screen

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -27,6 +27,7 @@ upcoming:
     - Add Auctions Info screen - mounir
     - Fix Fair2 sticky tab UI + interaction - david
     - Loading state for My Collection - brian
+    - Show up to 5 marketing collections on fair screen - devon
     - Adds no bids view to bid management - lily
     - Loading plcaeholders on new auction screen - mounir
     - Adds Show2 viewing room - damon

--- a/src/__generated__/Fair2CollectionsTestsQuery.graphql.ts
+++ b/src/__generated__/Fair2CollectionsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 446c3f0050d031107564dfd216745399 */
+/* @relayHash 0049b3e34d0d66e84ae049ddf8dc44bd */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -33,7 +33,7 @@ query Fair2CollectionsTestsQuery(
 fragment Fair2Collections_fair on Fair {
   internalID
   slug
-  marketingCollections(size: 4) {
+  marketingCollections(size: 5) {
     slug
     title
     category
@@ -149,7 +149,7 @@ return {
               {
                 "kind": "Literal",
                 "name": "size",
-                "value": 4
+                "value": 5
               }
             ],
             "concreteType": "MarketingCollection",
@@ -239,7 +239,7 @@ return {
               },
               (v3/*: any*/)
             ],
-            "storageKey": "marketingCollections(size:4)"
+            "storageKey": "marketingCollections(size:5)"
           },
           (v3/*: any*/)
         ],
@@ -248,7 +248,7 @@ return {
     ]
   },
   "params": {
-    "id": "446c3f0050d031107564dfd216745399",
+    "id": "0049b3e34d0d66e84ae049ddf8dc44bd",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "fair": {

--- a/src/__generated__/Fair2Collections_fair.graphql.ts
+++ b/src/__generated__/Fair2Collections_fair.graphql.ts
@@ -59,7 +59,7 @@ return {
         {
           "kind": "Literal",
           "name": "size",
-          "value": 4
+          "value": 5
         }
       ],
       "concreteType": "MarketingCollection",
@@ -146,12 +146,12 @@ return {
           "storageKey": "artworksConnection(first:3)"
         }
       ],
-      "storageKey": "marketingCollections(size:4)"
+      "storageKey": "marketingCollections(size:5)"
     }
   ],
   "type": "Fair",
   "abstractKey": null
 };
 })();
-(node as any).hash = '1c2a4ac29f977c8da57e844650726019';
+(node as any).hash = 'dc2fac754448b2d5f16e6057429929ec';
 export default node;

--- a/src/__generated__/Fair2Query.graphql.ts
+++ b/src/__generated__/Fair2Query.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 9f4bb99a693f864b561e9fbf93b48e31 */
+/* @relayHash 817dfd31494e9a31d9241db776fef3b4 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -111,7 +111,7 @@ fragment Fair2Artworks_fair on Fair {
 fragment Fair2Collections_fair on Fair {
   internalID
   slug
-  marketingCollections(size: 4) {
+  marketingCollections(size: 5) {
     slug
     title
     category
@@ -318,7 +318,7 @@ fragment Fair2_fair on Fair {
       __typename
     }
   }
-  marketingCollections(size: 4) {
+  marketingCollections(size: 5) {
     __typename
     id
   }
@@ -768,7 +768,7 @@ return {
               {
                 "kind": "Literal",
                 "name": "size",
-                "value": 4
+                "value": 5
               }
             ],
             "concreteType": "MarketingCollection",
@@ -853,7 +853,7 @@ return {
                 "storageKey": "artworksConnection(first:3)"
               }
             ],
-            "storageKey": "marketingCollections(size:4)"
+            "storageKey": "marketingCollections(size:5)"
           },
           {
             "alias": null,
@@ -1611,7 +1611,7 @@ return {
     ]
   },
   "params": {
-    "id": "9f4bb99a693f864b561e9fbf93b48e31",
+    "id": "817dfd31494e9a31d9241db776fef3b4",
     "metadata": {},
     "name": "Fair2Query",
     "operationKind": "query",

--- a/src/__generated__/Fair2TestsQuery.graphql.ts
+++ b/src/__generated__/Fair2TestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 5c7798badce879b2a9e99ea2bb1cffa6 */
+/* @relayHash aada6299875bec325f2babc3192bdd1a */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -111,7 +111,7 @@ fragment Fair2Artworks_fair on Fair {
 fragment Fair2Collections_fair on Fair {
   internalID
   slug
-  marketingCollections(size: 4) {
+  marketingCollections(size: 5) {
     slug
     title
     category
@@ -318,7 +318,7 @@ fragment Fair2_fair on Fair {
       __typename
     }
   }
-  marketingCollections(size: 4) {
+  marketingCollections(size: 5) {
     __typename
     id
   }
@@ -876,7 +876,7 @@ return {
               {
                 "kind": "Literal",
                 "name": "size",
-                "value": 4
+                "value": 5
               }
             ],
             "concreteType": "MarketingCollection",
@@ -961,7 +961,7 @@ return {
                 "storageKey": "artworksConnection(first:3)"
               }
             ],
-            "storageKey": "marketingCollections(size:4)"
+            "storageKey": "marketingCollections(size:5)"
           },
           {
             "alias": null,
@@ -1719,7 +1719,7 @@ return {
     ]
   },
   "params": {
-    "id": "5c7798badce879b2a9e99ea2bb1cffa6",
+    "id": "aada6299875bec325f2babc3192bdd1a",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "fair": (v30/*: any*/),

--- a/src/__generated__/Fair2_fair.graphql.ts
+++ b/src/__generated__/Fair2_fair.graphql.ts
@@ -111,7 +111,7 @@ return {
         {
           "kind": "Literal",
           "name": "size",
-          "value": 4
+          "value": 5
         }
       ],
       "concreteType": "MarketingCollection",
@@ -119,7 +119,7 @@ return {
       "name": "marketingCollections",
       "plural": true,
       "selections": (v0/*: any*/),
-      "storageKey": "marketingCollections(size:4)"
+      "storageKey": "marketingCollections(size:5)"
     },
     {
       "alias": null,
@@ -213,5 +213,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '309372249ee2e639d9068f2c0565ad66';
+(node as any).hash = '8fd7cb4f36e5484e4881cd726d7a1ac3';
 export default node;

--- a/src/__generated__/VanityURLEntityQuery.graphql.ts
+++ b/src/__generated__/VanityURLEntityQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash dcb535cde8b03438532e86ba59615795 */
+/* @relayHash 2a0f9b922b1e9699fd7da1c672bafb74 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -133,7 +133,7 @@ fragment Fair2Artworks_fair on Fair {
 fragment Fair2Collections_fair on Fair {
   internalID
   slug
-  marketingCollections(size: 4) {
+  marketingCollections(size: 5) {
     slug
     title
     category
@@ -340,7 +340,7 @@ fragment Fair2_fair on Fair {
       __typename
     }
   }
-  marketingCollections(size: 4) {
+  marketingCollections(size: 5) {
     __typename
     id
   }
@@ -1583,7 +1583,7 @@ return {
                       {
                         "kind": "Literal",
                         "name": "size",
-                        "value": 4
+                        "value": 5
                       }
                     ],
                     "concreteType": "MarketingCollection",
@@ -1662,7 +1662,7 @@ return {
                         "storageKey": "artworksConnection(first:3)"
                       }
                     ],
-                    "storageKey": "marketingCollections(size:4)"
+                    "storageKey": "marketingCollections(size:5)"
                   },
                   {
                     "alias": null,
@@ -3038,7 +3038,7 @@ return {
     ]
   },
   "params": {
-    "id": "dcb535cde8b03438532e86ba59615795",
+    "id": "2a0f9b922b1e9699fd7da1c672bafb74",
     "metadata": {},
     "name": "VanityURLEntityQuery",
     "operationKind": "query",

--- a/src/lib/Scenes/Fair2/Components/Fair2Collections.tsx
+++ b/src/lib/Scenes/Fair2/Components/Fair2Collections.tsx
@@ -75,7 +75,7 @@ export const Fair2CollectionsFragmentContainer = createFragmentContainer(Fair2Co
     fragment Fair2Collections_fair on Fair {
       internalID
       slug
-      marketingCollections(size: 4) {
+      marketingCollections(size: 5) {
         slug
         title
         category

--- a/src/lib/Scenes/Fair2/Fair2.tsx
+++ b/src/lib/Scenes/Fair2/Fair2.tsx
@@ -291,7 +291,7 @@ export const Fair2FragmentContainer = createFragmentContainer(Fair2, {
           __typename
         }
       }
-      marketingCollections(size: 4) {
+      marketingCollections(size: 5) {
         __typename
       }
       counts {


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

Follow-up to similar web PR: https://github.com/artsy/force/pull/6609

This commit bumps the max number of marketing collections fetched from 4 to 5.

Slack thread: https://artsy.slack.com/archives/C9SATFLUU/p1604617773492800

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434

### Screen Recording

<img src="https://user-images.githubusercontent.com/123595/98556583-3291d900-2271-11eb-94c7-2ec736121e4a.gif" width="360">