### PR TITLE
fix: ignore membership expiration warnings for message notifications #trivial

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -194,7 +194,8 @@ lane :notify_if_new_license_agreement do
   client.team_id = '479887'
   messages = Spaceship::Tunes.client.fetch_program_license_agreement_messages
 
-  if !messages.empty?
+  # ignore membership expiration warnings, auto-renew should take care of
+  if !messages.empty? and !messages[0].include? "membership expiration"
     message = <<~MSG
                 :apple: :handshake: :pencil:
                 There is a new developer program agreement that needs to be signed to continue shipping!

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -195,7 +195,7 @@ lane :notify_if_new_license_agreement do
   messages = Spaceship::Tunes.client.fetch_program_license_agreement_messages
 
   # ignore membership expiration warnings, auto-renew should take care of
-  if !messages.empty? and !messages[0].include? "membership expiration"
+  unless messages.empty? || messages[0].include?("membership expiration")
     message = <<~MSG
                 :apple: :handshake: :pencil:
                 There is a new developer program agreement that needs to be signed to continue shipping!


### PR DESCRIPTION
The type of this PR is: **Bugfix**

### Description

Don't send a slack notification when App Store connect warns us about dev account expiration date. This notification is meant to be for new license agreements that need to be reviewed.

