### PR TITLE
Fix: Contact gallery should be primary

### DIFF
--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryButtons.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryButtons.tsx
@@ -37,13 +37,7 @@ const InquiryButtons: React.FC<InquiryButtonsProps> = ({ artwork }) => {
         modalVisible={notificationVisibility}
         toggleNotification={(state: boolean) => setNotificationVisibility(state)}
       />
-      <Button
-        onPress={() => dispatchAction(InquiryOptions.ContactGallery)}
-        size="large"
-        block
-        width={100}
-        variant="secondaryOutline"
-      >
+      <Button onPress={() => dispatchAction(InquiryOptions.ContactGallery)} size="large" block width={100}>
         {InquiryOptions.ContactGallery}
       </Button>
       <InquiryModalFragmentContainer


### PR DESCRIPTION
The type of this PR is: Bugfix



<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [PURCHASE-2229]

### Description

before:

<img width="424" alt="a black contact gallery button" src="https://user-images.githubusercontent.com/3087225/100658132-97929900-331c-11eb-88d8-ee23ee2653dd.jpeg">

after: 

<img width="424" alt="a white contact gallery button" src="https://user-images.githubusercontent.com/3087225/100659990-68315b80-331f-11eb-89a3-ee5c51b3628e.jpeg">


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[PURCHASE-2229]: https://artsyproduct.atlassian.net/browse/PURCHASE-2229