### PR TITLE
chore: Add artist name to auctions and articles section in my collection artwork view

### DIFF
--- a/src/__generated__/MyCollectionArtworkArtistArticlesTestsQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkArtistArticlesTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 10474bb4dd0289a459d14d24c9336d6a */
+/* @relayHash 5c534f656d33b78a04430d5c14c02f12 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -29,6 +29,7 @@ query MyCollectionArtworkArtistArticlesTestsQuery {
 fragment MyCollectionArtworkArtistArticles_artwork on Artwork {
   artist {
     slug
+    name
     articlesConnection(first: 3, sort: PUBLISHED_AT_DESC, inEditorialFeed: true) {
       edges {
         node {
@@ -72,16 +73,23 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "name",
   "storageKey": null
 },
 v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v4 = {
+v5 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -137,6 +145,7 @@ return {
             "plural": false,
             "selections": [
               (v1/*: any*/),
+              (v2/*: any*/),
               {
                 "alias": null,
                 "args": [
@@ -207,14 +216,8 @@ return {
                             "name": "author",
                             "plural": false,
                             "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "name",
-                                "storageKey": null
-                              },
-                              (v2/*: any*/)
+                              (v2/*: any*/),
+                              (v3/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -249,7 +252,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v2/*: any*/)
+                          (v3/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -259,18 +262,18 @@ return {
                 ],
                 "storageKey": "articlesConnection(first:3,inEditorialFeed:true,sort:\"PUBLISHED_AT_DESC\")"
               },
-              (v2/*: any*/)
+              (v3/*: any*/)
             ],
             "storageKey": null
           },
-          (v2/*: any*/)
+          (v3/*: any*/)
         ],
         "storageKey": "artwork(id:\"some-slug\")"
       }
     ]
   },
   "params": {
-    "id": "10474bb4dd0289a459d14d24c9336d6a",
+    "id": "5c534f656d33b78a04430d5c14c02f12",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artwork": {
@@ -309,24 +312,25 @@ return {
           "plural": false,
           "type": "Author"
         },
-        "artwork.artist.articlesConnection.edges.node.author.id": (v3/*: any*/),
-        "artwork.artist.articlesConnection.edges.node.author.name": (v4/*: any*/),
-        "artwork.artist.articlesConnection.edges.node.href": (v4/*: any*/),
-        "artwork.artist.articlesConnection.edges.node.id": (v3/*: any*/),
-        "artwork.artist.articlesConnection.edges.node.internalID": (v3/*: any*/),
-        "artwork.artist.articlesConnection.edges.node.publishedAt": (v4/*: any*/),
-        "artwork.artist.articlesConnection.edges.node.slug": (v4/*: any*/),
+        "artwork.artist.articlesConnection.edges.node.author.id": (v4/*: any*/),
+        "artwork.artist.articlesConnection.edges.node.author.name": (v5/*: any*/),
+        "artwork.artist.articlesConnection.edges.node.href": (v5/*: any*/),
+        "artwork.artist.articlesConnection.edges.node.id": (v4/*: any*/),
+        "artwork.artist.articlesConnection.edges.node.internalID": (v4/*: any*/),
+        "artwork.artist.articlesConnection.edges.node.publishedAt": (v5/*: any*/),
+        "artwork.artist.articlesConnection.edges.node.slug": (v5/*: any*/),
         "artwork.artist.articlesConnection.edges.node.thumbnailImage": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "artwork.artist.articlesConnection.edges.node.thumbnailImage.url": (v4/*: any*/),
-        "artwork.artist.articlesConnection.edges.node.thumbnailTitle": (v4/*: any*/),
-        "artwork.artist.id": (v3/*: any*/),
-        "artwork.artist.slug": (v3/*: any*/),
-        "artwork.id": (v3/*: any*/)
+        "artwork.artist.articlesConnection.edges.node.thumbnailImage.url": (v5/*: any*/),
+        "artwork.artist.articlesConnection.edges.node.thumbnailTitle": (v5/*: any*/),
+        "artwork.artist.id": (v4/*: any*/),
+        "artwork.artist.name": (v5/*: any*/),
+        "artwork.artist.slug": (v4/*: any*/),
+        "artwork.id": (v4/*: any*/)
       }
     },
     "name": "MyCollectionArtworkArtistArticlesTestsQuery",

--- a/src/__generated__/MyCollectionArtworkArtistArticles_artwork.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkArtistArticles_artwork.graphql.ts
@@ -7,6 +7,7 @@ import { FragmentRefs } from "relay-runtime";
 export type MyCollectionArtworkArtistArticles_artwork = {
     readonly artist: {
         readonly slug: string;
+        readonly name: string | null;
         readonly articlesConnection: {
             readonly edges: ReadonlyArray<{
                 readonly node: {
@@ -42,6 +43,13 @@ var v0 = {
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
 };
 return {
   "argumentDefinitions": [],
@@ -58,6 +66,7 @@ return {
       "plural": false,
       "selections": [
         (v0/*: any*/),
+        (v1/*: any*/),
         {
           "alias": null,
           "args": [
@@ -128,13 +137,7 @@ return {
                       "name": "author",
                       "plural": false,
                       "selections": [
-                        {
-                          "alias": null,
-                          "args": null,
-                          "kind": "ScalarField",
-                          "name": "name",
-                          "storageKey": null
-                        }
+                        (v1/*: any*/)
                       ],
                       "storageKey": null
                     },
@@ -186,5 +189,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = 'ff2eb4e9aab66c5f0211b9ff7f3548ab';
+(node as any).hash = '0e857b0be8c6e538ac60c40dc2b5e602';
 export default node;

--- a/src/__generated__/MyCollectionArtworkArtistAuctionResultsTestsQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkArtistAuctionResultsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 064757c4726ff8c90ce9c5feee413fbc */
+/* @relayHash 38c332eeb62c997e054d513c706b3301 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -31,6 +31,7 @@ fragment MyCollectionArtworkArtistAuctionResults_artwork on Artwork {
   slug
   artist {
     slug
+    name
     auctionResultsConnection(first: 3, sort: DATE_DESC) {
       edges {
         node {
@@ -151,6 +152,13 @@ return {
             "plural": false,
             "selections": [
               (v2/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              },
               {
                 "alias": null,
                 "args": [
@@ -297,7 +305,7 @@ return {
     ]
   },
   "params": {
-    "id": "064757c4726ff8c90ce9c5feee413fbc",
+    "id": "38c332eeb62c997e054d513c706b3301",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artwork": {
@@ -364,6 +372,7 @@ return {
         "artwork.artist.auctionResultsConnection.edges.node.saleDate": (v4/*: any*/),
         "artwork.artist.auctionResultsConnection.edges.node.title": (v4/*: any*/),
         "artwork.artist.id": (v5/*: any*/),
+        "artwork.artist.name": (v4/*: any*/),
         "artwork.artist.slug": (v5/*: any*/),
         "artwork.id": (v5/*: any*/),
         "artwork.internalID": (v5/*: any*/),

--- a/src/__generated__/MyCollectionArtworkArtistAuctionResults_artwork.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkArtistAuctionResults_artwork.graphql.ts
@@ -9,6 +9,7 @@ export type MyCollectionArtworkArtistAuctionResults_artwork = {
     readonly slug: string;
     readonly artist: {
         readonly slug: string;
+        readonly name: string | null;
         readonly auctionResultsConnection: {
             readonly edges: ReadonlyArray<{
                 readonly node: {
@@ -73,6 +74,13 @@ return {
       "plural": false,
       "selections": [
         (v1/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
         {
           "alias": null,
           "args": [
@@ -215,5 +223,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '3d00943bd40f20adb05a457801012abc';
+(node as any).hash = 'dc02f16b38b70305764e33e184cba631';
 export default node;

--- a/src/__generated__/MyCollectionArtworkInsightsTestsQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkInsightsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash fb1627cedfefd1b02e63b74dba86132f */
+/* @relayHash 6c94071c70c9e0951ab7c62ff01065e3 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -35,6 +35,7 @@ query MyCollectionArtworkInsightsTestsQuery {
 fragment MyCollectionArtworkArtistArticles_artwork on Artwork {
   artist {
     slug
+    name
     articlesConnection(first: 3, sort: PUBLISHED_AT_DESC, inEditorialFeed: true) {
       edges {
         node {
@@ -63,6 +64,7 @@ fragment MyCollectionArtworkArtistAuctionResults_artwork on Artwork {
   slug
   artist {
     slug
+    name
     auctionResultsConnection(first: 3, sort: DATE_DESC) {
       edges {
         node {
@@ -735,7 +737,7 @@ return {
     ]
   },
   "params": {
-    "id": "fb1627cedfefd1b02e63b74dba86132f",
+    "id": "6c94071c70c9e0951ab7c62ff01065e3",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artwork": {

--- a/src/__generated__/MyCollectionArtworkQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash ad3326385642cdbc61de31f8c83791e9 */
+/* @relayHash e667c4dadffd829dee0d05c622d697a2 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -99,6 +99,7 @@ query MyCollectionArtworkQuery(
 fragment MyCollectionArtworkArtistArticles_artwork on Artwork {
   artist {
     slug
+    name
     articlesConnection(first: 3, sort: PUBLISHED_AT_DESC, inEditorialFeed: true) {
       edges {
         node {
@@ -127,6 +128,7 @@ fragment MyCollectionArtworkArtistAuctionResults_artwork on Artwork {
   slug
   artist {
     slug
+    name
     auctionResultsConnection(first: 3, sort: DATE_DESC) {
       edges {
         node {
@@ -973,7 +975,7 @@ return {
     ]
   },
   "params": {
-    "id": "ad3326385642cdbc61de31f8c83791e9",
+    "id": "e667c4dadffd829dee0d05c622d697a2",
     "metadata": {},
     "name": "MyCollectionArtworkQuery",
     "operationKind": "query",

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistArticles.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistArticles.tsx
@@ -23,7 +23,7 @@ const MyCollectionArtworkArtistArticles: React.FC<MyCollectionArtworkArtistArtic
   return (
     <ScreenMargin>
       <Text variant="mediumText" mb="1">
-        Latest Articles
+        Latest Articles featuring {artist?.name}
       </Text>
 
       {articleEdges.map(({ thumbnailTitle, slug, publishedAt, internalID, thumbnailImage }) => {
@@ -65,6 +65,7 @@ export const MyCollectionArtworkArtistArticlesFragmentContainer = createFragment
       fragment MyCollectionArtworkArtistArticles_artwork on Artwork {
         artist {
           slug
+          name
           articlesConnection(first: 3, sort: PUBLISHED_AT_DESC, inEditorialFeed: true) {
             edges {
               node {

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistAuctionResults.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistAuctionResults.tsx
@@ -29,7 +29,7 @@ const MyCollectionArtworkArtistAuctionResults: React.FC<MyCollectionArtworkArtis
     <View>
       <ScreenMargin>
         <InfoButton
-          title="Auction Results"
+          title={`Auction Results for ${props?.artwork?.artist?.name}`}
           modalContent={
             <>
               <Text>
@@ -107,6 +107,7 @@ export const MyCollectionArtworkArtistAuctionResultsFragmentContainer = createFr
         slug
         artist {
           slug
+          name
           auctionResultsConnection(
             first: 3
             sort: DATE_DESC # organizations: $organizations # categories: $categories # sizes: $sizes # earliestCreatedYear: $createdAfterYear # latestCreatedYear: $createdBeforeYear # allowEmptyCreatedDates: $allowEmptyCreatedDates

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/__tests__/MyCollectionArtworkArtistArticles-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/__tests__/MyCollectionArtworkArtistArticles-tests.tsx
@@ -45,10 +45,16 @@ describe("MyCollectionArtworkArtistArticles", () => {
 
   it("renders without throwing an error", () => {
     const wrapper = renderWithWrappers(<TestRenderer />)
-    resolveData()
+    resolveData({
+      Artwork: () => ({
+        artist: {
+          name: "Banksy",
+        },
+      }),
+    })
     expect(wrapper.root.findByType(Image)).toBeDefined()
     const text = extractText(wrapper.root)
-    expect(text).toContain("Latest Articles")
+    expect(text).toContain("Latest Articles featuring Banksy")
     expect(text).toContain("thumbnailTitle")
     expect(text).toContain("publishedAt")
   })

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/__tests__/MyCollectionArtworkArtistAuctionResults-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/__tests__/MyCollectionArtworkArtistAuctionResults-tests.tsx
@@ -62,6 +62,7 @@ describe("MyCollectionArtworkArtistAuctionResults", () => {
     const wrapper = renderWithWrappers(<TestRenderer />)
     resolveData({
       Artist: () => ({
+        name: "Banksy",
         auctionResultsConnection: {
           edges: [
             {
@@ -79,7 +80,7 @@ describe("MyCollectionArtworkArtistAuctionResults", () => {
     })
     expect(wrapper.root.findByType(OpaqueImageView)).toBeDefined()
     const text = extractText(wrapper.root)
-    expect(text).toContain("Auction Results")
+    expect(text).toContain("Auction Results for Banksy")
     expect(text).toContain("title")
     expect(text).toContain(`Sold`)
     expect(text).toContain("4.00")


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-916]

### Description
Added artist name to graphQL queries on `MyCollectionArtworkArtistAuctionResults` and `MyCollectionArtworkArtistArticles.tsx` to include artist name. Added dynamic text to include in the headers for the sections. Added check in tests to ensure it is filling in the artist name correctly.

![Simulator Screen Shot - iPhone 12 - 2020-12-17 at 18 29 44](https://user-images.githubusercontent.com/9466631/102630501-db054980-4109-11eb-941c-497174db47af.png)

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [ ] I have documented any follow-up work that this PR will require, or it does not require any.
- [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-916]: https://artsyproduct.atlassian.net/browse/CX-916