### PR TITLE
feat: Add empty messages notice and cta for new inbox

### DIFF
--- a/src/__generated__/ConversationsTestsQuery.graphql.ts
+++ b/src/__generated__/ConversationsTestsQuery.graphql.ts
@@ -1,0 +1,574 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash 1f330a01a6b3359136c587cf2572cd41 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ConversationsTestsQueryVariables = {};
+export type ConversationsTestsQueryResponse = {
+    readonly me: {
+        readonly " $fragmentRefs": FragmentRefs<"Conversations_me">;
+    } | null;
+};
+export type ConversationsTestsQuery = {
+    readonly response: ConversationsTestsQueryResponse;
+    readonly variables: ConversationsTestsQueryVariables;
+};
+
+
+
+/*
+query ConversationsTestsQuery {
+  me {
+    ...Conversations_me
+    id
+  }
+}
+
+fragment ConversationSnippet_conversation on Conversation {
+  internalID
+  to {
+    name
+    id
+  }
+  lastMessage
+  lastMessageAt
+  unread
+  items {
+    item {
+      __typename
+      ... on Artwork {
+        date
+        title
+        artistNames
+        image {
+          url
+        }
+      }
+      ... on Show {
+        fair {
+          name
+          id
+        }
+        name
+        coverImage {
+          url
+        }
+      }
+      ... on Node {
+        __isNode: __typename
+        id
+      }
+    }
+  }
+  messagesConnection {
+    totalCount
+  }
+}
+
+fragment Conversations_me on Me {
+  conversations: conversationsConnection(first: 10, after: "") {
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    edges {
+      node {
+        internalID
+        last_message: lastMessage
+        ...ConversationSnippet_conversation
+        id
+        __typename
+      }
+      cursor
+    }
+    totalUnreadCount
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "after",
+    "value": ""
+  },
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = [
+  (v1/*: any*/),
+  (v2/*: any*/)
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "url",
+    "storageKey": null
+  }
+],
+v6 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v7 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v8 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v9 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Image"
+},
+v10 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ConversationsTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "Conversations_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ConversationsTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": "conversations",
+            "args": (v0/*: any*/),
+            "concreteType": "ConversationConnection",
+            "kind": "LinkedField",
+            "name": "conversationsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "kind": "LinkedField",
+                "name": "pageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "endCursor",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "hasNextPage",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ConversationEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Conversation",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "last_message",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lastMessage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ConversationResponder",
+                        "kind": "LinkedField",
+                        "name": "to",
+                        "plural": false,
+                        "selections": (v3/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lastMessage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lastMessageAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "unread",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ConversationItem",
+                        "kind": "LinkedField",
+                        "name": "items",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": null,
+                            "kind": "LinkedField",
+                            "name": "item",
+                            "plural": false,
+                            "selections": [
+                              (v4/*: any*/),
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "date",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "title",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "artistNames",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": (v5/*: any*/),
+                                    "storageKey": null
+                                  }
+                                ],
+                                "type": "Artwork",
+                                "abstractKey": null
+                              },
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Fair",
+                                    "kind": "LinkedField",
+                                    "name": "fair",
+                                    "plural": false,
+                                    "selections": (v3/*: any*/),
+                                    "storageKey": null
+                                  },
+                                  (v1/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "coverImage",
+                                    "plural": false,
+                                    "selections": (v5/*: any*/),
+                                    "storageKey": null
+                                  }
+                                ],
+                                "type": "Show",
+                                "abstractKey": null
+                              },
+                              {
+                                "kind": "InlineFragment",
+                                "selections": [
+                                  (v2/*: any*/)
+                                ],
+                                "type": "Node",
+                                "abstractKey": "__isNode"
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "MessageConnection",
+                        "kind": "LinkedField",
+                        "name": "messagesConnection",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "totalCount",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v2/*: any*/),
+                      (v4/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "cursor",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "totalUnreadCount",
+                "storageKey": null
+              }
+            ],
+            "storageKey": "conversationsConnection(after:\"\",first:10)"
+          },
+          {
+            "alias": "conversations",
+            "args": (v0/*: any*/),
+            "filters": null,
+            "handle": "connection",
+            "key": "Conversations_conversations",
+            "kind": "LinkedHandle",
+            "name": "conversationsConnection"
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "1f330a01a6b3359136c587cf2572cd41",
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "me": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Me"
+        },
+        "me.conversations": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ConversationConnection"
+        },
+        "me.conversations.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "ConversationEdge"
+        },
+        "me.conversations.edges.cursor": (v6/*: any*/),
+        "me.conversations.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Conversation"
+        },
+        "me.conversations.edges.node.__typename": (v6/*: any*/),
+        "me.conversations.edges.node.id": (v7/*: any*/),
+        "me.conversations.edges.node.internalID": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ID"
+        },
+        "me.conversations.edges.node.items": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "ConversationItem"
+        },
+        "me.conversations.edges.node.items.item": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ConversationItemType"
+        },
+        "me.conversations.edges.node.items.item.__isNode": (v6/*: any*/),
+        "me.conversations.edges.node.items.item.__typename": (v6/*: any*/),
+        "me.conversations.edges.node.items.item.artistNames": (v8/*: any*/),
+        "me.conversations.edges.node.items.item.coverImage": (v9/*: any*/),
+        "me.conversations.edges.node.items.item.coverImage.url": (v8/*: any*/),
+        "me.conversations.edges.node.items.item.date": (v8/*: any*/),
+        "me.conversations.edges.node.items.item.fair": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Fair"
+        },
+        "me.conversations.edges.node.items.item.fair.id": (v7/*: any*/),
+        "me.conversations.edges.node.items.item.fair.name": (v8/*: any*/),
+        "me.conversations.edges.node.items.item.id": (v7/*: any*/),
+        "me.conversations.edges.node.items.item.image": (v9/*: any*/),
+        "me.conversations.edges.node.items.item.image.url": (v8/*: any*/),
+        "me.conversations.edges.node.items.item.name": (v8/*: any*/),
+        "me.conversations.edges.node.items.item.title": (v8/*: any*/),
+        "me.conversations.edges.node.lastMessage": (v8/*: any*/),
+        "me.conversations.edges.node.lastMessageAt": (v8/*: any*/),
+        "me.conversations.edges.node.last_message": (v8/*: any*/),
+        "me.conversations.edges.node.messagesConnection": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "MessageConnection"
+        },
+        "me.conversations.edges.node.messagesConnection.totalCount": (v10/*: any*/),
+        "me.conversations.edges.node.to": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "ConversationResponder"
+        },
+        "me.conversations.edges.node.to.id": (v7/*: any*/),
+        "me.conversations.edges.node.to.name": (v6/*: any*/),
+        "me.conversations.edges.node.unread": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Boolean"
+        },
+        "me.conversations.pageInfo": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "PageInfo"
+        },
+        "me.conversations.pageInfo.endCursor": (v8/*: any*/),
+        "me.conversations.pageInfo.hasNextPage": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Boolean"
+        },
+        "me.conversations.totalUnreadCount": (v10/*: any*/),
+        "me.id": (v7/*: any*/)
+      }
+    },
+    "name": "ConversationsTestsQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = '1ce6c9c77b0615883bc152300e102875';
+export default node;

--- a/src/lib/Scenes/Inbox/Components/Conversations/Conversations.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/Conversations.tsx
@@ -5,6 +5,7 @@ import { ActivityIndicator, FlatList, RefreshControl, View } from "react-native"
 
 import { navigate } from "lib/navigation/navigate"
 import ConversationSnippet from "./ConversationSnippet"
+import { NoMessages } from "./NoMessages"
 
 import { PAGE_SIZE } from "lib/data/constants"
 
@@ -75,10 +76,6 @@ export class Conversations extends Component<Props, State> {
   render() {
     const conversations = extractNodes(this.props.me.conversations)
 
-    if (conversations.length === 0) {
-      return null
-    }
-
     const unreadCount = this.props.me.conversations?.totalUnreadCount
     const unreadCounter = unreadCount ? `(${unreadCount})` : null
     const shouldDisplayMyBids = getCurrentEmissionState().options.AROptionsBidManagement
@@ -111,6 +108,8 @@ export class Conversations extends Component<Props, State> {
           }}
           onEndReached={this.fetchData}
           onEndReachedThreshold={2}
+          contentContainerStyle={{ flexGrow: 1, justifyContent: !conversations.length ? "center" : "flex-start" }}
+          ListEmptyComponent={<NoMessages />}
         />
         {!!(this.props.relay.hasMore() && this.state.isLoading) && (
           <Flex p={3} alignItems="center">

--- a/src/lib/Scenes/Inbox/Components/Conversations/NoMessages.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/NoMessages.tsx
@@ -1,0 +1,24 @@
+import { navigate } from "lib/navigation/navigate"
+import { Button, Flex, Text } from "palette"
+import React from "react"
+
+export const NoMessages: React.FC = () => {
+  const handleViewWorks = () => {
+    navigate(`/`)
+  }
+  return (
+    <Flex mt={3}>
+      <Text variant="title" textAlign="center" fontWeight="normal">
+        Keep track of your conversations with galleries
+      </Text>
+      <Text mb={2} mt={1} mx={4} variant="text" textAlign="center" fontWeight="normal" color="black60">
+        Contact galleries to learn more about works you want to collect. Use your inbox to stay on top of your inquiries
+      </Text>
+      <Flex width="100%" justifyContent="center" flexDirection="row">
+        <Button variant="primaryBlack" onPress={handleViewWorks}>
+          Explore works
+        </Button>
+      </Flex>
+    </Flex>
+  )
+}

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/Conversations-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/Conversations-tests.tsx
@@ -50,9 +50,7 @@ describe("messaging inbox", () => {
     expect(wrapper.root.findAllByType(ConversationsContainer)).toHaveLength(1)
   })
 
-  it("doesn't render the header when there are no messages", () => {
-    const expected = "Messages"
-
+  it("renders the no messages notice when there are no messages", () => {
     const wrapper = getWrapper({
       Me: () => ({
         conversations: {
@@ -65,6 +63,6 @@ describe("messaging inbox", () => {
       }),
     })
 
-    expect(extractText(wrapper.root)).not.toContain(expected)
+    expect(extractText(wrapper.root)).toContain("Keep track of your conversations with galleries")
   })
 })

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/Conversations-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/Conversations-tests.tsx
@@ -1,103 +1,70 @@
-import { Conversations_me } from "__generated__/Conversations_me.graphql"
+import { ConversationsTestsQuery } from "__generated__/ConversationsTestsQuery.graphql"
+import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
-import { getTextTree } from "lib/utils/getTestWrapper"
 import React from "react"
-import { Conversations } from "../Conversations"
+import { graphql, QueryRenderer } from "react-relay"
+import { act } from "react-test-renderer"
+import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { ConversationsContainer } from "../Conversations"
+
+jest.unmock("react-relay")
 
 describe("messaging inbox", () => {
-  it("renders without throwing a error", () => {
-    renderWithWrappers(
-      <Conversations
-        me={meProps}
-        relay={
-          {
-            hasMore: jest.fn(),
-          } as any
+  let env: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => {
+    env = createMockEnvironment()
+  })
+
+  const TestRenderer = () => (
+    <QueryRenderer<ConversationsTestsQuery>
+      environment={env}
+      query={graphql`
+        query ConversationsTestsQuery @relay_test_operation {
+          me {
+            ...Conversations_me
+          }
         }
-      />
-    )
+      `}
+      variables={{}}
+      render={({ error, props }) => {
+        if (props?.me) {
+          return <ConversationsContainer me={props.me} />
+        } else if (error) {
+          console.error(error)
+        }
+      }}
+    />
+  )
+
+  const getWrapper = (mockResolvers = {}) => {
+    const tree = renderWithWrappers(<TestRenderer />)
+    act(() => {
+      env.mock.resolveMostRecentOperation((operation) => MockPayloadGenerator.generate(operation, mockResolvers))
+    })
+    return tree
+  }
+
+  it("renders without throwing an error", () => {
+    const wrapper = getWrapper()
+    expect(wrapper.root.findAllByType(ConversationsContainer)).toHaveLength(1)
   })
 
   it("doesn't render the header when there are no messages", () => {
     const expected = "Messages"
-    const inboxText = getTextTree(<Conversations me={mePropsEmpty} relay={{ hasMore: jest.fn() } as any} />)
-    expect(inboxText).not.toContain(expected)
+
+    const wrapper = getWrapper({
+      Me: () => ({
+        conversations: {
+          pageInfo: {
+            hasNextPage: false,
+            endCursor: null,
+          },
+          edges: [],
+        },
+      }),
+    })
+
+    expect(extractText(wrapper.root)).not.toContain(expected)
   })
-
-  const meProps = ({
-    conversations: {
-      pageInfo: {
-        hasNextPage: false,
-        endCursor: null,
-      },
-      edges: [
-        {
-          node: {
-            id: "582",
-            inquiry_id: "59302144275b244a81d0f9c6",
-            from: { name: "Jean-Luc Collecteur", email: "luc+messaging@artsymail.com" },
-            to: { name: "ACA Galleries" },
-            lastMessage: "Karl and Anna... Fab!",
-            createdAt: "2017-06-01T14:14:35.538Z",
-            items: [
-              {
-                title: "Karl and Anna Face Off (Diptych)",
-                item: {
-                  __typename: "Artwork",
-                  id: "bradley-theodore-karl-and-anna-face-off-diptych",
-                  href: "/artwork/bradley-theodore-karl-and-anna-face-off-diptych",
-                  title: "Karl and Anna Face Off (Diptych)",
-                  date: "2016",
-                  artistNames: "Bradley Theodore",
-                  image: {
-                    url: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/normalized.jpg",
-                    imageUrl: "https://d32dm0rphc51dk.cloudfront.net/bJ9I_vJX9ksaKFJAkOAIKg/:version.jpg",
-                  },
-                },
-              },
-            ],
-          },
-        },
-        {
-          node: {
-            id: "581",
-            inquiry_id: "593020be8b3b814f9f86f2fd",
-            from: { name: "Jean-Luc Collecteur", email: "luc+messaging@artsymail.com" },
-            to: { name: "David Krut Projects" },
-            lastMessage:
-              "Hi, I’m interested in purchasing this work. \
-                    Could you please provide more information about the piece?",
-            createdAt: "2017-06-01T14:12:19.155Z",
-            items: [
-              {
-                title: "Darkness Give Way to Light",
-                item: {
-                  __typename: "Artwork",
-                  id: "aida-muluneh-darkness-give-way-to-light-1",
-                  href: "/artwork/aida-muluneh-darkness-give-way-to-light-1",
-                  title: "Darkness Give Way to Light",
-                  date: "2016",
-                  artistNames: "Aida Muluneh",
-                  image: {
-                    url: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/normalized.jpg",
-                    imageUrl: "https://d32dm0rphc51dk.cloudfront.net/FDIuqbZUY1kLR-1Pd-Ec8w/:version.jpg",
-                  },
-                },
-              },
-            ],
-          },
-        },
-      ],
-    },
-  } as any) as Conversations_me
-
-  const mePropsEmpty = ({
-    conversations: {
-      pageInfo: {
-        hasNextPage: false,
-        endCursor: null,
-      },
-      edges: [],
-    },
-  } as any) as Conversations_me
 })


### PR DESCRIPTION
The type of this PR is: Enhancement

This PR resolves [PURCHASE-2304]

### Description

This PR adds a missing screen for when a user has no messages on the new inbox.
<img width="372" alt="Screenshot 2020-12-10 at 15 17 42" src="https://user-images.githubusercontent.com/7117670/101799985-09cd5f80-3b0d-11eb-9b9b-8ab73edff778.png">


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[PURCHASE-2304]: https://artsyproduct.atlassian.net/browse/PURCHASE-2304