### PR TITLE
tooling(relay-tests): add default mock resolvers and an array generator and some helpers

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -6,6 +6,7 @@ upcoming:
     - Upgrade CI to Xcode 12 - pavlos
     - Update url for echo, now in s3 - ash, pavlos
     - Move bottom tabs navigator to TS - david
+    - Add some relay mock helpers - pavlos
     - Fix city guide CTA images not showing when running using Xcode 12 - pavlos
     - Fix minimize startup api requests - brian
     - Remove analytics tracking on back-arrow taps - pepopowitz

--- a/patches/@types+relay-test-utils+6.0.1.patch
+++ b/patches/@types+relay-test-utils+6.0.1.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@types/relay-test-utils/lib/RelayMockPayloadGenerator.d.ts b/node_modules/@types/relay-test-utils/lib/RelayMockPayloadGenerator.d.ts
+index 04d356e..89c707c 100644
+--- a/node_modules/@types/relay-test-utils/lib/RelayMockPayloadGenerator.d.ts
++++ b/node_modules/@types/relay-test-utils/lib/RelayMockPayloadGenerator.d.ts
+@@ -10,7 +10,7 @@ import {
+     NormalizationSplitOperation,
+ } from 'relay-runtime';
+ 
+-interface MockResolverContext {
++export interface MockResolverContext {
+     parentType?: string;
+     name?: string;
+     alias?: string;

--- a/src/lib/Scenes/Sale/__tests__/RegisterToBidButton-tests.tsx
+++ b/src/lib/Scenes/Sale/__tests__/RegisterToBidButton-tests.tsx
@@ -1,5 +1,6 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { RegisterToBidButtonTestsQuery } from "__generated__/RegisterToBidButtonTestsQuery.graphql"
+import { mockEnvironmentPayload } from "lib/tests/mockEnvironmentPayload"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { Button, Text } from "palette"
 import React from "react"
@@ -42,29 +43,19 @@ describe("RegisterToBidButton", () => {
     />
   )
 
-  beforeEach(() => {
-    mockEnvironment = createMockEnvironment()
-  })
+  beforeEach(() => (mockEnvironment = createMockEnvironment()))
 
   it("shows button when not registered", () => {
     const tree = renderWithWrappers(<TestRenderer />)
 
-    mockEnvironment.mock.resolveMostRecentOperation((operation) =>
-      MockPayloadGenerator.generate(operation, {
-        Sale: () => ({
-          slug: "the-sale",
-          name: "the sale",
-          internalID: "the-sale-internal",
-          startAt: null,
-          endAt: null,
-          requireIdentityVerification: false,
-          registrationStatus: null,
-        }),
-        Me: () => ({
-          biddedLots: [],
-        }),
-      })
-    )
+    mockEnvironmentPayload(mockEnvironment, {
+      Sale: () => ({
+        startAt: null,
+        endAt: null,
+        requireIdentityVerification: false,
+        registrationStatus: null,
+      }),
+    })
 
     expect(tree.root.findAllByType(Button)[0].props.children).toMatch("Register to bid")
   })

--- a/src/lib/Scenes/Sale/__tests__/RegisterToBidButton-tests.tsx
+++ b/src/lib/Scenes/Sale/__tests__/RegisterToBidButton-tests.tsx
@@ -5,7 +5,7 @@ import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { Button, Text } from "palette"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { createMockEnvironment } from "relay-test-utils"
 import { extractText } from "../../../tests/extractText"
 import { RegisterToBidButtonContainer } from "../Components/RegisterToBidButton"
 
@@ -83,24 +83,16 @@ describe("RegisterToBidButton", () => {
   it("hides the approve to bid hint if the user has active lots standing", () => {
     const tree = renderWithWrappers(<TestRenderer />)
 
-    mockEnvironment.mock.resolveMostRecentOperation((operation) =>
-      MockPayloadGenerator.generate(operation, {
-        Sale: () => ({
-          slug: "the-sale",
-          name: "the sale",
-          internalID: "the-sale-internal",
-          startAt: null,
-          endAt: null,
-          requireIdentityVerification: false,
-          registrationStatus: {
-            qualifiedForBidding: true,
-          },
-        }),
-        Me: () => ({
-          biddedLots: [{ lot1: "lot1" }, { lot2: "lot2" }],
-        }),
-      })
-    )
+    mockEnvironmentPayload(mockEnvironment, {
+      Sale: () => ({
+        startAt: null,
+        endAt: null,
+        requireIdentityVerification: false,
+        registrationStatus: {
+          qualifiedForBidding: true,
+        },
+      }),
+    })
 
     expect(extractText(tree.root)).not.toContain("You're approved to bid")
   })

--- a/src/lib/Scenes/Sale/__tests__/RegisterToBidButton-tests.tsx
+++ b/src/lib/Scenes/Sale/__tests__/RegisterToBidButton-tests.tsx
@@ -63,24 +63,19 @@ describe("RegisterToBidButton", () => {
   it("shows green checkmark when registered", () => {
     const tree = renderWithWrappers(<TestRenderer />)
 
-    mockEnvironment.mock.resolveMostRecentOperation((operation) =>
-      MockPayloadGenerator.generate(operation, {
-        Sale: () => ({
-          slug: "the-sale",
-          name: "the sale",
-          internalID: "the-sale-internal",
-          startAt: null,
-          endAt: null,
-          requireIdentityVerification: false,
-          registrationStatus: {
-            qualifiedForBidding: true,
-          },
-        }),
-        Me: () => ({
-          biddedLots: [],
-        }),
-      })
-    )
+    mockEnvironmentPayload(mockEnvironment, {
+      Sale: () => ({
+        startAt: null,
+        endAt: null,
+        requireIdentityVerification: false,
+        registrationStatus: {
+          qualifiedForBidding: true,
+        },
+      }),
+      Me: () => ({
+        biddedLots: [],
+      }),
+    })
 
     expect(tree.root.findAllByType(Text)[0].props.children).toMatch("You're approved to bid")
   })

--- a/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomSubsections-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/__tests__/ViewingRoomSubsections-tests.tsx
@@ -1,10 +1,11 @@
 import { ViewingRoomSubsectionsTestsQuery } from "__generated__/ViewingRoomSubsectionsTestsQuery.graphql"
+import { mockEnvironmentPayload } from "lib/tests/mockEnvironmentPayload"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import { Box } from "palette"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { createMockEnvironment } from "relay-test-utils"
 import { ViewingRoomSubsectionsContainer } from "../ViewingRoomSubsections"
 
 jest.unmock("react-relay")
@@ -25,16 +26,12 @@ describe("ViewingRoomSubsections", () => {
       variables={{}}
     />
   )
-  beforeEach(() => {
-    mockEnvironment = createMockEnvironment()
-  })
+  beforeEach(() => (mockEnvironment = createMockEnvironment()))
 
   it("renders a Box for each subsection", () => {
     const tree = renderWithWrappers(<TestRenderer />)
-    mockEnvironment.mock.resolveMostRecentOperation((operation) => {
-      const result = MockPayloadGenerator.generate(operation)
-      return result
-    })
+    mockEnvironmentPayload(mockEnvironment)
+
     expect(tree.root.findAllByType(Box).filter((box) => box.props.testID === "subsection")).toHaveLength(1)
   })
 })

--- a/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomArtworks-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomArtworks-tests.tsx
@@ -1,6 +1,7 @@
 import { ViewingRoomArtworksTestsQuery } from "__generated__/ViewingRoomArtworksTestsQuery.graphql"
 import { navigate } from "lib/navigation/navigate"
 import { extractText } from "lib/tests/extractText"
+import { mockArray, mockEnvironmentPayload } from "lib/tests/mockEnvironmentPayload"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import { Touchable } from "palette"
@@ -8,7 +9,7 @@ import React from "react"
 import { FlatList, TouchableHighlight } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
 import { useTracking } from "react-tracking"
-import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { createMockEnvironment } from "relay-test-utils"
 import { tracks, ViewingRoomArtworksContainer } from "../ViewingRoomArtworks"
 
 jest.unmock("react-relay")
@@ -29,81 +30,48 @@ describe("ViewingRoom", () => {
       variables={{}}
     />
   )
-  beforeEach(() => {
-    mockEnvironment = createMockEnvironment()
-  })
+  beforeEach(() => (mockEnvironment = createMockEnvironment()))
 
   it("renders a flatlist with one artwork", () => {
     const tree = renderWithWrappers(<TestRenderer />)
-    mockEnvironment.mock.resolveMostRecentOperation((operation) => {
-      const result = MockPayloadGenerator.generate(operation, {
-        ViewingRoom: () => ({ artworksConnection: { edges: ["Foo"] } }),
-      })
-      return result
+    mockEnvironmentPayload(mockEnvironment, {
+      ViewingRoom: () => ({ artworksConnection: { edges: mockArray(1) } }),
     })
+
     expect(tree.root.findAllByType(FlatList)).toHaveLength(1)
     expect(tree.root.findAllByType(TouchableHighlight)).toHaveLength(1)
   })
 
   it("renders additional information if it exists", () => {
     const tree = renderWithWrappers(<TestRenderer />)
-    mockEnvironment.mock.resolveMostRecentOperation((operation) => {
-      const result = MockPayloadGenerator.generate(operation, {
-        ViewingRoom: () => ({
-          artworksConnection: {
-            edges: [
-              {
-                node: {
-                  title: "Described Work",
-                  additionalInformation: "Very cool. Love the style.",
-                },
-              },
-            ],
-          },
-        }),
-      })
-      return result
+    mockEnvironmentPayload(mockEnvironment, {
+      ViewingRoom: () => ({
+        artworksConnection: {
+          edges: mockArray(1),
+        },
+      }),
     })
+
     expect(extractText(tree.root.findByProps({ "data-test-id": "artwork-additional-information" }))).toEqual(
-      "Very cool. Love the style."
+      "additionalInformation-1"
     )
   })
 
   it("navigates to artwork screen + calls tracking on press", () => {
     const tree = renderWithWrappers(<TestRenderer />)
-    mockEnvironment.mock.resolveMostRecentOperation((operation) => {
-      const result = MockPayloadGenerator.generate(operation, {
-        ViewingRoom: () => ({
-          slug: "gallery-name-viewing-room-name",
-          internalID: "2955ab33-c205-44ea-93d2-514cd7ee2bcd",
-          artworksConnection: {
-            edges: [
-              {
-                node: {
-                  href: "/artwork/nicolas-party-rocks-ii",
-                  internalID: "5deff4b96fz7e7000f36ce37",
-                  slug: "nicolas-party-rocks-ii",
-                },
-              },
-            ],
-          },
-        }),
-      })
-      return result
+    mockEnvironmentPayload(mockEnvironment, {
+      ViewingRoom: () => ({
+        artworksConnection: { edges: mockArray(1) },
+      }),
     })
 
     tree.root.findByType(Touchable).props.onPress()
 
-    expect(navigate).toHaveBeenCalledWith("/viewing-room/gallery-name-viewing-room-name/nicolas-party-rocks-ii")
+    expect(navigate).toHaveBeenCalledWith("/viewing-room/slug-1/node.slug-1")
 
     expect(useTracking().trackEvent).toHaveBeenCalledWith({
-      ...tracks.context("2955ab33-c205-44ea-93d2-514cd7ee2bcd", "gallery-name-viewing-room-name"),
-      ...tracks.tappedArtworkGroup(
-        "2955ab33-c205-44ea-93d2-514cd7ee2bcd",
-        "gallery-name-viewing-room-name",
-        "5deff4b96fz7e7000f36ce37",
-        "nicolas-party-rocks-ii"
-      ),
+      ...tracks.context("internalID-1", "slug-1"),
+      ...tracks.tappedArtworkGroup("internalID-1", "slug-1", "node.internalID-1", "node.slug-1"),
     })
   })
 })

--- a/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomArtworks-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomArtworks-tests.tsx
@@ -1,7 +1,7 @@
 import { ViewingRoomArtworksTestsQuery } from "__generated__/ViewingRoomArtworksTestsQuery.graphql"
 import { navigate } from "lib/navigation/navigate"
 import { extractText } from "lib/tests/extractText"
-import { mockArray, mockEnvironmentPayload } from "lib/tests/mockEnvironmentPayload"
+import { mockEdges, mockEnvironmentPayload } from "lib/tests/mockEnvironmentPayload"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import { Touchable } from "palette"
@@ -35,7 +35,7 @@ describe("ViewingRoom", () => {
   it("renders a flatlist with one artwork", () => {
     const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironmentPayload(mockEnvironment, {
-      ViewingRoom: () => ({ artworksConnection: { edges: mockArray(1) } }),
+      ViewingRoom: () => ({ artworksConnection: { edges: mockEdges(1) } }),
     })
 
     expect(tree.root.findAllByType(FlatList)).toHaveLength(1)
@@ -47,7 +47,7 @@ describe("ViewingRoom", () => {
     mockEnvironmentPayload(mockEnvironment, {
       ViewingRoom: () => ({
         artworksConnection: {
-          edges: mockArray(1),
+          edges: mockEdges(1),
         },
       }),
     })
@@ -61,7 +61,7 @@ describe("ViewingRoom", () => {
     const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironmentPayload(mockEnvironment, {
       ViewingRoom: () => ({
-        artworksConnection: { edges: mockArray(1) },
+        artworksConnection: { edges: mockEdges(1) },
       }),
     })
 

--- a/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomArtworks-tests.tsx
+++ b/src/lib/Scenes/ViewingRoom/__tests__/ViewingRoomArtworks-tests.tsx
@@ -67,11 +67,16 @@ describe("ViewingRoom", () => {
 
     tree.root.findByType(Touchable).props.onPress()
 
-    expect(navigate).toHaveBeenCalledWith("/viewing-room/slug-1/node.slug-1")
+    expect(navigate).toHaveBeenCalledWith("/viewing-room/slug-1/artworksConnection.slug-1")
 
     expect(useTracking().trackEvent).toHaveBeenCalledWith({
       ...tracks.context("internalID-1", "slug-1"),
-      ...tracks.tappedArtworkGroup("internalID-1", "slug-1", "node.internalID-1", "node.slug-1"),
+      ...tracks.tappedArtworkGroup(
+        "internalID-1",
+        "slug-1",
+        "artworksConnection.internalID-1",
+        "artworksConnection.slug-1"
+      ),
     })
   })
 })

--- a/src/lib/tests/mockEnvironmentPayload.ts
+++ b/src/lib/tests/mockEnvironmentPayload.ts
@@ -22,14 +22,15 @@ export const generateID = (pathComponents: readonly string[] | undefined) => {
 export const mockArray = (length: number) => new Array(length).fill({ node: {} })
 
 export const DefaultMockResolvers: MockResolvers = {
+  ID: (ctx) => `${ctx.name}-${generateID(ctx.path)}`,
   String: (ctx) => `${ctx.name}-${generateID(ctx.path)}`,
 }
 
 export const mockEnvironmentPayload = (
   mockEnvironment: ReturnType<typeof createMockEnvironment>,
-  mockResolvers: MockResolvers = DefaultMockResolvers
+  mockResolvers?: MockResolvers
 ) => {
   mockEnvironment.mock.resolveMostRecentOperation((operation) =>
-    MockPayloadGenerator.generate(operation, mockResolvers)
+    MockPayloadGenerator.generate(operation, { ...DefaultMockResolvers, ...mockResolvers })
   )
 }

--- a/src/lib/tests/mockEnvironmentPayload.ts
+++ b/src/lib/tests/mockEnvironmentPayload.ts
@@ -3,8 +3,9 @@ import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { MockResolverContext, MockResolvers } from "relay-test-utils/lib/RelayMockPayloadGenerator"
 
 let counters: { [path: string]: number } = {}
-const resetCounters = () => {
+const reset = () => {
   counters = {}
+  paths = {}
 }
 export const generateID = (pathComponents: readonly string[] | undefined) => {
   const path: string = pathComponents?.join(".") ?? "_GLOBAL_"
@@ -25,7 +26,7 @@ export const generateID = (pathComponents: readonly string[] | undefined) => {
  */
 export const mockEdges = (length: number) => new Array(length).fill({ node: {} })
 
-const paths: { [name: string]: string } = {}
+let paths: { [name: string]: string } = {}
 const goodMockResolver = (ctx: MockResolverContext) => {
   const makePrefix = (path: string) => takeRight(path.split("."), length).join(".")
 
@@ -50,7 +51,7 @@ export const mockEnvironmentPayload = (
   mockEnvironment: ReturnType<typeof createMockEnvironment>,
   mockResolvers?: MockResolvers
 ) => {
-  resetCounters()
+  reset()
   mockEnvironment.mock.resolveMostRecentOperation((operation) =>
     MockPayloadGenerator.generate(operation, { ...DefaultMockResolvers, ...mockResolvers })
   )

--- a/src/lib/tests/mockEnvironmentPayload.ts
+++ b/src/lib/tests/mockEnvironmentPayload.ts
@@ -1,7 +1,35 @@
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { MockResolvers } from "relay-test-utils/lib/RelayMockPayloadGenerator"
 
-export type RelayMockEnvironment = ReturnType<typeof createMockEnvironment>
+const counters: { [path: string]: number } = {}
+export const generateID = (pathComponents: readonly string[] | undefined) => {
+  const path: string = pathComponents?.join(".") ?? "_GLOBAL_"
+  const currentCounter = counters[path]
+  counters[path] = currentCounter === undefined ? 1 : currentCounter + 1
+  return counters[path]
+}
 
-export const mockEnvironmentPayload = (mockEnvironment: RelayMockEnvironment, passedProps = {}) => {
-  mockEnvironment.mock.resolveMostRecentOperation((operation) => MockPayloadGenerator.generate(operation, passedProps))
+/**
+ * Used to generate results in an array.
+ * Usage: ```
+ * Artist: () => ({
+ *   auctionResultsConnection: {
+ *     edges: mockArray(10), // <- this will generate an array with 10 results, all prefilled
+ *   }
+ * })
+ * ```
+ */
+export const mockArray = (length: number) => new Array(length).fill({ node: {} })
+
+export const DefaultMockResolvers: MockResolvers = {
+  String: (ctx) => `${ctx.name}-${generateID(ctx.path)}`,
+}
+
+export const mockEnvironmentPayload = (
+  mockEnvironment: ReturnType<typeof createMockEnvironment>,
+  mockResolvers: MockResolvers = DefaultMockResolvers
+) => {
+  mockEnvironment.mock.resolveMostRecentOperation((operation) =>
+    MockPayloadGenerator.generate(operation, mockResolvers)
+  )
 }

--- a/src/lib/tests/mockEnvironmentPayload.ts
+++ b/src/lib/tests/mockEnvironmentPayload.ts
@@ -27,13 +27,15 @@ export const mockArray = (length: number) => new Array(length).fill({ node: {} }
 
 const paths: { [name: string]: string } = {}
 const goodMockResolver = (ctx: MockResolverContext) => {
-  const fullpath = ctx.path?.join(".") ?? "_GLOBAL_"
+  const makePrefix = (path: string) => takeRight(path.split("."), length).join(".")
+
+  const fullpath = (ctx.path?.join(".") ?? "_GLOBAL_").replace(".edges.node", "")
   let length = 1
-  let prefix = takeRight(fullpath.split("."), length).join(".")
+  let prefix = makePrefix(fullpath)
 
   while (Object.keys(paths).includes(prefix) && paths[prefix] !== fullpath) {
     length += 1
-    prefix = takeRight(fullpath.split("."), length).join(".")
+    prefix = makePrefix(fullpath)
   }
   paths[prefix] = fullpath
 

--- a/src/lib/tests/mockEnvironmentPayload.ts
+++ b/src/lib/tests/mockEnvironmentPayload.ts
@@ -18,12 +18,12 @@ export const generateID = (pathComponents: readonly string[] | undefined) => {
  * Usage: ```
  * Artist: () => ({
  *   auctionResultsConnection: {
- *     edges: mockArray(10), // <- this will generate an array with 10 results, all prefilled
+ *     edges: mockEdges(10), // <- this will generate an array with 10 results, all prefilled
  *   }
  * })
  * ```
  */
-export const mockArray = (length: number) => new Array(length).fill({ node: {} })
+export const mockEdges = (length: number) => new Array(length).fill({ node: {} })
 
 const paths: { [name: string]: string } = {}
 const goodMockResolver = (ctx: MockResolverContext) => {

--- a/src/lib/tests/mockEnvironmentPayload.ts
+++ b/src/lib/tests/mockEnvironmentPayload.ts
@@ -1,7 +1,10 @@
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
-import { MockResolvers } from "relay-test-utils/lib/RelayMockPayloadGenerator"
+import { MockResolverContext, MockResolvers } from "relay-test-utils/lib/RelayMockPayloadGenerator"
 
-const counters: { [path: string]: number } = {}
+let counters: { [path: string]: number } = {}
+const resetCounters = () => {
+  counters = {}
+}
 export const generateID = (pathComponents: readonly string[] | undefined) => {
   const path: string = pathComponents?.join(".") ?? "_GLOBAL_"
   const currentCounter = counters[path]
@@ -30,6 +33,7 @@ export const mockEnvironmentPayload = (
   mockEnvironment: ReturnType<typeof createMockEnvironment>,
   mockResolvers?: MockResolvers
 ) => {
+  resetCounters()
   mockEnvironment.mock.resolveMostRecentOperation((operation) =>
     MockPayloadGenerator.generate(operation, { ...DefaultMockResolvers, ...mockResolvers })
   )


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-]

### Description

The motivation for this PR was me wanting to test without having to fill all the required fields, and ideally no fields at all. I guess it's kinda RFC too?

<!-- Implementation description -->

- I added `DefaultMockResolvers` for `ID` and `String` fields, so that they generate mock data like 
```
{
  id: "id-1",
  title: "title-1"
}
```

- One extra thing here is that if we have something with possible duplicate names, it will fix it like so:
```
{
  artist: {
    id: "id-1"
    name: "name-1",
    artworks: {
      edges: [
        { node: {
          id: "artworks.id-1",
          slug: "slug-1"
        }},
      ]
    }
  }
}
```

- Also, in an `edges` array, this will generate this like `id-1`, `title-1` for the first item, `id-2`, `title-2` for the second etc.

- Lastly, I added a `mockArray` that takes a number for the length of the array to generate. Normally only one item is generated, so when we need to test for empty edges, `edges: []`, when we need 3 edges, `edges: mockArray(3)` and it will generate 3 items with the fields filled in as above.

Of course, the ability to override any of the autogenerated fields is possible. I have three test files I touched here, so show how all possibilities would work. I can follow up with another PR to change more files if we like this way.


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434