### PR TITLE
[PURCHASE-2099] Enhancement: Enable inquiry request notifications

### DIFF
--- a/src/__generated__/InquiryButtonsTestsQuery.graphql.ts
+++ b/src/__generated__/InquiryButtonsTestsQuery.graphql.ts
@@ -1,0 +1,525 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash 7d023c8dbc2561bc397f430c5c99e33f */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type InquiryButtonsTestsQueryVariables = {
+    id: string;
+};
+export type InquiryButtonsTestsQueryResponse = {
+    readonly artwork: {
+        readonly " $fragmentRefs": FragmentRefs<"InquiryButtons_artwork">;
+    } | null;
+};
+export type InquiryButtonsTestsQuery = {
+    readonly response: InquiryButtonsTestsQueryResponse;
+    readonly variables: InquiryButtonsTestsQueryVariables;
+};
+
+
+
+/*
+query InquiryButtonsTestsQuery(
+  $id: String!
+) {
+  artwork(id: $id) {
+    ...InquiryButtons_artwork
+    id
+  }
+}
+
+fragment CollapsibleArtworkDetails_artwork on Artwork {
+  image {
+    url
+    width
+    height
+  }
+  internalID
+  title
+  date
+  saleMessage
+  attributionClass {
+    name
+    id
+  }
+  category
+  manufacturer
+  publisher
+  medium
+  conditionDescription {
+    details
+  }
+  certificateOfAuthenticity {
+    details
+  }
+  framed {
+    details
+  }
+  dimensions {
+    in
+    cm
+  }
+  signatureInfo {
+    details
+  }
+  artistNames
+}
+
+fragment InquiryButtons_artwork on Artwork {
+  image {
+    url
+    width
+    height
+  }
+  internalID
+  isPriceHidden
+  title
+  date
+  medium
+  dimensions {
+    in
+    cm
+  }
+  editionOf
+  signatureInfo {
+    details
+  }
+  artist {
+    name
+    id
+  }
+  ...InquiryModal_artwork
+}
+
+fragment InquiryModal_artwork on Artwork {
+  ...CollapsibleArtworkDetails_artwork
+  internalID
+  inquiryQuestions {
+    internalID
+    question
+    id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v3 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "details",
+    "storageKey": null
+  }
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "name",
+    "storageKey": null
+  },
+  (v4/*: any*/)
+],
+v6 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v7 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v8 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "ArtworkInfoRow"
+},
+v9 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "InquiryButtonsTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "InquiryButtons_artwork"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "InquiryButtonsTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "url",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "width",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "height",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isPriceHidden",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "title",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "date",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "medium",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "dimensions",
+            "kind": "LinkedField",
+            "name": "dimensions",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "in",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "cm",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "editionOf",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "signatureInfo",
+            "plural": false,
+            "selections": (v3/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Artist",
+            "kind": "LinkedField",
+            "name": "artist",
+            "plural": false,
+            "selections": (v5/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "saleMessage",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AttributionClass",
+            "kind": "LinkedField",
+            "name": "attributionClass",
+            "plural": false,
+            "selections": (v5/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "category",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "manufacturer",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "publisher",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "conditionDescription",
+            "plural": false,
+            "selections": (v3/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "certificateOfAuthenticity",
+            "plural": false,
+            "selections": (v3/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "framed",
+            "plural": false,
+            "selections": (v3/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "artistNames",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "InquiryQuestion",
+            "kind": "LinkedField",
+            "name": "inquiryQuestions",
+            "plural": true,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "question",
+                "storageKey": null
+              },
+              (v4/*: any*/)
+            ],
+            "storageKey": null
+          },
+          (v4/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "7d023c8dbc2561bc397f430c5c99e33f",
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "artwork": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "artwork.artist": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artist"
+        },
+        "artwork.artist.id": (v6/*: any*/),
+        "artwork.artist.name": (v7/*: any*/),
+        "artwork.artistNames": (v7/*: any*/),
+        "artwork.attributionClass": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "AttributionClass"
+        },
+        "artwork.attributionClass.id": (v6/*: any*/),
+        "artwork.attributionClass.name": (v7/*: any*/),
+        "artwork.category": (v7/*: any*/),
+        "artwork.certificateOfAuthenticity": (v8/*: any*/),
+        "artwork.certificateOfAuthenticity.details": (v7/*: any*/),
+        "artwork.conditionDescription": (v8/*: any*/),
+        "artwork.conditionDescription.details": (v7/*: any*/),
+        "artwork.date": (v7/*: any*/),
+        "artwork.dimensions": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "dimensions"
+        },
+        "artwork.dimensions.cm": (v7/*: any*/),
+        "artwork.dimensions.in": (v7/*: any*/),
+        "artwork.editionOf": (v7/*: any*/),
+        "artwork.framed": (v8/*: any*/),
+        "artwork.framed.details": (v7/*: any*/),
+        "artwork.id": (v6/*: any*/),
+        "artwork.image": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Image"
+        },
+        "artwork.image.height": (v9/*: any*/),
+        "artwork.image.url": (v7/*: any*/),
+        "artwork.image.width": (v9/*: any*/),
+        "artwork.inquiryQuestions": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "InquiryQuestion"
+        },
+        "artwork.inquiryQuestions.id": (v6/*: any*/),
+        "artwork.inquiryQuestions.internalID": (v6/*: any*/),
+        "artwork.inquiryQuestions.question": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "String"
+        },
+        "artwork.internalID": (v6/*: any*/),
+        "artwork.isPriceHidden": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Boolean"
+        },
+        "artwork.manufacturer": (v7/*: any*/),
+        "artwork.medium": (v7/*: any*/),
+        "artwork.publisher": (v7/*: any*/),
+        "artwork.saleMessage": (v7/*: any*/),
+        "artwork.signatureInfo": (v8/*: any*/),
+        "artwork.signatureInfo.details": (v7/*: any*/),
+        "artwork.title": (v7/*: any*/)
+      }
+    },
+    "name": "InquiryButtonsTestsQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = '75079d2eedfd2a625ffa3568e08cdbb3';
+export default node;

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryButtons.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryButtons.tsx
@@ -1,4 +1,5 @@
 import { InquiryButtons_artwork } from "__generated__/InquiryButtons_artwork.graphql"
+import { InquirySuccessNotification } from "lib/Scenes/Artwork/Components/CommercialButtons/InquirySuccessNotification"
 import { ArtworkInquiryContext, ArtworkInquiryStateProvider } from "lib/utils/ArtworkInquiry/ArtworkInquiryStore"
 import { InquiryTypes } from "lib/utils/ArtworkInquiry/ArtworkInquiryTypes"
 import { InquiryOptions } from "lib/utils/ArtworkInquiry/ArtworkInquiryTypes"
@@ -19,6 +20,7 @@ export interface InquiryButtonsState {
 
 const InquiryButtons: React.FC<InquiryButtonsProps> = ({ artwork, ...props }) => {
   const [modalVisibility, setModalVisibility] = useState(false)
+  const [notificationVisibility, setNotificationVisibility] = useState(false)
   const { dispatch } = useContext(ArtworkInquiryContext)
   const dispatchAction = (buttonText: string) => {
     dispatch({
@@ -31,6 +33,10 @@ const InquiryButtons: React.FC<InquiryButtonsProps> = ({ artwork, ...props }) =>
 
   return (
     <>
+      <InquirySuccessNotification
+        modalVisible={notificationVisibility}
+        toggleNotification={(state: boolean) => setNotificationVisibility(state)}
+      />
       {!!artwork.isPriceHidden && (
         <Button
           onPress={() => dispatchAction(InquiryOptions.RequestPrice)}
@@ -68,6 +74,7 @@ const InquiryButtons: React.FC<InquiryButtonsProps> = ({ artwork, ...props }) =>
         artwork={artwork}
         modalIsVisible={modalVisibility}
         toggleVisibility={() => setModalVisibility(!modalVisibility)}
+        onMutationSuccessful={(state: boolean) => setNotificationVisibility(state)}
       />
     </>
   )

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquirySuccessNotification.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquirySuccessNotification.tsx
@@ -1,0 +1,88 @@
+import { navigate } from "lib/navigation/navigate"
+import { useScreenDimensions } from "lib/utils/useScreenDimensions"
+import { CloseIcon, color, Flex, Text, Theme } from "palette"
+import React, { useEffect } from "react"
+import { Animated, Modal, TouchableOpacity, TouchableWithoutFeedback } from "react-native"
+import styled from "styled-components/native"
+
+interface InquirySuccessNotificationProps {
+  modalVisible: boolean
+  toggleNotification: (state: boolean) => void
+}
+
+export const InquirySuccessNotification: React.FC<InquirySuccessNotificationProps> = ({
+  modalVisible,
+  toggleNotification,
+}) => {
+  let delayNotification: NodeJS.Timeout | any
+  const navigateToConversation = () => {
+    toggleNotification(false)
+    navigate("inbox")
+  }
+
+  useEffect(() => {
+    delayNotification = setTimeout(() => {
+      toggleNotification(false)
+    }, 2000)
+    return () => {
+      clearTimeout(delayNotification)
+    }
+  }, [modalVisible])
+
+  return (
+    <Theme>
+      <Modal visible={modalVisible} onRequestClose={() => toggleNotification(false)} animationType="fade" transparent>
+        <Animated.View
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            bottom: 0,
+            top: useScreenDimensions().safeAreaInsets.top,
+          }}
+        >
+          <SuccessfulInquirySentContainer
+            style={{
+              shadowColor: "#000",
+              shadowOffset: {
+                width: 0,
+                height: 1,
+              },
+              shadowOpacity: 0.18,
+              shadowRadius: 1.0,
+            }}
+          >
+            <TouchableOpacity onPress={navigateToConversation}>
+              <Flex ml={1}>
+                <Flex flexDirection="row" justifyContent="space-between">
+                  <Text color="green100" variant="mediumText">
+                    Message Sent
+                  </Text>
+                  <TouchableWithoutFeedback
+                    hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                    onPress={() => toggleNotification(false)}
+                  >
+                    <CloseIcon />
+                  </TouchableWithoutFeedback>
+                </Flex>
+                <Text color="black60" variant="text">
+                  Expect a response within 1-3 business days.
+                </Text>
+              </Flex>
+            </TouchableOpacity>
+          </SuccessfulInquirySentContainer>
+        </Animated.View>
+      </Modal>
+    </Theme>
+  )
+}
+
+const SuccessfulInquirySentContainer = styled(Flex)`
+  position: relative;
+  z-index: 5;
+  height: 65px;
+  margin: 10px;
+  flex-direction: column;
+  background-color: ${color("white100")};
+  padding: 0.5px;
+`

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/InquiryButtons-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/InquiryButtons-tests.tsx
@@ -1,0 +1,89 @@
+import { InquiryButtonsTestsQuery } from "__generated__/InquiryButtonsTestsQuery.graphql"
+import { navigate } from "lib/navigation/navigate"
+import { InquiryButtonsFragmentContainer } from "lib/Scenes/Artwork/Components/CommercialButtons/InquiryButtons"
+import { InquirySuccessNotification } from "lib/Scenes/Artwork/Components/CommercialButtons/InquirySuccessNotification"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import React from "react"
+import { TouchableOpacity } from "react-native"
+import { graphql, QueryRenderer } from "react-relay"
+import { act } from "react-test-renderer"
+import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+
+jest.unmock("react-relay")
+jest.mock("lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal", () => {
+  return {
+    InquiryModalFragmentContainer: ({ onMutationSuccessful }: any) => {
+      mockSuccessfulMutation.mockImplementation((mockState) => {
+        onMutationSuccessful(mockState)
+      })
+      return null
+    },
+  }
+})
+
+beforeEach(() => {
+  jest.useFakeTimers()
+  env = createMockEnvironment()
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+const mockSuccessfulMutation = jest.fn()
+let env: ReturnType<typeof createMockEnvironment>
+
+const TestRenderer = () => {
+  return (
+    <QueryRenderer<InquiryButtonsTestsQuery>
+      environment={env}
+      query={graphql`
+        query InquiryButtonsTestsQuery($id: String!) @relay_test_operation {
+          artwork(id: $id) {
+            ...InquiryButtons_artwork
+          }
+        }
+      `}
+      variables={{ id: "great-artttt" }}
+      render={({ props, error }) => {
+        if (Boolean(props?.artwork!)) {
+          return <InquiryButtonsFragmentContainer artwork={props!.artwork!} />
+        } else if (Boolean(error)) {
+          console.error(error)
+        }
+      }}
+    />
+  )
+}
+
+const getWrapper = (mockResolvers = {}) => {
+  const tree = renderWithWrappers(<TestRenderer />)
+  act(() => {
+    env.mock.resolveMostRecentOperation((operation) => MockPayloadGenerator.generate(operation, mockResolvers))
+  })
+  return tree
+}
+
+describe("Inquiry message notification", () => {
+  it("renders the message sent notifcation", () => {
+    const wrapper = getWrapper()
+    mockSuccessfulMutation(true)
+    expect(wrapper.root.findByType(InquirySuccessNotification).props.modalVisible).toBe(true)
+  })
+
+  it("clears the message sent notifcation after 2000 ms", () => {
+    const wrapper = getWrapper()
+    mockSuccessfulMutation(true)
+    expect(wrapper.root.findByType(InquirySuccessNotification).props.modalVisible).toBe(true)
+    jest.advanceTimersByTime(2001)
+    jest.runAllTicks()
+    expect(wrapper.root.findByType(InquirySuccessNotification).props.modalVisible).toBe(false)
+  })
+
+  it("navigates to the inbox route when notifcation tapped", () => {
+    const wrapper = getWrapper()
+    mockSuccessfulMutation(true)
+    wrapper.root.findByType(TouchableOpacity).props.onPress()
+    expect(navigate).toHaveBeenCalledWith("inbox")
+  })
+})

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/InquiryModal-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/InquiryModal-tests.tsx
@@ -19,11 +19,13 @@ import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { InquiryModalFragmentContainer } from "../InquiryModal"
 import { ShippingModal } from "../ShippingModal"
 import { press, typeInInput } from "./helpers"
+
 jest.unmock("react-relay")
 
 let env: ReturnType<typeof createMockEnvironment>
 
 const toggleVisibility = jest.fn()
+const onMutationSuccessful = jest.fn()
 
 // An app shell that holds modal visibility properties
 const FakeApp = (props: InquiryModalTestsQueryResponse) => {
@@ -32,6 +34,7 @@ const FakeApp = (props: InquiryModalTestsQueryResponse) => {
   const modalProps = {
     modalIsVisible,
     toggleVisibility,
+    onMutationSuccessful,
   }
 
   return (
@@ -39,6 +42,7 @@ const FakeApp = (props: InquiryModalTestsQueryResponse) => {
       artwork={props!.artwork!}
       modalIsVisible={modalProps.modalIsVisible}
       toggleVisibility={modalProps.toggleVisibility}
+      onMutationSuccessful={modalProps.onMutationSuccessful}
     />
   )
 }

--- a/src/lib/Scenes/Artwork/Components/Mutation/SubmitInquiryRequest.ts
+++ b/src/lib/Scenes/Artwork/Components/Mutation/SubmitInquiryRequest.ts
@@ -7,6 +7,7 @@ export const SubmitInquiryRequest = (
   environment: Environment,
   inquireable: any,
   inquiryState: ArtworkInquiryContextState,
+  setMutationSuccessful: (arg0: boolean) => void,
   showErrorMessage?: any
 ) => {
   const formattedQuestions = inquiryState.inquiryQuestions.map((q: InquiryQuestionInput) => {
@@ -29,11 +30,10 @@ export const SubmitInquiryRequest = (
 
   return commitMutation<SubmitInquiryRequestMutation>(environment, {
     onError: () => {
-      // Show error state
       showErrorMessage(true)
     },
     onCompleted: () => {
-      // Show delayed comfirmation notification
+      setMutationSuccessful(true)
     },
     variables: {
       input: {


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PURCHASE-2099]`
     The Jira integration will turn it into a clickable link for you. -->



This PR resolves [PURCHASE-2099]

### Description
Enables a 2 second notification after an inquiry message mutation successfully completes.

<!-- Implementation description -->

![Kapture 2020-11-16 at 14 09 15](https://user-images.githubusercontent.com/10385964/99299120-c555e900-2818-11eb-9f70-8ddb840d8e68.gif)
![Kapture 2020-11-18 at 15 56 10](https://user-images.githubusercontent.com/10385964/99587224-c91f7200-29b6-11eb-9ac2-40a271b02378.gif)

cc @artsy/purchase-devs 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[PURCHASE-2099]: https://artsyproduct.atlassian.net/browse/PURCHASE-2099