### PR TITLE
bug: Increase height of DemandRankScale box to match purple linear gradient

### DIFF
--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkDemandIndex.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkDemandIndex.tsx
@@ -131,7 +131,7 @@ const ProgressBar: React.FC<{ width: number }> = ({ width }) => {
           <TriangleDown />
         </Box>
       </Box>
-      <Box height={20} width="100%" bg="black5">
+      <Box height={24} width="100%" bg="black5">
         <LinearGradient
           colors={["rgba(243, 240, 248, 2.6)", `rgba(110, 30, 255, ${opacity})`]}
           start={{ x: 0, y: 0 }}


### PR DESCRIPTION
The type of this PR is: **Bug**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-914]

### Description

Added 4px to height of container box in `DemandRankScale` to match height of purple linear gradient.

![Simulator Screen Shot - iPhone 12 - 2020-12-18 at 15 21 31](https://user-images.githubusercontent.com/9466631/102666702-d14d0780-4144-11eb-8cce-3acecde30882.png)

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [ ] I have documented any follow-up work that this PR will require, or it does not require any.
- [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-914]: https://artsyproduct.atlassian.net/browse/CX-914