### PR TITLE
chore: split old and new inboxes

### DIFF
--- a/src/__generated__/InboxOldQuery.graphql.ts
+++ b/src/__generated__/InboxOldQuery.graphql.ts
@@ -1,0 +1,685 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash 46a2767d8c7991260e86874c8be46ce4 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type InboxOldQueryVariables = {};
+export type InboxOldQueryResponse = {
+    readonly me: {
+        readonly " $fragmentRefs": FragmentRefs<"InboxOld_me">;
+    } | null;
+};
+export type InboxOldQuery = {
+    readonly response: InboxOldQueryResponse;
+    readonly variables: InboxOldQueryVariables;
+};
+
+
+
+/*
+query InboxOldQuery {
+  me {
+    ...InboxOld_me
+    id
+  }
+}
+
+fragment ActiveBid_bid on LotStanding {
+  is_leading_bidder: isLeadingBidder
+  sale {
+    href
+    is_live_open: isLiveOpen
+    id
+  }
+  most_recent_bid: mostRecentBid {
+    id
+    sale_artwork: saleArtwork {
+      artwork {
+        href
+        image {
+          url
+        }
+        artist_names: artistNames
+        id
+      }
+      counts {
+        bidder_positions: bidderPositions
+      }
+      highest_bid: highestBid {
+        display
+      }
+      lot_label: lotLabel
+      reserve_status: reserveStatus
+      id
+    }
+  }
+}
+
+fragment ActiveBids_me on Me {
+  lot_standings: lotStandings(live: true) {
+    most_recent_bid: mostRecentBid {
+      id
+    }
+    ...ActiveBid_bid
+  }
+}
+
+fragment ConversationSnippet_conversation on Conversation {
+  internalID
+  to {
+    name
+    id
+  }
+  lastMessage
+  lastMessageAt
+  unread
+  items {
+    item {
+      __typename
+      ... on Artwork {
+        date
+        title
+        artistNames
+        image {
+          url
+        }
+      }
+      ... on Show {
+        fair {
+          name
+          id
+        }
+        name
+        coverImage {
+          url
+        }
+      }
+      ... on Node {
+        __isNode: __typename
+        id
+      }
+    }
+  }
+  messagesConnection {
+    totalCount
+  }
+}
+
+fragment Conversations_me on Me {
+  conversations: conversationsConnection(first: 10, after: "") {
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    edges {
+      node {
+        internalID
+        last_message: lastMessage
+        ...ConversationSnippet_conversation
+        id
+        __typename
+      }
+      cursor
+    }
+    totalUnreadCount
+  }
+}
+
+fragment InboxOld_me on Me {
+  lot_standings: lotStandings(live: true) {
+    most_recent_bid: mostRecentBid {
+      id
+    }
+  }
+  conversations_existence_check: conversationsConnection(first: 1) {
+    edges {
+      node {
+        internalID
+        id
+      }
+    }
+  }
+  ...Conversations_me
+  ...ActiveBids_me
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v2 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "url",
+    "storageKey": null
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Image",
+  "kind": "LinkedField",
+  "name": "image",
+  "plural": false,
+  "selections": (v2/*: any*/),
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v5 = [
+  {
+    "kind": "Literal",
+    "name": "after",
+    "value": ""
+  },
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+],
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v7 = [
+  (v6/*: any*/),
+  (v0/*: any*/)
+],
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "InboxOldQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "InboxOld_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "InboxOldQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": "lot_standings",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "live",
+                "value": true
+              }
+            ],
+            "concreteType": "LotStanding",
+            "kind": "LinkedField",
+            "name": "lotStandings",
+            "plural": true,
+            "selections": [
+              {
+                "alias": "most_recent_bid",
+                "args": null,
+                "concreteType": "BidderPosition",
+                "kind": "LinkedField",
+                "name": "mostRecentBid",
+                "plural": false,
+                "selections": [
+                  (v0/*: any*/),
+                  {
+                    "alias": "sale_artwork",
+                    "args": null,
+                    "concreteType": "SaleArtwork",
+                    "kind": "LinkedField",
+                    "name": "saleArtwork",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artwork",
+                        "kind": "LinkedField",
+                        "name": "artwork",
+                        "plural": false,
+                        "selections": [
+                          (v1/*: any*/),
+                          (v3/*: any*/),
+                          {
+                            "alias": "artist_names",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "artistNames",
+                            "storageKey": null
+                          },
+                          (v0/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "SaleArtworkCounts",
+                        "kind": "LinkedField",
+                        "name": "counts",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "bidder_positions",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "bidderPositions",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "highest_bid",
+                        "args": null,
+                        "concreteType": "SaleArtworkHighestBid",
+                        "kind": "LinkedField",
+                        "name": "highestBid",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "display",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "lot_label",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lotLabel",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "reserve_status",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "reserveStatus",
+                        "storageKey": null
+                      },
+                      (v0/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": "is_leading_bidder",
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isLeadingBidder",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Sale",
+                "kind": "LinkedField",
+                "name": "sale",
+                "plural": false,
+                "selections": [
+                  (v1/*: any*/),
+                  {
+                    "alias": "is_live_open",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "isLiveOpen",
+                    "storageKey": null
+                  },
+                  (v0/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "lotStandings(live:true)"
+          },
+          {
+            "alias": "conversations_existence_check",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 1
+              }
+            ],
+            "concreteType": "ConversationConnection",
+            "kind": "LinkedField",
+            "name": "conversationsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ConversationEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Conversation",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v4/*: any*/),
+                      (v0/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "conversationsConnection(first:1)"
+          },
+          {
+            "alias": "conversations",
+            "args": (v5/*: any*/),
+            "concreteType": "ConversationConnection",
+            "kind": "LinkedField",
+            "name": "conversationsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "kind": "LinkedField",
+                "name": "pageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "endCursor",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "hasNextPage",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ConversationEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Conversation",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v4/*: any*/),
+                      {
+                        "alias": "last_message",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lastMessage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ConversationResponder",
+                        "kind": "LinkedField",
+                        "name": "to",
+                        "plural": false,
+                        "selections": (v7/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lastMessage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lastMessageAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "unread",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ConversationItem",
+                        "kind": "LinkedField",
+                        "name": "items",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": null,
+                            "kind": "LinkedField",
+                            "name": "item",
+                            "plural": false,
+                            "selections": [
+                              (v8/*: any*/),
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "date",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "title",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "artistNames",
+                                    "storageKey": null
+                                  },
+                                  (v3/*: any*/)
+                                ],
+                                "type": "Artwork",
+                                "abstractKey": null
+                              },
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Fair",
+                                    "kind": "LinkedField",
+                                    "name": "fair",
+                                    "plural": false,
+                                    "selections": (v7/*: any*/),
+                                    "storageKey": null
+                                  },
+                                  (v6/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "coverImage",
+                                    "plural": false,
+                                    "selections": (v2/*: any*/),
+                                    "storageKey": null
+                                  }
+                                ],
+                                "type": "Show",
+                                "abstractKey": null
+                              },
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  (v0/*: any*/)
+                                ],
+                                "type": "Node",
+                                "abstractKey": "__isNode"
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "MessageConnection",
+                        "kind": "LinkedField",
+                        "name": "messagesConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "totalCount",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v0/*: any*/),
+                      (v8/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "cursor",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "totalUnreadCount",
+                "storageKey": null
+              }
+            ],
+            "storageKey": "conversationsConnection(after:\"\",first:10)"
+          },
+          {
+            "alias": "conversations",
+            "args": (v5/*: any*/),
+            "filters": null,
+            "handle": "connection",
+            "key": "Conversations_conversations",
+            "kind": "LinkedHandle",
+            "name": "conversationsConnection"
+          },
+          (v0/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "46a2767d8c7991260e86874c8be46ce4",
+    "metadata": {},
+    "name": "InboxOldQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = 'eae0abe64a27d2e666699ca914538dc3';
+export default node;

--- a/src/__generated__/InboxOldRefetchQuery.graphql.ts
+++ b/src/__generated__/InboxOldRefetchQuery.graphql.ts
@@ -1,0 +1,685 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash 4c9734522705abd7c9f8096112bfa7e9 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type InboxOldRefetchQueryVariables = {};
+export type InboxOldRefetchQueryResponse = {
+    readonly me: {
+        readonly " $fragmentRefs": FragmentRefs<"InboxOld_me">;
+    } | null;
+};
+export type InboxOldRefetchQuery = {
+    readonly response: InboxOldRefetchQueryResponse;
+    readonly variables: InboxOldRefetchQueryVariables;
+};
+
+
+
+/*
+query InboxOldRefetchQuery {
+  me {
+    ...InboxOld_me
+    id
+  }
+}
+
+fragment ActiveBid_bid on LotStanding {
+  is_leading_bidder: isLeadingBidder
+  sale {
+    href
+    is_live_open: isLiveOpen
+    id
+  }
+  most_recent_bid: mostRecentBid {
+    id
+    sale_artwork: saleArtwork {
+      artwork {
+        href
+        image {
+          url
+        }
+        artist_names: artistNames
+        id
+      }
+      counts {
+        bidder_positions: bidderPositions
+      }
+      highest_bid: highestBid {
+        display
+      }
+      lot_label: lotLabel
+      reserve_status: reserveStatus
+      id
+    }
+  }
+}
+
+fragment ActiveBids_me on Me {
+  lot_standings: lotStandings(live: true) {
+    most_recent_bid: mostRecentBid {
+      id
+    }
+    ...ActiveBid_bid
+  }
+}
+
+fragment ConversationSnippet_conversation on Conversation {
+  internalID
+  to {
+    name
+    id
+  }
+  lastMessage
+  lastMessageAt
+  unread
+  items {
+    item {
+      __typename
+      ... on Artwork {
+        date
+        title
+        artistNames
+        image {
+          url
+        }
+      }
+      ... on Show {
+        fair {
+          name
+          id
+        }
+        name
+        coverImage {
+          url
+        }
+      }
+      ... on Node {
+        __isNode: __typename
+        id
+      }
+    }
+  }
+  messagesConnection {
+    totalCount
+  }
+}
+
+fragment Conversations_me on Me {
+  conversations: conversationsConnection(first: 10, after: "") {
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    edges {
+      node {
+        internalID
+        last_message: lastMessage
+        ...ConversationSnippet_conversation
+        id
+        __typename
+      }
+      cursor
+    }
+    totalUnreadCount
+  }
+}
+
+fragment InboxOld_me on Me {
+  lot_standings: lotStandings(live: true) {
+    most_recent_bid: mostRecentBid {
+      id
+    }
+  }
+  conversations_existence_check: conversationsConnection(first: 1) {
+    edges {
+      node {
+        internalID
+        id
+      }
+    }
+  }
+  ...Conversations_me
+  ...ActiveBids_me
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v2 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "url",
+    "storageKey": null
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Image",
+  "kind": "LinkedField",
+  "name": "image",
+  "plural": false,
+  "selections": (v2/*: any*/),
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v5 = [
+  {
+    "kind": "Literal",
+    "name": "after",
+    "value": ""
+  },
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+],
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v7 = [
+  (v6/*: any*/),
+  (v0/*: any*/)
+],
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "InboxOldRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "InboxOld_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "InboxOldRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": "lot_standings",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "live",
+                "value": true
+              }
+            ],
+            "concreteType": "LotStanding",
+            "kind": "LinkedField",
+            "name": "lotStandings",
+            "plural": true,
+            "selections": [
+              {
+                "alias": "most_recent_bid",
+                "args": null,
+                "concreteType": "BidderPosition",
+                "kind": "LinkedField",
+                "name": "mostRecentBid",
+                "plural": false,
+                "selections": [
+                  (v0/*: any*/),
+                  {
+                    "alias": "sale_artwork",
+                    "args": null,
+                    "concreteType": "SaleArtwork",
+                    "kind": "LinkedField",
+                    "name": "saleArtwork",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artwork",
+                        "kind": "LinkedField",
+                        "name": "artwork",
+                        "plural": false,
+                        "selections": [
+                          (v1/*: any*/),
+                          (v3/*: any*/),
+                          {
+                            "alias": "artist_names",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "artistNames",
+                            "storageKey": null
+                          },
+                          (v0/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "SaleArtworkCounts",
+                        "kind": "LinkedField",
+                        "name": "counts",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "bidder_positions",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "bidderPositions",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "highest_bid",
+                        "args": null,
+                        "concreteType": "SaleArtworkHighestBid",
+                        "kind": "LinkedField",
+                        "name": "highestBid",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "display",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "lot_label",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lotLabel",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "reserve_status",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "reserveStatus",
+                        "storageKey": null
+                      },
+                      (v0/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": "is_leading_bidder",
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isLeadingBidder",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Sale",
+                "kind": "LinkedField",
+                "name": "sale",
+                "plural": false,
+                "selections": [
+                  (v1/*: any*/),
+                  {
+                    "alias": "is_live_open",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "isLiveOpen",
+                    "storageKey": null
+                  },
+                  (v0/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "lotStandings(live:true)"
+          },
+          {
+            "alias": "conversations_existence_check",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 1
+              }
+            ],
+            "concreteType": "ConversationConnection",
+            "kind": "LinkedField",
+            "name": "conversationsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ConversationEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Conversation",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v4/*: any*/),
+                      (v0/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "conversationsConnection(first:1)"
+          },
+          {
+            "alias": "conversations",
+            "args": (v5/*: any*/),
+            "concreteType": "ConversationConnection",
+            "kind": "LinkedField",
+            "name": "conversationsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "kind": "LinkedField",
+                "name": "pageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "endCursor",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "hasNextPage",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ConversationEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Conversation",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v4/*: any*/),
+                      {
+                        "alias": "last_message",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lastMessage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ConversationResponder",
+                        "kind": "LinkedField",
+                        "name": "to",
+                        "plural": false,
+                        "selections": (v7/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lastMessage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lastMessageAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "unread",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ConversationItem",
+                        "kind": "LinkedField",
+                        "name": "items",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": null,
+                            "kind": "LinkedField",
+                            "name": "item",
+                            "plural": false,
+                            "selections": [
+                              (v8/*: any*/),
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "date",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "title",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "artistNames",
+                                    "storageKey": null
+                                  },
+                                  (v3/*: any*/)
+                                ],
+                                "type": "Artwork",
+                                "abstractKey": null
+                              },
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Fair",
+                                    "kind": "LinkedField",
+                                    "name": "fair",
+                                    "plural": false,
+                                    "selections": (v7/*: any*/),
+                                    "storageKey": null
+                                  },
+                                  (v6/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "coverImage",
+                                    "plural": false,
+                                    "selections": (v2/*: any*/),
+                                    "storageKey": null
+                                  }
+                                ],
+                                "type": "Show",
+                                "abstractKey": null
+                              },
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  (v0/*: any*/)
+                                ],
+                                "type": "Node",
+                                "abstractKey": "__isNode"
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "MessageConnection",
+                        "kind": "LinkedField",
+                        "name": "messagesConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "totalCount",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v0/*: any*/),
+                      (v8/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "cursor",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "totalUnreadCount",
+                "storageKey": null
+              }
+            ],
+            "storageKey": "conversationsConnection(after:\"\",first:10)"
+          },
+          {
+            "alias": "conversations",
+            "args": (v5/*: any*/),
+            "filters": null,
+            "handle": "connection",
+            "key": "Conversations_conversations",
+            "kind": "LinkedHandle",
+            "name": "conversationsConnection"
+          },
+          (v0/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "4c9734522705abd7c9f8096112bfa7e9",
+    "metadata": {},
+    "name": "InboxOldRefetchQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = '9536bb69dfb8e4b05b919ee2d91fffb6';
+export default node;

--- a/src/__generated__/InboxOld_me.graphql.ts
+++ b/src/__generated__/InboxOld_me.graphql.ts
@@ -1,0 +1,133 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type InboxOld_me = {
+    readonly lot_standings: ReadonlyArray<{
+        readonly most_recent_bid: {
+            readonly id: string;
+        } | null;
+    } | null> | null;
+    readonly conversations_existence_check: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly internalID: string | null;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $fragmentRefs": FragmentRefs<"Conversations_me" | "ActiveBids_me">;
+    readonly " $refType": "InboxOld_me";
+};
+export type InboxOld_me$data = InboxOld_me;
+export type InboxOld_me$key = {
+    readonly " $data"?: InboxOld_me$data;
+    readonly " $fragmentRefs": FragmentRefs<"InboxOld_me">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "InboxOld_me",
+  "selections": [
+    {
+      "alias": "lot_standings",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "live",
+          "value": true
+        }
+      ],
+      "concreteType": "LotStanding",
+      "kind": "LinkedField",
+      "name": "lotStandings",
+      "plural": true,
+      "selections": [
+        {
+          "alias": "most_recent_bid",
+          "args": null,
+          "concreteType": "BidderPosition",
+          "kind": "LinkedField",
+          "name": "mostRecentBid",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "id",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "lotStandings(live:true)"
+    },
+    {
+      "alias": "conversations_existence_check",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 1
+        }
+      ],
+      "concreteType": "ConversationConnection",
+      "kind": "LinkedField",
+      "name": "conversationsConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ConversationEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Conversation",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "internalID",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "conversationsConnection(first:1)"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "Conversations_me"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "ActiveBids_me"
+    }
+  ],
+  "type": "Me",
+  "abstractKey": null
+};
+(node as any).hash = '5a2d576a87c5e38497201071a392af04';
+export default node;

--- a/src/__generated__/InboxQuery.graphql.ts
+++ b/src/__generated__/InboxQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 6336acbd37a66624004b382643415a58 */
+/* @relayHash d49c74840fe5edd83cf6163e321ee881 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -23,46 +23,6 @@ query InboxQuery {
   me {
     ...Inbox_me
     id
-  }
-}
-
-fragment ActiveBid_bid on LotStanding {
-  is_leading_bidder: isLeadingBidder
-  sale {
-    href
-    is_live_open: isLiveOpen
-    id
-  }
-  most_recent_bid: mostRecentBid {
-    id
-    sale_artwork: saleArtwork {
-      artwork {
-        href
-        image {
-          url
-        }
-        artist_names: artistNames
-        id
-      }
-      counts {
-        bidder_positions: bidderPositions
-      }
-      highest_bid: highestBid {
-        display
-      }
-      lot_label: lotLabel
-      reserve_status: reserveStatus
-      id
-    }
-  }
-}
-
-fragment ActiveBids_me on Me {
-  lot_standings: lotStandings(live: true) {
-    most_recent_bid: mostRecentBid {
-      id
-    }
-    ...ActiveBid_bid
   }
 }
 
@@ -180,21 +140,17 @@ fragment Conversations_me on Me {
 }
 
 fragment Inbox_me on Me {
-  lot_standings: lotStandings(live: true) {
-    most_recent_bid: mostRecentBid {
-      id
+  lotStandingsExistenceCheck: auctionsLotStandingConnection(first: 1) {
+    edges {
+      cursor
     }
   }
-  conversations_existence_check: conversationsConnection(first: 1) {
+  conversationsExistenceCheck: conversationsConnection(first: 1) {
     edges {
-      node {
-        internalID
-        id
-      }
+      cursor
     }
   }
   ...Conversations_me
-  ...ActiveBids_me
   ...MyBids_me
 }
 
@@ -256,47 +212,24 @@ fragment SaleCard_sale on Sale {
 */
 
 const node: ConcreteRequest = (function(){
-var v0 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 1
+  }
+],
 v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "href",
+  "name": "cursor",
   "storageKey": null
 },
 v2 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "url",
-    "storageKey": null
-  }
+  (v1/*: any*/)
 ],
-v3 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "Image",
-  "kind": "LinkedField",
-  "name": "image",
-  "plural": false,
-  "selections": (v2/*: any*/),
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v5 = [
+v3 = [
   {
     "kind": "Literal",
     "name": "after",
@@ -308,16 +241,30 @@ v5 = [
     "value": 10
   }
 ],
-v6 = {
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
 v7 = [
-  (v6/*: any*/),
-  (v0/*: any*/)
+  (v5/*: any*/),
+  (v6/*: any*/)
 ],
 v8 = {
   "alias": null,
@@ -333,17 +280,26 @@ v9 = {
   "name": "artistNames",
   "storageKey": null
 },
-v10 = {
+v10 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "url",
+    "storageKey": null
+  }
+],
+v11 = {
   "alias": null,
   "args": null,
   "concreteType": "Image",
   "kind": "LinkedField",
   "name": "coverImage",
   "plural": false,
-  "selections": (v2/*: any*/),
+  "selections": (v10/*: any*/),
   "storageKey": null
 },
-v11 = [
+v12 = [
   {
     "alias": null,
     "args": [
@@ -357,7 +313,14 @@ v11 = [
     "name": "displayAmount",
     "storageKey": "displayAmount(fractionalDigits:0)"
   }
-];
+],
+v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": [],
@@ -400,153 +363,29 @@ return {
         "plural": false,
         "selections": [
           {
-            "alias": "lot_standings",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "live",
-                "value": true
-              }
-            ],
-            "concreteType": "LotStanding",
+            "alias": "lotStandingsExistenceCheck",
+            "args": (v0/*: any*/),
+            "concreteType": "AuctionsLotStandingConnection",
             "kind": "LinkedField",
-            "name": "lotStandings",
-            "plural": true,
+            "name": "auctionsLotStandingConnection",
+            "plural": false,
             "selections": [
-              {
-                "alias": "most_recent_bid",
-                "args": null,
-                "concreteType": "BidderPosition",
-                "kind": "LinkedField",
-                "name": "mostRecentBid",
-                "plural": false,
-                "selections": [
-                  (v0/*: any*/),
-                  {
-                    "alias": "sale_artwork",
-                    "args": null,
-                    "concreteType": "SaleArtwork",
-                    "kind": "LinkedField",
-                    "name": "saleArtwork",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Artwork",
-                        "kind": "LinkedField",
-                        "name": "artwork",
-                        "plural": false,
-                        "selections": [
-                          (v1/*: any*/),
-                          (v3/*: any*/),
-                          {
-                            "alias": "artist_names",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "artistNames",
-                            "storageKey": null
-                          },
-                          (v0/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "SaleArtworkCounts",
-                        "kind": "LinkedField",
-                        "name": "counts",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": "bidder_positions",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "bidderPositions",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "highest_bid",
-                        "args": null,
-                        "concreteType": "SaleArtworkHighestBid",
-                        "kind": "LinkedField",
-                        "name": "highestBid",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "display",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "lot_label",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "lotLabel",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "reserve_status",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "reserveStatus",
-                        "storageKey": null
-                      },
-                      (v0/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              {
-                "alias": "is_leading_bidder",
-                "args": null,
-                "kind": "ScalarField",
-                "name": "isLeadingBidder",
-                "storageKey": null
-              },
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "Sale",
+                "concreteType": "AuctionsLotStandingEdge",
                 "kind": "LinkedField",
-                "name": "sale",
-                "plural": false,
-                "selections": [
-                  (v1/*: any*/),
-                  {
-                    "alias": "is_live_open",
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "isLiveOpen",
-                    "storageKey": null
-                  },
-                  (v0/*: any*/)
-                ],
+                "name": "edges",
+                "plural": true,
+                "selections": (v2/*: any*/),
                 "storageKey": null
               }
             ],
-            "storageKey": "lotStandings(live:true)"
+            "storageKey": "auctionsLotStandingConnection(first:1)"
           },
           {
-            "alias": "conversations_existence_check",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 1
-              }
-            ],
+            "alias": "conversationsExistenceCheck",
+            "args": (v0/*: any*/),
             "concreteType": "ConversationConnection",
             "kind": "LinkedField",
             "name": "conversationsConnection",
@@ -559,21 +398,7 @@ return {
                 "kind": "LinkedField",
                 "name": "edges",
                 "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Conversation",
-                    "kind": "LinkedField",
-                    "name": "node",
-                    "plural": false,
-                    "selections": [
-                      (v4/*: any*/),
-                      (v0/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
+                "selections": (v2/*: any*/),
                 "storageKey": null
               }
             ],
@@ -581,7 +406,7 @@ return {
           },
           {
             "alias": "conversations",
-            "args": (v5/*: any*/),
+            "args": (v3/*: any*/),
             "concreteType": "ConversationConnection",
             "kind": "LinkedField",
             "name": "conversationsConnection",
@@ -702,7 +527,16 @@ return {
                                     "storageKey": null
                                   },
                                   (v9/*: any*/),
-                                  (v3/*: any*/)
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": (v10/*: any*/),
+                                    "storageKey": null
+                                  }
                                 ],
                                 "type": "Artwork",
                                 "abstractKey": null
@@ -720,8 +554,8 @@ return {
                                     "selections": (v7/*: any*/),
                                     "storageKey": null
                                   },
-                                  (v6/*: any*/),
-                                  (v10/*: any*/)
+                                  (v5/*: any*/),
+                                  (v11/*: any*/)
                                 ],
                                 "type": "Show",
                                 "abstractKey": null
@@ -729,7 +563,7 @@ return {
                               {
                                 "kind": "InlineFragment",
                                 "selections": [
-                                  (v0/*: any*/)
+                                  (v6/*: any*/)
                                 ],
                                 "type": "Node",
                                 "abstractKey": "__isNode"
@@ -758,18 +592,12 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v0/*: any*/),
+                      (v6/*: any*/),
                       (v8/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "cursor",
-                    "storageKey": null
-                  }
+                  (v1/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -785,7 +613,7 @@ return {
           },
           {
             "alias": "conversations",
-            "args": (v5/*: any*/),
+            "args": (v3/*: any*/),
             "filters": null,
             "handle": "connection",
             "key": "Conversations_conversations",
@@ -866,7 +694,7 @@ return {
                             "kind": "LinkedField",
                             "name": "onlineAskingPrice",
                             "plural": false,
-                            "selections": (v11/*: any*/),
+                            "selections": (v12/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -876,10 +704,10 @@ return {
                             "kind": "LinkedField",
                             "name": "floorSellingPrice",
                             "plural": false,
-                            "selections": (v11/*: any*/),
+                            "selections": (v12/*: any*/),
                             "storageKey": null
                           },
-                          (v0/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -914,7 +742,7 @@ return {
                             "plural": false,
                             "selections": [
                               (v9/*: any*/),
-                              (v1/*: any*/),
+                              (v13/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -939,7 +767,7 @@ return {
                                 ],
                                 "storageKey": null
                               },
-                              (v0/*: any*/)
+                              (v6/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -958,7 +786,7 @@ return {
                                 "name": "liveStartAt",
                                 "storageKey": null
                               },
-                              (v0/*: any*/),
+                              (v6/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -973,9 +801,9 @@ return {
                                 "name": "status",
                                 "storageKey": null
                               },
-                              (v1/*: any*/),
-                              (v6/*: any*/),
-                              (v10/*: any*/),
+                              (v13/*: any*/),
+                              (v5/*: any*/),
+                              (v11/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -990,7 +818,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v0/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1001,7 +829,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v0/*: any*/)
+                      (v6/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1011,14 +839,14 @@ return {
             ],
             "storageKey": "auctionsLotStandingConnection(first:25)"
           },
-          (v0/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "6336acbd37a66624004b382643415a58",
+    "id": "d49c74840fe5edd83cf6163e321ee881",
     "metadata": {},
     "name": "InboxQuery",
     "operationKind": "query",

--- a/src/__generated__/InboxRefetchQuery.graphql.ts
+++ b/src/__generated__/InboxRefetchQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash c558293a69044a1b81692195964a20cc */
+/* @relayHash 8c2fcb97badd1c6925be622e0c41913b */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -23,46 +23,6 @@ query InboxRefetchQuery {
   me {
     ...Inbox_me
     id
-  }
-}
-
-fragment ActiveBid_bid on LotStanding {
-  is_leading_bidder: isLeadingBidder
-  sale {
-    href
-    is_live_open: isLiveOpen
-    id
-  }
-  most_recent_bid: mostRecentBid {
-    id
-    sale_artwork: saleArtwork {
-      artwork {
-        href
-        image {
-          url
-        }
-        artist_names: artistNames
-        id
-      }
-      counts {
-        bidder_positions: bidderPositions
-      }
-      highest_bid: highestBid {
-        display
-      }
-      lot_label: lotLabel
-      reserve_status: reserveStatus
-      id
-    }
-  }
-}
-
-fragment ActiveBids_me on Me {
-  lot_standings: lotStandings(live: true) {
-    most_recent_bid: mostRecentBid {
-      id
-    }
-    ...ActiveBid_bid
   }
 }
 
@@ -180,21 +140,17 @@ fragment Conversations_me on Me {
 }
 
 fragment Inbox_me on Me {
-  lot_standings: lotStandings(live: true) {
-    most_recent_bid: mostRecentBid {
-      id
+  lotStandingsExistenceCheck: auctionsLotStandingConnection(first: 1) {
+    edges {
+      cursor
     }
   }
-  conversations_existence_check: conversationsConnection(first: 1) {
+  conversationsExistenceCheck: conversationsConnection(first: 1) {
     edges {
-      node {
-        internalID
-        id
-      }
+      cursor
     }
   }
   ...Conversations_me
-  ...ActiveBids_me
   ...MyBids_me
 }
 
@@ -256,47 +212,24 @@ fragment SaleCard_sale on Sale {
 */
 
 const node: ConcreteRequest = (function(){
-var v0 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 1
+  }
+],
 v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "href",
+  "name": "cursor",
   "storageKey": null
 },
 v2 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "url",
-    "storageKey": null
-  }
+  (v1/*: any*/)
 ],
-v3 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "Image",
-  "kind": "LinkedField",
-  "name": "image",
-  "plural": false,
-  "selections": (v2/*: any*/),
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v5 = [
+v3 = [
   {
     "kind": "Literal",
     "name": "after",
@@ -308,16 +241,30 @@ v5 = [
     "value": 10
   }
 ],
-v6 = {
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
 v7 = [
-  (v6/*: any*/),
-  (v0/*: any*/)
+  (v5/*: any*/),
+  (v6/*: any*/)
 ],
 v8 = {
   "alias": null,
@@ -333,17 +280,26 @@ v9 = {
   "name": "artistNames",
   "storageKey": null
 },
-v10 = {
+v10 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "url",
+    "storageKey": null
+  }
+],
+v11 = {
   "alias": null,
   "args": null,
   "concreteType": "Image",
   "kind": "LinkedField",
   "name": "coverImage",
   "plural": false,
-  "selections": (v2/*: any*/),
+  "selections": (v10/*: any*/),
   "storageKey": null
 },
-v11 = [
+v12 = [
   {
     "alias": null,
     "args": [
@@ -357,7 +313,14 @@ v11 = [
     "name": "displayAmount",
     "storageKey": "displayAmount(fractionalDigits:0)"
   }
-];
+],
+v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": [],
@@ -400,153 +363,29 @@ return {
         "plural": false,
         "selections": [
           {
-            "alias": "lot_standings",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "live",
-                "value": true
-              }
-            ],
-            "concreteType": "LotStanding",
+            "alias": "lotStandingsExistenceCheck",
+            "args": (v0/*: any*/),
+            "concreteType": "AuctionsLotStandingConnection",
             "kind": "LinkedField",
-            "name": "lotStandings",
-            "plural": true,
+            "name": "auctionsLotStandingConnection",
+            "plural": false,
             "selections": [
-              {
-                "alias": "most_recent_bid",
-                "args": null,
-                "concreteType": "BidderPosition",
-                "kind": "LinkedField",
-                "name": "mostRecentBid",
-                "plural": false,
-                "selections": [
-                  (v0/*: any*/),
-                  {
-                    "alias": "sale_artwork",
-                    "args": null,
-                    "concreteType": "SaleArtwork",
-                    "kind": "LinkedField",
-                    "name": "saleArtwork",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Artwork",
-                        "kind": "LinkedField",
-                        "name": "artwork",
-                        "plural": false,
-                        "selections": [
-                          (v1/*: any*/),
-                          (v3/*: any*/),
-                          {
-                            "alias": "artist_names",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "artistNames",
-                            "storageKey": null
-                          },
-                          (v0/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "SaleArtworkCounts",
-                        "kind": "LinkedField",
-                        "name": "counts",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": "bidder_positions",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "bidderPositions",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "highest_bid",
-                        "args": null,
-                        "concreteType": "SaleArtworkHighestBid",
-                        "kind": "LinkedField",
-                        "name": "highestBid",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "display",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "lot_label",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "lotLabel",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "reserve_status",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "reserveStatus",
-                        "storageKey": null
-                      },
-                      (v0/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              {
-                "alias": "is_leading_bidder",
-                "args": null,
-                "kind": "ScalarField",
-                "name": "isLeadingBidder",
-                "storageKey": null
-              },
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "Sale",
+                "concreteType": "AuctionsLotStandingEdge",
                 "kind": "LinkedField",
-                "name": "sale",
-                "plural": false,
-                "selections": [
-                  (v1/*: any*/),
-                  {
-                    "alias": "is_live_open",
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "isLiveOpen",
-                    "storageKey": null
-                  },
-                  (v0/*: any*/)
-                ],
+                "name": "edges",
+                "plural": true,
+                "selections": (v2/*: any*/),
                 "storageKey": null
               }
             ],
-            "storageKey": "lotStandings(live:true)"
+            "storageKey": "auctionsLotStandingConnection(first:1)"
           },
           {
-            "alias": "conversations_existence_check",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 1
-              }
-            ],
+            "alias": "conversationsExistenceCheck",
+            "args": (v0/*: any*/),
             "concreteType": "ConversationConnection",
             "kind": "LinkedField",
             "name": "conversationsConnection",
@@ -559,21 +398,7 @@ return {
                 "kind": "LinkedField",
                 "name": "edges",
                 "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Conversation",
-                    "kind": "LinkedField",
-                    "name": "node",
-                    "plural": false,
-                    "selections": [
-                      (v4/*: any*/),
-                      (v0/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
+                "selections": (v2/*: any*/),
                 "storageKey": null
               }
             ],
@@ -581,7 +406,7 @@ return {
           },
           {
             "alias": "conversations",
-            "args": (v5/*: any*/),
+            "args": (v3/*: any*/),
             "concreteType": "ConversationConnection",
             "kind": "LinkedField",
             "name": "conversationsConnection",
@@ -702,7 +527,16 @@ return {
                                     "storageKey": null
                                   },
                                   (v9/*: any*/),
-                                  (v3/*: any*/)
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": (v10/*: any*/),
+                                    "storageKey": null
+                                  }
                                 ],
                                 "type": "Artwork",
                                 "abstractKey": null
@@ -720,8 +554,8 @@ return {
                                     "selections": (v7/*: any*/),
                                     "storageKey": null
                                   },
-                                  (v6/*: any*/),
-                                  (v10/*: any*/)
+                                  (v5/*: any*/),
+                                  (v11/*: any*/)
                                 ],
                                 "type": "Show",
                                 "abstractKey": null
@@ -729,7 +563,7 @@ return {
                               {
                                 "kind": "InlineFragment",
                                 "selections": [
-                                  (v0/*: any*/)
+                                  (v6/*: any*/)
                                 ],
                                 "type": "Node",
                                 "abstractKey": "__isNode"
@@ -758,18 +592,12 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v0/*: any*/),
+                      (v6/*: any*/),
                       (v8/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "cursor",
-                    "storageKey": null
-                  }
+                  (v1/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -785,7 +613,7 @@ return {
           },
           {
             "alias": "conversations",
-            "args": (v5/*: any*/),
+            "args": (v3/*: any*/),
             "filters": null,
             "handle": "connection",
             "key": "Conversations_conversations",
@@ -866,7 +694,7 @@ return {
                             "kind": "LinkedField",
                             "name": "onlineAskingPrice",
                             "plural": false,
-                            "selections": (v11/*: any*/),
+                            "selections": (v12/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -876,10 +704,10 @@ return {
                             "kind": "LinkedField",
                             "name": "floorSellingPrice",
                             "plural": false,
-                            "selections": (v11/*: any*/),
+                            "selections": (v12/*: any*/),
                             "storageKey": null
                           },
-                          (v0/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -914,7 +742,7 @@ return {
                             "plural": false,
                             "selections": [
                               (v9/*: any*/),
-                              (v1/*: any*/),
+                              (v13/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -939,7 +767,7 @@ return {
                                 ],
                                 "storageKey": null
                               },
-                              (v0/*: any*/)
+                              (v6/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -958,7 +786,7 @@ return {
                                 "name": "liveStartAt",
                                 "storageKey": null
                               },
-                              (v0/*: any*/),
+                              (v6/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -973,9 +801,9 @@ return {
                                 "name": "status",
                                 "storageKey": null
                               },
-                              (v1/*: any*/),
-                              (v6/*: any*/),
-                              (v10/*: any*/),
+                              (v13/*: any*/),
+                              (v5/*: any*/),
+                              (v11/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -990,7 +818,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v0/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1001,7 +829,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v0/*: any*/)
+                      (v6/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1011,14 +839,14 @@ return {
             ],
             "storageKey": "auctionsLotStandingConnection(first:25)"
           },
-          (v0/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "c558293a69044a1b81692195964a20cc",
+    "id": "8c2fcb97badd1c6925be622e0c41913b",
     "metadata": {},
     "name": "InboxRefetchQuery",
     "operationKind": "query",

--- a/src/__generated__/InboxTestsQuery.graphql.ts
+++ b/src/__generated__/InboxTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash b1f14211cec67a6bde4938013f87a2ed */
+/* @relayHash 6f7c983416e949a715ed486c11be34c2 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -23,46 +23,6 @@ query InboxTestsQuery {
   me {
     ...Inbox_me
     id
-  }
-}
-
-fragment ActiveBid_bid on LotStanding {
-  is_leading_bidder: isLeadingBidder
-  sale {
-    href
-    is_live_open: isLiveOpen
-    id
-  }
-  most_recent_bid: mostRecentBid {
-    id
-    sale_artwork: saleArtwork {
-      artwork {
-        href
-        image {
-          url
-        }
-        artist_names: artistNames
-        id
-      }
-      counts {
-        bidder_positions: bidderPositions
-      }
-      highest_bid: highestBid {
-        display
-      }
-      lot_label: lotLabel
-      reserve_status: reserveStatus
-      id
-    }
-  }
-}
-
-fragment ActiveBids_me on Me {
-  lot_standings: lotStandings(live: true) {
-    most_recent_bid: mostRecentBid {
-      id
-    }
-    ...ActiveBid_bid
   }
 }
 
@@ -180,21 +140,17 @@ fragment Conversations_me on Me {
 }
 
 fragment Inbox_me on Me {
-  lot_standings: lotStandings(live: true) {
-    most_recent_bid: mostRecentBid {
-      id
+  lotStandingsExistenceCheck: auctionsLotStandingConnection(first: 1) {
+    edges {
+      cursor
     }
   }
-  conversations_existence_check: conversationsConnection(first: 1) {
+  conversationsExistenceCheck: conversationsConnection(first: 1) {
     edges {
-      node {
-        internalID
-        id
-      }
+      cursor
     }
   }
   ...Conversations_me
-  ...ActiveBids_me
   ...MyBids_me
 }
 
@@ -256,47 +212,24 @@ fragment SaleCard_sale on Sale {
 */
 
 const node: ConcreteRequest = (function(){
-var v0 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 1
+  }
+],
 v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "href",
+  "name": "cursor",
   "storageKey": null
 },
 v2 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "url",
-    "storageKey": null
-  }
+  (v1/*: any*/)
 ],
-v3 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "Image",
-  "kind": "LinkedField",
-  "name": "image",
-  "plural": false,
-  "selections": (v2/*: any*/),
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v5 = [
+v3 = [
   {
     "kind": "Literal",
     "name": "after",
@@ -308,16 +241,30 @@ v5 = [
     "value": 10
   }
 ],
-v6 = {
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
 v7 = [
-  (v6/*: any*/),
-  (v0/*: any*/)
+  (v5/*: any*/),
+  (v6/*: any*/)
 ],
 v8 = {
   "alias": null,
@@ -333,17 +280,26 @@ v9 = {
   "name": "artistNames",
   "storageKey": null
 },
-v10 = {
+v10 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "url",
+    "storageKey": null
+  }
+],
+v11 = {
   "alias": null,
   "args": null,
   "concreteType": "Image",
   "kind": "LinkedField",
   "name": "coverImage",
   "plural": false,
-  "selections": (v2/*: any*/),
+  "selections": (v10/*: any*/),
   "storageKey": null
 },
-v11 = [
+v12 = [
   {
     "alias": null,
     "args": [
@@ -358,89 +314,72 @@ v11 = [
     "storageKey": "displayAmount(fractionalDigits:0)"
   }
 ],
-v12 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "ID"
-},
 v13 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "Boolean"
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
 },
 v14 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
-  "type": "String"
+  "type": "AuctionsLotStandingConnection"
 },
 v15 = {
   "enumValues": null,
   "nullable": true,
-  "plural": false,
-  "type": "SaleArtwork"
+  "plural": true,
+  "type": "AuctionsLotStandingEdge"
 },
 v16 = {
   "enumValues": null,
-  "nullable": true,
+  "nullable": false,
   "plural": false,
-  "type": "Artwork"
+  "type": "ID"
 },
 v17 = {
   "enumValues": null,
-  "nullable": true,
+  "nullable": false,
   "plural": false,
-  "type": "String"
+  "type": "Boolean"
 },
 v18 = {
   "enumValues": null,
-  "nullable": true,
+  "nullable": false,
   "plural": false,
-  "type": "Image"
+  "type": "String"
 },
 v19 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Sale"
+  "type": "String"
 },
 v20 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "ConversationConnection"
+  "type": "Image"
 },
 v21 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "ConversationConnection"
+},
+v22 = {
   "enumValues": null,
   "nullable": true,
   "plural": true,
   "type": "ConversationEdge"
 },
-v22 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Conversation"
-},
 v23 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "ID"
-},
-v24 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
   "type": "Int"
-},
-v25 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Boolean"
 };
 return {
   "fragment": {
@@ -484,153 +423,29 @@ return {
         "plural": false,
         "selections": [
           {
-            "alias": "lot_standings",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "live",
-                "value": true
-              }
-            ],
-            "concreteType": "LotStanding",
+            "alias": "lotStandingsExistenceCheck",
+            "args": (v0/*: any*/),
+            "concreteType": "AuctionsLotStandingConnection",
             "kind": "LinkedField",
-            "name": "lotStandings",
-            "plural": true,
+            "name": "auctionsLotStandingConnection",
+            "plural": false,
             "selections": [
-              {
-                "alias": "most_recent_bid",
-                "args": null,
-                "concreteType": "BidderPosition",
-                "kind": "LinkedField",
-                "name": "mostRecentBid",
-                "plural": false,
-                "selections": [
-                  (v0/*: any*/),
-                  {
-                    "alias": "sale_artwork",
-                    "args": null,
-                    "concreteType": "SaleArtwork",
-                    "kind": "LinkedField",
-                    "name": "saleArtwork",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Artwork",
-                        "kind": "LinkedField",
-                        "name": "artwork",
-                        "plural": false,
-                        "selections": [
-                          (v1/*: any*/),
-                          (v3/*: any*/),
-                          {
-                            "alias": "artist_names",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "artistNames",
-                            "storageKey": null
-                          },
-                          (v0/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "SaleArtworkCounts",
-                        "kind": "LinkedField",
-                        "name": "counts",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": "bidder_positions",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "bidderPositions",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "highest_bid",
-                        "args": null,
-                        "concreteType": "SaleArtworkHighestBid",
-                        "kind": "LinkedField",
-                        "name": "highestBid",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "display",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "lot_label",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "lotLabel",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "reserve_status",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "reserveStatus",
-                        "storageKey": null
-                      },
-                      (v0/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              {
-                "alias": "is_leading_bidder",
-                "args": null,
-                "kind": "ScalarField",
-                "name": "isLeadingBidder",
-                "storageKey": null
-              },
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "Sale",
+                "concreteType": "AuctionsLotStandingEdge",
                 "kind": "LinkedField",
-                "name": "sale",
-                "plural": false,
-                "selections": [
-                  (v1/*: any*/),
-                  {
-                    "alias": "is_live_open",
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "isLiveOpen",
-                    "storageKey": null
-                  },
-                  (v0/*: any*/)
-                ],
+                "name": "edges",
+                "plural": true,
+                "selections": (v2/*: any*/),
                 "storageKey": null
               }
             ],
-            "storageKey": "lotStandings(live:true)"
+            "storageKey": "auctionsLotStandingConnection(first:1)"
           },
           {
-            "alias": "conversations_existence_check",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 1
-              }
-            ],
+            "alias": "conversationsExistenceCheck",
+            "args": (v0/*: any*/),
             "concreteType": "ConversationConnection",
             "kind": "LinkedField",
             "name": "conversationsConnection",
@@ -643,21 +458,7 @@ return {
                 "kind": "LinkedField",
                 "name": "edges",
                 "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Conversation",
-                    "kind": "LinkedField",
-                    "name": "node",
-                    "plural": false,
-                    "selections": [
-                      (v4/*: any*/),
-                      (v0/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
+                "selections": (v2/*: any*/),
                 "storageKey": null
               }
             ],
@@ -665,7 +466,7 @@ return {
           },
           {
             "alias": "conversations",
-            "args": (v5/*: any*/),
+            "args": (v3/*: any*/),
             "concreteType": "ConversationConnection",
             "kind": "LinkedField",
             "name": "conversationsConnection",
@@ -786,7 +587,16 @@ return {
                                     "storageKey": null
                                   },
                                   (v9/*: any*/),
-                                  (v3/*: any*/)
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": (v10/*: any*/),
+                                    "storageKey": null
+                                  }
                                 ],
                                 "type": "Artwork",
                                 "abstractKey": null
@@ -804,8 +614,8 @@ return {
                                     "selections": (v7/*: any*/),
                                     "storageKey": null
                                   },
-                                  (v6/*: any*/),
-                                  (v10/*: any*/)
+                                  (v5/*: any*/),
+                                  (v11/*: any*/)
                                 ],
                                 "type": "Show",
                                 "abstractKey": null
@@ -813,7 +623,7 @@ return {
                               {
                                 "kind": "InlineFragment",
                                 "selections": [
-                                  (v0/*: any*/)
+                                  (v6/*: any*/)
                                 ],
                                 "type": "Node",
                                 "abstractKey": "__isNode"
@@ -842,18 +652,12 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v0/*: any*/),
+                      (v6/*: any*/),
                       (v8/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "cursor",
-                    "storageKey": null
-                  }
+                  (v1/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -869,7 +673,7 @@ return {
           },
           {
             "alias": "conversations",
-            "args": (v5/*: any*/),
+            "args": (v3/*: any*/),
             "filters": null,
             "handle": "connection",
             "key": "Conversations_conversations",
@@ -950,7 +754,7 @@ return {
                             "kind": "LinkedField",
                             "name": "onlineAskingPrice",
                             "plural": false,
-                            "selections": (v11/*: any*/),
+                            "selections": (v12/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -960,10 +764,10 @@ return {
                             "kind": "LinkedField",
                             "name": "floorSellingPrice",
                             "plural": false,
-                            "selections": (v11/*: any*/),
+                            "selections": (v12/*: any*/),
                             "storageKey": null
                           },
-                          (v0/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -998,7 +802,7 @@ return {
                             "plural": false,
                             "selections": [
                               (v9/*: any*/),
-                              (v1/*: any*/),
+                              (v13/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1023,7 +827,7 @@ return {
                                 ],
                                 "storageKey": null
                               },
-                              (v0/*: any*/)
+                              (v6/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1042,7 +846,7 @@ return {
                                 "name": "liveStartAt",
                                 "storageKey": null
                               },
-                              (v0/*: any*/),
+                              (v6/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1057,9 +861,9 @@ return {
                                 "name": "status",
                                 "storageKey": null
                               },
-                              (v1/*: any*/),
-                              (v6/*: any*/),
-                              (v10/*: any*/),
+                              (v13/*: any*/),
+                              (v5/*: any*/),
+                              (v11/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1074,7 +878,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v0/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1085,7 +889,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v0/*: any*/)
+                      (v6/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1095,14 +899,14 @@ return {
             ],
             "storageKey": "auctionsLotStandingConnection(first:25)"
           },
-          (v0/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "b1f14211cec67a6bde4938013f87a2ed",
+    "id": "6f7c983416e949a715ed486c11be34c2",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "me": {
@@ -1111,26 +915,16 @@ return {
           "plural": false,
           "type": "Me"
         },
-        "me.auctionsLotStandingConnection": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "AuctionsLotStandingConnection"
-        },
-        "me.auctionsLotStandingConnection.edges": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "AuctionsLotStandingEdge"
-        },
+        "me.auctionsLotStandingConnection": (v14/*: any*/),
+        "me.auctionsLotStandingConnection.edges": (v15/*: any*/),
         "me.auctionsLotStandingConnection.edges.node": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "AuctionsLotStanding"
         },
-        "me.auctionsLotStandingConnection.edges.node.id": (v12/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.isHighestBidder": (v13/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.id": (v16/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.isHighestBidder": (v17/*: any*/),
         "me.auctionsLotStandingConnection.edges.node.lotState": {
           "enumValues": null,
           "nullable": false,
@@ -1143,15 +937,15 @@ return {
           "plural": false,
           "type": "AuctionsMoney"
         },
-        "me.auctionsLotStandingConnection.edges.node.lotState.askingPrice.displayAmount": (v14/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.lotState.askingPrice.displayAmount": (v18/*: any*/),
         "me.auctionsLotStandingConnection.edges.node.lotState.bidCount": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Int"
         },
-        "me.auctionsLotStandingConnection.edges.node.lotState.id": (v12/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.lotState.internalID": (v12/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.lotState.id": (v16/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.lotState.internalID": (v16/*: any*/),
         "me.auctionsLotStandingConnection.edges.node.lotState.reserveStatus": {
           "enumValues": [
             "NoReserve",
@@ -1162,14 +956,14 @@ return {
           "plural": false,
           "type": "AuctionsReserveStatus"
         },
-        "me.auctionsLotStandingConnection.edges.node.lotState.saleId": (v12/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.lotState.saleId": (v16/*: any*/),
         "me.auctionsLotStandingConnection.edges.node.lotState.sellingPrice": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AuctionsMoney"
         },
-        "me.auctionsLotStandingConnection.edges.node.lotState.sellingPrice.displayAmount": (v14/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.lotState.sellingPrice.displayAmount": (v18/*: any*/),
         "me.auctionsLotStandingConnection.edges.node.lotState.soldStatus": {
           "enumValues": [
             "ForSale",
@@ -1180,46 +974,71 @@ return {
           "plural": false,
           "type": "AuctionsSoldStatus"
         },
-        "me.auctionsLotStandingConnection.edges.node.saleArtwork": (v15/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.saleArtwork.artwork": (v16/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.saleArtwork.artwork.artistNames": (v17/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.saleArtwork.artwork.href": (v17/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.saleArtwork.artwork.id": (v12/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.saleArtwork.artwork.image": (v18/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.saleArtwork.artwork.image.url": (v17/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.saleArtwork.id": (v12/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.saleArtwork.lotLabel": (v17/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.saleArtwork": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtwork"
+        },
+        "me.auctionsLotStandingConnection.edges.node.saleArtwork.artwork": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "me.auctionsLotStandingConnection.edges.node.saleArtwork.artwork.artistNames": (v19/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.saleArtwork.artwork.href": (v19/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.saleArtwork.artwork.id": (v16/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.saleArtwork.artwork.image": (v20/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.saleArtwork.artwork.image.url": (v19/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.saleArtwork.id": (v16/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.saleArtwork.lotLabel": (v19/*: any*/),
         "me.auctionsLotStandingConnection.edges.node.saleArtwork.position": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Float"
         },
-        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale": (v19/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.coverImage": (v18/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.coverImage.url": (v17/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.endAt": (v17/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.href": (v17/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.id": (v12/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.internalID": (v12/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.liveStartAt": (v17/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.name": (v17/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Sale"
+        },
+        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.coverImage": (v20/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.coverImage.url": (v19/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.endAt": (v19/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.href": (v19/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.id": (v16/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.internalID": (v16/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.liveStartAt": (v19/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.name": (v19/*: any*/),
         "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.partner.id": (v12/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.partner.name": (v17/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.status": (v17/*: any*/),
-        "me.conversations": (v20/*: any*/),
-        "me.conversations.edges": (v21/*: any*/),
-        "me.conversations.edges.cursor": (v14/*: any*/),
-        "me.conversations.edges.node": (v22/*: any*/),
-        "me.conversations.edges.node.__typename": (v14/*: any*/),
-        "me.conversations.edges.node.id": (v12/*: any*/),
-        "me.conversations.edges.node.internalID": (v23/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.partner.id": (v16/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.partner.name": (v19/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.saleArtwork.sale.status": (v19/*: any*/),
+        "me.conversations": (v21/*: any*/),
+        "me.conversations.edges": (v22/*: any*/),
+        "me.conversations.edges.cursor": (v18/*: any*/),
+        "me.conversations.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Conversation"
+        },
+        "me.conversations.edges.node.__typename": (v18/*: any*/),
+        "me.conversations.edges.node.id": (v16/*: any*/),
+        "me.conversations.edges.node.internalID": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ID"
+        },
         "me.conversations.edges.node.items": {
           "enumValues": null,
           "nullable": true,
@@ -1232,106 +1051,65 @@ return {
           "plural": false,
           "type": "ConversationItemType"
         },
-        "me.conversations.edges.node.items.item.__isNode": (v14/*: any*/),
-        "me.conversations.edges.node.items.item.__typename": (v14/*: any*/),
-        "me.conversations.edges.node.items.item.artistNames": (v17/*: any*/),
-        "me.conversations.edges.node.items.item.coverImage": (v18/*: any*/),
-        "me.conversations.edges.node.items.item.coverImage.url": (v17/*: any*/),
-        "me.conversations.edges.node.items.item.date": (v17/*: any*/),
+        "me.conversations.edges.node.items.item.__isNode": (v18/*: any*/),
+        "me.conversations.edges.node.items.item.__typename": (v18/*: any*/),
+        "me.conversations.edges.node.items.item.artistNames": (v19/*: any*/),
+        "me.conversations.edges.node.items.item.coverImage": (v20/*: any*/),
+        "me.conversations.edges.node.items.item.coverImage.url": (v19/*: any*/),
+        "me.conversations.edges.node.items.item.date": (v19/*: any*/),
         "me.conversations.edges.node.items.item.fair": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Fair"
         },
-        "me.conversations.edges.node.items.item.fair.id": (v12/*: any*/),
-        "me.conversations.edges.node.items.item.fair.name": (v17/*: any*/),
-        "me.conversations.edges.node.items.item.id": (v12/*: any*/),
-        "me.conversations.edges.node.items.item.image": (v18/*: any*/),
-        "me.conversations.edges.node.items.item.image.url": (v17/*: any*/),
-        "me.conversations.edges.node.items.item.name": (v17/*: any*/),
-        "me.conversations.edges.node.items.item.title": (v17/*: any*/),
-        "me.conversations.edges.node.lastMessage": (v17/*: any*/),
-        "me.conversations.edges.node.lastMessageAt": (v17/*: any*/),
-        "me.conversations.edges.node.last_message": (v17/*: any*/),
+        "me.conversations.edges.node.items.item.fair.id": (v16/*: any*/),
+        "me.conversations.edges.node.items.item.fair.name": (v19/*: any*/),
+        "me.conversations.edges.node.items.item.id": (v16/*: any*/),
+        "me.conversations.edges.node.items.item.image": (v20/*: any*/),
+        "me.conversations.edges.node.items.item.image.url": (v19/*: any*/),
+        "me.conversations.edges.node.items.item.name": (v19/*: any*/),
+        "me.conversations.edges.node.items.item.title": (v19/*: any*/),
+        "me.conversations.edges.node.lastMessage": (v19/*: any*/),
+        "me.conversations.edges.node.lastMessageAt": (v19/*: any*/),
+        "me.conversations.edges.node.last_message": (v19/*: any*/),
         "me.conversations.edges.node.messagesConnection": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "MessageConnection"
         },
-        "me.conversations.edges.node.messagesConnection.totalCount": (v24/*: any*/),
+        "me.conversations.edges.node.messagesConnection.totalCount": (v23/*: any*/),
         "me.conversations.edges.node.to": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "ConversationResponder"
         },
-        "me.conversations.edges.node.to.id": (v12/*: any*/),
-        "me.conversations.edges.node.to.name": (v14/*: any*/),
-        "me.conversations.edges.node.unread": (v25/*: any*/),
+        "me.conversations.edges.node.to.id": (v16/*: any*/),
+        "me.conversations.edges.node.to.name": (v18/*: any*/),
+        "me.conversations.edges.node.unread": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Boolean"
+        },
         "me.conversations.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "me.conversations.pageInfo.endCursor": (v17/*: any*/),
-        "me.conversations.pageInfo.hasNextPage": (v13/*: any*/),
-        "me.conversations.totalUnreadCount": (v24/*: any*/),
-        "me.conversations_existence_check": (v20/*: any*/),
-        "me.conversations_existence_check.edges": (v21/*: any*/),
-        "me.conversations_existence_check.edges.node": (v22/*: any*/),
-        "me.conversations_existence_check.edges.node.id": (v12/*: any*/),
-        "me.conversations_existence_check.edges.node.internalID": (v23/*: any*/),
-        "me.id": (v12/*: any*/),
-        "me.lot_standings": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "LotStanding"
-        },
-        "me.lot_standings.is_leading_bidder": (v25/*: any*/),
-        "me.lot_standings.most_recent_bid": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "BidderPosition"
-        },
-        "me.lot_standings.most_recent_bid.id": (v12/*: any*/),
-        "me.lot_standings.most_recent_bid.sale_artwork": (v15/*: any*/),
-        "me.lot_standings.most_recent_bid.sale_artwork.artwork": (v16/*: any*/),
-        "me.lot_standings.most_recent_bid.sale_artwork.artwork.artist_names": (v17/*: any*/),
-        "me.lot_standings.most_recent_bid.sale_artwork.artwork.href": (v17/*: any*/),
-        "me.lot_standings.most_recent_bid.sale_artwork.artwork.id": (v12/*: any*/),
-        "me.lot_standings.most_recent_bid.sale_artwork.artwork.image": (v18/*: any*/),
-        "me.lot_standings.most_recent_bid.sale_artwork.artwork.image.url": (v17/*: any*/),
-        "me.lot_standings.most_recent_bid.sale_artwork.counts": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "SaleArtworkCounts"
-        },
-        "me.lot_standings.most_recent_bid.sale_artwork.counts.bidder_positions": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "FormattedNumber"
-        },
-        "me.lot_standings.most_recent_bid.sale_artwork.highest_bid": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "SaleArtworkHighestBid"
-        },
-        "me.lot_standings.most_recent_bid.sale_artwork.highest_bid.display": (v17/*: any*/),
-        "me.lot_standings.most_recent_bid.sale_artwork.id": (v12/*: any*/),
-        "me.lot_standings.most_recent_bid.sale_artwork.lot_label": (v17/*: any*/),
-        "me.lot_standings.most_recent_bid.sale_artwork.reserve_status": (v17/*: any*/),
-        "me.lot_standings.sale": (v19/*: any*/),
-        "me.lot_standings.sale.href": (v17/*: any*/),
-        "me.lot_standings.sale.id": (v12/*: any*/),
-        "me.lot_standings.sale.is_live_open": (v25/*: any*/)
+        "me.conversations.pageInfo.endCursor": (v19/*: any*/),
+        "me.conversations.pageInfo.hasNextPage": (v17/*: any*/),
+        "me.conversations.totalUnreadCount": (v23/*: any*/),
+        "me.conversationsExistenceCheck": (v21/*: any*/),
+        "me.conversationsExistenceCheck.edges": (v22/*: any*/),
+        "me.conversationsExistenceCheck.edges.cursor": (v18/*: any*/),
+        "me.id": (v16/*: any*/),
+        "me.lotStandingsExistenceCheck": (v14/*: any*/),
+        "me.lotStandingsExistenceCheck.edges": (v15/*: any*/),
+        "me.lotStandingsExistenceCheck.edges.cursor": (v18/*: any*/)
       }
     },
     "name": "InboxTestsQuery",

--- a/src/__generated__/Inbox_me.graphql.ts
+++ b/src/__generated__/Inbox_me.graphql.ts
@@ -5,19 +5,17 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type Inbox_me = {
-    readonly lot_standings: ReadonlyArray<{
-        readonly most_recent_bid: {
-            readonly id: string;
-        } | null;
-    } | null> | null;
-    readonly conversations_existence_check: {
+    readonly lotStandingsExistenceCheck: {
         readonly edges: ReadonlyArray<{
-            readonly node: {
-                readonly internalID: string | null;
-            } | null;
+            readonly cursor: string;
+        } | null> | null;
+    };
+    readonly conversationsExistenceCheck: {
+        readonly edges: ReadonlyArray<{
+            readonly cursor: string;
         } | null> | null;
     } | null;
-    readonly " $fragmentRefs": FragmentRefs<"Conversations_me" | "ActiveBids_me" | "MyBids_me">;
+    readonly " $fragmentRefs": FragmentRefs<"Conversations_me" | "MyBids_me">;
     readonly " $refType": "Inbox_me";
 };
 export type Inbox_me$data = Inbox_me;
@@ -28,56 +26,53 @@ export type Inbox_me$key = {
 
 
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 1
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "cursor",
+    "storageKey": null
+  }
+];
+return {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
   "name": "Inbox_me",
   "selections": [
     {
-      "alias": "lot_standings",
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "live",
-          "value": true
-        }
-      ],
-      "concreteType": "LotStanding",
+      "alias": "lotStandingsExistenceCheck",
+      "args": (v0/*: any*/),
+      "concreteType": "AuctionsLotStandingConnection",
       "kind": "LinkedField",
-      "name": "lotStandings",
-      "plural": true,
+      "name": "auctionsLotStandingConnection",
+      "plural": false,
       "selections": [
         {
-          "alias": "most_recent_bid",
+          "alias": null,
           "args": null,
-          "concreteType": "BidderPosition",
+          "concreteType": "AuctionsLotStandingEdge",
           "kind": "LinkedField",
-          "name": "mostRecentBid",
-          "plural": false,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "id",
-              "storageKey": null
-            }
-          ],
+          "name": "edges",
+          "plural": true,
+          "selections": (v1/*: any*/),
           "storageKey": null
         }
       ],
-      "storageKey": "lotStandings(live:true)"
+      "storageKey": "auctionsLotStandingConnection(first:1)"
     },
     {
-      "alias": "conversations_existence_check",
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "first",
-          "value": 1
-        }
-      ],
+      "alias": "conversationsExistenceCheck",
+      "args": (v0/*: any*/),
       "concreteType": "ConversationConnection",
       "kind": "LinkedField",
       "name": "conversationsConnection",
@@ -90,26 +85,7 @@ const node: ReaderFragment = {
           "kind": "LinkedField",
           "name": "edges",
           "plural": true,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "concreteType": "Conversation",
-              "kind": "LinkedField",
-              "name": "node",
-              "plural": false,
-              "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "internalID",
-                  "storageKey": null
-                }
-              ],
-              "storageKey": null
-            }
-          ],
+          "selections": (v1/*: any*/),
           "storageKey": null
         }
       ],
@@ -123,16 +99,12 @@ const node: ReaderFragment = {
     {
       "args": null,
       "kind": "FragmentSpread",
-      "name": "ActiveBids_me"
-    },
-    {
-      "args": null,
-      "kind": "FragmentSpread",
       "name": "MyBids_me"
     }
   ],
   "type": "Me",
   "abstractKey": null
 };
-(node as any).hash = '4dbc88516d60bbd83176dd0e3e241405';
+})();
+(node as any).hash = 'ad5400c5eb8366c25ea765a60b88736e';
 export default node;

--- a/src/lib/Containers/Inbox/Inbox.tsx
+++ b/src/lib/Containers/Inbox/Inbox.tsx
@@ -1,0 +1,178 @@
+import { Inbox_me } from "__generated__/Inbox_me.graphql"
+import { InboxQuery } from "__generated__/InboxQuery.graphql"
+import { defaultEnvironment } from "lib/relay/createEnvironment"
+import { ActiveBids as ActiveBidsRef } from "lib/Scenes/Inbox/Components/ActiveBids"
+import { ConversationsContainer } from "lib/Scenes/Inbox/Components/Conversations/Conversations"
+import ZeroStateInbox from "lib/Scenes/Inbox/Components/Conversations/ZeroStateInbox"
+import { MyBidsContainer } from "lib/Scenes/MyBids/MyBids"
+import { listenToNativeEvents } from "lib/store/NativeModel"
+import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
+import { Flex, Spacer, Text } from "palette"
+import React from "react"
+import { EmitterSubscription, RefreshControl } from "react-native"
+import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
+import styled from "styled-components/native"
+
+interface State {
+  fetchingData: boolean
+  inquiryTabIsSelected: boolean
+}
+
+interface Props {
+  me: Inbox_me
+  relay: RelayRefetchProp
+  isVisible: boolean
+}
+
+const Container = styled.ScrollView`
+  flex: 1;
+`
+export class Inbox extends React.Component<Props, State> {
+  // @ts-ignore STRICTNESS_MIGRATION
+  conversations: ConversationsRef
+  // @ts-ignore STRICTNESS_MIGRATION
+  activeBids: ActiveBidsRef
+
+  state = {
+    fetchingData: false,
+    inquiryTabIsSelected: false,
+  }
+
+  listener: EmitterSubscription | null = null
+
+  flatListHeight = 0
+
+  componentDidMount() {
+    this.listener = listenToNativeEvents((event) => {
+      if (event.type === "NOTIFICATION_RECEIVED") {
+        this.fetchData()
+      }
+    })
+  }
+
+  componentWillUnmount() {
+    this.listener?.remove()
+  }
+
+  UNSAFE_componentWillReceiveProps(newProps: Props) {
+    if (newProps.isVisible) {
+      this.fetchData()
+    }
+  }
+
+  fetchData = () => {
+    if (this.state.fetchingData) {
+      return
+    }
+
+    this.setState({ fetchingData: true })
+
+    if (this.activeBids && this.conversations) {
+      // Allow Conversations & Active Bids to properly force-fetch themselves.
+      this.activeBids.refreshActiveBids()
+      this.conversations.refreshConversations(() => {
+        this.setState({ fetchingData: false })
+      })
+    } else {
+      this.props.relay.refetch({}, null, () => {
+        this.setState({ fetchingData: false })
+      })
+    }
+  }
+
+  render() {
+    const somethingToShow = Boolean(
+      // tslint:disable-next-line: strict-boolean-expressions
+      this.props.me.lotStandingsExistenceCheck.edges?.length || this.props.me.conversationsExistenceCheck?.edges?.length
+    )
+
+    if (!somethingToShow) {
+      return (
+        <Flex style={{ flex: 1 }}>
+          <ZeroStateInbox />
+        </Flex>
+      )
+    }
+    return (
+      <Container refreshControl={<RefreshControl refreshing={this.state.fetchingData} onRefresh={this.fetchData} />}>
+        <Spacer pb={5} />
+        <Flex flexDirection="row" px={1.5} mb={1}>
+          <Text
+            mr={2}
+            color={this.state.inquiryTabIsSelected ? "black30" : "black100"}
+            onPress={() => {
+              this.setState({ inquiryTabIsSelected: false })
+            }}
+            variant="largeTitle"
+          >
+            Bids
+          </Text>
+          <Text
+            color={this.state.inquiryTabIsSelected ? "black100" : "black30"}
+            onPress={() => {
+              this.setState({ inquiryTabIsSelected: true })
+            }}
+            variant="largeTitle"
+          >
+            Inquiries
+          </Text>
+        </Flex>
+        {this.state.inquiryTabIsSelected ? (
+          <ConversationsContainer
+            me={this.props.me}
+            componentRef={(conversations) => (this.conversations = conversations)}
+          />
+        ) : (
+          <MyBidsContainer me={this.props.me} />
+        )}
+      </Container>
+    )
+  }
+}
+
+export const InboxContainer = createRefetchContainer(
+  Inbox,
+  {
+    me: graphql`
+      fragment Inbox_me on Me {
+        lotStandingsExistenceCheck: auctionsLotStandingConnection(first: 1) {
+          edges {
+            cursor
+          }
+        }
+        conversationsExistenceCheck: conversationsConnection(first: 1) {
+          edges {
+            cursor
+          }
+        }
+        ...Conversations_me
+        ...MyBids_me
+      }
+    `,
+  },
+  graphql`
+    query InboxRefetchQuery {
+      me {
+        ...Inbox_me
+      }
+    }
+  `
+)
+
+export const InboxQueryRenderer: React.FC = () => {
+  return (
+    <QueryRenderer<InboxQuery>
+      environment={defaultEnvironment}
+      query={graphql`
+        query InboxQuery {
+          me {
+            ...Inbox_me
+          }
+        }
+      `}
+      cacheConfig={{ force: true }}
+      variables={{}}
+      render={renderWithLoadProgress(InboxContainer)}
+    />
+  )
+}

--- a/src/lib/Containers/Inbox/InboxOld.tsx
+++ b/src/lib/Containers/Inbox/InboxOld.tsx
@@ -15,22 +15,23 @@ import React from "react"
 import { EmitterSubscription, RefreshControl } from "react-native"
 import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
 import styled from "styled-components/native"
+import { InboxOldQuery } from "__generated__/InboxOldQuery.graphql"
+import { InboxOld_me } from "__generated__/InboxOld_me.graphql"
 interface Props {
-  me: Inbox_me
+  me: InboxOld_me
   relay: RelayRefetchProp
   isVisible: boolean
 }
 
 interface State {
   fetchingData: boolean
-  inquiryTabIsSelected: boolean
 }
 
 const Container = styled.ScrollView`
   flex: 1;
 `
 
-export class Inbox extends React.Component<Props, State> {
+export class InboxOld extends React.Component<Props, State> {
   // @ts-ignore STRICTNESS_MIGRATION
   conversations: ConversationsRef
   // @ts-ignore STRICTNESS_MIGRATION
@@ -38,7 +39,6 @@ export class Inbox extends React.Component<Props, State> {
 
   state = {
     fetchingData: false,
-    inquiryTabIsSelected: false,
   }
 
   listener: EmitterSubscription | null = null
@@ -88,58 +88,19 @@ export class Inbox extends React.Component<Props, State> {
     const conversationsExistenceCheck = extractNodes(this.props.me.conversations_existence_check)
     const hasBids = !!lotStanding && lotStanding.length > 0
     const hasConversations = !!conversationsExistenceCheck && conversationsExistenceCheck.length > 0
-    const shouldDisplayMyBids = getCurrentEmissionState().options.AROptionsBidManagement
-
-    if (shouldDisplayMyBids) {
-      return (
-        <Container refreshControl={<RefreshControl refreshing={this.state.fetchingData} onRefresh={this.fetchData} />}>
-          <Spacer pb={5} />
-          <Flex flexDirection="row" px={1.5} mb={1}>
-            <Text
-              mr={2}
-              color={this.state.inquiryTabIsSelected ? "black30" : "black100"}
-              onPress={() => {
-                this.setState({ inquiryTabIsSelected: false })
-              }}
-              variant="largeTitle"
-            >
-              Bids
-            </Text>
-            <Text
-              color={this.state.inquiryTabIsSelected ? "black100" : "black30"}
-              onPress={() => {
-                this.setState({ inquiryTabIsSelected: true })
-              }}
-              variant="largeTitle"
-            >
-              Inquiries
-            </Text>
-          </Flex>
-          {this.state.inquiryTabIsSelected ? (
-            <ConversationsContainer
-              me={this.props.me}
-              componentRef={(conversations) => (this.conversations = conversations)}
-            />
-          ) : (
-            <MyBidsContainer me={this.props.me} />
-          )}
-        </Container>
-      )
-    } else {
-      return hasBids || hasConversations ? (
-        <Container refreshControl={<RefreshControl refreshing={this.state.fetchingData} onRefresh={this.fetchData} />}>
-          <ActiveBids me={this.props.me} componentRef={(activeBids) => (this.activeBids = activeBids)} />
-          <ConversationsContainer
-            me={this.props.me}
-            componentRef={(conversations) => (this.conversations = conversations)}
-          />
-        </Container>
-      ) : (
-        <Flex style={{ flex: 1 }}>
-          <ZeroStateInbox />
-        </Flex>
-      )
-    }
+    return hasBids || hasConversations ? (
+      <Container refreshControl={<RefreshControl refreshing={this.state.fetchingData} onRefresh={this.fetchData} />}>
+        <ActiveBids me={this.props.me} componentRef={(activeBids) => (this.activeBids = activeBids)} />
+        <ConversationsContainer
+          me={this.props.me}
+          componentRef={(conversations) => (this.conversations = conversations)}
+        />
+      </Container>
+    ) : (
+      <Flex style={{ flex: 1 }}>
+        <ZeroStateInbox />
+      </Flex>
+    )
   }
 }
 
@@ -154,11 +115,11 @@ export class Inbox extends React.Component<Props, State> {
 //        ...Conversations_me @relay(mask: false)
 //        ...ActiveBids_me @relay(mask: false)
 //
-export const InboxContainer = createRefetchContainer(
-  Inbox,
+export const InboxOldContainer = createRefetchContainer(
+  InboxOld,
   {
     me: graphql`
-      fragment Inbox_me on Me {
+      fragment InboxOld_me on Me {
         lot_standings: lotStandings(live: true) {
           most_recent_bid: mostRecentBid {
             id
@@ -173,33 +134,32 @@ export const InboxContainer = createRefetchContainer(
         }
         ...Conversations_me
         ...ActiveBids_me
-        ...MyBids_me
       }
     `,
   },
   graphql`
-    query InboxRefetchQuery {
+    query InboxOldRefetchQuery {
       me {
-        ...Inbox_me
+        ...InboxOld_me
       }
     }
   `
 )
 
-export const InboxQueryRenderer: React.SFC = () => {
+export const InboxOldQueryRenderer: React.FC = () => {
   return (
-    <QueryRenderer<InboxQuery>
+    <QueryRenderer<InboxOldQuery>
       environment={defaultEnvironment}
       query={graphql`
-        query InboxQuery {
+        query InboxOldQuery {
           me {
-            ...Inbox_me
+            ...InboxOld_me
           }
         }
       `}
       cacheConfig={{ force: true }}
       variables={{}}
-      render={renderWithLoadProgress(InboxContainer)}
+      render={renderWithLoadProgress(InboxOldContainer)}
     />
   )
 }

--- a/src/lib/Containers/Inbox/index.tsx
+++ b/src/lib/Containers/Inbox/index.tsx
@@ -1,0 +1,13 @@
+import { getCurrentEmissionState } from "lib/store/AppStore"
+import React from "react"
+import { InboxQueryRenderer } from "./Inbox"
+import { InboxOldQueryRenderer } from "./InboxOld"
+
+/**
+ * A wrapper containing the logic for whether to display our new inbox
+ */
+export const InboxWrapper: React.FC = () => {
+  const shouldDisplayMyBids = getCurrentEmissionState().options.AROptionsBidManagement
+
+  return shouldDisplayMyBids ? <InboxQueryRenderer /> : <InboxOldQueryRenderer />
+}

--- a/src/lib/Containers/__tests__/Inbox-tests.tsx
+++ b/src/lib/Containers/__tests__/Inbox-tests.tsx
@@ -1,25 +1,32 @@
 import { InboxTestsQuery } from "__generated__/InboxTestsQuery.graphql"
 import { press } from "lib/Scenes/Artwork/Components/CommercialButtons/__tests__/helpers"
-import { __appStoreTestUtils__ } from "lib/store/AppStore"
+import { ConversationsContainer } from "lib/Scenes/Inbox/Components/Conversations/Conversations"
+import { MyBidsContainer } from "lib/Scenes/MyBids/MyBids"
 import { extractText } from "lib/tests/extractText"
 import { RelayMockEnvironment } from "lib/tests/mockEnvironmentPayload"
-import { renderWithLayout } from "lib/tests/renderWithLayout"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { Text } from "palette"
 import React from "react"
 import "react-native"
 import { graphql, QueryRenderer } from "react-relay"
 import { Environment } from "relay-runtime"
-import { MockPayloadGenerator } from "relay-test-utils"
+import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { MockResolvers } from "relay-test-utils/lib/RelayMockPayloadGenerator"
-import { createMockEnvironment } from "relay-test-utils/lib/RelayModernMockEnvironment"
-import { Inbox as ActualInbox, InboxContainer } from "../Inbox"
+import { Inbox as ActualInbox, InboxContainer } from "../Inbox/Inbox"
 
 jest.unmock("react-relay")
 
-jest.mock("lib/Scenes/Inbox/Components/Conversations/Conversations", () => ({
-  ConversationsContainer: () => "Conversations",
-}))
+jest.mock("lib/Scenes/Inbox/Components/Conversations/Conversations", () => {
+  return {
+    ConversationsContainer: () => "(The ConversationsContainer)",
+  }
+})
+
+jest.mock("lib/Scenes/MyBids/MyBids", () => {
+  return {
+    MyBidsContainer: () => "(The MyBidsContainer)",
+  }
+})
 
 let env: RelayMockEnvironment
 
@@ -34,7 +41,6 @@ const getWrapper = (mockResolvers: MockResolvers = {}) => {
         query InboxTestsQuery @relay_test_operation {
           me {
             ...Inbox_me
-            ...MyBids_me
           }
         }
       `}
@@ -54,47 +60,36 @@ const getWrapper = (mockResolvers: MockResolvers = {}) => {
     return MockPayloadGenerator.generate(operation, mockResolvers)
   })
 
-  // wrapper.update(wrapper)
-
   return wrapper
 }
 
 const emptyMeProps = {
-  lot_standings: [],
-  conversations_existence_check: null,
+  lotStandingsExistenceCheck: { edges: [] },
+  conversationsExistenceCheck: { edges: [] },
 }
 
 it("Shows a zero state when there are no bids/conversations", () => {
-  const tree = getWrapper({ Me: () => emptyMeProps })
+  const tree = getWrapper({
+    Me: () => emptyMeProps,
+  })
   expect(extractText(tree.root)).toContain("Buying art on Artsy is simple")
 })
 
 it("renders without throwing an error", () => {
-  getWrapper({ Me: () => meProps() })
+  getWrapper({})
 })
 
-fit("renders bids tab by default when bids are enabled", () => {
-  __appStoreTestUtils__?.injectEmissionOptions({ AROptionsBidManagement: true })
-  const tree = getWrapper({ Me: () => meProps() })
-  expect(extractText(tree.root)).toContain("Untitled (Flag 2), 2017")
+it("renders bids tab by default when bids are enabled", () => {
+  const tree = getWrapper()
+
+  expect(tree.root.findAllByType(MyBidsContainer).length).toEqual(1)
 })
 
 it("renders inquiries tab when inquiries tab is selected", async () => {
-  __appStoreTestUtils__?.injectEmissionOptions({ AROptionsBidManagement: true })
-  // const tree = getWrapper({ Me: () => ({ conversations: { edges: [{ node: { to: { name: "ACA Galleries" } } }] } }) })
-  const tree = getWrapper({ Me: () => meProps() })
-  // const inquiriesTab = tree.root.findAllByType(Text)[1]
-  // console.log("INQUIREIS TAB", extractText(inquiriesTab))
+  const tree = getWrapper()
 
   await press(tree.root, { text: "Inquiries", componentType: Text })
-
-  // env.mock.resolveMostRecentOperation((operation) => {
-  //   return MockPayloadGenerator.generate(operation, {
-  //     Me: () => ({ conversations: { edges: [{ node: { to: { name: "ACA Galleries" } } }] } }),
-  //   })
-  // })
-  // inquiriesTab.props.onPress()
-  expect(extractText(tree.root)).toContain("ACA Galleries")
+  expect(tree.root.findAllByType(ConversationsContainer).length).toEqual(1)
 })
 
 it("requests a relay refetch when fetchData is called in ZeroState", () => {
@@ -114,178 +109,3 @@ it("requests a relay refetch when fetchData is called in ZeroState", () => {
   inbox.fetchData()
   expect(relayEmptyProps.relay.refetch).toBeCalled()
 })
-
-const meProps = (withBids: boolean = true, withMessages: boolean = true) => {
-  const conversations = withMessages
-    ? {
-        edges: [
-          {
-            node: {
-              id: "582",
-              inquiry_id: "59302144275b244a81d0f9c6",
-              from: { name: "Jean-Luc Collecteur", email: "luc+messaging@artsymail.com" },
-              to: { name: "ACA Galleries" },
-              last_message: "Karl and Anna... Fab!",
-              created_at: "2017-06-01T14:14:35.538Z",
-              items: [
-                {
-                  title: "Karl and Anna Face Off (Diptych)",
-                  item: {
-                    __typename: "Artwork",
-                    title: "Karl and Anna Face Off (Diptych)",
-                    id: "bradley-theodore-karl-and-anna-face-off-diptych",
-                    href: "/artwork/bradley-theodore-karl-and-anna-face-off-diptych",
-                    date: "2016",
-                    artist_names: "Bradley Theodore",
-                    image: {
-                      url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
-                      image_url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/:version.jpg",
-                    },
-                  },
-                },
-              ],
-            },
-          },
-          {
-            node: {
-              id: "581",
-              inquiry_id: "593020be8b3b814f9f86f2fd",
-              from: { name: "Jean-Luc Collecteur", email: "luc+messaging@artsymail.com" },
-              to: { name: "David Krut Projects" },
-              last_message:
-                "Hi, I’m interested in purchasing this work. \
-                    Could you please provide more information about the piece?",
-              created_at: "2017-06-01T14:12:19.155Z",
-              items: [
-                {
-                  title: "Darkness Give Way to Light",
-                  item: {
-                    __typename: "Artwork",
-                    id: "aida-muluneh-darkness-give-way-to-light-1",
-                    href: "/artwork/aida-muluneh-darkness-give-way-to-light-1",
-                    title: "Darkness Give Way to Light",
-                    date: "2016",
-                    artist_names: "Aida Muluneh",
-                    image: {
-                      url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/normalized.jpg",
-                      image_url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/:version.jpg",
-                    },
-                  },
-                },
-              ],
-            },
-          },
-        ],
-      }
-    : { edges: [] }
-
-  const lotStandings = withBids
-    ? [
-        {
-          most_recent_bid: {
-            gravityID: "594934048b3b8174796e285a",
-            id: "594934048b3b8174796e285a",
-            display_max_bid_amount_dollars: "$1,100",
-            max_bid: {
-              cents: 110000,
-              display: "$1,100",
-            },
-            sale_artwork: {
-              counts: {
-                bidder_positions: 1,
-              },
-              lot_label: "14",
-              lot_number: "14",
-              position: 14,
-              highest_bid: {
-                cents: 110000,
-                display: "$1,100",
-              },
-              artwork: {
-                id: "josephine-meckseper-untitled-flag-2-2017",
-                title: "Untitled (Flag 2), 2017",
-                image: {
-                  image_url: "https://d32dm0rphc51dk.cloudfront.net/3N6jyj5G_jjzYbkwbIM4tA/:version.jpg",
-                },
-                artist: {
-                  name: "Josephine Meckseper",
-                },
-              },
-            },
-          },
-        },
-        {
-          most_recent_bid: {
-            gravityID: "594933e6275b244305851e9c",
-            id: "594933e6275b244305851e9c",
-            display_max_bid_amount_dollars: "$10,000",
-            max_bid: {
-              cents: 1000000,
-              display: "$10,000",
-            },
-            sale_artwork: {
-              counts: {
-                bidder_positions: 1,
-              },
-              lot_label: "8",
-              lot_number: "8",
-              position: 8,
-              highest_bid: {
-                cents: 1000000,
-                display: "$10,000",
-              },
-              artwork: {
-                id: "robert-longo-untitled-dividing-time",
-                title: "Untitled (Dividing Time)",
-                image: {
-                  image_url: "https://d32dm0rphc51dk.cloudfront.net/4GlhFa7ci5-0W25sjDNFIQ/:version.jpg",
-                },
-                artist: {
-                  name: "Robert Longo",
-                },
-              },
-            },
-          },
-        },
-        {
-          most_recent_bid: {
-            gravityID: "594932d0275b244305851e99",
-            id: "594932d0275b244305851e99",
-            display_max_bid_amount_dollars: "$5,000",
-            max_bid: {
-              cents: 500000,
-              display: "$5,000",
-            },
-            sale_artwork: {
-              counts: {
-                bidder_positions: 1,
-              },
-              lot_label: "2",
-              lot_number: "2",
-              position: 2,
-              highest_bid: {
-                cents: 500000,
-                display: "$5,000",
-              },
-              artwork: {
-                id: "trevor-paglen-weeping-angel",
-                title: "Weeping Angel",
-                image: {
-                  image_url: "https://d32dm0rphc51dk.cloudfront.net/W-XblMAGxZJbhx0FfH1HtQ/:version.jpg",
-                },
-                artist: {
-                  name: "Trevor Paglen",
-                },
-              },
-            },
-          },
-        },
-      ]
-    : []
-
-  return {
-    conversations,
-    conversations_existence_check: conversations,
-    lot_standings: lotStandings,
-  }
-}

--- a/src/lib/Containers/__tests__/InboxOld-tests.tsx
+++ b/src/lib/Containers/__tests__/InboxOld-tests.tsx
@@ -1,0 +1,222 @@
+import React from "react"
+import "react-native"
+import { Environment } from "relay-runtime"
+
+import { renderWithLayout } from "lib/tests/renderWithLayout"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+
+import { InboxOld as ActualInbox, InboxOldContainer as InboxContainer } from "../Inbox/InboxOld"
+
+jest.mock("lib/Scenes/Inbox/Components/Conversations/Conversations", () => ({
+  ConversationsContainer: () => "Conversations",
+}))
+
+const emptyMeProps = {
+  lot_standings: [],
+  conversations_existence_check: null,
+}
+
+it("renders without throwing an error", () => {
+  renderWithWrappers(<InboxContainer me={meProps() as any} isVisible={true} />)
+})
+
+it("Shows a zero state when there are no bids/conversations", () => {
+  const tree = JSON.stringify(
+    renderWithLayout(<InboxContainer me={emptyMeProps as any} isVisible={true} />, { width: 768, height: 1024 })
+  )
+  // Taken from the title in ZeroStateInbox
+  expect(tree).toContain("Buying art on Artsy is simple")
+})
+
+it("requests a relay refetch when fetchData is called in ZeroState", () => {
+  const relayEmptyProps = {
+    me: emptyMeProps,
+    isVisible: true,
+    relay: {
+      // @ts-ignore STRICTNESS_MIGRATION
+      environment: null as Environment,
+      refetch: jest.fn(),
+    },
+  }
+
+  const inbox = new ActualInbox(relayEmptyProps as any)
+  inbox.setState = jest.fn()
+
+  inbox.fetchData()
+  expect(relayEmptyProps.relay.refetch).toBeCalled()
+})
+
+const meProps = (withBids: boolean = true, withMessages: boolean = true) => {
+  const conversations = withMessages
+    ? {
+        edges: [
+          {
+            node: {
+              id: "582",
+              inquiry_id: "59302144275b244a81d0f9c6",
+              from: { name: "Jean-Luc Collecteur", email: "luc+messaging@artsymail.com" },
+              to: { name: "ACA Galleries" },
+              last_message: "Karl and Anna... Fab!",
+              created_at: "2017-06-01T14:14:35.538Z",
+              items: [
+                {
+                  title: "Karl and Anna Face Off (Diptych)",
+                  item: {
+                    __typename: "Artwork",
+                    title: "Karl and Anna Face Off (Diptych)",
+                    id: "bradley-theodore-karl-and-anna-face-off-diptych",
+                    href: "/artwork/bradley-theodore-karl-and-anna-face-off-diptych",
+                    date: "2016",
+                    artist_names: "Bradley Theodore",
+                    image: {
+                      url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
+                      image_url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/:version.jpg",
+                    },
+                  },
+                },
+              ],
+            },
+          },
+          {
+            node: {
+              id: "581",
+              inquiry_id: "593020be8b3b814f9f86f2fd",
+              from: { name: "Jean-Luc Collecteur", email: "luc+messaging@artsymail.com" },
+              to: { name: "David Krut Projects" },
+              last_message:
+                "Hi, I’m interested in purchasing this work. \
+                    Could you please provide more information about the piece?",
+              created_at: "2017-06-01T14:12:19.155Z",
+              items: [
+                {
+                  title: "Darkness Give Way to Light",
+                  item: {
+                    __typename: "Artwork",
+                    id: "aida-muluneh-darkness-give-way-to-light-1",
+                    href: "/artwork/aida-muluneh-darkness-give-way-to-light-1",
+                    title: "Darkness Give Way to Light",
+                    date: "2016",
+                    artist_names: "Aida Muluneh",
+                    image: {
+                      url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/normalized.jpg",
+                      image_url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/:version.jpg",
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      }
+    : { edges: [] }
+
+  const lotStandings = withBids
+    ? [
+        {
+          most_recent_bid: {
+            gravityID: "594934048b3b8174796e285a",
+            id: "594934048b3b8174796e285a",
+            display_max_bid_amount_dollars: "$1,100",
+            max_bid: {
+              cents: 110000,
+              display: "$1,100",
+            },
+            sale_artwork: {
+              counts: {
+                bidder_positions: 1,
+              },
+              lot_label: "14",
+              lot_number: "14",
+              position: 14,
+              highest_bid: {
+                cents: 110000,
+                display: "$1,100",
+              },
+              artwork: {
+                id: "josephine-meckseper-untitled-flag-2-2017",
+                title: "Untitled (Flag 2), 2017",
+                image: {
+                  image_url: "https://d32dm0rphc51dk.cloudfront.net/3N6jyj5G_jjzYbkwbIM4tA/:version.jpg",
+                },
+                artist: {
+                  name: "Josephine Meckseper",
+                },
+              },
+            },
+          },
+        },
+        {
+          most_recent_bid: {
+            gravityID: "594933e6275b244305851e9c",
+            id: "594933e6275b244305851e9c",
+            display_max_bid_amount_dollars: "$10,000",
+            max_bid: {
+              cents: 1000000,
+              display: "$10,000",
+            },
+            sale_artwork: {
+              counts: {
+                bidder_positions: 1,
+              },
+              lot_label: "8",
+              lot_number: "8",
+              position: 8,
+              highest_bid: {
+                cents: 1000000,
+                display: "$10,000",
+              },
+              artwork: {
+                id: "robert-longo-untitled-dividing-time",
+                title: "Untitled (Dividing Time)",
+                image: {
+                  image_url: "https://d32dm0rphc51dk.cloudfront.net/4GlhFa7ci5-0W25sjDNFIQ/:version.jpg",
+                },
+                artist: {
+                  name: "Robert Longo",
+                },
+              },
+            },
+          },
+        },
+        {
+          most_recent_bid: {
+            gravityID: "594932d0275b244305851e99",
+            id: "594932d0275b244305851e99",
+            display_max_bid_amount_dollars: "$5,000",
+            max_bid: {
+              cents: 500000,
+              display: "$5,000",
+            },
+            sale_artwork: {
+              counts: {
+                bidder_positions: 1,
+              },
+              lot_label: "2",
+              lot_number: "2",
+              position: 2,
+              highest_bid: {
+                cents: 500000,
+                display: "$5,000",
+              },
+              artwork: {
+                id: "trevor-paglen-weeping-angel",
+                title: "Weeping Angel",
+                image: {
+                  image_url: "https://d32dm0rphc51dk.cloudfront.net/W-XblMAGxZJbhx0FfH1HtQ/:version.jpg",
+                },
+                artist: {
+                  name: "Trevor Paglen",
+                },
+              },
+            },
+          },
+        },
+      ]
+    : []
+
+  return {
+    conversations,
+    conversations_existence_check: conversations,
+    lot_standings: lotStandings,
+  }
+}

--- a/src/lib/Containers/__tests__/InboxWrapper-tests.tsx
+++ b/src/lib/Containers/__tests__/InboxWrapper-tests.tsx
@@ -1,0 +1,28 @@
+import { __appStoreTestUtils__ } from "lib/store/AppStore"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import React from "react"
+import { InboxWrapper } from "../Inbox"
+import { InboxQueryRenderer } from "../Inbox/Inbox"
+import { InboxOldQueryRenderer } from "../Inbox/InboxOld"
+
+jest.mock("lib/Containers/Inbox/Inbox", () => ({
+  InboxQueryRenderer: () => "(The InboxQueryRenderer)",
+}))
+jest.mock("lib/Containers/Inbox/InboxOld", () => ({
+  InboxOldQueryRenderer: () => "(The InboxOldQueryRenderer)",
+}))
+
+describe("InboxWrapper", () => {
+  it("shows the OldInbox if the AROptionsBidManagement flag is not set", () => {
+    const tree = renderWithWrappers(<InboxWrapper />)
+    expect(tree.root.findAllByType(InboxOldQueryRenderer).length).toEqual(1)
+    expect(tree.root.findAllByType(InboxQueryRenderer).length).toEqual(0)
+  })
+
+  it("shows the Inbox if the flag is set", () => {
+    __appStoreTestUtils__?.injectEmissionOptions({ AROptionsBidManagement: true })
+    const tree = renderWithWrappers(<InboxWrapper />)
+    expect(tree.root.findAllByType(InboxOldQueryRenderer).length).toEqual(0)
+    expect(tree.root.findAllByType(InboxQueryRenderer).length).toEqual(1)
+  })
+})


### PR DESCRIPTION
This is a PR to your development branch @lilyfromseattle - totally your call on whether to incorporate it, and I'm not sure if it would be considered best practice or not so tagging some others as well.
I was thinking about the sort of complicated display logic in our Inbox component and in particular how we are fetching both  the old `lotStandings` (from gravity) and the new `auctionsLotStandingConnection`* and wondered if we can separate these out, so I made a PR to do that.

In short, I split `Inbox.tsx` into a directory with `Inbox` & `InboxOld` (the version of `Inbox.tsx` currently on master) plus an `InboxWrapper` (which checks the AREmissionOptions to decide which to display. 

As a side benefit we are working with a new single component now so can iterate on it without worrying about breaking old functionality, and when we do switch over completely we can just delete the OldInbox + wrapper files and move back to a single-file module.

*side note- if this isn't the best way to go about it we will want to change the `hadBids` logic in some other way, since the two queries for lot standings return different results.
