### PR TITLE
fix: Ensure image still renders if first message empty

### DIFF
--- a/src/lib/Scenes/Inbox/Components/Conversations/MessageGroup.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/MessageGroup.tsx
@@ -54,12 +54,14 @@ export class MessageGroup extends React.Component<MessageGroupProps> {
             )}
           </SubjectContainer>
         )}
-        <Message
-          message={message}
-          key={message.internalID}
-          showTimeSince={!!(message.createdAt && today && group.length - 1 === messageIndex)}
-          conversationId={conversationId!}
-        />
+        {!!message.body && (
+          <Message
+            message={message}
+            key={message.internalID}
+            showTimeSince={!!(message.createdAt && today && group.length - 1 === messageIndex)}
+            conversationId={conversationId!}
+          />
+        )}
         <Spacer mb={spaceAfter} />
       </React.Fragment>
     )

--- a/src/lib/Scenes/Inbox/Components/Conversations/Messages.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/Messages.tsx
@@ -33,7 +33,12 @@ export const Messages: React.FC<Props> = forwardRef((props, ref) => {
   const [messages, setMessages] = useState<MessageGroupType[]>()
   useEffect(() => {
     const nodes = extractNodes(conversation.messagesConnection)
-      .filter((node) => node.body?.length || node.attachments?.length)
+      .filter((node) => {
+        if (node.isFirstMessage) {
+          return true
+        }
+        return node.body?.length || node.attachments?.length
+      })
       .map((node) => {
         return { key: node.id, ...node }
       })


### PR DESCRIPTION
The type of this PR is: Bugfix

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [PURCHASE-2234]

### Description

@xtina-starr noticed that inquiries sent w/ no message caused the artwork preview not to display at the beginning on the conversation. 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[PURCHASE-2234]: https://artsyproduct.atlassian.net/browse/PURCHASE-2234