### PR TITLE
[PURCHASE-2253] Fix: enable active state on border when inq question selected

### DIFF
--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -61,7 +61,16 @@ const InquiryQuestionOption: React.FC<{
 
   return (
     <React.Fragment>
-      <InquiryField>
+      <Flex
+        style={{
+          borderColor: questionSelected ? color("black100") : color("black10"),
+          borderWidth: 1,
+          borderRadius: 5,
+          flexDirection: "column",
+          marginTop: space(1),
+          padding: space(2),
+        }}
+      >
         <Flex flexDirection="row" justifyContent="space-between">
           <Flex flexDirection="row">
             <Checkbox
@@ -118,7 +127,7 @@ const InquiryQuestionOption: React.FC<{
             </TouchableOpacity>
           </>
         )}
-      </InquiryField>
+      </Flex>
     </React.Fragment>
   )
 }
@@ -216,14 +225,6 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, ...props })
     </FancyModal>
   )
 }
-
-const InquiryField = styled(Flex)`
-  border-radius: 5;
-  border: solid 1px ${color("black10")};
-  flex-direction: column;
-  margin-top: ${space(1)}px;
-  padding: ${space(2)}px;
-`
 
 const StyledTextArea = styled(TextInput)`
   border: solid 1px;


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [PURCHASE-2253](https://artsyproduct.atlassian.net/browse/PURCHASE-2253)

### Description

Inquiry question border should be black100/#FFFFF when selected. This PR adds a prop to enable this.

<!-- Implementation description -->
![Kapture 2020-12-02 at 15 39 33](https://user-images.githubusercontent.com/10385964/100928763-9f854100-34b4-11eb-8048-ced3c00b7904.gif)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434