### PR TITLE
chore: Edit order of size, medium (pluralize), and artist copy in market insights in My Collection artwork view

### DIFF
--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkInsights.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkInsights.tsx
@@ -1,9 +1,11 @@
 import { MyCollectionArtworkInsights_artwork } from "__generated__/MyCollectionArtworkInsights_artwork.graphql"
 import { MyCollectionArtworkInsights_marketPriceInsights } from "__generated__/MyCollectionArtworkInsights_marketPriceInsights.graphql"
 import { ScreenMargin } from "lib/Scenes/MyCollection/Components/ScreenMargin"
+import { capitalize } from "lodash"
 import { Separator, Spacer, Text } from "palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { pluralizeMedium } from "../../../../utils/pluralizeArtworkMedium"
 import { MyCollectionArtworkArtistArticlesFragmentContainer } from "./MyCollectionArtworkArtistArticles"
 import { MyCollectionArtworkArtistAuctionResultsFragmentContainer } from "./MyCollectionArtworkArtistAuctionResults"
 import { MyCollectionArtworkArtistMarketFragmentContainer } from "./MyCollectionArtworkArtistMarket"
@@ -20,7 +22,6 @@ export const MyCollectionArtworkInsights: React.FC<MyCollectionArtworkInsightsPr
   marketPriceInsights,
 }) => {
   const showMarketPriceInsights = Boolean(marketPriceInsights)
-
   return (
     <>
       {showMarketPriceInsights && (
@@ -31,7 +32,8 @@ export const MyCollectionArtworkInsights: React.FC<MyCollectionArtworkInsightsPr
           <ScreenMargin>
             <Text variant="title">Price and market insights</Text>
             <Text variant="small" color="black60">
-              For {artwork.artist?.name || "Unknown Artist"}, {artwork.medium}, size {artwork.sizeBucket}
+              {capitalize(artwork.sizeBucket!)} {pluralizeMedium(artwork.medium!)} by{" "}
+              {artwork.artist?.name || "Unknown Artist"}
             </Text>
           </ScreenMargin>
           <Spacer mt={3} />

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/__tests__/MyCollectionArtworkInsights-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/__tests__/MyCollectionArtworkInsights-tests.tsx
@@ -59,9 +59,7 @@ describe("MyCollectionArtworkInsights", () => {
     resolveData()
     const text = extractText(wrapper.root)
     expect(text).toContain("Price and market insights")
-    expect(text).toContain(
-      'For <mock-value-for-field-"name">, <mock-value-for-field-"medium">, size <mock-value-for-field-"sizeBucket">'
-    )
+    expect(text).toContain('<mock-value-for-field-"sizebucket"> other by <mock-value-for-field-"name">')
     expect(wrapper.root.findByType(MyCollectionArtworkDemandIndexFragmentContainer)).toBeDefined()
     expect(wrapper.root.findByType(MyCollectionArtworkPriceEstimateFragmentContainer)).toBeDefined()
     expect(wrapper.root.findByType(MyCollectionArtworkArtistMarketFragmentContainer)).toBeDefined()

--- a/src/lib/Scenes/MyCollection/utils/__tests__/pluralizeArtworkMedium-tests.ts
+++ b/src/lib/Scenes/MyCollection/utils/__tests__/pluralizeArtworkMedium-tests.ts
@@ -1,0 +1,9 @@
+import { pluralizeMedium } from "../pluralizeArtworkMedium"
+
+describe("pluralizeArtworkMedium", () => {
+  it("pluralize medium correctly", () => {
+    expect(pluralizeMedium("Painting")).toBe("paintings")
+    expect(pluralizeMedium("Photography")).toBe("photographs")
+    expect(pluralizeMedium("some other medium")).toBe("other")
+  })
+})

--- a/src/lib/Scenes/MyCollection/utils/pluralizeArtworkMedium.ts
+++ b/src/lib/Scenes/MyCollection/utils/pluralizeArtworkMedium.ts
@@ -1,0 +1,20 @@
+export const pluralizeMedium = (medium: string): string => {
+  const mediums: { [medium: string]: string } = {
+    Painting: "paintings",
+    Sculpture: "sculptures",
+    Photography: "photographs",
+    Installation: "installations",
+    Architecture: "architecture",
+    Jewelry: "jewelry",
+    Print: "prints",
+    "Mixed Media": "mixed media",
+    "Drawing, Collage or other Work on Paper": "drawings, collages, or other works on paper",
+    "Performance Art": "performance art",
+    "Video/Film/Animation": "video/film/animation",
+    "Fashion Design and Wearable Art": "fashion, design, and wearable art",
+    "Design/Decorative Art": "design/decorative art",
+    "Textile Arts": "textile arts",
+    Other: "other",
+  }
+  return mediums[medium] || "other"
+}


### PR DESCRIPTION
This PR resolves [CX-897]

Updated the copy on artwork view page under "Price and market insights" to read "[Size] [medium-plural] by [artist]". 

Pluralizing the medium required mapping the medium to its pluralized version. Would love feedback on how I did that. Feeling like my method was not all that elegant/scalable. 

![Simulator Screen Shot - iPhone 12 - 2020-12-15 at 10 28 16](https://user-images.githubusercontent.com/9466631/102250652-08ab8200-3ec1-11eb-9097-caab58fb4def.png)


[CX-897]: https://artsyproduct.atlassian.net/browse/CX-897