### PR TITLE
fix: Fix artwork information overlap in first inquiry collapse

### DIFF
--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails.tsx
@@ -2,7 +2,7 @@ import { CollapsibleArtworkDetails_artwork } from "__generated__/CollapsibleArtw
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import ChevronIcon from "lib/Icons/ChevronIcon"
 import { ArtworkDetailsRow } from "lib/Scenes/Artwork/Components/ArtworkDetailsRow"
-import { Flex, Join, Separator, Spacer, Text } from "palette"
+import { Collapse, Flex, Join, Separator, Spacer, Text } from "palette"
 import React, { useState } from "react"
 import { LayoutAnimation, TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -62,7 +62,7 @@ export const CollapsibleArtworkDetails: React.FC<CollapsibleArtworkDetailsProps>
           <ChevronIcon color="black" expanded={isExpanded} initialDirection="down" />
         </Flex>
       </TouchableOpacity>
-      {isExpanded && (
+      <Collapse open={isExpanded}>
         <Flex mx={2} mb={1}>
           <Join separator={<Spacer my={1} />}>
             {detailItems.map(({ title, value }, index) => (
@@ -70,7 +70,7 @@ export const CollapsibleArtworkDetails: React.FC<CollapsibleArtworkDetailsProps>
             ))}
           </Join>
         </Flex>
-      )}
+      </Collapse>
       <Separator />
     </>
   ) : null

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/CollapsibleArtworkDetails-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/__tests__/CollapsibleArtworkDetails-tests.tsx
@@ -50,7 +50,6 @@ describe("CollapsibleArtworkDetails", () => {
     resolveData()
     expect(wrapper.root.findAllByType(OpaqueImageView)).toHaveLength(1)
     expect(wrapper.root.findAllByType(Text)).toHaveLength(2)
-    expect(wrapper.root.findAllByType(ArtworkDetailsRow)).toHaveLength(0)
   })
 
   it("renders artist names", () => {

--- a/src/palette/elements/Collapse/Collapse.tsx
+++ b/src/palette/elements/Collapse/Collapse.tsx
@@ -12,7 +12,7 @@ export interface CollapseProps {
    * If we're rendering within a statically-sized component (e.g. FlatList), we need
    * to propagate a sentinel value in order to trigger re-render or re-measure.
    */
-  onAnimationFrame: (animateValue: { height: number }) => void
+  onAnimationFrame?: (animateValue: { height: number }) => void
 }
 
 interface State {


### PR DESCRIPTION
The type of this PR is: Bugfix

This PR resolves [PURCHASE-2248]

### Description

Replaced the makeshift component with Pallette's collapse to avoid issue where artwork information would visually overlap. See ticket for former behaviour. Current behaviour:
![hide_info](https://user-images.githubusercontent.com/7117670/100921734-3e259800-34dd-11eb-9a0c-943f4ff1d2db.gif)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[PURCHASE-2248]: https://artsyproduct.atlassian.net/browse/PURCHASE-2248