### PR TITLE
bug: Center artist name and metadata on artwork page About the artist section

### DIFF
--- a/src/palette/elements/EntityHeader/EntityHeader.tsx
+++ b/src/palette/elements/EntityHeader/EntityHeader.tsx
@@ -40,6 +40,12 @@ export const EntityHeader: React.FC<EntityHeaderProps> = ({
     </Sans>
   )
 
+  const headerMeta = meta && (
+    <Sans ellipsizeMode="tail" numberOfLines={1} size="2" color="black60">
+      {meta}
+    </Sans>
+  )
+
   return (
     <Flex flexDirection="row" justifyContent="space-between" flexWrap="nowrap" {...remainderProps}>
       {!!(imageUrl || initials) && (
@@ -60,12 +66,9 @@ export const EntityHeader: React.FC<EntityHeaderProps> = ({
         </Flex>
       ) : (
         <Flex justifyContent="space-between" width={0} flexGrow={1} flexDirection="row">
-          <Flex>
+          <Flex alignSelf="center">
             {headerName}
-
-            <Sans ellipsizeMode="tail" numberOfLines={1} size="2" color="black60">
-              {meta ? meta : ""}
-            </Sans>
+            {headerMeta}
           </Flex>
           {followButton}
         </Flex>


### PR DESCRIPTION
The type of this PR is: **Bug**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-797]

### Description

Centered the flexbox that contains the artist name and metadata and only the `meta` div if `meta` is present. This centers the artist name when there is no `meta` present. 

![simulator_screenshot_B0C54BF6-C13F-44CE-AAA0-BB7763B2E224](https://user-images.githubusercontent.com/9466631/102417721-7935ca00-3fb9-11eb-8e79-4e175a917e1a.png)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [ ] I have documented any follow-up work that this PR will require, or it does not require any.
- [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-797]: https://artsyproduct.atlassian.net/browse/CX-797