### PR TITLE
fix: set close button property in modals

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -58,6 +58,7 @@ upcoming:
     - Fix artist name truncation on add/edit artwork page (my collection) - david
     - Fix photo layout in add/edit artwork page (my collection) - adam
     - Improve buttons in edit artwork page (my collection) - adam
+    - Fix modal buttons behind keyboard (consignments, inquiry) - brian, steve, david
 
 releases:
   - version: 6.6.7

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -391,7 +391,10 @@ export const modules = defineModules({
   CitySavedList: reactModule(CitySavedListQueryRenderer),
   CitySectionList: reactModule(CitySectionListQueryRenderer),
   Collection: reactModule(CollectionQueryRenderer, { fullBleed: true }),
-  ConsignmentsSubmissionForm: reactModule(ConsignmentsSubmissionForm, { alwaysPresentModally: true }),
+  ConsignmentsSubmissionForm: reactModule(ConsignmentsSubmissionForm, {
+    alwaysPresentModally: true,
+    hasOwnModalCloseButton: true,
+  }),
   Conversation: reactModule(Conversation, { onlyShowInTabName: "inbox" }),
   Fair: reactModule(FairQueryRenderer, { fullBleed: true }),
   Fair2: reactModule(Fair2QueryRenderer, { fullBleed: true }),
@@ -410,7 +413,7 @@ export const modules = defineModules({
   Gene: reactModule(Gene),
   Home: reactModule(HomeQueryRenderer, { isRootViewForTabName: "home" }),
   Inbox: reactModule(Inbox, { isRootViewForTabName: "inbox" }),
-  Inquiry: reactModule(Inquiry, { alwaysPresentModally: true }),
+  Inquiry: reactModule(Inquiry, { alwaysPresentModally: true, hasOwnModalCloseButton: true }),
   LiveAuction: nativeModule({
     alwaysPresentModally: true,
     hasOwnModalCloseButton: true,


### PR DESCRIPTION
The type of this PR is: **Bugfix**

### Description

Adds `hasOwnModalCloseButton` property to consignments and inquiry modals registration, without this property a close button is added to the top of screen pushing content down. For these screens this cause the close/done button that is supposed to hover above the keyboard to be pushed below the keyboard making it untappable. 

### Screenshots

#### Before

![buttonBelowBoard](https://user-images.githubusercontent.com/49686530/98716744-15850500-235a-11eb-882b-2f2e94816719.gif)

#### After 

![buttonAboveBoard](https://user-images.githubusercontent.com/49686530/98716751-19188c00-235a-11eb-8c80-fb21ee9bde7a.gif)


### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.