### PR TITLE
fix: my collection visual qa #trivial

### DIFF
--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistArticles.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistArticles.tsx
@@ -1,12 +1,11 @@
 import { MyCollectionArtworkArtistArticles_artwork } from "__generated__/MyCollectionArtworkArtistArticles_artwork.graphql"
 import { CaretButton } from "lib/Components/Buttons/CaretButton"
-import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { navigate } from "lib/navigation/navigate"
 import { ScreenMargin } from "lib/Scenes/MyCollection/Components/ScreenMargin"
 import { extractNodes } from "lib/utils/extractNodes"
 import { Box, Flex, Spacer, Text } from "palette"
 import React from "react"
-import { TouchableOpacity } from "react-native"
+import { Image, TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 
 interface MyCollectionArtworkArtistArticlesProps {
@@ -32,15 +31,18 @@ const MyCollectionArtworkArtistArticles: React.FC<MyCollectionArtworkArtistArtic
           <TouchableOpacity onPress={() => navigate(`/article/${slug}`)} key={internalID}>
             <Box my={0.5}>
               <Flex flexDirection="row">
-                <Box pr={1} maxWidth="80%">
+                <Box pr={1} style={{ flex: 1 }}>
                   <Flex flexDirection="row">
-                    <Text style={{ flexShrink: 1 }}>{thumbnailTitle}</Text>
+                    <Text style={{ flex: 1 }}>{thumbnailTitle}</Text>
                   </Flex>
                   <Text color="black60" my={0.5}>
                     {publishedAt}
                   </Text>
                 </Box>
-                <OpaqueImageView imageURL={thumbnailImage?.url} width={80} height={60} />
+                <Image
+                  style={{ flexShrink: 1, width: 80, height: 60 }}
+                  source={{ uri: thumbnailImage?.url ?? undefined }}
+                />
               </Flex>
             </Box>
           </TouchableOpacity>

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistAuctionResults.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistAuctionResults.tsx
@@ -45,7 +45,7 @@ const MyCollectionArtworkArtistAuctionResults: React.FC<MyCollectionArtworkArtis
           onPress={() => navigate(`/artist/${props?.artwork?.artist?.slug!}/auction-results`)}
           data-test-id="AuctionsResultsButton"
         >
-          <Box>
+          <Box mr={2}>
             {results.map(({ title, saleDate, priceRealized, internalID, images }) => {
               const dateOfSale = DateTime.fromISO(saleDate as string).toLocaleString(DateTime.DATE_MED)
               const salePrice = priceRealized?.centsUSD === 0 ? null : priceRealized?.display

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistAuctionResults.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistAuctionResults.tsx
@@ -1,12 +1,11 @@
 import { MyCollectionArtworkArtistAuctionResults_artwork } from "__generated__/MyCollectionArtworkArtistAuctionResults_artwork.graphql"
-import { Divider } from "lib/Components/Bidding/Components/Divider"
 import { CaretButton } from "lib/Components/Buttons/CaretButton"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { navigate } from "lib/navigation/navigate"
 import { ScreenMargin } from "lib/Scenes/MyCollection/Components/ScreenMargin"
 import { extractNodes } from "lib/utils/extractNodes"
 import { DateTime } from "luxon"
-import { Box, Flex, Spacer, Text } from "palette"
+import { Box, Flex, Separator, Spacer, Text } from "palette"
 import React from "react"
 import { TouchableWithoutFeedback, View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -91,7 +90,7 @@ const MyCollectionArtworkArtistAuctionResults: React.FC<MyCollectionArtworkArtis
       </ScreenMargin>
 
       <Box my={3}>
-        <Divider />
+        <Separator />
       </Box>
     </View>
   )

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkInsights.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkInsights.tsx
@@ -1,6 +1,5 @@
 import { MyCollectionArtworkInsights_artwork } from "__generated__/MyCollectionArtworkInsights_artwork.graphql"
 import { MyCollectionArtworkInsights_marketPriceInsights } from "__generated__/MyCollectionArtworkInsights_marketPriceInsights.graphql"
-import { Divider } from "lib/Components/Bidding/Components/Divider"
 import { ScreenMargin } from "lib/Scenes/MyCollection/Components/ScreenMargin"
 import { Separator, Spacer, Text } from "palette"
 import React from "react"
@@ -38,18 +37,18 @@ export const MyCollectionArtworkInsights: React.FC<MyCollectionArtworkInsightsPr
           <Spacer mt={3} />
           <MyCollectionArtworkDemandIndexFragmentContainer marketPriceInsights={marketPriceInsights} />
           <ScreenMargin my={3}>
-            <Divider />
+            <Separator />
           </ScreenMargin>
           <MyCollectionArtworkPriceEstimateFragmentContainer
             artwork={artwork}
             marketPriceInsights={marketPriceInsights}
           />
           <ScreenMargin mt={2} mb={3}>
-            <Divider />
+            <Separator />
           </ScreenMargin>
           <MyCollectionArtworkArtistMarketFragmentContainer marketPriceInsights={marketPriceInsights} />
           <ScreenMargin mt={2} mb={3}>
-            <Divider />
+            <Separator />
           </ScreenMargin>
         </>
       )}

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/__tests__/MyCollectionArtworkArtistArticles-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/__tests__/MyCollectionArtworkArtistArticles-tests.tsx
@@ -1,11 +1,10 @@
 import { MyCollectionArtworkArtistArticlesTestsQuery } from "__generated__/MyCollectionArtworkArtistArticlesTestsQuery.graphql"
 import { CaretButton } from "lib/Components/Buttons/CaretButton"
-import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { navigate } from "lib/navigation/navigate"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
-import { TouchableOpacity } from "react-native"
+import { Image, TouchableOpacity } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { MyCollectionArtworkArtistArticlesFragmentContainer } from "../MyCollectionArtworkArtistArticles"
@@ -47,7 +46,7 @@ describe("MyCollectionArtworkArtistArticles", () => {
   it("renders without throwing an error", () => {
     const wrapper = renderWithWrappers(<TestRenderer />)
     resolveData()
-    expect(wrapper.root.findByType(OpaqueImageView)).toBeDefined()
+    expect(wrapper.root.findByType(Image)).toBeDefined()
     const text = extractText(wrapper.root)
     expect(text).toContain("Latest Articles")
     expect(text).toContain("thumbnailTitle")

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/WhySell.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/WhySell.tsx
@@ -38,7 +38,7 @@ const WhySellStep: React.FC<{ step: number; title: string; description: string }
       <Box mr={2}>
         <Text>{step}</Text>
       </Box>
-      <Box>
+      <Box mr={2}>
         <Text>{title}</Text>
         <Text color="black60">{description}</Text>
       </Box>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [CX-781]

### Description

Minor visual qa fixes for my collection:
- Respect margins in lists on artwork page
- Update separators to be 1 px
- List view padding and additional details padding mentioned in ticket were fixed already in previous PRs

### Screenshots

### Before:

![articlesBefore](https://user-images.githubusercontent.com/49686530/99832278-48838180-2b2e-11eb-93f2-c691a468dd46.png)

![auctionResultsBefore](https://user-images.githubusercontent.com/49686530/99832294-50dbbc80-2b2e-11eb-9c29-6b24b658aaed.png)
![interestedInSellingBefore](https://user-images.githubusercontent.com/49686530/99832322-5df8ab80-2b2e-11eb-81ee-5ec6b00697a0.png)

### After:

![articlesAfter](https://user-images.githubusercontent.com/49686530/99832244-3e618300-2b2e-11eb-8f06-8951f7cef531.png)
![auctionResultsAfter](https://user-images.githubusercontent.com/49686530/99832215-3570b180-2b2e-11eb-83a5-581003a73c1e.png)
![interestedInSellingAfter](https://user-images.githubusercontent.com/49686530/99832238-3c97bf80-2b2e-11eb-8416-a2828fc403f1.png)

### Unchanged:

![myCollectionAfterBefore](https://user-images.githubusercontent.com/49686530/99832195-30136700-2b2e-11eb-9d12-aa1891c459ba.png)
![artworkDetailsAfterBefore](https://user-images.githubusercontent.com/49686530/99832200-3275c100-2b2e-11eb-8925-ba636da2652f.png)




### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-781]: https://artsyproduct.atlassian.net/browse/CX-781