### PR TITLE
fix: persist shipping location for inquiry requests

### DIFF
--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -5,7 +5,7 @@ import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
 import ChevronIcon from "lib/Icons/ChevronIcon"
 import { ArtworkInquiryContext } from "lib/utils/ArtworkInquiry/ArtworkInquiryStore"
 import { InquiryQuestionIDs } from "lib/utils/ArtworkInquiry/ArtworkInquiryTypes"
-import { LocationDetails } from "lib/utils/googleMaps"
+import { LocationWithDetails } from "lib/utils/googleMaps"
 import { Box, color, Flex, Separator, space, Text } from "palette"
 import React, { useContext, useState } from "react"
 import { LayoutAnimation, TouchableOpacity } from "react-native"
@@ -127,7 +127,7 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, ...props })
   const { state, dispatch } = useContext(ArtworkInquiryContext)
   const [shippingModalVisibility, setShippingModalVisibility] = useState(false)
   const [errorMessageVisibility, setErrorMessageVisibility] = useState(false)
-  const selectShippingLocation = (locationDetails: LocationDetails) =>
+  const selectShippingLocation = (locationDetails: LocationWithDetails) =>
     dispatch({ type: "selectShippingLocation", payload: locationDetails })
 
   const resetAndExit = () => {

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -5,6 +5,7 @@ import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
 import ChevronIcon from "lib/Icons/ChevronIcon"
 import { ArtworkInquiryContext } from "lib/utils/ArtworkInquiry/ArtworkInquiryStore"
 import { InquiryQuestionIDs } from "lib/utils/ArtworkInquiry/ArtworkInquiryTypes"
+import { LocationDetails } from "lib/utils/googleMaps"
 import { Box, color, Flex, Separator, space, Text } from "palette"
 import React, { useContext, useState } from "react"
 import { LayoutAnimation, TouchableOpacity } from "react-native"
@@ -70,7 +71,7 @@ const InquiryQuestionOption: React.FC<{
                   type: "selectInquiryQuestion",
                   payload: {
                     questionID: id,
-                    details: isShipping ? state.shippingLocation : null,
+                    details: isShipping ? state.shippingLocation?.name : null,
                     isChecked: !questionSelected,
                   },
                 })
@@ -104,7 +105,7 @@ const InquiryQuestionOption: React.FC<{
                 ) : (
                   <>
                     <Text variant="text" color="black100" style={{ width: "70%" }}>
-                      {state.shippingLocation}
+                      {state.shippingLocation.name}
                     </Text>
                     <Text variant="text" color="purple100">
                       Edit
@@ -126,7 +127,8 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, ...props })
   const { state, dispatch } = useContext(ArtworkInquiryContext)
   const [shippingModalVisibility, setShippingModalVisibility] = useState(false)
   const [errorMessageVisibility, setErrorMessageVisibility] = useState(false)
-  const selectShippingLocation = (l: string) => dispatch({ type: "selectShippingLocation", payload: l })
+  const selectShippingLocation = (locationDetails: LocationDetails) =>
+    dispatch({ type: "selectShippingLocation", payload: locationDetails })
 
   const resetAndExit = () => {
     dispatch({ type: "resetForm", payload: null })
@@ -181,7 +183,7 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, ...props })
         toggleVisibility={() => setShippingModalVisibility(!shippingModalVisibility)}
         modalIsVisible={shippingModalVisibility}
         setLocation={selectShippingLocation}
-        location={state.shippingLocation as string}
+        location={state.shippingLocation}
       />
     </FancyModal>
   )

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/LocationAutocomplete.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/LocationAutocomplete.tsx
@@ -1,5 +1,5 @@
 import { Input } from "lib/Components/Input/Input"
-import { autocompleteLocation, SimpleLocationAutocomplete } from "lib/utils/googleMaps"
+import { getLocationPredictions, SimpleLocation } from "lib/utils/googleMaps"
 import { color, Flex, LocationIcon, Text, Touchable } from "palette"
 import React, { useEffect, useRef, useState } from "react"
 import { Dimensions, TouchableWithoutFeedback, View } from "react-native"
@@ -7,12 +7,12 @@ import styled from "styled-components/native"
 
 interface Props {
   onChange: any
-  initialLocation: SimpleLocationAutocomplete | null
+  initialLocation: SimpleLocation | null
 }
 
 export const LocationAutocomplete: React.FC<Props> = ({ onChange, initialLocation }) => {
-  const [predictions, setPredictions] = useState<SimpleLocationAutocomplete[]>([])
-  const [selectedLocation, setSelectedLocation] = useState<SimpleLocationAutocomplete | null>(initialLocation)
+  const [predictions, setPredictions] = useState<SimpleLocation[]>([])
+  const [selectedLocation, setSelectedLocation] = useState<SimpleLocation | null>(initialLocation)
   const [query, setQuery] = useState(selectedLocation?.name || "")
 
   // Autofocus
@@ -35,7 +35,7 @@ export const LocationAutocomplete: React.FC<Props> = ({ onChange, initialLocatio
       setPredictions([])
     } else {
       ;(async () => {
-        const googlePredictions = await autocompleteLocation(query)
+        const googlePredictions = await getLocationPredictions(query)
         setPredictions(googlePredictions)
       })()
     }
@@ -82,9 +82,9 @@ export const LocationPredictions = ({
   onSelect,
   onOutsidePress,
 }: {
-  predictions: SimpleLocationAutocomplete[]
+  predictions: SimpleLocation[]
   query?: string
-  onSelect: (l: SimpleLocationAutocomplete) => void
+  onSelect: (l: SimpleLocation) => void
   onOutsidePress: () => void
 }) => {
   const [height, setHeight] = useState(0)

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/LocationAutocomplete.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/LocationAutocomplete.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 export const LocationAutocomplete: React.FC<Props> = ({ onChange, initialLocation }) => {
   const [predictions, setPredictions] = useState<SimpleLocation[]>([])
-  const [selectedLocation, setSelectedLocation] = useState<SimpleLocation | null>(initialLocation)
+  const [selectedLocation, setSelectedLocation] = useState(initialLocation)
   const [query, setQuery] = useState(selectedLocation?.name || "")
 
   // Autofocus

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/LocationAutocomplete.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/LocationAutocomplete.tsx
@@ -1,5 +1,5 @@
 import { Input } from "lib/Components/Input/Input"
-import { GMapsLocation, queryLocation } from "lib/utils/googleMaps"
+import { autocompleteLocation, SimpleLocationAutocomplete } from "lib/utils/googleMaps"
 import { color, Flex, LocationIcon, Text, Touchable } from "palette"
 import React, { useEffect, useRef, useState } from "react"
 import { Dimensions, TouchableWithoutFeedback, View } from "react-native"
@@ -7,13 +7,13 @@ import styled from "styled-components/native"
 
 interface Props {
   onChange: any
-  initialLocation: string
+  initialLocation: SimpleLocationAutocomplete | null
 }
 
 export const LocationAutocomplete: React.FC<Props> = ({ onChange, initialLocation }) => {
-  const [predictions, setPredictions] = useState<GMapsLocation[]>([])
-  const [selectedLocation, setSelectedLocation] = useState(initialLocation ? initialLocation : "")
-  const [query, setQuery] = useState(selectedLocation)
+  const [predictions, setPredictions] = useState<SimpleLocationAutocomplete[]>([])
+  const [selectedLocation, setSelectedLocation] = useState<SimpleLocationAutocomplete | null>(initialLocation)
+  const [query, setQuery] = useState(selectedLocation?.name || "")
 
   // Autofocus
   const input = useRef<Input>(null)
@@ -27,15 +27,15 @@ export const LocationAutocomplete: React.FC<Props> = ({ onChange, initialLocatio
   }, [selectedLocation])
 
   useEffect(() => {
-    if (query !== selectedLocation) {
-      setSelectedLocation("")
+    if (query !== selectedLocation?.name) {
+      setSelectedLocation(null)
     }
 
-    if (query.length < 3 || selectedLocation === query) {
+    if (query.length < 3 || selectedLocation?.name === query) {
       setPredictions([])
     } else {
       ;(async () => {
-        const googlePredictions = await queryLocation(query)
+        const googlePredictions = await autocompleteLocation(query)
         setPredictions(googlePredictions)
       })()
     }
@@ -43,7 +43,7 @@ export const LocationAutocomplete: React.FC<Props> = ({ onChange, initialLocatio
 
   const reset = () => {
     if (selectedLocation) {
-      setQuery(selectedLocation)
+      setQuery(selectedLocation.name)
     }
   }
   const touchOut = () => {
@@ -61,7 +61,7 @@ export const LocationAutocomplete: React.FC<Props> = ({ onChange, initialLocatio
         style={{ marginVertical: 10 }}
         onChangeText={setQuery}
         onFocus={reset}
-        value={selectedLocation ? selectedLocation : query}
+        value={selectedLocation ? selectedLocation.name : query}
       />
       <LocationPredictions
         predictions={predictions}
@@ -70,8 +70,7 @@ export const LocationAutocomplete: React.FC<Props> = ({ onChange, initialLocatio
         onOutsidePress={touchOut}
       />
       <Text color="black60">
-        Sharing your location with galleries helps them provide fast and accurate shipping quotes. You can always edit
-        this information later in your Collector Profile.
+        Sharing your location with galleries helps them provide fast and accurate shipping quotes.
       </Text>
     </Flex>
   )
@@ -83,9 +82,9 @@ export const LocationPredictions = ({
   onSelect,
   onOutsidePress,
 }: {
-  predictions: GMapsLocation[]
+  predictions: SimpleLocationAutocomplete[]
   query?: string
-  onSelect: (l: string) => void
+  onSelect: (l: SimpleLocationAutocomplete) => void
   onOutsidePress: () => void
 }) => {
   const [height, setHeight] = useState(0)
@@ -123,7 +122,7 @@ export const LocationPredictions = ({
           <Touchable
             key={p.id}
             onPress={() => {
-              onSelect(p.name)
+              onSelect(p)
             }}
             style={{ padding: 10 }}
           >

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/ShippingModal.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/ShippingModal.tsx
@@ -1,6 +1,6 @@
 import { FancyModal } from "lib/Components/FancyModal/FancyModal"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
-import { getLocationDetails, LocationDetails, SimpleLocationAutocomplete } from "lib/utils/googleMaps"
+import { getLocationDetails, LocationWithDetails, SimpleLocation } from "lib/utils/googleMaps"
 import { Flex } from "palette"
 import React, { useState } from "react"
 
@@ -9,14 +9,14 @@ import { LocationAutocomplete } from "./LocationAutocomplete"
 interface ShippingModalProps {
   toggleVisibility: () => void
   modalIsVisible: boolean
-  setLocation: (locationDetails: LocationDetails) => void
-  location: LocationDetails | null
+  setLocation: (locationDetails: LocationWithDetails) => void
+  location: LocationWithDetails | null
 }
 
 export const ShippingModal: React.FC<ShippingModalProps> = (props) => {
   const { location, toggleVisibility, modalIsVisible, setLocation } = props
 
-  const [locationInput, setLocationInput] = useState<SimpleLocationAutocomplete | null>(null)
+  const [locationInput, setLocationInput] = useState<SimpleLocation | null>(null)
 
   return (
     <FancyModal visible={modalIsVisible} onBackgroundPressed={() => toggleVisibility()}>
@@ -27,7 +27,7 @@ export const ShippingModal: React.FC<ShippingModalProps> = (props) => {
         }}
         rightButtonText="Apply"
         onRightButtonPress={async () => {
-          const locationDetails = await getLocationDetails(locationInput as SimpleLocationAutocomplete)
+          const locationDetails = await getLocationDetails(locationInput as SimpleLocation)
 
           setLocation(locationDetails)
           toggleVisibility()

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/ShippingModal.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/ShippingModal.tsx
@@ -1,5 +1,6 @@
 import { FancyModal } from "lib/Components/FancyModal/FancyModal"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
+import { getLocationDetails, LocationDetails, SimpleLocationAutocomplete } from "lib/utils/googleMaps"
 import { Flex } from "palette"
 import React, { useState } from "react"
 
@@ -8,14 +9,14 @@ import { LocationAutocomplete } from "./LocationAutocomplete"
 interface ShippingModalProps {
   toggleVisibility: () => void
   modalIsVisible: boolean
-  setLocation: (location: string) => void
-  location: string
+  setLocation: (locationDetails: LocationDetails) => void
+  location: LocationDetails | null
 }
 
 export const ShippingModal: React.FC<ShippingModalProps> = (props) => {
   const { location, toggleVisibility, modalIsVisible, setLocation } = props
 
-  const [locationInput, setLocationInput] = useState("")
+  const [locationInput, setLocationInput] = useState<SimpleLocationAutocomplete | null>(null)
 
   return (
     <FancyModal visible={modalIsVisible} onBackgroundPressed={() => toggleVisibility()}>
@@ -25,8 +26,10 @@ export const ShippingModal: React.FC<ShippingModalProps> = (props) => {
           toggleVisibility()
         }}
         rightButtonText="Apply"
-        onRightButtonPress={() => {
-          setLocation(locationInput)
+        onRightButtonPress={async () => {
+          const locationDetails = await getLocationDetails(locationInput as SimpleLocationAutocomplete)
+
+          setLocation(locationDetails)
           toggleVisibility()
         }}
         rightButtonDisabled={!locationInput}

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/InquiryModal-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/InquiryModal-tests.tsx
@@ -1,4 +1,7 @@
-jest.mock("../../../../../utils/googleMaps", () => ({ queryLocation: jest.fn() }))
+jest.mock("../../../../../utils/googleMaps", () => ({
+  getLocationPredictions: jest.fn(),
+  getLocationDetails: jest.fn(),
+}))
 
 import { InquiryModalTestsQuery, InquiryModalTestsQueryResponse } from "__generated__/InquiryModalTestsQuery.graphql"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
@@ -7,7 +10,7 @@ import { extractText } from "lib/tests/extractText"
 import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { ArtworkInquiryContext, ArtworkInquiryStateProvider } from "lib/utils/ArtworkInquiry/ArtworkInquiryStore"
-import { autocompleteLocation } from "lib/utils/googleMaps"
+import { getLocationDetails, getLocationPredictions } from "lib/utils/googleMaps"
 import { Touchable } from "palette"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
@@ -196,10 +199,18 @@ describe("<InquiryModal />", () => {
     })
 
     it("User adds a location from the shipping modal", async () => {
-      ;(autocompleteLocation as jest.Mock).mockResolvedValue([
+      ;(getLocationPredictions as jest.Mock).mockResolvedValue([
         { id: "a", name: "Coxsackie, NY, USA" },
         { id: "b", name: "Coxs Creek, KY, USA" },
       ])
+      ;(getLocationDetails as jest.Mock).mockResolvedValue({
+        city: "Coxsackie",
+        country: "USA",
+        state: "New York",
+        stateCode: "NY",
+        id: "a",
+        name: "Coxsackie, NY, USA",
+      })
       const wrapper = getWrapper()
       wrapper.root.findByProps({ "data-test-id": "checkbox-shipping_quote" }).props.onPress()
       await press(wrapper.root, { text: /^Add your location/ })

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/InquiryModal-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/InquiryModal-tests.tsx
@@ -7,7 +7,7 @@ import { extractText } from "lib/tests/extractText"
 import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { ArtworkInquiryContext, ArtworkInquiryStateProvider } from "lib/utils/ArtworkInquiry/ArtworkInquiryStore"
-import { queryLocation } from "lib/utils/googleMaps"
+import { autocompleteLocation } from "lib/utils/googleMaps"
 import { Touchable } from "palette"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
@@ -196,7 +196,7 @@ describe("<InquiryModal />", () => {
     })
 
     it("User adds a location from the shipping modal", async () => {
-      ;(queryLocation as jest.Mock).mockResolvedValue([
+      ;(autocompleteLocation as jest.Mock).mockResolvedValue([
         { id: "a", name: "Coxsackie, NY, USA" },
         { id: "b", name: "Coxs Creek, KY, USA" },
       ])

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/LocationAutocomplete-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/LocationAutocomplete-tests.tsx
@@ -1,17 +1,17 @@
-jest.mock("../../../../../utils/googleMaps", () => ({ queryLocation: jest.fn() }))
+jest.mock("../../../../../utils/googleMaps", () => ({ getLocationPredictions: jest.fn() }))
 import { Input } from "lib/Components/Input/Input"
 import { extractText } from "lib/tests/extractText"
 import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
-import { autocompleteLocation } from "lib/utils/googleMaps"
+import { getLocationPredictions, SimpleLocation } from "lib/utils/googleMaps"
 import { Touchable } from "palette"
 import React from "react"
 import { ReactTestRenderer } from "react-test-renderer"
-import { LocationPredictions, SimpleLocationAutocomplete } from "../LocationAutocomplete"
+import { LocationAutocomplete, LocationPredictions } from "../LocationAutocomplete"
 import { press, typeInInput } from "./helpers"
 
 const mockOnChange = jest.fn()
-const getWrapper = (initialLocation: string = "") =>
+const getWrapper = (initialLocation: SimpleLocation | null = null) =>
   renderWithWrappers(<LocationAutocomplete initialLocation={initialLocation} onChange={mockOnChange} />)
 
 const locationQueryResult = [
@@ -23,30 +23,30 @@ describe("<LocationAutocomplete/>", () => {
   let wrapper: ReactTestRenderer
 
   it("pre-fills the input with an initialLocation prop", async () => {
-    wrapper = getWrapper("Anytown, USA")
+    wrapper = getWrapper({ id: "1234", name: "Anytown, USA" })
     expect(wrapper.root.findByType(Input).props.value).toEqual("Anytown, USA")
   })
 
   describe("no preselected location", () => {
     beforeEach(() => {
-      ;(autocompleteLocation as jest.Mock).mockResolvedValue(locationQueryResult)
+      ;(getLocationPredictions as jest.Mock).mockResolvedValue(locationQueryResult)
       wrapper = getWrapper()
     })
 
     it("queries google when the user types 3 or more characters", async () => {
       await typeInInput(wrapper.root, "h")
 
-      expect(autocompleteLocation).not.toHaveBeenCalled()
+      expect(getLocationPredictions).not.toHaveBeenCalled()
       expect(wrapper.root.findAllByProps({ "data-test-id": "dropdown" }).length).toEqual(0)
 
       await typeInInput(wrapper.root, "he")
 
-      expect(autocompleteLocation).not.toHaveBeenCalled()
+      expect(getLocationPredictions).not.toHaveBeenCalled()
       expect(wrapper.root.findAllByProps({ "data-test-id": "dropdown" }).length).toEqual(0)
 
       await typeInInput(wrapper.root, "hel")
 
-      expect(autocompleteLocation).toHaveBeenCalled()
+      expect(getLocationPredictions).toHaveBeenCalled()
       expect(wrapper.root.findAllByProps({ "data-test-id": "dropdown" }).length).not.toEqual(0)
       const text = extractText(wrapper.root)
       expect(text).toContain("Busytown, USA")
@@ -58,7 +58,7 @@ describe("<LocationAutocomplete/>", () => {
     await typeInInput(wrapper.root, "hel")
     await press(wrapper.root, { text: "Busytown, USA", componentType: Touchable })
 
-    expect(mockOnChange).toHaveBeenCalledWith("Busytown, USA")
+    expect(mockOnChange).toHaveBeenCalledWith({ id: "a", name: "Busytown, USA" })
     expect(wrapper.root.findByType(Input).props.value).toMatch("Busytown, USA")
     expect(wrapper.root.findAllByProps({ "data-test-id": "dropdown" }).length).toEqual(0)
   })
@@ -77,7 +77,7 @@ describe("<LocationAutocomplete/>", () => {
   })
 
   it("Highlights matched text in the autocomplete", async () => {
-    ;(autocompleteLocation as jest.Mock).mockResolvedValue([{ id: "x", name: "Hello, World" }])
+    ;(getLocationPredictions as jest.Mock).mockResolvedValue([{ id: "x", name: "Hello, World" }])
     await typeInInput(wrapper.root, "hell World")
 
     expect(extractText(wrapper.root)).toContain("Hello, World")

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/LocationAutocomplete-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/LocationAutocomplete-tests.tsx
@@ -3,11 +3,11 @@ import { Input } from "lib/Components/Input/Input"
 import { extractText } from "lib/tests/extractText"
 import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
-import { queryLocation } from "lib/utils/googleMaps"
+import { autocompleteLocation } from "lib/utils/googleMaps"
 import { Touchable } from "palette"
 import React from "react"
 import { ReactTestRenderer } from "react-test-renderer"
-import { LocationAutocomplete, LocationPredictions } from "../LocationAutocomplete"
+import { LocationPredictions, SimpleLocationAutocomplete } from "../LocationAutocomplete"
 import { press, typeInInput } from "./helpers"
 
 const mockOnChange = jest.fn()
@@ -29,24 +29,24 @@ describe("<LocationAutocomplete/>", () => {
 
   describe("no preselected location", () => {
     beforeEach(() => {
-      ;(queryLocation as jest.Mock).mockResolvedValue(locationQueryResult)
+      ;(autocompleteLocation as jest.Mock).mockResolvedValue(locationQueryResult)
       wrapper = getWrapper()
     })
 
     it("queries google when the user types 3 or more characters", async () => {
       await typeInInput(wrapper.root, "h")
 
-      expect(queryLocation).not.toHaveBeenCalled()
+      expect(autocompleteLocation).not.toHaveBeenCalled()
       expect(wrapper.root.findAllByProps({ "data-test-id": "dropdown" }).length).toEqual(0)
 
       await typeInInput(wrapper.root, "he")
 
-      expect(queryLocation).not.toHaveBeenCalled()
+      expect(autocompleteLocation).not.toHaveBeenCalled()
       expect(wrapper.root.findAllByProps({ "data-test-id": "dropdown" }).length).toEqual(0)
 
       await typeInInput(wrapper.root, "hel")
 
-      expect(queryLocation).toHaveBeenCalled()
+      expect(autocompleteLocation).toHaveBeenCalled()
       expect(wrapper.root.findAllByProps({ "data-test-id": "dropdown" }).length).not.toEqual(0)
       const text = extractText(wrapper.root)
       expect(text).toContain("Busytown, USA")
@@ -77,7 +77,7 @@ describe("<LocationAutocomplete/>", () => {
   })
 
   it("Highlights matched text in the autocomplete", async () => {
-    ;(queryLocation as jest.Mock).mockResolvedValue([{ id: "x", name: "Hello, World" }])
+    ;(autocompleteLocation as jest.Mock).mockResolvedValue([{ id: "x", name: "Hello, World" }])
     await typeInInput(wrapper.root, "hell World")
 
     expect(extractText(wrapper.root)).toContain("Hello, World")

--- a/src/lib/Scenes/Artwork/Components/Mutation/SubmitInquiryRequest.ts
+++ b/src/lib/Scenes/Artwork/Components/Mutation/SubmitInquiryRequest.ts
@@ -39,7 +39,6 @@ export const SubmitInquiryRequest = (
       input: {
         inquireableID: inquireable.internalID,
         inquireableType: "Artwork",
-        // message: inquiryState.message,
         questions: formattedQuestions,
       },
     },

--- a/src/lib/Scenes/Artwork/Components/Mutation/SubmitInquiryRequest.ts
+++ b/src/lib/Scenes/Artwork/Components/Mutation/SubmitInquiryRequest.ts
@@ -9,9 +9,7 @@ export const SubmitInquiryRequest = (
   inquiryState: ArtworkInquiryContextState,
   showErrorMessage?: any
 ) => {
-  let inquiryQuestions
-
-  inquiryQuestions = inquiryState.inquiryQuestions.map((q: InquiryQuestionInput) => {
+  const formattedQuestions = inquiryState.inquiryQuestions.map((q: InquiryQuestionInput) => {
     if (q.questionID === "shipping_quote" && inquiryState.shippingLocation) {
       const { city, coordinates, country, postalCode, state, stateCode } = inquiryState.shippingLocation
       const locationInput = {
@@ -22,9 +20,11 @@ export const SubmitInquiryRequest = (
         state,
         state_code: stateCode,
       }
-      q.details = JSON.stringify(locationInput)
+      const details = JSON.stringify(locationInput)
+      return { ...q, details }
+    } else {
+      return q
     }
-    return q
   })
 
   return commitMutation<SubmitInquiryRequestMutation>(environment, {
@@ -40,7 +40,7 @@ export const SubmitInquiryRequest = (
         inquireableID: inquireable.internalID,
         inquireableType: "Artwork",
         // message: inquiryState.message,
-        questions: inquiryState.inquiryQuestions,
+        questions: formattedQuestions,
       },
     },
     mutation: graphql`

--- a/src/lib/utils/ArtworkInquiry/ArtworkInquiryTypes.ts
+++ b/src/lib/utils/ArtworkInquiry/ArtworkInquiryTypes.ts
@@ -1,6 +1,6 @@
 import { InquiryQuestionInput } from "__generated__/SubmitInquiryRequestMutation.graphql"
 import { Dispatch } from "react"
-import { LocationDetails } from "../googleMaps"
+import { LocationWithDetails } from "../googleMaps"
 
 export type ArtworkInquiryActions = SelectInquiryType | SelectLocation | SelectInquiryQuestion | ResetForm
 
@@ -11,7 +11,7 @@ export interface ArtworkInquiryContextProps {
 
 export interface ArtworkInquiryContextState {
   readonly inquiryType: InquiryTypes | null
-  readonly shippingLocation: LocationDetails | null
+  readonly shippingLocation: LocationWithDetails | null
   readonly inquiryQuestions: InquiryQuestionInput[]
 }
 
@@ -28,7 +28,7 @@ interface SelectInquiryType {
 
 interface SelectLocation {
   type: "selectShippingLocation"
-  payload: LocationDetails
+  payload: LocationWithDetails
 }
 
 interface SelectInquiryQuestion {

--- a/src/lib/utils/ArtworkInquiry/ArtworkInquiryTypes.ts
+++ b/src/lib/utils/ArtworkInquiry/ArtworkInquiryTypes.ts
@@ -1,5 +1,6 @@
 import { InquiryQuestionInput } from "__generated__/SubmitInquiryRequestMutation.graphql"
 import { Dispatch } from "react"
+import { LocationDetails } from "../googleMaps"
 
 export type ArtworkInquiryActions = SelectInquiryType | SelectLocation | SelectInquiryQuestion | ResetForm
 
@@ -10,7 +11,7 @@ export interface ArtworkInquiryContextProps {
 
 export interface ArtworkInquiryContextState {
   readonly inquiryType: InquiryTypes | null
-  readonly shippingLocation: string | null
+  readonly shippingLocation: LocationDetails | null
   readonly inquiryQuestions: InquiryQuestionInput[]
 }
 
@@ -27,7 +28,7 @@ interface SelectInquiryType {
 
 interface SelectLocation {
   type: "selectShippingLocation"
-  payload: string
+  payload: LocationDetails
 }
 
 interface SelectInquiryQuestion {

--- a/src/lib/utils/__tests__/googleMaps-tests.ts
+++ b/src/lib/utils/__tests__/googleMaps-tests.ts
@@ -1,4 +1,4 @@
-import { autocompleteLocation } from "../googleMaps"
+import { getLocationPredictions } from "../googleMaps"
 
 jest.mock("react-native-config", () => ({
   GOOGLE_MAPS_API_KEY: "keykey",
@@ -31,7 +31,7 @@ describe("queryLocation()", () => {
       })
     })
 
-    const result = await autocompleteLocation("Cox")
+    const result = await getLocationPredictions("Cox")
 
     expect(result).toEqual([
       {

--- a/src/lib/utils/__tests__/googleMaps-tests.ts
+++ b/src/lib/utils/__tests__/googleMaps-tests.ts
@@ -1,4 +1,4 @@
-import { queryLocation } from "../googleMaps"
+import { autocompleteLocation } from "../googleMaps"
 
 jest.mock("react-native-config", () => ({
   GOOGLE_MAPS_API_KEY: "keykey",
@@ -31,7 +31,7 @@ describe("queryLocation()", () => {
       })
     })
 
-    const result = await queryLocation("Cox")
+    const result = await autocompleteLocation("Cox")
 
     expect(result).toEqual([
       {

--- a/src/lib/utils/googleMaps.ts
+++ b/src/lib/utils/googleMaps.ts
@@ -1,7 +1,9 @@
 import { stringify } from "querystring"
 import Config from "react-native-config"
 
-export interface GMapsLocation {
+const API_KEY = Config.GOOGLE_MAPS_API_KEY
+
+export interface SimpleLocationAutocomplete {
   id: string
   name: string
 }
@@ -12,10 +14,9 @@ interface LocationResult {
   description: string
 }
 
-export const queryLocation = async (query: string): Promise<GMapsLocation[]> => {
-  const apiKey = Config.GOOGLE_MAPS_API_KEY
+export const autocompleteLocation = async (query: string): Promise<SimpleLocationAutocomplete[]> => {
   const queryString = stringify({
-    key: apiKey,
+    key: API_KEY,
     language: "en",
     types: "(cities)",
     input: query,
@@ -26,6 +27,53 @@ export const queryLocation = async (query: string): Promise<GMapsLocation[]> => 
   return results.predictions.map(predictionToResult)
 }
 
-const predictionToResult = (prediction: LocationResult): GMapsLocation => {
+const predictionToResult = (prediction: LocationResult): SimpleLocationAutocomplete => {
   return { id: prediction.place_id, name: prediction.description }
+}
+
+export interface LocationDetails extends SimpleLocationAutocomplete {
+  city: string
+  coordinates?: string[]
+  country: string
+  postalCode: string
+  state: string
+  stateCode: string
+}
+
+export const getLocationDetails = async ({ id, name }: SimpleLocationAutocomplete): Promise<LocationDetails> => {
+  const queryString = stringify({
+    key: API_KEY,
+    placeid: id,
+  })
+
+  const response = await fetch("https://maps.googleapis.com/maps/api/place/details/json?" + queryString)
+  const results = await response.json()
+
+  // TODO: Add dedicated error handling to the maps response
+  const { address_components, geometry } = results.result
+  // @ts-ignore STRICTNESS_MIGRATION
+  const cityPlace = address_components.find((comp) => comp.types[0] === "locality")
+  // @ts-ignore STRICTNESS_MIGRATION
+  const statePlace = address_components.find((comp) => comp.types[0] === "administrative_area_level_1")
+  // @ts-ignore STRICTNESS_MIGRATION
+  const countryPlace = address_components.find((comp) => comp.types[0] === "country")
+  const postalCodePlace = address_components.find((comp) => comp.types[0] === "postal_code")
+  const { lat, lng } = geometry.location
+
+  const city = cityPlace && cityPlace.long_name
+  const country = countryPlace && countryPlace.long_name
+  const state = statePlace && statePlace.long_name
+  const stateCode = statePlace && statePlace.short_name
+  const postalCode = postalCodePlace && postalCodePlace.long_name
+
+  return {
+    city,
+    coordinates: [lat, lng],
+    country,
+    state,
+    stateCode,
+    postalCode,
+    id,
+    name,
+  }
 }


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR resolves [PURCHASE-2226]

### Description
When a user checks the shipping quote checkbox and adds a shipping location, the location was not being persisted through to the Inquiry Request instance in gravity. This is caused by two bugs:

1. The way we were previously assigning the shipping location to details was incorrect.
2. We were passing the shipping location as a string when the backend expects an object/hash.

The new implementation makes an additional api request to get an object that represents the city location and handles updating the shipping quote inquiry questions with details in the submit function when we have all the necessary data. 

![shipping location](https://user-images.githubusercontent.com/5201004/99695353-78ae2000-2a5b-11eb-937e-6d296cb73234.gif)

<img width="834" alt="Screen Shot 2020-11-19 at 11 36 12 AM" src="https://user-images.githubusercontent.com/5201004/99695372-7e0b6a80-2a5b-11eb-8ce9-213702ac17ab.png">
 
Paired with @erikdstock 

### PR Checklist (tick all before merging)
- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[PURCHASE-2226]: https://artsyproduct.atlassian.net/browse/PURCHASE-2226