### PR TITLE
fix: pass id into  event instead of slug

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -6,6 +6,7 @@ upcoming:
     - Add tracking to new auction screen - mounir
     - Fix echo not being checked for updated when _OSS_ flag is missing - pavlos
     - Move bottom tabs navigator to TS - david
+    - Pass correct arguments to auction artwork grid tracking - pepopowitz
   user_facing:
     - Move My Collection into My Profile - adam
     - Switch to live auction from new sale page - barry, brian

--- a/src/lib/Scenes/Sale/Sale.tsx
+++ b/src/lib/Scenes/Sale/Sale.tsx
@@ -173,7 +173,7 @@ export const Sale: React.FC<Props> = ({ sale, me, below, relay }) => {
       content: below ? (
         <SaleLotsListContainer
           saleArtworksConnection={below}
-          saleID={sale.slug}
+          saleID={sale.internalID}
           saleSlug={sale.slug}
           scrollToTop={scrollToTop}
         />


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR is related to [CX-805]

### Description

We were passing the artwork slug where we should be passing the artwork ID when tracking taps on the sale home grid. This PR resolves that issue.

What the event looks like now:


![image](https://user-images.githubusercontent.com/1627089/98738427-47ec2d80-236d-11eb-936b-7e6e85d9428d.png)



### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-805]: https://artsyproduct.atlassian.net/browse/CX-805