### PR TITLE
enhancement: Remove the 'X' to exit the confirmation modal

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -10,6 +10,7 @@ upcoming:
     - Add artist past shows screen - mounir
     - Add loading spinner to infinite artwork grid on artist page - david
     - Avoid shrinking the background on non-fullscreen fancy modals - david
+    - removed x from inquiry sent notification - lily
 releases:
   - version: 6.7.2
     date: November 30, 2020

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquirySuccessNotification.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquirySuccessNotification.tsx
@@ -58,12 +58,6 @@ export const InquirySuccessNotification: React.FC<InquirySuccessNotificationProp
                   <Text color="green100" variant="mediumText">
                     Message Sent
                   </Text>
-                  <TouchableWithoutFeedback
-                    hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-                    onPress={() => toggleNotification(false)}
-                  >
-                    <CloseIcon />
-                  </TouchableWithoutFeedback>
                 </Flex>
                 <Text color="black60" variant="text">
                   Expect a response within 1-3 business days.

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquirySuccessNotification.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquirySuccessNotification.tsx
@@ -1,8 +1,8 @@
 import { navigate } from "lib/navigation/navigate"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
-import { CloseIcon, color, Flex, Text, Theme } from "palette"
+import { color, Flex, Text, Theme } from "palette"
 import React, { useEffect } from "react"
-import { Animated, Modal, TouchableOpacity, TouchableWithoutFeedback } from "react-native"
+import { Animated, Modal, TouchableOpacity } from "react-native"
 import styled from "styled-components/native"
 
 interface InquirySuccessNotificationProps {


### PR DESCRIPTION
# [PURCHASE-2273]

This 'X' is intended to dismiss the modal but because this delay is short tapping the 'X' in the 'Toast' is mainly just linking me to the inbox as its a very quick tap. We should remove the 'X' to eliminate confusion. 

_It now looks like this:_ 
<img width="506" alt="Screen Shot 2020-12-03 at 11 55 45 AM" src="https://user-images.githubusercontent.com/5643895/101062094-33abe280-355f-11eb-8ac9-2f96d35bf8a5.png">


[PURCHASE-2273]: https://artsyproduct.atlassian.net/browse/PURCHASE-2273