### PR TITLE
chore: Add missing artwork placeholder in My Collection Artwork page for empty state

### DIFF
--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistAuctionResults.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistAuctionResults.tsx
@@ -6,7 +6,7 @@ import { navigate } from "lib/navigation/navigate"
 import { ScreenMargin } from "lib/Scenes/MyCollection/Components/ScreenMargin"
 import { extractNodes } from "lib/utils/extractNodes"
 import { DateTime } from "luxon"
-import { Box, Flex, Separator, Spacer, Text } from "palette"
+import { Box, Flex, NoArtworkIcon, Separator, Spacer, Text } from "palette"
 import React from "react"
 import { TouchableWithoutFeedback, View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -57,7 +57,19 @@ const MyCollectionArtworkArtistAuctionResults: React.FC<MyCollectionArtworkArtis
                   <Box my={0.5}>
                     <Flex flexDirection="row">
                       <Box pr={1}>
-                        <OpaqueImageView imageURL={images?.thumbnail?.url} width={80} height={60} />
+                        {images?.thumbnail?.url ? (
+                          <OpaqueImageView imageURL={images?.thumbnail?.url} width={80} height={60} />
+                        ) : (
+                          <Flex
+                            width={60}
+                            height={60}
+                            backgroundColor="black10"
+                            alignItems="center"
+                            justifyContent="center"
+                          >
+                            <NoArtworkIcon width={28} height={28} opacity={0.3} />
+                          </Flex>
+                        )}
                       </Box>
                       <Box pr={1} maxWidth="80%">
                         <Flex flexDirection="row">


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-913]

### Description
Change empty state auction result image in the MyCollections artwork view to include `<MissingArtworkIcon` in a square instead of a rectangle. I think @samchieng and @admbtlr were discussing reusing the `ArtistInsightsAuctionResult` component, which would require some refactoring of the `auctionResult` being passed and the formatting of the component to fit in this place. For now, keeping this change small :)

![Simulator Screen Shot - iPhone 12 - 2020-12-21 at 14 35 39](https://user-images.githubusercontent.com/9466631/102824534-46654a80-439a-11eb-9489-2e73a93bc846.png)

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [ ] I have documented any follow-up work that this PR will require, or it does not require any.
- [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-913]: https://artsyproduct.atlassian.net/browse/CX-913