### PR TITLE
fix: Move first inquiry message trim

### DIFF
--- a/src/lib/Scenes/Artwork/Components/Mutation/SubmitInquiryRequest.ts
+++ b/src/lib/Scenes/Artwork/Components/Mutation/SubmitInquiryRequest.ts
@@ -40,7 +40,7 @@ export const SubmitInquiryRequest = (
         inquireableID: inquireable.internalID,
         inquireableType: "Artwork",
         questions: formattedQuestions,
-        message: inquiryState.message,
+        message: inquiryState.message?.trim(),
       },
     },
     mutation: graphql`

--- a/src/lib/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
+++ b/src/lib/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
@@ -52,7 +52,7 @@ export const reducer = (
     case "setMessage":
       return {
         ...inquiryState,
-        message: action.payload.trim(),
+        message: action.payload,
       }
   }
 }


### PR DESCRIPTION
The type of this PR is: Bugfix

### Description

Moved the trim to the submit to avoid it getting triggered on every keyup. Otherwise, every time the user would put in a space between words the trim would trigger.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
