### PR TITLE
fix: check user is logged in before registering token, clear out on f…

### DIFF
--- a/Artsy/App/ARAppNotificationsDelegate.m
+++ b/Artsy/App/ARAppNotificationsDelegate.m
@@ -238,12 +238,17 @@
     // for notifications even if the user has not signed-in, we must be sure to always update this to ensure the Artsy
     // service always has an up-to-date record of devices and associated users.
     // https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622958-application?language=objc
-    if (![self tokensAreTheSame:deviceToken previousToken:previousToken]) {
+    if ([User currentUser] && ![self tokensAreTheSame:deviceToken previousToken:previousToken]) {
         [ArtsyAPI setAPNTokenForCurrentDevice:deviceToken success:^(id response) {
             ARActionLog(@"Pushed device token to Artsy's servers");
         } failure:^(NSError *error) {
             ARErrorLog(@"Couldn't push the device token to Artsy, error: %@", error.localizedDescription);
+            // Clear out saved token to make sure we register on log in
+            [[NSUserDefaults standardUserDefaults] setValue:nil forKey:ARAPNSDeviceTokenKey];
         }];
+    } else {
+        // Clear out saved token to make sure we register on log in
+        [[NSUserDefaults standardUserDefaults] setValue:nil forKey:ARAPNSDeviceTokenKey];
     }
 #endif
 }

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -18,6 +18,7 @@ upcoming:
     - removed x from inquiry sent notification - lily
     - Minor copy changes for My Collection - pepopowitz
     - Fix city guide hang on iOS 14 - brian
+    - Fix apns token registration issue - brian
 releases:
   - version: 6.7.2
     date: November 30, 2020


### PR DESCRIPTION
The type of this PR is: **Bugfix**

### Description

Sailthru is causing didRegister callback to be called on app launch before a user is logged in, the token is then not correctly associated with the user on our backend and we don't attempt to register again because of the newly added previous token check. 

This checks that there is a current user before attempting to save the token on the backend and also clears out the token on error saving or if the callback was called without a user to be sure the token is saved the next time around.

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
