### PR TITLE
feat: change title and ordering of artwork price range filter

### DIFF
--- a/src/lib/Components/ArtworkFilterOptions/PriceRangeOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/PriceRangeOptions.tsx
@@ -27,7 +27,7 @@ const priceRangeDisplayText: Map<string, string> = new Map([
 ])
 
 const priceSort = (left: FilterData, right: FilterData): number => {
-  const sortOrder = ["*-*", "*-1000", "1000-5000", "5000-10000", "10000-50000", "50000-*"]
+  const sortOrder = ["*-*", "50000-*", "10000-50000", "5000-10000", "1000-5000", "*-1000"]
   const leftParam = left.paramValue as string
   const rightParam = right.paramValue as string
   if (sortOrder.indexOf(leftParam) < sortOrder.indexOf(rightParam)) {

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/PriceRangeOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/PriceRangeOptions-tests.tsx
@@ -104,6 +104,14 @@ describe("Price Range Options Screen", () => {
     expect(extractText(firstOption)).toContain("All")
   })
 
+  it("renders price range options from most to least expensive", () => {
+    const tree = renderWithWrappers(<MockPriceRangeScreen initialState={state} />)
+    const options = tree.root.findAllByType(OptionListItem)
+    const renderedOptions = options.map(extractText)
+
+    expect(renderedOptions).toEqual(["All", "$50,000+", "$10,000-50,000", "$5,000-10,000", "$1000-5,000", "$0-1,000"])
+  })
+
   describe("selectedPriceRangeOption", () => {
     it("returns the default option if there are no selected or applied filters", () => {
       const tree = renderWithWrappers(<MockPriceRangeScreen initialState={state} />)

--- a/src/lib/utils/ArtworkFilter/FilterArtworksHelpers.ts
+++ b/src/lib/utils/ArtworkFilter/FilterArtworksHelpers.ts
@@ -42,7 +42,7 @@ export enum FilterDisplayName {
   gallery = "Gallery",
   institution = "Institution",
   medium = "Medium",
-  priceRange = "Price/estimate range",
+  priceRange = "Price",
   size = "Size",
   sort = "Sort by",
   timePeriod = "Time period",


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR resolves [FX-2398]

### Description

This tackles two of the tasks in the associated ticket:

- Change the title of the price range filter from "Price/estimate range"
- Change the ordering of the price buckets from highest to lowest

After looking into it, this PR _punts on_ the following change from the ticket, since this appears to require upstream changes to Gravity ~and Metaphysics(?)~ (I will split out the ticket accordingly):

- Split the USD 10,000–50,000 bucket into 10,000–25,000 and 25,000–50,000

While the change was ticketed for Fairs…

<img width="200" alt="fair: all filters" src="https://user-images.githubusercontent.com/140521/99838832-baac9400-2b37-11eb-9204-079f08d20b62.png"> <img width="200" alt="fair: price filter selected" src="https://user-images.githubusercontent.com/140521/99838837-bd0eee00-2b37-11eb-96d5-1983434e5c77.png">


…it is also intended to take effect globally (artist, series, collection, show), which these screen caps partly demonstrate: 

<img width="200" alt="series" src="https://user-images.githubusercontent.com/140521/99838886-d57f0880-2b37-11eb-9c38-6166d65767f6.png" /> <img width="200" alt="collection" src="https://user-images.githubusercontent.com/140521/99838914-e0399d80-2b37-11eb-8be7-19655aa72fa5.png">


The one exception is the auction filters, which should continue to show the "Price/estimate" language…

<img width="200" alt="auctions" src="https://user-images.githubusercontent.com/140521/99839099-2db60a80-2b38-11eb-907c-8cd3e18d3c40.png" />


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2398]: https://artsyproduct.atlassian.net/browse/FX-2398