### PR TITLE
Fix: live lots a user is winning always appear as 'reserve not met'

### DIFF
--- a/src/lib/Scenes/MyBids/Components/ActiveLot.tsx
+++ b/src/lib/Scenes/MyBids/Components/ActiveLot.tsx
@@ -9,7 +9,6 @@ import { LotFragmentContainer as Lot } from "./Lot"
 
 export const ActiveLot = ({ lotStanding }: { lotStanding: ActiveLot_lotStanding }, smallScreen: boolean) => {
   const timelySale = TimelySale.create(lotStanding?.saleArtwork?.sale!)
-  const isLAI = timelySale.isLiveBiddingNow()
 
   const sellingPrice = lotStanding?.lotState?.sellingPrice?.display
   const bidCount = lotStanding?.lotState?.bidCount
@@ -35,7 +34,9 @@ export const ActiveLot = ({ lotStanding }: { lotStanding: ActiveLot_lotStanding 
           </Text>
         </Flex>
         <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
-          {!isLAI && lotStanding?.isHighestBidder && lotStanding.lotState.reserveStatus === "ReserveNotMet" ? (
+          {!timelySale.isLAI &&
+          lotStanding?.isHighestBidder &&
+          lotStanding.lotState.reserveStatus === "ReserveNotMet" ? (
             <ReserveNotMet />
           ) : lotStanding?.isHighestBidder ? (
             <HighestBid />

--- a/src/lib/Scenes/MyBids/__tests__/ActiveLot-tests.tsx
+++ b/src/lib/Scenes/MyBids/__tests__/ActiveLot-tests.tsx
@@ -58,12 +58,14 @@ describe(ActiveLot, () => {
     })
 
     it("says 'Highest bid' if the user is winning the lot but the reserveStatus is ReserveNotMet in a Live Auction", () => {
+      const date = new Date()
+      date.setDate(date.getDate() + 1)
       const tree = renderWithWrappers(
         <ActiveLot
           lotStanding={lotStandingFixture({
             isHighestBidder: true,
             lotState: { reserveStatus: "ReserveNotMet" },
-            saleArtwork: { sale: { liveStartAt: new Date().toJSON() } },
+            saleArtwork: { sale: { liveStartAt: date } },
           })}
         />
       )


### PR DESCRIPTION
The type of this PR is: **fix**
[PURCHASE-2293]
This pr fixes an issue where live auctions would show all winning lots as 'reserve not met.' in fact, reserve is never met in a live auction. This PR fixes the property check. The test was written in a way that it passed wrongly.

#squashongreen

[PURCHASE-2293]: https://artsyproduct.atlassian.net/browse/PURCHASE-2293