### PR TITLE
feat: Add analytics tracking to image click in MyCollectionArtworkHeader

### DIFF
--- a/src/__generated__/MyCollectionArtworkHeaderTestsQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkHeaderTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash f1a743e85490355180b334aec5c5ac54 */
+/* @relayHash 9edf7ba9d9dfd4003fd9709fbd9608db */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -37,6 +37,7 @@ fragment MyCollectionArtworkHeader_artwork on Artwork {
     internalID
   }
   internalID
+  slug
   title
 }
 */
@@ -174,6 +175,13 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "title",
             "storageKey": null
           },
@@ -190,7 +198,7 @@ return {
     ]
   },
   "params": {
-    "id": "f1a743e85490355180b334aec5c5ac54",
+    "id": "9edf7ba9d9dfd4003fd9709fbd9608db",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artwork": {
@@ -224,6 +232,7 @@ return {
         },
         "artwork.images.width": (v4/*: any*/),
         "artwork.internalID": (v3/*: any*/),
+        "artwork.slug": (v3/*: any*/),
         "artwork.title": (v2/*: any*/)
       }
     },

--- a/src/__generated__/MyCollectionArtworkHeader_artwork.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkHeader_artwork.graphql.ts
@@ -15,6 +15,7 @@ export type MyCollectionArtworkHeader_artwork = {
         readonly internalID: string | null;
     } | null> | null;
     readonly internalID: string;
+    readonly slug: string;
     readonly title: string | null;
     readonly " $refType": "MyCollectionArtworkHeader_artwork";
 };
@@ -99,6 +100,13 @@ return {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
       "name": "title",
       "storageKey": null
     }
@@ -107,5 +115,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '795f451361a9142446d36ea529f1637a';
+(node as any).hash = 'b41f7e8057147e4d4baad3a87aac684e';
 export default node;

--- a/src/__generated__/MyCollectionArtworkQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 0b1f9b0eb129c15a471657fe8cc3724e */
+/* @relayHash ad3326385642cdbc61de31f8c83791e9 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -187,6 +187,7 @@ fragment MyCollectionArtworkHeader_artwork on Artwork {
     internalID
   }
   internalID
+  slug
   title
 }
 
@@ -972,7 +973,7 @@ return {
     ]
   },
   "params": {
-    "id": "0b1f9b0eb129c15a471657fe8cc3724e",
+    "id": "ad3326385642cdbc61de31f8c83791e9",
     "metadata": {},
     "name": "MyCollectionArtworkQuery",
     "operationKind": "query",

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkHeader.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkHeader.tsx
@@ -1,3 +1,4 @@
+import { tappedCollectedArtworkImages } from "@artsy/cohesion"
 import { MyCollectionArtworkHeader_artwork } from "__generated__/MyCollectionArtworkHeader_artwork.graphql"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { navigate } from "lib/navigation/navigate"
@@ -8,6 +9,7 @@ import { ArtworkIcon, color, Flex, Spacer, Text } from "palette"
 import React from "react"
 import { TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
+import { useTracking } from "react-tracking"
 
 interface MyCollectionArtworkHeaderProps {
   artwork: MyCollectionArtworkHeader_artwork
@@ -15,12 +17,14 @@ interface MyCollectionArtworkHeaderProps {
 
 const MyCollectionArtworkHeader: React.FC<MyCollectionArtworkHeaderProps> = (props) => {
   const {
-    artwork: { artistNames, date, images, internalID, title },
+    artwork: { artistNames, date, images, internalID, title, slug },
   } = props
   const dimensions = useScreenDimensions()
   const formattedTitleAndYear = [title, date].filter(Boolean).join(", ")
 
   const defaultImage = images?.find((i) => i?.isDefault) || (images && images[0])
+
+  const { trackEvent } = useTracking()
 
   const isImage = (toCheck: any): toCheck is Image => !!toCheck
 
@@ -84,6 +88,7 @@ const MyCollectionArtworkHeader: React.FC<MyCollectionArtworkHeaderProps> = (pro
         disabled={hasImagesStillProcessing(defaultImage, images)}
         onPress={() => {
           navigate(`/my-collection/artwork-images/${internalID}`)
+          trackEvent(tracks.tappedCollectedArtworkImages(internalID, slug))
         }}
       >
         {renderMainImageView()}
@@ -127,7 +132,14 @@ export const MyCollectionArtworkHeaderFragmentContainer = createFragmentContaine
         internalID
       }
       internalID
+      slug
       title
     }
   `,
 })
+
+const tracks = {
+  tappedCollectedArtworkImages: (internalID: string, slug: string) => {
+    return tappedCollectedArtworkImages({ contextOwnerId: internalID, contextOwnerSlug: slug })
+  },
+}


### PR DESCRIPTION
Added analytics tracking to `TappedCollectionArtworkImages`, as part of @pepopowitz's [PR #4259](https://github.com/artsy/eigen/pull/4259). In MyCollection, this action is on an artwork view when a user taps the main image. The change includes a test.