### PR TITLE
chore: add Sentry commit integration

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -63,6 +63,13 @@ lane :ship_beta do
                           finalize: false
     puts "Created a release for #{project_slug}"
 
+    sentry_set_commits auth_token: ENV['SentryUploadAuthKey'],
+                       org_slug: org_slug,
+                       project_slug: project_slug,
+                       version: sentry_version,
+                       auto: true
+    puts "Associated commits for Sentry release"
+
     Dir.glob(File.join(dsyms_path, '*.dSYM')).each do |dsym_path|
       # No need to specify `dist` as the build number is encoded in the dSYM's Info.plist
       sentry_upload_dsym auth_token: ENV['SentryUploadAuthKey'],


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->


### Description

Added this based on the Lunch&Learn. It was added to Sentry's fastlane plugin here: https://github.com/getsentry/sentry-fastlane-plugin/pull/54 I think I'm adding in some extraneous properties here, but better safe than sorry. I've kicked off a beta to test this here: https://app.circleci.com/pipelines/github/artsy/eigen/7528/workflows/532a48c0-562f-40e1-9e1b-198fa5056c1d

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434