### PR TITLE
fix: add extra padding to new show screen

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -58,6 +58,7 @@ upcoming:
     - Fix artist name truncation on add/edit artwork page (my collection) - david
     - Fix photo layout in add/edit artwork page (my collection) - adam
     - Improve buttons in edit artwork page (my collection) - adam
+    - Fix padding issue on new show screen - mounir
 
 releases:
   - version: 6.6.7

--- a/src/lib/Scenes/Show2/Show2.tsx
+++ b/src/lib/Scenes/Show2/Show2.tsx
@@ -92,6 +92,7 @@ export const Show2: React.FC<Show2Props> = ({ show }) => {
           ListHeaderComponent={<Spacer mt={6} pt={2} />}
           ListFooterComponent={<Spacer my={2} />}
           ItemSeparatorComponent={() => <Spacer my={15} />}
+          contentContainerStyle={{ paddingBottom: 40 }}
           renderItem={({ item: { element } }) => element}
         />
         <AnimatedArtworkFilterButton isVisible onPress={toggleFilterArtworksModal} />


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-817]

### Description
- Add extra padding to new show screen

**Before**
<img width="326" alt="Screenshot 2020-11-10 at 17 51 04" src="https://user-images.githubusercontent.com/11945712/98705073-9a354a80-237d-11eb-9423-155911bd118f.png">

___
**After**
<img width="330" alt="Screenshot 2020-11-10 at 17 50 48" src="https://user-images.githubusercontent.com/11945712/98704964-85f14d80-237d-11eb-83ec-f87a0f39d21b.png">

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-817]: https://artsyproduct.atlassian.net/browse/CX-817