### PR TITLE
Bugfix: Conversation does not move to the top of the inbox when a gallery responds

### DIFF
--- a/src/lib/Containers/Inbox/Inbox.tsx
+++ b/src/lib/Containers/Inbox/Inbox.tsx
@@ -1,7 +1,6 @@
 import { Inbox_me } from "__generated__/Inbox_me.graphql"
 import { InboxQuery } from "__generated__/InboxQuery.graphql"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
-import { ActiveBids as ActiveBidsRef } from "lib/Scenes/Inbox/Components/ActiveBids"
 import { ConversationsContainer } from "lib/Scenes/Inbox/Components/Conversations/Conversations"
 import { MyBidsContainer } from "lib/Scenes/MyBids/MyBids"
 import { listenToNativeEvents } from "lib/store/NativeModel"
@@ -29,8 +28,6 @@ const Container = styled.ScrollView`
 export class Inbox extends React.Component<Props, State> {
   // @ts-ignore STRICTNESS_MIGRATION
   conversations: ConversationsRef
-  // @ts-ignore STRICTNESS_MIGRATION
-  activeBids: ActiveBidsRef
 
   state = {
     fetchingData: false,
@@ -66,9 +63,7 @@ export class Inbox extends React.Component<Props, State> {
 
     this.setState({ fetchingData: true })
 
-    if (this.activeBids && this.conversations) {
-      // Allow Conversations & Active Bids to properly force-fetch themselves.
-      this.activeBids.refreshActiveBids()
+    if (this.conversations) {
       this.conversations.refreshConversations(() => {
         this.setState({ fetchingData: false })
       })

--- a/src/lib/Scenes/Inbox/Components/Conversations/Conversations.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/Conversations.tsx
@@ -22,20 +22,13 @@ interface Props {
 
 interface State {
   isLoading?: boolean
+  isRefreshing: boolean
 }
 
 export class Conversations extends Component<Props, State> {
   state = {
     isLoading: false,
-  }
-
-  componentDidUpdate() {
-    const { relay } = this.props
-    relay.refetchConnection(PAGE_SIZE, (error) => {
-      if (error) {
-        throw new Error("Conversations error: " + error.message)
-      }
-    })
+    isRefreshing: false,
   }
 
   fetchData = () => {
@@ -60,14 +53,12 @@ export class Conversations extends Component<Props, State> {
 
   refreshConversations = (callback?: () => void) => {
     const { relay } = this.props
-
     if (!relay.isLoading()) {
       relay.refetchConnection(PAGE_SIZE, (error) => {
         if (error) {
           console.error("Conversations/index.tsx #refreshConversations", error.message)
           // FIXME: Handle error
         }
-
         if (callback) {
           callback()
         }

--- a/src/lib/Scenes/Inbox/Components/Conversations/Conversations.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/Conversations.tsx
@@ -29,6 +29,16 @@ export class Conversations extends Component<Props, State> {
     isLoading: false,
   }
 
+  componentDidUpdate() {
+    const { relay } = this.props
+    relay.refetchConnection(PAGE_SIZE, (error) => {
+      alert("WOOO!")
+      if (error) {
+        throw new Error("Conversations error: " + error.message)
+      }
+    })
+  }
+
   fetchData = () => {
     const { relay } = this.props
 
@@ -77,6 +87,8 @@ export class Conversations extends Component<Props, State> {
       return null
     }
 
+    console.log("CONVOS12", conversations)
+
     const unreadCount = this.props.me.conversations?.totalUnreadCount
     const unreadCounter = unreadCount ? `(${unreadCount})` : null
     const shouldDisplayMyBids = getCurrentEmissionState().options.AROptionsBidManagement
@@ -121,7 +133,7 @@ export const ConversationsContainer = createPaginationContainer(
       fragment Conversations_me on Me
       @argumentDefinitions(count: { type: "Int", defaultValue: 10 }, cursor: { type: "String", defaultValue: "" }) {
         conversations: conversationsConnection(first: $count, after: $cursor)
-        @connection(key: "Conversations_conversations") {
+          @connection(key: "Conversations_conversations") {
           pageInfo {
             endCursor
             hasNextPage

--- a/src/lib/Scenes/Inbox/Components/Conversations/Conversations.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/Conversations.tsx
@@ -32,7 +32,6 @@ export class Conversations extends Component<Props, State> {
   componentDidUpdate() {
     const { relay } = this.props
     relay.refetchConnection(PAGE_SIZE, (error) => {
-      alert("WOOO!")
       if (error) {
         throw new Error("Conversations error: " + error.message)
       }

--- a/src/lib/Scenes/Inbox/Components/Conversations/Conversations.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/Conversations.tsx
@@ -86,8 +86,6 @@ export class Conversations extends Component<Props, State> {
       return null
     }
 
-    console.log("CONVOS12", conversations)
-
     const unreadCount = this.props.me.conversations?.totalUnreadCount
     const unreadCounter = unreadCount ? `(${unreadCount})` : null
     const shouldDisplayMyBids = getCurrentEmissionState().options.AROptionsBidManagement


### PR DESCRIPTION
The type of this PR is: Bugfix

[PURCHASE-2275]

The conversation order does not update on refresh - for example, a convo with a new reply from the gallery doesn't appear at the top of the inbox. This PR fixes that.

After struggling with this for hours, I paired with @ashleyjelks who solved it in 10 minutes!

UPDATE: Ended up changing my implementation entirely after realizing that leftover `activeBids` stuff in `Inbox` was preventing the existing refresh logic from working

[PURCHASE-2275]: https://artsyproduct.atlassian.net/browse/PURCHASE-2275