### PR TITLE
POC/Spike: Convert Inbox to use a FC

### DIFF
--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -131,7 +131,7 @@ interface PartnerLocationsProps {
 }
 const PartnerLocations: React.FC<PartnerLocationsProps> = (props) => <PartnerLocationsQueryRenderer {...props} />
 
-const Inbox: React.FC<{}> = screenTrack<{}>(() => {
+const Inbox: React.FC<{ isVisible: boolean }> = screenTrack<{}>(() => {
   return { context_screen: Schema.PageNames.InboxPage, context_screen_owner_type: null }
 })((props) => <InboxWrapper {...props} />)
 

--- a/src/lib/Containers/Inbox/index.tsx
+++ b/src/lib/Containers/Inbox/index.tsx
@@ -6,8 +6,8 @@ import { InboxOldQueryRenderer } from "./InboxOld"
 /**
  * A wrapper containing the logic for whether to display our new inbox
  */
-export const InboxWrapper: React.FC = () => {
+export const InboxWrapper: React.FC<{ isVisible: boolean }> = (props) => {
   const shouldDisplayMyBids = getCurrentEmissionState().options.AROptionsBidManagement
 
-  return shouldDisplayMyBids ? <InboxQueryRenderer /> : <InboxOldQueryRenderer />
+  return shouldDisplayMyBids ? <InboxQueryRenderer {...props} /> : <InboxOldQueryRenderer {...props} />
 }

--- a/src/lib/Scenes/Inbox/Components/Conversations/Conversations.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/Conversations.tsx
@@ -32,7 +32,7 @@ export class Conversations extends Component<Props, State> {
     fetching: false,
   }
 
-  fetchData = () => {
+  fetchMoreData = () => {
     const { relay } = this.props
 
     if (relay.hasMore() && !relay.isLoading()) {
@@ -52,7 +52,7 @@ export class Conversations extends Component<Props, State> {
     }
   }
 
-  refreshConversations = (callback?: () => void) => {
+  refetchData = (callback?: () => void) => {
     const { relay } = this.props
     if (!relay.isLoading()) {
       this.setState({ fetching: true })
@@ -95,7 +95,7 @@ export class Conversations extends Component<Props, State> {
             <RefreshControl
               refreshing={this.state.fetching}
               onRefresh={() => {
-                this.refreshConversations()
+                this.refetchData()
               }}
             />
           }
@@ -106,7 +106,7 @@ export class Conversations extends Component<Props, State> {
               <ConversationSnippet conversation={item} onSelected={() => navigate(`conversation/${item.internalID}`)} />
             )
           }}
-          onEndReached={this.fetchData}
+          onEndReached={this.fetchMoreData}
           onEndReachedThreshold={2}
           contentContainerStyle={{ flexGrow: 1, justifyContent: !conversations.length ? "center" : "flex-start" }}
           ListEmptyComponent={<NoMessages />}

--- a/src/lib/Scenes/MyBids/MyBids.tsx
+++ b/src/lib/Scenes/MyBids/MyBids.tsx
@@ -29,11 +29,12 @@ export interface MyBidsProps {
 
 type Sale = NonNullable<NonNullable<NonNullable<MyBids_me["bidders"]>[0]>["sale"]>
 
-class MyBids extends React.Component<MyBidsProps> {
+export class MyBids extends React.Component<MyBidsProps> {
   state = {
     fetching: false,
   }
-  refreshMyBids = (callback?: () => void) => {
+  refetchData = (callback?: () => void) => {
+    console.warn("refetching")
     const { relay } = this.props
     if (!relay.isLoading()) {
       this.setState({ fetching: true })
@@ -93,7 +94,7 @@ class MyBids extends React.Component<MyBidsProps> {
           <RefreshControl
             refreshing={this.state.fetching}
             onRefresh={() => {
-              this.refreshMyBids()
+              this.refetchData()
             }}
           />
         }


### PR DESCRIPTION
This PR was originally intended to fix a simple problem - refetching the active inbox view when the user exits and revisits so they always get the latest data. This was a result of testing and QA where people coming in fresh didn't intuitively pull to refresh which led to reports that new data wasn't loading. We discussed 2 possible approaches: either manually refetching data when the view reappears or doing something with relay to make it always refetch.

In the process we did a spike on converting the inbox to use a function component because the class component was very old and hard to understand. Tests are still passing and it all appears to work fine but this would be a big diff so we should be strategic if we decide to merge.

Some problems that remain with this approach:
- the `isVisible` prop passed in from Objective C code doesn't flip until you have exited the inbox by at least 2 screens, so it fundamentally doesn't work.
- Still relying on refs and class components for the underlying bids/conversations views. We don't know if this is an anti-pattern. In any case we are duck-typing our children views so we can call the same `refetchData` method on either active tab.
- even though the view refreshes immediately, in some cases we don't see the new data we expect right away. Maybe this is fine UX since the problem is coming from the backend.

I think our main question for now is whether we want to go with this big of a change or if there is a better way to make the inbox refresh automatically (maybe a relay container/renderer setting?).


Co-authored-by: Lily Pacegit <lilyfpace@gmail.com>
