### PR TITLE
fix: Allow conversations to take up full height

### DIFF
--- a/src/lib/Containers/Inbox/Inbox.tsx
+++ b/src/lib/Containers/Inbox/Inbox.tsx
@@ -132,7 +132,7 @@ export class Inbox extends React.Component<Props, State> {
         <TabWrapper tabLabel="Bids" key="bids" style={{ flexGrow: 1, justifyContent: "center" }}>
           <MyBidsContainer me={this.props.me} componentRef={(myBids) => (this.myBids = myBids)} />
         </TabWrapper>
-        <TabWrapper tabLabel="Inquiries" key="inquiries">
+        <TabWrapper tabLabel="Inquiries" key="inquiries" style={{ flexGrow: 1, justifyContent: "flex-start" }}>
           <ConversationsContainer
             me={this.props.me}
             componentRef={(conversations) => (this.conversations = conversations)}

--- a/src/lib/Scenes/Inbox/Components/Conversations/Conversations.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/Conversations.tsx
@@ -84,7 +84,7 @@ export class Conversations extends Component<Props, State> {
     const shouldDisplayMyBids = getCurrentEmissionState().options.AROptionsBidManagement
 
     return (
-      <View>
+      <View style={{ flexGrow: 1 }}>
         {!shouldDisplayMyBids && (
           <Flex py={1} style={{ borderBottomWidth: 1, borderBottomColor: color("black10") }}>
             <Sans mx={2} mt={1} size="8" style={{ borderBottomWidth: 1, borderBottomColor: color("black10") }}>


### PR DESCRIPTION
The type of this PR is: Bugfix

This PR resolves [PURCHASE-2303]

### Description

Fixes an issue that would cut the messages when there were only a few present and pulling to refresh (see ticket). Now looks like this:
![inbox_fix](https://user-images.githubusercontent.com/7117670/101703540-09888200-3a83-11eb-8397-6c5d3af2cd7f.gif)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[PURCHASE-2303]: https://artsyproduct.atlassian.net/browse/PURCHASE-2303