### PR TITLE
fix: safer empty location check #trivial

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -11,6 +11,7 @@ upcoming:
     - Removes unused native code - ash
     - More analytics for My Collection - brian
     - Points to Artsy forks only - ash
+    - Fix crash on entering city guide - brian
   user_facing:
     - Fix logout alert not showing up on changing password - brian
     - Fix a layout bug (double separator) in My Collection Artwork Details

--- a/src/lib/Scenes/Map/GlobalMap.tsx
+++ b/src/lib/Scenes/Map/GlobalMap.tsx
@@ -492,9 +492,10 @@ export class GlobalMap extends React.Component<Props, State> {
   }
 
   onUserLocationUpdate = (location: MapboxGL.Location) => {
-    if (location === null || location.coords === null) {
+    if (!location || !location.coords) {
       return
     }
+
     this.setState({
       userLocation: GlobalMap.longCoordsToLocation(location.coords),
     })


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [CX-927]

### Description

Check for undefined values rather than explicitly null values. A crash was occurring on entering city guide and giving location permission, best guess is the first location update callback was returning an  empty/undefined location object and the location.coords check was then causing a crash accessing an undefined property.

![IMG_0974](https://user-images.githubusercontent.com/49686530/103585640-6a07b500-4eb1-11eb-8d96-9a4aa2d90d09.PNG)


### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-927]: https://artsyproduct.atlassian.net/browse/CX-927