### PR TITLE
logic(bought-in): change the logic for the string in auction insights results

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
   dev:
     - Analytics tracking for My Collection - pepopowitz, annacarey
     - Fix `isVisible` root view prop to respect tab switches - david, erik, lily
+    - Change logic for Auction Insights Result - pavlos
     - Add slack notification when betas fail - brian
     - Add analytics tracking for My Bids - ashley, erik, christina
   user_facing:

--- a/src/lib/Components/Artist/ArtistInsights/ArtistInsightsAuctionResult.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/ArtistInsightsAuctionResult.tsx
@@ -95,7 +95,7 @@ const ArtistInsightsAuctionResult: React.FC<Props> = ({ auctionResult }) => {
               </Flex>
             ) : (
               <Text variant="mediumText" style={{ width: 70 }} textAlign="right">
-                {isFromPastMonth ? "Awaiting results" : auctionResult.boughtIn === true ? "Bought in" : "Not available"}
+                {auctionResult.boughtIn === true ? "Bought in" : isFromPastMonth ? "Awaiting results" : "Not available"}
               </Text>
             )}
           </Flex>


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-792]

### Description

New logic is to swap the check of bought in with the past month check. 


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-792]: https://artsyproduct.atlassian.net/browse/CX-792