### PR TITLE
fix: switch to preferred lot and sellingPrice fields

### DIFF
--- a/src/__generated__/ActiveLot_lotStanding.graphql.ts
+++ b/src/__generated__/ActiveLot_lotStanding.graphql.ts
@@ -8,7 +8,7 @@ export type AuctionsReserveStatus = "NoReserve" | "ReserveMet" | "ReserveNotMet"
 export type AuctionsSoldStatus = "ForSale" | "Passed" | "Sold" | "%future added value";
 export type ActiveLot_lotStanding = {
     readonly isHighestBidder: boolean;
-    readonly lotState: {
+    readonly lot: {
         readonly internalID: string;
         readonly bidCount: number;
         readonly reserveStatus: AuctionsReserveStatus;
@@ -64,7 +64,7 @@ return {
       "args": null,
       "concreteType": "AuctionsLotState",
       "kind": "LinkedField",
-      "name": "lotState",
+      "name": "lot",
       "plural": false,
       "selections": [
         {
@@ -106,11 +106,11 @@ return {
           "storageKey": null
         },
         {
-          "alias": "sellingPrice",
+          "alias": null,
           "args": null,
           "concreteType": "Money",
           "kind": "LinkedField",
-          "name": "floorSellingPrice",
+          "name": "sellingPrice",
           "plural": false,
           "selections": (v0/*: any*/),
           "storageKey": null
@@ -157,5 +157,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '78ad33822042ca3df166ba20d09de074';
+(node as any).hash = '73cf6b7591e59069730b37b2e13e69b2';
 export default node;

--- a/src/__generated__/ClosedLot_lotStanding.graphql.ts
+++ b/src/__generated__/ClosedLot_lotStanding.graphql.ts
@@ -8,15 +8,12 @@ export type AuctionsReserveStatus = "NoReserve" | "ReserveMet" | "ReserveNotMet"
 export type AuctionsSoldStatus = "ForSale" | "Passed" | "Sold" | "%future added value";
 export type ClosedLot_lotStanding = {
     readonly isHighestBidder: boolean;
-    readonly lotState: {
+    readonly lot: {
         readonly internalID: string;
         readonly saleId: string;
         readonly bidCount: number;
         readonly reserveStatus: AuctionsReserveStatus;
         readonly soldStatus: AuctionsSoldStatus;
-        readonly askingPrice: {
-            readonly display: string | null;
-        } | null;
         readonly sellingPrice: {
             readonly display: string | null;
         } | null;
@@ -38,17 +35,7 @@ export type ClosedLot_lotStanding$key = {
 
 
 
-const node: ReaderFragment = (function(){
-var v0 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "display",
-    "storageKey": null
-  }
-];
-return {
+const node: ReaderFragment = {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
@@ -66,7 +53,7 @@ return {
       "args": null,
       "concreteType": "AuctionsLotState",
       "kind": "LinkedField",
-      "name": "lotState",
+      "name": "lot",
       "plural": false,
       "selections": [
         {
@@ -105,23 +92,21 @@ return {
           "storageKey": null
         },
         {
-          "alias": "askingPrice",
+          "alias": null,
           "args": null,
           "concreteType": "Money",
           "kind": "LinkedField",
-          "name": "onlineAskingPrice",
+          "name": "sellingPrice",
           "plural": false,
-          "selections": (v0/*: any*/),
-          "storageKey": null
-        },
-        {
-          "alias": "sellingPrice",
-          "args": null,
-          "concreteType": "Money",
-          "kind": "LinkedField",
-          "name": "floorSellingPrice",
-          "plural": false,
-          "selections": (v0/*: any*/),
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "display",
+              "storageKey": null
+            }
+          ],
           "storageKey": null
         }
       ],
@@ -172,6 +157,5 @@ return {
   "type": "AuctionsLotStanding",
   "abstractKey": null
 };
-})();
-(node as any).hash = '4a5e3b7db9b08a583aa471db21ece37e';
+(node as any).hash = '3ab56e4e50230ad593b01efa228b3bf3';
 export default node;

--- a/src/__generated__/InboxQuery.graphql.ts
+++ b/src/__generated__/InboxQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash cd5d4672388bd97d87aed3748dbfdd7c */
+/* @relayHash 902786f3b879922961dbe86008507d7c */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -28,7 +28,7 @@ query InboxQuery {
 
 fragment ActiveLot_lotStanding on AuctionsLotStanding {
   isHighestBidder
-  lotState {
+  lot {
     internalID
     bidCount
     reserveStatus
@@ -36,7 +36,7 @@ fragment ActiveLot_lotStanding on AuctionsLotStanding {
     askingPrice: onlineAskingPrice {
       display
     }
-    sellingPrice: floorSellingPrice {
+    sellingPrice {
       display
     }
     id
@@ -53,16 +53,13 @@ fragment ActiveLot_lotStanding on AuctionsLotStanding {
 
 fragment ClosedLot_lotStanding on AuctionsLotStanding {
   isHighestBidder
-  lotState {
+  lot {
     internalID
     saleId
     bidCount
     reserveStatus
     soldStatus
-    askingPrice: onlineAskingPrice {
-      display
-    }
-    sellingPrice: floorSellingPrice {
+    sellingPrice {
       display
     }
     id
@@ -179,7 +176,7 @@ fragment MyBids_me on Me {
       node {
         ...ActiveLot_lotStanding
         ...ClosedLot_lotStanding
-        lotState {
+        lot {
           internalID
           saleId
           soldStatus
@@ -760,7 +757,7 @@ return {
                         "args": null,
                         "concreteType": "AuctionsLotState",
                         "kind": "LinkedField",
-                        "name": "lotState",
+                        "name": "lot",
                         "plural": false,
                         "selections": [
                           (v3/*: any*/),
@@ -796,11 +793,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "alias": "sellingPrice",
+                            "alias": null,
                             "args": null,
                             "concreteType": "Money",
                             "kind": "LinkedField",
-                            "name": "floorSellingPrice",
+                            "name": "sellingPrice",
                             "plural": false,
                             "selections": (v21/*: any*/),
                             "storageKey": null
@@ -941,7 +938,7 @@ return {
     ]
   },
   "params": {
-    "id": "cd5d4672388bd97d87aed3748dbfdd7c",
+    "id": "902786f3b879922961dbe86008507d7c",
     "metadata": {},
     "name": "InboxQuery",
     "operationKind": "query",

--- a/src/__generated__/InboxRefetchQuery.graphql.ts
+++ b/src/__generated__/InboxRefetchQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 5fb536701a522558e17a1c5d2eaa549b */
+/* @relayHash 3b343e56405d7bf078771a1b1d3ae0a4 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -28,7 +28,7 @@ query InboxRefetchQuery {
 
 fragment ActiveLot_lotStanding on AuctionsLotStanding {
   isHighestBidder
-  lotState {
+  lot {
     internalID
     bidCount
     reserveStatus
@@ -36,7 +36,7 @@ fragment ActiveLot_lotStanding on AuctionsLotStanding {
     askingPrice: onlineAskingPrice {
       display
     }
-    sellingPrice: floorSellingPrice {
+    sellingPrice {
       display
     }
     id
@@ -53,16 +53,13 @@ fragment ActiveLot_lotStanding on AuctionsLotStanding {
 
 fragment ClosedLot_lotStanding on AuctionsLotStanding {
   isHighestBidder
-  lotState {
+  lot {
     internalID
     saleId
     bidCount
     reserveStatus
     soldStatus
-    askingPrice: onlineAskingPrice {
-      display
-    }
-    sellingPrice: floorSellingPrice {
+    sellingPrice {
       display
     }
     id
@@ -179,7 +176,7 @@ fragment MyBids_me on Me {
       node {
         ...ActiveLot_lotStanding
         ...ClosedLot_lotStanding
-        lotState {
+        lot {
           internalID
           saleId
           soldStatus
@@ -760,7 +757,7 @@ return {
                         "args": null,
                         "concreteType": "AuctionsLotState",
                         "kind": "LinkedField",
-                        "name": "lotState",
+                        "name": "lot",
                         "plural": false,
                         "selections": [
                           (v3/*: any*/),
@@ -796,11 +793,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "alias": "sellingPrice",
+                            "alias": null,
                             "args": null,
                             "concreteType": "Money",
                             "kind": "LinkedField",
-                            "name": "floorSellingPrice",
+                            "name": "sellingPrice",
                             "plural": false,
                             "selections": (v21/*: any*/),
                             "storageKey": null
@@ -941,7 +938,7 @@ return {
     ]
   },
   "params": {
-    "id": "5fb536701a522558e17a1c5d2eaa549b",
+    "id": "3b343e56405d7bf078771a1b1d3ae0a4",
     "metadata": {},
     "name": "InboxRefetchQuery",
     "operationKind": "query",

--- a/src/__generated__/InboxTestsQuery.graphql.ts
+++ b/src/__generated__/InboxTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 7586c08c265edd05072d6b38b6a604ab */
+/* @relayHash 97cf71c0ae66288ac0ee56aeb7557650 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -28,7 +28,7 @@ query InboxTestsQuery {
 
 fragment ActiveLot_lotStanding on AuctionsLotStanding {
   isHighestBidder
-  lotState {
+  lot {
     internalID
     bidCount
     reserveStatus
@@ -36,7 +36,7 @@ fragment ActiveLot_lotStanding on AuctionsLotStanding {
     askingPrice: onlineAskingPrice {
       display
     }
-    sellingPrice: floorSellingPrice {
+    sellingPrice {
       display
     }
     id
@@ -53,16 +53,13 @@ fragment ActiveLot_lotStanding on AuctionsLotStanding {
 
 fragment ClosedLot_lotStanding on AuctionsLotStanding {
   isHighestBidder
-  lotState {
+  lot {
     internalID
     saleId
     bidCount
     reserveStatus
     soldStatus
-    askingPrice: onlineAskingPrice {
-      display
-    }
-    sellingPrice: floorSellingPrice {
+    sellingPrice {
       display
     }
     id
@@ -179,7 +176,7 @@ fragment MyBids_me on Me {
       node {
         ...ActiveLot_lotStanding
         ...ClosedLot_lotStanding
-        lotState {
+        lot {
           internalID
           saleId
           soldStatus
@@ -826,7 +823,7 @@ return {
                         "args": null,
                         "concreteType": "AuctionsLotState",
                         "kind": "LinkedField",
-                        "name": "lotState",
+                        "name": "lot",
                         "plural": false,
                         "selections": [
                           (v3/*: any*/),
@@ -862,11 +859,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "alias": "sellingPrice",
+                            "alias": null,
                             "args": null,
                             "concreteType": "Money",
                             "kind": "LinkedField",
-                            "name": "floorSellingPrice",
+                            "name": "sellingPrice",
                             "plural": false,
                             "selections": (v21/*: any*/),
                             "storageKey": null
@@ -1007,7 +1004,7 @@ return {
     ]
   },
   "params": {
-    "id": "7586c08c265edd05072d6b38b6a604ab",
+    "id": "97cf71c0ae66288ac0ee56aeb7557650",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "me": {
@@ -1038,23 +1035,23 @@ return {
         "me.auctionsLotStandingConnection.edges.node.__typename": (v22/*: any*/),
         "me.auctionsLotStandingConnection.edges.node.id": (v23/*: any*/),
         "me.auctionsLotStandingConnection.edges.node.isHighestBidder": (v24/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.lotState": {
+        "me.auctionsLotStandingConnection.edges.node.lot": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "AuctionsLotState"
         },
-        "me.auctionsLotStandingConnection.edges.node.lotState.askingPrice": (v25/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.lotState.askingPrice.display": (v26/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.lotState.bidCount": {
+        "me.auctionsLotStandingConnection.edges.node.lot.askingPrice": (v25/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.lot.askingPrice.display": (v26/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.lot.bidCount": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Int"
         },
-        "me.auctionsLotStandingConnection.edges.node.lotState.id": (v23/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.lotState.internalID": (v23/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.lotState.reserveStatus": {
+        "me.auctionsLotStandingConnection.edges.node.lot.id": (v23/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.lot.internalID": (v23/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.lot.reserveStatus": {
           "enumValues": [
             "NoReserve",
             "ReserveMet",
@@ -1064,10 +1061,10 @@ return {
           "plural": false,
           "type": "AuctionsReserveStatus"
         },
-        "me.auctionsLotStandingConnection.edges.node.lotState.saleId": (v23/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.lotState.sellingPrice": (v25/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.lotState.sellingPrice.display": (v26/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.lotState.soldStatus": {
+        "me.auctionsLotStandingConnection.edges.node.lot.saleId": (v23/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.lot.sellingPrice": (v25/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.lot.sellingPrice.display": (v26/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.lot.soldStatus": {
           "enumValues": [
             "ForSale",
             "Passed",

--- a/src/__generated__/MyBidsPaginatedQuery.graphql.ts
+++ b/src/__generated__/MyBidsPaginatedQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 834dbc811b0c5d003632fa4a4c148bfa */
+/* @relayHash e0103896e17e77345e8fa3b7a330a23c */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -34,7 +34,7 @@ query MyBidsPaginatedQuery(
 
 fragment ActiveLot_lotStanding on AuctionsLotStanding {
   isHighestBidder
-  lotState {
+  lot {
     internalID
     bidCount
     reserveStatus
@@ -42,7 +42,7 @@ fragment ActiveLot_lotStanding on AuctionsLotStanding {
     askingPrice: onlineAskingPrice {
       display
     }
-    sellingPrice: floorSellingPrice {
+    sellingPrice {
       display
     }
     id
@@ -59,16 +59,13 @@ fragment ActiveLot_lotStanding on AuctionsLotStanding {
 
 fragment ClosedLot_lotStanding on AuctionsLotStanding {
   isHighestBidder
-  lotState {
+  lot {
     internalID
     saleId
     bidCount
     reserveStatus
     soldStatus
-    askingPrice: onlineAskingPrice {
-      display
-    }
-    sellingPrice: floorSellingPrice {
+    sellingPrice {
       display
     }
     id
@@ -119,7 +116,7 @@ fragment MyBids_me_1G22uz on Me {
       node {
         ...ActiveLot_lotStanding
         ...ClosedLot_lotStanding
-        lotState {
+        lot {
           internalID
           saleId
           soldStatus
@@ -474,7 +471,7 @@ return {
                         "args": null,
                         "concreteType": "AuctionsLotState",
                         "kind": "LinkedField",
-                        "name": "lotState",
+                        "name": "lot",
                         "plural": false,
                         "selections": [
                           (v1/*: any*/),
@@ -510,11 +507,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "alias": "sellingPrice",
+                            "alias": null,
                             "args": null,
                             "concreteType": "Money",
                             "kind": "LinkedField",
-                            "name": "floorSellingPrice",
+                            "name": "sellingPrice",
                             "plural": false,
                             "selections": (v14/*: any*/),
                             "storageKey": null
@@ -688,7 +685,7 @@ return {
     ]
   },
   "params": {
-    "id": "834dbc811b0c5d003632fa4a4c148bfa",
+    "id": "e0103896e17e77345e8fa3b7a330a23c",
     "metadata": {},
     "name": "MyBidsPaginatedQuery",
     "operationKind": "query",

--- a/src/__generated__/MyBidsQuery.graphql.ts
+++ b/src/__generated__/MyBidsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 7d244ad4d77a53f15855adb085fc68cf */
+/* @relayHash fbe430c67d12b229483211d4b74eefa4 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -28,7 +28,7 @@ query MyBidsQuery {
 
 fragment ActiveLot_lotStanding on AuctionsLotStanding {
   isHighestBidder
-  lotState {
+  lot {
     internalID
     bidCount
     reserveStatus
@@ -36,7 +36,7 @@ fragment ActiveLot_lotStanding on AuctionsLotStanding {
     askingPrice: onlineAskingPrice {
       display
     }
-    sellingPrice: floorSellingPrice {
+    sellingPrice {
       display
     }
     id
@@ -53,16 +53,13 @@ fragment ActiveLot_lotStanding on AuctionsLotStanding {
 
 fragment ClosedLot_lotStanding on AuctionsLotStanding {
   isHighestBidder
-  lotState {
+  lot {
     internalID
     saleId
     bidCount
     reserveStatus
     soldStatus
-    askingPrice: onlineAskingPrice {
-      display
-    }
-    sellingPrice: floorSellingPrice {
+    sellingPrice {
       display
     }
     id
@@ -113,7 +110,7 @@ fragment MyBids_me on Me {
       node {
         ...ActiveLot_lotStanding
         ...ClosedLot_lotStanding
-        lotState {
+        lot {
           internalID
           saleId
           soldStatus
@@ -445,7 +442,7 @@ return {
                         "args": null,
                         "concreteType": "AuctionsLotState",
                         "kind": "LinkedField",
-                        "name": "lotState",
+                        "name": "lot",
                         "plural": false,
                         "selections": [
                           (v0/*: any*/),
@@ -481,11 +478,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "alias": "sellingPrice",
+                            "alias": null,
                             "args": null,
                             "concreteType": "Money",
                             "kind": "LinkedField",
-                            "name": "floorSellingPrice",
+                            "name": "sellingPrice",
                             "plural": false,
                             "selections": (v13/*: any*/),
                             "storageKey": null
@@ -659,7 +656,7 @@ return {
     ]
   },
   "params": {
-    "id": "7d244ad4d77a53f15855adb085fc68cf",
+    "id": "fbe430c67d12b229483211d4b74eefa4",
     "metadata": {},
     "name": "MyBidsQuery",
     "operationKind": "query",

--- a/src/__generated__/MyBidsTestsQuery.graphql.ts
+++ b/src/__generated__/MyBidsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash bed67826bbc6c6d6c501d1cf5e3f227c */
+/* @relayHash 0982a688ffc5f2e3347716cb27307fc9 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -28,7 +28,7 @@ query MyBidsTestsQuery {
 
 fragment ActiveLot_lotStanding on AuctionsLotStanding {
   isHighestBidder
-  lotState {
+  lot {
     internalID
     bidCount
     reserveStatus
@@ -36,7 +36,7 @@ fragment ActiveLot_lotStanding on AuctionsLotStanding {
     askingPrice: onlineAskingPrice {
       display
     }
-    sellingPrice: floorSellingPrice {
+    sellingPrice {
       display
     }
     id
@@ -53,16 +53,13 @@ fragment ActiveLot_lotStanding on AuctionsLotStanding {
 
 fragment ClosedLot_lotStanding on AuctionsLotStanding {
   isHighestBidder
-  lotState {
+  lot {
     internalID
     saleId
     bidCount
     reserveStatus
     soldStatus
-    askingPrice: onlineAskingPrice {
-      display
-    }
-    sellingPrice: floorSellingPrice {
+    sellingPrice {
       display
     }
     id
@@ -113,7 +110,7 @@ fragment MyBids_me on Me {
       node {
         ...ActiveLot_lotStanding
         ...ClosedLot_lotStanding
-        lotState {
+        lot {
           internalID
           saleId
           soldStatus
@@ -505,7 +502,7 @@ return {
                         "args": null,
                         "concreteType": "AuctionsLotState",
                         "kind": "LinkedField",
-                        "name": "lotState",
+                        "name": "lot",
                         "plural": false,
                         "selections": [
                           (v0/*: any*/),
@@ -541,11 +538,11 @@ return {
                             "storageKey": null
                           },
                           {
-                            "alias": "sellingPrice",
+                            "alias": null,
                             "args": null,
                             "concreteType": "Money",
                             "kind": "LinkedField",
-                            "name": "floorSellingPrice",
+                            "name": "sellingPrice",
                             "plural": false,
                             "selections": (v13/*: any*/),
                             "storageKey": null
@@ -719,7 +716,7 @@ return {
     ]
   },
   "params": {
-    "id": "bed67826bbc6c6d6c501d1cf5e3f227c",
+    "id": "0982a688ffc5f2e3347716cb27307fc9",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "me": {
@@ -750,23 +747,23 @@ return {
         "me.auctionsLotStandingConnection.edges.node.__typename": (v14/*: any*/),
         "me.auctionsLotStandingConnection.edges.node.id": (v15/*: any*/),
         "me.auctionsLotStandingConnection.edges.node.isHighestBidder": (v16/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.lotState": {
+        "me.auctionsLotStandingConnection.edges.node.lot": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "AuctionsLotState"
         },
-        "me.auctionsLotStandingConnection.edges.node.lotState.askingPrice": (v17/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.lotState.askingPrice.display": (v18/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.lotState.bidCount": {
+        "me.auctionsLotStandingConnection.edges.node.lot.askingPrice": (v17/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.lot.askingPrice.display": (v18/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.lot.bidCount": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Int"
         },
-        "me.auctionsLotStandingConnection.edges.node.lotState.id": (v15/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.lotState.internalID": (v15/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.lotState.reserveStatus": {
+        "me.auctionsLotStandingConnection.edges.node.lot.id": (v15/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.lot.internalID": (v15/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.lot.reserveStatus": {
           "enumValues": [
             "NoReserve",
             "ReserveMet",
@@ -776,10 +773,10 @@ return {
           "plural": false,
           "type": "AuctionsReserveStatus"
         },
-        "me.auctionsLotStandingConnection.edges.node.lotState.saleId": (v15/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.lotState.sellingPrice": (v17/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.lotState.sellingPrice.display": (v18/*: any*/),
-        "me.auctionsLotStandingConnection.edges.node.lotState.soldStatus": {
+        "me.auctionsLotStandingConnection.edges.node.lot.saleId": (v15/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.lot.sellingPrice": (v17/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.lot.sellingPrice.display": (v18/*: any*/),
+        "me.auctionsLotStandingConnection.edges.node.lot.soldStatus": {
           "enumValues": [
             "ForSale",
             "Passed",

--- a/src/__generated__/MyBids_me.graphql.ts
+++ b/src/__generated__/MyBids_me.graphql.ts
@@ -22,7 +22,7 @@ export type MyBids_me = {
     readonly auctionsLotStandingConnection: {
         readonly edges: ReadonlyArray<{
             readonly node: {
-                readonly lotState: {
+                readonly lot: {
                     readonly internalID: string;
                     readonly saleId: string;
                     readonly soldStatus: AuctionsSoldStatus;
@@ -201,7 +201,7 @@ return {
                   "args": null,
                   "concreteType": "AuctionsLotState",
                   "kind": "LinkedField",
-                  "name": "lotState",
+                  "name": "lot",
                   "plural": false,
                   "selections": [
                     (v0/*: any*/),
@@ -324,5 +324,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = 'd245db0915dcfad6612f1d6ea10f7d37';
+(node as any).hash = '3b7393a5d5db8d2f7c959fea97ac9530';
 export default node;

--- a/src/lib/Scenes/MyBids/Components/ActiveLot.tsx
+++ b/src/lib/Scenes/MyBids/Components/ActiveLot.tsx
@@ -10,9 +10,9 @@ import { LotFragmentContainer as Lot } from "./Lot"
 export const ActiveLot = ({ lotStanding }: { lotStanding: ActiveLot_lotStanding }, smallScreen: boolean) => {
   const timelySale = TimelySale.create(lotStanding?.saleArtwork?.sale!)
 
-  const sellingPrice = lotStanding?.lotState?.sellingPrice?.display
-  const bidCount = lotStanding?.lotState?.bidCount
-  const { saleArtwork, lotState } = lotStanding
+  const sellingPrice = lotStanding?.lot?.sellingPrice?.display
+  const bidCount = lotStanding?.lot?.bidCount
+  const { saleArtwork, lot } = lotStanding
 
   const displayBidCount = (): string | undefined => {
     if (isSmallScreen) {
@@ -24,7 +24,7 @@ export const ActiveLot = ({ lotStanding }: { lotStanding: ActiveLot_lotStanding 
 
   return (
     saleArtwork &&
-    lotState && (
+    lot && (
       <Lot saleArtwork={saleArtwork} isSmallScreen={smallScreen}>
         <Flex flexDirection="row" justifyContent="flex-end">
           <Text variant="caption">{sellingPrice}</Text>
@@ -34,9 +34,7 @@ export const ActiveLot = ({ lotStanding }: { lotStanding: ActiveLot_lotStanding 
           </Text>
         </Flex>
         <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
-          {!timelySale.isLAI &&
-          lotStanding?.isHighestBidder &&
-          lotStanding.lotState.reserveStatus === "ReserveNotMet" ? (
+          {!timelySale.isLAI && lotStanding?.isHighestBidder && lotStanding.lot.reserveStatus === "ReserveNotMet" ? (
             <ReserveNotMet />
           ) : lotStanding?.isHighestBidder ? (
             <HighestBid />
@@ -53,7 +51,7 @@ export const ActiveLotFragmentContainer = createFragmentContainer(ActiveLot, {
   lotStanding: graphql`
     fragment ActiveLot_lotStanding on AuctionsLotStanding {
       isHighestBidder
-      lotState {
+      lot {
         internalID
         bidCount
         reserveStatus
@@ -61,7 +59,7 @@ export const ActiveLotFragmentContainer = createFragmentContainer(ActiveLot, {
         askingPrice: onlineAskingPrice {
           display
         }
-        sellingPrice: floorSellingPrice {
+        sellingPrice {
           display
         }
       }

--- a/src/lib/Scenes/MyBids/Components/ClosedLot.tsx
+++ b/src/lib/Scenes/MyBids/Components/ClosedLot.tsx
@@ -28,11 +28,11 @@ export const ClosedLot = ({
   withTimelyInfo?: boolean
 }) => {
   const sale = lotStanding?.saleArtwork?.sale!
-  const sellingPrice = lotStanding?.lotState?.sellingPrice?.display
+  const sellingPrice = lotStanding?.lot?.sellingPrice?.display
   const subtitle = withTimelyInfo ? saleClosedMessage(sale) : undefined
 
   const result: BidderResult =
-    lotStanding?.lotState.soldStatus === "Passed" ? "passed" : lotStanding?.isHighestBidder ? "won" : "lost"
+    lotStanding?.lot.soldStatus === "Passed" ? "passed" : lotStanding?.isHighestBidder ? "won" : "lost"
   const Badge = result === "won" ? StarCircleFill : undefined
 
   const bidderMessages: { [k in BidderResult]: React.ComponentType } = {
@@ -59,16 +59,13 @@ export const ClosedLotFragmentContainer = createFragmentContainer(ClosedLot, {
   lotStanding: graphql`
     fragment ClosedLot_lotStanding on AuctionsLotStanding {
       isHighestBidder
-      lotState {
+      lot {
         internalID
         saleId
         bidCount
         reserveStatus
         soldStatus
-        askingPrice: onlineAskingPrice {
-          display
-        }
-        sellingPrice: floorSellingPrice {
+        sellingPrice {
           display
         }
       }

--- a/src/lib/Scenes/MyBids/MyBids.tsx
+++ b/src/lib/Scenes/MyBids/MyBids.tsx
@@ -123,7 +123,7 @@ class MyBids extends React.Component<MyBidsProps> {
                       {activeLotStandings.map((ls) => {
                         if (ls && sale) {
                           const LotInfoComponent = isLotStandingComplete(ls) ? ClosedLot : ActiveLot
-                          return <LotInfoComponent lotStanding={ls} key={ls?.lotState?.internalID} />
+                          return <LotInfoComponent lotStanding={ls} key={ls?.lot?.internalID} />
                         }
                       })}
                     </Join>
@@ -145,7 +145,7 @@ class MyBids extends React.Component<MyBidsProps> {
                         withTimelyInfo
                         data-test-id="closed-sale-lot"
                         lotStanding={ls}
-                        key={ls?.lotState?.internalID}
+                        key={ls?.lot?.internalID}
                       />
                     )
                   )
@@ -195,7 +195,7 @@ export const MyBidsContainer = createPaginationContainer(
             node {
               ...ActiveLot_lotStanding
               ...ClosedLot_lotStanding
-              lotState {
+              lot {
                 internalID
                 saleId
                 soldStatus

--- a/src/lib/Scenes/MyBids/__tests__/ActiveLot-tests.tsx
+++ b/src/lib/Scenes/MyBids/__tests__/ActiveLot-tests.tsx
@@ -8,7 +8,7 @@ import { ActiveLot } from "../Components/ActiveLot"
 
 const defaultLotStanding = {
   isHighestBidder: true,
-  lotState: {
+  lot: {
     internalID: "123",
     bidCount: 1,
     soldStatus: "ForSale",
@@ -41,9 +41,7 @@ describe(ActiveLot, () => {
   describe("User winning status", () => {
     it("says 'Highest bid' if the user is winning the lot", () => {
       const tree = renderWithWrappers(
-        <ActiveLot
-          lotStanding={lotStandingFixture({ isHighestBidder: true, lotState: { reserveStatus: "ReserveMet" } })}
-        />
+        <ActiveLot lotStanding={lotStandingFixture({ isHighestBidder: true, lot: { reserveStatus: "ReserveMet" } })} />
       )
       expect(extractText(tree.root)).toContain("Highest bid")
     })
@@ -51,7 +49,7 @@ describe(ActiveLot, () => {
     it("says 'Highest bid' if the user is has the high bid and reserveStatus is UnknownReserve", () => {
       const tree = renderWithWrappers(
         <ActiveLot
-          lotStanding={lotStandingFixture({ isHighestBidder: true, lotState: { reserveStatus: "UnknownReserve" } })}
+          lotStanding={lotStandingFixture({ isHighestBidder: true, lot: { reserveStatus: "UnknownReserve" } })}
         />
       )
       expect(extractText(tree.root)).toContain("Highest bid")
@@ -64,7 +62,7 @@ describe(ActiveLot, () => {
         <ActiveLot
           lotStanding={lotStandingFixture({
             isHighestBidder: true,
-            lotState: { reserveStatus: "ReserveNotMet" },
+            lot: { reserveStatus: "ReserveNotMet" },
             saleArtwork: { sale: { liveStartAt: date } },
           })}
         />
@@ -75,7 +73,7 @@ describe(ActiveLot, () => {
     it("says 'Reserve not met' if the user is winning the lot, but the reserveStatus is ReserveNotMet", () => {
       const tree = renderWithWrappers(
         <ActiveLot
-          lotStanding={lotStandingFixture({ isHighestBidder: true, lotState: { reserveStatus: "ReserveNotMet" } })}
+          lotStanding={lotStandingFixture({ isHighestBidder: true, lot: { reserveStatus: "ReserveNotMet" } })}
         />
       )
       expect(extractText(tree.root)).toContain("Reserve not met")
@@ -84,7 +82,7 @@ describe(ActiveLot, () => {
     it("says 'Outbid' if the user is outbid on the lot, but the reserveStatus is ReserveNotMet", () => {
       const tree = renderWithWrappers(
         <ActiveLot
-          lotStanding={lotStandingFixture({ isHighestBidder: false, lotState: { reserveStatus: "ReserveNotMet" } })}
+          lotStanding={lotStandingFixture({ isHighestBidder: false, lot: { reserveStatus: "ReserveNotMet" } })}
         />
       )
       expect(extractText(tree.root)).toContain("Outbid")
@@ -92,9 +90,7 @@ describe(ActiveLot, () => {
 
     it("says 'outbid' if the user is outbid on the lot and reserve is met", () => {
       const tree = renderWithWrappers(
-        <ActiveLot
-          lotStanding={lotStandingFixture({ isHighestBidder: false, lotState: { reserveStatus: "ReserveMet" } })}
-        />
+        <ActiveLot lotStanding={lotStandingFixture({ isHighestBidder: false, lot: { reserveStatus: "ReserveMet" } })} />
       )
       expect(extractText(tree.root)).toContain("Outbid")
     })
@@ -103,9 +99,7 @@ describe(ActiveLot, () => {
   describe("selling price", () => {
     it("shows floor selling price", () => {
       const tree = renderWithWrappers(
-        <ActiveLot
-          lotStanding={lotStandingFixture({ isHighestBidder: true, lotState: { reserveStatus: "ReserveMet" } })}
-        />
+        <ActiveLot lotStanding={lotStandingFixture({ isHighestBidder: true, lot: { reserveStatus: "ReserveMet" } })} />
       )
       expect(extractText(tree.root)).toContain("CHF 1,800")
     })

--- a/src/lib/Scenes/MyBids/__tests__/ClosedLot-tests.tsx
+++ b/src/lib/Scenes/MyBids/__tests__/ClosedLot-tests.tsx
@@ -9,7 +9,7 @@ import { ClosedLot } from "../Components/ClosedLot"
 
 const defaultLotStanding = {
   isHighestBidder: true,
-  lotState: {
+  lot: {
     internalID: "123",
     bidCount: 1,
     soldStatus: "Passed",
@@ -45,21 +45,21 @@ describe(ClosedLot, () => {
   describe("result message", () => {
     it("says 'You won!' if the user won the lot", () => {
       const tree = renderWithWrappers(
-        <ClosedLot lotStanding={lotStandingFixture({ isHighestBidder: true, lotState: { soldStatus: "Sold" } })} />
+        <ClosedLot lotStanding={lotStandingFixture({ isHighestBidder: true, lot: { soldStatus: "Sold" } })} />
       )
       expect(extractText(tree.root)).toContain("You won!")
     })
 
     it("says 'Outbid' if the the lot sold to someone else", () => {
       const tree = renderWithWrappers(
-        <ClosedLot lotStanding={lotStandingFixture({ isHighestBidder: false, lotState: { soldStatus: "Sold" } })} />
+        <ClosedLot lotStanding={lotStandingFixture({ isHighestBidder: false, lot: { soldStatus: "Sold" } })} />
       )
       expect(extractText(tree.root)).toContain("Outbid")
     })
 
     it("says 'Passed' if the lot did not sell at all", () => {
       const tree = renderWithWrappers(
-        <ClosedLot lotStanding={lotStandingFixture({ isHighestBidder: true, lotState: { soldStatus: "Passed" } })} />
+        <ClosedLot lotStanding={lotStandingFixture({ isHighestBidder: true, lot: { soldStatus: "Passed" } })} />
       )
       expect(extractText(tree.root)).toContain("Passed")
     })
@@ -69,7 +69,7 @@ describe(ClosedLot, () => {
     it("has a little star badge if the user won the lot", () => {
       expect(
         renderWithWrappers(
-          <ClosedLot lotStanding={lotStandingFixture({ isHighestBidder: true, lotState: { soldStatus: "Sold" } })} />
+          <ClosedLot lotStanding={lotStandingFixture({ isHighestBidder: true, lot: { soldStatus: "Sold" } })} />
         ).root.findAllByType(StarCircleFill).length
       ).toBe(1)
     })

--- a/src/lib/Scenes/MyBids/__tests__/MyBids-tests.tsx
+++ b/src/lib/Scenes/MyBids/__tests__/MyBids-tests.tsx
@@ -88,7 +88,7 @@ describe("My Bids", () => {
               {
                 node: {
                   isHighestBidder: true,
-                  lotState: {
+                  lot: {
                     soldStatus: "Passed",
                   },
                   saleArtwork: {
@@ -127,7 +127,7 @@ describe("My Bids", () => {
               {
                 node: {
                   isHighestBidder: true,
-                  lotState: {
+                  lot: {
                     soldStatus: "Passed",
                     reserveStatus: "ReserveNotMet",
                   },

--- a/src/lib/Scenes/MyBids/helpers/timely.ts
+++ b/src/lib/Scenes/MyBids/helpers/timely.ts
@@ -9,8 +9,8 @@ export const lotInActiveSale: (lotStanding: {
 }
 
 /** Whether the lot has been completed, regardless of the sale's closed status */
-export const isLotStandingComplete: (lotStanding: { lotState?: { soldStatus?: string } }) => boolean = (lotStanding) =>
-  !!(lotStanding.lotState?.soldStatus && ["sold", "passed"].includes(lotStanding.lotState.soldStatus?.toLowerCase()))
+export const isLotStandingComplete: (lotStanding: { lot?: { soldStatus?: string } }) => boolean = (lotStanding) =>
+  !!(lotStanding.lot?.soldStatus && ["sold", "passed"].includes(lotStanding.lot.soldStatus?.toLowerCase()))
 
 interface SaleWithTimes {
   status?: string | null


### PR DESCRIPTION
The type of this PR is: **fix**
This PR completes [PURCHASE-2294]
#minor
In short this pr switches to use `sellingPrice` rather than `floorSellingPrice` (which only respects bids recognized by the live floor auctioneer) on the my bids screen. It also switches to use `LotStanding.lot` over the deprecated `lotState` field. It's mostly a find/replace and removing some aliased field names.




To QA: Verify that artworks display with identical current bid amount on both my bids and the artwork's screen. Bid count, also included in the jira ticket, should also match.
<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-]

### Description

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

![2020-12-11 00 42 16](https://user-images.githubusercontent.com/9088720/101867718-d6f58c80-3b49-11eb-8f3f-e366ea66aa1e.gif)

[PURCHASE-2294]: https://artsyproduct.atlassian.net/browse/PURCHASE-2294
[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434