### PR TITLE
feat: wrap first inquiry checkbox with touchable

### DIFF
--- a/src/lib/Components/Bidding/Components/Checkbox.tsx
+++ b/src/lib/Components/Bidding/Components/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react"
+import React, { Component, GetDerivedStateFromProps } from "react"
 import { StyleSheet, TouchableWithoutFeedback, TouchableWithoutFeedbackProps } from "react-native"
 import styled from "styled-components/native"
 
@@ -17,12 +17,13 @@ interface CheckboxProps extends TouchableWithoutFeedbackProps, FlexProps {
 }
 
 export class Checkbox extends Component<CheckboxProps, CheckboxState> {
-  static getDerivedStateFromProps(props: CheckboxProps, state: CheckboxState) {
+  static getDerivedStateFromProps: GetDerivedStateFromProps<CheckboxProps, CheckboxState> = (props, state) => {
     if (props.checked !== state.checked) {
       return {
         checked: props.checked,
       }
     }
+    return {}
   }
 
   private readonly checkboxSize = 20

--- a/src/lib/Components/Bidding/Components/Checkbox.tsx
+++ b/src/lib/Components/Bidding/Components/Checkbox.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react"
-import { StyleSheet, TouchableWithoutFeedback, TouchableWithoutFeedbackProperties } from "react-native"
+import { StyleSheet, TouchableWithoutFeedback, TouchableWithoutFeedbackProps } from "react-native"
 import styled from "styled-components/native"
 
 import { Flex, FlexProps } from "../Elements/Flex"
@@ -10,13 +10,21 @@ interface CheckboxState {
   checked: boolean
 }
 
-interface CheckboxProps extends TouchableWithoutFeedbackProperties, FlexProps {
+interface CheckboxProps extends TouchableWithoutFeedbackProps, FlexProps {
   checked?: boolean
   disabled?: boolean
   error?: boolean
 }
 
 export class Checkbox extends Component<CheckboxProps, CheckboxState> {
+  static getDerivedStateFromProps(props: CheckboxProps, state: CheckboxState) {
+    if (props.checked !== state.checked) {
+      return {
+        checked: props.checked,
+      }
+    }
+  }
+
   private readonly checkboxSize = 20
 
   private readonly duration = 250

--- a/src/lib/Components/Bidding/Components/Checkbox.tsx
+++ b/src/lib/Components/Bidding/Components/Checkbox.tsx
@@ -18,7 +18,7 @@ interface CheckboxProps extends TouchableWithoutFeedbackProps, FlexProps {
 
 export class Checkbox extends Component<CheckboxProps, CheckboxState> {
   static getDerivedStateFromProps: GetDerivedStateFromProps<CheckboxProps, CheckboxState> = (props, state) => {
-    if (props.checked !== state.checked) {
+    if (props.checked && props.checked !== state.checked) {
       return {
         checked: props.checked,
       }

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -59,75 +59,75 @@ const InquiryQuestionOption: React.FC<{
 
   React.useLayoutEffect(maybeRegisterAnimation, [questionSelected])
 
+  const setSelection = () => {
+    dispatch({
+      type: "selectInquiryQuestion",
+      payload: {
+        questionID: id,
+        details: isShipping ? state.shippingLocation?.name : null,
+        isChecked: !questionSelected,
+      },
+    })
+  }
+
   return (
     <React.Fragment>
-      <Flex
-        style={{
-          borderColor: questionSelected ? color("black100") : color("black10"),
-          borderWidth: 1,
-          borderRadius: 5,
-          flexDirection: "column",
-          marginTop: space(1),
-          padding: space(2),
-        }}
-      >
-        <Flex flexDirection="row" justifyContent="space-between">
-          <Flex flexDirection="row">
-            <Checkbox
-              data-test-id={`checkbox-${id}`}
-              checked={questionSelected}
-              onPress={() => {
-                dispatch({
-                  type: "selectInquiryQuestion",
-                  payload: {
-                    questionID: id,
-                    details: isShipping ? state.shippingLocation?.name : null,
-                    isChecked: !questionSelected,
-                  },
-                })
-              }}
-            />
-            <Text variant="text">{question}</Text>
+      <TouchableOpacity onPress={setSelection}>
+        <Flex
+          style={{
+            borderColor: questionSelected ? color("black100") : color("black10"),
+            borderWidth: 1,
+            borderRadius: 5,
+            flexDirection: "column",
+            marginTop: space(1),
+            padding: space(2),
+          }}
+        >
+          <Flex flexDirection="row" justifyContent="space-between">
+            <Flex flexDirection="row">
+              <Checkbox data-test-id={`checkbox-${id}`} checked={questionSelected} onPress={setSelection} />
+              <Text variant="text">{question}</Text>
+            </Flex>
           </Flex>
+
+          {!!isShipping && !!questionSelected && (
+            <>
+              <Separator my={2} />
+
+              <TouchableOpacity
+                data-test-id="toggle-shipping-modal"
+                onPress={() => {
+                  if (typeof setShippingModalVisibility === "function") {
+                    setShippingModalVisibility(true)
+                  }
+                }}
+              >
+                <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
+                  {!state.shippingLocation ? (
+                    <>
+                      <Text variant="text" color="black60">
+                        Add your location
+                      </Text>
+                      <Box>
+                        <ChevronIcon color="black60" />
+                      </Box>
+                    </>
+                  ) : (
+                    <>
+                      <Text variant="text" color="black100" style={{ width: "70%" }}>
+                        {state.shippingLocation.name}
+                      </Text>
+                      <Text variant="text" color="purple100">
+                        Edit
+                      </Text>
+                    </>
+                  )}
+                </Flex>
+              </TouchableOpacity>
+            </>
+          )}
         </Flex>
-
-        {!!isShipping && !!questionSelected && (
-          <>
-            <Separator my={2} />
-
-            <TouchableOpacity
-              data-test-id="toggle-shipping-modal"
-              onPress={() => {
-                if (typeof setShippingModalVisibility === "function") {
-                  setShippingModalVisibility(true)
-                }
-              }}
-            >
-              <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
-                {!state.shippingLocation ? (
-                  <>
-                    <Text variant="text" color="black60">
-                      Add your location
-                    </Text>
-                    <Box>
-                      <ChevronIcon color="black60" />
-                    </Box>
-                  </>
-                ) : (
-                  <>
-                    <Text variant="text" color="black100" style={{ width: "70%" }}>
-                      {state.shippingLocation.name}
-                    </Text>
-                    <Text variant="text" color="purple100">
-                      Edit
-                    </Text>
-                  </>
-                )}
-              </Flex>
-            </TouchableOpacity>
-          </>
-        )}
-      </Flex>
+      </TouchableOpacity>
     </React.Fragment>
   )
 }


### PR DESCRIPTION
The type of this PR is: Enhancement

This PR resolves [PURCHASE-2272]

### Description

This PR makes the whole area, not just the checkbox, clickable for first inquiry fields. It also adds functionality to the checkbox component to change when the `checked` prop changes.
![checkbox_click](https://user-images.githubusercontent.com/7117670/101073644-0e8b9400-35a0-11eb-9dfe-618a44712a0b.gif)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[PURCHASE-2272]: https://artsyproduct.atlassian.net/browse/PURCHASE-2272