### PR TITLE
Refresh active inbox view when revisiting

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -15,6 +15,7 @@ upcoming:
     - Fix bug preventing empty values from being saved (my collection) - brian
     - Add improved phone number input - david
     - Add support for deleting photos in my collection - brian. barry
+    - Inbox refreshes when tab is visited - lily
 
 releases:
   - version: 6.7.3

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -131,7 +131,7 @@ interface PartnerLocationsProps {
 }
 const PartnerLocations: React.FC<PartnerLocationsProps> = (props) => <PartnerLocationsQueryRenderer {...props} />
 
-const Inbox: React.FC<{}> = screenTrack<{}>(() => {
+const Inbox: React.FC<{ isVisible: boolean }> = screenTrack<{}>(() => {
   return { context_screen: Schema.PageNames.InboxPage, context_screen_owner_type: null }
 })((props) => <InboxWrapper {...props} />)
 

--- a/src/lib/Containers/Inbox/Inbox.tsx
+++ b/src/lib/Containers/Inbox/Inbox.tsx
@@ -81,7 +81,6 @@ export class Inbox extends React.Component<Props, State> {
   flatListHeight = 0
 
   componentDidMount() {
-    console.warn("MOUNT", this.props.isVisible)
     this.listener = listenToNativeEvents((event) => {
       if (event.type === "NOTIFICATION_RECEIVED") {
         this.fetchData()
@@ -94,14 +93,12 @@ export class Inbox extends React.Component<Props, State> {
   }
 
   UNSAFE_componentWillReceiveProps(newProps: Props) {
-    console.warn("recieve props", newProps)
     if (newProps.isVisible) {
       this.fetchData()
     }
   }
 
   fetchData = () => {
-    console.warn("FETCH!")
     if (this.state.fetchingData) {
       return
     }
@@ -111,11 +108,11 @@ export class Inbox extends React.Component<Props, State> {
     if (this.conversations) {
       this.conversations.refreshConversations(() => {
         this.setState({ fetchingData: false })
-      })
+      }, true)
     } else if (this.myBids) {
-      this.myBids.refreshMyBidsWithoutSpinner(() => {
+      this.myBids.refreshMyBids(() => {
         this.setState({ fetchingData: false })
-      })
+      }, true)
     } else {
       this.props.relay.refetch({}, null, () => {
         this.setState({ fetchingData: false })

--- a/src/lib/Containers/Inbox/Inbox.tsx
+++ b/src/lib/Containers/Inbox/Inbox.tsx
@@ -81,6 +81,7 @@ export class Inbox extends React.Component<Props, State> {
   flatListHeight = 0
 
   componentDidMount() {
+    console.warn("MOUNT", this.props.isVisible)
     this.listener = listenToNativeEvents((event) => {
       if (event.type === "NOTIFICATION_RECEIVED") {
         this.fetchData()
@@ -93,12 +94,14 @@ export class Inbox extends React.Component<Props, State> {
   }
 
   UNSAFE_componentWillReceiveProps(newProps: Props) {
+    console.warn("recieve props", newProps)
     if (newProps.isVisible) {
       this.fetchData()
     }
   }
 
   fetchData = () => {
+    console.warn("FETCH!")
     if (this.state.fetchingData) {
       return
     }
@@ -110,7 +113,7 @@ export class Inbox extends React.Component<Props, State> {
         this.setState({ fetchingData: false })
       })
     } else if (this.myBids) {
-      this.myBids.refreshMyBids(() => {
+      this.myBids.refreshMyBidsWithoutSpinner(() => {
         this.setState({ fetchingData: false })
       })
     } else {
@@ -169,7 +172,7 @@ export const InboxContainer = createRefetchContainer(
   `
 )
 
-export const InboxQueryRenderer: React.FC = () => {
+export const InboxQueryRenderer: React.FC<{ isVisible: boolean }> = (props) => {
   return (
     <QueryRenderer<InboxQuery>
       environment={defaultEnvironment}
@@ -182,7 +185,9 @@ export const InboxQueryRenderer: React.FC = () => {
       `}
       cacheConfig={{ force: true }}
       variables={{}}
-      render={renderWithLoadProgress(InboxContainer)}
+      render={(...args) => {
+        return renderWithLoadProgress(InboxContainer, props)(...args)
+      }}
     />
   )
 }

--- a/src/lib/Containers/Inbox/index.tsx
+++ b/src/lib/Containers/Inbox/index.tsx
@@ -6,8 +6,8 @@ import { InboxOldQueryRenderer } from "./InboxOld"
 /**
  * A wrapper containing the logic for whether to display our new inbox
  */
-export const InboxWrapper: React.FC = () => {
+export const InboxWrapper: React.FC<{ isVisible: boolean }> = (props) => {
   const shouldDisplayMyBids = getCurrentEmissionState().options.AROptionsBidManagement
 
-  return shouldDisplayMyBids ? <InboxQueryRenderer /> : <InboxOldQueryRenderer />
+  return shouldDisplayMyBids ? <InboxQueryRenderer {...props} /> : <InboxOldQueryRenderer {...props} />
 }

--- a/src/lib/Containers/__tests__/InboxWrapper-tests.tsx
+++ b/src/lib/Containers/__tests__/InboxWrapper-tests.tsx
@@ -14,14 +14,14 @@ jest.mock("lib/Containers/Inbox/InboxOld", () => ({
 
 describe("InboxWrapper", () => {
   it("shows the OldInbox if the AROptionsBidManagement flag is not set", () => {
-    const tree = renderWithWrappers(<InboxWrapper />)
+    const tree = renderWithWrappers(<InboxWrapper isVisible={true} />)
     expect(tree.root.findAllByType(InboxOldQueryRenderer).length).toEqual(1)
     expect(tree.root.findAllByType(InboxQueryRenderer).length).toEqual(0)
   })
 
   it("shows the Inbox if the flag is set", () => {
     __globalStoreTestUtils__?.injectEmissionOptions({ AROptionsBidManagement: true })
-    const tree = renderWithWrappers(<InboxWrapper />)
+    const tree = renderWithWrappers(<InboxWrapper isVisible={true} />)
     expect(tree.root.findAllByType(InboxOldQueryRenderer).length).toEqual(0)
     expect(tree.root.findAllByType(InboxQueryRenderer).length).toEqual(1)
   })

--- a/src/lib/Scenes/Inbox/Components/Conversations/Conversations.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/Conversations.tsx
@@ -52,10 +52,13 @@ export class Conversations extends Component<Props, State> {
     }
   }
 
-  refreshConversations = (callback?: () => void) => {
+  refreshConversations = (callback?: () => void, noSpinner?: boolean) => {
     const { relay } = this.props
     if (!relay.isLoading()) {
-      this.setState({ fetching: true })
+      if (!noSpinner) {
+        this.setState({ fetching: true })
+      }
+
       relay.refetchConnection(PAGE_SIZE, (error) => {
         if (error) {
           console.error("Conversations/index.tsx #refreshConversations", error.message)
@@ -64,7 +67,9 @@ export class Conversations extends Component<Props, State> {
         if (callback) {
           callback()
         }
-        this.setState({ fetching: false })
+        if (!noSpinner) {
+          this.setState({ fetching: false })
+        }
       })
     } else {
       if (callback) {

--- a/src/lib/Scenes/MyBids/MyBids.tsx
+++ b/src/lib/Scenes/MyBids/MyBids.tsx
@@ -54,6 +54,25 @@ class MyBids extends React.Component<MyBidsProps> {
     }
   }
 
+  refreshMyBidsWithoutSpinner = (callback?: () => void) => {
+    const { relay } = this.props
+    if (!relay.isLoading()) {
+      relay.refetchConnection(PAGE_SIZE, (error) => {
+        if (error) {
+          console.error("MyBids/index.tsx #refreshMyBids", error.message)
+          // FIXME: Handle error
+        }
+        if (callback) {
+          callback()
+        }
+      })
+    } else {
+      if (callback) {
+        callback()
+      }
+    }
+  }
+
   render() {
     const { me } = this.props
     const lotStandings = extractNodes(me?.auctionsLotStandingConnection)

--- a/src/lib/Scenes/MyBids/MyBids.tsx
+++ b/src/lib/Scenes/MyBids/MyBids.tsx
@@ -33,30 +33,13 @@ class MyBids extends React.Component<MyBidsProps> {
   state = {
     fetching: false,
   }
-  refreshMyBids = (callback?: () => void) => {
+  refreshMyBids = (callback?: () => void, noSpinner?: boolean) => {
     const { relay } = this.props
     if (!relay.isLoading()) {
-      this.setState({ fetching: true })
-      relay.refetchConnection(PAGE_SIZE, (error) => {
-        if (error) {
-          console.error("MyBids/index.tsx #refreshMyBids", error.message)
-          // FIXME: Handle error
-        }
-        if (callback) {
-          callback()
-        }
-        this.setState({ fetching: false })
-      })
-    } else {
-      if (callback) {
-        callback()
+      if (!noSpinner) {
+        this.setState({ fetching: true })
       }
-    }
-  }
 
-  refreshMyBidsWithoutSpinner = (callback?: () => void) => {
-    const { relay } = this.props
-    if (!relay.isLoading()) {
       relay.refetchConnection(PAGE_SIZE, (error) => {
         if (error) {
           console.error("MyBids/index.tsx #refreshMyBids", error.message)
@@ -64,6 +47,9 @@ class MyBids extends React.Component<MyBidsProps> {
         }
         if (callback) {
           callback()
+        }
+        if (!noSpinner) {
+          this.setState({ fetching: false })
         }
       })
     } else {


### PR DESCRIPTION
# [PURCHASE-2307]

When the user revisits the inbox view it should refresh so they don't need to pull to update it.

Paired with @erikdstock 

The logic for refreshing the inbox when `isVisible` was true already existed, but isVisible wasn't being successfully passed to the inbox. This PR fixes that. This PR relies on [this one](https://github.com/artsy/eigen/pull/4267), which fixes `isVisible` so that it respects bottom bar tab switches.

In the future, the `Inbox` component should be refactored into a functional component, and the refresh should be done using hooks, however, I wanted to hold off on that portion so as not. to break the recently completed analytics work. 




[PURCHASE-2307]: https://artsyproduct.atlassian.net/browse/PURCHASE-2307