### PR TITLE
chore: my collection analytics part 2 

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -6,8 +6,9 @@ upcoming:
     - Fix `isVisible` root view prop to respect tab switches - david, erik, lily
     - Add slack notification when betas fail - brian
     - Add analytics tracking for My Bids - ashley, erik, christina
+    - More analytics for My Collection - brian
   user_facing:
-    - Fix a layout bug (double separator) in My Collection Artwork Details
+    - Fix a layout bug (double separator) in My Collection Artwork Details - adam
     - Fix layout in My Collection artwork form AdditionalDetails screen - david
 
 releases:

--- a/docs/analytics_and_tracking.md
+++ b/docs/analytics_and_tracking.md
@@ -1,20 +1,6 @@
-## Top level (AppRegistry)
+### Use cohesion for all new tracking code
 
-Make sure to register a new screen/component using `trackWrap`
-
-Now we have a function `trackWrap` that can wrap all components when we register them. So **use**:
-
-```typescript
-AppRegistry.registerComponent("Inquiry", trackWrap(Inquiry))
-```
-
-**instead of**:
-
-```typescript
-AppRegistry.registerComponent("Inquiry", () => Inquiry)
-```
-
-This will make sure that `Inquiry` is wrapped properly with the tracking context it's needed, regardless of it being a func or a class component.
+Use [cohesion](https://github.com/artsy/cohesion) events and helpers for all new tracking code. Cohesion is an artsy library for keeping analytics across our applications _cohesive_, it defines schemas, events and helpers for tracking code. It was recently adopted in Eigen so there still exists a lot of tracking code and helpers not using cohesion, all new tracking code should use cohesion if at all possible.
 
 ## Inside React components
 
@@ -50,9 +36,16 @@ This will minimize the tracking code sprinkled over the component code to just o
 export const MyFuncComp: React.FC<Props> = (props) => {
   const id = 42
   return (
-    <ProvideScreenTracking info={tracks.context(id, "aSlug")}>
+    <ProvideScreenTrackingWithCohesionSchema
+      info={{
+        action: ActionType.screen,
+        context_screen_owner_type: OwnerType.myCollectionArtwork,
+        context_screen_owner_id: artwork.internalID,
+        context_screen_owner_slug: artwork.slug,
+      }}
+    >
       <View />
-    </ProvideScreenTracking>
+    </ProvideScreenTrackingWithCohesionSchema>
   )
 }
 ```

--- a/docs/preferred_practices.md
+++ b/docs/preferred_practices.md
@@ -115,7 +115,9 @@ _Most_ interactions are made through a "SwitchBoard" to open links. Other intera
 
 ### Analytics
 
-There is [extensive inline documentation](https://github.com/artsy/eigen/blob/3281cd9ba54b1d316b68375f46389974a22a0091/src/lib/utils/track/index.tsx#L10-L212) in our tracking code, including examples.
+#### Follow the tracking docs and examples
+
+See our docs on implementing analytics [here](./docs/analytics_and_tracking.md)
 
 ### Miscellaneous
 

--- a/src/__generated__/MyCollectionArtworkArtistArticlesTestsQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkArtistArticlesTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 5c534f656d33b78a04430d5c14c02f12 */
+/* @relayHash 124ed00fd7ca13d78edc680f014942ac */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -27,6 +27,8 @@ query MyCollectionArtworkArtistArticlesTestsQuery {
 }
 
 fragment MyCollectionArtworkArtistArticles_artwork on Artwork {
+  internalID
+  slug
   artist {
     slug
     name
@@ -66,30 +68,37 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "slug",
+  "name": "internalID",
   "storageKey": null
 },
 v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "slug",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "name",
   "storageKey": null
 },
 v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v5 = {
+v6 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -136,6 +145,8 @@ return {
         "name": "artwork",
         "plural": false,
         "selections": [
+          (v1/*: any*/),
+          (v2/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -144,8 +155,8 @@ return {
             "name": "artist",
             "plural": false,
             "selections": [
-              (v1/*: any*/),
               (v2/*: any*/),
+              (v3/*: any*/),
               {
                 "alias": null,
                 "args": [
@@ -186,14 +197,8 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
+                          (v2/*: any*/),
                           (v1/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "internalID",
-                            "storageKey": null
-                          },
                           {
                             "alias": null,
                             "args": null,
@@ -216,8 +221,8 @@ return {
                             "name": "author",
                             "plural": false,
                             "selections": [
-                              (v2/*: any*/),
-                              (v3/*: any*/)
+                              (v3/*: any*/),
+                              (v4/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -252,7 +257,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v4/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -262,18 +267,18 @@ return {
                 ],
                 "storageKey": "articlesConnection(first:3,inEditorialFeed:true,sort:\"PUBLISHED_AT_DESC\")"
               },
-              (v3/*: any*/)
+              (v4/*: any*/)
             ],
             "storageKey": null
           },
-          (v3/*: any*/)
+          (v4/*: any*/)
         ],
         "storageKey": "artwork(id:\"some-slug\")"
       }
     ]
   },
   "params": {
-    "id": "5c534f656d33b78a04430d5c14c02f12",
+    "id": "124ed00fd7ca13d78edc680f014942ac",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artwork": {
@@ -312,25 +317,27 @@ return {
           "plural": false,
           "type": "Author"
         },
-        "artwork.artist.articlesConnection.edges.node.author.id": (v4/*: any*/),
-        "artwork.artist.articlesConnection.edges.node.author.name": (v5/*: any*/),
-        "artwork.artist.articlesConnection.edges.node.href": (v5/*: any*/),
-        "artwork.artist.articlesConnection.edges.node.id": (v4/*: any*/),
-        "artwork.artist.articlesConnection.edges.node.internalID": (v4/*: any*/),
-        "artwork.artist.articlesConnection.edges.node.publishedAt": (v5/*: any*/),
-        "artwork.artist.articlesConnection.edges.node.slug": (v5/*: any*/),
+        "artwork.artist.articlesConnection.edges.node.author.id": (v5/*: any*/),
+        "artwork.artist.articlesConnection.edges.node.author.name": (v6/*: any*/),
+        "artwork.artist.articlesConnection.edges.node.href": (v6/*: any*/),
+        "artwork.artist.articlesConnection.edges.node.id": (v5/*: any*/),
+        "artwork.artist.articlesConnection.edges.node.internalID": (v5/*: any*/),
+        "artwork.artist.articlesConnection.edges.node.publishedAt": (v6/*: any*/),
+        "artwork.artist.articlesConnection.edges.node.slug": (v6/*: any*/),
         "artwork.artist.articlesConnection.edges.node.thumbnailImage": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "artwork.artist.articlesConnection.edges.node.thumbnailImage.url": (v5/*: any*/),
-        "artwork.artist.articlesConnection.edges.node.thumbnailTitle": (v5/*: any*/),
-        "artwork.artist.id": (v4/*: any*/),
-        "artwork.artist.name": (v5/*: any*/),
-        "artwork.artist.slug": (v4/*: any*/),
-        "artwork.id": (v4/*: any*/)
+        "artwork.artist.articlesConnection.edges.node.thumbnailImage.url": (v6/*: any*/),
+        "artwork.artist.articlesConnection.edges.node.thumbnailTitle": (v6/*: any*/),
+        "artwork.artist.id": (v5/*: any*/),
+        "artwork.artist.name": (v6/*: any*/),
+        "artwork.artist.slug": (v5/*: any*/),
+        "artwork.id": (v5/*: any*/),
+        "artwork.internalID": (v5/*: any*/),
+        "artwork.slug": (v5/*: any*/)
       }
     },
     "name": "MyCollectionArtworkArtistArticlesTestsQuery",

--- a/src/__generated__/MyCollectionArtworkArtistArticles_artwork.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkArtistArticles_artwork.graphql.ts
@@ -5,6 +5,8 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type MyCollectionArtworkArtistArticles_artwork = {
+    readonly internalID: string;
+    readonly slug: string;
     readonly artist: {
         readonly slug: string;
         readonly name: string | null;
@@ -41,10 +43,17 @@ var v0 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "slug",
+  "name": "internalID",
   "storageKey": null
 },
 v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -57,6 +66,8 @@ return {
   "metadata": null,
   "name": "MyCollectionArtworkArtistArticles_artwork",
   "selections": [
+    (v0/*: any*/),
+    (v1/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -65,8 +76,8 @@ return {
       "name": "artist",
       "plural": false,
       "selections": [
-        (v0/*: any*/),
         (v1/*: any*/),
+        (v2/*: any*/),
         {
           "alias": null,
           "args": [
@@ -107,14 +118,8 @@ return {
                   "name": "node",
                   "plural": false,
                   "selections": [
+                    (v1/*: any*/),
                     (v0/*: any*/),
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "internalID",
-                      "storageKey": null
-                    },
                     {
                       "alias": null,
                       "args": null,
@@ -137,7 +142,7 @@ return {
                       "name": "author",
                       "plural": false,
                       "selections": [
-                        (v1/*: any*/)
+                        (v2/*: any*/)
                       ],
                       "storageKey": null
                     },
@@ -189,5 +194,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '0e857b0be8c6e538ac60c40dc2b5e602';
+(node as any).hash = 'f78acdccca4fb6a057ede81d4f1cef0b';
 export default node;

--- a/src/__generated__/MyCollectionArtworkFullDetailsQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkFullDetailsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 7fd0084c3582a2721c9b3926ab823509 */
+/* @relayHash c702208787d367baa1635c802d552701 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -63,6 +63,7 @@ fragment MyCollectionArtworkFullDetails_artwork on Artwork {
 }
 
 fragment MyCollectionArtworkMeta_artwork on Artwork {
+  slug
   internalID
   artistNames
   category
@@ -306,7 +307,7 @@ return {
     ]
   },
   "params": {
-    "id": "7fd0084c3582a2721c9b3926ab823509",
+    "id": "c702208787d367baa1635c802d552701",
     "metadata": {},
     "name": "MyCollectionArtworkFullDetailsQuery",
     "operationKind": "query",

--- a/src/__generated__/MyCollectionArtworkFullDetailsTestsQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkFullDetailsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 9057c08c7b28131adf12130c770e9b52 */
+/* @relayHash 0564e1f59acacacd1f3910c84ec50fcd */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -59,6 +59,7 @@ fragment MyCollectionArtworkFullDetails_artwork on Artwork {
 }
 
 fragment MyCollectionArtworkMeta_artwork on Artwork {
+  slug
   internalID
   artistNames
   category
@@ -313,7 +314,7 @@ return {
     ]
   },
   "params": {
-    "id": "9057c08c7b28131adf12130c770e9b52",
+    "id": "0564e1f59acacacd1f3910c84ec50fcd",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artwork": {

--- a/src/__generated__/MyCollectionArtworkInsightsTestsQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkInsightsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 6c94071c70c9e0951ab7c62ff01065e3 */
+/* @relayHash 5425739e008771d1ddaeff53c11dd165 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -33,6 +33,8 @@ query MyCollectionArtworkInsightsTestsQuery {
 }
 
 fragment MyCollectionArtworkArtistArticles_artwork on Artwork {
+  internalID
+  slug
   artist {
     slug
     name
@@ -737,7 +739,7 @@ return {
     ]
   },
   "params": {
-    "id": "6c94071c70c9e0951ab7c62ff01065e3",
+    "id": "5425739e008771d1ddaeff53c11dd165",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artwork": {

--- a/src/__generated__/MyCollectionArtworkMetaTestsQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkMetaTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 5bed2d5e758704b1cb3a204831165026 */
+/* @relayHash e95371724d6510f34d5afe283595007b */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -27,6 +27,7 @@ query MyCollectionArtworkMetaTestsQuery {
 }
 
 fragment MyCollectionArtworkMeta_artwork on Artwork {
+  slug
   internalID
   artistNames
   category
@@ -105,6 +106,13 @@ return {
         "name": "artwork",
         "plural": false,
         "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
           {
             "alias": null,
             "args": null,
@@ -216,7 +224,7 @@ return {
     ]
   },
   "params": {
-    "id": "5bed2d5e758704b1cb3a204831165026",
+    "id": "e95371724d6510f34d5afe283595007b",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artwork": {
@@ -243,6 +251,7 @@ return {
         "artwork.internalID": (v2/*: any*/),
         "artwork.medium": (v1/*: any*/),
         "artwork.metric": (v1/*: any*/),
+        "artwork.slug": (v2/*: any*/),
         "artwork.title": (v1/*: any*/),
         "artwork.width": (v1/*: any*/)
       }

--- a/src/__generated__/MyCollectionArtworkMeta_artwork.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkMeta_artwork.graphql.ts
@@ -5,6 +5,7 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type MyCollectionArtworkMeta_artwork = {
+    readonly slug: string;
     readonly internalID: string;
     readonly artistNames: string | null;
     readonly category: string | null;
@@ -35,6 +36,13 @@ const node: ReaderFragment = {
   "metadata": null,
   "name": "MyCollectionArtworkMeta_artwork",
   "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
+    },
     {
       "alias": null,
       "args": null,
@@ -137,5 +145,5 @@ const node: ReaderFragment = {
   "type": "Artwork",
   "abstractKey": null
 };
-(node as any).hash = 'f778795a2bbcfc5871bad191ba76a525';
+(node as any).hash = '32cc24cec59381a9ee19a8e44115a815';
 export default node;

--- a/src/__generated__/MyCollectionArtworkQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash e667c4dadffd829dee0d05c622d697a2 */
+/* @relayHash c16859aaff26f50e74fce41a0344f5ce */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -97,6 +97,8 @@ query MyCollectionArtworkQuery(
 }
 
 fragment MyCollectionArtworkArtistArticles_artwork on Artwork {
+  internalID
+  slug
   artist {
     slug
     name
@@ -214,6 +216,7 @@ fragment MyCollectionArtworkInsights_marketPriceInsights on MarketPriceInsights 
 }
 
 fragment MyCollectionArtworkMeta_artwork on Artwork {
+  slug
   internalID
   artistNames
   category
@@ -975,7 +978,7 @@ return {
     ]
   },
   "params": {
-    "id": "e667c4dadffd829dee0d05c622d697a2",
+    "id": "c16859aaff26f50e74fce41a0344f5ce",
     "metadata": {},
     "name": "MyCollectionArtworkQuery",
     "operationKind": "query",

--- a/src/lib/Scenes/MyCollection/MyCollection.tsx
+++ b/src/lib/Scenes/MyCollection/MyCollection.tsx
@@ -1,4 +1,4 @@
-import { addCollectedArtwork } from "@artsy/cohesion"
+import { ActionType, addCollectedArtwork, OwnerType } from "@artsy/cohesion"
 import { MyCollection_me } from "__generated__/MyCollection_me.graphql"
 import { MyCollectionQuery } from "__generated__/MyCollectionQuery.graphql"
 import { EventEmitter } from "events"
@@ -11,6 +11,7 @@ import { extractNodes } from "lib/utils/extractNodes"
 import { isCloseToBottom } from "lib/utils/isCloseToBottom"
 import { PlaceholderBox, PlaceholderRaggedText, PlaceholderText } from "lib/utils/placeholders"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
+import { ProvideScreenTrackingWithCohesionSchema } from "lib/utils/track"
 import { Box, Button, Flex, Join, Separator, Spacer, Text } from "palette"
 import React, { useEffect, useState } from "react"
 import { FlatList, RefreshControl, ScrollView, View } from "react-native"
@@ -66,75 +67,82 @@ const MyCollection: React.FC<{
   }
 
   return (
-    <View style={{ flex: 1 }}>
-      <MyCollectionArtworkFormModal
-        mode="add"
-        visible={showModal}
-        onDismiss={() => setShowModal(false)}
-        onSuccess={() => setShowModal(false)}
-      />
-      <FancyModalHeader
-        rightButtonText="Add artwork"
-        hideBottomDivider
-        onRightButtonPress={() => {
-          trackEvent(tracks.addCollectedArtwork())
-          GlobalStore.actions.myCollection.artwork.resetForm()
-          setShowModal(true)
-        }}
-      ></FancyModalHeader>
-      <Text variant="largeTitle" ml={2} mb={2}>
-        My Collection
-      </Text>
-      {artworks.length === 0 ? (
-        <ScrollView
-          refreshControl={
-            <RefreshControl
-              refreshing={isRefreshing}
-              onRefresh={() => {
-                refreshMyCollection()
-              }}
-            />
-          }
-          contentContainerStyle={{ flex: 1 }}
-        >
-          <Flex>
-            <ZeroState
-              subtitle="Add details about an artwork from your collection to access price and market insights."
-              callToAction={
-                <Button
-                  data-test-id="add-artwork-button-zero-state"
-                  onPress={() => {
-                    setShowModal(true)
-                    trackEvent(tracks.addCollectedArtwork())
-                  }}
-                >
-                  Add artwork
-                </Button>
-              }
-            />
-          </Flex>
-        </ScrollView>
-      ) : (
-        <FlatList
-          refreshControl={
-            <RefreshControl
-              refreshing={isRefreshing}
-              onRefresh={() => {
-                refreshMyCollection()
-              }}
-            />
-          }
-          data={artworks}
-          showsVerticalScrollIndicator={false}
-          ItemSeparatorComponent={() => <Separator />}
-          keyExtractor={(node) => node.id}
-          onScroll={isCloseToBottom(fetchNextPage)}
-          renderItem={({ item }) => {
-            return <MyCollectionArtworkListItemFragmentContainer artwork={item} />
-          }}
+    <ProvideScreenTrackingWithCohesionSchema
+      info={{
+        action: ActionType.screen,
+        context_screen_owner_type: OwnerType.myCollection,
+      }}
+    >
+      <View style={{ flex: 1 }}>
+        <MyCollectionArtworkFormModal
+          mode="add"
+          visible={showModal}
+          onDismiss={() => setShowModal(false)}
+          onSuccess={() => setShowModal(false)}
         />
-      )}
-    </View>
+        <FancyModalHeader
+          rightButtonText="Add artwork"
+          hideBottomDivider
+          onRightButtonPress={() => {
+            trackEvent(tracks.addCollectedArtwork())
+            GlobalStore.actions.myCollection.artwork.resetForm()
+            setShowModal(true)
+          }}
+        ></FancyModalHeader>
+        <Text variant="largeTitle" ml={2} mb={2}>
+          My Collection
+        </Text>
+        {artworks.length === 0 ? (
+          <ScrollView
+            refreshControl={
+              <RefreshControl
+                refreshing={isRefreshing}
+                onRefresh={() => {
+                  refreshMyCollection()
+                }}
+              />
+            }
+            contentContainerStyle={{ flex: 1 }}
+          >
+            <Flex>
+              <ZeroState
+                subtitle="Add details about an artwork from your collection to access price and market insights."
+                callToAction={
+                  <Button
+                    data-test-id="add-artwork-button-zero-state"
+                    onPress={() => {
+                      setShowModal(true)
+                      trackEvent(tracks.addCollectedArtwork())
+                    }}
+                  >
+                    Add artwork
+                  </Button>
+                }
+              />
+            </Flex>
+          </ScrollView>
+        ) : (
+          <FlatList
+            refreshControl={
+              <RefreshControl
+                refreshing={isRefreshing}
+                onRefresh={() => {
+                  refreshMyCollection()
+                }}
+              />
+            }
+            data={artworks}
+            showsVerticalScrollIndicator={false}
+            ItemSeparatorComponent={() => <Separator />}
+            keyExtractor={(node) => node.id}
+            onScroll={isCloseToBottom(fetchNextPage)}
+            renderItem={({ item }) => {
+              return <MyCollectionArtworkListItemFragmentContainer artwork={item} />
+            }}
+          />
+        )}
+      </View>
+    </ProvideScreenTrackingWithCohesionSchema>
   )
 }
 

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistArticles.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistArticles.tsx
@@ -1,3 +1,4 @@
+import { ActionType, ContextModule, OwnerType, TappedShowMore } from "@artsy/cohesion"
 import { MyCollectionArtworkArtistArticles_artwork } from "__generated__/MyCollectionArtworkArtistArticles_artwork.graphql"
 import { CaretButton } from "lib/Components/Buttons/CaretButton"
 import { navigate } from "lib/navigation/navigate"
@@ -7,6 +8,7 @@ import { Box, Flex, Separator, Spacer, Text } from "palette"
 import React from "react"
 import { Image, TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
+import { useTracking } from "react-tracking"
 
 interface MyCollectionArtworkArtistArticlesProps {
   artwork: MyCollectionArtworkArtistArticles_artwork
@@ -15,6 +17,7 @@ interface MyCollectionArtworkArtistArticlesProps {
 const MyCollectionArtworkArtistArticles: React.FC<MyCollectionArtworkArtistArticlesProps> = (props) => {
   const artist = props?.artwork?.artist!
   const articleEdges = extractNodes(artist?.articlesConnection)
+  const { trackEvent } = useTracking()
 
   if (!articleEdges.length) {
     return null
@@ -55,7 +58,13 @@ const MyCollectionArtworkArtistArticles: React.FC<MyCollectionArtworkArtistArtic
       <Spacer my={1} />
 
       <Box>
-        <CaretButton onPress={() => navigate(`/artist/${artist?.slug}/articles`)} text="See all articles" />
+        <CaretButton
+          onPress={() => {
+            trackEvent(tracks.tappedShowMore(props.artwork.internalID, props.artwork.slug, "See all articles"))
+            navigate(`/artist/${artist?.slug}/articles`)
+          }}
+          text="See all articles"
+        />
       </Box>
     </ScreenMargin>
   )
@@ -66,6 +75,8 @@ export const MyCollectionArtworkArtistArticlesFragmentContainer = createFragment
   {
     artwork: graphql`
       fragment MyCollectionArtworkArtistArticles_artwork on Artwork {
+        internalID
+        slug
         artist {
           slug
           name
@@ -92,3 +103,17 @@ export const MyCollectionArtworkArtistArticlesFragmentContainer = createFragment
     `,
   }
 )
+
+const tracks = {
+  tappedShowMore: (internalID: string, slug: string, subject: string) => {
+    const tappedShowMore: TappedShowMore = {
+      action: ActionType.tappedShowMore,
+      context_module: ContextModule.myCollectionArtwork,
+      context_screen_owner_type: OwnerType.myCollectionArtwork,
+      context_screen_owner_id: internalID,
+      context_screen_owner_slug: slug,
+      subject,
+    }
+    return tappedShowMore
+  },
+}

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistArticles.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistArticles.tsx
@@ -108,7 +108,7 @@ const tracks = {
   tappedShowMore: (internalID: string, slug: string, subject: string) => {
     const tappedShowMore: TappedShowMore = {
       action: ActionType.tappedShowMore,
-      context_module: ContextModule.myCollectionArtwork,
+      context_module: ContextModule.relatedArticles,
       context_screen_owner_type: OwnerType.myCollectionArtwork,
       context_screen_owner_id: internalID,
       context_screen_owner_slug: slug,

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistAuctionResults.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistAuctionResults.tsx
@@ -1,4 +1,4 @@
-import { ContextModule, OwnerType, tappedInfoBubble } from "@artsy/cohesion"
+import { ActionType, ContextModule, OwnerType, tappedInfoBubble, TappedShowMore } from "@artsy/cohesion"
 import { MyCollectionArtworkArtistAuctionResults_artwork } from "__generated__/MyCollectionArtworkArtistAuctionResults_artwork.graphql"
 import { CaretButton } from "lib/Components/Buttons/CaretButton"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
@@ -100,7 +100,12 @@ const MyCollectionArtworkArtistAuctionResults: React.FC<MyCollectionArtworkArtis
 
         <Box>
           <CaretButton
-            onPress={() => navigate(`/artist/${props?.artwork?.artist?.slug!}/auction-results`)}
+            onPress={() => {
+              trackEvent(
+                tracks.tappedShowMore(props.artwork?.internalID, props.artwork?.slug, "Explore auction results")
+              )
+              navigate(`/artist/${props?.artwork?.artist?.slug!}/auction-results`)
+            }}
             text="Explore auction results"
           />
         </Box>
@@ -158,5 +163,16 @@ const tracks = {
       contextScreenOwnerSlug: slug,
       subject: "auctionResults",
     })
+  },
+  tappedShowMore: (internalID: string, slug: string, subject: string) => {
+    const tappedShowMore: TappedShowMore = {
+      action: ActionType.tappedShowMore,
+      context_module: ContextModule.myCollectionArtwork,
+      context_screen_owner_type: OwnerType.myCollectionArtwork,
+      context_screen_owner_id: internalID,
+      context_screen_owner_slug: slug,
+      subject,
+    }
+    return tappedShowMore
   },
 }

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistAuctionResults.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistAuctionResults.tsx
@@ -157,7 +157,7 @@ export const MyCollectionArtworkArtistAuctionResultsFragmentContainer = createFr
 const tracks = {
   tappedInfoBubble: (internalID: string, slug: string) => {
     return tappedInfoBubble({
-      contextModule: ContextModule.myCollectionArtwork,
+      contextModule: ContextModule.auctionResults,
       contextScreenOwnerType: OwnerType.myCollectionArtwork,
       contextScreenOwnerId: internalID,
       contextScreenOwnerSlug: slug,
@@ -167,7 +167,7 @@ const tracks = {
   tappedShowMore: (internalID: string, slug: string, subject: string) => {
     const tappedShowMore: TappedShowMore = {
       action: ActionType.tappedShowMore,
-      context_module: ContextModule.myCollectionArtwork,
+      context_module: ContextModule.auctionResults,
       context_screen_owner_type: OwnerType.myCollectionArtwork,
       context_screen_owner_id: internalID,
       context_screen_owner_slug: slug,

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/__tests__/MyCollectionArtworkArtistArticles-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/__tests__/MyCollectionArtworkArtistArticles-tests.tsx
@@ -106,7 +106,7 @@ describe("MyCollectionArtworkArtistArticles", () => {
     expect(trackEvent).toHaveBeenCalledTimes(1)
     expect(trackEvent).toHaveBeenCalledWith({
       action: ActionType.tappedShowMore,
-      context_module: ContextModule.myCollectionArtwork,
+      context_module: ContextModule.relatedArticles,
       context_screen_owner_type: OwnerType.myCollectionArtwork,
       context_screen_owner_id: "some-id",
       context_screen_owner_slug: "some-slug",

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/__tests__/MyCollectionArtworkArtistArticles-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/__tests__/MyCollectionArtworkArtistArticles-tests.tsx
@@ -1,3 +1,4 @@
+import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import { MyCollectionArtworkArtistArticlesTestsQuery } from "__generated__/MyCollectionArtworkArtistArticlesTestsQuery.graphql"
 import { CaretButton } from "lib/Components/Buttons/CaretButton"
 import { navigate } from "lib/navigation/navigate"
@@ -6,12 +7,15 @@ import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { Image, TouchableOpacity } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
+import { useTracking } from "react-tracking"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { MyCollectionArtworkArtistArticlesFragmentContainer } from "../MyCollectionArtworkArtistArticles"
 
 jest.unmock("react-relay")
+jest.mock("react-tracking")
 
 describe("MyCollectionArtworkArtistArticles", () => {
+  const trackEvent = jest.fn()
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
   const TestRenderer = () => (
     <QueryRenderer<MyCollectionArtworkArtistArticlesTestsQuery>
@@ -35,6 +39,16 @@ describe("MyCollectionArtworkArtistArticles", () => {
 
   beforeEach(() => {
     mockEnvironment = createMockEnvironment()
+    const mockTracking = useTracking as jest.Mock
+    mockTracking.mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
   })
 
   const resolveData = (passedProps = {}) => {
@@ -75,5 +89,28 @@ describe("MyCollectionArtworkArtistArticles", () => {
     })
     wrapper.root.findAllByType(CaretButton)[0].props.onPress()
     expect(navigate).toHaveBeenCalledWith("/artist/artist-slug/articles")
+  })
+
+  it("tracks taps on all articles button", () => {
+    const wrapper = renderWithWrappers(<TestRenderer />)
+    resolveData({
+      Artwork: () => ({
+        internalID: "some-id",
+        slug: "some-slug",
+      }),
+      Artist: () => ({
+        slug: "artist-slug",
+      }),
+    })
+    wrapper.root.findAllByType(CaretButton)[0].props.onPress()
+    expect(trackEvent).toHaveBeenCalledTimes(1)
+    expect(trackEvent).toHaveBeenCalledWith({
+      action: ActionType.tappedShowMore,
+      context_module: ContextModule.myCollectionArtwork,
+      context_screen_owner_type: OwnerType.myCollectionArtwork,
+      context_screen_owner_id: "some-id",
+      context_screen_owner_slug: "some-slug",
+      subject: "See all articles",
+    })
   })
 })

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/__tests__/MyCollectionArtworkArtistAuctionResults-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/__tests__/MyCollectionArtworkArtistAuctionResults-tests.tsx
@@ -1,4 +1,4 @@
-import { ContextModule, OwnerType, tappedInfoBubble } from "@artsy/cohesion"
+import { ActionType, ContextModule, OwnerType, tappedInfoBubble } from "@artsy/cohesion"
 import { MyCollectionArtworkArtistAuctionResultsTestsQuery } from "__generated__/MyCollectionArtworkArtistAuctionResultsTestsQuery.graphql"
 import { CaretButton } from "lib/Components/Buttons/CaretButton"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
@@ -133,5 +133,26 @@ describe("MyCollectionArtworkArtistAuctionResults", () => {
         contextScreenOwnerSlug: "artwork-slug",
       })
     )
+  })
+
+  it("tracks analytics event when `Explore Auction Results` is tapped", () => {
+    const wrapper = renderWithWrappers(<TestRenderer />)
+    resolveData({
+      Artwork: () => ({
+        internalID: "artwork-id",
+        slug: "artwork-slug",
+      }),
+    })
+    wrapper.root.findByType(CaretButton).props.onPress()
+
+    expect(trackEvent).toHaveBeenCalledTimes(1)
+    expect(trackEvent).toHaveBeenCalledWith({
+      action: ActionType.tappedShowMore,
+      context_module: ContextModule.myCollectionArtwork,
+      context_screen_owner_type: OwnerType.myCollectionArtwork,
+      context_screen_owner_id: "artwork-id",
+      context_screen_owner_slug: "artwork-slug",
+      subject: "Explore auction results",
+    })
   })
 })

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/__tests__/MyCollectionArtworkArtistAuctionResults-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/__tests__/MyCollectionArtworkArtistAuctionResults-tests.tsx
@@ -126,7 +126,7 @@ describe("MyCollectionArtworkArtistAuctionResults", () => {
     expect(trackEvent).toHaveBeenCalledTimes(1)
     expect(trackEvent).toHaveBeenCalledWith(
       tappedInfoBubble({
-        contextModule: ContextModule.myCollectionArtwork,
+        contextModule: ContextModule.auctionResults,
         contextScreenOwnerType: OwnerType.myCollectionArtwork,
         subject: "auctionResults",
         contextScreenOwnerId: "artwork-id",
@@ -148,7 +148,7 @@ describe("MyCollectionArtworkArtistAuctionResults", () => {
     expect(trackEvent).toHaveBeenCalledTimes(1)
     expect(trackEvent).toHaveBeenCalledWith({
       action: ActionType.tappedShowMore,
-      context_module: ContextModule.myCollectionArtwork,
+      context_module: ContextModule.auctionResults,
       context_screen_owner_type: OwnerType.myCollectionArtwork,
       context_screen_owner_id: "artwork-id",
       context_screen_owner_slug: "artwork-slug",

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkMeta.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkMeta.tsx
@@ -1,3 +1,4 @@
+import { ActionType, ContextModule, OwnerType, TappedShowMore } from "@artsy/cohesion"
 import { MyCollectionArtworkMeta_artwork } from "__generated__/MyCollectionArtworkMeta_artwork.graphql"
 import { CaretButton } from "lib/Components/Buttons/CaretButton"
 import { navigate } from "lib/navigation/navigate"
@@ -7,6 +8,7 @@ import { capitalize } from "lodash"
 import { Spacer } from "palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { useTracking } from "react-tracking"
 import { Field } from "./Field"
 
 interface MyCollectionArtworkMetaProps {
@@ -32,6 +34,8 @@ const MyCollectionArtworkMeta: React.FC<MyCollectionArtworkMetaProps> = ({ artwo
   } = artwork
 
   const dimensions = formatArtworkDimensions({ height, width, depth, metric })
+
+  const { trackEvent } = useTracking()
 
   if (viewAll) {
     return (
@@ -70,7 +74,10 @@ const MyCollectionArtworkMeta: React.FC<MyCollectionArtworkMetaProps> = ({ artwo
         <Spacer my={0.5} />
 
         <CaretButton
-          onPress={() => navigate(`/my-collection/artwork-details/${artwork.internalID}`)}
+          onPress={() => {
+            trackEvent(tracks.tappedShowMore(artwork.internalID, artwork.slug, "View more"))
+            navigate(`/my-collection/artwork-details/${artwork.internalID}`)
+          }}
           text="View more"
         />
       </ScreenMargin>
@@ -81,6 +88,7 @@ const MyCollectionArtworkMeta: React.FC<MyCollectionArtworkMetaProps> = ({ artwo
 export const MyCollectionArtworkMetaFragmentContainer = createFragmentContainer(MyCollectionArtworkMeta, {
   artwork: graphql`
     fragment MyCollectionArtworkMeta_artwork on Artwork {
+      slug
       internalID
       artistNames
       category
@@ -98,3 +106,17 @@ export const MyCollectionArtworkMetaFragmentContainer = createFragmentContainer(
     }
   `,
 })
+
+const tracks = {
+  tappedShowMore: (internalID: string, slug: string, subject: string) => {
+    const tappedShowMore: TappedShowMore = {
+      action: ActionType.tappedShowMore,
+      context_module: ContextModule.myCollectionArtwork,
+      context_screen_owner_type: OwnerType.myCollectionArtwork,
+      context_screen_owner_id: internalID,
+      context_screen_owner_slug: slug,
+      subject,
+    }
+    return tappedShowMore
+  },
+}

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkMeta.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkMeta.tsx
@@ -111,7 +111,7 @@ const tracks = {
   tappedShowMore: (internalID: string, slug: string, subject: string) => {
     const tappedShowMore: TappedShowMore = {
       action: ActionType.tappedShowMore,
-      context_module: ContextModule.myCollectionArtwork,
+      context_module: ContextModule.artworkMetadata,
       context_screen_owner_type: OwnerType.myCollectionArtwork,
       context_screen_owner_id: internalID,
       context_screen_owner_slug: slug,

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/__tests__/MyCollectionArtworkMeta-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/__tests__/MyCollectionArtworkMeta-tests.tsx
@@ -7,7 +7,7 @@ import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import track, { useTracking } from "react-tracking"
+import { useTracking } from "react-tracking"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { MyCollectionArtworkMetaFragmentContainer } from "../MyCollectionArtworkMeta"
 

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/__tests__/MyCollectionArtworkMeta-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/__tests__/MyCollectionArtworkMeta-tests.tsx
@@ -140,7 +140,7 @@ describe("MyCollectionArtworkMeta", () => {
       expect(trackEvent).toHaveBeenCalledTimes(1)
       expect(trackEvent).toHaveBeenCalledWith({
         action: ActionType.tappedShowMore,
-        context_module: ContextModule.myCollectionArtwork,
+        context_module: ContextModule.artworkMetadata,
         context_screen_owner_type: OwnerType.myCollectionArtwork,
         context_screen_owner_id: "some-internal-id",
         context_screen_owner_slug: "some-slug",

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/__tests__/MyCollectionArtworkMeta-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/__tests__/MyCollectionArtworkMeta-tests.tsx
@@ -38,6 +38,7 @@ describe("MyCollectionArtworkMeta", () => {
   })
 
   const sharedArtworkProps: Omit<MyCollectionArtworkMeta_artwork, " $refType"> = {
+    slug: "some slug",
     artistNames: "some artist name",
     category: "Painting",
     costMinor: 200,

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/__tests__/MyCollectionArtworkMeta-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/__tests__/MyCollectionArtworkMeta-tests.tsx
@@ -1,3 +1,4 @@
+import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import { MyCollectionArtworkMeta_artwork } from "__generated__/MyCollectionArtworkMeta_artwork.graphql"
 import { MyCollectionArtworkMetaTestsQuery } from "__generated__/MyCollectionArtworkMetaTestsQuery.graphql"
 import { CaretButton } from "lib/Components/Buttons/CaretButton"
@@ -6,12 +7,15 @@ import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
+import track, { useTracking } from "react-tracking"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { MyCollectionArtworkMetaFragmentContainer } from "../MyCollectionArtworkMeta"
 
 jest.unmock("react-relay")
+jest.mock("react-tracking")
 
 describe("MyCollectionArtworkMeta", () => {
+  const trackEvent = jest.fn()
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
   const TestRenderer = (passedProps: { viewAll: boolean }) => (
     <QueryRenderer<MyCollectionArtworkMetaTestsQuery>
@@ -35,11 +39,21 @@ describe("MyCollectionArtworkMeta", () => {
 
   beforeEach(() => {
     mockEnvironment = createMockEnvironment()
+    const mockTracking = useTracking as jest.Mock
+    mockTracking.mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
   })
 
   const sharedArtworkProps: Omit<MyCollectionArtworkMeta_artwork, " $refType"> = {
-    slug: "some slug",
-    artistNames: "some artist name",
+    slug: "some-slug",
+    artistNames: "some-artist-name",
     category: "Painting",
     costMinor: 200,
     costCurrencyCode: "USD",
@@ -97,7 +111,7 @@ describe("MyCollectionArtworkMeta", () => {
 
         const text = extractText(wrapper.root)
         expect(text).toContain("Artist")
-        expect(text).toContain("some artist name")
+        expect(text).toContain("some-artist-name")
         expect(text).toContain("Title")
         expect(text).toContain("some title")
         expect(text).toContain("Year created")
@@ -114,6 +128,23 @@ describe("MyCollectionArtworkMeta", () => {
         expect(text).toContain("1")
         expect(text).toContain("Price paid")
         expect(text).toContain("200 USD")
+      })
+    })
+  })
+
+  describe("analytics", () => {
+    it("tracks taps on `View more`", () => {
+      const wrapper = renderWithWrappers(<TestRenderer viewAll={false} />)
+      resolveData()
+      wrapper.root.findByType(CaretButton).props.onPress()
+      expect(trackEvent).toHaveBeenCalledTimes(1)
+      expect(trackEvent).toHaveBeenCalledWith({
+        action: ActionType.tappedShowMore,
+        context_module: ContextModule.myCollectionArtwork,
+        context_screen_owner_type: OwnerType.myCollectionArtwork,
+        context_screen_owner_id: "some-internal-id",
+        context_screen_owner_slug: "some-slug",
+        subject: "View more",
       })
     })
   })

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
@@ -1,4 +1,4 @@
-import { editCollectedArtwork } from "@artsy/cohesion"
+import { ActionType, ContextModule, editCollectedArtwork, OwnerType, tappedSell, TappedShowMore } from "@artsy/cohesion"
 import {
   MyCollectionArtworkQuery,
   MyCollectionArtworkQueryResponse,
@@ -60,7 +60,15 @@ export const MyCollectionArtwork: React.FC<MyCollectionArtworkProps> = ({ artwor
         <WhySell />
 
         <ScreenMargin>
-          <Button size="large" block onPress={() => navigate("/consign/submission")} data-test-id="SubmitButton">
+          <Button
+            size="large"
+            block
+            onPress={() => {
+              trackEvent(tracks.tappedSellArtwork(artwork.internalID, artwork.slug, "Submit this work"))
+              navigate("/consign/submission")
+            }}
+            data-test-id="SubmitButton"
+          >
             Submit this work
           </Button>
 
@@ -70,7 +78,10 @@ export const MyCollectionArtwork: React.FC<MyCollectionArtworkProps> = ({ artwor
             size="large"
             variant="secondaryGray"
             block
-            onPress={() => navigate("/sales")}
+            onPress={() => {
+              trackEvent(tracks.tappedShowMore(artwork.internalID, artwork.slug, "Learn More"))
+              navigate("/sales")
+            }}
             data-test-id="LearnMoreButton"
           >
             Learn more
@@ -226,5 +237,25 @@ export const tests = {
 const tracks = {
   editCollectedArtwork: (internalID: string, slug: string) => {
     return editCollectedArtwork({ contextOwnerId: internalID, contextOwnerSlug: slug })
+  },
+  tappedSellArtwork: (internalID: string, slug: string, subject: string) => {
+    return tappedSell({
+      contextModule: ContextModule.sellFooter,
+      contextScreenOwnerType: OwnerType.myCollectionArtwork,
+      contextScreenOwnerId: internalID,
+      contextScreenOwnerSlug: slug,
+      subject,
+    })
+  },
+  tappedShowMore: (internalID: string, slug: string, subject: string) => {
+    const tappedShowMore: TappedShowMore = {
+      action: ActionType.tappedShowMore,
+      context_module: ContextModule.sellFooter,
+      context_screen_owner_type: OwnerType.myCollectionArtwork,
+      context_screen_owner_id: internalID,
+      context_screen_owner_slug: slug,
+      subject,
+    }
+    return tappedShowMore
   },
 }

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
@@ -250,7 +250,7 @@ const tracks = {
   },
   tappedSellArtwork: (internalID: string, slug: string, subject: string) => {
     return tappedSell({
-      contextModule: ContextModule.myCollectionArtwork,
+      contextModule: ContextModule.sellFooter,
       contextScreenOwnerType: OwnerType.myCollectionArtwork,
       contextScreenOwnerId: internalID,
       contextScreenOwnerSlug: slug,
@@ -260,7 +260,7 @@ const tracks = {
   tappedShowMore: (internalID: string, slug: string, subject: string) => {
     const tappedShowMore: TappedShowMore = {
       action: ActionType.tappedShowMore,
-      context_module: ContextModule.myCollectionArtwork,
+      context_module: ContextModule.sellFooter,
       context_screen_owner_type: OwnerType.myCollectionArtwork,
       context_screen_owner_id: internalID,
       context_screen_owner_slug: slug,

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
@@ -12,6 +12,7 @@ import { MyCollectionArtworkInsightsFragmentContainer } from "lib/Scenes/MyColle
 import { GlobalStore } from "lib/store/GlobalStore"
 import { PlaceholderBox, PlaceholderText } from "lib/utils/placeholders"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
+import { ProvideScreenTrackingWithCohesionSchema } from "lib/utils/track"
 import { Button, Flex, Join, Spacer } from "palette"
 import React, { useState } from "react"
 import { ScrollView } from "react-native"
@@ -32,65 +33,74 @@ export const MyCollectionArtwork: React.FC<MyCollectionArtworkProps> = ({ artwor
   const [showModal, setShowModal] = useState(false)
 
   return (
-    <ScrollView>
-      <MyCollectionArtworkFormModal
-        mode="edit"
-        visible={showModal}
-        onDismiss={() => setShowModal(false)}
-        onSuccess={() => setShowModal(false)}
-        onDelete={() => {
-          setShowModal(false)
-          setTimeout(popParentViewController, 50)
-        }}
-        artwork={artwork}
-      />
-      <FancyModalHeader
-        rightButtonText="Edit"
-        onRightButtonPress={() => {
-          trackEvent(tracks.editCollectedArtwork(artwork.internalID, artwork.slug))
-          GlobalStore.actions.myCollection.artwork.startEditingArtwork(artwork as any)
-          setShowModal(true)
-        }}
-        hideBottomDivider
-      />
-      <Join separator={<Spacer my={1} />}>
-        <MyCollectionArtworkHeaderFragmentContainer artwork={artwork} />
-        <MyCollectionArtworkMetaFragmentContainer artwork={artwork} />
-        <MyCollectionArtworkInsightsFragmentContainer artwork={artwork} marketPriceInsights={marketPriceInsights} />
-        <WhySell />
+    <ProvideScreenTrackingWithCohesionSchema
+      info={{
+        action: ActionType.screen,
+        context_screen_owner_type: OwnerType.myCollectionArtwork,
+        context_screen_owner_id: artwork.internalID,
+        context_screen_owner_slug: artwork.slug,
+      }}
+    >
+      <ScrollView>
+        <MyCollectionArtworkFormModal
+          mode="edit"
+          visible={showModal}
+          onDismiss={() => setShowModal(false)}
+          onSuccess={() => setShowModal(false)}
+          onDelete={() => {
+            setShowModal(false)
+            setTimeout(popParentViewController, 50)
+          }}
+          artwork={artwork}
+        />
+        <FancyModalHeader
+          rightButtonText="Edit"
+          onRightButtonPress={() => {
+            trackEvent(tracks.editCollectedArtwork(artwork.internalID, artwork.slug))
+            GlobalStore.actions.myCollection.artwork.startEditingArtwork(artwork as any)
+            setShowModal(true)
+          }}
+          hideBottomDivider
+        />
+        <Join separator={<Spacer my={1} />}>
+          <MyCollectionArtworkHeaderFragmentContainer artwork={artwork} />
+          <MyCollectionArtworkMetaFragmentContainer artwork={artwork} />
+          <MyCollectionArtworkInsightsFragmentContainer artwork={artwork} marketPriceInsights={marketPriceInsights} />
+          <WhySell />
 
-        <ScreenMargin>
-          <Button
-            size="large"
-            block
-            onPress={() => {
-              trackEvent(tracks.tappedSellArtwork(artwork.internalID, artwork.slug, "Submit this work"))
-              navigate("/consign/submission")
-            }}
-            data-test-id="SubmitButton"
-          >
-            Submit this work
-          </Button>
+          <ScreenMargin>
+            <Button
+              size="large"
+              block
+              onPress={() => {
+                trackEvent(tracks.tappedSellArtwork(artwork.internalID, artwork.slug, "Submit this work"))
+                navigate("/consign/submission")
+              }}
+              data-test-id="SubmitButton"
+            >
+              Submit this work
+            </Button>
 
-          <Spacer my={0.5} />
+            <Spacer my={0.5} />
 
-          <Button
-            size="large"
-            variant="secondaryGray"
-            block
-            onPress={() => {
-              trackEvent(tracks.tappedShowMore(artwork.internalID, artwork.slug, "Learn More"))
-              navigate("/sales")
-            }}
-            data-test-id="LearnMoreButton"
-          >
-            Learn more
-          </Button>
-        </ScreenMargin>
+            <Button
+              size="large"
+              variant="secondaryGray"
+              block
+              onPress={() => {
+                trackEvent(tracks.tappedShowMore(artwork.internalID, artwork.slug, "Learn More"))
+                navigate("/sales")
+              }}
+              data-test-id="LearnMoreButton"
+            >
+              Learn more
+            </Button>
+          </ScreenMargin>
 
-        <Spacer my={2} />
-      </Join>
-    </ScrollView>
+          <Spacer my={2} />
+        </Join>
+      </ScrollView>
+    </ProvideScreenTrackingWithCohesionSchema>
   )
 }
 
@@ -240,7 +250,7 @@ const tracks = {
   },
   tappedSellArtwork: (internalID: string, slug: string, subject: string) => {
     return tappedSell({
-      contextModule: ContextModule.sellFooter,
+      contextModule: ContextModule.myCollectionArtwork,
       contextScreenOwnerType: OwnerType.myCollectionArtwork,
       contextScreenOwnerId: internalID,
       contextScreenOwnerSlug: slug,
@@ -250,7 +260,7 @@ const tracks = {
   tappedShowMore: (internalID: string, slug: string, subject: string) => {
     const tappedShowMore: TappedShowMore = {
       action: ActionType.tappedShowMore,
-      context_module: ContextModule.sellFooter,
+      context_module: ContextModule.myCollectionArtwork,
       context_screen_owner_type: OwnerType.myCollectionArtwork,
       context_screen_owner_id: internalID,
       context_screen_owner_slug: slug,

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/__tests__/MyCollectionArtwork-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/__tests__/MyCollectionArtwork-tests.tsx
@@ -101,7 +101,7 @@ describe("MyCollectionArtworkDetail", () => {
       expect(trackEvent).toHaveBeenCalledTimes(1)
       expect(trackEvent).toHaveBeenCalledWith(
         tappedSell({
-          contextModule: ContextModule.myCollectionArtwork,
+          contextModule: ContextModule.sellFooter,
           contextScreenOwnerType: OwnerType.myCollectionArtwork,
           contextScreenOwnerId: "someInternalId",
           contextScreenOwnerSlug: "someSlug",
@@ -120,7 +120,7 @@ describe("MyCollectionArtworkDetail", () => {
       expect(trackEvent).toHaveBeenCalledTimes(1)
       expect(trackEvent).toHaveBeenCalledWith({
         action: ActionType.tappedShowMore,
-        context_module: ContextModule.myCollectionArtwork,
+        context_module: ContextModule.sellFooter,
         context_screen_owner_type: OwnerType.myCollectionArtwork,
         context_screen_owner_id: "someInternalId",
         context_screen_owner_slug: "someSlug",

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/__tests__/MyCollectionArtwork-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/__tests__/MyCollectionArtwork-tests.tsx
@@ -46,7 +46,8 @@ describe("MyCollectionArtworkDetail", () => {
 
   describe("artwork detail behavior", () => {
     it("renders correct components", () => {
-      const wrapper = getWrapper()
+      const artworkProps = { artwork: { internalID: "someInternalId" } }
+      const wrapper = getWrapper(artworkProps)
       expect(wrapper.root.findByType(MyCollectionArtworkHeaderFragmentContainer)).toBeDefined()
       expect(wrapper.root.findByType(MyCollectionArtworkMetaFragmentContainer)).toBeDefined()
       expect(wrapper.root.findByType(MyCollectionArtworkInsightsFragmentContainer)).toBeDefined()
@@ -75,13 +76,15 @@ describe("MyCollectionArtworkDetail", () => {
     })
 
     it("navigates to consign submission when submit button is pressed", () => {
-      const wrapper = getWrapper()
+      const artworkProps = { artwork: { internalID: "someInternalId" } }
+      const wrapper = getWrapper(artworkProps)
       wrapper.root.findByProps({ "data-test-id": "SubmitButton" }).props.onPress()
       expect(navigate).toHaveBeenCalledWith("/consign/submission")
     })
 
     it("navigates to sales page when learn more button is pressed", () => {
-      const wrapper = getWrapper()
+      const artworkProps = { artwork: { internalID: "someInternalId" } }
+      const wrapper = getWrapper(artworkProps)
       wrapper.root.findByProps({ "data-test-id": "LearnMoreButton" }).props.onPress()
       expect(navigate).toHaveBeenCalledWith("/sales")
     })

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/__tests__/MyCollectionArtwork-tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/__tests__/MyCollectionArtwork-tests.tsx
@@ -1,4 +1,4 @@
-import { editCollectedArtwork } from "@artsy/cohesion"
+import { ActionType, ContextModule, editCollectedArtwork, OwnerType, tappedSell } from "@artsy/cohesion"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
 import { navigate } from "lib/navigation/navigate"
 import { GlobalStore } from "lib/store/GlobalStore"
@@ -62,6 +62,22 @@ describe("MyCollectionArtworkDetail", () => {
       expect(spy).toHaveBeenCalledWith(artworkProps.artwork)
     })
 
+    it("navigates to consign submission when submit button is pressed", () => {
+      const artworkProps = { artwork: { internalID: "someInternalId" } }
+      const wrapper = getWrapper(artworkProps)
+      wrapper.root.findByProps({ "data-test-id": "SubmitButton" }).props.onPress()
+      expect(navigate).toHaveBeenCalledWith("/consign/submission")
+    })
+
+    it("navigates to sales page when learn more button is pressed", () => {
+      const artworkProps = { artwork: { internalID: "someInternalId" } }
+      const wrapper = getWrapper(artworkProps)
+      wrapper.root.findByProps({ "data-test-id": "LearnMoreButton" }).props.onPress()
+      expect(navigate).toHaveBeenCalledWith("/sales")
+    })
+
+    // Analytics
+
     it("tracks an analytics event when edit button is pressed", () => {
       const artworkProps = { artwork: { internalID: "someInternalId", slug: "someSlug" } }
       GlobalStore.actions.myCollection.artwork.startEditingArtwork = jest.fn() as any
@@ -75,18 +91,41 @@ describe("MyCollectionArtworkDetail", () => {
       )
     })
 
-    it("navigates to consign submission when submit button is pressed", () => {
-      const artworkProps = { artwork: { internalID: "someInternalId" } }
+    it("tracks an analytics event submit button is pressed", () => {
+      const artworkProps = { artwork: { internalID: "someInternalId", slug: "someSlug" } }
+      GlobalStore.actions.myCollection.artwork.startEditingArtwork = jest.fn() as any
+
       const wrapper = getWrapper(artworkProps)
       wrapper.root.findByProps({ "data-test-id": "SubmitButton" }).props.onPress()
-      expect(navigate).toHaveBeenCalledWith("/consign/submission")
+
+      expect(trackEvent).toHaveBeenCalledTimes(1)
+      expect(trackEvent).toHaveBeenCalledWith(
+        tappedSell({
+          contextModule: ContextModule.myCollectionArtwork,
+          contextScreenOwnerType: OwnerType.myCollectionArtwork,
+          contextScreenOwnerId: "someInternalId",
+          contextScreenOwnerSlug: "someSlug",
+          subject: "Submit this work",
+        })
+      )
     })
 
-    it("navigates to sales page when learn more button is pressed", () => {
-      const artworkProps = { artwork: { internalID: "someInternalId" } }
+    it("tracks an analytics event learn more button is pressed", () => {
+      const artworkProps = { artwork: { internalID: "someInternalId", slug: "someSlug" } }
+      GlobalStore.actions.myCollection.artwork.startEditingArtwork = jest.fn() as any
+
       const wrapper = getWrapper(artworkProps)
       wrapper.root.findByProps({ "data-test-id": "LearnMoreButton" }).props.onPress()
-      expect(navigate).toHaveBeenCalledWith("/sales")
+
+      expect(trackEvent).toHaveBeenCalledTimes(1)
+      expect(trackEvent).toHaveBeenCalledWith({
+        action: ActionType.tappedShowMore,
+        context_module: ContextModule.myCollectionArtwork,
+        context_screen_owner_type: OwnerType.myCollectionArtwork,
+        context_screen_owner_id: "someInternalId",
+        context_screen_owner_slug: "someSlug",
+        subject: "Learn More",
+      })
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,9 +8,9 @@
   integrity sha512-mJyuKNDMYZcgc2oLIkvmpVIr1RexklV71JmU+to5qs3Y9pv5dsj4WHl8+wf9g74EQNOyhWH2SYMGBm1JoPYh/Q==
 
 "@artsy/cohesion@^1.67.8":
-  version "1.67.8"
-  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-1.67.8.tgz#ea6506f0ab5e1d0ce534ee78cf3c1dbbe52aa130"
-  integrity sha512-YaTTMT1zEVCK+lb+CLj6KuUh8XwrbcSov3f/DehimWcaNVs97JBOknuvVxj9mo9s901/Kv2m0Fj5xHNHxrpphw==
+  version "1.68.0"
+  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-1.68.0.tgz#e7b0608cf37a57fa846f09d1eefce3537bce295a"
+  integrity sha512-NwGMFH1DBgkMsigxcYs1y0qFb7bif8xnLp6T5xwHzmWWqHB17lOjf0GhIydkam3vUxvo/TLxAMVeXt+BPD7vww==
 
 "@artsy/update-repo@0.2.0":
   version "0.2.0"


### PR DESCRIPTION
The type of this PR is: **Analytics**

This PR resolves [CX-923]

### Description

Adds tracking events for taps and screen views in my collection

- adds screen tracking for:  **MyCollection, MyCollectionArtwork** 
- tap tracking for:
   - **TappedSell**
   - **TappedShowMore for ‘Learn more’**
   - **TappedShowMore for ‘See all articles’**
   - **TappedShowMore for ‘Explore auction results’**
   - **TappedShowMore for ‘View more’**
 - updates cohesion to get latest schema
 - updates our analytics docs


Tap tracking for:


All these events should be implemented, just keeping a draft until I have addressed follow-ups below.

### TODO

- [x] Get clarity on if contextModules are correct
- [x] Tests on analytics firing
- [x] Update docs to advise using new cohesion screen tracking

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-923]: https://artsyproduct.atlassian.net/browse/CX-923