### PR TITLE
fix: low quality my collection images

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -7,6 +7,7 @@ upcoming:
     - Fix multi-image upload and add processing state in my collection - brian, barry
     - Add auction lots history to artist insights tab - mounir, pavlos
     - Move shows entry point to about tab - mounir
+    - Fix image graininess in my collection - brian
 
 releases:
   - version: 6.7.3

--- a/emission/Pod/Classes/EigenCommunications/ARPHPhotoPickerModule.m
+++ b/emission/Pod/Classes/EigenCommunications/ARPHPhotoPickerModule.m
@@ -77,7 +77,8 @@ RCT_EXPORT_METHOD(requestPhotos:(RCTPromiseResolveBlock)resolve
                 [result.itemProvider loadObjectOfClass:[UIImage class] completionHandler:^(__kindof id<NSItemProviderReading> _Nullable object, NSError * _Nullable error) {
                     if ([object isKindOfClass:[UIImage class]]) {
                         UIImage *image = (UIImage*)object;
-                        ImageResult *imageResult = [compression compressImage:[image fixOrientation] withOptions:nil];
+                        NSDictionary *compressionOption = @{ @"compressImageQuality": @1.0 };
+                        ImageResult *imageResult = [compression compressImage:[image fixOrientation] withOptions:compressionOption];
                         NSString *filePath = [self persistFile:imageResult.data];
                         NSDictionary *imageDict = [self dictFromImageResult:imageResult filePath:filePath];
                         [images addObject:imageDict];

--- a/src/__generated__/MyCollectionArtworkHeaderTestsQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkHeaderTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 8e0072dd70dce3eebc02d33af8e8890e */
+/* @relayHash d08a1b05da100966a9dda5a5510436ec */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -32,7 +32,7 @@ fragment MyCollectionArtworkHeader_artwork on Artwork {
   images {
     height
     isDefault
-    url
+    imageURL
     width
   }
   internalID
@@ -147,7 +147,7 @@ return {
                 "alias": null,
                 "args": null,
                 "kind": "ScalarField",
-                "name": "url",
+                "name": "imageURL",
                 "storageKey": null
               },
               {
@@ -187,7 +187,7 @@ return {
     ]
   },
   "params": {
-    "id": "8e0072dd70dce3eebc02d33af8e8890e",
+    "id": "d08a1b05da100966a9dda5a5510436ec",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artwork": {
@@ -206,13 +206,13 @@ return {
           "type": "Image"
         },
         "artwork.images.height": (v3/*: any*/),
+        "artwork.images.imageURL": (v1/*: any*/),
         "artwork.images.isDefault": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Boolean"
         },
-        "artwork.images.url": (v1/*: any*/),
         "artwork.images.width": (v3/*: any*/),
         "artwork.internalID": (v2/*: any*/),
         "artwork.title": (v1/*: any*/)

--- a/src/__generated__/MyCollectionArtworkHeader_artwork.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkHeader_artwork.graphql.ts
@@ -10,7 +10,7 @@ export type MyCollectionArtworkHeader_artwork = {
     readonly images: ReadonlyArray<{
         readonly height: number | null;
         readonly isDefault: boolean | null;
-        readonly url: string | null;
+        readonly imageURL: string | null;
         readonly width: number | null;
     } | null> | null;
     readonly internalID: string;
@@ -71,7 +71,7 @@ const node: ReaderFragment = {
           "alias": null,
           "args": null,
           "kind": "ScalarField",
-          "name": "url",
+          "name": "imageURL",
           "storageKey": null
         },
         {
@@ -102,5 +102,5 @@ const node: ReaderFragment = {
   "type": "Artwork",
   "abstractKey": null
 };
-(node as any).hash = '482f0b0d9bfa5d2bfd6a35f9af7991bb';
+(node as any).hash = '67faaadf501c1e837dfbdaedb3dfde56';
 export default node;

--- a/src/__generated__/MyCollectionArtworkImagesQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkImagesQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash d55a45b3d1816acfa35868802ae6dea0 */
+/* @relayHash 4bc4ebdae3eea936f8eb22d0ccc0537b */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -34,7 +34,7 @@ fragment MyCollectionArtworkImages_artwork on Artwork {
   images {
     height
     isDefault
-    url
+    imageURL
     width
   }
 }
@@ -122,7 +122,7 @@ return {
                 "alias": null,
                 "args": null,
                 "kind": "ScalarField",
-                "name": "url",
+                "name": "imageURL",
                 "storageKey": null
               },
               {
@@ -148,7 +148,7 @@ return {
     ]
   },
   "params": {
-    "id": "d55a45b3d1816acfa35868802ae6dea0",
+    "id": "4bc4ebdae3eea936f8eb22d0ccc0537b",
     "metadata": {},
     "name": "MyCollectionArtworkImagesQuery",
     "operationKind": "query",

--- a/src/__generated__/MyCollectionArtworkImages_artwork.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkImages_artwork.graphql.ts
@@ -8,7 +8,7 @@ export type MyCollectionArtworkImages_artwork = {
     readonly images: ReadonlyArray<{
         readonly height: number | null;
         readonly isDefault: boolean | null;
-        readonly url: string | null;
+        readonly imageURL: string | null;
         readonly width: number | null;
     } | null> | null;
     readonly " $refType": "MyCollectionArtworkImages_artwork";
@@ -53,7 +53,7 @@ const node: ReaderFragment = {
           "alias": null,
           "args": null,
           "kind": "ScalarField",
-          "name": "url",
+          "name": "imageURL",
           "storageKey": null
         },
         {
@@ -70,5 +70,5 @@ const node: ReaderFragment = {
   "type": "Artwork",
   "abstractKey": null
 };
-(node as any).hash = 'a57b8405b948f9508f0af757d3fb74bc';
+(node as any).hash = '7b416a19f52c8e14e0b0b2e05cba5b31';
 export default node;

--- a/src/__generated__/MyCollectionArtworkQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 5d874d4f046f77e70bb772e694c5f45d */
+/* @relayHash 34bc05b66fb9e2c5926a7ba693b68d47 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -168,7 +168,7 @@ fragment MyCollectionArtworkHeader_artwork on Artwork {
   images {
     height
     isDefault
-    url
+    imageURL
     width
   }
   internalID
@@ -337,35 +337,21 @@ v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "url",
+  "name": "isDefault",
   "storageKey": null
 },
 v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "width",
+  "name": "url",
   "storageKey": null
 },
 v17 = {
   "alias": null,
   "args": null,
-  "concreteType": "Image",
-  "kind": "LinkedField",
-  "name": "images",
-  "plural": true,
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "isDefault",
-      "storageKey": null
-    },
-    (v15/*: any*/),
-    (v16/*: any*/),
-    (v13/*: any*/)
-  ],
+  "kind": "ScalarField",
+  "name": "width",
   "storageKey": null
 },
 v18 = {
@@ -428,7 +414,7 @@ v25 = {
   "value": 3
 },
 v26 = [
-  (v15/*: any*/)
+  (v16/*: any*/)
 ];
 return {
   "fragment": {
@@ -471,14 +457,28 @@ return {
           (v12/*: any*/),
           (v13/*: any*/),
           (v14/*: any*/),
-          (v17/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "images",
+            "plural": true,
+            "selections": [
+              (v15/*: any*/),
+              (v16/*: any*/),
+              (v17/*: any*/),
+              (v13/*: any*/)
+            ],
+            "storageKey": null
+          },
           (v4/*: any*/),
           (v18/*: any*/),
           (v19/*: any*/),
           (v20/*: any*/),
           (v21/*: any*/),
           (v22/*: any*/),
-          (v16/*: any*/),
+          (v17/*: any*/),
           {
             "args": null,
             "kind": "FragmentSpread",
@@ -775,14 +775,35 @@ return {
           (v12/*: any*/),
           (v13/*: any*/),
           (v14/*: any*/),
-          (v17/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "images",
+            "plural": true,
+            "selections": [
+              (v15/*: any*/),
+              (v16/*: any*/),
+              (v17/*: any*/),
+              (v13/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "imageURL",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
           (v4/*: any*/),
           (v18/*: any*/),
           (v19/*: any*/),
           (v20/*: any*/),
           (v21/*: any*/),
           (v22/*: any*/),
-          (v16/*: any*/),
+          (v17/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -947,7 +968,7 @@ return {
     ]
   },
   "params": {
-    "id": "5d874d4f046f77e70bb772e694c5f45d",
+    "id": "34bc05b66fb9e2c5926a7ba693b68d47",
     "metadata": {},
     "name": "MyCollectionArtworkQuery",
     "operationKind": "query",

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarousel.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarousel.tsx
@@ -148,7 +148,7 @@ const imageVersionsSortedBySize = ["normalized", "larger", "large", "medium", "s
 // we used to rely on there being a "normalized" version of every image, but that
 // turns out not to be the case, so in those rare situations we order the image versions
 // by size and pick the largest avaialable. These large images will then be resized by
-// gemini for the actual thumnail we fetch.
+// gemini for the actual thumbnail we fetch.
 function getBestImageVersionForThumbnail(imageVersions: readonly string[]) {
   for (const size of imageVersionsSortedBySize) {
     if (imageVersions.includes(size)) {

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkHeader.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkHeader.tsx
@@ -63,7 +63,7 @@ const MyCollectionArtworkHeader: React.FC<MyCollectionArtworkHeaderProps> = (pro
       // TODO: figure out if "normalized" is the correct version
       return (
         <OpaqueImageView
-          imageURL={defaultImage.url.replace(":version", "normalized")}
+          imageURL={defaultImage.imageURL.replace(":version", "normalized")}
           height={defaultImage.height * (dimensions.width / defaultImage.width)}
           width={dimensions.width}
         />
@@ -122,7 +122,7 @@ export const MyCollectionArtworkHeaderFragmentContainer = createFragmentContaine
       images {
         height
         isDefault
-        url
+        imageURL
         width
       }
       internalID

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkFormModal/Screens/MyCollectionArtworkFormAddPhotos.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkFormModal/Screens/MyCollectionArtworkFormAddPhotos.tsx
@@ -27,7 +27,7 @@ export const MyCollectionAddPhotos: React.FC<StackScreenProps<ArtworkFormModalSc
         <Box key={index}>
           <Image
             style={{ width: imageSize, height: imageSize, resizeMode: "cover" }}
-            source={{ uri: photo.url || photo.path }}
+            source={{ uri: photo.imageURL || photo.path }}
           />
           <DeletePhotoButton photo={photo} />
         </Box>

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkImages/MyCollectionArtworkImages.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkImages/MyCollectionArtworkImages.tsx
@@ -30,7 +30,7 @@ const MyCollectionArtworkImages: React.FC<MyCollectionArtworkImagesProps> = ({ a
           <View key={index}>
             <OpaqueImageView
               // TODO: figure out if "normalized" is the correct version
-              imageURL={image!.url?.replace(":version", "normalized")}
+              imageURL={image!.imageURL?.replace(":version", "normalized")}
               height={(dimensions.width / (image!.width || 1)) * (image!.height || 1)}
               width={dimensions.width}
             />
@@ -48,7 +48,7 @@ const MyCollectionArtworkImagesFragmentContainer = createFragmentContainer(MyCol
       images {
         height
         isDefault
-        url
+        imageURL
         width
       }
     }

--- a/src/lib/Scenes/MyCollection/State/MyCollectionArtworkModel.tsx
+++ b/src/lib/Scenes/MyCollection/State/MyCollectionArtworkModel.tsx
@@ -11,7 +11,7 @@ import { Metric } from "../Screens/ArtworkFormModal/Components/Dimensions"
 export interface Image {
   height?: number
   isDefault?: boolean
-  url?: string
+  imageURL?: string
   path?: string
   width?: number
 }
@@ -136,13 +136,13 @@ export const MyCollectionArtworkModel: MyCollectionArtworkModel = {
   addPhotos: action((state, photos) => {
     state.sessionState.formValues.photos = uniqBy(
       state.sessionState.formValues.photos.concat(photos),
-      (photo) => photo.url || photo.path
+      (photo) => photo.imageURL || photo.path
     )
   }),
 
   removePhoto: action((state, photoToRemove) => {
     state.sessionState.formValues.photos = state.sessionState.formValues.photos.filter(
-      (photo) => photo.path !== photoToRemove.path || photo.url !== photoToRemove.url
+      (photo) => photo.path !== photoToRemove.path || photo.imageURL !== photoToRemove.imageURL
     )
   }),
 
@@ -192,7 +192,7 @@ export const MyCollectionArtworkModel: MyCollectionArtworkModel = {
       artistSearchResult: {
         internalID: artwork?.artist?.internalID,
         displayLabel: artwork?.artistNames,
-        imageUrl: artwork?.images?.[0]?.url?.replace(":version", "square"),
+        imageUrl: artwork?.images?.[0]?.imageURL?.replace(":version", "square"),
       },
       category: artwork.category,
       date: artwork.date,


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [CX-889]

### Description

Fixes an issue that was causing artwork images to appear grainy in My Collection. The url we were using from metaphysics was not the gemini url with ":version" component so we were getting the wrong processed  image to display.

- Uses `imageURL` with version component rather than `url` from metaphysics
- Passes in explicit compression options to avoid unnecessary compression in native module 

### Screenshots

#### Before

![towel_before](https://user-images.githubusercontent.com/49686530/101910725-5a849d00-3b8d-11eb-971b-a70789f3b4f4.PNG)

#### After

![towel_after](https://user-images.githubusercontent.com/49686530/101910732-5ce6f700-3b8d-11eb-8b26-02f10d3f1c5c.PNG)

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-889]: https://artsyproduct.atlassian.net/browse/CX-889