### PR TITLE
fix(show): only display sort/filter control if eligible artworks present

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -59,6 +59,7 @@ upcoming:
     - Fix photo layout in add/edit artwork page (my collection) - adam
     - Improve buttons in edit artwork page (my collection) - adam
     - Fix modal buttons behind keyboard (consignments, inquiry) - brian, steve, david
+    - Fix visibility of sort/filter control for shows with no eligible artworks - devon
 
 releases:
   - version: 6.6.7

--- a/src/lib/Scenes/Show2/Show2.tsx
+++ b/src/lib/Scenes/Show2/Show2.tsx
@@ -94,7 +94,10 @@ export const Show2: React.FC<Show2Props> = ({ show }) => {
           ItemSeparatorComponent={() => <Spacer my={15} />}
           renderItem={({ item: { element } }) => element}
         />
-        <AnimatedArtworkFilterButton isVisible onPress={toggleFilterArtworksModal} />
+        <AnimatedArtworkFilterButton
+          isVisible={Boolean(show.counts?.eligibleArtworks)}
+          onPress={toggleFilterArtworksModal}
+        />
       </ArtworkFilterGlobalStateProvider>
     </ProvideScreenTracking>
   )

--- a/src/lib/Scenes/Show2/__tests__/Show2-tests.tsx
+++ b/src/lib/Scenes/Show2/__tests__/Show2-tests.tsx
@@ -1,4 +1,5 @@
 import { Show2TestsQuery } from "__generated__/Show2TestsQuery.graphql"
+import { AnimatedArtworkFilterButton } from "lib/Components/FilterModal"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
@@ -92,5 +93,17 @@ describe("Show2", () => {
     const wrapper = getWrapper()
 
     expect(wrapper.root.findAllByType(Show2ContextCard)).toHaveLength(1)
+  })
+
+  it("does not render the sort/filter control if there are no eligible artworks", () => {
+    const wrapper = getWrapper({
+      Show: () => ({
+        counts: {
+          eligibleArtworks: 0,
+        },
+      }),
+    })
+
+    expect(wrapper.root.findByType(AnimatedArtworkFilterButton).props.isVisible).toEqual(false)
   })
 })


### PR DESCRIPTION
The type of this PR is: Bugfix

This PR resolves [FX-2437]

### Description

Hide the (sort/filter) control unless there are artworks present to
sort/filter.

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2437]: https://artsyproduct.atlassian.net/browse/FX-2437

### Screenshots

Show in screenshots: https://www.artsy.net/show/annka-kultys-gallery-group-show-quid-est-veritas-curated-by-anton-svyatsky

#### Before

<img width="474" alt="Screen Shot 2020-11-10 at 2 13 09 PM" src="https://user-images.githubusercontent.com/123595/98726616-bd9fcb80-2364-11eb-9134-f95095b9bd51.png">

#### After

<img width="450" alt="Screen Shot 2020-11-10 at 2 45 57 PM" src="https://user-images.githubusercontent.com/123595/98726622-c0022580-2364-11eb-929e-e9278ca0af8b.png">
