### PR TITLE
fix: link sort and filter screen to scroll position on new show screen

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -58,6 +58,7 @@ upcoming:
     - Fix artist name truncation on add/edit artwork page (my collection) - david
     - Fix photo layout in add/edit artwork page (my collection) - adam
     - Improve buttons in edit artwork page (my collection) - adam
+    - Link sort and filter button to scroll position on new show screen - mounir
 
 releases:
   - version: 6.6.7


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-816]

### Description
- Link sort and filter screen to scroll position on new show screen
![Screen_Recording_2020-11-10_at_18 05 26](https://user-images.githubusercontent.com/11945712/98706810-973b5980-237f-11eb-842b-f5672cc04a6e.gif)

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-816]: https://artsyproduct.atlassian.net/browse/CX-816