### PR TITLE
fix: Visual QA fixes for new Inbox

### DIFF
--- a/src/lib/Containers/Inbox/Inbox.tsx
+++ b/src/lib/Containers/Inbox/Inbox.tsx
@@ -21,7 +21,7 @@ const TabWrapper: React.FC<TabWrapperProps> = (props) => <View {...props} />
 
 const InboxTabs: React.FC<TabBarProps> = (props) => (
   <>
-    <Flex flexDirection="row" px={1.5} mb={1}>
+    <Flex flexDirection="row" px={1.5} mb={2}>
       {props.tabs?.map((name: JSX.Element, page: number) => {
         const isTabActive = props.activeTab === page
         return (
@@ -121,7 +121,7 @@ export class Inbox extends React.Component<Props, State> {
     const bottomInset = this.scrollViewVerticalStart
     return (
       <ScrollableTabView
-        style={{ paddingTop: 50 }}
+        style={{ paddingTop: 30 }}
         initialPage={0}
         renderTabBar={() => <InboxTabs />}
         contentProps={{

--- a/src/lib/Scenes/MyBids/Components/Lot.tsx
+++ b/src/lib/Scenes/MyBids/Components/Lot.tsx
@@ -35,7 +35,7 @@ class Lot extends React.Component<Props> {
                 )}
               </Flex>
 
-              <Flex alignItems="baseline" width="50%">
+              <Flex alignItems="baseline">
                 <Text variant="caption" numberOfLines={2}>
                   {saleArtwork?.artwork?.artistNames}
                 </Text>

--- a/src/lib/Scenes/MyBids/Components/SaleCard.tsx
+++ b/src/lib/Scenes/MyBids/Components/SaleCard.tsx
@@ -14,6 +14,7 @@ export const COVER_IMAGE_HEIGHT = 100
 
 export const RegistrationCTAWrapper: React.FunctionComponent<{ navLink?: string }> = (props) => (
   <Touchable
+    style={{ marginTop: 15 }}
     underlayColor={props.navLink ? "black5" : "transparent"}
     onPress={() => props.navLink && navigate(props.navLink)}
   >

--- a/src/lib/Scenes/MyBids/MyBids.tsx
+++ b/src/lib/Scenes/MyBids/MyBids.tsx
@@ -87,7 +87,7 @@ class MyBids extends React.Component<MyBidsProps> {
 
     return (
       <ScrollView
-        contentContainerStyle={{ flexGrow: 1, justifyContent: !!somethingToShow ? "center" : "flex-start" }}
+        contentContainerStyle={{ flexGrow: 1, justifyContent: !somethingToShow ? "center" : "flex-start" }}
         stickyHeaderIndices={[0, 2]}
         refreshControl={
           <RefreshControl


### PR DESCRIPTION
The type of this PR is: Bugfix

This PR resolves [PURCHASE-2305]

Context [here](https://www.notion.so/artsy/Visual-QA-f9e712e683d94b41a4bf36ed511a1d01).

### Description

This PR fixes a few small issues found while QAing. [Context](https://www.notion.so/artsy/Visual-QA-f9e712e683d94b41a4bf36ed511a1d01).

1. Fixes issue that would show bids aligning centre instead of on top.
2. Wrapping on lot first column was incorrectly calculated. This allows for more space for the artist name.
3. Adjusts margins on top of Inbox to fit with My Profile top.
4. Added margin on top of registration CTA to make it look more even (not in GIF).
![visual_fixes](https://user-images.githubusercontent.com/7117670/101815781-59695680-3b20-11eb-9842-2ed824c0cc5d.gif)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[PURCHASE-2305]: https://artsyproduct.atlassian.net/browse/PURCHASE-2305