### PR TITLE
feat(ci): add slack notification when betas fail

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -7,6 +7,7 @@ upcoming:
     - Set price and marketing text dynamically - adam
     - Migrate floor selling price and online asking price in My Bids to the new type - starsirius
     - remove new inquiry flow feature flag in favor of echo flag - lily
+    - Add slack notification when betas fail - brian
   user_facing:
     - Add artist past shows screen - mounir
     - Add loading spinner to infinite artwork grid on artist page - david

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -211,6 +211,22 @@ lane :notify_if_new_license_agreement do
   end
 end
 
+lane :notify_beta_failed do |options|
+  exception = options[:exception]
+  message = ':x: :iphone:\n'\
+            'Looks like the latest beta failed to deploy!\n'\
+            'See circle job for more details.'
+  slack(
+    message: message,
+    success: false,
+    payload: {
+      'Circle Build' => ENV['CIRCLE_BUILD_URL'],
+      'Exception' => exception.message
+    },
+    default_payloads: []
+  )
+end
+
 lane :tag_and_push do |options|
   # Do a tag, we use a http git remote so we can have push access
   # as the default remote for circle is read-only
@@ -219,4 +235,10 @@ lane :tag_and_push do |options|
   add_git_tag tag: tag
   `git remote add http https://github.com/artsy/eigen.git`
   `git push http #{tag} -f`
+end
+
+error do |lane, exception|
+ if lane == :ship_beta
+  notify_beta_failed(exception: exception)
+ end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -195,10 +195,12 @@ lane :notify_if_new_license_agreement do
   messages = Spaceship::Tunes.client.fetch_program_license_agreement_messages
 
   if !messages.empty?
-    message = ':apple: :handshake: :pencil:\n'\
-              'There is a new developer program agreement that needs to be signed to continue shipping!\n'\
-              'Reach out to legal :scales: for approval before signing.\n'\
-              'https://appstoreconnect.apple.com/agreements/#/'
+    message = <<~MSG
+                :apple: :handshake: :pencil:
+                There is a new developer program agreement that needs to be signed to continue shipping!
+                Reach out to legal :scales: for approval before signing.
+                https://appstoreconnect.apple.com/agreements/#/
+              MSG
     puts message
     puts messages[0]
     slack(
@@ -213,9 +215,11 @@ end
 
 lane :notify_beta_failed do |options|
   exception = options[:exception]
-  message = ':x: :iphone:\n'\
-            'Looks like the latest beta failed to deploy!\n'\
-            'See circle job for more details.'
+  message = <<~MSG
+              :x: :iphone:
+              Looks like the latest beta failed to deploy!
+              See circle job for more details.
+            MSG
   slack(
     message: message,
     success: false,


### PR DESCRIPTION
The type of this PR is: **Enhancement**

### Description

Adds a slack notification when beta lane fails for any reason based on discussion in retro and feedback at front-end-ios (now mobile) practice.

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
