### PR TITLE
feat: respect artwork size when showing price estimates

### DIFF
--- a/src/__generated__/MyCollectionArtworkInsightsTestsQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkInsightsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 3d60a40260c18190255dd1c3dc8c036c */
+/* @relayHash c6cf395dfaa860ff36d7827cf0fc0c1d */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -115,12 +115,22 @@ fragment MyCollectionArtworkInsights_marketPriceInsights on MarketPriceInsights 
 fragment MyCollectionArtworkPriceEstimate_artwork on Artwork {
   costCurrencyCode
   costMinor
+  sizeBucket
 }
 
 fragment MyCollectionArtworkPriceEstimate_marketPriceInsights on MarketPriceInsights {
-  lowRangeCents
-  midRangeCents
   highRangeCents
+  largeHighRangeCents
+  largeLowRangeCents
+  largeMidRangeCents
+  lowRangeCents
+  mediumHighRangeCents
+  mediumLowRangeCents
+  mediumMidRangeCents
+  midRangeCents
+  smallHighRangeCents
+  smallLowRangeCents
+  smallMidRangeCents
   artsyQInventory
 }
 */
@@ -285,6 +295,13 @@ return {
             "args": null,
             "kind": "ScalarField",
             "name": "costMinor",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "sizeBucket",
             "storageKey": null
           },
           {
@@ -550,7 +567,56 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "highRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "largeHighRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "largeLowRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "largeMidRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "lowRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "mediumHighRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "mediumLowRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "mediumMidRangeCents",
             "storageKey": null
           },
           {
@@ -564,7 +630,21 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "highRangeCents",
+            "name": "smallHighRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "smallLowRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "smallMidRangeCents",
             "storageKey": null
           },
           {
@@ -622,7 +702,7 @@ return {
     ]
   },
   "params": {
-    "id": "3d60a40260c18190255dd1c3dc8c036c",
+    "id": "c6cf395dfaa860ff36d7827cf0fc0c1d",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artwork": {
@@ -717,6 +797,7 @@ return {
         "artwork.costCurrencyCode": (v8/*: any*/),
         "artwork.costMinor": (v11/*: any*/),
         "artwork.id": (v7/*: any*/),
+        "artwork.sizeBucket": (v8/*: any*/),
         "marketPriceInsights": {
           "enumValues": null,
           "nullable": true,
@@ -729,11 +810,20 @@ return {
         "marketPriceInsights.demandRank": (v10/*: any*/),
         "marketPriceInsights.demandTrend": (v10/*: any*/),
         "marketPriceInsights.highRangeCents": (v12/*: any*/),
+        "marketPriceInsights.largeHighRangeCents": (v12/*: any*/),
+        "marketPriceInsights.largeLowRangeCents": (v12/*: any*/),
+        "marketPriceInsights.largeMidRangeCents": (v12/*: any*/),
         "marketPriceInsights.liquidityRank": (v10/*: any*/),
         "marketPriceInsights.lowRangeCents": (v12/*: any*/),
         "marketPriceInsights.medianSaleToEstimateRatio": (v10/*: any*/),
+        "marketPriceInsights.mediumHighRangeCents": (v12/*: any*/),
+        "marketPriceInsights.mediumLowRangeCents": (v12/*: any*/),
+        "marketPriceInsights.mediumMidRangeCents": (v12/*: any*/),
         "marketPriceInsights.midRangeCents": (v12/*: any*/),
-        "marketPriceInsights.sellThroughRate": (v10/*: any*/)
+        "marketPriceInsights.sellThroughRate": (v10/*: any*/),
+        "marketPriceInsights.smallHighRangeCents": (v12/*: any*/),
+        "marketPriceInsights.smallLowRangeCents": (v12/*: any*/),
+        "marketPriceInsights.smallMidRangeCents": (v12/*: any*/)
       }
     },
     "name": "MyCollectionArtworkInsightsTestsQuery",

--- a/src/__generated__/MyCollectionArtworkPriceEstimateTestsQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkPriceEstimateTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash d390f1995bfcadc940cb21f450a58bce */
+/* @relayHash e1d69042a5c3f99f1f7167fd85323e96 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -35,12 +35,22 @@ query MyCollectionArtworkPriceEstimateTestsQuery {
 fragment MyCollectionArtworkPriceEstimate_artwork on Artwork {
   costCurrencyCode
   costMinor
+  sizeBucket
 }
 
 fragment MyCollectionArtworkPriceEstimate_marketPriceInsights on MarketPriceInsights {
-  lowRangeCents
-  midRangeCents
   highRangeCents
+  largeHighRangeCents
+  largeLowRangeCents
+  largeMidRangeCents
+  lowRangeCents
+  mediumHighRangeCents
+  mediumLowRangeCents
+  mediumMidRangeCents
+  midRangeCents
+  smallHighRangeCents
+  smallLowRangeCents
+  smallMidRangeCents
   artsyQInventory
 }
 */
@@ -69,9 +79,15 @@ v2 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Int"
+  "type": "String"
 },
 v3 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+},
+v4 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -152,6 +168,13 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "sizeBucket",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "id",
             "storageKey": null
           }
@@ -170,7 +193,56 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "highRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "largeHighRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "largeLowRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "largeMidRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "lowRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "mediumHighRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "mediumLowRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "mediumMidRangeCents",
             "storageKey": null
           },
           {
@@ -184,7 +256,21 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "highRangeCents",
+            "name": "smallHighRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "smallLowRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "smallMidRangeCents",
             "storageKey": null
           },
           {
@@ -200,7 +286,7 @@ return {
     ]
   },
   "params": {
-    "id": "d390f1995bfcadc940cb21f450a58bce",
+    "id": "e1d69042a5c3f99f1f7167fd85323e96",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artwork": {
@@ -209,29 +295,34 @@ return {
           "plural": false,
           "type": "Artwork"
         },
-        "artwork.costCurrencyCode": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "String"
-        },
-        "artwork.costMinor": (v2/*: any*/),
+        "artwork.costCurrencyCode": (v2/*: any*/),
+        "artwork.costMinor": (v3/*: any*/),
         "artwork.id": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "ID"
         },
+        "artwork.sizeBucket": (v2/*: any*/),
         "marketPriceInsights": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "MarketPriceInsights"
         },
-        "marketPriceInsights.artsyQInventory": (v2/*: any*/),
-        "marketPriceInsights.highRangeCents": (v3/*: any*/),
-        "marketPriceInsights.lowRangeCents": (v3/*: any*/),
-        "marketPriceInsights.midRangeCents": (v3/*: any*/)
+        "marketPriceInsights.artsyQInventory": (v3/*: any*/),
+        "marketPriceInsights.highRangeCents": (v4/*: any*/),
+        "marketPriceInsights.largeHighRangeCents": (v4/*: any*/),
+        "marketPriceInsights.largeLowRangeCents": (v4/*: any*/),
+        "marketPriceInsights.largeMidRangeCents": (v4/*: any*/),
+        "marketPriceInsights.lowRangeCents": (v4/*: any*/),
+        "marketPriceInsights.mediumHighRangeCents": (v4/*: any*/),
+        "marketPriceInsights.mediumLowRangeCents": (v4/*: any*/),
+        "marketPriceInsights.mediumMidRangeCents": (v4/*: any*/),
+        "marketPriceInsights.midRangeCents": (v4/*: any*/),
+        "marketPriceInsights.smallHighRangeCents": (v4/*: any*/),
+        "marketPriceInsights.smallLowRangeCents": (v4/*: any*/),
+        "marketPriceInsights.smallMidRangeCents": (v4/*: any*/)
       }
     },
     "name": "MyCollectionArtworkPriceEstimateTestsQuery",

--- a/src/__generated__/MyCollectionArtworkPriceEstimate_artwork.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkPriceEstimate_artwork.graphql.ts
@@ -7,6 +7,7 @@ import { FragmentRefs } from "relay-runtime";
 export type MyCollectionArtworkPriceEstimate_artwork = {
     readonly costCurrencyCode: string | null;
     readonly costMinor: number | null;
+    readonly sizeBucket: string | null;
     readonly " $refType": "MyCollectionArtworkPriceEstimate_artwork";
 };
 export type MyCollectionArtworkPriceEstimate_artwork$data = MyCollectionArtworkPriceEstimate_artwork;
@@ -36,10 +37,17 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "costMinor",
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "sizeBucket",
+      "storageKey": null
     }
   ],
   "type": "Artwork",
   "abstractKey": null
 };
-(node as any).hash = 'cc20cca835416f0c81a766093a50c9a3';
+(node as any).hash = 'ed3863356afb703062edcc03183f51f0';
 export default node;

--- a/src/__generated__/MyCollectionArtworkPriceEstimate_marketPriceInsights.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkPriceEstimate_marketPriceInsights.graphql.ts
@@ -5,9 +5,18 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type MyCollectionArtworkPriceEstimate_marketPriceInsights = {
-    readonly lowRangeCents: unknown | null;
-    readonly midRangeCents: unknown | null;
     readonly highRangeCents: unknown | null;
+    readonly largeHighRangeCents: unknown | null;
+    readonly largeLowRangeCents: unknown | null;
+    readonly largeMidRangeCents: unknown | null;
+    readonly lowRangeCents: unknown | null;
+    readonly mediumHighRangeCents: unknown | null;
+    readonly mediumLowRangeCents: unknown | null;
+    readonly mediumMidRangeCents: unknown | null;
+    readonly midRangeCents: unknown | null;
+    readonly smallHighRangeCents: unknown | null;
+    readonly smallLowRangeCents: unknown | null;
+    readonly smallMidRangeCents: unknown | null;
     readonly artsyQInventory: number | null;
     readonly " $refType": "MyCollectionArtworkPriceEstimate_marketPriceInsights";
 };
@@ -29,7 +38,56 @@ const node: ReaderFragment = {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
+      "name": "highRangeCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "largeHighRangeCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "largeLowRangeCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "largeMidRangeCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
       "name": "lowRangeCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "mediumHighRangeCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "mediumLowRangeCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "mediumMidRangeCents",
       "storageKey": null
     },
     {
@@ -43,7 +101,21 @@ const node: ReaderFragment = {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
-      "name": "highRangeCents",
+      "name": "smallHighRangeCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "smallLowRangeCents",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "smallMidRangeCents",
       "storageKey": null
     },
     {
@@ -57,5 +129,5 @@ const node: ReaderFragment = {
   "type": "MarketPriceInsights",
   "abstractKey": null
 };
-(node as any).hash = 'c4741bd74a0ecbda63e9ed4d64c6524b';
+(node as any).hash = 'c5528817f0ed2109eb23e454510a27bd';
 export default node;

--- a/src/__generated__/MyCollectionArtworkQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 01eb3dfb3f30d65bbb348e58f9bb7dec */
+/* @relayHash 3e0d07aee35ae08457ee3362fb32ae60 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -195,12 +195,22 @@ fragment MyCollectionArtworkMeta_artwork on Artwork {
 fragment MyCollectionArtworkPriceEstimate_artwork on Artwork {
   costCurrencyCode
   costMinor
+  sizeBucket
 }
 
 fragment MyCollectionArtworkPriceEstimate_marketPriceInsights on MarketPriceInsights {
-  lowRangeCents
-  midRangeCents
   highRangeCents
+  largeHighRangeCents
+  largeLowRangeCents
+  largeMidRangeCents
+  lowRangeCents
+  mediumHighRangeCents
+  mediumLowRangeCents
+  mediumMidRangeCents
+  midRangeCents
+  smallHighRangeCents
+  smallLowRangeCents
+  smallMidRangeCents
   artsyQInventory
 }
 */
@@ -731,7 +741,14 @@ return {
           (v18/*: any*/),
           (v19/*: any*/),
           (v20/*: any*/),
-          (v21/*: any*/)
+          (v21/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "sizeBucket",
+            "storageKey": null
+          }
         ],
         "storageKey": null
       },
@@ -754,7 +771,56 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "highRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "largeHighRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "largeLowRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "largeMidRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "lowRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "mediumHighRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "mediumLowRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "mediumMidRangeCents",
             "storageKey": null
           },
           {
@@ -768,7 +834,21 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "highRangeCents",
+            "name": "smallHighRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "smallLowRangeCents",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "smallMidRangeCents",
             "storageKey": null
           },
           {
@@ -826,7 +906,7 @@ return {
     ]
   },
   "params": {
-    "id": "01eb3dfb3f30d65bbb348e58f9bb7dec",
+    "id": "3e0d07aee35ae08457ee3362fb32ae60",
     "metadata": {},
     "name": "MyCollectionArtworkQuery",
     "operationKind": "query",

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkPriceEstimate.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkPriceEstimate.tsx
@@ -13,6 +13,68 @@ interface MyCollectionArtworkPriceEstimateProps {
   marketPriceInsights: MyCollectionArtworkPriceEstimate_marketPriceInsights
 }
 
+const rangeCents = (
+  artwork: MyCollectionArtworkPriceEstimate_artwork,
+  marketPriceInsights: MyCollectionArtworkPriceEstimate_marketPriceInsights
+) => {
+  const {
+    lowRangeCents,
+    midRangeCents,
+    highRangeCents,
+    largeHighRangeCents,
+    largeLowRangeCents,
+    largeMidRangeCents,
+    mediumHighRangeCents,
+    mediumLowRangeCents,
+    mediumMidRangeCents,
+    smallHighRangeCents,
+    smallLowRangeCents,
+    smallMidRangeCents,
+  } = marketPriceInsights
+
+  let lowCents
+  let midCents
+  let highCents
+
+  switch (artwork.sizeBucket) {
+    case "small": {
+      lowCents = smallLowRangeCents
+      midCents = smallMidRangeCents
+      highCents = smallHighRangeCents
+      break
+    }
+    case "medium": {
+      lowCents = mediumLowRangeCents
+      midCents = mediumMidRangeCents
+      highCents = mediumHighRangeCents
+      break
+    }
+    case "large": {
+      lowCents = largeLowRangeCents
+      midCents = largeMidRangeCents
+      highCents = largeHighRangeCents
+      break
+    }
+    default: {
+      lowCents = lowRangeCents
+      midCents = midRangeCents
+      highCents = highRangeCents
+    }
+  }
+
+  if (Number(lowCents) === 0 || Number(midCents) === 0 || Number(highCents) === 0) {
+    lowCents = lowRangeCents
+    midCents = midRangeCents
+    highCents = highRangeCents
+  }
+
+  return {
+    lowRangeCents: lowCents,
+    midRangeCents: midCents,
+    highRangeCents: highCents,
+  }
+}
+
 const MyCollectionArtworkPriceEstimate: React.FC<MyCollectionArtworkPriceEstimateProps> = ({
   artwork,
   marketPriceInsights,
@@ -21,7 +83,10 @@ const MyCollectionArtworkPriceEstimate: React.FC<MyCollectionArtworkPriceEstimat
     return null
   }
 
-  const { lowRangeCents, midRangeCents, highRangeCents, artsyQInventory } = marketPriceInsights
+  const { artsyQInventory } = marketPriceInsights
+
+  const { lowRangeCents, midRangeCents, highRangeCents } = rangeCents(artwork, marketPriceInsights)
+
   const lowRangeDollars = formatCentsToDollars(Number(lowRangeCents))
   const midRangeDollars = formatCentsToDollars(Number(midRangeCents))
   const highRangeDollars = formatCentsToDollars(Number(highRangeCents))
@@ -73,14 +138,24 @@ export const MyCollectionArtworkPriceEstimateFragmentContainer = createFragmentC
       fragment MyCollectionArtworkPriceEstimate_artwork on Artwork {
         costCurrencyCode
         costMinor
+        sizeBucket
       }
     `,
     marketPriceInsights: graphql`
       fragment MyCollectionArtworkPriceEstimate_marketPriceInsights on MarketPriceInsights {
-        # FIXME: These props are coming back from diffusion untyped
-        lowRangeCents
-        midRangeCents
+        # FIXME: These props are coming back from diffusion untyped as strings
         highRangeCents
+        largeHighRangeCents
+        largeLowRangeCents
+        largeMidRangeCents
+        lowRangeCents
+        mediumHighRangeCents
+        mediumLowRangeCents
+        mediumMidRangeCents
+        midRangeCents
+        smallHighRangeCents
+        smallLowRangeCents
+        smallMidRangeCents
         artsyQInventory
       }
     `,


### PR DESCRIPTION
Paired with @pepopowitz on this.

The type of this PR is: Feature

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-632]

### Description

Use artwork size bucket to choose price estimates from Metaphysics/Diffusion.

<img width="341" alt="Screen Shot 2020-11-23 at 8 28 32 PM" src="https://user-images.githubusercontent.com/19369/100035059-4d189600-2dcb-11eb-94af-0cb4ce480ef0.png">

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-632]: https://artsyproduct.atlassian.net/browse/CX-632