### PR TITLE
fix: MyBids visual QA round 2

### DIFF
--- a/src/lib/Containers/Inbox/Inbox.tsx
+++ b/src/lib/Containers/Inbox/Inbox.tsx
@@ -29,7 +29,7 @@ const InboxTabs: React.FC<TabBarProps> = (props) => (
           <CssTransition style={[{ opacity: isTabActive ? 1 : 0.3 }]} animate={["opacity"]} duration={200}>
             <Text
               mr={2}
-              color={"black100"}
+              color="black100"
               variant="largeTitle"
               onPress={() => {
                 if (!!props.goToPage) {

--- a/src/lib/Containers/Inbox/Inbox.tsx
+++ b/src/lib/Containers/Inbox/Inbox.tsx
@@ -26,7 +26,12 @@ const InboxTabs: React.FC<TabBarProps> = (props) => (
       {props.tabs?.map((name: JSX.Element, page: number) => {
         const isTabActive = props.activeTab === page
         return (
-          <CssTransition style={[{ opacity: isTabActive ? 1 : 0.3 }]} animate={["opacity"]} duration={200}>
+          <CssTransition
+            style={[{ opacity: isTabActive ? 1 : 0.3 }]}
+            animate={["opacity"]}
+            duration={200}
+            key={`inbox-tab-${name}`}
+          >
             <Text
               mr={2}
               color="black100"

--- a/src/lib/Containers/Inbox/Inbox.tsx
+++ b/src/lib/Containers/Inbox/Inbox.tsx
@@ -1,5 +1,6 @@
 import { Inbox_me } from "__generated__/Inbox_me.graphql"
 import { InboxQuery } from "__generated__/InboxQuery.graphql"
+import { CssTransition } from "lib/Components/Bidding/Components/Animation/CssTransition"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { ConversationsContainer } from "lib/Scenes/Inbox/Components/Conversations/Conversations"
 import { MyBidsContainer } from "lib/Scenes/MyBids/MyBids"
@@ -25,19 +26,20 @@ const InboxTabs: React.FC<TabBarProps> = (props) => (
       {props.tabs?.map((name: JSX.Element, page: number) => {
         const isTabActive = props.activeTab === page
         return (
-          <Text
-            mr={2}
-            key={`inbox-tab-${name}`}
-            color={isTabActive ? "black100" : "black30"}
-            variant="largeTitle"
-            onPress={() => {
-              if (!!props.goToPage) {
-                props.goToPage(page)
-              }
-            }}
-          >
-            {name}
-          </Text>
+          <CssTransition style={[{ opacity: isTabActive ? 1 : 0.3 }]} animate={["opacity"]} duration={200}>
+            <Text
+              mr={2}
+              color={"black100"}
+              variant="largeTitle"
+              onPress={() => {
+                if (!!props.goToPage) {
+                  props.goToPage(page)
+                }
+              }}
+            >
+              {name}
+            </Text>
+          </CssTransition>
         )
       })}
     </Flex>

--- a/src/lib/Scenes/Inbox/Components/Conversations/NoMessages.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/NoMessages.tsx
@@ -9,10 +9,11 @@ export const NoMessages: React.FC = () => {
   return (
     <Flex mt={3} mx={2}>
       <Text variant="title" textAlign="center" fontWeight="normal">
-        Keep track of your conversations with galleries
+        Keep track of your conversations with galleries.
       </Text>
       <Text mb={2} mt={1} mx={4} variant="text" textAlign="center" fontWeight="normal" color="black60">
-        Contact galleries to learn more about works you want to collect. Use your inbox to stay on top of your inquiries
+        Contact galleries to learn more about works you want to collect. Use your inbox to stay on top of your
+        inquiries.
       </Text>
       <Flex width="100%" justifyContent="center" flexDirection="row">
         <Button variant="primaryBlack" onPress={handleViewWorks}>

--- a/src/lib/Scenes/Inbox/Components/Conversations/NoMessages.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/NoMessages.tsx
@@ -7,7 +7,7 @@ export const NoMessages: React.FC = () => {
     navigate(`/`)
   }
   return (
-    <Flex mt={3}>
+    <Flex mt={3} mx={2}>
       <Text variant="title" textAlign="center" fontWeight="normal">
         Keep track of your conversations with galleries
       </Text>

--- a/src/lib/Scenes/MyBids/Components/ActiveLot.tsx
+++ b/src/lib/Scenes/MyBids/Components/ActiveLot.tsx
@@ -7,7 +7,7 @@ import { TimelySale } from "../helpers/timely"
 import { HighestBid, Outbid, ReserveNotMet } from "./BiddingStatuses"
 import { LotFragmentContainer as Lot } from "./Lot"
 
-export const ActiveLot = ({ lotStanding }: { lotStanding: ActiveLot_lotStanding }, smallScreen: boolean) => {
+export const ActiveLot = ({ lotStanding }: { lotStanding: ActiveLot_lotStanding }) => {
   const timelySale = TimelySale.create(lotStanding?.saleArtwork?.sale!)
 
   const sellingPrice = lotStanding?.lot?.sellingPrice?.display
@@ -25,7 +25,7 @@ export const ActiveLot = ({ lotStanding }: { lotStanding: ActiveLot_lotStanding 
   return (
     saleArtwork &&
     lot && (
-      <Lot saleArtwork={saleArtwork} isSmallScreen={smallScreen}>
+      <Lot saleArtwork={saleArtwork} isSmallScreen={isSmallScreen}>
         <Flex flexDirection="row" justifyContent="flex-end">
           <Text variant="caption">{sellingPrice}</Text>
           <Text variant="caption" color="black60">

--- a/src/lib/Scenes/MyBids/Components/Lot.tsx
+++ b/src/lib/Scenes/MyBids/Components/Lot.tsx
@@ -27,7 +27,12 @@ class Lot extends React.Component<Props> {
           <Flex width="50%">
             <Flex flexDirection="row">
               <Flex mr={isSmallScreen! ? 0.5 : 1}>
-                <OpaqueImageView width={50} height={50} imageURL={saleArtwork?.artwork?.image?.url} />
+                <OpaqueImageView
+                  width={50}
+                  height={50}
+                  style={{ borderRadius: 2, overflow: "hidden" }}
+                  imageURL={saleArtwork?.artwork?.image?.url}
+                />
                 {!!ArtworkBadge && (
                   <Box position="absolute" top={-2} left={-5}>
                     {<ArtworkBadge />}

--- a/src/lib/Scenes/MyBids/Components/NoBids.tsx
+++ b/src/lib/Scenes/MyBids/Components/NoBids.tsx
@@ -9,7 +9,7 @@ export class NoBids extends React.Component<{ headerText: string }> {
     }
     const { headerText } = this.props
     return (
-      <Flex mt={3}>
+      <Flex mt={3} mx={2}>
         <Text variant="title" textAlign="center" fontWeight="normal">
           {headerText}
         </Text>

--- a/src/lib/Scenes/MyBids/Components/SaleCard.tsx
+++ b/src/lib/Scenes/MyBids/Components/SaleCard.tsx
@@ -74,7 +74,7 @@ export class SaleCard extends React.Component<{
     return (
       <React.Fragment>
         <Touchable underlayColor="transparent" activeOpacity={0.8} onPress={() => navigate(sale?.href as string)}>
-          <Flex overflow="hidden" borderWidth={1} borderStyle="solid" borderColor="black10">
+          <Flex borderWidth={1} borderStyle="solid" borderColor="black10">
             <OpaqueImageView height={COVER_IMAGE_HEIGHT} imageURL={sale?.coverImage?.url} />
             <Flex style={{ margin: smallScreen! ? 10 : 15 }}>
               {!!sale.partner?.name && (

--- a/src/lib/Scenes/MyBids/Components/SaleCard.tsx
+++ b/src/lib/Scenes/MyBids/Components/SaleCard.tsx
@@ -74,7 +74,7 @@ export class SaleCard extends React.Component<{
     return (
       <React.Fragment>
         <Touchable underlayColor="transparent" activeOpacity={0.8} onPress={() => navigate(sale?.href as string)}>
-          <Flex overflow="hidden" borderWidth={1} borderStyle="solid" borderColor="black10" borderRadius={4}>
+          <Flex overflow="hidden" borderWidth={1} borderStyle="solid" borderColor="black10">
             <OpaqueImageView height={COVER_IMAGE_HEIGHT} imageURL={sale?.coverImage?.url} />
             <Flex style={{ margin: smallScreen! ? 10 : 15 }}>
               {!!sale.partner?.name && (

--- a/src/lib/Scenes/MyBids/MyBids.tsx
+++ b/src/lib/Scenes/MyBids/MyBids.tsx
@@ -117,7 +117,7 @@ class MyBids extends React.Component<MyBidsProps> {
                     <Join separator={<Separator my={1} />}>
                       {!!showNoBids && (
                         <Text color="black60" py={1} textAlign="center">
-                          You haven't placed any bids on this sale
+                          You haven't placed any bids on this sale.
                         </Text>
                       )}
                       {activeLotStandings.map((ls) => {


### PR DESCRIPTION
The type of this PR is: Bugfix

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [PURCHASE-2312]

Resolves the items marked `visual` [here](https://www.notion.so/artsy/Bid-Management-5c1c86e18ded47be9c76d3d109b0c988).

### Description
This PR resolves the visual issues found during the second round of My Bids QA:
- Animates opacity of tabs when switching back and forth
- Adds border radius to thumbnails
- Corrects right margin on thumbnail
- Removes border radius on banner image
- Adds horizontal margin on empty bids and inquiries pages

![visual_qa_2](https://user-images.githubusercontent.com/7117670/102095615-05ae8400-3e24-11eb-8d87-2f0d7012178f.gif)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[PURCHASE-2312]: https://artsyproduct.atlassian.net/browse/PURCHASE-2312