### PR TITLE
chore: remove back arrow analytics tracking

### DIFF
--- a/Artsy/App/ARAnalyticsConstants.h
+++ b/Artsy/App/ARAnalyticsConstants.h
@@ -5,10 +5,6 @@
 // https://docs.google.com/spreadsheets/u/1/d/1bLbeOgVFaWzLSjxLOBDNOKs757-zBGoLSM1lIz3OPiI/edit#gid=497747862
 //
 
-// Global
-
-extern NSString *const ARAnalyticsBackTapped;
-
 // User properties
 
 extern NSString *const ARAnalyticsAppUsageCountProperty;

--- a/Artsy/App/ARAnalyticsConstants.m
+++ b/Artsy/App/ARAnalyticsConstants.m
@@ -1,7 +1,5 @@
 #import "ARAnalyticsConstants.h"
 
-NSString *const ARAnalyticsBackTapped = @"Back arrow";
-
 NSString *const ARAnalyticsAppUsageCountProperty = @"app launched count";
 NSString *const ARAnalyticsCollectorLevelProperty = @"collector level";
 NSString *const ARAnalyticsPriceRangeProperty = @"collector price range";

--- a/Artsy/View_Controllers/Util/ARNavigationController.m
+++ b/Artsy/View_Controllers/Util/ARNavigationController.m
@@ -409,7 +409,6 @@ ShouldHideItem(UIViewController *viewController, SEL itemSelector, ...)
 
 - (IBAction)back:(id)sender
 {
-    [ARAnalytics event:ARAnalyticsBackTapped];
     if (self.isAnimatingTransition) return;
 
     UINavigationController *navigationController = self.ar_innermostTopViewController.navigationController;

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -7,6 +7,7 @@ upcoming:
     - Update url for echo, now in s3 - ash, pavlos
     - Move bottom tabs navigator to TS - david
     - Fix city guide CTA images not showing when running using Xcode 12 - pavlos
+    - Remove analytics tracking on back-arrow taps - pepopowitz
   user_facing:
     -
 releases:


### PR DESCRIPTION
The type of this PR is: **Deprecation**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-824]

### Description

We were tracking every tap of the back arrow, but per @mikehrom no one was using it. This PR removes that tracking to help prevent us from reaching our tracking event budget. 

_This gif demonstrates that I've got on-screen analytics enabled, but no event is being tracked on tap of back-arrow:_

![back-tracking](https://user-images.githubusercontent.com/1627089/99584200-41336b00-29aa-11eb-91fa-2656ee161e57.gif)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-824]: https://artsyproduct.atlassian.net/browse/CX-824