### PR TITLE
fix: alignment issue with fairs header #trivial

### DIFF
--- a/src/lib/Scenes/Home/Components/FairsRail.tsx
+++ b/src/lib/Scenes/Home/Components/FairsRail.tsx
@@ -43,11 +43,11 @@ const FairsRail: React.FC<Props & RailScrollProps> = (props) => {
 
   return (
     <View>
+      {props.fairsModule.results.length ? <FairHeader /> : null}
       <CardRailFlatList<FairItem>
         listRef={listRef}
         data={props.fairsModule.results}
         ListEmptyComponent={() => <React.Fragment />}
-        ListHeaderComponent={() => (props.fairsModule.results.length ? <FairHeader /> : null)}
         renderItem={({ item: result, index }) => {
           // Fairs are expected to always have >= 2 artworks and a hero image.
           // We can make assumptions about this in UI layout, but should still


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [CX-930]

### Description

Looks like there is an alignment issue with the list header prop for horizontal rails. This uses the same logic of the but moves header outside this prop. 

### Before:

![featured_fairs_header_before](https://user-images.githubusercontent.com/49686530/103707755-3d20d400-4f7d-11eb-93c4-a797f32ab131.PNG)

### After:
![featured_fairs_header](https://user-images.githubusercontent.com/49686530/103707690-1b275180-4f7d-11eb-8ce1-ff27a9609fd0.png)


### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-930]: https://artsyproduct.atlassian.net/browse/CX-930