### PR TITLE
fix: selecting search suggestion requires double tap (to clear keyboard)

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -882,7 +882,7 @@ SPEC CHECKSUMS:
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   CocoaLumberjack: aa9dcab71bdf9eaf2a63bbd9ddc87863efe45457
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
-  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
   Emission: 5c5fb14e43f9ddc811185e8f17e11ab03a98dc09
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
@@ -904,7 +904,7 @@ SPEC CHECKSUMS:
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   Forgeries: 64ced144ea8341d89a7eec9d1d7986f0f1366250
   FXBlurView: 5121730176fd52bcf7bffd0bd8c1485e8aabc3cb
-  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   Interstellar: ab67502af03105f92100a043e178d188a1a437c9
   INTUAnimationEngine: 3a7d63738cd51af573d16848a771feedea7cc9f2
   ISO8601DateFormatter: 8311a2d4e265b269b2fed7ab4db685dcb0a7ccb2

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -289,6 +289,7 @@ export class Artwork extends React.Component<Props, State> {
   render() {
     return (
       <FlatList<ArtworkPageSection>
+        keyboardShouldPersistTaps="always"
         data={this.sections()}
         ItemSeparatorComponent={() => (
           <Box mx={2} my={3}>

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -289,7 +289,7 @@ export class Artwork extends React.Component<Props, State> {
   render() {
     return (
       <FlatList<ArtworkPageSection>
-        keyboardShouldPersistTaps="always"
+        keyboardShouldPersistTaps="handled"
         data={this.sections()}
         ItemSeparatorComponent={() => (
           <Box mx={2} my={3}>

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/LocationAutocomplete.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/LocationAutocomplete.tsx
@@ -1,8 +1,8 @@
 import { Input } from "lib/Components/Input/Input"
 import { getLocationPredictions, SimpleLocation } from "lib/utils/googleMaps"
-import { Button, color, Flex, LocationIcon, Text, Touchable } from "palette"
-import React, { useEffect, useRef, useState } from "react"
-import { Dimensions, Keyboard, ScrollView, TouchableWithoutFeedback, View } from "react-native"
+import { color, Flex, LocationIcon, Text, Touchable } from "palette"
+import React, { useEffect, useState } from "react"
+import { Dimensions, TouchableWithoutFeedback, View } from "react-native"
 import styled from "styled-components/native"
 
 interface Props {
@@ -14,12 +14,6 @@ export const LocationAutocomplete: React.FC<Props> = ({ onChange, initialLocatio
   const [predictions, setPredictions] = useState<SimpleLocation[]>([])
   const [selectedLocation, setSelectedLocation] = useState(initialLocation)
   const [query, setQuery] = useState(selectedLocation?.name || "")
-
-  // Autofocus
-  const input = useRef<Input>(null)
-  useEffect(() => {
-    input.current?.focus()
-  }, [input])
 
   useEffect(() => {
     setPredictions([])
@@ -56,9 +50,9 @@ export const LocationAutocomplete: React.FC<Props> = ({ onChange, initialLocatio
     <Flex>
       <Text>Location</Text>
       <Input
-        ref={input}
         placeholder="Add Location"
         style={{ marginVertical: 10 }}
+        autoFocus
         onChangeText={setQuery}
         onFocus={reset}
         value={selectedLocation ? selectedLocation.name : query}
@@ -122,7 +116,6 @@ export const LocationPredictions = ({
           <Touchable
             key={p.id}
             onPress={() => {
-              Keyboard.dismiss()
               onSelect(p)
             }}
             style={{ padding: 10 }}

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/LocationAutocomplete.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/LocationAutocomplete.tsx
@@ -1,8 +1,8 @@
 import { Input } from "lib/Components/Input/Input"
 import { getLocationPredictions, SimpleLocation } from "lib/utils/googleMaps"
-import { color, Flex, LocationIcon, Text, Touchable } from "palette"
+import { Button, color, Flex, LocationIcon, Text, Touchable } from "palette"
 import React, { useEffect, useRef, useState } from "react"
-import { Dimensions, TouchableWithoutFeedback, View } from "react-native"
+import { Dimensions, Keyboard, ScrollView, TouchableWithoutFeedback, View } from "react-native"
 import styled from "styled-components/native"
 
 interface Props {
@@ -122,6 +122,7 @@ export const LocationPredictions = ({
           <Touchable
             key={p.id}
             onPress={() => {
+              Keyboard.dismiss()
               onSelect(p)
             }}
             style={{ padding: 10 }}

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/ShippingModal.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/ShippingModal.tsx
@@ -3,6 +3,7 @@ import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
 import { getLocationDetails, LocationWithDetails, SimpleLocation } from "lib/utils/googleMaps"
 import { Flex } from "palette"
 import React, { useState } from "react"
+import { ScrollView } from "react-native"
 
 import { LocationAutocomplete } from "./LocationAutocomplete"
 
@@ -36,9 +37,11 @@ export const ShippingModal: React.FC<ShippingModalProps> = (props) => {
       >
         Add Location
       </FancyModalHeader>
-      <Flex m={2} flex={1}>
-        <LocationAutocomplete onChange={setLocationInput} initialLocation={location} />
-      </Flex>
+      <ScrollView keyboardShouldPersistTaps="always">
+        <Flex m={2} flex={1}>
+          <LocationAutocomplete onChange={setLocationInput} initialLocation={location} />
+        </Flex>
+      </ScrollView>
     </FancyModal>
   )
 }


### PR DESCRIPTION
The type of this PR is: **fix**
#minor

This PR resolves [PURCHASE-2250]

### Description
This PR fixes a bug where the user, when trying to tap a search suggestion, must tap twice since the first dismisses the keyboard. It also includes an optimization for autofocusing the input.

It requires adding a prop at the very top of the Artwork Scene component hierarchy, so we should be aware if there are any unusual keyboard behaviors within an artwork view that we want to avoid. I'm not aware of any.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
![2020-12-03 17 56 48](https://user-images.githubusercontent.com/9088720/101098501-037d3780-3591-11eb-88ea-0a9aa0b6ad09.gif)


[PURCHASE-2250]: https://artsyproduct.atlassian.net/browse/PURCHASE-2250