### PR TITLE
fix: show 2 skeleton adjustment

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -58,6 +58,7 @@ upcoming:
     - Fix artist name truncation on add/edit artwork page (my collection) - david
     - Fix photo layout in add/edit artwork page (my collection) - adam
     - Improve buttons in edit artwork page (my collection) - adam
+    - Fix title hidden by back button on Show2 - mounir
 
 releases:
   - version: 6.6.7

--- a/src/lib/Scenes/Show2/Show2.tsx
+++ b/src/lib/Scenes/Show2/Show2.tsx
@@ -7,6 +7,7 @@ import { PlaceholderBox, PlaceholderGrid, PlaceholderText } from "lib/utils/plac
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "lib/utils/track"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
+import { times } from "lodash"
 import { Box, Flex, Separator, Spacer } from "palette"
 import React, { useState } from "react"
 import { FlatList } from "react-native"
@@ -146,21 +147,32 @@ export const Show2QueryRenderer: React.FC<Show2QueryRendererProps> = ({ showID }
 }
 
 export const Show2Placeholder: React.FC = () => (
-  <Flex>
-    <PlaceholderBox height={400} />
-    <Flex flexDirection="row" justifyContent="space-between" alignItems="center" px="2">
-      <Flex>
-        <Spacer mb={2} />
-        {/* Show name */}
-        <PlaceholderText width={220} />
-        {/* Show info */}
-        <PlaceholderText width={190} />
-        <PlaceholderText width={190} />
-      </Flex>
+  <Flex px={2} pt={useScreenDimensions().safeAreaInsets.top + 80}>
+    {/* Title */}
+    <PlaceholderText height={25} width={200 + Math.random() * 100} />
+    <PlaceholderText height={25} width={100 + Math.random() * 100} />
+    <Spacer mb={15} />
+    <PlaceholderText width={220} />
+    <Spacer mb={20} />
+    {/* Owner */}
+    <PlaceholderText width={70} />
+    <Spacer mb={15} />
+    {/* Images */}
+    <Flex flexDirection="row" py={2}>
+      {times(3).map((index: number) => (
+        <Flex key={index} marginRight={1}>
+          <PlaceholderBox height={300} width={250} />
+        </Flex>
+      ))}
     </Flex>
-    <Spacer mb={2} />
-    <Separator />
-    <Spacer mb={2} />
+    <Spacer mb={15} />
+    <PlaceholderText width="100%" />
+    <PlaceholderText width="100%" />
+    <PlaceholderText width="100%" />
+    <PlaceholderText width="100%" />
+    <PlaceholderText width="100%" />
+    <Spacer mb={15} />
+
     {/* masonry grid */}
     <PlaceholderGrid />
   </Flex>

--- a/src/lib/Scenes/Show2/Show2.tsx
+++ b/src/lib/Scenes/Show2/Show2.tsx
@@ -6,6 +6,7 @@ import { ArtworkFilterGlobalStateProvider } from "lib/utils/ArtworkFilter/Artwor
 import { PlaceholderBox, PlaceholderGrid, PlaceholderText } from "lib/utils/placeholders"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "lib/utils/track"
+import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { Box, Flex, Separator, Spacer } from "palette"
 import React, { useState } from "react"
 import { FlatList } from "react-native"
@@ -92,6 +93,7 @@ export const Show2: React.FC<Show2Props> = ({ show }) => {
           ListHeaderComponent={<Spacer mt={6} pt={2} />}
           ListFooterComponent={<Spacer my={2} />}
           ItemSeparatorComponent={() => <Spacer my={15} />}
+          contentContainerStyle={{ paddingTop: useScreenDimensions().safeAreaInsets.top }}
           renderItem={({ item: { element } }) => element}
         />
         <AnimatedArtworkFilterButton isVisible onPress={toggleFilterArtworksModal} />


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-818]

### Description
- Fix Skeleton loader on Shows page to match actual layout
<img width="525" alt="Screenshot 2020-11-10 at 18 51 24" src="https://user-images.githubusercontent.com/11945712/98712250-5a269580-2386-11eb-8f4f-bb1d33a7572a.png">



<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-818]: https://artsyproduct.atlassian.net/browse/CX-818