### PR TITLE
chore: improve STRICTNESS_MIGRATION situation

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -10,6 +10,7 @@ upcoming:
     - Fix minimize startup api requests - brian
     - Remove analytics tracking on back-arrow taps - pepopowitz
     - Rename AppStore to GlobalStore - david
+    - Update STRICTNESS_MIGRATION comments - david
   user_facing:
     -
 releases:

--- a/docs/preferred_practices.md
+++ b/docs/preferred_practices.md
@@ -46,7 +46,7 @@ We used to have many different `renderX` functions throughout our components, bu
 We use TypeScript to maximize runtime code safety. In April 2020, [we adopted TypeScript's `strict` mode](https://github.com/artsy/eigen/pull/3210). This disables "implicit any" and require strict null checks. The change left a lot of comments like this throughout the codebase:
 
 ```ts
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 ```
 
 Our goal is to reduce the number of `STRICTNESS_MIGRATION` migrations checks to zero over time. We use CI tooling to require PRs never to increase the number. You can opt in to helping out by requiring _all_ the files you change to fix all the migration comments by running the following command:

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -182,7 +182,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ViewableItemRefs> = 
         <>
           <Spacer mb={2} />
           <InfiniteScrollArtworksGrid
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             connection={artist.artworks}
             loadMore={relay.loadMore}
             hasMore={relay.hasMore}

--- a/src/lib/Components/Artist/ArtistShows/__tests__/VariableSizeShowsList-tests.tsx
+++ b/src/lib/Components/Artist/ArtistShows/__tests__/VariableSizeShowsList-tests.tsx
@@ -14,7 +14,7 @@ it("renders without throwing an error", () => {
   renderWithWrappers(<ShowsList shows={shows as any} showSize={"medium"} />)
 })
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const showProps = (n) => {
   return {
     id: `show-expansive-exhibition-${n}`,

--- a/src/lib/Components/Artist/__tests__/ArtistConsignButton-tests.tsx
+++ b/src/lib/Components/Artist/__tests__/ArtistConsignButton-tests.tsx
@@ -114,7 +114,7 @@ describe("ArtistConsignButton", () => {
       const tree = renderWithWrappers(<TestRenderer />)
       act(() => {
         const responseWithoutImage = cloneDeep(response)
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         responseWithoutImage.artist.image = null
         env.mock.resolveMostRecentOperation({
           errors: [],

--- a/src/lib/Components/ArtistListItem.tsx
+++ b/src/lib/Components/ArtistListItem.tsx
@@ -91,7 +91,7 @@ export class ArtistListItem extends React.Component<Props, State> {
     )
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   @track((props: Props) => ({
     action_name: props.artist.is_followed ? Schema.ActionNames.ArtistFollow : Schema.ActionNames.ArtistUnfollow,
     action_type: Schema.ActionTypes.Success,

--- a/src/lib/Components/ArtistsGroupedByName.tsx
+++ b/src/lib/Components/ArtistsGroupedByName.tsx
@@ -39,7 +39,7 @@ export const ArtistsGroupedByName: React.FC<Props> = ({ data, onEndReached }) =>
         </Sans>
       </Box>
     )}
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     renderSectionFooter={({ section }) => {
       if (section.index < data.length - 1) {
         return (

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/SortOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/SortOptions-tests.tsx
@@ -35,7 +35,7 @@ describe("Sort Options Screen", () => {
         <ArtworkFilterContext.Provider
           value={{
             state: initialState,
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             dispatch: null,
           }}
         >

--- a/src/lib/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/lib/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -54,7 +54,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
       ? onPress(artwork.slug)
       : SwitchBoard.presentNavigationViewController(
           itemRef.current!,
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           artwork.href
         )
   }

--- a/src/lib/Components/ArtworkGrids/GenericGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/GenericGrid.tsx
@@ -44,13 +44,13 @@ export class GenericArtworksGrid extends React.Component<Props, State> {
 
   width = 0
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   layoutState(width): State {
     const isPad = width > 600
     const isPadHorizontal = width > 900
 
     const sectionCount = isPad ? (isPadHorizontal ? 4 : 3) : 2
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const sectionMargins = this.props.sectionMargin * (sectionCount - 1)
     const sectionDimension = (width - sectionMargins) / sectionCount
 
@@ -82,9 +82,9 @@ export class GenericArtworksGrid extends React.Component<Props, State> {
   }
 
   sectionedArtworks() {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const sectionedArtworks = []
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const sectionRatioSums = []
     for (let i = 0; i < this.state.sectionCount; i++) {
       sectionedArtworks.push([])
@@ -94,11 +94,11 @@ export class GenericArtworksGrid extends React.Component<Props, State> {
     this.props.artworks.forEach((artwork) => {
       if (artwork.image) {
         let lowestRatioSum = Number.MAX_VALUE
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         let sectionIndex: number = null
 
         for (let j = 0; j < sectionRatioSums.length; j++) {
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           const ratioSum = sectionRatioSums[j]
           if (ratioSum < lowestRatioSum) {
             sectionIndex = j
@@ -107,13 +107,13 @@ export class GenericArtworksGrid extends React.Component<Props, State> {
         }
 
         if (sectionIndex != null) {
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           const section = sectionedArtworks[sectionIndex]
           section.push(artwork)
 
           // total section aspect ratio
           const aspectRatio = artwork.image.aspect_ratio || 1
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           sectionRatioSums[sectionIndex] += 1 / aspectRatio
         }
       }
@@ -137,7 +137,7 @@ export class GenericArtworksGrid extends React.Component<Props, State> {
         artworkComponents.push(
           <Artwork
             artwork={artwork}
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             key={artwork.id + i + j}
             trackingFlow={trackingFlow}
             contextModule={contextModule}

--- a/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -174,7 +174,7 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
     const artworks = extractNodes(this.props.connection)
     const sectionedArtworks: Array<typeof artworks> = []
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     for (let i = 0; i < this.props.sectionCount; i++) {
       sectionedArtworks.push([])
       sectionRatioSums.push(0)
@@ -244,7 +244,7 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
 
       const sectionSpecificStyle = {
         width: this.state.sectionDimension,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         marginRight: i === this.props.sectionCount - 1 ? 0 : this.props.sectionMargin,
       }
 

--- a/src/lib/Components/ArtworkTileRail/__tests__/ArtworkTileRailCard-tests.tsx
+++ b/src/lib/Components/ArtworkTileRail/__tests__/ArtworkTileRailCard-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { Theme } from "palette"
 import React from "react"

--- a/src/lib/Components/Bidding/Components/Animation/CssTransition.tsx
+++ b/src/lib/Components/Bidding/Components/Animation/CssTransition.tsx
@@ -13,7 +13,7 @@ interface CssTransitionState {
 export class CssTransition extends React.Component<CssTransitionProps, CssTransitionState> {
   private animatedValue: Animated.Value = new Animated.Value(0)
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   constructor(props) {
     super(props)
 
@@ -43,7 +43,7 @@ export class CssTransition extends React.Component<CssTransitionProps, CssTransi
     const prevStyle = this.mergeStyles(previousStyle)
     const nextStyle = this.mergeStyles(style)
     const animateCheckboxStyle = this.props.animate.reduce((acc, cssProperty) => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       acc[cssProperty] = this.animatedValue.interpolate({
         inputRange: [0, 1],
         outputRange: [prevStyle[cssProperty], nextStyle[cssProperty]],
@@ -54,9 +54,9 @@ export class CssTransition extends React.Component<CssTransitionProps, CssTransi
     return <Animated.View style={[style, animateCheckboxStyle]} {...props} />
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private mergeStyles(style) {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     return style.reduce((acc, obj) => {
       Object.keys(obj).forEach((key) => (acc[key] = obj[key]))
       return acc

--- a/src/lib/Components/Bidding/Components/Input.tsx
+++ b/src/lib/Components/Bidding/Components/Input.tsx
@@ -12,7 +12,7 @@ interface InputState {
 }
 
 export class Input extends Component<InputProps, InputState> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   constructor(props) {
     super(props)
 
@@ -21,14 +21,14 @@ export class Input extends Component<InputProps, InputState> {
     }
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   componentDidUpdate(prevProps) {
     if (this.props.error !== prevProps.error) {
       this.setState({ borderColor: this.props.error ? "red100" : "black10" })
     }
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   onBlur(e) {
     if (this.props.onBlur) {
       this.props.onBlur(e)
@@ -39,7 +39,7 @@ export class Input extends Component<InputProps, InputState> {
     })
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   onFocus(e) {
     if (this.props.onFocus) {
       this.props.onFocus(e)
@@ -59,9 +59,7 @@ export class Input extends Component<InputProps, InputState> {
         {...this.props}
         // These props should not be overridden so they are declared after `{...this.props}`
         ref={this.props.inputRef}
-        // @ts-ignore STRICTNESS_MIGRATION
         onBlur={(e) => this.onBlur(e)}
-        // @ts-ignore STRICTNESS_MIGRATION
         onFocus={(e) => this.onFocus(e)}
       />
     )

--- a/src/lib/Components/Bidding/Components/PaymentInfo.tsx
+++ b/src/lib/Components/Bidding/Components/PaymentInfo.tsx
@@ -22,18 +22,18 @@ interface PaymentInfoProps extends FlexProps {
 }
 
 export class PaymentInfo extends React.Component<PaymentInfoProps> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   constructor(props) {
     super(props)
   }
 
   presentCreditCardForm() {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.props.navigator.push({
       component: CreditCardForm,
       title: "",
       passProps: {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         onSubmit: (token, params) => this.onCreditCardAdded(token, params),
         params: this.props.creditCardFormParams,
         navigator: this.props.navigator,
@@ -42,12 +42,12 @@ export class PaymentInfo extends React.Component<PaymentInfoProps> {
   }
 
   presentBillingAddressForm() {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.props.navigator.push({
       component: BillingAddress,
       title: "",
       passProps: {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         onSubmit: (address) => this.onBillingAddressAdded(address),
         billingAddress: this.props.billingAddress,
         navigator: this.props.navigator,
@@ -73,7 +73,7 @@ export class PaymentInfo extends React.Component<PaymentInfoProps> {
 
           <BidInfoRow
             label="Credit card"
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             value={token && this.formatCard(token)}
             onPress={() => this.presentCreditCardForm()}
           />
@@ -82,7 +82,7 @@ export class PaymentInfo extends React.Component<PaymentInfoProps> {
 
           <BidInfoRow
             label="Billing address"
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             value={billingAddress && this.formatAddress(billingAddress)}
             onPress={() => this.presentBillingAddressForm()}
           />

--- a/src/lib/Components/Bidding/Components/Timer.tsx
+++ b/src/lib/Components/Bidding/Components/Timer.tsx
@@ -39,18 +39,18 @@ export function relevantStateData(currentState: AuctionTimerState, { liveStartsA
       if (!startsAt) {
         console.error("startsAt is required when isPreview is true")
       }
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       return { date: startsAt, label: `Starts ${formatDate(startsAt)}` }
     }
     case AuctionTimerState.LIVE_INTEGRATION_UPCOMING: {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       return { date: liveStartsAt, label: `Live ${formatDate(liveStartsAt)}` }
     }
     case AuctionTimerState.LIVE_INTEGRATION_ONGOING: {
       return { date: null, label: "In progress" }
     }
     case AuctionTimerState.CLOSING: {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       return { date: endsAt, label: `Ends ${formatDate(endsAt)}` }
     }
     default: {

--- a/src/lib/Components/Bidding/Components/__tests__/PaymentInfo-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/PaymentInfo-tests.tsx
@@ -16,9 +16,9 @@ jest.mock("tipsi-stripe", () => ({
   createTokenWithCard: jest.fn(),
 }))
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 let nextStep
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const mockNavigator = { push: (route) => (nextStep = route), pop: () => null }
 jest.useFakeTimers()
 
@@ -37,7 +37,7 @@ it("shows the billing address that the user typed in the billing address form", 
     </BiddingThemeProvider>
   ).root.findAllByType(BidInfoRow)[1]
   billingAddressRow.instance.props.onPress()
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   expect(nextStep.component).toEqual(BillingAddress)
 
   expect(billingAddressRow.findAllByType(Serif)[1].props.children).toEqual("401 Broadway 25th floor New York NY")
@@ -50,7 +50,7 @@ it("shows the cc info that the user had typed into the form", () => {
     </BiddingThemeProvider>
   ).root.findAllByType(BidInfoRow)[0]
   creditCardRow.instance.props.onPress()
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   expect(nextStep.component).toEqual(CreditCardForm)
 
   expect(creditCardRow.findAllByType(Serif)[1].props.children).toEqual("VISA •••• 4242")

--- a/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
+++ b/src/lib/Components/Bidding/Components/__tests__/Timer-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import moment from "moment"
@@ -16,21 +16,21 @@ const MINUTES = 60 * SECONDS
 
 const dateNow = 1525983752000 // Thursday, May 10, 2018 8:22:32.000 PM UTC in milliseconds
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const getTimerLabel = (timerComponent) => timerComponent.root.findAllByType(Sans)[1].props.children
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const getTimerText = (timerComponent) => timerComponent.root.findAllByType(Sans)[0].props.children
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const getMountedTimerLabel = (timerComponent) => timerComponent.find(Sans).at(1).text()
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const getMountedTimerText = (timerComponent) => timerComponent.find(Sans).at(0).text()
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 let pastTime
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 let futureTime
 
 beforeEach(() => {
@@ -132,7 +132,7 @@ it("shows 'In progress' when the auction is in live auction integration mode", (
         startsAt="2018-04-14T20:00:00+00:00"
         isPreview={false}
         liveStartsAt={
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           pastTime
         }
         isClosed={false}
@@ -209,7 +209,7 @@ it("omits the minutes when the sale ends on the hour", () => {
 
 describe("timer transitions", () => {
   it("transitions state from preview --> closing when the timer ends", () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const timer = mount(<Timer isPreview={true} startsAt={futureTime} endsAt={futureTime} />)
 
     expect(getMountedTimerLabel(timer)).toContain("Starts")
@@ -222,7 +222,7 @@ describe("timer transitions", () => {
   })
 
   it("transitions state from preview --> live upcoming when the timer ends", () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const timer = mount(<Timer isPreview={true} startsAt={futureTime} liveStartsAt={futureTime} />)
 
     expect(getMountedTimerLabel(timer)).toContain("Starts")
@@ -235,7 +235,7 @@ describe("timer transitions", () => {
   })
 
   it("transitions state from live upcoming --> live ongoing when the timer ends", () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const timer = mount(<Timer isPreview={false} startsAt={pastTime} liveStartsAt={futureTime} />)
 
     expect(getMountedTimerLabel(timer)).toContain("Live")
@@ -248,7 +248,7 @@ describe("timer transitions", () => {
   })
 
   it("transitions state from closing --> closed when the timer ends", () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const timer = mount(<Timer isPreview={false} startsAt={pastTime} endsAt={futureTime} />)
 
     expect(getMountedTimerLabel(timer)).toContain("Ends")

--- a/src/lib/Components/Bidding/Context/TimeOffsetProvider.tsx
+++ b/src/lib/Components/Bidding/Context/TimeOffsetProvider.tsx
@@ -29,7 +29,7 @@ const getGravityTimestampInMilliSeconds = async () => {
   const { system } = await fetchSystemTime()
 
   const possibleNetworkLatencyInMilliSeconds = (getLocalTimestampInMilliSeconds() - startTime) / 2
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const serverTimestampInMilliSeconds = system.time.unix * 1e3 + possibleNetworkLatencyInMilliSeconds
 
   if (__DEV__) {

--- a/src/lib/Components/Bidding/Context/__tests__/TimeOffsetProvider-tests.tsx
+++ b/src/lib/Components/Bidding/Context/__tests__/TimeOffsetProvider-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import * as PropTypes from "prop-types"
 import React from "react"
@@ -48,7 +48,7 @@ it("injects timeOffsetInMilliSeconds as a context", async () => {
         <TestConsumer />
       </TimeOffsetProvider>
     </BiddingThemeProvider>
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   ).renderUntil((wrapper) => {
     return wrapper.find(TestConsumer).instance().context.timeOffsetInMilliSeconds === 10 * MINUTES
   })

--- a/src/lib/Components/Bidding/Screens/BidResult.tsx
+++ b/src/lib/Components/Bidding/Screens/BidResult.tsx
@@ -62,7 +62,7 @@ export class BidResult extends React.Component<BidResultProps> {
 
   exitBidFlow = async () => {
     if (this.props.bidderPositionResult.status === "LIVE_BIDDING_STARTED") {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const saleSlug = this.props.sale_artwork.sale.slug
       const url = `${getCurrentEmissionState().predictionURL}/${saleSlug}`
       SwitchBoard.presentModalViewController(this, url)
@@ -73,7 +73,7 @@ export class BidResult extends React.Component<BidResultProps> {
 
   render() {
     const { sale_artwork, bidderPositionResult } = this.props
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const { liveStartAt, endAt } = sale_artwork.sale
     const { status, message_header, message_description_md } = bidderPositionResult
 
@@ -84,7 +84,7 @@ export class BidResult extends React.Component<BidResultProps> {
             <Flex alignItems="center">
               <Icon20
                 source={
-                  // @ts-ignore STRICTNESS_MIGRATION
+                  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                   Icons[status] || require("../../../../../images/circle-x-red.png")
                 }
               />

--- a/src/lib/Components/Bidding/Screens/BillingAddress.tsx
+++ b/src/lib/Components/Bidding/Screens/BillingAddress.tsx
@@ -74,53 +74,52 @@ interface BillingAddressState {
 
 @screenTrack({
   context_screen: Schema.PageNames.BidFlowBillingAddressPage,
-  // @ts-ignore STRICTNESS_MIGRATION
   context_screen_owner_type: null,
 })
 export class BillingAddress extends React.Component<BillingAddressProps, BillingAddressState> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private addressLine1: StyledInputInterface
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private addressLine2: StyledInputInterface
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private city: StyledInputInterface
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private stateProvinceRegion: StyledInputInterface
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private postalCode: StyledInputInterface
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private phoneNumber: StyledInputInterface
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private fullNameLayout: LayoutRectangle
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private addressLine1Layout: LayoutRectangle
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private addressLine2Layout: LayoutRectangle
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private cityLayout: LayoutRectangle
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private stateProvinceRegionLayout: LayoutRectangle
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private postalCodeLayout: LayoutRectangle
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private phoneNumberLayout: LayoutRectangle
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private keyboardDidShowListener: EmitterSubscription
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private keyboardHeight: number
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private scrollView: ScrollView
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   constructor(props) {
     super(props)
 
     this.state = {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       values: { ...this.props.billingAddress },
       errors: {},
     }
@@ -142,7 +141,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
 
   validateField(field: string) {
     this.setState({
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       errors: { ...this.state.errors, [field]: this.validateAddress(this.state.values)[field] },
     })
   }
@@ -150,7 +149,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
   onSubmit() {
     const errors = this.validateAddress(this.state.values)
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     if (Object.keys(errors).filter((key) => errors[key]).length > 0) {
       this.setState({ errors })
     } else {
@@ -175,14 +174,14 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
     action_name: Schema.ActionNames.BidFlowSaveBillingAddress,
   })
   submitValidAddress() {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.props.onSubmit(this.state.values)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.props.navigator.pop()
   }
 
   presentSelectCountry() {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.props.navigator.push({
       component: SelectCountry,
       title: "",
@@ -211,7 +210,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
       <BiddingThemeProvider>
         <KeyboardAvoidingView behavior="padding" keyboardVerticalOffset={this.verticalOffset} style={{ flex: 1 }}>
           <BackButton
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             navigator={this.props.navigator}
           />
           <ScrollView ref={(scrollView) => (this.scrollView = scrollView as any)}>
@@ -226,7 +225,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 placeholder="Add your full name"
                 autoFocus={true}
                 textContentType="name"
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 onSubmitEditing={() => this.addressLine1.focus()}
                 onLayout={({ nativeEvent }) => (this.fullNameLayout = nativeEvent.layout)}
                 onFocus={() => this.scrollView.scrollTo({ x: 0, y: this.yPosition(this.fullNameLayout) })}
@@ -237,7 +236,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 label="Address line 1"
                 placeholder="Add your street address"
                 textContentType="streetAddressLine1"
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 onSubmitEditing={() => this.addressLine2.focus()}
                 onLayout={({ nativeEvent }) => (this.addressLine1Layout = nativeEvent.layout)}
                 onFocus={() => this.scrollView.scrollTo({ x: 0, y: this.yPosition(this.addressLine1Layout) })}
@@ -248,7 +247,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 label="Address line 2 (optional)"
                 placeholder="Add your apt, floor, suite, etc."
                 textContentType="streetAddressLine2"
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 onSubmitEditing={() => this.city.focus()}
                 onLayout={({ nativeEvent }) => (this.addressLine2Layout = nativeEvent.layout)}
                 onFocus={() => this.scrollView.scrollTo({ x: 0, y: this.yPosition(this.addressLine2Layout) })}
@@ -259,7 +258,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 label="City"
                 placeholder="Add your city"
                 textContentType="addressCity"
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 onSubmitEditing={() => this.stateProvinceRegion.focus()}
                 onLayout={({ nativeEvent }) => (this.cityLayout = nativeEvent.layout)}
                 onFocus={() => this.scrollView.scrollTo({ x: 0, y: this.yPosition(this.cityLayout) })}
@@ -270,7 +269,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 label="State, Province, or Region"
                 placeholder="Add state, province, or region"
                 textContentType="addressState"
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 onSubmitEditing={() => this.postalCode.focus()}
                 inputRef={(el) => (this.stateProvinceRegion = el)}
                 onLayout={({ nativeEvent }) => (this.stateProvinceRegionLayout = nativeEvent.layout)}
@@ -287,7 +286,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 label="Postal code"
                 placeholder="Add your postal code"
                 textContentType="postalCode"
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 onSubmitEditing={() => this.phoneNumber.focus()}
                 onLayout={({ nativeEvent }) => (this.postalCodeLayout = nativeEvent.layout)}
                 onFocus={() => this.scrollView.scrollTo({ x: 0, y: this.yPosition(this.postalCodeLayout) })}
@@ -341,19 +340,19 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
   private defaultPropsForInput(field: string): Partial<StyledInputProps> {
     return {
       autoCapitalize: "words",
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       errorMessage: this.state.errors[field],
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       inputRef: (el) => (this[field] = el),
       onBlur: () => this.validateField(field),
       onChangeText: (value) => this.setState({ values: { ...this.state.values, [field]: value } }),
       returnKeyType: "next",
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       value: this.state.values[field],
     }
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private yPosition({ y, height }) {
     const windowHeight = Dimensions.get("window").height
 

--- a/src/lib/Components/Bidding/Screens/ConfirmBid/PriceSummary.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid/PriceSummary.tsx
@@ -89,11 +89,11 @@ export const PriceSummary = ({ saleArtworkId, bid }: PriceSummaryProps) => (
       }
     `}
     variables={{
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       saleArtworkId,
       bidAmountMinor: bid.cents,
     }}
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     render={renderWithLoadProgress<PriceSummaryQueryResponse>(({ node: { calculatedCost } }) => (
       <PriceSummaryFragmentContainer bid={bid} calculatedCost={calculatedCost} />
     ))}

--- a/src/lib/Components/Bidding/Screens/ConfirmBid/index.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid/index.tsx
@@ -5,7 +5,7 @@ import { Image, NativeModules, ScrollView, ViewProperties } from "react-native"
 import NavigatorIOS from "react-native-navigator-ios"
 import { commitMutation, createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { PayloadError } from "relay-runtime"
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import stripe from "tipsi-stripe"
 
 import { BiddingThemeProvider } from "lib/Components/Bidding/Components/BiddingThemeProvider"
@@ -76,29 +76,28 @@ const resultForNetworkError = {
 
 @screenTrack({
   context_screen: Schema.PageNames.BidFlowConfirmBidPage,
-  // @ts-ignore STRICTNESS_MIGRATION
   context_screen_owner_type: null,
 })
 export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState> {
   private pollCount = 0
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   constructor(props) {
     super(props)
 
     const { bidders, has_qualified_credit_cards } = this.props.me
     const { requiresCheckbox, requiresPaymentInformation } = this.determineDisplayRequirements(
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       bidders,
       has_qualified_credit_cards
     )
 
     this.state = {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       billingAddress: null,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       creditCardToken: null,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       creditCardFormParams: null,
       conditionsOfSaleChecked: false,
       isLoading: false,
@@ -148,7 +147,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
       await this.createBidderPosition()
     } catch (error) {
       if (!this.state.errorModalVisible) {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         this.presentErrorModal(error, null)
       }
     }
@@ -160,12 +159,12 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
    */
   async updatePhoneNumber() {
     return new Promise((done, reject) => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const { phoneNumber } = this.state.billingAddress
       commitMutation<ConfirmBidUpdateUserMutation>(this.props.relay.environment, {
         onCompleted: (_, errors) => {
           if (errors && errors.length) {
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             this.presentErrorModal(errors, null)
             reject(errors)
           } else {
@@ -193,19 +192,19 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
 
     return stripe.createTokenWithCard({
       ...creditCardFormParams,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       name: billingAddress.fullName,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       addressLine1: billingAddress.addressLine1,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       addressLine2: billingAddress.addressLine2,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       addressCity: billingAddress.city,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       addressState: billingAddress.state,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       addressZip: billingAddress.postalCode,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       addressCountry: billingAddress.country.shortName,
     })
   }
@@ -221,7 +220,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
               const mutationError = data && get(data, "createCreditCard.creditCardOrError.mutationError")
               this.presentErrorModal(mutationError, mutationError.detail)
             } else {
-              // @ts-ignore STRICTNESS_MIGRATION
+              // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
               this.presentErrorModal(errors, null)
             }
           }
@@ -260,7 +259,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
   createBidderPosition() {
     commitMutation<ConfirmBidCreateBidderPositionMutation>(this.props.relay.environment, {
       onCompleted: (results, errors) => {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         return isEmpty(errors) ? this.verifyBidderPosition(results) : this.presentErrorResult(errors)
       },
       onError: this.presentErrorResult.bind(this),
@@ -305,9 +304,9 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
       `,
       variables: {
         input: {
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           saleID: this.props.sale_artwork.sale.slug,
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           artworkID: this.props.sale_artwork.artwork.slug,
           maxBidAmountCents: this.selectedBid().cents,
         },
@@ -316,7 +315,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
   }
 
   verifyBidderPosition(results: ConfirmBidCreateBidderPositionMutationResponse) {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const { result } = results.createBidderPosition
 
     if (result.status === "SUCCESS") {
@@ -337,7 +336,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
   }
 
   checkBidderPosition(data: BidderPositionQueryResponse) {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const { bidder_position } = data.me
 
     if (bidder_position.status === "PENDING" && this.pollCount < MAX_POLL_ATTEMPTS) {
@@ -365,7 +364,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
   refreshBidderInfo = () => {
     this.props.relay.refetch(
       // FIXME: Should this be internalID?
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       { saleID: this.props.sale_artwork.sale.slug },
       null,
       (error) => {
@@ -374,7 +373,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
         }
         const { bidders, has_qualified_credit_cards } = this.props.me
         const { requiresCheckbox, requiresPaymentInformation } = this.determineDisplayRequirements(
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           bidders,
           has_qualified_credit_cards
         )
@@ -393,7 +392,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
   }
 
   goBackToSelectMaxBid() {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.props.navigator.push({
       component: SelectMaxBidEdit,
       title: "",
@@ -408,7 +407,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
   presentErrorResult(error: Error | ReadonlyArray<PayloadError>) {
     console.error(error)
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.props.navigator.push({
       component: BidResultScreen,
       title: "",
@@ -423,17 +422,17 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
 
   presentBidResult(bidderPositionResult: BidderPositionResult) {
     NativeModules.ARNotificationsManager.postNotificationName("ARAuctionArtworkBidUpdated", {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       ARAuctionID: this.props.sale_artwork.sale.slug,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       ARAuctionArtworkID: this.props.sale_artwork.artwork.slug,
     })
     NativeModules.ARNotificationsManager.postNotificationName("ARAuctionArtworkRegistrationUpdated", {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       ARAuctionID: this.props.sale_artwork.sale.slug,
     })
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.props.navigator.push({
       component: BidResultScreen,
       title: "",
@@ -467,7 +466,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
   render() {
     const { id, artwork, lot_label, sale } = this.props.sale_artwork
     const { requiresPaymentInformation, requiresCheckbox, isLoading } = this.state
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const artworkImage = artwork.image
 
     // GOTCHA: Don't copy this kind of code if you're working in a functional component. use `useEmissionOption` instead
@@ -480,9 +479,9 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
             <Flex alignItems="center">
               <Title mb={3}>Confirm your bid</Title>
               <Timer
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 liveStartsAt={sale.live_start_at}
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 endsAt={sale.end_at}
               />
             </Flex>
@@ -490,13 +489,13 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
             <Box>
               <Flex m={4} alignItems="center">
                 {!!artworkImage && (
-                  // @ts-ignore STRICTNESS_MIGRATION
+                  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                   <Image resizeMode="contain" style={{ width: 50, height: 50 }} source={{ uri: artworkImage.url }} />
                 )}
 
                 <Serif mt={4} size="4t" weight="semibold" numberOfLines={1} ellipsizeMode={"tail"}>
                   {
-                    // @ts-ignore STRICTNESS_MIGRATION
+                    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                     artwork.artist_names
                   }
                 </Serif>
@@ -506,14 +505,14 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
 
                 <Serif italic size="2" color="black60" textAlign="center" numberOfLines={1} ellipsizeMode={"tail"}>
                   {
-                    // @ts-ignore STRICTNESS_MIGRATION
+                    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                     artwork.title
                   }
                   {!!artwork! /* STRICTNESS_MIGRATION */.date && (
                     <Serif size="2">
                       ,{" "}
                       {
-                        // @ts-ignore STRICTNESS_MIGRATION
+                        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                         artwork.date
                       }
                     </Serif>
@@ -594,7 +593,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
                 block
                 width={100}
                 disabled={!this.canPlaceBid()}
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 onPress={this.canPlaceBid() ? () => this.placeBid() : null}
               >
                 Bid

--- a/src/lib/Components/Bidding/Screens/CreditCardForm.tsx
+++ b/src/lib/Components/Bidding/Screens/CreditCardForm.tsx
@@ -3,7 +3,7 @@ import { Box, Button, Sans, Serif } from "palette"
 import React, { Component } from "react"
 import { ScrollView, StyleSheet, View } from "react-native"
 import NavigatorIOS from "react-native-navigator-ios"
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import stripe, { PaymentCardTextField, StripeToken } from "tipsi-stripe"
 
 import BottomAlignedButtonWrapper from "lib/Components/Buttons/BottomAlignedButtonWrapper"
@@ -30,12 +30,12 @@ interface CreditCardFormState {
 export class CreditCardForm extends Component<CreditCardFormProps, CreditCardFormState> {
   private paymentInfo: PaymentCardTextField
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   constructor(props) {
     super(props)
 
     this.paymentInfo = (React as any).createRef()
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.state = { valid: null, params: { ...this.props.params }, isLoading: false, isError: false }
   }
 
@@ -46,7 +46,7 @@ export class CreditCardForm extends Component<CreditCardFormProps, CreditCardFor
     }
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   handleFieldParamsChange = (valid, params: PaymentCardTextFieldParams) => {
     this.setState({ valid, params })
   }
@@ -60,7 +60,7 @@ export class CreditCardForm extends Component<CreditCardFormProps, CreditCardFor
       const token = await stripe.createTokenWithCard({ ...params })
       this.props.onSubmit(token, this.state.params)
       this.setState({ isLoading: false })
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       this.props.navigator.pop()
     } catch (error) {
       console.error("CreditCardForm.tsx", error)
@@ -76,7 +76,7 @@ export class CreditCardForm extends Component<CreditCardFormProps, CreditCardFor
           loading={this.state.isLoading}
           block
           width={100}
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           onPress={this.state.valid ? () => this.tokenizeCardAndSubmit() : null}
         >
           Add credit card
@@ -101,12 +101,12 @@ export class CreditCardForm extends Component<CreditCardFormProps, CreditCardFor
     return (
       <BiddingThemeProvider>
         <BottomAlignedButtonWrapper
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           onPress={this.state.valid ? () => this.tokenizeCardAndSubmit() : null}
           buttonComponent={buttonComponent}
         >
           <BackButton
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             navigator={this.props.navigator}
           />
           <ScrollView scrollEnabled={false}>

--- a/src/lib/Components/Bidding/Screens/Registration.tsx
+++ b/src/lib/Components/Bidding/Screens/Registration.tsx
@@ -4,7 +4,7 @@ import React from "react"
 import { NativeModules, ScrollView, View, ViewProperties } from "react-native"
 import NavigatorIOS from "react-native-navigator-ios"
 import { commitMutation, createFragmentContainer, graphql, RelayProp } from "react-relay"
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import stripe from "tipsi-stripe"
 
 import { bidderNeedsIdentityVerification } from "lib/utils/auction"
@@ -52,18 +52,17 @@ interface RegistrationState {
   errorModalDetailText: string
 }
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const Hint = (props) => {
   return <Sans mt="5" mx="4" size="3t" textAlign="center" {...props} />
 }
 
 @screenTrack({
   context_screen: Schema.PageNames.BidFlowRegistration,
-  // @ts-ignore STRICTNESS_MIGRATION
   context_screen_owner_type: null,
 })
 export class Registration extends React.Component<RegistrationProps, RegistrationState> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   constructor(props) {
     super(props)
 
@@ -71,11 +70,11 @@ export class Registration extends React.Component<RegistrationProps, Registratio
     const requiresPaymentInformation = !has_credit_cards
 
     this.state = {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       billingAddress: null,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       creditCardToken: null,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       creditCardFormParams: null,
       conditionsOfSaleChecked: false,
       requiresPaymentInformation,
@@ -142,7 +141,7 @@ export class Registration extends React.Component<RegistrationProps, Registratio
    */
   async updatePhoneNumber() {
     return new Promise((done, reject) => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const { phoneNumber } = this.state.billingAddress
       commitMutation<RegistrationUpdateUserMutation>(this.props.relay.environment, {
         onCompleted: (_, errors) => {
@@ -175,19 +174,19 @@ export class Registration extends React.Component<RegistrationProps, Registratio
     const { billingAddress, creditCardFormParams } = this.state
     return stripe.createTokenWithCard({
       ...creditCardFormParams,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       name: billingAddress.fullName,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       addressLine1: billingAddress.addressLine1,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       addressLine2: billingAddress.addressLine2,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       addressCity: billingAddress.city,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       addressState: billingAddress.state,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       addressZip: billingAddress.postalCode,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       addressCountry: billingAddress.country.shortName,
     })
   }
@@ -267,7 +266,7 @@ export class Registration extends React.Component<RegistrationProps, Registratio
     })
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   presentRegistrationSuccess({ createBidder }) {
     NativeModules.ARNotificationsManager.postNotificationName("ARAuctionArtworkRegistrationUpdated", {
       ARAuctionID: this.props.sale.slug,
@@ -281,7 +280,7 @@ export class Registration extends React.Component<RegistrationProps, Registratio
     }
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   presentRegistrationError(error, status) {
     console.error("Registration.tsx", error)
     this.presentRegistrationResult(status)
@@ -290,14 +289,13 @@ export class Registration extends React.Component<RegistrationProps, Registratio
   presentRegistrationResult(status: RegistrationStatus) {
     const { sale, me, navigator } = this.props
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     navigator.push({
-      // @ts-ignore STRICTNESS_MIGRATION
       component: RegistrationResult,
       title: "",
       passProps: {
         status,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         needsIdentityVerification: bidderNeedsIdentityVerification({ sale, user: me }),
       },
     })
@@ -305,7 +303,7 @@ export class Registration extends React.Component<RegistrationProps, Registratio
     this.setState({ isLoading: false })
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   presentErrorModal(errors, mutationMessage) {
     console.error("Registration.tsx", errors)
 
@@ -330,13 +328,13 @@ export class Registration extends React.Component<RegistrationProps, Registratio
             <Flex alignItems="center">
               <Title mb={3}>Register to bid</Title>
               <Timer
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 liveStartsAt={live_start_at}
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 endsAt={end_at}
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 isPreview={is_preview}
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 startsAt={start_at}
               />
               <Serif size="4t" weight="semibold" my={5} mx={6} textAlign="center">
@@ -357,7 +355,7 @@ export class Registration extends React.Component<RegistrationProps, Registratio
               </>
             )}
             {!!bidderNeedsIdentityVerification(
-              // @ts-ignore STRICTNESS_MIGRATION
+              // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
               { sale, user: me }
             ) && (
               <>
@@ -369,7 +367,7 @@ export class Registration extends React.Component<RegistrationProps, Registratio
             )}
             {!requiresPaymentInformation &&
               !bidderNeedsIdentityVerification(
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 { sale, user: me }
               ) && <Hint>To complete your registration, please confirm that you agree to the Conditions of Sale.</Hint>}
             <Modal
@@ -395,7 +393,7 @@ export class Registration extends React.Component<RegistrationProps, Registratio
 
             <Box m={4}>
               <Button
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 onPress={this.canCreateBidder() ? this.register.bind(this) : null}
                 loading={isLoading}
                 block

--- a/src/lib/Components/Bidding/Screens/RegistrationResult.tsx
+++ b/src/lib/Components/Bidding/Screens/RegistrationResult.tsx
@@ -107,7 +107,6 @@ const resultEnumToPageName = (result: RegistrationStatus) => {
 )
 export class RegistrationResult extends React.Component<RegistrationResultProps> {
   exitBidFlow = async () => {
-    // @ts-ignore STRICTNESS_MIGRATION
     await SwitchBoard.dismissModalViewController(this)
   }
 

--- a/src/lib/Components/Bidding/Screens/SelectMaxBid.tsx
+++ b/src/lib/Components/Bidding/Screens/SelectMaxBid.tsx
@@ -31,7 +31,6 @@ interface SelectMaxBidState {
 
 @screenTrack({
   context_screen: Schema.PageNames.BidFlowMaxBidPage,
-  // @ts-ignore STRICTNESS_MIGRATION
   context_screen_owner_type: null,
 })
 export class SelectMaxBid extends React.Component<SelectMaxBidProps, SelectMaxBidState> {
@@ -77,7 +76,7 @@ export class SelectMaxBid extends React.Component<SelectMaxBidProps, SelectMaxBi
             <Spinner />
           ) : (
             <MaxBidPicker
-              // @ts-ignore STRICTNESS_MIGRATION
+              // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
               bids={bids}
               onValueChange={(_, index) => this.setState({ selectedBidIndex: index })}
               selectedValue={this.state.selectedBidIndex}

--- a/src/lib/Components/Bidding/Screens/SelectMaxBidEdit.tsx
+++ b/src/lib/Components/Bidding/Screens/SelectMaxBidEdit.tsx
@@ -24,7 +24,6 @@ interface SelectMaxBidState {
 
 @screenTrack({
   context_screen: Schema.PageNames.BidFlowMaxBidPage,
-  // @ts-ignore STRICTNESS_MIGRATION
   context_screen_owner_type: null,
 })
 export class SelectMaxBidEdit extends React.Component<SelectMaxBidProps, SelectMaxBidState> {

--- a/src/lib/Components/Bidding/Screens/__tests__/BidResult-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/BidResult-tests.tsx
@@ -1,5 +1,5 @@
 import { BidResult_sale_artwork } from "__generated__/BidResult_sale_artwork.graphql"
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { shallow } from "enzyme"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
@@ -224,14 +224,14 @@ describe("BidResult component", () => {
 })
 
 const Statuses = {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   winning: {
     status: "WINNING",
     message_header: null,
     message_description_md: null,
     position: null,
   } as BidderPositionResult,
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   outbid: {
     status: "OUTBID",
     message_header: "Your bid wasn’t high enough",
@@ -240,7 +240,7 @@ const Statuses = {
     `,
     position: null,
   } as BidderPositionResult,
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   live_bidding_started: {
     status: "LIVE_BIDDING_STARTED",
     message_header: "Live bidding has started",

--- a/src/lib/Components/Bidding/Screens/__tests__/BillingAddress-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/BillingAddress-tests.tsx
@@ -8,7 +8,7 @@ import { FakeNavigator } from "../../__tests__/Helpers/FakeNavigator"
 import { BiddingThemeProvider } from "../../Components/BiddingThemeProvider"
 import { BillingAddress } from "../BillingAddress"
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const selectCountry = (component, navigator, country) => {
   // The second `<TouchableWithoutFeedback>` is a button that pushes a new `<SelectCountry>` instance.
   component.root.findAllByType(TouchableWithoutFeedback)[1].instance.props.onPress()
@@ -109,13 +109,13 @@ it("pre-fills the fields if initial billing address is provided", () => {
   expect(countryField.props.children).toEqual("United States")
 })
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const errorTextComponent = (component, label) => findFieldForInput(component, { label }).findByType(Sans)
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const textInputComponent = (component, label) => findFieldForInput(component, { label }).findByType(TextInput)
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const findFieldForInput = (component, { label }) => component.root.findByProps({ label })
 
 const billingAddress = {

--- a/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/ConfirmBid-tests.tsx
@@ -36,7 +36,7 @@ jest.mock("tipsi-stripe", () => ({
   paymentRequestWithCardForm: jest.fn(),
   createTokenWithCard: jest.fn(),
 }))
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import stripe from "tipsi-stripe"
 
 import { BidderPositionQueryResponse } from "__generated__/BidderPositionQuery.graphql"
@@ -55,19 +55,19 @@ import { BiddingThemeProvider } from "../../Components/BiddingThemeProvider"
 import { Address } from "../../types"
 import { SelectMaxBidEdit } from "../SelectMaxBidEdit"
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 let nextStep
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const mockNavigator = { push: (route) => (nextStep = route) }
 jest.useFakeTimers()
 const mockPostNotificationName = NativeModules.ARNotificationsManager.postNotificationName as jest.Mock
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const findPlaceBidButton = (component) => {
   return component.root.findAllByType(Button)[1]
 }
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const mountConfirmBidComponent = (props) => {
   return renderWithWrappers(
     <BiddingThemeProvider>
@@ -117,7 +117,7 @@ it("displays the artwork title correctly without date", () => {
     </BiddingThemeProvider>
   )
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   expect(serifChildren(component)).not.toContain(`${saleArtwork.artwork.title},`)
 })
 
@@ -277,9 +277,9 @@ describe("when pressing bid button", () => {
 
         component.root.findByType(Checkbox).props.onPress()
         console.error = jest.fn() // Silences component logging.
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         relay.commitMutation = commitMutationMock((_, { onError }) => {
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           onError(new Error("An error occurred."))
           return null
         }) as any
@@ -297,18 +297,18 @@ describe("when pressing bid button", () => {
         console.error = jest.fn() // Silences component logging.
 
         // A TypeError is raised when the device has no internet connection.
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         relay.commitMutation = commitMutationMock((_, { onError }) => {
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           onError(new TypeError("Network request failed"))
           return null
         }) as any
 
         findPlaceBidButton(component).props.onPress()
 
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         expect(nextStep.component).toEqual(BidResultScreen)
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         expect(nextStep.passProps).toEqual(
           expect.objectContaining({
             bidderPositionResult: {
@@ -325,9 +325,9 @@ describe("when pressing bid button", () => {
           message: 'GraphQL Timeout Error: Mutation.createBidderPosition has timed out after waiting for 5000ms"}',
         }
 
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         relay.commitMutation = commitMutationMock((_, { onCompleted }) => {
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           onCompleted({}, [error])
           return null
         }) as any
@@ -337,12 +337,12 @@ describe("when pressing bid button", () => {
         component.root.findByType(Checkbox).props.onPress()
         findPlaceBidButton(component).props.onPress()
 
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         await waitUntil(() => nextStep)
 
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         expect(nextStep.component).toEqual(BidResultScreen)
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         expect(nextStep.passProps).toEqual(
           expect.objectContaining({
             bidderPositionResult: {
@@ -392,9 +392,9 @@ describe("polling to verify bid position", () => {
       const component = mountConfirmBidComponent(initialProps)
 
       component.root.findByType(Checkbox).props.onPress()
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       relay.commitMutation = commitMutationMock((_, { onCompleted }) => {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         onCompleted(mockRequestResponses.placingBid.bidAccepted, null)
         return null
       }) as any
@@ -409,15 +409,15 @@ describe("polling to verify bid position", () => {
       })
 
       findPlaceBidButton(component).props.onPress()
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       await waitUntil(() => nextStep)
 
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       expect(nextStep.component).toEqual(BidResultScreen)
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       expect(nextStep.passProps).toEqual(
         expect.objectContaining({
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           bidderPositionResult: mockRequestResponses.pollingForBid.highestBidder.me.bidder_position,
         })
       )
@@ -428,23 +428,23 @@ describe("polling to verify bid position", () => {
 
       component.root.findByType(Checkbox).props.onPress()
       bidderPositionQueryMock.mockReturnValue(Promise.resolve(mockRequestResponses.pollingForBid.pending))
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       relay.commitMutation = commitMutationMock((_, { onCompleted }) => {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         onCompleted(mockRequestResponses.placingBid.bidAccepted, null)
         return null
       }) as any
 
       findPlaceBidButton(component).props.onPress()
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       await waitUntil(() => nextStep)
 
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       expect(nextStep.component).toEqual(BidResultScreen)
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       expect(nextStep.passProps).toEqual(
         expect.objectContaining({
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           bidderPositionResult: mockRequestResponses.pollingForBid.pending.me.bidder_position,
         })
       )
@@ -455,23 +455,23 @@ describe("polling to verify bid position", () => {
 
       component.root.findByType(Checkbox).props.onPress()
       bidderPositionQueryMock.mockReturnValueOnce(Promise.resolve(mockRequestResponses.pollingForBid.highestBidder))
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       relay.commitMutation = commitMutationMock((_, { onCompleted }) => {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         onCompleted(mockRequestResponses.placingBid.bidAccepted, null)
         return null
       }) as any
 
       findPlaceBidButton(component).props.onPress()
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       await waitUntil(() => nextStep)
 
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       expect(nextStep.component).toEqual(BidResultScreen)
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       expect(nextStep.passProps).toEqual(
         expect.objectContaining({
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           bidderPositionResult: mockRequestResponses.pollingForBid.highestBidder.me.bidder_position,
         })
       )
@@ -482,23 +482,23 @@ describe("polling to verify bid position", () => {
 
       component.root.findByType(Checkbox).props.onPress()
       bidderPositionQueryMock.mockReturnValueOnce(Promise.resolve(mockRequestResponses.pollingForBid.outbid))
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       relay.commitMutation = commitMutationMock((_, { onCompleted }) => {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         onCompleted(mockRequestResponses.placingBid.bidAccepted, null)
         return null
       }) as any
 
       findPlaceBidButton(component).props.onPress()
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       await waitUntil(() => nextStep)
 
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       expect(nextStep.component).toEqual(BidResultScreen)
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       expect(nextStep.passProps).toEqual(
         expect.objectContaining({
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           bidderPositionResult: mockRequestResponses.pollingForBid.outbid.me.bidder_position,
         })
       )
@@ -509,23 +509,23 @@ describe("polling to verify bid position", () => {
 
       component.root.findByType(Checkbox).props.onPress()
       bidderPositionQueryMock.mockReturnValueOnce(Promise.resolve(mockRequestResponses.pollingForBid.reserveNotMet))
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       relay.commitMutation = commitMutationMock((_, { onCompleted }) => {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         onCompleted(mockRequestResponses.placingBid.bidAccepted, null)
         return null
       }) as any
 
       findPlaceBidButton(component).props.onPress()
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       await waitUntil(() => nextStep)
 
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       expect(nextStep.component).toEqual(BidResultScreen)
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       expect(nextStep.passProps).toEqual(
         expect.objectContaining({
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           bidderPositionResult: mockRequestResponses.pollingForBid.reserveNotMet.me.bidder_position,
         })
       )
@@ -540,9 +540,9 @@ describe("polling to verify bid position", () => {
       })
       component.root.findByType(Checkbox).props.onPress()
       bidderPositionQueryMock.mockReturnValueOnce(Promise.resolve(mockRequestResponses.pollingForBid.reserveNotMet))
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       relay.commitMutation = commitMutationMock((_, { onCompleted }) => {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         onCompleted(mockRequestResponses.placingBid.bidAccepted, null)
         return null
       }) as any
@@ -606,23 +606,23 @@ describe("polling to verify bid position", () => {
       const component = mountConfirmBidComponent(initialProps)
 
       component.root.findByType(Checkbox).props.onPress()
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       relay.commitMutation = commitMutationMock((_, { onCompleted }) => {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         onCompleted(mockRequestResponses.placingBid.bidRejected, null)
         return null
       }) as any
 
       findPlaceBidButton(component).props.onPress()
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       await waitUntil(() => nextStep)
 
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       expect(nextStep.component).toEqual(BidResultScreen)
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       expect(nextStep.passProps).toEqual(
         expect.objectContaining({
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           bidderPositionResult: mockRequestResponses.placingBid.bidRejected.createBidderPosition.result,
         })
       )
@@ -631,7 +631,7 @@ describe("polling to verify bid position", () => {
 })
 
 describe("ConfirmBid for unqualified user", () => {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const fillOutFormAndSubmit = (component) => {
     // manually setting state to avoid duplicating tests for skipping UI interaction, but practically better not to do this.
     component.root.findByType(ConfirmBid).instance.setState({ billingAddress })
@@ -649,10 +649,10 @@ describe("ConfirmBid for unqualified user", () => {
 
     billingAddressRow.instance.props.onPress()
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.component).toEqual(BillingAddress)
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     nextStep.passProps.onSubmit(billingAddress)
 
     expect(billingAddressRow.findAllByType(Serif)[1].props.children).toEqual("401 Broadway 25th floor New York NY")
@@ -665,14 +665,14 @@ describe("ConfirmBid for unqualified user", () => {
 
     creditcardRow.instance.props.onPress()
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.component).toEqual(CreditCardForm)
   })
 
   it("shows the error screen when stripe's API returns an error", () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     relay.commitMutation = commitMutationMock((_, { onCompleted }) => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       onCompleted({}, null)
       return null
     }) as any
@@ -697,9 +697,9 @@ describe("ConfirmBid for unqualified user", () => {
   it("shows the error screen with the correct error message on a createCreditCard mutation failure", () => {
     console.error = jest.fn() // Silences component logging.
     stripe.createTokenWithCard.mockReturnValueOnce(stripeToken)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     relay.commitMutation = commitMutationMock((_, { onCompleted }) => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       onCompleted(mockRequestResponses.creatingCreditCardError, null)
       return null
     }) as any
@@ -721,9 +721,9 @@ describe("ConfirmBid for unqualified user", () => {
 
     console.error = jest.fn() // Silences component logging.
     stripe.createTokenWithCard.mockReturnValueOnce(stripeToken)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     relay.commitMutation = commitMutationMock((_, { onCompleted }) => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       onCompleted({}, errors)
       return null
     }) as any
@@ -744,9 +744,9 @@ describe("ConfirmBid for unqualified user", () => {
   it("shows the error screen with the default error message if the creditCardMutation error message is empty", () => {
     console.error = jest.fn() // Silences component logging.
     stripe.createTokenWithCard.mockReturnValueOnce(stripeToken)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     relay.commitMutation = commitMutationMock((_, { onCompleted }) => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       onCompleted(mockRequestResponses.creatingCreditCardEmptyError, null)
       return null
     }) as any
@@ -766,9 +766,9 @@ describe("ConfirmBid for unqualified user", () => {
   it("shows the generic error screen on a createCreditCard mutation network failure", () => {
     console.error = jest.fn() // Silences component logging.
     stripe.createTokenWithCard.mockReturnValueOnce(stripeToken)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     relay.commitMutation = commitMutationMock((_, { onError }) => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       onError(new TypeError("Network request failed"))
       return null
     }) as any
@@ -777,9 +777,9 @@ describe("ConfirmBid for unqualified user", () => {
 
     fillOutFormAndSubmit(component)
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.component).toEqual(BidResultScreen)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.passProps).toEqual(
       expect.objectContaining({
         bidderPositionResult: {
@@ -837,9 +837,9 @@ describe("ConfirmBid for unqualified user", () => {
         expect.objectContaining({
           variables: {
             input: {
-              // @ts-ignore STRICTNESS_MIGRATION
+              // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
               saleID: saleArtwork.sale.slug,
-              // @ts-ignore STRICTNESS_MIGRATION
+              // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
               artworkID: saleArtwork.artwork.slug,
               maxBidAmountCents: 450000,
             },
@@ -866,12 +866,12 @@ describe("ConfirmBid for unqualified user", () => {
       const component = mountConfirmBidComponent(initialPropsForUnqualifiedUser)
 
       fillOutFormAndSubmit(component)
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       await waitUntil(() => nextStep)
 
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       expect(nextStep.component).toEqual(BidResultScreen)
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       expect(nextStep.passProps).toEqual(
         expect.objectContaining({
           bidderPositionResult: {
@@ -885,11 +885,11 @@ describe("ConfirmBid for unqualified user", () => {
   })
 })
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const serifChildren = (comp) =>
   comp.root
     .findAllByType(Serif)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     .map((c) => (c.props.children.join ? c.props.children.join("") : c.props.children))
     .join(" ")
 
@@ -915,9 +915,9 @@ const saleArtwork: ConfirmBid_sale_artwork = {
     },
   },
   lot_label: "538",
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   " $fragmentRefs": null, // needs this to keep TS happy
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   " $refType": null, // needs this to keep TS happy
 }
 

--- a/src/lib/Components/Bidding/Screens/__tests__/Registration-tests.tsx
+++ b/src/lib/Components/Bidding/Screens/__tests__/Registration-tests.tsx
@@ -29,15 +29,15 @@ jest.mock("tipsi-stripe", () => ({
 }))
 import { RegistrationResult, RegistrationStatus } from "lib/Components/Bidding/Screens/RegistrationResult"
 import { Modal } from "lib/Components/Modal"
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import stripe from "tipsi-stripe"
 import { Address } from "../../types"
 
 import { BiddingThemeProvider } from "../../Components/BiddingThemeProvider"
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 let nextStep
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const mockNavigator = { push: (route) => (nextStep = route), pop: () => null }
 jest.useFakeTimers()
 const mockPostNotificationName = NativeModules.ARNotificationsManager.postNotificationName
@@ -95,10 +95,10 @@ it("shows the billing address that the user typed in the billing address form", 
     </BiddingThemeProvider>
   ).root.findAllByType(BidInfoRow)[1]
   billingAddressRow.instance.props.onPress()
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   expect(nextStep.component).toEqual(BillingAddress)
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   nextStep.passProps.onSubmit(billingAddress)
 
   expect(billingAddressRow.findAllByType(Serif)[1].props.children).toEqual("401 Broadway 25th floor New York NY")
@@ -113,7 +113,7 @@ it("shows the credit card form when the user tap the edit text in the credit car
 
   creditcardRow.instance.props.onPress()
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   expect(nextStep.component).toEqual(CreditCardForm)
 })
 
@@ -176,18 +176,18 @@ describe("when the sale requires identity verification", () => {
 describe("when pressing register button", () => {
   it("when a credit card needs to be added, it commits two mutations on button press", async () => {
     relay.commitMutation = commitMutationMock()
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       .mockImplementationOnce((_, { onCompleted }) => {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         onCompleted(mockRequestResponses.updateMyUserProfile, null)
         return null
       })
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       .mockImplementationOnce((_, { onCompleted }) => {
         onCompleted?.(mockRequestResponses.creatingCreditCardSuccess, null)
         return null
       })
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       .mockImplementationOnce((_, { onCompleted }) => {
         onCompleted?.(mockRequestResponses.qualifiedBidder, null)
         return null
@@ -315,9 +315,9 @@ describe("when pressing register button", () => {
 
     jest.runAllTicks()
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.component).toEqual(RegistrationResult)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.passProps).toEqual({
       status: RegistrationStatus.RegistrationStatusError,
       needsIdentityVerification: false,
@@ -328,9 +328,9 @@ describe("when pressing register button", () => {
     const errors = [{ message: "malformed error" }]
 
     console.error = jest.fn() // Silences component logging.
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     relay.commitMutation = commitMutationMock((_, { onCompleted }) => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       onCompleted({}, errors)
       return null
     }) as any
@@ -362,9 +362,9 @@ describe("when pressing register button", () => {
     console.error = jest.fn() // Silences component logging.
 
     const errors = [{ message: "There was an error with your request" }]
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     relay.commitMutation = commitMutationMock((_, { onCompleted }) => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       onCompleted({}, errors)
       return null
     }) as any
@@ -409,9 +409,9 @@ describe("when pressing register button", () => {
 
     jest.runAllTicks()
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.component).toEqual(RegistrationResult)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.passProps).toEqual({
       status: RegistrationStatus.RegistrationStatusNetworkError,
       needsIdentityVerification: false,
@@ -422,13 +422,13 @@ describe("when pressing register button", () => {
     console.error = jest.fn() // Silences component logging.
     stripe.createTokenWithCard.mockReturnValueOnce(stripeToken)
     relay.commitMutation = commitMutationMock()
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       .mockImplementationOnce((_, { onCompleted }) => {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         onCompleted(mockRequestResponses.updateMyUserProfile, null)
         return null
       })
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       .mockImplementationOnce((_, { onCompleted }) => {
         onCompleted?.(mockRequestResponses.creatingCreditCardError, null)
         return null
@@ -461,13 +461,13 @@ describe("when pressing register button", () => {
     stripe.createTokenWithCard.mockReturnValueOnce(stripeToken)
 
     relay.commitMutation = commitMutationMock()
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       .mockImplementationOnce((_, { onCompleted }) => {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         onCompleted(mockRequestResponses.updateMyUserProfile, null)
         return null
       })
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       .mockImplementationOnce((_, { onCompleted }) => {
         onCompleted?.({}, errors)
         return null
@@ -500,13 +500,13 @@ describe("when pressing register button", () => {
     console.error = jest.fn() // Silences component logging.
     stripe.createTokenWithCard.mockReturnValueOnce(stripeToken)
     relay.commitMutation = commitMutationMock()
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       .mockImplementationOnce((_, { onCompleted }) => {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         onCompleted(mockRequestResponses.creatingCreditCardSuccess, null)
         return null
       })
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       .mockImplementationOnce((_, { onError }) => {
         onError?.(new TypeError("Network request failed"))
         return null
@@ -524,9 +524,9 @@ describe("when pressing register button", () => {
 
     jest.runAllTicks()
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.component).toEqual(RegistrationResult)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.passProps).toEqual({
       status: RegistrationStatus.RegistrationStatusNetworkError,
       needsIdentityVerification: false,
@@ -553,9 +553,9 @@ describe("when pressing register button", () => {
 
     jest.runAllTicks()
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.component).toEqual(RegistrationResult)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.passProps).toEqual({
       status: RegistrationStatus.RegistrationStatusError,
       needsIdentityVerification: false,
@@ -565,9 +565,9 @@ describe("when pressing register button", () => {
   it("displays an error message on a network failure", () => {
     console.error = jest.fn() // Silences component logging.
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     relay.commitMutation = commitMutationMock((_, { onError }) => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       onError(new TypeError("Network request failed"))
       return null
     }) as any
@@ -583,9 +583,9 @@ describe("when pressing register button", () => {
 
     jest.runAllTicks()
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.component).toEqual(RegistrationResult)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.passProps).toEqual({
       status: RegistrationStatus.RegistrationStatusNetworkError,
       needsIdentityVerification: false,
@@ -593,9 +593,9 @@ describe("when pressing register button", () => {
   })
 
   it("displays the pending result when the bidder is not qualified_for_bidding", () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     relay.commitMutation = commitMutationMock((_, { onCompleted }) => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       onCompleted({ createBidder: { bidder: { qualified_for_bidding: false } } }, null)
       return null
     }) as any
@@ -614,9 +614,9 @@ describe("when pressing register button", () => {
       ARAuctionID: "sale-id",
     })
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.component).toEqual(RegistrationResult)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.passProps).toEqual({
       status: RegistrationStatus.RegistrationStatusPending,
       needsIdentityVerification: false,
@@ -632,9 +632,9 @@ describe("when pressing register button", () => {
       },
     }
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     relay.commitMutation = commitMutationMock((_, { onCompleted }) => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       onCompleted({ createBidder: { bidder: { qualified_for_bidding: false } } }, null)
       return null
     }) as any
@@ -649,9 +649,9 @@ describe("when pressing register button", () => {
     component.root.findAllByType(Button)[1].props.onPress()
     jest.runAllTicks()
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.component).toEqual(RegistrationResult)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.passProps).toEqual({
       status: RegistrationStatus.RegistrationStatusPending,
       needsIdentityVerification: true,
@@ -659,9 +659,9 @@ describe("when pressing register button", () => {
   })
 
   it("displays the completed result when the bidder is qualified_for_bidding", () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     relay.commitMutation = commitMutationMock((_, { onCompleted }) => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       onCompleted({ createBidder: { bidder: { qualified_for_bidding: true } } }, null)
       return null
     }) as any
@@ -681,9 +681,9 @@ describe("when pressing register button", () => {
       ARAuctionID: "sale-id",
     })
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.component).toEqual(RegistrationResult)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.passProps).toEqual({
       status: RegistrationStatus.RegistrationStatusComplete,
       needsIdentityVerification: false,
@@ -699,9 +699,9 @@ describe("when pressing register button", () => {
       },
     }
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     relay.commitMutation = commitMutationMock((_, { onCompleted }) => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       onCompleted({ createBidder: { bidder: { qualified_for_bidding: true } } }, null)
       return null
     }) as any
@@ -716,9 +716,9 @@ describe("when pressing register button", () => {
     component.root.findAllByType(Button)[1].props.onPress()
     jest.runAllTicks()
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.component).toEqual(RegistrationResult)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(nextStep.passProps.status).toEqual(RegistrationStatus.RegistrationStatusComplete)
   })
 })

--- a/src/lib/Components/Bidding/Validators/index.ts
+++ b/src/lib/Components/Bidding/Validators/index.ts
@@ -1,6 +1,6 @@
 import { isEmpty } from "lodash"
 
 export const validatePresence = (value: any): string => {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   return isEmpty(value) ? "This field is required" : null
 }

--- a/src/lib/Components/Bidding/__tests__/BidFlow-tests.tsx
+++ b/src/lib/Components/Bidding/__tests__/BidFlow-tests.tsx
@@ -24,7 +24,7 @@ jest.mock("tipsi-stripe", () => ({
   paymentRequestWithCardForm: jest.fn(),
   createTokenWithCard: jest.fn(),
 }))
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import stripe from "tipsi-stripe"
 
 import { BidderPositionQueryResponse } from "__generated__/BidderPositionQuery.graphql"
@@ -35,12 +35,12 @@ const commitMutationMock = (fn?: typeof relay.commitMutation) =>
 
 const bidderPositionQueryMock = bidderPositionQuery as jest.Mock<any>
 let fakeNavigator: FakeNavigator
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 let fakeRelay
 
 jest.useFakeTimers()
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const getTitleText = (component) => component.root.findByType(Title).props.children
 
 beforeEach(() => {
@@ -56,7 +56,7 @@ it("allows bidders with a qualified credit card to bid", async () => {
       me={Me.qualifiedUser as any}
       sale_artwork={SaleArtwork as any}
       navigator={fakeNavigator as any}
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       relay={fakeRelay as any}
     />
   )
@@ -68,9 +68,9 @@ it("allows bidders with a qualified credit card to bid", async () => {
   expect(getTitleText(screen)).toEqual("Confirm your bid")
 
   bidderPositionQueryMock.mockReturnValueOnce(Promise.resolve(mockRequestResponses.pollingForBid.highestBidder))
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   relay.commitMutation = commitMutationMock((_, { onCompleted }) => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     onCompleted(mockRequestResponses.placingBid.bidAccepted, null)
     return null
   }) as any
@@ -90,7 +90,7 @@ it("allows bidders without a qualified credit card to register a card and bid", 
       me={Me.unqualifiedUser as any}
       sale_artwork={SaleArtwork as any}
       navigator={fakeNavigator as any}
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       relay={fakeRelay as any}
     />
   )

--- a/src/lib/Components/Countdown/CountdownTimer.tsx
+++ b/src/lib/Components/Countdown/CountdownTimer.tsx
@@ -20,7 +20,7 @@ enum TimerState {
   PAST = "PAST",
 }
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 function relevantStateData(state, { startAt, endAt, formattedOpeningHours = "" }: Props) {
   switch (state) {
     case TimerState.UPCOMING:
@@ -54,7 +54,7 @@ function currentState({ startAt, endAt }: Props) {
 export const CountdownTimer: React.FC<Props> = (props: Props) => {
   const onState = () => {
     const state = currentState(props)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const { label, date } = relevantStateData(state, props)
     return { state, label, date }
   }

--- a/src/lib/Components/Countdown/DurationProvider.tsx
+++ b/src/lib/Components/Countdown/DurationProvider.tsx
@@ -13,10 +13,10 @@ interface State {
 }
 
 export class DurationProvider extends React.Component<Props, State> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private intervalId: ReturnType<typeof setInterval>
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   constructor(props) {
     super(props)
     this.state = { timeLeftInMilliseconds: Date.parse(props.startAt) - Date.now() }
@@ -29,16 +29,16 @@ export class DurationProvider extends React.Component<Props, State> {
   componentWillUnmount() {
     if (this.intervalId) {
       clearInterval(this.intervalId)
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       this.intervalId = null
     }
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.startAt !== this.props.startAt) {
       clearInterval(this.intervalId)
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       this.intervalId = null
       if (nextProps.startAt !== null) {
         this.setState(
@@ -62,7 +62,7 @@ export class DurationProvider extends React.Component<Props, State> {
       // Countdown expired, clear interval
       if (this.intervalId) {
         clearInterval(this.intervalId)
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         this.intervalId = null
       }
 

--- a/src/lib/Components/Countdown/StateManager.tsx
+++ b/src/lib/Components/Countdown/StateManager.tsx
@@ -21,7 +21,7 @@ interface State {
 }
 
 export class StateManager extends React.Component<Props, State> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   static getDerivedStateFromProps(props, state) {
     // If this component receives a new tickerState as props,
     // update to use the new props.
@@ -46,16 +46,15 @@ export class StateManager extends React.Component<Props, State> {
 
     return (
       <DurationProvider
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         startAt={date}
         timeOffsetInMilliseconds={timeOffsetInMilliseconds}
         onDurationEnd={this.handleDurationEnd}
       >
         <CountdownComponent
           label={label}
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           duration={null}
-          // @ts-ignore STRICTNESS_MIGRATION
           timerState={state}
           {...props}
         />

--- a/src/lib/Components/Countdown/Ticker.tsx
+++ b/src/lib/Components/Countdown/Ticker.tsx
@@ -53,7 +53,7 @@ export const LabeledTicker: React.FC<LabeledTickerProps> = ({ duration, renderSe
         <React.Fragment key={section.label}>
           <LabeledTimeSection
             {...section}
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             textProps={textProps}
           />
           {!!(idx < sections.length - 1 && renderSeparator) && renderSeparator()}

--- a/src/lib/Components/Countdown/__tests__/CountdownTimer-tests.tsx
+++ b/src/lib/Components/Countdown/__tests__/CountdownTimer-tests.tsx
@@ -5,7 +5,7 @@ jest.mock("moment", () => {
   return momentMock
 })
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { render } from "enzyme"
 import { Flex, Sans, Spacer } from "palette"
 import React from "react"

--- a/src/lib/Components/Countdown/__tests__/DurationProvider-tests.tsx
+++ b/src/lib/Components/Countdown/__tests__/DurationProvider-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { shallow } from "enzyme"
 import moment from "moment"
 import React from "react"

--- a/src/lib/Components/Countdown/__tests__/StateManager-tests.tsx
+++ b/src/lib/Components/Countdown/__tests__/StateManager-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import moment from "moment"
 import React from "react"
@@ -20,7 +20,7 @@ describe("StateManager", () => {
           date: new Date(Date.now() + 1000).toISOString(),
           label: "foo",
         })}
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         onNextTickerState={jest.fn(() => ({ label: "bar", date: null, state: "foo" }))}
       />
     )
@@ -38,7 +38,7 @@ describe("StateManager", () => {
           date: new Date(Date.now() + 1000).toISOString(),
           label: "foo",
         })}
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         onNextTickerState={onNextTickerState}
       />
     )

--- a/src/lib/Components/Countdown/__tests__/Ticker-tests.tsx
+++ b/src/lib/Components/Countdown/__tests__/Ticker-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { render } from "enzyme"
 import moment from "moment"
 import React from "react"
@@ -15,7 +15,7 @@ describe("SimpleTicker", () => {
   })
 
   it("renders properly when duration is over", () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const zeroDuration = moment.duration(null)
     const comp = render(<SimpleTicker duration={zeroDuration} separator="  " size="5" />)
     expect(comp.text()).toEqual("00d  00h  00m  00s")

--- a/src/lib/Components/EntityList/__tests__/index-tests.tsx
+++ b/src/lib/Components/EntityList/__tests__/index-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import React from "react"
 import { EntityList } from "../index"

--- a/src/lib/Components/EntityList/index.tsx
+++ b/src/lib/Components/EntityList/index.tsx
@@ -38,7 +38,7 @@ export const EntityList: React.FC<EntityListProps> = ({
           item={item}
           isFirst={i === 0}
           isLast={i === filteredList.length - 1}
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           onPress={onItemSelected}
         />
       ))}

--- a/src/lib/Components/FilterModal/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/FilterModal/__tests__/FilterModal-tests.tsx
@@ -4,7 +4,7 @@ import { act } from "react-test-renderer"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 
 import { FilterModalTestsQuery } from "__generated__/FilterModalTestsQuery.graphql"
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { CollectionFixture } from "lib/Scenes/Collection/Components/__fixtures__/CollectionFixture"
 import { CollectionArtworksFragmentContainer } from "lib/Scenes/Collection/Screens/CollectionArtworks"
@@ -175,7 +175,7 @@ const MockFilterModalNavigator = ({ initialState }: InitialState) => {
         }}
       >
         <FilterModalNavigator
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           collection={CollectionFixture}
           exitModal={exitModalMock}
           closeModal={closeModalMock}
@@ -223,7 +223,7 @@ describe("Filter modal navigation flow", () => {
         }}
       >
         {React.createElement(
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           nextRoute.component,
           {
             ...nextRoute.passProps,
@@ -237,7 +237,7 @@ describe("Filter modal navigation flow", () => {
       </ArtworkFilterContext.Provider>
     )
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const getNextScreenTitle = (component) => component.root.findByType(FancyModalHeader).props.children
 
     expect(getNextScreenTitle(nextScreen)).toEqual("Sort by")
@@ -255,7 +255,7 @@ describe("Filter modal navigation flow", () => {
             followedArtists: null,
           },
 
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           dispatch: null,
         }}
       >
@@ -287,12 +287,12 @@ describe("Filter modal navigation flow", () => {
             followedArtists: null,
           },
 
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           dispatch: null,
         }}
       >
         {React.createElement(
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           nextRoute.component,
           {
             ...nextRoute.passProps,
@@ -306,7 +306,7 @@ describe("Filter modal navigation flow", () => {
       </ArtworkFilterContext.Provider>
     )
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const getNextScreenTitle = (component) => component.root.findAllByType(Sans)[0].props.children
     expect(getNextScreenTitle(nextScreen)).toEqual("Medium")
   })
@@ -561,7 +561,6 @@ describe("Applying filters on Artworks", () => {
                 <ArtworkFilterContext.Provider
                   value={{
                     state,
-                    // @ts-ignore STRICTNESS_MIGRATION
                     dispatch: jest.fn(),
                   }}
                 >

--- a/src/lib/Components/FilteredInfiniteScrollGrid/FilteredInfiniteScrollGrid.tsx
+++ b/src/lib/Components/FilteredInfiniteScrollGrid/FilteredInfiniteScrollGrid.tsx
@@ -39,7 +39,7 @@ export class FilteredInfiniteScrollGrid extends React.Component<Props, State> {
     return null
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   handleFilterChange = (filter) => (selected) => {
     if (filter === "medium") {
       this.trackMediumChange()
@@ -80,7 +80,7 @@ export class FilteredInfiniteScrollGrid extends React.Component<Props, State> {
       <PortalProvider>
         <Box pt={3}>
           <InfiniteScrollArtworksGridContainer
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             connection={filterArtworksConnection}
             loadMore={this.props.relay.loadMore}
             hasMore={this.props.relay.hasMore}
@@ -91,7 +91,7 @@ export class FilteredInfiniteScrollGrid extends React.Component<Props, State> {
                 <Spacer m={2} />
                 <Serif size="8">Works</Serif>
                 <Filters
-                  // @ts-ignore STRICTNESS_MIGRATION
+                  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                   filteredArtworks={filterArtworksConnection}
                   priceRangeValue={priceRange}
                   mediumValue={medium}

--- a/src/lib/Components/FilteredInfiniteScrollGrid/Filters.tsx
+++ b/src/lib/Components/FilteredInfiniteScrollGrid/Filters.tsx
@@ -16,11 +16,11 @@ interface Props {
 }
 
 const getAggregationSlice = (sliceName: ArtworkAggregation, filteredArtworks: Filters_filteredArtworks) =>
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   filteredArtworks.aggregations.find(({ slice }) => slice === sliceName).counts
 
 const getAggregationOptions = (aggregation: ReturnType<typeof getAggregationSlice>) =>
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   aggregation.map(({ name, value }) => ({ text: name, value }))
 
 export const Filters: React.FC<Props> = ({ onFilterChange, mediumValue, priceRangeValue, filteredArtworks }) => {

--- a/src/lib/Components/FilteredInfiniteScrollGrid/__tests__/FilteredInfiniteScrollGrid-tests.tsx
+++ b/src/lib/Components/FilteredInfiniteScrollGrid/__tests__/FilteredInfiniteScrollGrid-tests.tsx
@@ -30,7 +30,7 @@ describe("FilteredInfiniteScrollGrid", () => {
       } as FilteredInfiniteScrollGridTestsQueryRawResponse,
     })
     expect(tree.find(InfiniteScrollArtworksGrid).props().filteredArtworks.artworks.edges.length).toBe(
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       ShowFixture.filterArtworksConnection.edges.length
     )
   })

--- a/src/lib/Components/FilteredInfiniteScrollGrid/__tests__/Filters-tests.tsx
+++ b/src/lib/Components/FilteredInfiniteScrollGrid/__tests__/Filters-tests.tsx
@@ -44,11 +44,11 @@ describe("Filters", () => {
       .find(Picker)
       .first()
       .props()
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       .options.map(({ text }) => text)
 
     // First Picker is the "Medium" picker
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const optionsFromFixture = ShowFixture.filterArtworksConnection.aggregations[1].counts[0].name
 
     expect(pickerOptions).toContain(optionsFromFixture)

--- a/src/lib/Components/Gene/Header.tsx
+++ b/src/lib/Components/Gene/Header.tsx
@@ -15,7 +15,7 @@ interface State {
   isFollowedChanging: boolean
 }
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const track: Track<Props, State> = _track
 
 @track()
@@ -85,7 +85,7 @@ class Header extends React.Component<Props, State> {
             },
           },
           updater: (store) => {
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             store.get(id).setValue(!isFollowed, "isFollowed")
           },
           onError: () => this.failedFollowChange(),

--- a/src/lib/Components/HoursCollapsible.tsx
+++ b/src/lib/Components/HoursCollapsible.tsx
@@ -29,7 +29,7 @@ const markdownRules = {
   ...basicRules,
   paragraph: {
     ...basicRules.paragraph,
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     react: (node, output, state) => (
       <Sans size="3t" color="black100" key={state.key}>
         {output(node.content, state)}
@@ -57,17 +57,17 @@ export class HoursCollapsible extends React.Component<Props, State> {
     } else if (openingHours && openingHours.schedules) {
       return openingHours.schedules.map((daySchedule, idx, arr) => {
         return (
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           <Box key={daySchedule.days}>
             <Sans size="3t" weight="medium">
               {
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 daySchedule.days
               }
             </Sans>
             <Sans size="3t" color="black60">
               {
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 daySchedule.hours
               }
             </Sans>

--- a/src/lib/Components/Lists/ShowItemRow.tsx
+++ b/src/lib/Components/Lists/ShowItemRow.tsx
@@ -27,7 +27,7 @@ interface State {
   isFollowedSaving: boolean
 }
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const track: Track<Props, {}> = _track
 
 @track()
@@ -67,7 +67,7 @@ export class ShowItemRow extends React.Component<Props, State> {
           isFollowedSaving: true,
         },
         () => {
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           return commitMutation<ShowItemRowMutation>(this.props.relay.environment, {
             onCompleted: () => this.handleShowSuccessfullyUpdated(),
             mutation: graphql`
@@ -97,7 +97,7 @@ export class ShowItemRow extends React.Component<Props, State> {
               },
             },
             updater: (store) => {
-              // @ts-ignore STRICTNESS_MIGRATION
+              // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
               store.get(nodeID).setValue(!isShowFollowed, "is_followed")
             },
           })
@@ -151,7 +151,7 @@ export class ShowItemRow extends React.Component<Props, State> {
                 ? show.status.charAt(0).toUpperCase() + show.status.slice(1)
                 : exhibitionDates(
                     show.exhibition_period,
-                    // @ts-ignore STRICTNESS_MIGRATION
+                    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                     show.end_at
                   )}
             </Sans>

--- a/src/lib/Components/LocationMap/index.tsx
+++ b/src/lib/Components/LocationMap/index.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import Mapbox from "@mapbox/react-native-mapbox-gl"
 import { LocationMap_location } from "__generated__/LocationMap_location.graphql"
 import { Pin } from "lib/Icons/Pin"

--- a/src/lib/Components/Modal.tsx
+++ b/src/lib/Components/Modal.tsx
@@ -30,14 +30,14 @@ const ModalInnerView = styled.View`
 `
 
 export class Modal extends React.Component<ModalProps, any> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   constructor(props) {
     super(props)
 
     this.state = { modalVisible: props.visible || false }
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   componentDidUpdate(prevProps) {
     if (this.props.visible !== prevProps.visible) {
       this.setState({ modalVisible: this.props.visible })

--- a/src/lib/Components/Picker.tsx
+++ b/src/lib/Components/Picker.tsx
@@ -90,7 +90,7 @@ export class Picker extends React.Component<Props, State> {
     }
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   handleValueChange = (selectedValue) => {
     const { options } = this.props
     const { isOpen } = this.state
@@ -102,7 +102,7 @@ export class Picker extends React.Component<Props, State> {
     }
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   shouldComponentUpdate(_nextProps, nextState) {
     /**
      * Picker is a controlled component, but we don't want to rerender due to a props/state change
@@ -129,21 +129,21 @@ export class Picker extends React.Component<Props, State> {
           precision={1}
         >
           {(
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             { bottom, progress, opacity }
           ) => {
             return (
               <>
                 <AnimatedView
                   style={{
-                    // @ts-ignore STRICTNESS_MIGRATION
+                    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                     display: progress.interpolate((p) => (p > 0.3 ? "flex" : "none")),
                     position: "absolute",
                     left: 0,
                     right: 0,
                     top: 0,
                     bottom: 0,
-                    // @ts-ignore STRICTNESS_MIGRATION
+                    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                     backgroundColor: opacity.interpolate((o) => `rgba(0, 0, 0, ${o})`),
                   }}
                 >
@@ -164,7 +164,7 @@ export class Picker extends React.Component<Props, State> {
                     </Flex>
                     <Separator />
                     <PickerIOS
-                      // @ts-ignore STRICTNESS_MIGRATION
+                      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                       selectedValue={pendingSelected ? pendingSelected.value : null}
                       onValueChange={this.handleValueChange}
                     >
@@ -184,7 +184,7 @@ export class Picker extends React.Component<Props, State> {
 
   renderSelect = () => {
     const { selected, options, prompt } = this.props
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const displayPrompt = selected ? options.find(({ value }) => value === selected).text : prompt
     return (
       <TouchableOpacity onPress={this.handleOpen}>

--- a/src/lib/Components/Portal.tsx
+++ b/src/lib/Components/Portal.tsx
@@ -23,7 +23,7 @@ export class PortalProvider extends React.Component<PortalProviderProps> {
    * portal provider - each Portal will destructively update the children to
    * render.
    */
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   handleSetPortalChildren = (children) => {
     this.setState({ portalChildren: children })
   }
@@ -58,7 +58,7 @@ class InnerPortal extends React.Component<InnerPortalProps> {
     this.props.onSetPortalChildren(this.props.children)
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.children !== nextProps.children) {
       this.props.onSetPortalChildren(nextProps.children)

--- a/src/lib/Components/ReadMore.tsx
+++ b/src/lib/Components/ReadMore.tsx
@@ -45,7 +45,7 @@ export const ReadMore = React.memo(
       ...basicRules,
       paragraph: {
         ...basicRules.paragraph,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         react: (node, output, state) => {
           return (
             <TextComponent {...textProps} color={color || "black100"} key={state.key}>
@@ -111,7 +111,7 @@ function truncate({
   // keep track of how many text nodes deep we are
   let textDepth = 0
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   function traverse(node: React.ReactNode) {
     if (offset === maxChars) {
       return null
@@ -120,7 +120,7 @@ function truncate({
     if (Array.isArray(node)) {
       const result = []
       for (const child of node) {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         const truncated = traverse(child)
         if (truncated) {
           result.push(truncated)
@@ -139,7 +139,7 @@ function truncate({
         textDepth += 1
       }
       const children = React.Children.toArray((node.props as any).children)
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const truncatedChildren = traverse(children)
 
       if (node.type === Sans || node.type === Serif || node.type === PaletteText) {
@@ -156,7 +156,7 @@ function truncate({
         textDepth -= 1
       }
 
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       return React.cloneElement(node, null, ...truncatedChildren)
     }
 

--- a/src/lib/Components/RelatedArtists/RelatedArtist.tsx
+++ b/src/lib/Components/RelatedArtists/RelatedArtist.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 class RelatedArtist extends Component<Props> {
   handleTap() {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     SwitchBoard.presentNavigationViewController(this, this.props.artist.href)
   }
 
@@ -40,14 +40,14 @@ class RelatedArtist extends Component<Props> {
   }
 
   artworksString(counts: RelatedArtist_artist["counts"]) {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const totalWorks = counts.artworks ? counts.artworks + (counts.artworks > 1 ? " works" : " work") : null
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     if (totalWorks && counts.forSaleArtworks === counts.artworks) {
       return totalWorks + " for sale"
     }
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const forSale = counts.forSaleArtworks ? counts.forSaleArtworks + " for sale" : null
     if (forSale && totalWorks) {
       return totalWorks + ", " + forSale

--- a/src/lib/Components/RetryErrorBoundary.tsx
+++ b/src/lib/Components/RetryErrorBoundary.tsx
@@ -19,7 +19,7 @@ interface State {
 /// Catches any errors and shows a failure screen. The user can tap a button to retry the render, which is indicated to
 /// the render prop with a parameter value of `true`.
 export class RetryErrorBoundary extends React.Component<Props, State> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   static getDerivedStateFromError(error) {
     console.error(error)
     captureMessage(error.stack)

--- a/src/lib/Components/ScrollableTabBar.tsx
+++ b/src/lib/Components/ScrollableTabBar.tsx
@@ -33,10 +33,7 @@ const TabButton = styled(View)<{ active: boolean }>`
   padding-left: 20px;
   padding-right: 20px;
   flex-grow: 1;
-  ${(
-    // @ts-ignore STRICTNESS_MIGRATION
-    p
-  ) =>
+  ${(p) =>
     p.active &&
     `
     border-color: ${color("black100")};
@@ -49,10 +46,7 @@ interface ScrollableTabProps {
 }
 
 const TabLabel = styled(Sans)<{ isActive: boolean }>`
-  color: ${(
-    // @ts-ignore STRICTNESS_MIGRATION
-    p
-  ) => (p.isActive ? color("black100") : color("black30"))};
+  color: ${(p) => (p.isActive ? color("black100") : color("black30"))};
 `
 
 export const ScrollableTab: React.FC<ScrollableTabProps> = ({ children }) => (
@@ -63,7 +57,7 @@ export interface ScrollableTabBarState {
   activeTab: number
 }
 export default class ScrollableTabBar extends React.Component<ScrollableTabBarProps, ScrollableTabBarState> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   scrollView: ScrollView = null
   // Default to screen width under first render
   scrollViewWidth: number = Dimensions.get("window").width
@@ -75,11 +69,11 @@ export default class ScrollableTabBar extends React.Component<ScrollableTabBarPr
   }
 
   UNSAFE_componentWillReceiveProps(newProps: ScrollableTabBarProps) {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.centerOnTab(newProps.activeTab)
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   renderTab = (name, page, isTabActive, onPressHandler) => {
     return (
       <Button
@@ -87,7 +81,6 @@ export default class ScrollableTabBar extends React.Component<ScrollableTabBarPr
         accessible={true}
         accessibilityLabel={name}
         accessibilityTraits="button"
-        // @ts-ignore STRICTNESS_MIGRATION
         onLayout={(e) => {
           const layout = e.nativeEvent.layout
           this.els[page] = layout
@@ -148,7 +141,6 @@ export default class ScrollableTabBar extends React.Component<ScrollableTabBarPr
         showsHorizontalScrollIndicator={false}
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{ flexDirection: "row", justifyContent: "space-between" }}
-        // @ts-ignore STRICTNESS_MIGRATION
         onContentSizeChange={(width) => (this.scrollViewWidth = width)}
         horizontal
       >

--- a/src/lib/Components/Show/ShowArtistsPreview.tsx
+++ b/src/lib/Components/Show/ShowArtistsPreview.tsx
@@ -36,7 +36,7 @@ export class ShowArtistsPreview extends React.Component<Props> {
   render() {
     const { show, onViewAllArtistsPressed, Component } = this.props
     const artistsShown = 5
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const artists = get(show, (s) => s.artists, []).concat(get(show, (s) => s.artists_without_artworks, []))
     const items = take(artists, artistsShown)
 
@@ -45,12 +45,12 @@ export class ShowArtistsPreview extends React.Component<Props> {
         <Sans size="4t">Artists</Sans>
         <Spacer m={1} />
         {items.map((artist, idx, arr) => {
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           const { id } = artist
           return (
             <React.Fragment key={id}>
               <ArtistListItem
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 artist={artist}
                 Component={Component}
               />

--- a/src/lib/Components/Show/ShowArtworksPreview.tsx
+++ b/src/lib/Components/Show/ShowArtworksPreview.tsx
@@ -33,7 +33,7 @@ export class ShowArtworksPreview extends React.Component<Props> {
           <Box mt={1}>
             <CaretButton
               text={`View all ${
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 counts.artworks
               } works`}
               onPress={() => onViewAllArtworksPressed()}

--- a/src/lib/Components/States/__tests__/ZeroState-tests.tsx
+++ b/src/lib/Components/States/__tests__/ZeroState-tests.tsx
@@ -7,7 +7,7 @@ import { ZeroState } from "../ZeroState"
 it("presents the title and subtitle", () => {
   const title = "A title for the zero state"
   const subtitle = "the subtitle for zero state"
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const { text } = getTestWrapper(<ZeroState title={title} subtitle={subtitle} />)
   expect(text).toContain(title)
   expect(text).toContain(subtitle)

--- a/src/lib/Components/StickyTabPage/reanimatedHelpers.ts
+++ b/src/lib/Components/StickyTabPage/reanimatedHelpers.ts
@@ -54,7 +54,7 @@ export function useValueReader<T extends { [k: string]: Animated.Adaptable<numbe
           const cb = readCallback.current
           readCallback.current = undefined
           result.current = undefined
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           cb(
             keys.reduce((acc, k, i) => {
               acc[k] = vs[i]

--- a/src/lib/Components/TabBar.tsx
+++ b/src/lib/Components/TabBar.tsx
@@ -40,14 +40,8 @@ const TabButton = styled.View<{ spaceEvenly?: boolean; active?: boolean }>`
   justify-content: center;
   padding-top: 5;
   flex-grow: 1;
-  ${(
-    // @ts-ignore STRICTNESS_MIGRATION
-    p
-  ) => p.spaceEvenly && `flex: 1;`};
-  ${(
-    // @ts-ignore STRICTNESS_MIGRATION
-    p
-  ) =>
+  ${(p) => p.spaceEvenly && `flex: 1;`};
+  ${(p) =>
     !p.spaceEvenly &&
     p.active &&
     `
@@ -64,7 +58,7 @@ interface TabProps {
 export const Tab: React.FC<TabProps> = ({ children }) => <View style={{ flex: 1, overflow: "hidden" }}>{children}</View>
 
 export default class TabBar extends React.Component<TabBarProps> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   renderTab(name, page, isTabActive, onPressHandler) {
     return (
       <Button
@@ -90,11 +84,11 @@ export default class TabBar extends React.Component<TabBarProps> {
   }
 
   render() {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const containerWidth = this.props.containerWidth - space(4)
     const numberOfTabs = this.props.tabs.length
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const translateX = this.props.scrollValue.interpolate({
       inputRange: [0, 1],
       outputRange: [0, containerWidth / numberOfTabs],

--- a/src/lib/Components/WorksForYou/__tests__/Notification-tests.tsx
+++ b/src/lib/Components/WorksForYou/__tests__/Notification-tests.tsx
@@ -17,7 +17,7 @@ it("renders without throwing an error for read notification", () => {
 
 it("renders without throwing an error if no avatar image exists", () => {
   const props = notification()
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   props.image.resized.url = null
   renderWithLayout(<Notification width={300} notification={props as any} />, { width: 300 })
 })

--- a/src/lib/Components/__tests__/HoursCollapsible-tests.tsx
+++ b/src/lib/Components/__tests__/HoursCollapsible-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { Markdown } from "lib/Components/Markdown"
 import { Theme } from "palette"

--- a/src/lib/Components/__tests__/Markdown-tests.tsx
+++ b/src/lib/Components/__tests__/Markdown-tests.tsx
@@ -78,7 +78,7 @@ describe("Markdown", () => {
       ...basicRules,
       paragraph: {
         ...basicRules.paragraph,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         react: (node, output, state) => <Text testID="foobar">{output(node.content, state)}</Text>,
       },
     }

--- a/src/lib/Components/__tests__/Picker-tests.tsx
+++ b/src/lib/Components/__tests__/Picker-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { render } from "enzyme"
 import { Picker, PickerType } from "lib/Components/Picker"
 import React from "react"

--- a/src/lib/Components/__tests__/Portal-tests.tsx
+++ b/src/lib/Components/__tests__/Portal-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import React from "react"
 

--- a/src/lib/Components/__tests__/ReadMore-tests.tsx
+++ b/src/lib/Components/__tests__/ReadMore-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount, shallow } from "enzyme"
 import SwitchBoard from "lib/NativeModules/SwitchBoard"
 import { Sans, Serif, Text, Theme } from "palette"

--- a/src/lib/Containers/BidFlow.tsx
+++ b/src/lib/Containers/BidFlow.tsx
@@ -68,12 +68,12 @@ export const BidFlowQueryRenderer: React.FC<{ artworkID?: string; saleID: string
       `}
       cacheConfig={{ force: true }} // We want to always fetch latest bid increments.
       variables={{
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         artworkID,
         saleID,
       }}
       render={renderWithLoadProgress<BidFlowQuery["response"]>((props) => (
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         <BidFlowFragmentContainer sale_artwork={props.artwork.sale_artwork} me={props.me} />
       ))}
     />

--- a/src/lib/Containers/Gene.tsx
+++ b/src/lib/Containers/Gene.tsx
@@ -11,7 +11,7 @@ import * as _ from "lodash"
 import { Box, Button, Sans } from "palette"
 import React from "react"
 import { Dimensions, StyleSheet, View, ViewProperties, ViewStyle } from "react-native"
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import ParallaxScrollView from "react-native-parallax-scroll-view"
 import { createPaginationContainer, graphql, QueryRenderer, RelayPaginationProp } from "react-relay"
 import { InfiniteScrollArtworksGridContainer as InfiniteScrollArtworksGrid } from "../Components/ArtworkGrids/InfiniteScrollArtworksGrid"
@@ -41,7 +41,7 @@ interface State {
   selectedMedium?: string
   selectedPriceRange?: string
 }
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const track: Track<Props, State> = _track
 
 /**
@@ -143,7 +143,7 @@ export class Gene extends React.Component<Props, State> {
       sort: "-partner_updated_at",
       selectedMedium: this.props.medium || "*",
       selectedPrice: this.props.price_range || "*-*",
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       aggregations: this.props.gene.artworks.aggregations,
     }
 
@@ -151,13 +151,13 @@ export class Gene extends React.Component<Props, State> {
       sort: this.state.sort,
       selectedMedium: this.state.selectedMedium,
       selectedPrice: this.state.selectedPriceRange,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       aggregations: this.props.gene.artworks.aggregations,
     }
 
     // We're returning the promise so that it's easier
     // to write tests with the resolved state
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     return Refine.triggerRefine(this, initialSettings, currentSettings).then((newSettings) => {
       if (newSettings) {
         this.setState({
@@ -208,7 +208,7 @@ export class Gene extends React.Component<Props, State> {
               content: (
                 <StickyTabPageScrollView disableScrollViewPanResponder>
                   <InfiniteScrollArtworksGrid
-                    // @ts-ignore STRICTNESS_MIGRATION
+                    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                     connection={this.props.gene.artworks}
                     hasMore={this.props.relay.hasMore}
                     loadMore={this.props.relay.loadMore}
@@ -243,7 +243,7 @@ export class Gene extends React.Component<Props, State> {
   /** The summary string of the current refine settings */
   artworkQuerySummaryString = () => {
     const items: string[] = []
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const works = this.props.gene.artworks.counts.total.toLocaleString()
     items.push(`${works} works`)
 
@@ -251,7 +251,7 @@ export class Gene extends React.Component<Props, State> {
       items.push(_.startCase(this.state.selectedMedium))
     }
     if (this.state.selectedPriceRange !== "*-*") {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       items.push(this.priceRangeToHumanReadableString(this.state.selectedPriceRange))
     }
     return items.join(" ・ ")
@@ -275,7 +275,7 @@ export class Gene extends React.Component<Props, State> {
       return `Above ${below}`
     }
     if (range.includes("*-")) {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const below = dollars(range.split("*-").pop())
       return `Below ${below}`
     }
@@ -292,9 +292,9 @@ interface Styles {
 
 const styles = StyleSheet.create<Styles>({
   header: {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     width: isPad ? 330 : null,
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     alignSelf: isPad ? "center" : null,
   },
   stickyHeader: {

--- a/src/lib/Containers/Inbox.tsx
+++ b/src/lib/Containers/Inbox.tsx
@@ -29,9 +29,9 @@ const Container = styled.ScrollView`
 `
 
 export class Inbox extends React.Component<Props, State> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   conversations: ConversationsRef
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   activeBids: ActiveBidsRef
 
   state = {

--- a/src/lib/Containers/WorksForYou.tsx
+++ b/src/lib/Containers/WorksForYou.tsx
@@ -39,7 +39,7 @@ export class WorksForYou extends React.Component<Props, State> {
 
   componentDidMount() {
     // Update read status in gravity
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     NativeModules.ARTemporaryAPIModule.markNotificationsRead((error) => {
       if (error) {
         console.warn(error)

--- a/src/lib/Containers/__tests__/BidFlow-tests.tsx
+++ b/src/lib/Containers/__tests__/BidFlow-tests.tsx
@@ -7,7 +7,7 @@ import { BidFlowFragmentContainer } from "../BidFlow"
 jest.mock("tipsi-stripe", () => ({ setOptions: jest.fn() }))
 
 jest.mock("../../Components/Bidding/Context/TimeOffsetProvider.tsx", () => ({
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   TimeOffsetProvider: ({ children }) => children,
 }))
 

--- a/src/lib/Containers/__tests__/Gene-tests.tsx
+++ b/src/lib/Containers/__tests__/Gene-tests.tsx
@@ -19,11 +19,11 @@ const exampleProps = {
 describe("state", () => {
   it("sets up the initial state", () => {
     const gene = new Gene({
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       gene: null,
       medium: "glitch",
       price_range: "*-*",
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       relay: null,
     })
 

--- a/src/lib/Containers/__tests__/Inbox-tests.tsx
+++ b/src/lib/Containers/__tests__/Inbox-tests.tsx
@@ -33,7 +33,7 @@ it("requests a relay refetch when fetchData is called in ZeroState", () => {
     me: emptyMeProps,
     isVisible: true,
     relay: {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       environment: null as Environment,
       refetch: jest.fn(),
     },

--- a/src/lib/Containers/__tests__/WorksForYou-tests.tsx
+++ b/src/lib/Containers/__tests__/WorksForYou-tests.tsx
@@ -16,7 +16,7 @@ describe("with notifications", () => {
     renderWithWrappers(
       <WorksForYou
         me={me as any}
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         relay={null}
       />
     )
@@ -25,7 +25,7 @@ describe("with notifications", () => {
 
   it("renders without throwing an error", () => {
     const me = notificationsResponse().query.me
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     renderWithWrappers(<WorksForYou me={me as any} relay={null} />)
   })
 })
@@ -33,7 +33,7 @@ describe("with notifications", () => {
 describe("without notifications", () => {
   it("renders without throwing an error", () => {
     const me = emptyStateResponse().query.me
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     renderWithWrappers(<WorksForYou me={me as any} relay={null} />)
   })
 })
@@ -68,7 +68,7 @@ interface NotificationsResponse {
 }
 
 const notificationsResponse = () => {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   return {
     query: {
       me: {

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -99,7 +99,7 @@ export class Artwork extends React.Component<Props, State> {
     this.markArtworkAsRecentlyViewed()
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   componentDidUpdate(prevProps) {
     // If we are visible, but weren't, then we are re-appearing (not called on first render).
     if (this.props.isVisible && !prevProps.isVisible) {
@@ -127,7 +127,7 @@ export class Artwork extends React.Component<Props, State> {
 
   shouldRenderOtherWorks = () => {
     const { contextGrids } = this.props.artworkBelowTheFold
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const gridsToShow = populatedGrids(contextGrids)
 
     if (gridsToShow && gridsToShow.length > 0) {
@@ -464,11 +464,11 @@ export const ArtworkQueryRenderer: React.FC<{
               renderComponent: ({ above, below }) => {
                 return (
                   <ArtworkContainer
-                    // @ts-ignore STRICTNESS_MIGRATION
+                    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                     artworkAboveTheFold={above.artwork}
-                    // @ts-ignore STRICTNESS_MIGRATION
+                    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                     artworkBelowTheFold={below?.artwork ?? null}
-                    // @ts-ignore STRICTNESS_MIGRATION
+                    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                     me={above.me}
                     {...others}
                   />
@@ -489,7 +489,6 @@ export const ArtworkQueryRenderer: React.FC<{
 const AboveTheFoldPlaceholder: React.FC<{}> = ({}) => {
   const screenDimensions = useScreenDimensions()
   // The logic for artworkHeight comes from the zeplin spec https://zpl.io/25JLX0Q
-  // @ts-ignore STRICTNESS_MIGRATION
   const artworkHeight = screenDimensions.width >= 375 ? 340 : 290
 
   return (

--- a/src/lib/Scenes/Artwork/Components/AboutArtist.tsx
+++ b/src/lib/Scenes/Artwork/Components/AboutArtist.tsx
@@ -18,7 +18,7 @@ export class AboutArtist extends React.Component<AboutArtistProps> {
     } = this.props
     const hasSingleArtist = artists && artists.length === 1
     const text =
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       hasSingleArtist && artists[0].biography_blurb && artists[0].biography_blurb.text
         ? artists! /* STRICTNESS_MIGRATION */[0]! /* STRICTNESS_MIGRATION */.biography_blurb.text
         : null
@@ -33,7 +33,7 @@ export class AboutArtist extends React.Component<AboutArtistProps> {
           <Join separator={<Spacer my={1} />}>
             {artists! /* STRICTNESS_MIGRATION */
               .map((artist) => (
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 <ArtistListItem key={artist.id} artist={artist} contextModule={Schema.ContextModules.AboutTheArtist} />
               ))}
           </Join>

--- a/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -30,16 +30,16 @@ interface ArtworkActionsProps {
 export const shareContent = (title: string, href: string, artists: ArtworkActions_artwork["artists"]) => {
   let computedTitle: string | null
   if (artists && artists.length) {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const names = take(artists, 3).map((artist) => artist.name)
     computedTitle = `${title} by ${names.join(", ")} on Artsy`
   } else if (title) {
     computedTitle = `${title} on Artsy`
   }
   return {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     title: computedTitle,
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     message: computedTitle,
     url: `https://artsy.net${href}?utm_content=artwork-share`,
   }
@@ -56,7 +56,7 @@ export class ArtworkActions extends React.Component<ArtworkActionsProps> {
   })
   handleArtworkSave() {
     const { artwork, relay } = this.props
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     commitMutation<ArtworkActionsSaveMutation>(relay.environment, {
       mutation: graphql`
         mutation ArtworkActionsSaveMutation($input: SaveArtworkInput!) {
@@ -82,7 +82,7 @@ export class ArtworkActions extends React.Component<ArtworkActionsProps> {
   async handleArtworkShare() {
     const { title, href, artists } = this.props.artwork
     try {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       await Share.share(shareContent(title, href, artists))
     } catch (error) {
       console.error("ArtworkActions.tsx", error)

--- a/src/lib/Scenes/Artwork/Components/ArtworkExtraLinks/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkExtraLinks/__tests__/index-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { ArtworkFixture } from "lib/__fixtures__/ArtworkFixture"
 import { Sans, Theme } from "palette"
@@ -54,7 +54,7 @@ describe("ArtworkExtraLinks", () => {
 
     const component = getWrapper({ artwork })
     const consignmentsLink = component.find(Text).at(1)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const texts = component.find(Sans).map((x) => x.text())
 
     expect(texts[0]).toContain("Consign with Artsy.")
@@ -304,7 +304,7 @@ describe("ArtworkExtraLinks", () => {
     it("posts proper event in when clicking Ask A Specialist", () => {
       component
         .find("Text")
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         .findWhere((t) => t.text() === "ask a specialist")
         .first()
         .props()
@@ -319,7 +319,7 @@ describe("ArtworkExtraLinks", () => {
     it("posts proper event in when clicking Read our auction FAQs", () => {
       component
         .find("Text")
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         .findWhere((t) => t.text() === "Read our auction FAQs")
         .first()
         .props()
@@ -334,7 +334,7 @@ describe("ArtworkExtraLinks", () => {
     it("posts proper event in when clicking Conditions of Sale", () => {
       component
         .find("Text")
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         .findWhere((t) => t.text() === "Conditions of Sale")
         .first()
         .props()

--- a/src/lib/Scenes/Artwork/Components/ArtworkExtraLinks/__tests__/partnerName-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkExtraLinks/__tests__/partnerName-tests.tsx
@@ -5,42 +5,42 @@ describe("partnerName", () => {
   const sale = { isBenefit: false, partner: null } as ArtworkExtraLinks_artwork["sale"]
 
   it(`returns "Artsy's" if the sale is a benefit auction`, () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(partnerName({ ...sale, isBenefit: true })).toEqual("Artsy's")
   })
 
   it(`returns "Artsy's" if the partner is empty`, () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(partnerName({ ...sale, partner: null })).toEqual("Artsy's")
   })
 
   it(`adds a "Artsy's" prefix and "'s" to the end of the partner name`, () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(partnerName({ ...sale, partner: { name: "Digard" } })).toEqual("Artsy's and Digard's")
   })
 
   it(`adds a "Artsy's" prefix and "s" to the end of the partner name if the partner name ends with "'" (normal single quote)`, () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(partnerName({ ...sale, partner: { name: "GALERIE K'" } })).toEqual("Artsy's and GALERIE K's")
   })
 
   it(`adds a "Artsy's" prefix and "s" to the end of the partner name if the partner name ends with "’" (smart quote)`, () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(partnerName({ ...sale, partner: { name: "GALERIE K’" } })).toEqual("Artsy's and GALERIE K’s")
   })
 
   it(`only adds a "Artsy's" prefix if the partner name ends with a "'s" (normal single quote)`, () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(partnerName({ ...sale, partner: { name: "Christie's" } })).toEqual("Artsy's and Christie's")
   })
 
   it(`only adds a "Artsy's" prefix if the partner name ends with a "’s" (smart quote) `, () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(partnerName({ ...sale, partner: { name: "Christie’s" } })).toEqual("Artsy's and Christie’s")
   })
 
   it(`adds a "Artsy's" prefix and "'" (single quote) to the end of the partner name if the partner name ends with "s"`, () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(partnerName({ ...sale, partner: { name: "Phillips" } })).toEqual("Artsy's and Phillips's")
   })
 })

--- a/src/lib/Scenes/Artwork/Components/ArtworkExtraLinks/index.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkExtraLinks/index.tsx
@@ -26,7 +26,7 @@ export class ArtworkExtraLinks extends React.Component<ArtworkExtraLinksProps> {
     action_type: Schema.ActionTypes.Tap,
     context_module: Schema.ContextModules.ArtworkExtraLinks,
   })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   handleAskASpecialistTap(emailAddress) {
     const { artwork } = this.props
     const mailtoSubject = `Inquiry on ${artwork.title}`.concat(
@@ -113,9 +113,9 @@ export class ArtworkExtraLinks extends React.Component<ArtworkExtraLinksProps> {
     const {
       artwork: { artists },
     } = this.props
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const consignableArtistsCount = artists.filter((artist) => artist.isConsignable).length
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const artistName = artists && artists.length === 1 ? artists[0].name : null
 
     return (

--- a/src/lib/Scenes/Artwork/Components/ArtworkHistory.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkHistory.tsx
@@ -34,7 +34,7 @@ export class ArtworkHistory extends React.Component<ArtworkHistoryProps> {
               {title}
             </Sans>
             <ReadMore
-              // @ts-ignore STRICTNESS_MIGRATION
+              // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
               content={value}
               contextModule={contextModule}
               maxChars={textLimit}

--- a/src/lib/Scenes/Artwork/Components/ArtworkTombstone.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkTombstone.tsx
@@ -56,7 +56,7 @@ export class ArtworkTombstone extends React.Component<ArtworkTombstoneProps, Art
       <React.Fragment>
         <Text>
           {this.renderArtistName(
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             artist.name,
             artist.href
           )}
@@ -88,14 +88,14 @@ export class ArtworkTombstone extends React.Component<ArtworkTombstoneProps, Art
       artwork: { artists },
     } = this.props
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const truncatedArtists = !this.state.showingMoreArtists ? artists.slice(0, 3) : artists
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const artistNames = truncatedArtists.map((artist, index) => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const artistNameWithComma = index !== artists.length - 1 ? artist.name + ", " : artist.name
       return (
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         <React.Fragment key={artist.href}>{this.renderArtistName(artistNameWithComma, artist.href)}</React.Fragment>
       )
     })
@@ -131,12 +131,12 @@ export class ArtworkTombstone extends React.Component<ArtworkTombstoneProps, Art
         <Flex flexDirection="row" flexWrap="wrap">
           {artwork.artists! /* STRICTNESS_MIGRATION */.length === 1
             ? this.renderSingleArtist(
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 artwork.artists[0]
               )
             : this.renderMultipleArtists()}
           {!!(artwork.artists! /* STRICTNESS_MIGRATION */.length === 0 && artwork.cultural_maker) &&
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             this.renderArtistName(artwork.cultural_maker, null)}
         </Flex>
         <Spacer mb={1} />
@@ -144,7 +144,7 @@ export class ArtworkTombstone extends React.Component<ArtworkTombstoneProps, Art
           <Sans color="black100" size="3" weight="medium">
             Lot{" "}
             {
-              // @ts-ignore STRICTNESS_MIGRATION
+              // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
               artwork.saleArtwork.lotLabel
             }
           </Sans>

--- a/src/lib/Scenes/Artwork/Components/AuctionPrice.tsx
+++ b/src/lib/Scenes/Artwork/Components/AuctionPrice.tsx
@@ -20,11 +20,11 @@ export class AuctionPrice extends React.Component<AuctionPriceProps> {
     }
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   bidText = (bidsPresent, bidsCount) => {
     const { artwork } = this.props
     const bidTextParts = []
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     let reserveMessage = artwork.saleArtwork.reserveMessage
 
     if (bidsPresent) {
@@ -59,15 +59,15 @@ export class AuctionPrice extends React.Component<AuctionPriceProps> {
 
     const myLotStanding = artwork.myLotStanding && artwork.myLotStanding[0]
     const myBidPresent = !!(myLotStanding && myLotStanding.mostRecentBid)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const myBidWinning = myBidPresent && get(myLotStanding, (s) => s.activeBid.isWinning)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const myMostRecent = myBidPresent && myLotStanding.mostRecentBid
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const myMaxBid = get(myMostRecent, (bid) => bid.maxBid.display)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const bidsCount = get(artwork, (a) => a.saleArtwork.counts.bidderPositions)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const bidsPresent = bidsCount > 0
     const bidText = this.bidText(bidsPresent, bidsCount) ? this.bidText(bidsPresent, bidsCount) : null
 

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/BidButton.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/BidButton.tsx
@@ -19,14 +19,14 @@ export interface BidButtonProps {
   relay: RelayProp
 }
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const watchOnly = (sale) => sale.isRegistrationClosed && !sale?.registrationStatus?.qualifiedForBidding
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const getMyLotStanding = (artwork) => artwork.myLotStanding && artwork.myLotStanding.length && artwork.myLotStanding[0]
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const getHasBid = (myLotStanding) => !!(myLotStanding && myLotStanding.mostRecentBid)
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const IdentityVerificationRequiredMessage = ({ onPress, ...remainderProps }) => (
   <Sans mt="1" size="3" color="black60" pb="1" textAlign="center" {...remainderProps}>
     Identity verification required to bid.{" "}
@@ -52,7 +52,7 @@ export class BidButton extends React.Component<BidButtonProps> {
   })
   redirectToRegister() {
     const { sale } = this.props.artwork
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     SwitchBoard.presentNavigationViewController(this, `/auction-registration/${sale.slug}`)
   }
 
@@ -64,7 +64,7 @@ export class BidButton extends React.Component<BidButtonProps> {
     }
   })
   redirectToLiveBidding() {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const { slug } = this.props.artwork.sale
     const liveUrl = `${PREDICTION_URL}/${slug}`
     SwitchBoard.presentNavigationViewController(this, liveUrl)
@@ -83,12 +83,12 @@ export class BidButton extends React.Component<BidButtonProps> {
     const { slug, sale } = this.props.artwork
     const bid = firstIncrement
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     SwitchBoard.presentNavigationViewController(this, `/auction/${sale.slug}/bid/${slug}?bid=${bid}`)
   }
 
   renderIsPreview(
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     registrationStatus: BidButton_artwork["sale"]["registrationStatus"],
     needsIdentityVerification: boolean
   ) {
@@ -143,7 +143,7 @@ export class BidButton extends React.Component<BidButtonProps> {
   render() {
     const { artwork, auctionState, me } = this.props
     const { sale, saleArtwork } = artwork
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const { registrationStatus } = sale
 
     // TODO: Do we need a nil check against +sale+?
@@ -152,7 +152,7 @@ export class BidButton extends React.Component<BidButtonProps> {
     }
 
     const qualifiedForBidding = registrationStatus?.qualifiedForBidding
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const needsIdentityVerification = bidderNeedsIdentityVerification({ sale, user: me, bidder: registrationStatus })
 
     /**
@@ -178,7 +178,7 @@ export class BidButton extends React.Component<BidButtonProps> {
           )}
         </>
       )
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     } else if (sale.isRegistrationClosed && !qualifiedForBidding) {
       return (
         <Button width={100} block size="large" disabled>
@@ -196,13 +196,13 @@ export class BidButton extends React.Component<BidButtonProps> {
       )
     } else {
       const myLastMaxBid = hasBid && myLotStanding.mostRecentBid.maxBid.cents
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const increments = saleArtwork.increments.filter((increment) => increment.cents > (myLastMaxBid || 0))
       const firstIncrement = increments && increments.length && increments[0]
       const incrementCents = firstIncrement && firstIncrement.cents
 
       return (
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         <Button width={100} size="large" block onPress={() => this.redirectToBid(incrementCents)}>
           {hasBid ? "Increase max bid" : "Bid"}
         </Button>

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/BuyNowButton.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/BuyNowButton.tsx
@@ -19,7 +19,7 @@ export interface State {
   isCommittingCreateOrderMutation: boolean
 }
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const track: Track<BuyNowButtonProps, State> = _track
 
 @track()
@@ -28,7 +28,7 @@ export class BuyNowButton extends React.Component<BuyNowButtonProps, State> {
     isCommittingCreateOrderMutation: false,
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   onMutationError(error) {
     Alert.alert("Sorry, we couldn't process the request.", "Please try again or contact orders@artsy.net for help.", [
       {
@@ -91,7 +91,7 @@ export class BuyNowButton extends React.Component<BuyNowButtonProps, State> {
           onCompleted: (data) => {
             this.setState({ isCommittingCreateOrderMutation: false }, () => {
               const {
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 commerceCreateOrderWithArtwork: { orderOrError },
               } = data
               if (orderOrError.__typename === "CommerceOrderWithMutationFailure") {

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/CommercialButtons.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/CommercialButtons.tsx
@@ -49,7 +49,7 @@ export class CommercialButtons extends React.Component<CommercialButtonProps> {
               <BuyNowButtonFragmentContainer
                 variant="secondaryOutline"
                 artwork={artwork}
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 editionSetID={this.props.editionSetID}
               />
             </>
@@ -63,23 +63,23 @@ export class CommercialButtons extends React.Component<CommercialButtonProps> {
         <>
           <BuyNowButtonFragmentContainer
             artwork={artwork}
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             editionSetID={this.props.editionSetID}
           />
           <Spacer mb={1} />
           <MakeOfferButtonFragmentContainer
             artwork={artwork}
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             editionSetID={this.props.editionSetID}
             variant="secondaryOutline"
           />
         </>
       )
     } else if (isAcquireable) {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       return <BuyNowButtonFragmentContainer artwork={artwork} editionSetID={this.props.editionSetID} />
     } else if (isOfferable) {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       return <MakeOfferButtonFragmentContainer artwork={artwork} editionSetID={this.props.editionSetID} />
     } else if (isInquireable && !newFirstInquiry) {
       return (

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/MakeOfferButton.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/MakeOfferButton.tsx
@@ -19,7 +19,7 @@ export interface State {
   isCommittingCreateOfferOrderMutation: boolean
 }
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const track: Track<MakeOfferButtonProps, State> = _track
 
 @track()
@@ -28,7 +28,7 @@ export class MakeOfferButton extends React.Component<MakeOfferButtonProps, State
     isCommittingCreateOfferOrderMutation: false,
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   onMutationError(error) {
     Alert.alert("Sorry, we couldn't process the request.", "Please try again or contact orders@artsy.net for help.", [
       {
@@ -93,7 +93,7 @@ export class MakeOfferButton extends React.Component<MakeOfferButtonProps, State
           onCompleted: (data) => {
             this.setState({ isCommittingCreateOfferOrderMutation: false }, () => {
               const {
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 commerceCreateOfferOrderWithArtwork: { orderOrError },
               } = data
               if (orderOrError.__typename === "CommerceOrderWithMutationFailure") {

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/BidButton-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/BidButton-tests.tsx
@@ -45,7 +45,7 @@ describe("BidButton", () => {
     Settings.defaultZoneName = realDefaultZone
   })
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const getWrapper = async (artwork, me, auctionState) => {
     return await renderRelayTree({
       Component: (props: any) => (

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/CommercialButtons-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/CommercialButtons-tests.tsx
@@ -22,7 +22,7 @@ afterEach(() => {
   SwitchBoardMock.presentModalViewController.mockReset()
 })
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const componentWithQuery = async ({ mockArtworkData, mockOrderMutationResults, mockOfferMutationResults }) => {
   return await renderRelayTree({
     Component: CommercialButtonsFragmentContainer,
@@ -59,7 +59,7 @@ const wrapper = (mockArtwork: _FragmentRefs<"CommercialButtons_artwork">): JSX.E
   </ArtworkInquiryContext.Provider>
 )
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const relayComponent = async ({ artwork }) => {
   return await renderRelayTree({
     Component: () => wrapper(artwork),

--- a/src/lib/Scenes/Artwork/Components/CommercialEditionSetInformation.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialEditionSetInformation.tsx
@@ -6,7 +6,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components/native"
 import { CommercialPartnerInformationFragmentContainer as CommercialPartnerInformation } from "./CommercialPartnerInformation"
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 type EditionSet = CommercialEditionSetInformation_artwork["editionSets"][0]
 
 interface Props {
@@ -33,14 +33,14 @@ export class CommercialEditionSetInformation extends React.Component<Props, Stat
     }
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   selectEdition = (internalID) => {
     const { setEditionSetId, artwork } = this.props
     const editionSets = artwork.editionSets
     this.setState({
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       selectedEdition: editionSets.find((edition) => {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         return edition.internalID === internalID
       }),
     })
@@ -64,9 +64,9 @@ export class CommercialEditionSetInformation extends React.Component<Props, Stat
         </Sans>
         <Flex flexDirection="row" alignContent="center" flexWrap="wrap">
           {editionSets.map((edition) => {
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             const { id, internalID, dimensions } = edition
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             const selected = internalID === selectedEdition.internalID
             return (
               <TouchableWithoutFeedback key={id} onPress={() => this.selectEdition(internalID)}>
@@ -84,7 +84,7 @@ export class CommercialEditionSetInformation extends React.Component<Props, Stat
             <Spacer mb={1} />
             <Sans size="3t" color="black30">
               {
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 selectedEdition.editionOf
               }
             </Sans>
@@ -96,7 +96,7 @@ export class CommercialEditionSetInformation extends React.Component<Props, Stat
 
             <Sans size="4" weight="medium" color="black100">
               {
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 selectedEdition.saleMessage
               }
             </Sans>

--- a/src/lib/Scenes/Artwork/Components/CommercialInformation.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialInformation.tsx
@@ -43,15 +43,15 @@ export class CommercialInformationTimerWrapper extends React.Component<
   render() {
     if (this.props.artwork.isInAuction) {
       const {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         isPreview,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         isClosed,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         liveStartAt: liveStartsAt,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         startAt: startsAt,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         endAt: endsAt,
       } = this.props.artwork.sale
 
@@ -105,7 +105,7 @@ export const SaleAvailability: React.FC<{ dotColor?: string; saleMessage: string
 
 @track()
 export class CommercialInformation extends React.Component<CommercialInformationProps, CommercialInformationState> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   state = {
     editionSetID: null,
   }
@@ -117,14 +117,14 @@ export class CommercialInformation extends React.Component<CommercialInformation
     const artworkIsInActiveAuction = artwork.isInAuction && timerState !== AuctionTimerState.CLOSED
 
     if (artworkIsInActiveAuction) {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       this.props.tracking.trackEvent({
         action_type: Schema.ActionNames.LotViewed,
         artwork_id: artwork.internalID,
         artwork_slug: artwork.slug,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         sale_id: artwork.sale.internalID,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         auction_slug: artwork.sale.slug,
       })
     }
@@ -136,7 +136,7 @@ export class CommercialInformation extends React.Component<CommercialInformation
     const saleMessage = artwork.saleMessage
       ? artwork.saleMessage
       : capitalize(
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           artwork.availability
         )
     let indicatorColor
@@ -202,7 +202,7 @@ export class CommercialInformation extends React.Component<CommercialInformation
     const isBiddableInAuction = isInAuction && sale && timerState !== AuctionTimerState.CLOSED && isForSale
     const isInClosedAuction = isInAuction && sale && timerState === AuctionTimerState.CLOSED
     const canTakeCommercialAction = isAcquireable || isOfferable || isInquireable || isBiddableInAuction
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const artistIsConsignable = artwork.artists.filter((artist) => artist.isConsignable).length
     const hidesPriceInformation = isInAuction && isForSale && timerState === AuctionTimerState.LIVE_INTEGRATION_ONGOING
 
@@ -216,9 +216,9 @@ export class CommercialInformation extends React.Component<CommercialInformation
               <CommercialButtons
                 artwork={artwork}
                 me={me}
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 auctionState={timerState}
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 editionSetID={editionSetID}
               />
             </>
@@ -228,7 +228,7 @@ export class CommercialInformation extends React.Component<CommercialInformation
               <Spacer mb={2} />
               <Countdown
                 label={this.props.label}
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 duration={this.props.duration}
               />
             </>
@@ -238,7 +238,7 @@ export class CommercialInformation extends React.Component<CommercialInformation
               <Spacer mb={2} />
               <ArtworkExtraLinks
                 artwork={artwork}
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 auctionState={timerState}
               />
             </>

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/FullScreen/DeepZoom/DeepZoomOverlay.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/FullScreen/DeepZoom/DeepZoomOverlay.tsx
@@ -30,7 +30,7 @@ export interface DeepZoomOverlayProps {
 export const DeepZoomOverlay: React.FC<DeepZoomOverlayProps> = ({
   image: {
     deepZoom: {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       image: { format, size: fullImageSize, tileSize, url },
     },
   },
@@ -51,7 +51,6 @@ export const DeepZoomOverlay: React.FC<DeepZoomOverlayProps> = ({
 
   // setup geometry
   const levels = useMemo(() => calculateDeepZoomLevels(fullImageSize), [fullImageSize])
-  // @ts-ignore STRICTNESS_MIGRATION
   const imageFittedWithinScreen = useMemo(() => fitInside(screenDimensions, { width, height }), [width, height])
   const zoomScaleBoundaries = useMemo(() => getZoomScaleBoundaries({ imageFittedWithinScreen, levels }), [
     levels,

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/FullScreen/DeepZoom/DeepZoomTile.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/FullScreen/DeepZoom/DeepZoomTile.tsx
@@ -21,12 +21,12 @@ export class DeepZoomTileID {
     return this.id
   }
   private intern() {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const result = DeepZoomTileID._cache[this.toString()]
     if (result) {
       return result
     }
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     DeepZoomTileID._cache[this.toString()] = this
     return this
   }

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/FullScreen/ImageCarouselFullScreen.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/FullScreen/ImageCarouselFullScreen.tsx
@@ -25,7 +25,6 @@ export const ImageCarouselFullScreen = () => {
   // update the imageIndex on scroll
   const onScroll = useCallback(
     (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-      // @ts-ignore STRICTNESS_MIGRATION
       const nextImageIndex = Math.round(e.nativeEvent.contentOffset.x / screenDimensions.width)
       if (fullScreenState.current === "entered" && nextImageIndex !== imageIndex.current) {
         dispatch({ type: "IMAGE_INDEX_CHANGED", nextImageIndex })
@@ -72,23 +71,19 @@ export const ImageCarouselFullScreen = () => {
         <WhiteUnderlay />
         <VerticalSwipeToDismiss onClose={onClose}>
           <FlatList<ImageDescriptor>
-            // @ts-ignore STRICTNESS_MIGRATION
             key={screenDimensions.orientation}
             data={images}
             horizontal
             showsHorizontalScrollIndicator={false}
             scrollEnabled={images.length > 1 && fullScreenState.current === "entered"}
-            // @ts-ignore STRICTNESS_MIGRATION
             snapToInterval={screenDimensions.width}
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             keyExtractor={(item) => item.url}
             decelerationRate="fast"
             initialScrollIndex={initialScrollIndex}
             getItemLayout={(_, index) => ({
               index,
-              // @ts-ignore STRICTNESS_MIGRATION
               offset: index * screenDimensions.width,
-              // @ts-ignore STRICTNESS_MIGRATION
               length: screenDimensions.width,
             })}
             onScroll={onScroll}
@@ -106,7 +101,7 @@ export const ImageCarouselFullScreen = () => {
                   image={item}
                   index={index}
                   ref={(ref) => {
-                    // @ts-ignore STRICTNESS_MIGRATION
+                    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                     zoomViewRefs[index] = ref
                   }}
                 />

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/FullScreen/__tests__/ImageCarouselFullScreen-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/FullScreen/__tests__/ImageCarouselFullScreen-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import React from "react"
 import { ImageCarouselContext, useNewImageCarouselContext } from "../../ImageCarouselContext"

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarousel.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarousel.tsx
@@ -28,10 +28,9 @@ export const ImageCarousel = (props: ImageCarouselProps) => {
   const screenDimensions = useScreenDimensions()
   const { cardHeight } = props
 
-  // @ts-ignore STRICTNESS_MIGRATION
   const embeddedCardBoundingBox = { width: screenDimensions.width, height: isPad() ? 460 : cardHeight }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const images: ImageDescriptor[] = useMemo(() => {
     let result = props.images
       .map((image) => {
@@ -39,13 +38,13 @@ export const ImageCarousel = (props: ImageCarouselProps) => {
           // something is very wrong
           return null
         }
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         const { width, height } = fitInside(embeddedCardBoundingBox, image)
         return {
           width,
           height,
           url: createGeminiUrl({
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             imageURL: image.url.replace(":version", getBestImageVersionForThumbnail(image.imageVersions)),
             // upscale to match screen resolution
             width: width * PixelRatio.get(),
@@ -56,9 +55,9 @@ export const ImageCarousel = (props: ImageCarouselProps) => {
       })
       .filter(Boolean)
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     if (result.some((image) => !image.deepZoom)) {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const filteredResult = result.filter((image) => image.deepZoom)
       if (filteredResult.length === 0) {
         result = [result[0]]
@@ -95,12 +94,9 @@ function PaginationDots() {
     <>
       <Spacer mb={2} />
       <Flex flexDirection="row" justifyContent="center">
-        {images.map(
-          // @ts-ignore STRICTNESS_MIGRATION
-          (_, index) => (
-            <PaginationDot key={index} diameter={5} index={index} />
-          )
-        )}
+        {images.map((_, index) => (
+          <PaginationDot key={index} diameter={5} index={index} />
+        ))}
       </Flex>
     </>
   )

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarouselContext.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarouselContext.tsx
@@ -54,7 +54,7 @@ export function useNewImageCarouselContext({ images }: { images: ImageDescriptor
   const [isZoomedCompletelyOut, setIsZoomedCompletelyOut] = useGlobalState(true)
   const tracking = useTracking()
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   return useMemo(
     () => ({
       imageIndex,
@@ -77,7 +77,7 @@ export function useNewImageCarouselContext({ images }: { images: ImageDescriptor
               setImageIndex(action.nextImageIndex)
               setIsZoomedCompletelyOut(true)
               if (fullScreenState.current !== "none") {
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 embeddedFlatListRef.current.scrollToIndex({ index: action.nextImageIndex, animated: false })
               }
             }

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarouselEmbedded.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarouselEmbedded.tsx
@@ -15,7 +15,6 @@ interface ImageCarouselEmbeddedProps {
 export const ImageCarouselEmbedded: React.FC<ImageCarouselEmbeddedProps> = ({ cardHeight }) => {
   const screenDimensions = useScreenDimensions()
 
-  // @ts-ignore STRICTNESS_MIGRATION
   const embeddedCardBoundingBox = { width: screenDimensions.width, height: isPad() ? 460 : cardHeight }
 
   const {
@@ -26,7 +25,7 @@ export const ImageCarouselEmbedded: React.FC<ImageCarouselEmbeddedProps> = ({ ca
     imageIndex,
   } = useContext(ImageCarouselContext)
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const measurements = getMeasurements({ images, boundingBox: embeddedCardBoundingBox })
   const offsets = measurements.map((m) => m.cumulativeScrollOffset)
 
@@ -94,7 +93,6 @@ export const ImageCarouselEmbedded: React.FC<ImageCarouselEmbeddedProps> = ({ ca
   return (
     <FlatList<ImageDescriptor>
       // force full re-render on orientation change
-      // @ts-ignore STRICTNESS_MIGRATION
       key={screenDimensions.orientation}
       data={images}
       horizontal
@@ -103,7 +101,7 @@ export const ImageCarouselEmbedded: React.FC<ImageCarouselEmbeddedProps> = ({ ca
       scrollEnabled={images.length > 1}
       getItemLayout={(_, index) => ({ index, offset: offsets[index], length: embeddedCardBoundingBox.width })}
       snapToOffsets={offsets}
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       keyExtractor={(item) => item.url}
       decelerationRate="fast"
       onScroll={onScroll}
@@ -114,7 +112,7 @@ export const ImageCarouselEmbedded: React.FC<ImageCarouselEmbeddedProps> = ({ ca
         const { cumulativeScrollOffset, ...styles } = measurements[index]
         return (
           <ImageWithLoadingState
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             imageURL={item.url}
             width={styles.width}
             height={styles.height}

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/__tests__/ImageCarousel-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/__tests__/ImageCarousel-tests.tsx
@@ -83,7 +83,7 @@ describe("ImageCarouselFragmentContainer", () => {
       }, // Enable/fix this when making large change to these components/fixtures: as ImageCarouselTestsQueryRawResponse,
     })
   }
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const getDotOpacity = (dot) => dot.find(Animated.View).props().style.opacity._value
   describe("with five images", () => {
     beforeEach(() => {
@@ -117,7 +117,7 @@ describe("ImageCarouselFragmentContainer", () => {
     it("'selects' subsequent pagination dots as a result of scrolling", async () => {
       const wrapper = await getWrapper()
 
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const measurements = getMeasurements({ images: artworkFixture.images, boundingBox: { width: 375, height: 275 } })
 
       wrapper
@@ -154,11 +154,11 @@ describe("ImageCarouselFragmentContainer", () => {
       const wrapper = await getWrapper({
         ...artworkFixture,
         // delete two of the images' deepZoom
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         images: [
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           ...artworkFixture.images.slice(0, 2).map((image) => ({ ...image, deepZoom: null })),
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           ...artworkFixture.images.slice(2),
         ],
       })
@@ -169,7 +169,7 @@ describe("ImageCarouselFragmentContainer", () => {
     it(`only shows one image when none of the images have deep zoom`, async () => {
       const wrapper = await getWrapper({
         ...artworkFixture,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         images: artworkFixture.images.map((image) => ({ ...image, deepZoom: null })),
       })
 
@@ -179,7 +179,7 @@ describe("ImageCarouselFragmentContainer", () => {
   })
 
   describe("with one image", () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const artwork = { ...artworkFixture, images: [artworkFixture.images[0]] }
     it("shows no pagination dots", async () => {
       const wrapper = await getWrapper(artwork)

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/__tests__/ImageCarouselContext-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/__tests__/ImageCarouselContext-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import React from "react"
 import { useTracking } from "react-tracking"
@@ -51,7 +51,7 @@ describe("image carousel context", () => {
     mount(<Mock />)
   })
   afterEach(() => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     context = null
   })
   it("sets up the context properly", () => {
@@ -110,11 +110,11 @@ describe("image carousel context", () => {
     expect(context.fullScreenState.current).toBe("entered")
 
     context.dispatch({ type: "IMAGE_INDEX_CHANGED", nextImageIndex: 1 })
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(context.embeddedFlatListRef.current.scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 1 })
 
     context.dispatch({ type: "IMAGE_INDEX_CHANGED", nextImageIndex: 0 })
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(context.embeddedFlatListRef.current.scrollToIndex).toHaveBeenCalledWith({ animated: false, index: 0 })
   })
 

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/__tests__/ImageCarouselEmbedded-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/__tests__/ImageCarouselEmbedded-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import React from "react"

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/__tests__/ImageWithLoadingState-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/__tests__/ImageWithLoadingState-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import React from "react"

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/__tests__/useAnimatedValue-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/__tests__/useAnimatedValue-tests.tsx
@@ -1,11 +1,11 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import React, { useState } from "react"
 import { Animated, View } from "react-native"
 import { useAnimatedValue } from "../useAnimatedValue"
 
 describe(useAnimatedValue, () => {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   let val = null
 
   function Mock() {
@@ -15,12 +15,12 @@ describe(useAnimatedValue, () => {
   }
   it("returns a stable animated value", () => {
     const wrapper = mount(<Mock />)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const prevVal = val
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(val).toBeInstanceOf(Animated.Value)
     wrapper.find(View).props().onMagicTap()
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(prevVal).toBe(val)
   })
 })

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/__tests__/useSpringValue-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/__tests__/useSpringValue-tests.tsx
@@ -1,11 +1,11 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import React, { useState } from "react"
 import { View } from "react-native"
 import { useSpringValue } from "../useSpringValue"
 
 describe(useSpringValue, () => {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   let val = null
 
   function Mock() {
@@ -18,15 +18,15 @@ describe(useSpringValue, () => {
   })
   it("returns a stable animated value", () => {
     const wrapper = mount(<Mock />)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const prevVal = val
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(val._value).toBe(0)
     wrapper.find(View).props().onMagicTap()
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(prevVal).toBe(val)
     jest.runTimersToTime(500)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(val._value).toBe(1)
   })
 })

--- a/src/lib/Scenes/Artwork/Components/OtherWorks/ContextGridCTA.tsx
+++ b/src/lib/Scenes/Artwork/Components/OtherWorks/ContextGridCTA.tsx
@@ -20,7 +20,7 @@ export class ContextGridCTA extends React.Component<ContextGridCTAProps> {
   }))
   openLink() {
     const { href } = this.props
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     SwitchBoard.presentNavigationViewController(this, href)
   }
 

--- a/src/lib/Scenes/Artwork/Components/OtherWorks/OtherWorks.tsx
+++ b/src/lib/Scenes/Artwork/Components/OtherWorks/OtherWorks.tsx
@@ -25,7 +25,7 @@ export const populatedGrids = (grids: ReadonlyArray<Grid>) => {
 export const OtherWorksFragmentContainer = createFragmentContainer<{ artwork: OtherWorks_artwork }>(
   (props) => {
     const grids = props.artwork.contextGrids
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const gridsToShow = populatedGrids(grids) as ReadonlyArray<OtherWorksGrid>
 
     if (gridsToShow && gridsToShow.length > 0) {

--- a/src/lib/Scenes/Artwork/Components/OtherWorks/__tests__/Header-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/OtherWorks/__tests__/Header-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { shallow } from "enzyme"
 import { Sans } from "palette"
 import React from "react"

--- a/src/lib/Scenes/Artwork/Components/RequestConditionReport.tsx
+++ b/src/lib/Scenes/Artwork/Components/RequestConditionReport.tsx
@@ -55,7 +55,7 @@ export class RequestConditionReport extends React.Component<RequestConditionRepo
           }
         `,
         variables: {
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           input: { saleArtworkID: artwork.saleArtwork.internalID },
         },
       })
@@ -89,7 +89,7 @@ export class RequestConditionReport extends React.Component<RequestConditionRepo
         if (data.requestConditionReport) {
           this.presentSuccessModal()
         } else {
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           this.presentErrorModal(null)
         }
         this.setState({ requestingConditionReport: false })
@@ -162,7 +162,7 @@ export const RequestConditionReportQueryRenderer: React.FC<{
       `}
       render={({ props }) => {
         if (props) {
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           return <RequestConditionReportFragmentContainer artwork={props.artwork} me={props.me} />
         } else {
           return null

--- a/src/lib/Scenes/Artwork/Components/__tests__/AboutArtist-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/AboutArtist-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { shallow } from "enzyme"
 import { ArtworkFixture } from "lib/__fixtures__/ArtworkFixture"
 import { ArtistListItem } from "lib/Components/ArtistListItem"
@@ -8,7 +8,7 @@ import { AboutArtist } from "../AboutArtist"
 
 describe("AboutArtist", () => {
   it("renders about artist correctly for one artist", () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const component = shallow(<AboutArtist artwork={ArtworkFixture} />)
     expect(component.find(Sans).length).toEqual(1)
 
@@ -21,7 +21,7 @@ describe("AboutArtist", () => {
       ...ArtworkFixture,
       artists: ArtworkFixture.artists.concat(ArtworkFixture.artists),
     }
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const component = shallow(<AboutArtist artwork={artworkMultipleArtists} />)
     expect(component.find(Sans).length).toEqual(1)
 

--- a/src/lib/Scenes/Artwork/Components/__tests__/AboutWork-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/AboutWork-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount, shallow } from "enzyme"
 import { ReadMore } from "lib/Components/ReadMore"
 import { Sans, Theme } from "palette"
@@ -17,7 +17,7 @@ describe("AboutWork", () => {
     ;(truncatedTextLimit as jest.Mock).mockReset()
   })
   it("renders the AboutWork correctly if all info is present", () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const component = shallow(<AboutWork artwork={aboutWorkArtwork} />)
     expect(component.find(Sans).length).toEqual(2)
     expect(component.find(Sans).at(0).text()).toMatchInlineSnapshot(`"About the work"`)
@@ -29,7 +29,7 @@ describe("AboutWork", () => {
   it("renders the AboutWork correctly if only additional information is present", () => {
     const artworkNoDescription = { ...aboutWorkArtwork, description: null }
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const component = shallow(<AboutWork artwork={artworkNoDescription} />)
     expect(component.find(Sans).length).toEqual(1)
     expect(component.find(Sans).at(0).text()).toMatchInlineSnapshot(`"About the work"`)
@@ -40,7 +40,7 @@ describe("AboutWork", () => {
   it("renders the AboutWork correctly if only description is present", () => {
     const artworkNoAdditionalInfo = { ...aboutWorkArtwork, additional_information: null }
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const component = shallow(<AboutWork artwork={artworkNoAdditionalInfo} />)
     expect(component.find(Sans).length).toEqual(2)
     expect(component.find(Sans).at(0).text()).toMatchInlineSnapshot(`"About the work"`)
@@ -53,14 +53,14 @@ describe("AboutWork", () => {
   it("renders nothing if no information is present", () => {
     const artworkNoInfo = { ...aboutWorkArtwork, additional_information: null, description: null }
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const component = shallow(<AboutWork artwork={artworkNoInfo} />)
     expect(component.find(Sans).length).toEqual(0)
   })
 
   it("hides 'From Artsy Specialist:' for auction works", () => {
     const artworkInAuction = { ...aboutWorkArtwork, isInAuction: true }
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const component = shallow(<AboutWork artwork={artworkInAuction} />)
     expect(component.find(Sans).length).toEqual(1)
     expect(component.find(Sans).at(0).text()).not.toEqual("From Artsy Specialist:")
@@ -71,7 +71,7 @@ describe("AboutWork", () => {
     const component = mount(
       <Theme>
         <AboutWork
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           artwork={aboutWorkArtwork}
         />
       </Theme>
@@ -86,7 +86,7 @@ describe("AboutWork", () => {
     const component = mount(
       <Theme>
         <AboutWork
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           artwork={aboutWorkArtwork}
         />
       </Theme>

--- a/src/lib/Scenes/Artwork/Components/__tests__/ArtworkActions-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/ArtworkActions-tests.tsx
@@ -1,5 +1,5 @@
 import { ArtworkActionsTestsQueryRawResponse } from "__generated__/ArtworkActionsTestsQuery.graphql"
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { shallow } from "enzyme"
 import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
 import { renderRelayTree } from "lib/tests/renderRelayTree"
@@ -57,7 +57,7 @@ describe("ArtworkActions", () => {
 
   describe("with AR enabled", () => {
     it("renders buttons correctly", () => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const component = shallow(<ArtworkActions artwork={artworkActionsArtwork} />)
       expect(component.find(Sans).length).toEqual(3)
 
@@ -73,7 +73,7 @@ describe("ArtworkActions", () => {
         ...artworkActionsArtwork,
         is_hangable: false,
       }
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const component = shallow(<ArtworkActions artwork={artworkActionsArtworkNotHangable} />)
       expect(component.find(Sans).length).toEqual(2)
 
@@ -91,7 +91,7 @@ describe("ArtworkActions", () => {
         isClosed: false,
       },
     }
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const component = shallow(<ArtworkActions artwork={artworkActionsArtworkInAuction} />)
     expect(component.find(Sans).length).toEqual(3)
 
@@ -103,7 +103,7 @@ describe("ArtworkActions", () => {
   describe("without AR enabled", () => {
     it("does not show the View in Room option if the phone does not have AREnabled", () => {
       NativeModules.ARCocoaConstantsModule.AREnabled = false
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const component = shallow(<ArtworkActions artwork={artworkActionsArtwork} />)
       expect(component.find(Sans).length).toEqual(2)
 
@@ -114,7 +114,7 @@ describe("ArtworkActions", () => {
   })
 
   describe("Saving an artwork", () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const getWrapper = async ({ mockArtworkData, mockSaveResults }) => {
       return await renderRelayTree({
         Component: ArtworkActionsFragmentContainer,

--- a/src/lib/Scenes/Artwork/Components/__tests__/ArtworkDetails-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/ArtworkDetails-tests.tsx
@@ -1,5 +1,5 @@
 import { ArtworkDetails_artwork } from "__generated__/ArtworkDetails_artwork.graphql"
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
 import { Theme } from "palette"
@@ -18,7 +18,7 @@ describe("Artwork Details", () => {
 
   it("renders the data if available", () => {
     const testArtwork: ArtworkDetails_artwork = {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       " $refType": null,
       category: "Oil on canvas",
       conditionDescription: null,
@@ -47,7 +47,7 @@ describe("Artwork Details", () => {
 
   it("hides certificate of authenticity, framed, and signature fields if null", () => {
     const testArtwork: ArtworkDetails_artwork = {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       " $refType": null,
       category: "Oil on canvas",
       conditionDescription: null,
@@ -74,7 +74,7 @@ describe("Artwork Details", () => {
 
   it("shows condition description if present and lot condition report disabled", () => {
     const testArtwork: ArtworkDetails_artwork = {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       " $refType": null,
       category: "Oil on canvas",
       conditionDescription: {
@@ -105,7 +105,7 @@ describe("Artwork Details", () => {
     __globalStoreTestUtils__?.injectEmissionOptions({ AROptionsLotConditionReport: true })
 
     const testArtwork: ArtworkDetails_artwork = {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       " $refType": null,
       category: "Oil on canvas",
       conditionDescription: {
@@ -138,7 +138,7 @@ describe("Artwork Details", () => {
     __globalStoreTestUtils__?.injectEmissionOptions({ AROptionsLotConditionReport: false })
 
     const testArtwork: ArtworkDetails_artwork = {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       " $refType": null,
       category: "Oil on canvas",
       conditionDescription: {

--- a/src/lib/Scenes/Artwork/Components/__tests__/ArtworkHeader-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/ArtworkHeader-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { shallow } from "enzyme"
 import { ArtworkFixture } from "lib/__fixtures__/ArtworkFixture"
 import React from "react"
@@ -9,19 +9,16 @@ import { ImageCarousel } from "../ImageCarousel/ImageCarousel"
 
 describe("ArtworkHeader", () => {
   it("renders tombstone component", () => {
-    // @ts-ignore STRICTNESS_MIGRATION
     const component = shallow(<ArtworkHeader artwork={ArtworkFixture} />)
     expect(component.find(ArtworkTombstone).length).toEqual(1)
   })
 
   it("renders artwork actions component", () => {
-    // @ts-ignore STRICTNESS_MIGRATION
     const component = shallow(<ArtworkHeader artwork={ArtworkFixture} />)
     expect(component.find(ArtworkActions).length).toEqual(1)
   })
 
   it("renders image carousel component", () => {
-    // @ts-ignore STRICTNESS_MIGRATION
     const component = shallow(<ArtworkHeader artwork={ArtworkFixture} />)
     expect(component.find(ImageCarousel).length).toEqual(1)
   })

--- a/src/lib/Scenes/Artwork/Components/__tests__/ArtworkHistory-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/ArtworkHistory-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { Theme } from "palette"
 import React from "react"
@@ -21,7 +21,7 @@ describe("Artwork History", () => {
       <Theme>
         <div>
           <ArtworkHistory
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             artwork={artworkHistoryInfo.artwork}
           />
         </div>
@@ -47,7 +47,7 @@ describe("Artwork History", () => {
       <Theme>
         <div>
           <ArtworkHistory
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             artwork={artworkHistoryInfo.artwork}
           />
         </div>
@@ -72,7 +72,7 @@ describe("Artwork History", () => {
       <Theme>
         <div>
           <ArtworkHistory
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             artwork={artworkHistoryInfo.artwork}
           />
         </div>

--- a/src/lib/Scenes/Artwork/Components/__tests__/ArtworkTombstone-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/ArtworkTombstone-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { ArtworkFixture } from "lib/__fixtures__/ArtworkFixture"
 import { Theme } from "palette"
@@ -133,7 +133,7 @@ describe("ArtworkTombstone", () => {
   // TODO: THESE TESTS SHOULD NOT MUTATE THE FIXTURE!!!
   describe("for an artwork with less than 4 artists but more than 1", () => {
     beforeEach(() => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       artworkTombstoneArtwork.artists = artworkTombstoneArtwork.artists.slice(0, 3)
     })
 
@@ -163,7 +163,7 @@ describe("ArtworkTombstone", () => {
 
   describe("for an artwork with one artist", () => {
     beforeEach(() => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       artworkTombstoneArtwork.artists = artworkTombstoneArtwork.artists.slice(0, 1)
     })
 
@@ -188,9 +188,9 @@ describe("ArtworkTombstone", () => {
 
   describe("for an artwork with no artists but a cultural maker", () => {
     beforeEach(() => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       artworkTombstoneArtwork.artists = []
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       artworkTombstoneArtwork.cultural_maker = "18th century American"
     })
 

--- a/src/lib/Scenes/Artwork/Components/__tests__/AuctionPrice-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/AuctionPrice-tests.tsx
@@ -23,7 +23,7 @@ import { AuctionPriceFragmentContainer as AuctionPrice } from "../AuctionPrice"
 jest.unmock("react-relay")
 
 describe("AuctionPrice", () => {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const getWrapper = async (response, auctionState: AuctionTimerState) => {
     return await renderRelayTree({
       Component: (props: any) => (
@@ -88,7 +88,7 @@ describe("AuctionPrice", () => {
   describe("open auction with no reserve with bids present", () => {
     it("displays proper current bid info including bid count", async () => {
       const wrapper = await getWrapper(OpenAuctionNoReserveWithBids, AuctionTimerState.CLOSING)
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const texts = wrapper.find(Sans).map((x) => x.text())
 
       expect(texts).toContain("Current bid")
@@ -100,7 +100,7 @@ describe("AuctionPrice", () => {
   describe("for open auction with reserve and no bids", () => {
     it("displays proper starting bid info and resserve message", async () => {
       const wrapper = await getWrapper(OpenAuctionReserveNoBids, AuctionTimerState.CLOSING)
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const texts = wrapper.find(Sans).map((x) => x.text())
 
       expect(texts).toContain("Starting bid")
@@ -112,7 +112,7 @@ describe("AuctionPrice", () => {
   describe("for open auction with some bids and reserve not met", () => {
     it("displays current bid message inculding reserve warning", async () => {
       const wrapper = await getWrapper(OpenAuctionReserveNotMetWithBids, AuctionTimerState.CLOSING)
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const texts = wrapper.find(Sans).map((x) => x.text())
 
       expect(texts).toContain("Current bid")
@@ -124,7 +124,7 @@ describe("AuctionPrice", () => {
   describe("for open auction with some bids and satisfied reserve", () => {
     it("displays current bid message inculding reserve met", async () => {
       const wrapper = await getWrapper(OpenAuctionReserveMetWithBids, AuctionTimerState.CLOSING)
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const texts = wrapper.find(Sans).map((x) => x.text())
 
       expect(texts).toContain("Current bid")
@@ -136,7 +136,7 @@ describe("AuctionPrice", () => {
   describe("for open auction with my bid winning", () => {
     it("displays max bid and winning indicator", async () => {
       const wrapper = await getWrapper(OpenAuctionReserveMetWithMyWinningBid, AuctionTimerState.CLOSING)
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const texts = wrapper.find(Sans).map((x) => x.text())
 
       expect(texts).toContain("Your max: $15,000")
@@ -147,7 +147,7 @@ describe("AuctionPrice", () => {
   describe("for open auction with my bid losing", () => {
     it("displays max bid and losing indicator", async () => {
       const wrapper = await getWrapper(OpenAuctionReserveMetWithMyLosingBid, AuctionTimerState.CLOSING)
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const texts = wrapper.find(Sans).map((x) => x.text())
 
       expect(texts).toContain("Your max: $400")
@@ -158,7 +158,7 @@ describe("AuctionPrice", () => {
   describe("for open auction with me increasing my max bid while winning", () => {
     it("displays max bid and winning indicator", async () => {
       const wrapper = await getWrapper(OpenAuctionReserveNotMetIncreasingOwnBid, AuctionTimerState.CLOSING)
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const texts = wrapper.find(Sans).map((x) => x.text())
 
       expect(texts).toContain("Your max: $15,000")

--- a/src/lib/Scenes/Artwork/Components/__tests__/CommercialEditionSetInformation-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/CommercialEditionSetInformation-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { Theme } from "palette"
 import React from "react"

--- a/src/lib/Scenes/Artwork/Components/__tests__/CommercialInformation-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/CommercialInformation-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { ArtworkFixture } from "lib/__fixtures__/ArtworkFixture"
 import { Countdown } from "lib/Components/Bidding/Components/Timer"

--- a/src/lib/Scenes/Artwork/Components/__tests__/CommercialPartnerInformation-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/CommercialPartnerInformation-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { Sans, Theme } from "palette"
 import React from "react"
@@ -9,7 +9,7 @@ describe("CommercialPartnerInformation", () => {
     const component = mount(
       <Theme>
         <CommercialPartnerInformation
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           artwork={CommercialPartnerInformationArtwork}
         />
       </Theme>
@@ -31,7 +31,7 @@ describe("CommercialPartnerInformation", () => {
     const component = mount(
       <Theme>
         <CommercialPartnerInformation
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           artwork={CommercialPartnerInformationArtworkClosedAuction}
         />
       </Theme>
@@ -51,7 +51,7 @@ describe("CommercialPartnerInformation", () => {
     const component = mount(
       <Theme>
         <CommercialPartnerInformation
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           artwork={CommercialPartnerInformationArtworkClosedAuction}
         />
       </Theme>
@@ -70,7 +70,7 @@ describe("CommercialPartnerInformation", () => {
     const component = mount(
       <Theme>
         <CommercialPartnerInformation
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           artwork={CommercialPartnerInformationNoEcommerce}
         />
       </Theme>
@@ -91,7 +91,7 @@ describe("CommercialPartnerInformation", () => {
     const component = mount(
       <Theme>
         <CommercialPartnerInformation
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           artwork={CommercialPartnerInformationArtworkClosedAuction}
         />
       </Theme>

--- a/src/lib/Scenes/Artwork/Components/__tests__/FollowArtistButton-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/FollowArtistButton-tests.tsx
@@ -1,6 +1,6 @@
 import { FollowArtistButtonTestsErrorQueryRawResponse } from "__generated__/FollowArtistButtonTestsErrorQuery.graphql"
 import { FollowArtistButtonTestsQueryRawResponse } from "__generated__/FollowArtistButtonTestsQuery.graphql"
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
 import { renderRelayTree } from "lib/tests/renderRelayTree"
@@ -18,7 +18,7 @@ describe("FollowArtistButton", () => {
       <Theme>
         <FollowArtistButton
           relay={{ environment: {} } as RelayProp}
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           artist={followArtistButtonArtist}
         />
       </Theme>
@@ -29,7 +29,7 @@ describe("FollowArtistButton", () => {
   })
 
   describe("Following an artist", () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const getWrapper = async ({ mockArtistData, mockFollowResults }) => {
       return await renderRelayTree({
         Component: (props: any) => (

--- a/src/lib/Scenes/Artwork/Components/__tests__/OtherWorks-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/OtherWorks-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount, shallow } from "enzyme"
 import { Sans } from "palette"
 import React from "react"
@@ -17,14 +17,14 @@ describe("OtherWorks", () => {
       contextGrids: null,
       " $fragmentRefs": null,
     }
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const component = shallow(<OtherWorks artwork={noGridsArtworkProps} />)
     expect(component.find(Header).length).toEqual(0)
   })
 
   it("renders no grids if an empty array is provided", () => {
     const noGridsArtworkProps = { contextGrids: [], " $fragmentRefs": null }
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const component = shallow(<OtherWorks artwork={noGridsArtworkProps} />)
     expect(component.find(Header).length).toEqual(0)
   })
@@ -49,7 +49,7 @@ describe("OtherWorks", () => {
       ],
       " $fragmentRefs": null,
     }
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const component = mount(<OtherWorks artwork={oneGridArtworkProps} />)
     expect(component.find(Header).length).toEqual(1)
     expect(component.find(Sans).first().text()).toEqual("Other works by Andy Warhol")
@@ -75,7 +75,7 @@ describe("OtherWorks", () => {
       ],
       " $fragmentRefs": null,
     }
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const component = mount(<OtherWorks artwork={oneGridArtworkProps} />)
     expect(component.find(Header).length).toEqual(2)
     expect(component.find(Sans).first().text()).toEqual("Other works by Andy Warhol")
@@ -112,7 +112,7 @@ describe("OtherWorks", () => {
       ],
       " $fragmentRefs": null,
     }
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const component = mount(<OtherWorks artwork={oneGridArtworkProps} />)
     expect(component.find(Header).length).toEqual(1)
     expect(component.find(Sans).first().text()).toEqual("Other works by Andy Warhol")

--- a/src/lib/Scenes/Artwork/Components/__tests__/RequestConditionReport-analytics-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/RequestConditionReport-analytics-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
 import { mockTracking } from "lib/tests/mockTracking"
@@ -15,7 +15,7 @@ import { RequestConditionReport } from "../RequestConditionReport"
 jest.mock("lib/NativeModules/Events", () => ({ postEvent: jest.fn() }))
 
 const artwork: RequestConditionReport_artwork = {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   " $refType": null,
   internalID: "some-internal-id",
   slug: "pablo-picasso-guernica",
@@ -24,7 +24,7 @@ const artwork: RequestConditionReport_artwork = {
   },
 }
 const me: RequestConditionReport_me = {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   " $refType": null,
   email: "someemail@testerino.net",
   internalID: "some-id",
@@ -34,7 +34,7 @@ beforeEach(jest.resetAllMocks)
 
 it("tracks request condition report tapped", () => {
   const RequestConditionReportTracking = mockTracking(() => (
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     <RequestConditionReport artwork={artwork} me={me} relay={null} />
   ))
   const requestConditionReportComponent = mount(<RequestConditionReportTracking />)
@@ -50,7 +50,7 @@ it("tracks request condition report tapped", () => {
 
 it("tracks request condition report success", async () => {
   const RequestConditionReportTracking = mockTracking(() => (
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     <RequestConditionReport artwork={artwork} me={me} relay={null} />
   ))
   const trackingComponent = mount(<RequestConditionReportTracking />)
@@ -74,7 +74,7 @@ it("tracks request condition report success", async () => {
 
 it("tracks request condition report failure", async () => {
   const RequestConditionReportTracking = mockTracking(() => (
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     <RequestConditionReport artwork={artwork} me={me} relay={null} />
   ))
   const trackingComponent = mount(<RequestConditionReportTracking />)

--- a/src/lib/Scenes/Artwork/Components/__tests__/RequestConditionReport-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/RequestConditionReport-tests.tsx
@@ -1,6 +1,6 @@
 import { RequestConditionReport_artwork } from "__generated__/RequestConditionReport_artwork.graphql"
 import { RequestConditionReport_me } from "__generated__/RequestConditionReport_me.graphql"
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { Modal } from "lib/Components/Modal"
 import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
@@ -9,7 +9,7 @@ import React from "react"
 import { RequestConditionReport } from "../RequestConditionReport"
 
 const artwork: RequestConditionReport_artwork = {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   " $refType": null,
   internalID: "some-internal-id",
   slug: "pablo-picasso-guernica",
@@ -18,7 +18,7 @@ const artwork: RequestConditionReport_artwork = {
   },
 }
 const me: RequestConditionReport_me = {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   " $refType": null,
   email: "someemail@testerino.net",
   internalID: "some-id",
@@ -26,7 +26,7 @@ const me: RequestConditionReport_me = {
 
 describe("RequestConditionReport", () => {
   it("renders correctly", () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const component = mount(<RequestConditionReport artwork={artwork} me={me} relay={null} />)
     const requestReportButton = component.find(Button).at(0)
     expect(requestReportButton.length).toEqual(1)
@@ -44,7 +44,7 @@ describe("RequestConditionReport", () => {
   })
 
   it("shows an error modal on failure", async () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const component = mount(<RequestConditionReport artwork={artwork} me={me} relay={null} />)
     component.instance().requestConditionReport = jest
       .fn()
@@ -64,7 +64,7 @@ describe("RequestConditionReport", () => {
   })
 
   it("shows a success modal on success", async () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const component = mount(<RequestConditionReport artwork={artwork} me={me} relay={null} />)
     component.instance().requestConditionReport = jest
       .fn()

--- a/src/lib/Scenes/ArtworkAttributionClassFAQ/__tests__/ArtworkAttributionClassFAQ-tests.tsx
+++ b/src/lib/Scenes/ArtworkAttributionClassFAQ/__tests__/ArtworkAttributionClassFAQ-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { Button, Sans } from "palette"
 import React from "react"
@@ -16,7 +16,7 @@ describe("ArtworkAttributionClassFAQ", () => {
     const component = mount(
       <ArtworkAttributionClassFAQ
         safeAreaInsets={{ top: 20, left: 0, right: 0, bottom: 0 }}
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         artworkAttributionClasses={attributionClasses}
       />
     )
@@ -27,7 +27,7 @@ describe("ArtworkAttributionClassFAQ", () => {
     const component = mount(
       <ArtworkAttributionClassFAQ
         safeAreaInsets={{ top: 20, left: 0, right: 0, bottom: 0 }}
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         artworkAttributionClasses={attributionClasses}
       />
     )
@@ -38,7 +38,7 @@ describe("ArtworkAttributionClassFAQ", () => {
     const component = mount(
       <ArtworkAttributionClassFAQ
         safeAreaInsets={{ top: 20, left: 0, right: 0, bottom: 0 }}
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         artworkAttributionClasses={attributionClasses}
       />
     )
@@ -51,7 +51,7 @@ describe("ArtworkAttributionClassFAQ", () => {
     const component = mount(
       <ArtworkAttributionClassFAQ
         safeAreaInsets={{ top: 20, left: 0, right: 0, bottom: 0 }}
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         artworkAttributionClasses={attributionClasses}
       />
     )

--- a/src/lib/Scenes/City/City.tsx
+++ b/src/lib/Scenes/City/City.tsx
@@ -4,7 +4,7 @@ import { Schema, screenTrack, track } from "lib/utils/track"
 import { Box, Button, color, Flex, Sans, Theme } from "palette"
 import React, { Component } from "react"
 import { NativeModules, View } from "react-native"
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import ScrollableTabView from "react-native-scrollable-tab-view"
 import { RelayProp } from "react-relay"
 import styled from "styled-components/native"
@@ -41,7 +41,7 @@ const AllCityMetaTab = 0
   context_screen_owner_id: props.citySlug,
 }))
 export class CityView extends Component<Props, State> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   state = {
     buckets: null,
     filter: cityTabs[0],
@@ -102,7 +102,7 @@ export class CityView extends Component<Props, State> {
     EventEmitter.unsubscribe("map:error", this.handleError)
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   setSelectedTab(selectedTab) {
     EventEmitter.dispatch("filters:change", selectedTab.i)
     NativeModules.ARNotificationsManager.postNotificationName("ARLocalDiscoveryCityGotScrollView", {})
@@ -136,19 +136,19 @@ export class CityView extends Component<Props, State> {
       action_type: Schema.ActionTypes.Tap,
     } as any
   })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   trackTab(_filter) {
     return null
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   componentDidUpdate(_, prevState) {
     if (prevState.filter.id !== this.state.filter.id) {
       this.trackTab(this.state.filter.id)
     }
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   renderTabBar(props) {
     return (
       <View>
@@ -158,11 +158,11 @@ export class CityView extends Component<Props, State> {
   }
 
   // TODO: Is it correct that we have these two similar ones?
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   onScrollableTabViewLayout = (layout) => {
     this.scrollViewVerticalStart = layout.nativeEvent.layout.y
   }
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   onScrollViewLayout = (layout) => {
     this.scrollViewVerticalStart = layout.nativeEvent.layout.y
     NativeModules.ARNotificationsManager.postNotificationName("ARLocalDiscoveryCityGotScrollView", {})
@@ -181,7 +181,7 @@ export class CityView extends Component<Props, State> {
             <Handle />
           </Flex>
           {relayErrorState ? (
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             <ErrorScreen relayErrorState={relayErrorState} key="error" />
           ) : (
             <ScrollableTabView
@@ -214,12 +214,12 @@ export class CityView extends Component<Props, State> {
                     <ScrollableTab tabLabel={tab.text} key={tab.id}>
                       <EventList
                         key={cityName + tab.id}
-                        // @ts-ignore STRICTNESS_MIGRATION
+                        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                         bucket={buckets[tab.id]}
                         type={tab.id}
                         cityName={cityName}
                         citySlug={citySlug}
-                        // @ts-ignore STRICTNESS_MIGRATION
+                        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                         relay={this.state.relay}
                         renderedInTab
                       />

--- a/src/lib/Scenes/City/CityBMWList.tsx
+++ b/src/lib/Scenes/City/CityBMWList.tsx
@@ -20,7 +20,7 @@ interface State {
   fetchingNextPage: boolean
 }
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 @screenTrack((props: Props) => ({
   context_screen: Schema.PageNames.CityGuideBMWList,
   context_screen_owner_type: Schema.OwnerEntityTypes.CityGuide,
@@ -53,7 +53,7 @@ class CityBMWList extends React.Component<Props, State> {
     const {
       city: {
         name,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         sponsoredContent: { shows },
       },
       relay,

--- a/src/lib/Scenes/City/CityFairList.tsx
+++ b/src/lib/Scenes/City/CityFairList.tsx
@@ -48,7 +48,7 @@ class CityFairList extends React.Component<Props, State> {
     })
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   renderItem = (item) => {
     return (
       <Box py={2}>
@@ -61,7 +61,7 @@ class CityFairList extends React.Component<Props, State> {
   render() {
     const {
       city: {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         fairs: { edges },
       },
     } = this.props
@@ -79,11 +79,10 @@ class CityFairList extends React.Component<Props, State> {
             }}
             data={edges}
             ItemSeparatorComponent={() => <Separator />}
-            // @ts-ignore STRICTNESS_MIGRATION
             keyExtractor={(item) => item.node.internalID}
             renderItem={({ item }) => this.renderItem(item)}
             onScroll={isCloseToBottom(this.fetchData)}
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             ListFooterComponent={!!fetchingNextPage && <Spinner style={{ marginTop: 20, marginBottom: 20 }} />}
           />
         </Box>

--- a/src/lib/Scenes/City/CitySectionList.tsx
+++ b/src/lib/Scenes/City/CitySectionList.tsx
@@ -29,7 +29,7 @@ interface State {
   fetchingNextPage: boolean
 }
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 @screenTrack((props: Props) => {
   let contextScreen
   switch (props.section) {

--- a/src/lib/Scenes/City/Components/AllEvents.tsx
+++ b/src/lib/Scenes/City/Components/AllEvents.tsx
@@ -41,7 +41,7 @@ export class AllEvents extends React.Component<Props, State> {
     this.updateSections(this.props)
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   UNSAFE_componentWillReceiveProps(nextProps) {
     const shouldUpdate = this.shouldUpdate(nextProps)
 
@@ -66,9 +66,9 @@ export class AllEvents extends React.Component<Props, State> {
     showsUpdated = ["saved", "closing", "museums", "opening", "closing"]
       .map((key) => {
         return !isEqual(
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           this.props.buckets[key].map((g) => g.is_followed),
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           otherProps.buckets[key].map((g) => g.is_followed)
         )
       })
@@ -77,7 +77,7 @@ export class AllEvents extends React.Component<Props, State> {
     return bmwUpdated || showsUpdated
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   updateSections = (props) => {
     const { buckets, cityName, sponsoredContent } = props
     const sections = []
@@ -89,7 +89,6 @@ export class AllEvents extends React.Component<Props, State> {
 
     if (buckets.saved) {
       sections.push({
-        // @ts-ignore STRICTNESS_MIGRATION
         type: "saved",
         data: buckets.saved,
       })
@@ -139,7 +138,7 @@ export class AllEvents extends React.Component<Props, State> {
     this.setState({ sections })
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   renderItemSeparator = ({ leadingItem }) => {
     if (["fairs", "saved", "header"].indexOf(leadingItem.type) === -1) {
       return (
@@ -227,7 +226,7 @@ export class AllEvents extends React.Component<Props, State> {
         <FlatList
           data={sections}
           ItemSeparatorComponent={this.renderItemSeparator}
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           keyExtractor={(item) => item.type}
           renderItem={(item) => this.renderItem(item)}
           ListFooterComponent={() => <Spacer m={3} />}

--- a/src/lib/Scenes/City/Components/BMWEventSection/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/City/Components/BMWEventSection/__tests__/index-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { Theme } from "palette"
 import React from "react"

--- a/src/lib/Scenes/City/Components/BMWEventSection/index.tsx
+++ b/src/lib/Scenes/City/Components/BMWEventSection/index.tsx
@@ -50,7 +50,7 @@ export class BMWEventSection extends React.Component<Props> {
       owner_type: citySlug,
     } as any
   })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   getArtGuidePressed(artGuideUrl, _citySlug) {
     SwitchBoard.presentNavigationViewController(this, artGuideUrl)
   }

--- a/src/lib/Scenes/City/Components/Event/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/City/Components/Event/__tests__/index-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { Show } from "lib/Scenes/Map/types"
 import { Theme } from "palette"

--- a/src/lib/Scenes/City/Components/Event/index.tsx
+++ b/src/lib/Scenes/City/Components/Event/index.tsx
@@ -24,7 +24,7 @@ interface State {
   isFollowedSaving: boolean
 }
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const track: Track<Props, {}> = _track
 
 @track()
@@ -95,7 +95,7 @@ export class Event extends React.Component<Props, State> {
               },
             },
             updater: (store) => {
-              // @ts-ignore STRICTNESS_MIGRATION
+              // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
               store.get(nodeID).setValue(!isShowFollowed, "is_followed")
             },
           })
@@ -116,7 +116,7 @@ export class Event extends React.Component<Props, State> {
       owner_slug: slug,
     } as any
   })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   trackShowTap(_actionName, _slug, _internalID) {
     return null
   }

--- a/src/lib/Scenes/City/Components/EventList.tsx
+++ b/src/lib/Scenes/City/Components/EventList.tsx
@@ -36,7 +36,7 @@ interface Props {
 
 // @TODO: Implement test for the EventList component https://artsyproduct.atlassian.net/browse/LD-562
 export class EventList extends React.Component<Props> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   renderItem = (item) => {
     const { type } = this.props
     return (

--- a/src/lib/Scenes/City/Components/EventSection/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/City/Components/EventSection/__tests__/index-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { Theme } from "palette"
 import React from "react"

--- a/src/lib/Scenes/City/Components/EventSection/index.tsx
+++ b/src/lib/Scenes/City/Components/EventSection/index.tsx
@@ -22,12 +22,12 @@ export class EventSection extends React.Component<Props> {
   renderEvents = () => {
     const { data } = this.props
     let finalShowsForPreviewBricks
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const eligibleForBrick = data.filter((s) => !s.isStubShow && !!s.cover_image && !!s.cover_image.url)
     finalShowsForPreviewBricks = eligibleForBrick.slice(0, 2)
 
     if (!!finalShowsForPreviewBricks) {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       return finalShowsForPreviewBricks.map((event) => {
         return (
           <Box key={event.id}>

--- a/src/lib/Scenes/City/Components/FairEventSection/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/City/Components/FairEventSection/__tests__/index-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { Theme } from "palette"
 import React from "react"

--- a/src/lib/Scenes/City/Components/FairEventSection/index.tsx
+++ b/src/lib/Scenes/City/Components/FairEventSection/index.tsx
@@ -24,7 +24,7 @@ export class FairEventSection extends Component<Props> {
     SwitchBoard.presentNavigationViewController(this, `/city-fair/${citySlug}`)
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   renderItem = ({ item }) => {
     const fair = item
     return (

--- a/src/lib/Scenes/City/Components/TabFairItemRow/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/City/Components/TabFairItemRow/__tests__/index-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { Fair } from "lib/Scenes/Map/types"
 import { Theme } from "palette"

--- a/src/lib/Scenes/City/cityTabs.ts
+++ b/src/lib/Scenes/City/cityTabs.ts
@@ -4,15 +4,15 @@ export const cityTabs: MapTab[] = [
   {
     id: "all",
     text: "All",
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     getShows: (bucket) => (bucket!.museums ? bucket.museums.concat(bucket.galleries) : bucket.galleries),
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     getFairs: (bucket) => bucket.fairs,
   },
   {
     id: "saved",
     text: "Saved",
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     getShows: (bucket) => bucket.saved,
     getFairs: (_) => [],
   },
@@ -20,20 +20,20 @@ export const cityTabs: MapTab[] = [
     id: "fairs",
     text: "Fairs",
     getShows: (_) => [],
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     getFairs: (bucket) => bucket.fairs,
   },
   {
     id: "galleries",
     text: "Galleries",
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     getShows: (bucket) => bucket.galleries,
     getFairs: (_) => [],
   },
   {
     id: "museums",
     text: "Museums",
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     getShows: (bucket) => bucket.museums,
     getFairs: (_) => [],
   },

--- a/src/lib/Scenes/Collection/Components/CollectionHubsRails/ArtistSeries/__tests__/CollectionArtistSeriesRail-tests.tsx
+++ b/src/lib/Scenes/Collection/Components/CollectionHubsRails/ArtistSeries/__tests__/CollectionArtistSeriesRail-tests.tsx
@@ -7,7 +7,7 @@ import {
   CollectionArtistSeriesRailTestsQuery,
   CollectionArtistSeriesRailTestsQueryRawResponse,
 } from "__generated__/CollectionArtistSeriesRailTestsQuery.graphql"
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import {
   GenericArtistSeriesMeta,

--- a/src/lib/Scenes/Collection/Components/FeaturedArtists.tsx
+++ b/src/lib/Scenes/Collection/Components/FeaturedArtists.tsx
@@ -15,7 +15,7 @@ interface FeaturedArtistsProps {
   tracking?: TrackingProp
 }
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const track: Track<FeaturedArtistsProps, {}> = _track
 
 @track()
@@ -25,10 +25,10 @@ export class FeaturedArtists extends React.Component<FeaturedArtistsProps, {}> {
   }
 
   getFeaturedArtistEntityCollection = (
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     artists: FeaturedArtists_collection["artworksConnection"]["merchandisableArtists"]
   ) => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     return artists.map((artist) => {
       return (
         <Box width="100%" key={artist.internalID} pb={20}>
@@ -44,12 +44,12 @@ export class FeaturedArtists extends React.Component<FeaturedArtistsProps, {}> {
     const artistIDs = this.props.collection?.query?.artistIDs || []
 
     if (artistIDs.length > 0) {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       return allArtists.filter((artist) => artistIDs.includes(artist.internalID))
     }
 
     if (featuredArtistExclusionIds.length > 0) {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       return allArtists.filter((artist) => !featuredArtistExclusionIds.includes(artist.internalID))
     }
     return allArtists
@@ -76,7 +76,7 @@ export class FeaturedArtists extends React.Component<FeaturedArtistsProps, {}> {
             <TouchableOpacity
               onPress={() => {
                 SwitchBoard.presentNavigationViewController(this, `/collection/${this.props.collection.slug}/artists`)
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 tracking.trackEvent({
                   action_type: Schema.ActionTypes.Tap,
                   action_name: Schema.ActionNames.ViewMore,

--- a/src/lib/Scenes/Collection/Components/FullFeaturedArtistList.tsx
+++ b/src/lib/Scenes/Collection/Components/FullFeaturedArtistList.tsx
@@ -22,14 +22,14 @@ export class FullFeaturedArtistList extends React.Component<Props> {
     // When a collection contains artistsIDs we want to only display those artists as featured
     // instead of all the artists in the collection.
     if (artistIDs.length > 0) {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       return allArtists.filter((artist) => artistIDs.includes(artist?.internalID))
     }
 
     // Some artist even though they are within the collection shouldn't be displayed as featured artists
     // https://artsyproduct.atlassian.net/browse/FX-1595
     if (featuredArtistExclusionIds.length > 0) {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       return allArtists.filter((artist) => !featuredArtistExclusionIds.includes(artist.internalID))
     }
     return allArtists
@@ -46,10 +46,10 @@ export class FullFeaturedArtistList extends React.Component<Props> {
           keyExtractor={(_item, index) => String(index)}
           renderItem={({ item }) => {
             return (
-              // @ts-ignore STRICTNESS_MIGRATION
+              // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
               <Box width="100%" key={item.internalID} pb={20}>
                 <ArtistListItem
-                  // @ts-ignore STRICTNESS_MIGRATION
+                  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                   artist={item}
                 />
               </Box>

--- a/src/lib/Scenes/Collection/Components/__tests__/FullFeaturedArtistList-tests.tsx
+++ b/src/lib/Scenes/Collection/Components/__tests__/FullFeaturedArtistList-tests.tsx
@@ -47,7 +47,7 @@ describe("FullFeaturedArtistList", () => {
   })
 
   it("does not render an EntityHeader for excluded artists", async () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const tree = await render({
       ...FullFeaturedArtistListCollectionFixture,
       featuredArtistExclusionIds: ["34534-andy-warhols-id", "2342-pablo-picassos-id"],
@@ -66,7 +66,7 @@ describe("FullFeaturedArtistList", () => {
 
   describe("when artist ids are explicitly requested", () => {
     it("does not render an EntityHeader for any non-requested artists", async () => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const tree = await render({
         ...FullFeaturedArtistListCollectionFixture,
         query: { id: "some-id", artistIDs: ["34534-andy-warhols-id"] },

--- a/src/lib/Scenes/Collection/Screens/CollectionHeader.tsx
+++ b/src/lib/Scenes/Collection/Screens/CollectionHeader.tsx
@@ -15,7 +15,7 @@ const HEADER_IMAGE_HEIGHT = 204
 
 export const CollectionHeader: React.FC<CollectionHeaderProps> = (props) => {
   const { title, image, headerImage, descriptionMarkdown: collectionDescription } = props.collection
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const defaultHeaderUrl = image?.edges[0]?.node?.image?.url || ""
   const url = headerImage ? headerImage : defaultHeaderUrl
   const { width: screenWidth } = Dimensions.get("window")

--- a/src/lib/Scenes/Collection/Screens/__tests__/CollectionHeader-tests.tsx
+++ b/src/lib/Scenes/Collection/Screens/__tests__/CollectionHeader-tests.tsx
@@ -1,5 +1,5 @@
 import { CollectionHeaderTestsQueryRawResponse } from "__generated__/CollectionHeaderTestsQuery.graphql"
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { ReadMore } from "lib/Components/ReadMore"
@@ -31,7 +31,6 @@ it("renders without throwing an error", async () => {
 })
 
 describe("collection header", () => {
-  // @ts-ignore STRICTNESS_MIGRATION
   let props: any
   beforeEach(() => {
     props = {

--- a/src/lib/Scenes/Collection/__tests__/Collection-tests.tsx
+++ b/src/lib/Scenes/Collection/__tests__/Collection-tests.tsx
@@ -24,7 +24,7 @@ describe("Collection", () => {
       variables={{ hello: true }}
       render={({ props, error }) => {
         if (props) {
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           return <CollectionContainer collection={props.marketingCollection} />
         } else if (error) {
           console.log(error)

--- a/src/lib/Scenes/Consignments/Components/ArtworkConsignmentTodo.tsx
+++ b/src/lib/Scenes/Consignments/Components/ArtworkConsignmentTodo.tsx
@@ -99,7 +99,7 @@ const render = (props: TODOProps, canSubmitMetadata: boolean) => (
 )
 
 export default class ConsignmentTODO extends React.Component<TODOProps> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   canSubmitMetadata = (props) =>
     props.metadata &&
     props.metadata.category &&

--- a/src/lib/Scenes/Consignments/Components/ImageSelection.tsx
+++ b/src/lib/Scenes/Consignments/Components/ImageSelection.tsx
@@ -124,7 +124,7 @@ const TakePhotoID = "take_photo"
 const BlankImageID = "blank"
 
 export default class ImageSelection extends React.Component<Props, State> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   constructor(props) {
     super(props)
 
@@ -165,11 +165,11 @@ export default class ImageSelection extends React.Component<Props, State> {
             return item.image.uri
           }
         }}
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         renderItem={({ item }) => {
           if (typeof item === "string") {
             if (item === TakePhotoID) {
-              // @ts-ignore STRICTNESS_MIGRATION
+              // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
               return <TakePhotoImage onPressNewPhoto={this.props.onPressNewPhoto} />
             } else if (item === BlankImageID) {
               return <EmptyView />

--- a/src/lib/Scenes/Consignments/Components/SearchResults.tsx
+++ b/src/lib/Scenes/Consignments/Components/SearchResults.tsx
@@ -19,7 +19,7 @@ export interface SearchQueryProps<T> extends TextInputProps {
   resultSelected?: (result: T) => void
 }
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const noResults = (props) => {
   if (!props.query || props.searching) {
     return null
@@ -32,14 +32,14 @@ const noResults = (props) => {
 }
 
 function render<T>(props: SearchQueryProps<T>) {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const rowForResult = (result) => {
     const resultID = !!result.internalID ? result.internalID : result.id
     return (
       <Box key={resultID}>
         <TouchableOpacity
           onPress={
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             () => props.resultSelected(result)
           }
         >
@@ -84,7 +84,7 @@ function render<T>(props: SearchQueryProps<T>) {
       />
       <ScrollView
         style={{ height: 182, paddingTop: 16 }}
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         scrollEnabled={props.results && !!props.results.length}
         keyboardShouldPersistTaps="always"
       >

--- a/src/lib/Scenes/Consignments/Components/TextArea.tsx
+++ b/src/lib/Scenes/Consignments/Components/TextArea.tsx
@@ -35,7 +35,7 @@ const Input = styled.TextInput`
 `
 
 export default class TextArea extends React.Component<TextAreaProps, State> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   constructor(props) {
     super(props)
     this.state = {
@@ -43,9 +43,9 @@ export default class TextArea extends React.Component<TextAreaProps, State> {
     }
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   onChangeText = (text) => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.props.text.onChangeText(text)
     this.setState({ text })
   }
@@ -53,9 +53,9 @@ export default class TextArea extends React.Component<TextAreaProps, State> {
   render() {
     const displayPlaceholder = this.state.text.length === 0
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const placeholderText = this.props.text.placeholder
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     delete this.props.text.placeholder
 
     return (

--- a/src/lib/Scenes/Consignments/Components/__tests__/FormElements-tests.tsx
+++ b/src/lib/Scenes/Consignments/Components/__tests__/FormElements-tests.tsx
@@ -14,10 +14,10 @@ describe("Row", () => {
         }}
       />
     ).toJSON()
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(tree.props.renderToHardwareTextureAndroid).toBeTruthy()
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const styles = Object.keys(tree.props.style[0])
     expect(styles).toContain("scaleX")
   })

--- a/src/lib/Scenes/Consignments/Screens/Confirmation.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Confirmation.tsx
@@ -52,7 +52,7 @@ export default class Confirmation extends React.Component<Props, State> {
   }
 
   checkForSubmissionStatus = () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const success = this.props.submissionRequestValidationCheck()
     if (success === undefined) {
       setTimeout(this.checkForSubmissionStatus, 1000)

--- a/src/lib/Scenes/Consignments/Screens/ConsignmentsArtist.tsx
+++ b/src/lib/Scenes/Consignments/Screens/ConsignmentsArtist.tsx
@@ -38,7 +38,7 @@ export default class Artist extends React.Component<Props, State> {
   }
 
   artistSelected = (result: ArtistResult) => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.props.updateWithArtist(result)
     this.props.navigator.pop()
   }
@@ -93,7 +93,7 @@ export default class Artist extends React.Component<Props, State> {
           >
             <SearchResults<ArtistResult>
               results={this.state.results}
-              // @ts-ignore STRICTNESS_MIGRATION
+              // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
               query={this.state.query}
               placeholder="Artist/Designer Name"
               noResultsMessage="Unfortunately we are not accepting consignments for works by"

--- a/src/lib/Scenes/Consignments/Screens/Edition.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Edition.tsx
@@ -27,7 +27,7 @@ export default class Edition extends React.Component<Props, ConsignmentSetup> {
   }
 
   updateAndCloseScreen = () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.props.updateWithEdition(this.state)
     this.props.navigator.pop()
   }
@@ -39,7 +39,7 @@ export default class Edition extends React.Component<Props, ConsignmentSetup> {
     animate()
 
     this.setState({
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       editionInfo: this.state.editionInfo ? null : {},
     })
   }
@@ -47,9 +47,9 @@ export default class Edition extends React.Component<Props, ConsignmentSetup> {
   updateSigned = () => this.setState({ signed: !this.state.signed })
   updateCert = () => this.setState({ certificateOfAuth: !this.state.certificateOfAuth })
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   updateEditionSize = (text) => this.setState({ editionInfo: { ...this.state.editionInfo, size: text } })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   updateEditionNumber = (text) => this.setState({ editionInfo: { ...this.state.editionInfo, number: text } })
 
   render() {

--- a/src/lib/Scenes/Consignments/Screens/Location.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Location.tsx
@@ -6,7 +6,6 @@ import { Route, View, ViewProperties } from "react-native"
 import NavigatorIOS from "react-native-navigator-ios"
 import { ConsignmentSetup, LocationResult } from "../index"
 
-// @ts-ignore STRICTNESS_MIGRATION
 import { stringify } from "qs"
 
 import { Theme } from "palette"
@@ -27,11 +26,11 @@ interface State {
 }
 
 export default class Location extends React.Component<Props, State> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   constructor(props) {
     super(props)
     this.state = {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       query: null,
       searching: false,
       results: null,
@@ -55,18 +54,18 @@ export default class Location extends React.Component<Props, State> {
     // TODO: Add dedicated error handling to the maps response
 
     const { address_components } = results.result
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const cityPlace = address_components.find((comp) => comp.types[0] === "locality")
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const statePlace = address_components.find((comp) => comp.types[0] === "administrative_area_level_1")
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const countryPlace = address_components.find((comp) => comp.types[0] === "country")
 
     const city = cityPlace && cityPlace.long_name
     const country = countryPlace && countryPlace.long_name
     const state = statePlace && statePlace.long_name
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.props.updateWithResult(city, state, country)
     this.props.navigator.pop()
   }
@@ -96,7 +95,7 @@ export default class Location extends React.Component<Props, State> {
     })
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   predictionToResult = (prediction) => ({
     id: prediction.place_id,
     name: prediction.description,

--- a/src/lib/Scenes/Consignments/Screens/Metadata.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Metadata.tsx
@@ -67,44 +67,44 @@ interface LiveStyledTextInput {
 }
 
 export default class Metadata extends React.Component<Props, State> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private yearInput: LiveStyledTextInput
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private mediumInput: LiveStyledTextInput
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private widthInput: LiveStyledTextInput
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private heightInput: LiveStyledTextInput
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   private depthInput: LiveStyledTextInput
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   constructor(props) {
     super(props)
     this.state = props.metadata || {}
   }
 
   doneTapped = () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.props.updateWithMetadata(this.state)
     this.props.navigator.pop()
   }
 
   updateUnit = () => this.setState({ unit: this.state.unit === "CM" ? "IN" : "CM" })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   updateTitle = (title) => this.setState({ title })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   updateYear = (year) => this.setState({ year })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   updateMedium = (medium) => this.setState({ medium })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   updateWidth = (width) => this.setState({ width })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   updateHeight = (height) => this.setState({ height })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   updateDepth = (depth) => this.setState({ depth })
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   animateStateChange = (newState) => {
     const animate = LayoutAnimation.easeInEaseOut as any
     animate()
@@ -120,7 +120,7 @@ export default class Metadata extends React.Component<Props, State> {
   }
 
   hideCategorySelection = () => this.animateStateChange({ showPicker: false })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   changeCategoryValue = (_value, index) => {
     this.setState({
       categoryName: categoryOptions[index].name,
@@ -131,7 +131,7 @@ export default class Metadata extends React.Component<Props, State> {
   selectNextInput = () => {
     const inputs = [this.yearInput, this.mediumInput, this.widthInput, this.heightInput, this.depthInput]
     for (const input of inputs) {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       if (input && input.root && input.root.focus && !input.root.props.value) {
         return input.root.focus()
       }
@@ -152,7 +152,7 @@ export default class Metadata extends React.Component<Props, State> {
                       placeholder: "Title",
                       onFocus: this.hideCategorySelection,
                       onChangeText: this.updateTitle,
-                      // @ts-ignore STRICTNESS_MIGRATION
+                      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                       value: this.state.title,
                       onSubmitEditing: this.selectNextInput,
                       returnKeyType: "next",
@@ -169,7 +169,7 @@ export default class Metadata extends React.Component<Props, State> {
                     text={{
                       placeholder: "Year",
                       onChangeText: this.updateYear,
-                      // @ts-ignore STRICTNESS_MIGRATION
+                      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                       value: this.state.year,
                       onFocus: this.hideCategorySelection,
                       onSubmitEditing: this.selectNextInput,
@@ -185,7 +185,7 @@ export default class Metadata extends React.Component<Props, State> {
                     text={{
                       placeholder: "Medium",
                       onChangeText: this.updateMedium,
-                      // @ts-ignore STRICTNESS_MIGRATION
+                      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                       value: this.state.medium,
                       onFocus: this.hideCategorySelection,
                       onSubmitEditing: this.selectNextInput,
@@ -202,7 +202,7 @@ export default class Metadata extends React.Component<Props, State> {
                       keyboardType: "numeric",
                       placeholder: "Width",
                       onChangeText: this.updateWidth,
-                      // @ts-ignore STRICTNESS_MIGRATION
+                      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                       value: this.state.width,
                       onFocus: this.hideCategorySelection,
                       onSubmitEditing: this.selectNextInput,
@@ -216,7 +216,7 @@ export default class Metadata extends React.Component<Props, State> {
                       keyboardType: "numeric",
                       placeholder: "Height",
                       onChangeText: this.updateHeight,
-                      // @ts-ignore STRICTNESS_MIGRATION
+                      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                       value: this.state.height,
                       onFocus: this.hideCategorySelection,
                       onSubmitEditing: this.selectNextInput,
@@ -258,7 +258,7 @@ export default class Metadata extends React.Component<Props, State> {
                     <Text
                       text={{
                         placeholder: "Category",
-                        // @ts-ignore STRICTNESS_MIGRATION
+                        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                         value: this.state.categoryName,
                       }}
                       readonly={true}

--- a/src/lib/Scenes/Consignments/Screens/Overview.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Overview.tsx
@@ -34,7 +34,7 @@ interface State extends ConsignmentSetup {
   hasSubmittedSuccessfully?: boolean
 }
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const track: Track<Props, State> = _track
 
 @screenTrack({
@@ -42,7 +42,7 @@ const track: Track<Props, State> = _track
   context_screen_owner_type: Schema.OwnerEntityTypes.Consignment,
 })
 export default class Overview extends React.Component<Props, State> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   constructor(props) {
     super(props)
     this.state = props.setup || {}
@@ -200,7 +200,7 @@ export default class Overview extends React.Component<Props, State> {
         // quickly it doesn't upload duplicates
         photo.uploading = true
         this.setState({ photos: this.state.photos })
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         await uploadImageAndPassToGemini(photo.file, "private", this.state.submissionID)
 
         // Mutate state 'unexpectedly', then send it back through "setState" to trigger the next

--- a/src/lib/Scenes/Consignments/Screens/Provenance.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Provenance.tsx
@@ -20,18 +20,18 @@ export default class Provenance extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
     this.state = {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       provenance: props.provenance,
     }
   }
 
   doneTapped = () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.props.updateWithProvenance(this.state.provenance)
     this.props.navigator.pop()
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   textChanged = (text) => this.setState({ provenance: text })
 
   render() {

--- a/src/lib/Scenes/Consignments/Screens/SelectFromPhotoLibrary.tsx
+++ b/src/lib/Scenes/Consignments/Screens/SelectFromPhotoLibrary.tsx
@@ -47,7 +47,7 @@ export default class SelectFromPhotoLibrary extends React.Component<Props, State
       loadingMore: false,
       lastCursor: "",
       noMorePhotos: false,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       selection: hasPhotos ? props.setup.photos.map((p) => p.file) : [],
     }
   }

--- a/src/lib/Scenes/Consignments/Screens/__tests__/Overview-analytics-tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/__tests__/Overview-analytics-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { shallow } from "enzyme"
 import React from "react"
 

--- a/src/lib/Scenes/Consignments/Screens/__tests__/Overview-local-storage-tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/__tests__/Overview-local-storage-tests.tsx
@@ -32,7 +32,7 @@ it("updates the local state when there an update is triggered", () => {
 
   overview.setState = (updated, callback) => {
     overview.state = Object.assign({}, overview.state, updated)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     callback()
   }
 

--- a/src/lib/Scenes/Consignments/Screens/__tests__/SelectFromPhotoLibrary-tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/__tests__/SelectFromPhotoLibrary-tests.tsx
@@ -57,7 +57,7 @@ it("adds new photo to the list, and selects it", () => {
 })
 
 describe("concerning camera errors", () => {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   let alert: jest.Mock<typeof Alert.alert> = null
   const { ARTakeCameraPhotoModule } = NativeModules
 

--- a/src/lib/Scenes/Consignments/Screens/__tests__/Welcome-tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/__tests__/Welcome-tests.tsx
@@ -18,7 +18,7 @@ Object.keys(devices).forEach((device) => {
   it(`renders without throwing an error for ${device}`, () => {
     const nav = {} as any
     const route = {} as any
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const dimensions = devices[device]
 
     renderWithLayout(<Welcome navigator={nav} route={route} />, dimensions)

--- a/src/lib/Scenes/Consignments/Submission/Gemini/createGeminiAssetWithS3Credentials.ts
+++ b/src/lib/Scenes/Consignments/Submission/Gemini/createGeminiAssetWithS3Credentials.ts
@@ -28,7 +28,7 @@ export const createGeminiAssetWithS3Credentials = (input: CreateGeminiEntryForAs
         if (errors && errors.length > 0) {
           reject(new Error(JSON.stringify(errors)))
         } else {
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           resolve(response.createGeminiEntryForAsset.asset.token)
         }
       },

--- a/src/lib/Scenes/Consignments/Submission/Gemini/getConvectionGeminiKey.ts
+++ b/src/lib/Scenes/Consignments/Submission/Gemini/getConvectionGeminiKey.ts
@@ -18,5 +18,5 @@ export const getConvectionGeminiKey = () =>
     `,
     {},
     { force: true }
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   ).then((data) => data.system.services.convection.geminiTemplateKey)

--- a/src/lib/Scenes/Consignments/Submission/Gemini/getGeminiCredentialsForEnvironment.ts
+++ b/src/lib/Scenes/Consignments/Submission/Gemini/getGeminiCredentialsForEnvironment.ts
@@ -6,7 +6,7 @@ import {
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { commitMutation, graphql } from "relay-runtime"
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 export type AssetCredentials = getGeminiCredentialsForEnvironmentMutationResponse["requestCredentialsForAssetUpload"]["asset"]
 
 export const getGeminiCredentialsForEnvironment = (input: RequestCredentialsForAssetUploadInput) => {
@@ -43,7 +43,7 @@ export const getGeminiCredentialsForEnvironment = (input: RequestCredentialsForA
         if (errors && errors.length > 0) {
           reject(new Error(JSON.stringify(errors)))
         } else {
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           resolve(response.requestCredentialsForAssetUpload.asset)
         }
       },

--- a/src/lib/Scenes/Consignments/Submission/consignmentSetupToSubmission.ts
+++ b/src/lib/Scenes/Consignments/Submission/consignmentSetupToSubmission.ts
@@ -21,7 +21,7 @@ export const consignmentSetupToMutationInput = (submission: ConsignmentSetup) =>
       dimensionsMetric: submission.metadata && submission.metadata.unit,
       edition: !!submission.editionInfo,
       editionNumber: submission.editionInfo && submission.editionInfo.number,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       editionSize: submission.editionInfo && (parseInt(submission.editionInfo.size, 10) || null), // parseInt(undefined) returns NaN, which errors on MP.
       height: submission.metadata && submission.metadata.height,
       locationCity: submission.location && submission.location.city,

--- a/src/lib/Scenes/Consignments/Submission/createConsignmentSubmission.ts
+++ b/src/lib/Scenes/Consignments/Submission/createConsignmentSubmission.ts
@@ -29,7 +29,7 @@ export const createConsignmentSubmission = (submission: ConsignmentSetup) => {
         if (errors && errors.length > 0) {
           reject(new Error(JSON.stringify(errors)))
         } else {
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           resolve(response.createConsignmentSubmission.consignmentSubmission.internalID)
         }
       },

--- a/src/lib/Scenes/Consignments/Submission/geminiUploadToS3.ts
+++ b/src/lib/Scenes/Consignments/Submission/geminiUploadToS3.ts
@@ -33,7 +33,7 @@ export const uploadFileToS3 = (file: string, acl: string, asset: AssetCredential
 
     for (const key in data) {
       if (data.hasOwnProperty(key)) {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         formData.append(key, data[key])
       }
     }
@@ -49,7 +49,7 @@ export const uploadFileToS3 = (file: string, acl: string, asset: AssetCredential
     //
     // Kinda sucks, but https://github.com/jhen0409/react-native-debugger/issues/38
     const request = new XMLHttpRequest()
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     request.onload = (e) => {
       if (e.target.status.toString() === asset.policyDocument.conditions.successActionStatus) {
         // e.g. https://artsy-media-uploads.s3.amazonaws.com/A3tfuXp0t5OuUKv07XaBOw%2F%24%7Bfilename%7D

--- a/src/lib/Scenes/Fair/Components/FairBoothHeader.tsx
+++ b/src/lib/Scenes/Fair/Components/FairBoothHeader.tsx
@@ -16,14 +16,14 @@ interface State {
   isFollowedChanging: boolean
 }
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const formatCounts = ({ artists, artworks }) => {
   const artistLabel = artists === 1 ? "artist" : "artists"
   const worksLabel = artworks === 1 ? "work" : "works"
   return `${artworks} ${worksLabel} by ${artists} ${artistLabel}`
 }
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const track: Track<Props, State> = _track
 
 @track()
@@ -44,7 +44,7 @@ export class FairBoothHeader extends React.Component<Props, State> {
       owner_type: Schema.OwnerEntityTypes.Gallery,
     } as any
   })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   trackFollowPartner(_partnerSlug, _partnerID) {
     return null
   }
@@ -53,11 +53,11 @@ export class FairBoothHeader extends React.Component<Props, State> {
     const { show, relay } = this.props
     const {
       partner: {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         slug: partnerSlug,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         internalID: partnerID,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         id: partnerRelayID,
       },
     } = show
@@ -106,7 +106,7 @@ export class FairBoothHeader extends React.Component<Props, State> {
             },
           },
           updater: (store) => {
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             store.get(partnerRelayID).setValue(!partnerFollowed, "is_followed")
           },
         })
@@ -118,14 +118,14 @@ export class FairBoothHeader extends React.Component<Props, State> {
     const { show, onTitlePressed } = this.props
     const {
       partner: {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         name: partnerName,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         href: partnerHref,
       },
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       fair: { name: fairName },
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       location: { display: boothLocation },
       counts,
     } = show
@@ -150,7 +150,7 @@ export class FairBoothHeader extends React.Component<Props, State> {
         )}
         <Sans size="3t" color="black60">
           {formatCounts(
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             counts
           )}
         </Sans>

--- a/src/lib/Scenes/Fair/Components/FairBoothPreview/index.tsx
+++ b/src/lib/Scenes/Fair/Components/FairBoothPreview/index.tsx
@@ -20,7 +20,7 @@ interface State {
   isFollowedChanging: boolean
 }
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const track: Track<Props, State> = _track
 
 @track()
@@ -34,7 +34,7 @@ export class FairBoothPreview extends React.Component<Props, State> {
     const internalID = args[1]
     const {
       show: {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         partner: { profile },
       },
     } = props
@@ -51,7 +51,7 @@ export class FairBoothPreview extends React.Component<Props, State> {
       owner_type: Schema.OwnerEntityTypes.Gallery,
     } as any
   })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   trackFollowPartner(_slug, _internalID) {
     return null
   }
@@ -59,7 +59,7 @@ export class FairBoothPreview extends React.Component<Props, State> {
   handleFollowPartner = () => {
     const { show, relay } = this.props
     const {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       partner: { slug: partnerSlug, internalID: partnerInternalID, id: partnerID, profile },
     } = show
     if (!profile) {
@@ -110,7 +110,7 @@ export class FairBoothPreview extends React.Component<Props, State> {
             },
           },
           updater: (store) => {
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             store.get(partnerID).setValue(!isFollowed, "isFollowed")
           },
         })
@@ -153,7 +153,7 @@ export class FairBoothPreview extends React.Component<Props, State> {
         coverImage,
         location,
         partner,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         counts: { artworks: artworkCount },
       },
     } = this.props

--- a/src/lib/Scenes/Fair/Components/FairHeader/index.tsx
+++ b/src/lib/Scenes/Fair/Components/FairHeader/index.tsx
@@ -56,7 +56,7 @@ const CountdownContainer = styled.View`
 `
 
 const CountdownText: React.FC<CountdownProps> = ({ duration, label }) =>
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   label !== "Closed" && (
     <Flex justifyContent="center" alignItems="center">
       <LabeledTicker
@@ -70,7 +70,7 @@ const CountdownText: React.FC<CountdownProps> = ({ duration, label }) =>
     </Flex>
   )
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const track: Track<Props, State> = _track
 
 @track()
@@ -95,9 +95,9 @@ export class FairHeader extends React.Component<Props, State> {
       <>
         <EntityList
           prefix="Works by"
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           list={uniqArtistList}
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           count={counts.artists}
           displayedItems={3}
           onItemSelected={this.handleArtistPress.bind(this)}
@@ -118,7 +118,7 @@ export class FairHeader extends React.Component<Props, State> {
       owner_type: Schema.OwnerEntityTypes.Gallery,
     } as any
   })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   handleExhibitorPress(href, _slug, _internalID) {
     SwitchBoard.presentNavigationViewController(this, `${href}?entity=fair-booth`)
   }
@@ -134,7 +134,7 @@ export class FairHeader extends React.Component<Props, State> {
       owner_type: Schema.OwnerEntityTypes.Artist,
     } as any
   })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   handleArtistPress(href, _slug, _internalID) {
     SwitchBoard.presentNavigationViewController(this, href)
   }
@@ -177,7 +177,7 @@ export class FairHeader extends React.Component<Props, State> {
                 countdownComponent={CountdownText}
                 startAt={startAt}
                 endAt={endAt}
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 formattedOpeningHours={formattedOpeningHours}
               />
             </CountdownContainer>

--- a/src/lib/Scenes/Fair/Screens/FairBooth.tsx
+++ b/src/lib/Scenes/Fair/Screens/FairBooth.tsx
@@ -69,7 +69,7 @@ export class FairBooth extends React.Component<Props, State> {
         onViewAllArtistsPressed: this.onViewFairBoothArtistsPressed.bind(this),
       },
     })
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.setState({ sections })
   }
 
@@ -84,7 +84,7 @@ export class FairBooth extends React.Component<Props, State> {
     }
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   onTitlePressed = (partnerId) => {
     SwitchBoard.presentNavigationViewController(this, partnerId)
   }
@@ -110,7 +110,7 @@ export class FairBooth extends React.Component<Props, State> {
               </Box>
             )
           }}
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           keyExtractor={(item, index) => item.type + String(index)}
         />
       </Theme>

--- a/src/lib/Scenes/Fair/Screens/FairExhibitors.tsx
+++ b/src/lib/Scenes/Fair/Screens/FairExhibitors.tsx
@@ -44,11 +44,11 @@ export class FairExhibitors extends React.Component<Props, State> {
     const exhibitorsGroupedByName = fair.exhibitorsGroupedByName || []
     exhibitorsGroupedByName.forEach((group) => {
       sections.push({
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         title: group.letter,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         data: group.exhibitors,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         count: group.exhibitors.length,
       })
     })
@@ -66,14 +66,14 @@ export class FairExhibitors extends React.Component<Props, State> {
       owner_type: Schema.OwnerEntityTypes.Gallery,
     } as any
   })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   handleOnPressName(profileID, _slug, _partnerID) {
     if (profileID) {
       SwitchBoard.presentNavigationViewController(this, `/show/${profileID}?entity=fair-booth`)
     }
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   renderExhibitor(data) {
     const { item, index, section } = data
     const { count } = section
@@ -114,7 +114,7 @@ export class FairExhibitors extends React.Component<Props, State> {
               <Separator />
             </Box>
           )}
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           renderSectionFooter={({ section }) => {
             if (section.index < this.state.sections.length - 1) {
               return (

--- a/src/lib/Scenes/Fair/Screens/FairMoreInfo.tsx
+++ b/src/lib/Scenes/Fair/Screens/FairMoreInfo.tsx
@@ -73,7 +73,7 @@ export class FairMoreInfo extends React.Component<Props, State> {
       })
     }
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.setState({ sections })
   }
 
@@ -92,7 +92,7 @@ export class FairMoreInfo extends React.Component<Props, State> {
       owner_type: Schema.OwnerEntityTypes.Fair,
     } as any
   })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   handleFairSitePress(website) {
     SwitchBoard.presentModalViewController(this, website)
   }
@@ -106,12 +106,12 @@ export class FairMoreInfo extends React.Component<Props, State> {
       owner_type: Schema.OwnerEntityTypes.Fair,
     } as any
   })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   handleBuyTicketsPress(ticketsLink) {
     SwitchBoard.presentModalViewController(this, ticketsLink)
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   renderItem = ({ item: { data, type } }) => {
     switch (type) {
       case "about":
@@ -151,7 +151,7 @@ export class FairMoreInfo extends React.Component<Props, State> {
             </>
           }
           ItemSeparatorComponent={this.renderItemSeparator}
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           keyExtractor={(item, index) => item.type + String(index)}
           onScroll={hideBackButtonOnScroll}
           scrollEventThrottle={100}

--- a/src/lib/Scenes/Favorites/FavoriteArtworks.tsx
+++ b/src/lib/Scenes/Favorites/FavoriteArtworks.tsx
@@ -135,7 +135,7 @@ const FavoriteArtworksContainer = createPaginationContainer(
   },
   {
     getConnectionFromProps(props) {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       return props.me && props.me.followsAndSaves.artworks
     },
     getVariables(_props, { count, cursor }, fragmentVariables) {

--- a/src/lib/Scenes/Favorites/FavoriteCategories.tsx
+++ b/src/lib/Scenes/Favorites/FavoriteCategories.tsx
@@ -128,7 +128,7 @@ const FavoriteCategoriesContainer = createPaginationContainer(
   },
   {
     getConnectionFromProps(props) {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       return props.me && props.me.followsAndSaves.genes
     },
     getVariables(_props, pageInfo, _fragmentVariables) {

--- a/src/lib/Scenes/Favorites/FavoriteShows.tsx
+++ b/src/lib/Scenes/Favorites/FavoriteShows.tsx
@@ -123,7 +123,7 @@ const FavoriteShowsContainer = createPaginationContainer(
   },
   {
     getConnectionFromProps(props) {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       return props.me && props.me.followsAndSaves.shows
     },
     getVariables(_props, { count, cursor }, fragmentVariables) {

--- a/src/lib/Scenes/Home/Components/__tests__/SalesRail-tests.tsx
+++ b/src/lib/Scenes/Home/Components/__tests__/SalesRail-tests.tsx
@@ -125,10 +125,10 @@ it("renders the correct subtitle based on auction type", async () => {
   )
   const subtitles = tree.root.findAllByProps({ "data-test-id": "sale-subtitle" })
   // Timed sale
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   expect(extractText(first(subtitles))).toMatchInlineSnapshot(`"Timed Auction • In 1 day"`)
   // LAI sale
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   expect(extractText(last(subtitles))).toMatchInlineSnapshot(`"Live Auction • Live in 1 day"`)
 })
 
@@ -137,11 +137,11 @@ it("routes to live URL if present, otherwise href", () => {
     <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
   )
   // Timed sale
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   first(tree.root.findAllByType(CardRailCard)).props.onPress()
   expect(navigate).toHaveBeenCalledWith("/auction/the-sale")
   // LAI sale
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   last(tree.root.findAllByType(CardRailCard)).props.onPress()
   expect(navigate).toHaveBeenCalledWith("https://live.artsy.net/the-lai-sale")
 })

--- a/src/lib/Scenes/Inbox/Components/ActiveBids/ActiveBid.tsx
+++ b/src/lib/Scenes/Inbox/Components/ActiveBids/ActiveBid.tsx
@@ -87,7 +87,7 @@ class ActiveBid extends React.Component<Props, State> {
       status = "live_auction"
     } else {
       const leadingBidder = bid.is_leading_bidder
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const reserveNotMet = bid.most_recent_bid.sale_artwork.reserve_status === "reserve_not_met"
 
       if (leadingBidder) {
@@ -113,32 +113,32 @@ class ActiveBid extends React.Component<Props, State> {
   handleTap = () => {
     const bid = this.props.bid
     // push user into live auction if it's open; otherwise go to artwork
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const href = this.state.status === "live_auction" ? bid.sale.href : bid.most_recent_bid.sale_artwork.artwork.href
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     SwitchBoard.presentNavigationViewController(this, href)
   }
 
   render() {
     const bid = this.props.bid.most_recent_bid
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const imageURL = bid.sale_artwork.artwork && bid.sale_artwork.artwork.image && bid.sale_artwork.artwork.image.url
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const lotNumber = bid.sale_artwork.lot_label
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const artistName = bid.sale_artwork.artwork.artist_names
 
     const headline = `Lot ${lotNumber} · ${artistName} `
 
     const isInOpenLiveAuction = this.props.bid.sale && this.props.bid.sale.is_live_open
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const bidderPositions = bid.sale_artwork.counts.bidder_positions
     const bidderPositionsLabel = bidderPositions + " " + (bidderPositions === 1 ? "Bid" : "Bids")
 
     const subtitle = isInOpenLiveAuction
       ? "Live bidding now open"
       : `${
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           bid.sale_artwork.highest_bid.display
         } (${bidderPositionsLabel})`
 

--- a/src/lib/Scenes/Inbox/Components/ActiveBids/index.tsx
+++ b/src/lib/Scenes/Inbox/Components/ActiveBids/index.tsx
@@ -31,14 +31,14 @@ export class ActiveBids extends React.Component<Props, State> {
   }
 
   hasContent() {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     return this.props.me.lot_standings.length > 0
   }
 
   renderRows() {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const bids = this.props.me.lot_standings.map((bidData) => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       return <ActiveBid key={bidData.most_recent_bid.id} bid={bidData as any} />
     })
     return bids
@@ -53,7 +53,7 @@ export class ActiveBids extends React.Component<Props, State> {
       fetchingData: true,
     })
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const onFetchComplete = (error) => {
       if (error) {
         // FIXME: Handle error

--- a/src/lib/Scenes/Inbox/Components/Conversations/ConversationSnippet.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/ConversationSnippet.tsx
@@ -46,7 +46,7 @@ const track: Track<Props, null, Schema.Entity> = _track
 
 @track()
 export class ConversationSnippet extends React.Component<Props> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   @track((props) => ({
     action_type: Schema.ActionTypes.Tap,
     action_name: Schema.ActionNames.ConversationSelected,
@@ -54,7 +54,7 @@ export class ConversationSnippet extends React.Component<Props> {
     owner_type: Schema.OwnerEntityTypes.Conversation,
   }))
   conversationSelected() {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.props.onSelected()
   }
 
@@ -63,30 +63,30 @@ export class ConversationSnippet extends React.Component<Props> {
     // If we cannot resolve items in the conversation, such as deleted fair booths
     // prior to snapshotting them at time of inquiry (generally older conversations),
     // just skip over the entire conversation.
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     if (conversation.items.length === 0) {
       console.warn(`Unable to load items for conversation with ID ${conversation.internalID}`)
       return null
     }
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const item = conversation.items[0].item
 
     let imageURL: string
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     if (item.__typename === "Artwork") {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       imageURL = item.image && item.image.url
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     } else if (item.__typename === "Show") {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       imageURL = item.coverImage && item.coverImage.url
     }
 
     const partnerName = conversation.to.name
 
     const conversationText = conversation.lastMessage && conversation.lastMessage.replace(/\n/g, " ")
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const date = moment(conversation.lastMessageAt).fromNow(true) + " ago"
     return (
       <Touchable onPress={() => this.conversationSelected()} underlayColor={color("black5")}>
@@ -100,7 +100,7 @@ export class ConversationSnippet extends React.Component<Props> {
               )}
               <ImageView
                 imageURL={
-                  // @ts-ignore STRICTNESS_MIGRATION
+                  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                   imageURL
                 }
               />

--- a/src/lib/Scenes/Inbox/Components/Conversations/Message.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/Message.tsx
@@ -3,7 +3,7 @@ import { Message_message } from "__generated__/Message_message.graphql"
 import { BoxProps, color, Flex, Sans, Spacer } from "palette"
 import React from "react"
 import { NativeModules, View } from "react-native"
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import Hyperlink from "react-native-hyperlink"
 import { createFragmentContainer } from "react-relay"
 import styled from "styled-components/native"

--- a/src/lib/Scenes/Inbox/Components/Conversations/SendConversationMessage.ts
+++ b/src/lib/Scenes/Inbox/Components/Conversations/SendConversationMessage.ts
@@ -20,12 +20,12 @@ export function sendConversationMessage(
 ) {
   const storeUpdater = (store: RecordSourceSelectorProxy) => {
     const mutationPayload = store.getRootField("sendConversationMessage")
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const newMessageEdge = mutationPayload.getLinkedRecord("messageEdge")
     const conversationStore = store.get(conversation.id)
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const connection = ConnectionHandler.getConnection(conversationStore, "Messages_messagesConnection")
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     ConnectionHandler.insertEdgeBefore(connection, newMessageEdge)
   }
   return commitMutation<SendConversationMessageMutation>(environment, {

--- a/src/lib/Scenes/Inbox/Components/Conversations/UpdateConversation.ts
+++ b/src/lib/Scenes/Inbox/Components/Conversations/UpdateConversation.ts
@@ -16,7 +16,7 @@ export function updateConversation(
 ) {
   return commitMutation<UpdateConversationMutation>(environment, {
     updater: (store) => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       store.get(conversation.id).setValue(false, "unread")
     },
     onCompleted,

--- a/src/lib/Scenes/Inbox/Components/Typography/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Typography/__tests__/index-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { shallow } from "enzyme"
 import React from "react"
 import "react-native"

--- a/src/lib/Scenes/Inbox/Screens/Conversation.tsx
+++ b/src/lib/Scenes/Inbox/Screens/Conversation.tsx
@@ -54,14 +54,14 @@ interface State {
   failedMessageText: string | null
 }
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const track: Track<Props, State> = _track
 
 @track()
 export class Conversation extends React.Component<Props, State> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   messages: MessagesComponent
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   composer: Composer
 
   // Assume if the component loads, connection exists (this way the banner won't flash unnecessarily)
@@ -82,7 +82,7 @@ export class Conversation extends React.Component<Props, State> {
     NetInfo.isConnected.removeEventListener("connectionChange", this.handleConnectivityChange)
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   handleConnectivityChange = (isConnected) => {
     this.setState({ isConnected })
   }
@@ -92,16 +92,13 @@ export class Conversation extends React.Component<Props, State> {
     if (conversation?.unread && !this.state.markedMessageAsRead) {
       updateConversation(
         this.props.relay.environment,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         conversation,
-        // @ts-ignore STRICTNESS_MIGRATION
         conversation.lastMessageID,
-        // @ts-ignore STRICTNESS_MIGRATION
         (_response) => {
           this.setState({ markedMessageAsRead: true })
           GlobalStore.actions.bottomTabs.fetchCurrentUnreadConversationCount()
         },
-        // @ts-ignore STRICTNESS_MIGRATION
         (error) => {
           console.warn(error)
           this.setState({ markedMessageAsRead: true })
@@ -111,11 +108,11 @@ export class Conversation extends React.Component<Props, State> {
     }
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   @track((props) => ({
     action_type: Schema.ActionTypes.Success,
     action_name: Schema.ActionNames.ConversationSendReply,
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     owner_id: props.me.conversation.internalID,
     owner_type: Schema.OwnerEntityTypes.Conversation,
   }))
@@ -127,11 +124,11 @@ export class Conversation extends React.Component<Props, State> {
     }
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   @track((props) => ({
     action_type: Schema.ActionTypes.Fail,
     action_name: Schema.ActionNames.ConversationSendReply,
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     owner_id: props.me.conversation.internalID,
     owner_type: Schema.OwnerEntityTypes.Conversation,
   }))
@@ -142,28 +139,26 @@ export class Conversation extends React.Component<Props, State> {
 
   render() {
     const conversation = this.props.me.conversation
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const partnerName = conversation.to.name
 
     return (
       <Composer
         disabled={this.state.sendingMessage || !this.state.isConnected}
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         ref={(composer) => (this.composer = composer)}
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         value={this.state.failedMessageText}
         onSubmit={(text) => {
           this.setState({ sendingMessage: true, failedMessageText: null })
           sendConversationMessage(
             this.props.relay.environment,
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             conversation,
             text,
-            // @ts-ignore STRICTNESS_MIGRATION
             (_response) => {
               this.messageSuccessfullySent(text)
             },
-            // @ts-ignore STRICTNESS_MIGRATION
             (error) => {
               this.messageFailedToSend(error, text)
             }

--- a/src/lib/Scenes/Map/Components/PinsShapeLayer.tsx
+++ b/src/lib/Scenes/Map/Components/PinsShapeLayer.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import Mapbox from "@mapbox/react-native-mapbox-gl"
 import { isEqual } from "lodash"
 import React, { Component } from "react"
@@ -8,7 +8,7 @@ import { FilterData, MapGeoFeatureCollection } from "../types"
 
 interface Props {
   featureCollections: { [key in BucketKey]: FilterData } | {}
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   onPress?: (nativeEvent) => void
   duration?: number
   filterID: string
@@ -69,7 +69,7 @@ export class ShapeLayer extends Component<Props, State> {
     const { filterID } = this.props
 
     const getFeatures = (props: Props) =>
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       props.featureCollections[filterID].featureCollection.features.map((g) => g.is_followed)
 
     return (
@@ -106,7 +106,7 @@ export class ShapeLayer extends Component<Props, State> {
 
   render() {
     const { featureCollections, filterID } = this.props
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const collection: MapGeoFeatureCollection = featureCollections[filterID].featureCollection
 
     return (

--- a/src/lib/Scenes/Map/Components/ShowCard.tsx
+++ b/src/lib/Scenes/Map/Components/ShowCard.tsx
@@ -45,7 +45,7 @@ const PageIndicator = styled(Box)`
 `
 
 export class ShowCard extends Component<ShowCardProps, ShowCardState> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   list: FlatList<Show | Fair>
 
   state = {
@@ -68,7 +68,7 @@ export class ShowCard extends Component<ShowCardProps, ShowCardState> {
     }
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   handleTap(item) {
     if (item.type === "Show") {
       SwitchBoard.presentNavigationViewController(this, item.href)
@@ -77,7 +77,7 @@ export class ShowCard extends Component<ShowCardProps, ShowCardState> {
     }
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   renderItem = ({ item }, noWidth = false) => {
     const props = noWidth ? { mr: 1 } : { width: this.cardWidth }
 
@@ -100,7 +100,7 @@ export class ShowCard extends Component<ShowCardProps, ShowCardState> {
     )
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   onScroll = (e) => {
     const newPageNum = Math.round(e.nativeEvent.contentOffset.x / this.cardWidth + 1)
 

--- a/src/lib/Scenes/Map/EventEmitter.ts
+++ b/src/lib/Scenes/Map/EventEmitter.ts
@@ -11,7 +11,7 @@ class _EventEmitter {
       console.warn(`There are currently no subscribers for the event: ${event}`)
       return
     }
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this._events.get(event).forEach((callback) => callback(data))
   }
 
@@ -19,7 +19,7 @@ class _EventEmitter {
     if (!this._events.has(event)) {
       this._events.set(event, [])
     }
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this._events.get(event).push(callback)
   }
 
@@ -36,7 +36,7 @@ class _EventEmitter {
           "that was used to subscribe."
       )
     }
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     subscriptions.splice(index, 1)
   }
 }

--- a/src/lib/Scenes/Map/GlobalMap.tsx
+++ b/src/lib/Scenes/Map/GlobalMap.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import Mapbox from "@mapbox/react-native-mapbox-gl"
 import { GlobalMap_viewer } from "__generated__/GlobalMap_viewer.graphql"
 import colors from "lib/data/colors"
@@ -153,10 +153,10 @@ export class GlobalMap extends React.Component<Props, State> {
   }
 
   map: Mapbox.MapView
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   filters: { [key: string]: FilterData }
   hideButtons = new Animated.Value(0)
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   currentZoom: number
 
   shows: { [id: string]: Show } = {}
@@ -192,7 +192,7 @@ export class GlobalMap extends React.Component<Props, State> {
     },
   })
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   constructor(props) {
     super(props)
 
@@ -202,13 +202,13 @@ export class GlobalMap extends React.Component<Props, State> {
       activeIndex: 0,
       currentLocation,
       bucketResults: emptyBucketResults,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       featureCollections: null,
       mapLoaded: false,
       isSavingShow: false,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       nearestFeature: null,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       activePin: null,
       currentZoom: DefaultZoomLevel,
     }
@@ -216,9 +216,9 @@ export class GlobalMap extends React.Component<Props, State> {
     this.updateShowIdMap()
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   handleFilterChange = (activeIndex) => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.setState({ activeIndex, activePin: null, activeShows: [] })
   }
 
@@ -242,14 +242,14 @@ export class GlobalMap extends React.Component<Props, State> {
     EventEmitter.unsubscribe("filters:change", this.handleFilterChange)
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   componentDidUpdate(_, prevState) {
     // Update the clusterMap if new bucket results
     if (this.state.bucketResults) {
       const shouldUpdate = !isEqual(
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         prevState.bucketResults.saved.map((g) => g.is_followed),
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         this.state.bucketResults.saved.map((g) => g.is_followed)
       )
 
@@ -313,7 +313,7 @@ export class GlobalMap extends React.Component<Props, State> {
       owner_type: !!type ? type : "",
     } as any
   })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   trackPinTap(_actionName, _show, _type) {
     return null
   }
@@ -340,7 +340,7 @@ export class GlobalMap extends React.Component<Props, State> {
 
       clusterEngine.load(geoJSONFeature.features as any)
 
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       featureCollections[tab.id] = {
         featureCollection: geoJSONFeature,
         filter: tab.id,
@@ -360,7 +360,7 @@ export class GlobalMap extends React.Component<Props, State> {
 
     const filter = cityTabs[this.state.activeIndex]
     const {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       city: { name: cityName, slug: citySlug, sponsoredContent },
     } = this.props.viewer
 
@@ -416,7 +416,7 @@ export class GlobalMap extends React.Component<Props, State> {
       const {
         nearestFeature: { properties, geometry },
       } = this.state
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const [clusterLat, clusterLng] = geometry.coordinates
 
       const clusterId = properties.cluster_id.toString()
@@ -524,7 +524,7 @@ export class GlobalMap extends React.Component<Props, State> {
               {!!hasShows && (
                 <ShowCard
                   shows={updatedShows}
-                  // @ts-ignore STRICTNESS_MIGRATION
+                  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                   relay={this.props.relay}
                   onSaveStarted={() => {
                     this.setState({ isSavingShow: true })
@@ -559,7 +559,7 @@ export class GlobalMap extends React.Component<Props, State> {
 
     if (this.currentZoom !== zoom) {
       this.setState({
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         activePin: null,
       })
     }
@@ -574,7 +574,7 @@ export class GlobalMap extends React.Component<Props, State> {
     if (!this.state.isSavingShow) {
       this.setState({
         activeShows: [],
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         activePin: null,
       })
     }
@@ -583,18 +583,18 @@ export class GlobalMap extends React.Component<Props, State> {
   onPressCitySwitcherButton = () => {
     this.setState({
       activeShows: [],
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       activePin: null,
     })
   }
 
   onPressUserPositionButton = () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const { lat, lng } = this.state.userLocation
     this.map.moveTo([lng, lat], 500)
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   onPressPinShapeLayer = (e) => this.handleFeaturePress(e.nativeEvent)
 
   storeMapRef = (c: any) => {
@@ -605,7 +605,7 @@ export class GlobalMap extends React.Component<Props, State> {
 
   get currentFeatureCollection(): FilterData {
     const filterID = cityTabs[this.state.activeIndex].id
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     return this.state.featureCollections[filterID]
   }
 
@@ -651,7 +651,7 @@ export class GlobalMap extends React.Component<Props, State> {
           >
             <Flex flexDirection="row" justifyContent="flex-end" alignContent="flex-end" px={3}>
               <CitySwitcherButton
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 sponsoredContentUrl={this.props.viewer && this.props.viewer.city.sponsoredContent.artGuideUrl}
                 city={city}
                 isLoading={!city && !(relayErrorState && !relayErrorState.isRetrying)}
@@ -786,7 +786,7 @@ export class GlobalMap extends React.Component<Props, State> {
 
   getNearestPointToLatLongInCollection(values: { lat: number; lng: number }, features: any[]) {
     // https://stackoverflow.com/a/21623206
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     function distance(lat1, lon1, lat2, lon2) {
       const p = 0.017453292519943295 // Math.PI / 180
       const c = Math.cos

--- a/src/lib/Scenes/Map/MapRenderer.tsx
+++ b/src/lib/Scenes/Map/MapRenderer.tsx
@@ -49,7 +49,7 @@ export const MapRenderer: React.FC<{
                 error,
                 retry: () => {
                   isRetrying = true
-                  // @ts-ignore STRICTNESS_MIGRATION
+                  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                   retry()
                 },
                 isRetrying,

--- a/src/lib/Scenes/Map/__tests__/Bucket-tests.ts
+++ b/src/lib/Scenes/Map/__tests__/Bucket-tests.ts
@@ -12,12 +12,12 @@ describe.skip(bucketCityResults, () => {
   })
 
   it("calculates galleries correctly", () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(uniq(results.galleries.map((s) => s.partner.type))).toEqual(["Gallery"])
   })
 
   it("calculates museums correctly", () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     expect(uniq(results.museums.map((s) => s.partner.type))).toEqual(["Institution"])
   })
 })

--- a/src/lib/Scenes/Map/bucketCityResults.ts
+++ b/src/lib/Scenes/Map/bucketCityResults.ts
@@ -6,45 +6,45 @@ export const bucketCityResults = (viewer: GlobalMap_viewer) => {
   // The saved shows needs to be sorted by end_date_asc
   const now = moment()
   const oneWeekFromNow = moment(new Date()).add(7, "days")
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const savedShows = viewer.city.shows.edges.filter((e) => e.node.is_followed === true)
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const savedUpcomingShows = viewer.city.upcomingShows.edges.filter((e) => e.node.is_followed === true)
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const savedFiltered = uniq(savedShows.concat(savedUpcomingShows)).map((n) => n.node)
   const saved = sortBy(savedFiltered, (event) => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     return event.end_at
   })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const fairs = viewer.city.fairs.edges.map((n) => n.node)
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const galleries = viewer.city.shows.edges.filter((e) => e.node.partner.type === "Gallery").map((n) => n.node)
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const museums = viewer.city.shows.edges
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     .filter((e) => e.node.partner.type === "Institution" || e.node.partner.type === "InstitutionalSeller")
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     .map((n) => n.node)
 
   // Opening shows need to be sorted by start_at_asc
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const opening = viewer.city.upcomingShows.edges.map((n) => n.node)
   // Closing needs to be sorted by end_at_asc
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const closingFiltered = viewer.city.shows.edges
     .filter((e) => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       if (e.node.end_at) {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         const showClosingTime = moment(e.node.end_at)
         return showClosingTime <= oneWeekFromNow && showClosingTime >= now
       }
     })
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     .map((n) => n.node)
   const closing = sortBy(closingFiltered, (event) => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     return moment(event.end_at)
   })
 

--- a/src/lib/Scenes/MyProfile/LoggedInUserInfo.tsx
+++ b/src/lib/Scenes/MyProfile/LoggedInUserInfo.tsx
@@ -42,7 +42,7 @@ export const UserProfileQueryRenderer: React.FC = () => (
       if (error) {
         return null
       } else if (props) {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         return <UserProfileFragmentContainer {...props} />
       } else {
         return (

--- a/src/lib/Scenes/Partner/Components/PartnerFollowButton.tsx
+++ b/src/lib/Scenes/Partner/Components/PartnerFollowButton.tsx
@@ -15,7 +15,7 @@ interface State {
   isFollowedChanging: boolean
 }
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const track: Track<Props, State> = _track
 
 @track()

--- a/src/lib/Scenes/Partner/Components/PartnerMap.tsx
+++ b/src/lib/Scenes/Partner/Components/PartnerMap.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import Mapbox from "@mapbox/react-native-mapbox-gl"
 import { PartnerMap_location } from "__generated__/PartnerMap_location.graphql"
 import { cityAndPostalCode, tappedOnMap } from "lib/Components/LocationMap"

--- a/src/lib/Scenes/PrivacyRequest/__tests__/PrivacyRequest-tests.tsx
+++ b/src/lib/Scenes/PrivacyRequest/__tests__/PrivacyRequest-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { shallow } from "enzyme"
 import React from "react"
 

--- a/src/lib/Scenes/Sales/Components/LotsByFollowedArtists.tsx
+++ b/src/lib/Scenes/Sales/Components/LotsByFollowedArtists.tsx
@@ -30,7 +30,6 @@ export class LotsByFollowedArtists extends Component<Props> {
           <InfiniteScrollArtworksGrid
             loadMore={this.props.relay.loadMore}
             hasMore={this.props.relay.hasMore}
-            // @ts-ignore STRICTNESS_MIGRATION
             connection={this.props.me.lotsByFollowedArtistsConnection}
             HeaderComponent={<SectionTitle title={title} />}
             hideUrgencyTags={hideUrgencyTags}

--- a/src/lib/Scenes/Sales/Components/__tests__/LotsByFollowedArtists-tests.tsx
+++ b/src/lib/Scenes/Sales/Components/__tests__/LotsByFollowedArtists-tests.tsx
@@ -6,7 +6,7 @@ import { getTestWrapper } from "lib/utils/getTestWrapper"
 import { LotsByFollowedArtists } from "../LotsByFollowedArtists"
 
 describe("LotsByFollowedArtists", () => {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   let props
 
   beforeEach(() => {
@@ -38,7 +38,7 @@ describe("LotsByFollowedArtists", () => {
   })
 
   it("looks correct when rendered", () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const { text } = getTestWrapper(<LotsByFollowedArtists {...props} />)
     expect(text).toContain("Test Lots")
   })

--- a/src/lib/Scenes/Sales/__tests__/index-tests.tsx
+++ b/src/lib/Scenes/Sales/__tests__/index-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { shallow } from "enzyme"
 import React from "react"
 import "react-native"
@@ -11,7 +11,7 @@ import { SalesFragmentContainer } from "../index"
 jest.mock("../Components/LotsByFollowedArtists", () => "")
 
 it("renders the ZeroState when there are no sales", () => {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const auctions = shallow(<SalesFragmentContainer {...props} sales={{ edges: [] } as any} me={null} />)
   expect(auctions.find("ZeroState").length).toEqual(1)
 })

--- a/src/lib/Scenes/Show/Components/ShowEventSection.tsx
+++ b/src/lib/Scenes/Show/Components/ShowEventSection.tsx
@@ -8,7 +8,7 @@ interface Props {
   event: ShowEventSection_event
 }
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const formatTime = (startAt, endAt) => {
   const startMoment = moment(startAt)
   const endMoment = moment(endAt)

--- a/src/lib/Scenes/Show/Components/ShowHeader/Components/Carousel.tsx
+++ b/src/lib/Scenes/Show/Components/ShowHeader/Components/Carousel.tsx
@@ -12,10 +12,10 @@ interface Props extends ScrollViewProperties {
 }
 
 export class Carousel extends React.Component<Props> {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   scrollView: ScrollView
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   keyForSource = ({ imageURL }) => imageURL
 
   renderItems = () => {
@@ -37,7 +37,7 @@ export class Carousel extends React.Component<Props> {
         <PageList
           {...this.props}
           ref={(ref) => {
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             this.scrollView = ref
           }}
           horizontal

--- a/src/lib/Scenes/Show/Components/ShowHeader/ShowHeader.tsx
+++ b/src/lib/Scenes/Show/Components/ShowHeader/ShowHeader.tsx
@@ -22,7 +22,7 @@ interface State {
   isFollowedSaving: boolean
 }
 
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const track: Track<Props, State> = _track
 
 @track()
@@ -34,7 +34,7 @@ export class ShowHeader extends React.Component<Props, State> {
     if (show.isStubShow) {
       return
     }
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     SwitchBoard.presentPartnerViewController(this, show.partner?.href)
   }
 
@@ -78,7 +78,7 @@ export class ShowHeader extends React.Component<Props, State> {
             },
           },
           updater: (store) => {
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             store.get(relayID).setValue(!isShowFollowed, "is_followed")
           },
         })
@@ -121,7 +121,7 @@ export class ShowHeader extends React.Component<Props, State> {
       owner_type: Schema.OwnerEntityTypes.Artist,
     } as any
   })
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   handleArtistSelected(url, _slug, _internalID) {
     SwitchBoard.presentNavigationViewController(this, url)
   }
@@ -176,9 +176,9 @@ export class ShowHeader extends React.Component<Props, State> {
         <Box px={2}>
           <EntityList
             prefix="Works by"
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             list={uniqArtistList}
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             count={artists.length}
             displayedItems={3}
             onItemSelected={this.handleArtistSelected.bind(this)}

--- a/src/lib/Scenes/Show/Components/Shows/Components/ShowItem.tsx
+++ b/src/lib/Scenes/Show/Components/Shows/Components/ShowItem.tsx
@@ -24,7 +24,7 @@ interface Props {
 export class ShowItem extends React.Component<Props> {
   get imageURL() {
     const {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       images: [image],
     } = this.props.show
 
@@ -47,7 +47,7 @@ export class ShowItem extends React.Component<Props> {
 
     const {
       name,
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       partner: { name: galleryName },
       exhibition_period,
       end_at,
@@ -70,7 +70,7 @@ export class ShowItem extends React.Component<Props> {
             </Sans>
             <Sans size="3t" color="black60">
               {exhibitionDates(
-                // @ts-ignore STRICTNESS_MIGRATION
+                // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 exhibition_period,
                 end_at
               )}

--- a/src/lib/Scenes/Show/Components/Shows/index.tsx
+++ b/src/lib/Scenes/Show/Components/Shows/index.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 export const Shows: React.FC<Props> = ({ show }) => {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const { edges } = show.nearbyShows
   return (
     <>
@@ -21,10 +21,8 @@ export const Shows: React.FC<Props> = ({ show }) => {
         horizontal
         data={edges}
         showsHorizontalScrollIndicator={false}
-        // @ts-ignore STRICTNESS_MIGRATION
         keyExtractor={(item) => item.node.id}
         renderItem={({ item }) => {
-          // @ts-ignore STRICTNESS_MIGRATION
           return <ShowItem show={item.node as any} />
         }}
       />

--- a/src/lib/Scenes/Show/Components/__tests__/TextSection-tests.tsx
+++ b/src/lib/Scenes/Show/Components/__tests__/TextSection-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import React from "react"
 import { View } from "react-native"

--- a/src/lib/Scenes/Show/Screens/Detail.tsx
+++ b/src/lib/Scenes/Show/Screens/Detail.tsx
@@ -72,7 +72,7 @@ export class Detail extends React.Component<Props, State> {
 
     if (show.location) {
       const { openingHours } = show.location
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       if ((openingHours.text && openingHours.text !== "") || openingHours.schedules) {
         sections.push({
           type: "hours",
@@ -92,7 +92,7 @@ export class Detail extends React.Component<Props, State> {
     }
 
     const hasArtsyArtists = show.counts && show.counts.artists
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const hasStubbedArtists = show.artistsWithoutArtworks.length > 0
     if (hasStubbedArtists || hasArtsyArtists) {
       sections.push({
@@ -112,11 +112,11 @@ export class Detail extends React.Component<Props, State> {
       })
     }
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.setState({ sections })
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   renderItemSeparator = (item) => {
     if (item && (item.leadingItem.type === "location" || item.leadingItem.type === "description")) {
       return null
@@ -145,7 +145,7 @@ export class Detail extends React.Component<Props, State> {
     return null
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   renderItem = ({ item: { data, type } }) => {
     switch (type) {
       case "location":

--- a/src/lib/Scenes/Show/Screens/MoreInfo.tsx
+++ b/src/lib/Scenes/Show/Screens/MoreInfo.tsx
@@ -25,7 +25,7 @@ interface Props extends ViewProperties {
 type Section =
   | {
       type: "event"
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       data: { event: MoreInfo_show["events"][number] }
     }
   | {
@@ -64,7 +64,7 @@ export class MoreInfo extends React.Component<Props, State> {
 
     const sections: Section[] = []
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     show.events.forEach((event) => {
       sections.push({
         type: "event",
@@ -93,7 +93,7 @@ export class MoreInfo extends React.Component<Props, State> {
       })
     }
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     if (show.partner.website) {
       sections.push({
         type: "galleryWebsite",
@@ -117,13 +117,13 @@ export class MoreInfo extends React.Component<Props, State> {
     owner_slug: props.show.id,
     owner_type: Schema.OwnerEntityTypes.Show,
   }))
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   renderGalleryWebsite(url) {
     Linking.openURL(url).catch((err) => console.error("An error occurred opening gallery link", err))
   }
 
   openPressReleaseLink = () => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     SwitchBoard.presentNavigationViewController(this, this.props.show.pressReleaseUrl)
   }
 
@@ -132,9 +132,9 @@ export class MoreInfo extends React.Component<Props, State> {
       case "galleryWebsite":
         return (
           <CaretButton
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             onPress={() => this.renderGalleryWebsite(item.data.partner.website)}
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             text={item.data.partner.type === "Gallery" ? "Visit gallery site" : "Visit institution site"}
           />
         )
@@ -154,7 +154,7 @@ export class MoreInfo extends React.Component<Props, State> {
       case "event":
         return <ShowEventSection {...item.data} />
       case "pressRelease":
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         return <TextSection title="Press Release" text={item.data.press_release} />
     }
   }
@@ -174,7 +174,7 @@ export class MoreInfo extends React.Component<Props, State> {
         ListFooterComponent={<Spacer pb={4} />}
         ItemSeparatorComponent={this.renderItemSeparator}
         renderItem={(item) => <Box px={2}>{this.renderItem(item)}</Box>}
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         keyExtractor={(item, index) => item.type + String(index)}
         onScroll={hideBackButtonOnScroll}
         scrollEventThrottle={100}

--- a/src/lib/Scenes/Show/Screens/ShowArtists.tsx
+++ b/src/lib/Scenes/Show/Screens/ShowArtists.tsx
@@ -35,7 +35,7 @@ export class ShowArtists extends React.Component<Props, State> {
   componentDidMount() {
     const { show } = this.props
     const artistsGroupedByName = get(show, "artists_grouped_by_name", []) as any
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     this.setState({ data: artistsGroupedByName.map(({ letter, items }, index) => ({ letter, data: items, index })) })
   }
 

--- a/src/lib/relay/middlewares/cacheMiddleware.ts
+++ b/src/lib/relay/middlewares/cacheMiddleware.ts
@@ -13,25 +13,25 @@ export const cacheMiddleware = () => {
 
     // If we have valid data in cache return
     if (isQuery && !cacheConfig.force) {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const dataFromCache = await cache.get(queryID, variables)
       if (dataFromCache) {
         return JSON.parse(dataFromCache)
       }
     }
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     cache.set(queryID, variables, null)
 
     // Get query body either from local queryMap or
     // send queryID to metaphysics
     let body: { variables?: object; query?: string; documentID?: string } = {}
     if (__DEV__) {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       body = { query: require("../../../../data/complete.queryMap.json")[queryID], variables }
       req.operation.text = body.query ?? null
     } else {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       body = { documentID: queryID, variables }
     }
 
@@ -46,7 +46,7 @@ export const cacheMiddleware = () => {
       if (!__DEV__ && e.toString().includes("Unable to serve persisted query with ID")) {
         // this should not happen normally, but let's try again with full query text to avoid ruining the user's day?
         captureMessage(e.stack)
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         body = { query: require("../../../../data/complete.queryMap.json")[queryID], variables }
         req.fetchOpts.body = JSON.stringify(body)
         response = await next(req)
@@ -56,7 +56,7 @@ export const cacheMiddleware = () => {
     }
 
     const clearCache = () => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       cache.clear(queryID, req.variables)
     }
 
@@ -64,7 +64,7 @@ export const cacheMiddleware = () => {
       if (isQuery) {
         // Don't cache responses with errors in them (GraphQL responses are always 200, even if they contain errors).
         if (response.json.errors === undefined) {
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           cache.set(queryID, req.variables, JSON.stringify(response.json), req.cacheConfig.emissionCacheTTLSeconds)
         } else {
           clearCache()

--- a/src/lib/relay/middlewares/metaphysicsMiddleware.ts
+++ b/src/lib/relay/middlewares/metaphysicsMiddleware.ts
@@ -6,9 +6,9 @@ import _ from "lodash"
  * time into your console at the same places as the relay queries.
  */
 export function metaphysicsExtensionsLoggerMiddleware() {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   return (next) => (req) => {
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     return next(req).then((res) => {
       if (res.json.extensions && console.groupCollapsed) {
         // See: https://github.com/artsy/metaphysics/blob/master/src/lib/loaders/api/extensionsLogger.ts

--- a/src/lib/relay/middlewares/timingMiddleware.ts
+++ b/src/lib/relay/middlewares/timingMiddleware.ts
@@ -1,11 +1,11 @@
 import { volleyClient } from "lib/utils/volleyClient"
 
 export function timingMiddleware() {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   return (next) => (req) => {
     const startTime = Date.now()
     const operation = req.operation.name || "UnknownOperation"
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     return next(req).then((res) => {
       const duration = Date.now() - startTime
       volleyClient.send({

--- a/src/lib/tests/MockRelayRenderer.tsx
+++ b/src/lib/tests/MockRelayRenderer.tsx
@@ -131,12 +131,12 @@ export class MockRelayRenderer<T extends OperationType> extends React.Component<
   MockRelayRendererProps<T>,
   MockRelayRendererState
 > {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   state = {
     caughtError: undefined,
   }
 
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   componentDidCatch(error, errorInfo) {
     this.setState({ caughtError: { error, errorInfo } })
   }
@@ -181,7 +181,7 @@ export class MockRelayRenderer<T extends OperationType> extends React.Component<
     }
 
     if (this.state.caughtError) {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const { error, errorInfo } = this.state.caughtError
       console.log({ error, errorInfo })
       return `Error occurred while rendering Relay component: ${error}`

--- a/src/lib/tests/__tests__/MockRelayRenderer-tests.tsx
+++ b/src/lib/tests/__tests__/MockRelayRenderer-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import * as React from "react"
 import { Image, Text, View } from "react-native"
@@ -11,7 +11,7 @@ jest.unmock("react-relay")
 describe("MockRelayRenderer", () => {
   it("renders a Relay tree", async () => {
     const tree = await renderUntil(
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       (wrapper) => wrapper.text().includes("Mona Lisa"),
       <MockRelayRenderer
         Component={Artwork}

--- a/src/lib/tests/__tests__/MockRelayRendererFixtures.tsx
+++ b/src/lib/tests/__tests__/MockRelayRendererFixtures.tsx
@@ -2,9 +2,9 @@ import { MockRelayRendererFixtures_artist } from "__generated__/MockRelayRendere
 import { MockRelayRendererFixtures_artwork } from "__generated__/MockRelayRendererFixtures_artwork.graphql"
 import { MockRelayRendererFixtures_artworkMetadata } from "__generated__/MockRelayRendererFixtures_artworkMetadata.graphql"
 import { MockRelayRendererFixturesArtistQuery } from "__generated__/MockRelayRendererFixturesArtistQuery.graphql"
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import cheerio from "cheerio"
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { render } from "enzyme"
 import * as React from "react"
 import { Image, Text, View } from "react-native"
@@ -27,7 +27,7 @@ export const Artwork = createFragmentContainer(
   (props: { artwork: MockRelayRendererFixtures_artwork }) => (
     <View>
       <Image
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         source={{ uri: props.artwork && props.artwork.image && props.artwork.image.url }}
       />
       <Metadata artworkMetadata={props.artwork} />
@@ -66,7 +66,7 @@ const ArtistQueryRenderer = (props: { id: string }) => (
     {({ relayEnvironment }) => {
       return (
         <QueryRenderer<MockRelayRendererFixturesArtistQuery>
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           environment={relayEnvironment}
           variables={props}
           query={graphql`

--- a/src/lib/tests/__tests__/renderRelayTree-tests.tsx
+++ b/src/lib/tests/__tests__/renderRelayTree-tests.tsx
@@ -59,7 +59,7 @@ describe("renderRelayTree", () => {
     }
 
     const tree = await renderRelayTree({
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       renderUntil: (wrapper) =>
         // FIXME: Why does this need `first`? Only a single Text component has this prop.
         wrapper.find({ testID: "much-later" }).first().text().length > 0,

--- a/src/lib/tests/__tests__/renderUntil-tests.tsx
+++ b/src/lib/tests/__tests__/renderUntil-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import * as React from "react"
 import { Text, View } from "react-native"
@@ -33,20 +33,20 @@ class Component extends React.Component {
 describe("renderUntil", () => {
   describe("as an enzyme API extension", () => {
     it("yields an enzyme wrapper to the `until` block until it returns true", async () => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const states = []
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       await mount(<Component />).renderUntil((tree) => {
         const text = tree.find(Text).text()
         states.push(text)
         return text !== "Loading"
       })
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       expect(states).toEqual(["Loading", "ohai"])
     })
 
     it("resolves the promise with an enzyme wrapper with the final state", async () => {
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const wrapper = await mount(<Component />).renderUntil((tree) => tree.find(Text).text() !== "Loading")
       expect(wrapper.find(Text).text()).toEqual("ohai")
     })

--- a/src/lib/tests/createMockNetworkLayer/index.ts
+++ b/src/lib/tests/createMockNetworkLayer/index.ts
@@ -7,10 +7,10 @@ import {
   responsePathAsArray,
 } from "graphql"
 import { IMocks } from "graphql-tools/dist/Interfaces"
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import getNetworkLayer from "relay-mock-network-layer"
 import { INetwork as RelayNetwork, Network } from "relay-runtime"
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import uuid from "uuid"
 
 import { get } from "lib/utils/get"
@@ -25,7 +25,7 @@ export const createMockNetworkLayer = (mockResolvers: IMocks) => {
     getNetworkLayer({
       schema,
       mocks: { FormattedNumber: () => FormattedNumber, ...mockResolvers },
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       resolveQueryFromOperation: ({ id }) => {
         return require("../../../../data/complete.queryMap.json")[id]
       },
@@ -73,7 +73,7 @@ export const createMockFetchQuery = ({
       // whether to resolve fields in a given value
       if (typeof source !== "object") {
         const parentPath = pathAsArray.slice(0, -1).join("/")
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         const operationName = get(info, (i) => i.operation.name.value)
         throw new Error(
           `The value at path '${parentPath}' for operation '${operationName}' should be an object but is a ${typeof source}.`
@@ -127,7 +127,7 @@ export const createMockFetchQuery = ({
       )
     }) as GraphQLFieldResolver<any, any>,
     schema,
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     resolveQueryFromOperation: ({ id }) => {
       return require("../../../../data/complete.queryMap.json")[id]
     },
@@ -139,7 +139,7 @@ export const createMockFetchQuery = ({
       Query: Object.keys(mockData).reduce(
         (acc, k) => ({
           ...acc,
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           [k]: typeof mockData[k] === "function" ? mockData[k] : () => mockData[k],
         }),
         {}
@@ -147,7 +147,7 @@ export const createMockFetchQuery = ({
       Mutation: Object.keys(mockMutationResults).reduce(
         (acc, k) => ({
           ...acc,
-          // @ts-ignore STRICTNESS_MIGRATION
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           [k]: typeof mockMutationResults[k] === "function" ? mockMutationResults[k] : () => mockMutationResults[k],
         }),
         {}
@@ -246,7 +246,7 @@ function error(
     renderMessage({
       path: responsePathAsArray(info.path).join("/"),
       type: info.returnType.inspect(),
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       operationName: get(info, (i) => i.operation.name.value, "(unknown)"),
     })
   )

--- a/src/lib/tests/renderRelayTree.tsx
+++ b/src/lib/tests/renderRelayTree.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount, RenderUntilPredicate } from "enzyme"
 import React from "react"
 import { Variables } from "relay-runtime"

--- a/src/lib/tests/renderUntil.tsx
+++ b/src/lib/tests/renderUntil.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount, ReactWrapper, RenderUntilPredicate } from "enzyme"
 import * as React from "react"
 import { waitUntil } from "./waitUntil"

--- a/src/lib/utils/CatchErrors.tsx
+++ b/src/lib/utils/CatchErrors.tsx
@@ -2,7 +2,7 @@ import React from "react"
 
 // Test util for logging async render errors in tests
 export class CatchErrors extends React.Component {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   static getDerivedStateFromError(error) {
     console.log("ERROR", error)
   }

--- a/src/lib/utils/__tests__/renderMarkdown-tests.tsx
+++ b/src/lib/utils/__tests__/renderMarkdown-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount, shallow } from "enzyme"
 import { LinkText } from "lib/Components/Text/LinkText"
 import { Flex, Sans, Serif, Text, Theme } from "palette"
@@ -70,7 +70,7 @@ describe("renderMarkdown", () => {
       ...basicRules,
       paragraph: {
         ...basicRules.paragraph,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         react: (node, output, state) => {
           return (
             <Serif size="3t" color="black60" key={state.key}>
@@ -99,7 +99,7 @@ describe("renderMarkdown", () => {
       ...basicRules,
       paragraph: {
         ...basicRules.paragraph,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         react: (node, output, state) => {
           return (
             <Serif size="3t" color="black60" key={state.key}>
@@ -132,7 +132,7 @@ describe("renderMarkdown", () => {
       ...basicRules,
       paragraph: {
         ...basicRules.paragraph,
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         react: (node, output, state) => {
           return (
             <Serif size="3t" color="black60" key={state.key}>
@@ -174,11 +174,9 @@ describe("renderMarkdown", () => {
 })
 
 function visitTree(tree: unknown, visit: (node: React.ReactElement) => void) {
-  // @ts-ignore STRICTNESS_MIGRATION
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   if (React.isValidElement(tree)) {
-    // @ts-ignore STRICTNESS_MIGRATION
     visit(tree)
-    // @ts-ignore STRICTNESS_MIGRATION
     React.Children.forEach((tree.props as any).children, (child) => visitTree(child, visit))
   } else if (Array.isArray(tree)) {
     tree.map((child) => visitTree(child, visit))

--- a/src/lib/utils/__tests__/renderWithLoadProgress-tests.tsx
+++ b/src/lib/utils/__tests__/renderWithLoadProgress-tests.tsx
@@ -11,7 +11,7 @@ describe(renderWithLoadProgress, () => {
 
     expect(React.isValidElement(result)).toBeTruthy()
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const tree = renderWithWrappers(result)
     expect(tree.root.findByType(Spinner)).toBeTruthy()
   })
@@ -21,7 +21,7 @@ describe(renderWithLoadProgress, () => {
       {}
     )({ error: null, props: {}, retry: () => null })
     expect(React.isValidElement(result)).toBeTruthy()
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const tree = renderWithWrappers(result)
     expect(extractText(tree.root)).toBe("the real content")
   })

--- a/src/lib/utils/__tests__/renderWithPlaceholder-tests.tsx
+++ b/src/lib/utils/__tests__/renderWithPlaceholder-tests.tsx
@@ -13,7 +13,7 @@ describe(renderWithPlaceholder, () => {
 
     expect(React.isValidElement(result)).toBeTruthy()
 
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const tree = renderWithWrappers(result)
     expect(extractText(tree.root)).toBe("this is the placeholder")
   })
@@ -23,7 +23,7 @@ describe(renderWithPlaceholder, () => {
       renderPlaceholder: () => <Text>this is the placeholder</Text>,
     })({ error: null, props: {}, retry: () => null })
     expect(React.isValidElement(result)).toBeTruthy()
-    // @ts-ignore STRICTNESS_MIGRATION
+    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const tree = renderWithWrappers(result)
     expect(extractText(tree.root)).toBe("the real content")
   })

--- a/src/lib/utils/__tests__/useGlobalState-tests.tsx
+++ b/src/lib/utils/__tests__/useGlobalState-tests.tsx
@@ -1,4 +1,4 @@
-// @ts-ignore STRICTNESS_MIGRATION
+// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import React from "react"
 import { useGlobalState } from "../useGlobalState"

--- a/src/lib/utils/convertCityToGeoJSON.ts
+++ b/src/lib/utils/convertCityToGeoJSON.ts
@@ -44,9 +44,9 @@ export const convertCityToGeoJSON = (data: any /* STRICTNESS_MIGRATION */) => {
     features: data
       // The API has (at least once) given us back shows without locations
       // so we should protect against runtime errors.
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       .filter((feature) => feature.location && feature.location.coordinates)
-      // @ts-ignore STRICTNESS_MIGRATION
+      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       .map((node) => {
         const {
           coordinates: { lat, lng },

--- a/src/lib/utils/googleMaps.ts
+++ b/src/lib/utils/googleMaps.ts
@@ -51,11 +51,8 @@ export const getLocationDetails = async ({ id, name }: SimpleLocation): Promise<
 
   // TODO: Add dedicated error handling to the maps response
   const { address_components, geometry } = data.result as PlaceResult
-  // @ts-ignore STRICTNESS_MIGRATION
   const cityPlace = address_components.find((comp) => comp.types[0] === "locality")
-  // @ts-ignore STRICTNESS_MIGRATION
   const statePlace = address_components.find((comp) => comp.types[0] === "administrative_area_level_1")
-  // @ts-ignore STRICTNESS_MIGRATION
   const countryPlace = address_components.find((comp) => comp.types[0] === "country")
   const postalCodePlace = address_components.find((comp) => comp.types[0] === "postal_code")
   const { lat, lng } = geometry.location

--- a/src/lib/utils/renderMarkdown.tsx
+++ b/src/lib/utils/renderMarkdown.tsx
@@ -46,9 +46,9 @@ export function defaultRules({
     link: {
       react: (node, output, state) => {
         state.withinText = true
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         let element
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         const openUrl = (url) => {
           if (node.target.startsWith("mailto:")) {
             Linking.canOpenURL(url)
@@ -61,16 +61,15 @@ export function defaultRules({
               })
               .catch((err) => console.error("An error occurred", err))
           } else if (modal) {
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             SwitchBoard.presentModalViewController(element, url)
           } else {
-            // @ts-ignore STRICTNESS_MIGRATION
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             SwitchBoard.presentNavigationViewController(element, url)
           }
         }
 
         return (
-          // @ts-ignore STRICTNESS_MIGRATION
           <LinkText key={state.key} onPress={() => openUrl(node.target)} ref={(el) => (element = el)}>
             {output(node.content, state)}
           </LinkText>
@@ -224,7 +223,7 @@ export function defaultRules({
           3: "subtitle",
           4: "text",
         }
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         const size = useNewTextStyles ? newTextMap[node.level] || "subtitle" : map[node.level] || "4"
         return useNewTextStyles ? (
           <Text mb="1" variant={size} key={state.key}>

--- a/src/lib/utils/renderWithPlaceholder.tsx
+++ b/src/lib/utils/renderWithPlaceholder.tsx
@@ -62,14 +62,14 @@ export function renderWithPlaceholder<Props>({
         return <LoadFailureView style={{ flex: 1 }} />
       } else {
         retrying = true
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         return <LoadFailureView onRetry={retry} style={{ flex: 1 }} />
       }
     } else if (props) {
       if (render) {
         return <>{render({ ...initialProps, ...(props as any) })}</>
       } else {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         return <Container {...initialProps} {...(props as any)} />
       }
     } else {

--- a/src/palette/elements/Button/Button.tsx
+++ b/src/palette/elements/Button/Button.tsx
@@ -245,7 +245,7 @@ export const Button: React.FC<ButtonProps> = (props) => {
   return (
     <Spring native from={from} to={to}>
       {
-        // @ts-ignore STRICTNESS_MIGRATION
+        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         (springProps) => (
           <TouchableWithoutFeedback
             onPress={onPress}


### PR DESCRIPTION
### Description

Folks are frequently copy-pasting `STRICTNESS_MIGRATION` comments and receiving feedback about it in PR reviews. I've done a couple of things here to give earlier and more useful feedback:

- Added extra inline context to let people know that code with `STRICTNESS_MIGRATION` comments is unsafe, gently implying that the code should not be reproduced.
- Use the new (since we turned on strict mode at least) TS compiler feature `@ts-expect-error` instead of `@ts-ignore`. `@ts-expect-error` will cause TS compiler errors when the comment is not actually suppressing one or more errors.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
