### PR TITLE
fix(infra): make isVisible prop respect tab switches.

### DIFF
--- a/Artsy/App/ARScreenPresenterModule.m
+++ b/Artsy/App/ARScreenPresenterModule.m
@@ -66,6 +66,7 @@ RCT_EXPORT_METHOD(pushView:(nonnull NSString *)currentTabStackID viewDescriptor:
         NSString *stackID = currentTabStackID;
         if ([currentlyPresentedVC isKindOfClass:ARModalWithBottomSafeAreaViewController.class]) {
             for(id key in [self.class cachedNavigationStacks]) {
+                // if the nav stack with id `key` is the same instance as the one we're about to push to, then `key` is the stackID we want to set.
                 if ([self.class cachedNavigationStacks][key] == stack) {
                     stackID = key;
                     break;

--- a/Artsy/App/ARScreenPresenterModule.m
+++ b/Artsy/App/ARScreenPresenterModule.m
@@ -72,7 +72,7 @@ RCT_EXPORT_METHOD(pushView:(nonnull NSString *)currentTabStackID viewDescriptor:
                 }
             }
         }
-        [reactVC setProperty:currentTabStackID forKey:@"navStackID"];
+        [reactVC setProperty:stackID forKey:@"navStackID"];
     }
 
     [stack pushViewController:vc animated:YES];

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
   dev:
     - Add slack notification when betas fail - brian
     - Enable my bids - lily
+    - Fix `isVisible` root view prop to respect tab switches - david, erik, lily
   user_facing:
     - Update copy in My Collection - annacarey
     - Fix multi-image upload and add processing state in my collection - brian, barry

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -77,7 +77,7 @@ import { Show2MoreInfoQueryRenderer, Show2QueryRenderer } from "./Scenes/Show2"
 import { VanityURLEntityRenderer } from "./Scenes/VanityURL/VanityURLEntity"
 
 import { BottomTabsNavigator } from "./Scenes/BottomTabs/BottomTabsNavigator"
-import { BottomTabType } from "./Scenes/BottomTabs/BottomTabType"
+import { BottomTabOption, BottomTabType } from "./Scenes/BottomTabs/BottomTabType"
 import { MyCollectionQueryRenderer } from "./Scenes/MyCollection/MyCollection"
 import { MyCollectionArtworkQueryRenderer } from "./Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork"
 import { MyCollectionArtworkFullDetailsQueryRenderer } from "./Scenes/MyCollection/Screens/ArtworkFullDetails/MyCollectionArtworkFullDetails"
@@ -86,7 +86,7 @@ import { ViewingRoomQueryRenderer } from "./Scenes/ViewingRoom/ViewingRoom"
 import { ViewingRoomArtworkQueryRenderer } from "./Scenes/ViewingRoom/ViewingRoomArtwork"
 import { ViewingRoomArtworksQueryRenderer } from "./Scenes/ViewingRoom/ViewingRoomArtworks"
 import { ViewingRoomsListQueryRenderer } from "./Scenes/ViewingRoom/ViewingRoomsList"
-import { GlobalStore, GlobalStoreProvider } from "./store/GlobalStore"
+import { GlobalStore, GlobalStoreProvider, useSelectedTab } from "./store/GlobalStore"
 import { Schema, screenTrack, track } from "./utils/track"
 import { ProvideScreenDimensions, useScreenDimensions } from "./utils/useScreenDimensions"
 
@@ -311,9 +311,20 @@ class PageWrapper extends React.Component<PageWrapperProps> {
 }
 
 function register(screenName: string, Component: React.ComponentType<any>, options?: PageWrapperProps) {
+  const ComponentWithVisibility = (props: any) => {
+    // if we're in a modal, just pass isVisible through
+    const currentTab = useSelectedTab()
+    let isVisible = props.isVisible
+    if (BottomTabOption[props.navStackID as BottomTabType]) {
+      // otherwise, make sure it respects the current tab
+      isVisible = isVisible && currentTab === props.navStackID
+    }
+    return <Component {...{ ...props, isVisible }} />
+  }
+
   const WrappedComponent = (props: any) => (
     <PageWrapper {...options}>
-      <Component {...props} />
+      <ComponentWithVisibility {...props} />
     </PageWrapper>
   )
   AppRegistry.registerComponent(screenName, () => WrappedComponent)

--- a/src/lib/Scenes/BottomTabs/BottomTabType.ts
+++ b/src/lib/Scenes/BottomTabs/BottomTabType.ts
@@ -1,2 +1,10 @@
 // This file must match "ARTabType.m/h"
-export type BottomTabType = "home" | "search" | "inbox" | "sell" | "profile"
+export const BottomTabOption = {
+  home: "home",
+  search: "search",
+  inbox: "inbox",
+  sell: "sell",
+  profile: "profile",
+} as const
+
+export type BottomTabType = keyof typeof BottomTabOption


### PR DESCRIPTION
### Description

This unblocks some purchase work on Inbox/MyBids. The `isVisible` prop set in objective-c is not totally reliable when switching tabs because, as an implementation detail, we sometimes have more than one tab stack VC mounted at once, even if only one is visible.

So we want to make sure that `isVisible` is true when

1. The view is the topmost view in a nav stack
2. The view is in the stack for the currently-visible tab

To do this a view needs to know three things

1. "Am I the topmost view on a nav stack?" — Already taken care of in `ARComponentViewController` by setting a prop on the root react component: `isVisible`.
2. "Which tab am I a view in?" — Not previously available, now taken care of in `ARScreenPresenterModule` by setting a new prop on the root react component: `navStackID`.
3. "Which tab is the user currently looking at?" — Already available through the `useSelectedTab()` react hook. 

We added another level of wrapping in `AppRegistry` to combine these three bits of state into a single `isVisible` prop.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
