### PR TITLE
fix: avoid shrinking the background on non-fullscreen fancy modals

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -17,6 +17,7 @@ upcoming:
     - Fix device token checking logic - david
   user_facing:
     - Add loading spinner to infinite artwork grid on artist page - david
+    - Avoid shrinking the background on non-fullscreen fancy modals - david
 releases:
   - version: 6.7.1
     date: November 13, 2020

--- a/src/lib/Components/FancyModal/FancyModal.tsx
+++ b/src/lib/Components/FancyModal/FancyModal.tsx
@@ -25,6 +25,7 @@ export const FancyModal: React.FC<{ visible: boolean; maxHeight?: number; onBack
   const context = useContext(FancyModalContext)
   const card = context.useCard({
     height,
+    backgroundShouldShrink: !maxHeight,
     content: showingUnderlyingModal ? (
       /* Keyboard Avoiding
         This works fine for full-screen fancy modals but a couple of caveats for the future:

--- a/src/lib/Components/FancyModal/FancyModalContext.tsx
+++ b/src/lib/Components/FancyModal/FancyModalContext.tsx
@@ -39,7 +39,13 @@ class FancyModalCardStack {
   getRootCard(height: number, content: React.ReactNode) {
     return (
       <View style={{ flex: 1, backgroundColor: "black" }}>
-        <FancyModalCard level={0} ref={this.stack[0]} onBackgroundPressed={() => null} height={height}>
+        <FancyModalCard
+          level={0}
+          ref={this.stack[0]}
+          onBackgroundPressed={() => null}
+          height={height}
+          backgroundShouldShrink={false}
+        >
           {content}
         </FancyModalCard>
       </View>
@@ -49,6 +55,7 @@ class FancyModalCardStack {
   useCard(config: {
     content: React.ReactNode
     height: number
+    backgroundShouldShrink: boolean
     onBackgroundPressed(): void
   }): {
     jsx: JSX.Element
@@ -62,6 +69,7 @@ class FancyModalCardStack {
         ref={ref}
         onBackgroundPressed={config.onBackgroundPressed}
         height={config.height}
+        backgroundShouldShrink={config.backgroundShouldShrink}
       >
         {config.content}
       </FancyModalCard>


### PR DESCRIPTION
This PR resolves [CX-765]

### Description

This ticket makes it so that half-page (non-fullscreen) fancy modals do not cause their backgrounds to shrink.

Fancy Modal is implemented as a stack of cards, of arbitrary depth. Before this change each card would shrink to a linear degree when it was below the top card. Now not all cards shrink relative to the card above, so it's no longer a linear calculation. Now we need to look at the whole stack and kinda merge the cards that don't shrink into the cards above them.

![no-shrinky](https://user-images.githubusercontent.com/1242537/100612218-850f6400-330a-11eb-8001-3547bd50de6a.gif)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-765]: https://artsyproduct.atlassian.net/browse/CX-765