### PR TITLE
fix(MyAccount): field edit nav issues

### DIFF
--- a/Artsy/App/ARScreenPresenterModule.m
+++ b/Artsy/App/ARScreenPresenterModule.m
@@ -148,7 +148,7 @@ RCT_EXPORT_METHOD(presentModal:(nonnull NSDictionary *)viewDescriptor           
 {
     UIViewController *vc = [[ARAppDelegate sharedInstance] window].rootViewController;
 
-    while ([vc presentedViewController]) {
+    while ([vc presentedViewController] && [[vc presentedViewController] isKindOfClass:ARModalWithBottomSafeAreaViewController.class]) {
         vc = [vc presentedViewController];
     }
 
@@ -163,7 +163,7 @@ RCT_EXPORT_METHOD(dismissModal)
 RCT_EXPORT_METHOD(goBack:(nonnull NSString *)currentTabStackID)
 {
     UINavigationController *vc = (id)[self.class currentlyPresentedVC];
-    if ([vc presentingViewController]) {
+    if ([vc presentingViewController] && [vc isKindOfClass:ARModalWithBottomSafeAreaViewController.class]) {
         // it's a modal
         if ([vc isKindOfClass:ARModalWithBottomSafeAreaViewController.class] && ((ARModalWithBottomSafeAreaViewController *)vc).stack.viewControllers.count > 1) {
             [((ARModalWithBottomSafeAreaViewController *)vc).stack popViewControllerAnimated:YES];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -244,6 +244,7 @@ releases:
       - Hide artists with 0 published works on Gallery page - mounir
       - Fix bug preventing galleries' recent and upcoming shows from displaying in some cases - david
       - Fix partner artist counts label logic - david
+      - Fix My Account field edit form dismiss issues - david
 
   - version: 6.6.0
     date: August 5, 2020

--- a/src/lib/Scenes/MyAccount/Components/MyAccountFieldEditScreen.tsx
+++ b/src/lib/Scenes/MyAccount/Components/MyAccountFieldEditScreen.tsx
@@ -1,6 +1,6 @@
 import LoadingModal from "lib/Components/Modals/LoadingModal"
 import { PageWithSimpleHeader } from "lib/Components/PageWithSimpleHeader"
-import SwitchBoard from "lib/NativeModules/SwitchBoard"
+import { goBack } from "lib/navigation/navigate"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { Sans } from "palette"
 import React, { useImperativeHandle, useRef, useState } from "react"
@@ -34,18 +34,9 @@ export const MyAccountFieldEditScreen = React.forwardRef<
   React.PropsWithChildren<MyAccountFieldEditScreenProps>
 >(({ children, canSave, onSave, title, contentContainerStyle }, ref) => {
   const [isSaving, setIsSaving] = useState<boolean>(false)
-  const [behindTheModalDismiss, setBehindTheModalDismiss] = useState(false)
   const [behindTheModalAlert, setBehindTheModalAlert] = useState<AlertArgs | undefined>(undefined)
   const scrollViewRef = useRef<ScrollView>(null)
   const screen = useScreenDimensions()
-
-  const onDismiss = () => {
-    SwitchBoard.dismissNavigationViewController(scrollViewRef.current!)
-  }
-
-  const doTheDismiss = () => {
-    setBehindTheModalDismiss(true)
-  }
 
   const doTheAlert: AlertStatic["alert"] = (...args) => {
     setBehindTheModalAlert(args)
@@ -57,7 +48,7 @@ export const MyAccountFieldEditScreen = React.forwardRef<
     }
     try {
       setIsSaving(true)
-      await onSave(doTheDismiss, doTheAlert)
+      await onSave(goBack, doTheAlert)
     } catch (e) {
       console.error(e)
     } finally {
@@ -84,7 +75,7 @@ export const MyAccountFieldEditScreen = React.forwardRef<
     <KeyboardAvoidingView behavior="padding" style={{ flex: 1 }} keyboardVerticalOffset={screen.safeAreaInsets.top}>
       <PageWithSimpleHeader
         left={
-          <TouchableOpacity onPress={onDismiss}>
+          <TouchableOpacity onPress={goBack}>
             <Sans size="4" textAlign="left">
               Cancel
             </Sans>
@@ -108,9 +99,6 @@ export const MyAccountFieldEditScreen = React.forwardRef<
           <LoadingModal
             isVisible={isSaving}
             onDismiss={() => {
-              if (behindTheModalDismiss) {
-                onDismiss()
-              }
               if (behindTheModalAlert !== undefined) {
                 Alert.alert(...behindTheModalAlert)
               }

--- a/src/lib/Scenes/MyAccount/Components/MyAccountFieldEditScreen.tsx
+++ b/src/lib/Scenes/MyAccount/Components/MyAccountFieldEditScreen.tsx
@@ -34,12 +34,12 @@ export const MyAccountFieldEditScreen = React.forwardRef<
   React.PropsWithChildren<MyAccountFieldEditScreenProps>
 >(({ children, canSave, onSave, title, contentContainerStyle }, ref) => {
   const [isSaving, setIsSaving] = useState<boolean>(false)
-  const [behindTheModalAlert, setBehindTheModalAlert] = useState<AlertArgs | undefined>(undefined)
+  const afterLoadingAlert = useRef<AlertArgs>()
   const scrollViewRef = useRef<ScrollView>(null)
   const screen = useScreenDimensions()
 
   const doTheAlert: AlertStatic["alert"] = (...args) => {
-    setBehindTheModalAlert(args)
+    afterLoadingAlert.current = args
   }
 
   const handleSave = async () => {
@@ -96,14 +96,17 @@ export const MyAccountFieldEditScreen = React.forwardRef<
           keyboardDismissMode="on-drag"
           keyboardShouldPersistTaps="handled"
         >
-          <LoadingModal
-            isVisible={isSaving}
-            onDismiss={() => {
-              if (behindTheModalAlert !== undefined) {
-                Alert.alert(...behindTheModalAlert)
-              }
-            }}
-          />
+          {!!isSaving && (
+            <LoadingModal
+              isVisible
+              onDismiss={() => {
+                if (afterLoadingAlert.current) {
+                  Alert.alert(...afterLoadingAlert.current)
+                  afterLoadingAlert.current = undefined
+                }
+              }}
+            />
+          )}
           {children}
         </ScrollView>
       </PageWithSimpleHeader>

--- a/src/lib/Scenes/MyProfile/MyProfilePaymentNewCreditCard.tsx
+++ b/src/lib/Scenes/MyProfile/MyProfilePaymentNewCreditCard.tsx
@@ -10,7 +10,6 @@ import { useInterval } from "lib/utils/useInterval"
 import { color } from "palette"
 import { fontFamily } from "palette/platform/fonts/fontFamily"
 import React, { useEffect, useRef, useState } from "react"
-import { Alert } from "react-native"
 import { commitMutation, graphql } from "react-relay"
 // @ts-ignore
 import stripe, { PaymentCardTextField } from "tipsi-stripe"
@@ -113,7 +112,7 @@ export const MyProfilePaymentNewCreditCard: React.FC<{}> = ({}) => {
       ref={screenRef}
       canSave={state.allPresent}
       title="Add new card"
-      onSave={async (dismiss) => {
+      onSave={async (dismiss, alert) => {
         try {
           const stripeResult = await stripe.createTokenWithCard({
             ...state.fields.creditCard.value?.params,
@@ -142,7 +141,7 @@ export const MyProfilePaymentNewCreditCard: React.FC<{}> = ({}) => {
           dismiss()
         } catch (e) {
           console.error(e)
-          Alert.alert("Something went wrong while attempting to save your credit card. Please try again or contact us.")
+          alert("Something went wrong while attempting to save your credit card. Please try again or contact us.")
         }
       }}
     >


### PR DESCRIPTION
This PR resolves 

- https://www.notion.so/artsy/Profile-Account-updating-phone-number-or-name-probably-others-doesn-t-dismiss-edit-field-scree-e46392df7c214ea388e1c4f11ee3d1c6
- https://www.notion.so/artsy/Profile-Payment-Add-new-card-error-message-doesn-t-appear-or-appears-for-only-a-split-second--2818c677b1b643c4a0527199d897593d

### Description

These bugs were triggered when react-native changed the way `Modal#onDismiss` is invoked. It used to be called whenever the native modal was hidden (controlled by the `visible` prop), and now it is only called when the react component unmounts. https://github.com/facebook/react-native/commit/bd2b7d6c0366b5f19de56b71cb706a0af4b0be43

On this edit screen we use the `onDismiss` callback to trigger alerts or navigation actions safely (these can cause bugs if triggered before the modal has a chance to be removed from the native view hierarchy).

So the way to fix this was to make sure that we unmount the loading modal component when we don't want to show it, triggering the callback at the appropriate time.

I also cleaned up some related code before figuring that out:

- Use the 'alert' callback in the credit card form, to opt in to the special `onDismiss` behaviour.
- Make our own native nav code more robust so that it works even if there's a `Modal` being shown.

TODO:

- [x] QA modal navigation in the whole app

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
