### PR TITLE
fix: fix fairs rail empty state in homepage

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -16,6 +16,7 @@ upcoming:
     - Fix a layout bug (double separator) in My Collection Artwork Details
     - Fix a layout bug (double separator) in My Collection Artwork Details - adam
     - Fix layout in My Collection artwork form AdditionalDetails screen - david
+    - Fix empty state featured fairs rail on homepage - anna, mounir
 
 releases:
   - version: 6.7.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -891,7 +891,7 @@ SPEC CHECKSUMS:
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   CocoaLumberjack: aa9dcab71bdf9eaf2a63bbd9ddc87863efe45457
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
-  DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
+  DoubleConversion: cde416483dac037923206447da6e1454df403714
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
   Emission: cb9fd158eac9aa56e44a65b15e7a525c1ce11a48
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
@@ -913,7 +913,7 @@ SPEC CHECKSUMS:
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   Forgeries: 64ced144ea8341d89a7eec9d1d7986f0f1366250
   FXBlurView: 5121730176fd52bcf7bffd0bd8c1485e8aabc3cb
-  glog: 1f3da668190260b06b429bb211bfbee5cd790c28
+  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   Interstellar: ab67502af03105f92100a043e178d188a1a437c9
   INTUAnimationEngine: 3a7d63738cd51af573d16848a771feedea7cc9f2
   ISO8601DateFormatter: 8311a2d4e265b269b2fed7ab4db685dcb0a7ccb2

--- a/src/lib/Scenes/Home/Components/FairsRail.tsx
+++ b/src/lib/Scenes/Home/Components/FairsRail.tsx
@@ -35,15 +35,19 @@ const FairsRail: React.FC<Props & RailScrollProps> = (props) => {
     scrollToTop: () => listRef.current?.scrollToOffset({ offset: 0, animated: false }),
   }))
 
+  const FairHeader = () => (
+    <Flex pl="2" pr="2">
+      <SectionTitle title="Featured fairs" subtitle="See works in top art fairs" />
+    </Flex>
+  )
+
   return (
     <View>
-      <Flex pl="2" pr="2">
-        <SectionTitle title="Featured fairs" subtitle="See works in top art fairs" />
-      </Flex>
-
       <CardRailFlatList<FairItem>
         listRef={listRef}
         data={props.fairsModule.results}
+        ListEmptyComponent={() => <React.Fragment />}
+        ListHeaderComponent={() => (props.fairsModule.results.length ? <FairHeader /> : null)}
         renderItem={({ item: result, index }) => {
           // Fairs are expected to always have >= 2 artworks and a hero image.
           // We can make assumptions about this in UI layout, but should still

--- a/src/lib/Scenes/Home/Components/SalesRail.tsx
+++ b/src/lib/Scenes/Home/Components/SalesRail.tsx
@@ -55,7 +55,6 @@ const SalesRail: React.FC<Props & RailScrollProps> = (props) => {
           }}
         />
       </Flex>
-
       <CardRailFlatList<Sale>
         listRef={listRef}
         data={props.salesModule.results}

--- a/src/lib/Scenes/Home/Components/__tests__/FairsRail-tests.tsx
+++ b/src/lib/Scenes/Home/Components/__tests__/FairsRail-tests.tsx
@@ -8,7 +8,9 @@ import { extractText } from "lib/tests/extractText"
 import { FairsRailFragmentContainer } from "../FairsRail"
 
 import { CardRailCard } from "lib/Components/Home/CardRailCard"
+import { SectionTitle } from "lib/Components/SectionTitle"
 import { navigate } from "lib/navigation/navigate"
+import { Text } from "palette"
 import { useTracking } from "react-tracking"
 import HomeAnalytics from "../../homeAnalytics"
 
@@ -18,6 +20,10 @@ const artworkNode = {
   node: {
     image: { url: "https://example.com/image.jpg" },
   },
+}
+
+const emptyFairsModule: Omit<FairsRail_fairsModule, " $refType"> = {
+  results: [],
 }
 const fairsModule: Omit<FairsRail_fairsModule, " $refType"> = {
   results: [
@@ -64,6 +70,20 @@ const fairsModule: Omit<FairsRail_fairsModule, " $refType"> = {
 
 it("renders without throwing an error", () => {
   renderWithWrappers(<FairsRailFragmentContainer fairsModule={fairsModule as any} scrollRef={mockScrollRef} />)
+})
+
+it("renders results when there are fairs returned", () => {
+  const tree = renderWithWrappers(
+    <FairsRailFragmentContainer fairsModule={fairsModule as any} scrollRef={mockScrollRef} />
+  )
+  expect(tree.root.findAllByType(Text)[0].props.children).toMatch("Featured fairs")
+})
+
+it("does not render results when there are no fairs returned", () => {
+  const tree = renderWithWrappers(
+    <FairsRailFragmentContainer fairsModule={emptyFairsModule as any} scrollRef={mockScrollRef} />
+  )
+  expect(tree.root.findAllByType(SectionTitle).length).toEqual(0)
 })
 
 it("renders without throwing an error when missing artworks", () => {


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-924]

### Description

<!-- Implementation description -->
Fix fairs rail empty state in homepage

<img width="410" alt="Screen Shot 2021-01-05 at 11 08 43 AM" src="https://user-images.githubusercontent.com/9466631/103682682-6b36f180-4f46-11eb-9b01-03f4411362fc.png">

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-924]: https://artsyproduct.atlassian.net/browse/CX-924