### PR TITLE
chore: upgrade typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "tslint": "5.14.0",
     "tslint-config-prettier": "1.18.0",
     "tslint-plugin-relay": "0.0.2",
-    "typescript": "4.0.2",
+    "typescript": "^4.1.2",
     "typescript-styled-plugin": "0.13.0",
     "vscode-apollo-relay": "1.5.0",
     "yaml": "1.9.2"

--- a/src/lib/Components/Bidding/Screens/ConfirmBid/index.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid/index.tsx
@@ -158,7 +158,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
    * need a separate call to update our User model to store that info
    */
   async updatePhoneNumber() {
-    return new Promise((done, reject) => {
+    return new Promise<void>((done, reject) => {
       // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const { phoneNumber } = this.state.billingAddress
       commitMutation<ConfirmBidUpdateUserMutation>(this.props.relay.environment, {
@@ -210,7 +210,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
   }
 
   async createCreditCard(token: any) {
-    return new Promise((done) => {
+    return new Promise<void>((done) => {
       commitMutation<ConfirmBidCreateCreditCardMutation>(this.props.relay.environment, {
         onCompleted: (data, errors) => {
           if (data && get(data, "createCreditCard.creditCardOrError.creditCard")) {

--- a/src/lib/Components/Bidding/Screens/Registration.tsx
+++ b/src/lib/Components/Bidding/Screens/Registration.tsx
@@ -140,7 +140,7 @@ export class Registration extends React.Component<RegistrationProps, Registratio
    * need a separate call to update our User model to store that info
    */
   async updatePhoneNumber() {
-    return new Promise((done, reject) => {
+    return new Promise<void>((done, reject) => {
       // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       const { phoneNumber } = this.state.billingAddress
       commitMutation<RegistrationUpdateUserMutation>(this.props.relay.environment, {
@@ -192,7 +192,7 @@ export class Registration extends React.Component<RegistrationProps, Registratio
   }
 
   async createCreditCard(token: any) {
-    return new Promise((done) => {
+    return new Promise<void>((done) => {
       commitMutation<RegistrationCreateCreditCardMutation>(this.props.relay.environment, {
         onCompleted: (data, errors) => {
           if (data && get(data, "createCreditCard.creditCardOrError.creditCard")) {

--- a/src/lib/Components/Bidding/__tests__/Helpers/FakeNavigator.tsx
+++ b/src/lib/Components/Bidding/__tests__/Helpers/FakeNavigator.tsx
@@ -36,7 +36,7 @@ export class FakeNavigator {
 
     return renderWithWrappers(
       <>
-        {React.createElement(currentRoute.component as any /* STRICTNESS_MIGRATION */, {
+        {React.createElement(currentRoute.component!, {
           ...currentRoute.passProps,
           nextScreen: true,
           navigator: this,

--- a/src/lib/Components/Disappearable.tsx
+++ b/src/lib/Components/Disappearable.tsx
@@ -21,7 +21,7 @@ export const Disappearable = React.forwardRef<Disappearable, React.PropsWithChil
     () => ({
       async disappear() {
         // first the content fades away and shrinks a little
-        await new Promise((resolve) => {
+        await new Promise<void>((resolve) => {
           if (__TEST__) {
             // .start doesn't exist at test time
             resolve()
@@ -33,10 +33,10 @@ export const Disappearable = React.forwardRef<Disappearable, React.PropsWithChil
             damping: 320,
             restSpeedThreshold: 0.1,
             toValue: 0,
-          }).start(resolve)
+          }).start(() => resolve())
         })
         // then we configure an animation layout to happen before removing the content
-        await new Promise((resolve) => {
+        await new Promise<void>((resolve) => {
           LayoutAnimation.configureNext(LayoutAnimation.create(210, "easeInEaseOut", "opacity"), resolve)
           setShowContent(false)
         })

--- a/src/lib/Components/Select.tsx
+++ b/src/lib/Components/Select.tsx
@@ -45,7 +45,7 @@ export class Select<ValueType> extends React.Component<SelectProps<ValueType>, S
       TextInput.State.blurTextInput(inputRef)
       await new Promise((r) => requestAnimationFrame(r))
     }
-    await new Promise((r) => this.setState({ showingModal: true }, r))
+    await new Promise<void>((r) => this.setState({ showingModal: true }, r))
   }
 
   close() {

--- a/src/lib/Scenes/MyCollection/State/MyCollectionArtworkModel.tsx
+++ b/src/lib/Scenes/MyCollection/State/MyCollectionArtworkModel.tsx
@@ -77,7 +77,7 @@ export interface MyCollectionArtworkModel {
     GlobalStoreModel
   >
 
-  takeOrPickPhotos: Thunk<MyCollectionArtworkModel, any, any, GlobalStoreModel>
+  takeOrPickPhotos: Thunk<MyCollectionArtworkModel, void, any, GlobalStoreModel>
 }
 
 export const MyCollectionArtworkModel: MyCollectionArtworkModel = {

--- a/src/lib/utils/__tests__/ExecutionQueue-tests.ts
+++ b/src/lib/utils/__tests__/ExecutionQueue-tests.ts
@@ -12,7 +12,7 @@ describe(ExecutionQueue, () => {
     // task 1
     queue?.executeInQueue(
       async () =>
-        await new Promise((resolve) => {
+        await new Promise<void>((resolve) => {
           startedTask1 = true
           resolveTask1 = () => {
             resolve()

--- a/yarn.lock
+++ b/yarn.lock
@@ -12935,10 +12935,10 @@ typescript-template-language-service-decorator@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/typescript-template-language-service-decorator/-/typescript-template-language-service-decorator-2.2.0.tgz#4ee6d580f307fb9239978e69626f2775b8a59b2a"
 
-typescript@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
-  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
+typescript@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
+  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
### Description

The main breaking change was that function signatures like  `blah(arg: any): whatever` can no longer be called without an explicit argument like `blah()`. You have to explicitly declare the parameter as having type `void`.

This was so painless 🙌 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
