### PR TITLE
fix: ensure we do not override the onFocus prop

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -18,6 +18,7 @@ upcoming:
     - removed x from inquiry sent notification - lily
     - Minor copy changes for My Collection - pepopowitz
     - Fix city guide hang on iOS 14 - brian
+    - Fix regression that hids textarea in 1st inquiry modal - christina
 releases:
   - version: 6.7.2
     date: November 30, 2020

--- a/src/lib/Components/TextArea.tsx
+++ b/src/lib/Components/TextArea.tsx
@@ -24,10 +24,12 @@ export const TextArea: React.FC<TextAreaProps> = ({ title, ...props }) => {
       )}
       <StyledTextArea
         {...props}
-        onFocus={() => {
+        onFocus={(e) => {
+          props.onFocus?.(e)
           setBorderColor(color("purple100"))
         }}
-        onBlur={() => {
+        onBlur={(e) => {
+          props.onBlur?.(e)
           setBorderColor(color("black10"))
         }}
         style={{ borderColor }}


### PR DESCRIPTION
The type of this PR is: **FIX**

This PR resolves [PURCHASE-2285]

### Description

While QA'ing during Sprintly CX Mobile App QA Session we noticed that the keyboard was hiding the textarea again. This was because we were overriding the onFocus prop in the TextArea component. This PR makes sure to call the `onFocus` and `onBlur` functions if they are present on `props`.

<img width="393" alt="Screen Shot 2020-12-07 at 11 55 10 AM" src="https://user-images.githubusercontent.com/5201004/101380772-ed6ac200-3883-11eb-800f-28056211e0b9.png">

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[PURCHASE-2285]: https://artsyproduct.atlassian.net/browse/PURCHASE-2285