### PR TITLE
feat: add auctionResults filters button and empty screen

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -19,6 +19,7 @@ upcoming:
     - Fix layout in My Collection artwork form AdditionalDetails screen - david
     - Make active bids clickable - anna, mounir
     - Fix empty state featured fairs rail on homepage - anna, mounir
+    - Add filter button and screen to the ArtistInsights AuctionResults - mounir
 
 releases:
   - version: 6.7.4

--- a/patches/@types+react-native+0.63.25.patch
+++ b/patches/@types+react-native+0.63.25.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/@types/react-native/index.d.ts b/node_modules/@types/react-native/index.d.ts
+index 5bfb410..7f43a26 100644
+--- a/node_modules/@types/react-native/index.d.ts
++++ b/node_modules/@types/react-native/index.d.ts
+@@ -6921,6 +6921,7 @@ export interface NativeScrollEvent {
+     contentOffset: NativeScrollPoint;
+     contentSize: NativeScrollSize;
+     layoutMeasurement: NativeScrollSize;
++    targetContentOffset: NativeScrollPoint;
+     velocity?: NativeScrollVelocity;
+     zoomScale: number;
+ }

--- a/src/__generated__/ArtistBelowTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtistBelowTheFoldQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash c8369d23b2d2f82ed4c8688d8ff71b9a */
+/* @relayHash 500888d510e9e7d2fb969eec5a3a2843 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -139,6 +139,8 @@ fragment ArtistInsightsAuctionResults_artist on Artist {
 
 fragment ArtistInsights_artist on Artist {
   name
+  id
+  slug
   ...ArtistInsightsAuctionResults_artist
 }
 
@@ -854,6 +856,7 @@ return {
             ],
             "storageKey": "articlesConnection(first:10)"
           },
+          (v5/*: any*/),
           {
             "alias": null,
             "args": (v12/*: any*/),
@@ -1080,7 +1083,6 @@ return {
             "kind": "LinkedHandle",
             "name": "auctionResultsConnection"
           },
-          (v5/*: any*/),
           {
             "condition": "isPad",
             "kind": "Condition",
@@ -1121,7 +1123,7 @@ return {
     ]
   },
   "params": {
-    "id": "c8369d23b2d2f82ed4c8688d8ff71b9a",
+    "id": "500888d510e9e7d2fb969eec5a3a2843",
     "metadata": {},
     "name": "ArtistBelowTheFoldQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistHeaderTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistHeaderTestsQuery.graphql.ts
@@ -1,0 +1,240 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash a31929eacfc4ec2a8bdfe5e06a9e019b */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ArtistHeaderTestsQueryVariables = {
+    artistID: string;
+};
+export type ArtistHeaderTestsQueryResponse = {
+    readonly artist: {
+        readonly " $fragmentRefs": FragmentRefs<"ArtistHeader_artist">;
+    } | null;
+};
+export type ArtistHeaderTestsQuery = {
+    readonly response: ArtistHeaderTestsQueryResponse;
+    readonly variables: ArtistHeaderTestsQueryVariables;
+};
+
+
+
+/*
+query ArtistHeaderTestsQuery(
+  $artistID: String!
+) {
+  artist(id: $artistID) {
+    ...ArtistHeader_artist
+    id
+  }
+}
+
+fragment ArtistHeader_artist on Artist {
+  id
+  internalID
+  slug
+  isFollowed
+  name
+  nationality
+  birthday
+  counts {
+    artworks
+    follows
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "artistID"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "artistID"
+  }
+],
+v2 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v3 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "FormattedNumber"
+},
+v4 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtistHeaderTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artist",
+        "kind": "LinkedField",
+        "name": "artist",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ArtistHeader_artist"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ArtistHeaderTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artist",
+        "kind": "LinkedField",
+        "name": "artist",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "internalID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isFollowed",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "nationality",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "birthday",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtistCounts",
+            "kind": "LinkedField",
+            "name": "counts",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "artworks",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "follows",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "a31929eacfc4ec2a8bdfe5e06a9e019b",
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "artist": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artist"
+        },
+        "artist.birthday": (v2/*: any*/),
+        "artist.counts": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtistCounts"
+        },
+        "artist.counts.artworks": (v3/*: any*/),
+        "artist.counts.follows": (v3/*: any*/),
+        "artist.id": (v4/*: any*/),
+        "artist.internalID": (v4/*: any*/),
+        "artist.isFollowed": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Boolean"
+        },
+        "artist.name": (v2/*: any*/),
+        "artist.nationality": (v2/*: any*/),
+        "artist.slug": (v4/*: any*/)
+      }
+    },
+    "name": "ArtistHeaderTestsQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = '2f7b7f0b600359c5326be3eada8ba832';
+export default node;

--- a/src/__generated__/ArtistInsightsTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistInsightsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 2814683178a8cf8893817007457734c1 */
+/* @relayHash fd7fc874bd9f87114780c47fea2a39c5 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -45,6 +45,8 @@ fragment ArtistInsightsAuctionResults_artist on Artist {
 
 fragment ArtistInsights_artist on Artist {
   name
+  id
+  slug
   ...ArtistInsightsAuctionResults_artist
 }
 
@@ -83,7 +85,14 @@ var v0 = [
     "value": "some-id"
   }
 ],
-v1 = [
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -95,13 +104,6 @@ v1 = [
     "value": "DATE_DESC"
   }
 ],
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
 v3 = {
   "enumValues": null,
   "nullable": false,
@@ -180,9 +182,17 @@ return {
             "name": "name",
             "storageKey": null
           },
+          (v1/*: any*/),
           {
             "alias": null,
-            "args": (v1/*: any*/),
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
             "concreteType": "AuctionResultConnection",
             "kind": "LinkedField",
             "name": "auctionResultsConnection",
@@ -204,7 +214,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v2/*: any*/),
+                      (v1/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -403,7 +413,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v1/*: any*/),
+            "args": (v2/*: any*/),
             "filters": [
               "sort"
             ],
@@ -411,15 +421,14 @@ return {
             "key": "artist_auctionResultsConnection",
             "kind": "LinkedHandle",
             "name": "auctionResultsConnection"
-          },
-          (v2/*: any*/)
+          }
         ],
         "storageKey": "artist(id:\"some-id\")"
       }
     ]
   },
   "params": {
-    "id": "2814683178a8cf8893817007457734c1",
+    "id": "fd7fc874bd9f87114780c47fea2a39c5",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artist": {
@@ -511,7 +520,8 @@ return {
           "type": "Boolean"
         },
         "artist.id": (v6/*: any*/),
-        "artist.name": (v4/*: any*/)
+        "artist.name": (v4/*: any*/),
+        "artist.slug": (v6/*: any*/)
       }
     },
     "name": "ArtistInsightsTestsQuery",

--- a/src/__generated__/ArtistInsights_artist.graphql.ts
+++ b/src/__generated__/ArtistInsights_artist.graphql.ts
@@ -6,6 +6,8 @@ import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ArtistInsights_artist = {
     readonly name: string | null;
+    readonly id: string;
+    readonly slug: string;
     readonly " $fragmentRefs": FragmentRefs<"ArtistInsightsAuctionResults_artist">;
     readonly " $refType": "ArtistInsights_artist";
 };
@@ -31,6 +33,20 @@ const node: ReaderFragment = {
       "storageKey": null
     },
     {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
+    },
+    {
       "args": null,
       "kind": "FragmentSpread",
       "name": "ArtistInsightsAuctionResults_artist"
@@ -39,5 +55,5 @@ const node: ReaderFragment = {
   "type": "Artist",
   "abstractKey": null
 };
-(node as any).hash = '0f4ed2f79178cc846918187f69af8a1d';
+(node as any).hash = 'c326ec4371dc0efa92927e40cb0a7016';
 export default node;

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -375,21 +375,21 @@ export default createPaginationContainer(
         node(id: $id) {
           ... on Artist {
             ...ArtistArtworks_artist
-            @arguments(
-              count: $count
-              cursor: $cursor
-              sort: $sort
-              medium: $medium
-              color: $color
-              partnerID: $partnerID
-              priceRange: $priceRange
-              dimensionRange: $dimensionRange
-              majorPeriods: $majorPeriods
-              acquireable: $acquireable
-              inquireableOnly: $inquireableOnly
-              atAuction: $atAuction
-              offerable: $offerable
-            )
+              @arguments(
+                count: $count
+                cursor: $cursor
+                sort: $sort
+                medium: $medium
+                color: $color
+                partnerID: $partnerID
+                priceRange: $priceRange
+                dimensionRange: $dimensionRange
+                majorPeriods: $majorPeriods
+                acquireable: $acquireable
+                inquireableOnly: $inquireableOnly
+                atAuction: $atAuction
+                offerable: $offerable
+              )
           }
         }
       }

--- a/src/lib/Components/Artist/ArtistHeader.tsx
+++ b/src/lib/Components/Artist/ArtistHeader.tsx
@@ -3,85 +3,31 @@ import { ArtistHeaderFollowArtistMutation } from "__generated__/ArtistHeaderFoll
 import { userHadMeaningfulInteraction } from "lib/NativeModules/Events"
 import { formatText } from "lib/utils/formatText"
 import { Box, bullet, Button, Flex, Sans, Spacer } from "palette"
-import React from "react"
+import React, { useState } from "react"
 import { Text } from "react-native"
 import { commitMutation, createFragmentContainer, graphql, RelayProp } from "react-relay"
+import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
-import { Schema, track } from "../../utils/track"
+import { Schema } from "../../utils/track"
 
 interface Props {
   artist: ArtistHeader_artist
   relay: RelayProp
 }
 
-interface State {
-  followersCount: number
-  isFollowedChanging: boolean
-}
+const ArtistHeader: React.FC<Props> = ({ artist, relay }) => {
+  const { trackEvent } = useTracking()
 
-@track()
-class Header extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props)
-    this.state = {
-      isFollowedChanging: false,
-      followersCount: props.artist.counts?.follows ?? 0,
-    }
-  }
+  const [isFollowedChanging, setIsFollowedChanging] = useState<boolean>(false)
+  const followersCount = artist.counts?.follows ?? 0
 
-  render() {
-    const { artist } = this.props
-    const followersCount = this.state.followersCount
-    const bylineRequired = artist.nationality || artist.birthday
-
-    return (
-      <Box px={2} pt={6} pb={1}>
-        <Sans size="8">{artist.name}</Sans>
-        <Spacer mb={1} />
-        {Boolean(followersCount || bylineRequired) && (
-          <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
-            <Flex flex={1}>
-              {!!bylineRequired && (
-                <Sans mr={1} size="3t">
-                  {this.descriptiveString()}
-                </Sans>
-              )}
-              <Sans size="3t">
-                {formatText(artist.counts?.artworks ?? 0, "work")}
-                {` ${bullet} `}
-                {formatText(artist.counts?.follows ?? 0, "follower")}
-              </Sans>
-            </Flex>
-            <Flex>
-              <Button
-                variant={this.props.artist.isFollowed ? "secondaryOutline" : "primaryBlack"}
-                loading={this.state.isFollowedChanging}
-                onPress={this.handleFollowChange.bind(this)}
-                size="small"
-                longestText="Following"
-              >
-                {this.props.artist.isFollowed ? "Following" : "Follow"}
-              </Button>
-            </Flex>
-          </Flex>
-        )}
-      </Box>
-    )
-  }
-
-  descriptiveString() {
-    const artist = this.props.artist
-    const descriptiveString = (artist.nationality || "") + this.birthdayString()
-    return descriptiveString
-  }
-
-  birthdayString() {
-    const birthday = this.props.artist.birthday
+  const getBirthdayString = () => {
+    const birthday = artist.birthday
     if (!birthday) {
       return ""
     }
 
-    const leadingSubstring = this.props.artist.nationality ? ", b." : ""
+    const leadingSubstring = artist.nationality ? ", b." : ""
 
     if (birthday.includes("born")) {
       return birthday.replace("born", leadingSubstring)
@@ -92,92 +38,117 @@ class Header extends React.Component<Props, State> {
     return leadingSubstring + " " + birthday
   }
 
-  @track((props) => ({
-    action_name: props.artist.isFollowed ? Schema.ActionNames.ArtistUnfollow : Schema.ActionNames.ArtistFollow,
-    action_type: Schema.ActionTypes.Tap,
-    owner_id: props.artist.internalID,
-    owner_slug: props.artist.slug,
-    owner_type: Schema.OwnerEntityTypes.Artist,
-  }))
-  handleFollowChange() {
-    const {
-      relay,
-      artist: { slug, id, isFollowed },
-    } = this.props
-    const { isFollowedChanging } = this.state
+  const handleFollowChange = () => {
+    trackEvent({
+      action_name: artist.isFollowed ? Schema.ActionNames.ArtistUnfollow : Schema.ActionNames.ArtistFollow,
+      action_type: Schema.ActionTypes.Tap,
+      owner_id: artist.internalID,
+      owner_slug: artist.slug,
+      owner_type: Schema.OwnerEntityTypes.Artist,
+    })
 
     if (isFollowedChanging) {
       return
     }
 
-    this.setState(
-      {
-        isFollowedChanging: true,
-      },
-      () => {
-        commitMutation<ArtistHeaderFollowArtistMutation>(relay.environment, {
-          onCompleted: () => this.successfulFollowChange(),
-          mutation: graphql`
-            mutation ArtistHeaderFollowArtistMutation($input: FollowArtistInput!) {
-              followArtist(input: $input) {
-                artist {
-                  id
-                  isFollowed
-                }
-              }
+    setIsFollowedChanging(true)
+
+    commitMutation<ArtistHeaderFollowArtistMutation>(relay.environment, {
+      onCompleted: () => successfulFollowChange(),
+      mutation: graphql`
+        mutation ArtistHeaderFollowArtistMutation($input: FollowArtistInput!) {
+          followArtist(input: $input) {
+            artist {
+              id
+              isFollowed
             }
-          `,
-          variables: {
-            input: {
-              artistID: slug,
-              unfollow: isFollowed,
-            },
+          }
+        }
+      `,
+      variables: {
+        input: {
+          artistID: artist.slug,
+          unfollow: artist.isFollowed,
+        },
+      },
+      optimisticResponse: {
+        followArtist: {
+          artist: {
+            id: artist.id,
+            isFollowed: !artist.isFollowed,
           },
-          optimisticResponse: {
-            followArtist: {
-              artist: {
-                id,
-                isFollowed: !isFollowed,
-              },
-            },
-          },
-          onError: () => this.failedFollowChange(),
-        })
-      }
-    )
+        },
+      },
+      onError: () => failedFollowChange(),
+    })
   }
 
-  @track((props) => ({
-    action_name: props.artist.isFollowed ? Schema.ActionNames.ArtistFollow : Schema.ActionNames.ArtistUnfollow,
-    action_type: Schema.ActionTypes.Success,
-    owner_id: props.artist.internalID,
-    owner_slug: props.artist.slug,
-    owner_type: Schema.OwnerEntityTypes.Artist,
-  }))
-  successfulFollowChange() {
+  const successfulFollowChange = () => {
+    trackEvent({
+      action_name: artist.isFollowed ? Schema.ActionNames.ArtistFollow : Schema.ActionNames.ArtistUnfollow,
+      action_type: Schema.ActionTypes.Success,
+      owner_id: artist.internalID,
+      owner_slug: artist.slug,
+      owner_type: Schema.OwnerEntityTypes.Artist,
+    })
+
     // callback for analytics purposes
     userHadMeaningfulInteraction()
-    this.setState({
-      isFollowedChanging: false,
-    })
+    setIsFollowedChanging(false)
   }
 
-  @track((props) => ({
-    action_name: props.artist.isFollowed ? Schema.ActionNames.ArtistFollow : Schema.ActionNames.ArtistUnfollow,
-    action_type: Schema.ActionTypes.Fail,
-    owner_id: props.artist.internalID,
-    owner_slug: props.artist.slug,
-    owner_type: Schema.OwnerEntityTypes.Artist,
-  }))
-  failedFollowChange() {
-    // callback for analytics purposes
-    this.setState({
-      isFollowedChanging: false,
+  const failedFollowChange = () => {
+    trackEvent({
+      action_name: artist.isFollowed ? Schema.ActionNames.ArtistFollow : Schema.ActionNames.ArtistUnfollow,
+      action_type: Schema.ActionTypes.Fail,
+      owner_id: artist.internalID,
+      owner_slug: artist.slug,
+      owner_type: Schema.OwnerEntityTypes.Artist,
     })
+    // callback for analytics purposes
+    setIsFollowedChanging(false)
   }
+
+  const descriptiveString = (artist.nationality || "") + getBirthdayString()
+
+  const bylineRequired = artist.nationality || artist.birthday
+
+  return (
+    <Box px={2} pt={6} pb={1}>
+      <Sans size="8">{artist.name}</Sans>
+      <Spacer mb={1} />
+      {Boolean(followersCount || bylineRequired) && (
+        <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
+          <Flex flex={1}>
+            {!!bylineRequired && (
+              <Sans mr={1} size="3t">
+                {descriptiveString}
+              </Sans>
+            )}
+            <Sans size="3t">
+              {formatText(artist.counts?.artworks ?? 0, "work")}
+              {` ${bullet} `}
+              {formatText(artist.counts?.follows ?? 0, "follower")}
+            </Sans>
+          </Flex>
+          <Flex>
+            <Button
+              variant={artist.isFollowed ? "secondaryOutline" : "primaryBlack"}
+              loading={isFollowedChanging}
+              onPress={handleFollowChange}
+              size="small"
+              longestText="Following"
+            >
+              {artist.isFollowed ? "Following" : "Follow"}
+            </Button>
+          </Flex>
+        </Flex>
+      )}
+    </Box>
+  )
 }
 
-export default createFragmentContainer(Header, {
+export const ArtistHeaderFragmentContainer = createFragmentContainer(ArtistHeader, {
   artist: graphql`
     fragment ArtistHeader_artist on Artist {
       id

--- a/src/lib/Components/Artist/ArtistHeader.tsx
+++ b/src/lib/Components/Artist/ArtistHeader.tsx
@@ -15,7 +15,7 @@ interface Props {
   relay: RelayProp
 }
 
-const ArtistHeader: React.FC<Props> = ({ artist, relay }) => {
+export const ArtistHeader: React.FC<Props> = ({ artist, relay }) => {
   const { trackEvent } = useTracking()
 
   const [isFollowedChanging, setIsFollowedChanging] = useState<boolean>(false)

--- a/src/lib/Components/Artist/ArtistInsights/ArtistInsights.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/ArtistInsights.tsx
@@ -89,6 +89,7 @@ export const ArtistInsights: React.FC<ArtistInsightsProps> = ({ artist }) => {
           onPress={() => {
             // show filters modal
           }}
+          text="Filter auction results"
         />
       </Flex>
     </ArtworkFilterGlobalStateProvider>

--- a/src/lib/Components/Artist/ArtistInsights/ArtistInsights.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/ArtistInsights.tsx
@@ -1,17 +1,44 @@
 import { ArtistInsights_artist } from "__generated__/ArtistInsights_artist.graphql"
+import { AnimatedArtworkFilterButton } from "lib/Components/FilterModal"
 import { StickyTabPageScrollView } from "lib/Components/StickyTabPage/StickyTabPageScrollView"
+import { ArtworkFilterGlobalStateProvider } from "lib/utils/ArtworkFilter/ArtworkFiltersStore"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { Flex, Join, Separator, Text } from "palette"
-import React from "react"
-import { Image, TouchableOpacity } from "react-native"
+import React, { useState } from "react"
+import { Image, NativeScrollEvent, NativeSyntheticEvent, TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
+import { ReactElement } from "simple-markdown"
 import { ArtistInsightsAuctionResultsPaginationContainer } from "./ArtistInsightsAuctionResults"
 
 interface ArtistInsightsProps {
   artist: ArtistInsights_artist
 }
 
+export interface ViewableItems {
+  viewableItems?: ViewToken[]
+}
+
+interface ViewToken {
+  item?: ReactElement
+  key?: string
+  index?: number | null
+  isViewable?: boolean
+  section?: any
+}
+
+const FILTER_BUTTON_OFFSET = 100
 export const ArtistInsights: React.FC<ArtistInsightsProps> = ({ artist }) => {
+  const [isFilterButtonVisible, setIsFilterButtonVisible] = useState(false)
+
+  // Show or hide floating filter button depending on the scroll position
+  const onScrollEndDrag = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    if (event.nativeEvent.targetContentOffset.y > FILTER_BUTTON_OFFSET) {
+      setIsFilterButtonVisible(true)
+      return
+    }
+    setIsFilterButtonVisible(false)
+  }
+
   const MarketStats = () => (
     <>
       {/* Market Stats Hint */}
@@ -49,12 +76,22 @@ export const ArtistInsights: React.FC<ArtistInsightsProps> = ({ artist }) => {
   )
 
   return (
-    <StickyTabPageScrollView contentContainerStyle={{ paddingTop: 20 }}>
-      <Join separator={<Separator my={2} ml={-2} width={useScreenDimensions().width} />}>
-        <MarketStats />
-        <ArtistInsightsAuctionResultsPaginationContainer artist={artist} />
-      </Join>
-    </StickyTabPageScrollView>
+    <ArtworkFilterGlobalStateProvider>
+      <StickyTabPageScrollView contentContainerStyle={{ paddingTop: 20 }} onScrollEndDrag={onScrollEndDrag}>
+        <Join separator={<Separator my={2} ml={-2} width={useScreenDimensions().width} />}>
+          <MarketStats />
+          <ArtistInsightsAuctionResultsPaginationContainer artist={artist} />
+        </Join>
+      </StickyTabPageScrollView>
+      <Flex position="absolute" width="100%" bottom={0}>
+        <AnimatedArtworkFilterButton
+          isVisible={isFilterButtonVisible}
+          onPress={() => {
+            // show filters modal
+          }}
+        />
+      </Flex>
+    </ArtworkFilterGlobalStateProvider>
   )
 }
 

--- a/src/lib/Components/Artist/ArtistInsights/ArtistInsights.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/ArtistInsights.tsx
@@ -1,5 +1,5 @@
 import { ArtistInsights_artist } from "__generated__/ArtistInsights_artist.graphql"
-import { AnimatedArtworkFilterButton } from "lib/Components/FilterModal"
+import { AnimatedArtworkFilterButton, FilterModalMode, FilterModalNavigator } from "lib/Components/FilterModal"
 import { StickyTabPageScrollView } from "lib/Components/StickyTabPage/StickyTabPageScrollView"
 import { ArtworkFilterGlobalStateProvider } from "lib/utils/ArtworkFilter/ArtworkFiltersStore"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
@@ -29,6 +29,15 @@ interface ViewToken {
 const FILTER_BUTTON_OFFSET = 100
 export const ArtistInsights: React.FC<ArtistInsightsProps> = ({ artist }) => {
   const [isFilterButtonVisible, setIsFilterButtonVisible] = useState(false)
+  const [isFilterModalVisible, setIsFilterModalVisible] = useState(false)
+
+  const openFilterModal = () => {
+    setIsFilterModalVisible(true)
+  }
+
+  const closeFilterModal = () => {
+    setIsFilterModalVisible(false)
+  }
 
   // Show or hide floating filter button depending on the scroll position
   const onScrollEndDrag = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
@@ -83,15 +92,22 @@ export const ArtistInsights: React.FC<ArtistInsightsProps> = ({ artist }) => {
           <ArtistInsightsAuctionResultsPaginationContainer artist={artist} />
         </Join>
       </StickyTabPageScrollView>
-      <Flex position="absolute" width="100%" bottom={0}>
-        <AnimatedArtworkFilterButton
-          isVisible={isFilterButtonVisible}
-          onPress={() => {
-            // show filters modal
-          }}
-          text="Filter auction results"
-        />
-      </Flex>
+
+      <AnimatedArtworkFilterButton
+        isVisible={isFilterButtonVisible}
+        onPress={openFilterModal}
+        text="Filter auction results"
+      />
+
+      <FilterModalNavigator
+        isFilterArtworksModalVisible={isFilterModalVisible}
+        id={artist.id}
+        slug={artist.slug}
+        mode={FilterModalMode.AuctionResults}
+        exitModal={closeFilterModal}
+        closeModal={closeFilterModal}
+        title="Filter auction results"
+      />
     </ArtworkFilterGlobalStateProvider>
   )
 }
@@ -100,6 +116,8 @@ export const ArtistInsightsFragmentContainer = createFragmentContainer(ArtistIns
   artist: graphql`
     fragment ArtistInsights_artist on Artist {
       name
+      id
+      slug
       ...ArtistInsightsAuctionResults_artist
     }
   `,

--- a/src/lib/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
@@ -1,9 +1,11 @@
 import { ArtistInsightsAuctionResults_artist } from "__generated__/ArtistInsightsAuctionResults_artist.graphql"
 import Spinner from "lib/Components/Spinner"
 import { PAGE_SIZE } from "lib/data/constants"
+import { ArtworkFilterContext } from "lib/utils/ArtworkFilter/ArtworkFiltersStore"
+import { filterArtworksParams } from "lib/utils/ArtworkFilter/FilterArtworksHelpers"
 import { extractNodes } from "lib/utils/extractNodes"
 import { Flex, Separator, Text } from "palette"
-import React, { useState } from "react"
+import React, { useContext, useEffect, useState } from "react"
 import { FlatList } from "react-native"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import { useScreenDimensions } from "../../../utils/useScreenDimensions"
@@ -15,6 +17,30 @@ interface Props {
 }
 
 const ArtistInsightsAuctionResults: React.FC<Props> = ({ artist, relay }) => {
+  const { state, dispatch } = useContext(ArtworkFilterContext)
+  const filterParams = filterArtworksParams(state.appliedFilters, "auctionResult")
+
+  useEffect(() => {
+    dispatch({
+      type: "setFilterType",
+      payload: "auctionResult",
+    })
+  }, [])
+
+  useEffect(() => {
+    if (state.applyFilters) {
+      relay.refetchConnection(
+        PAGE_SIZE,
+        (error) => {
+          if (error) {
+            throw new Error("ArtistArtworks/ArtistArtworks filter error: " + error.message)
+          }
+        },
+        filterParams
+      )
+    }
+  }, [state.appliedFilters])
+
   const auctionResults = extractNodes(artist.auctionResultsConnection)
   const [loadingMoreData, setLoadingMoreData] = useState(false)
 

--- a/src/lib/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
@@ -33,7 +33,7 @@ const ArtistInsightsAuctionResults: React.FC<Props> = ({ artist, relay }) => {
         PAGE_SIZE,
         (error) => {
           if (error) {
-            throw new Error("ArtistArtworks/ArtistArtworks filter error: " + error.message)
+            throw new Error("ArtistInsights/ArtistAuctionResults filter error: " + error.message)
           }
         },
         filterParams

--- a/src/lib/Components/Artist/ArtistInsights/__tests__/ArtistInsightsAuctionResults-tests.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/__tests__/ArtistInsightsAuctionResults-tests.tsx
@@ -1,6 +1,7 @@
 import { ArtistInsightsAuctionResultsTestsQuery } from "__generated__/ArtistInsightsAuctionResultsTestsQuery.graphql"
 import { mockEdges } from "lib/tests/mockEnvironmentPayload"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { ArtworkFilterContext, ArtworkFilterContextState } from "lib/utils/ArtworkFilter/ArtworkFiltersStore"
 import React from "react"
 import { FlatList } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
@@ -13,7 +14,23 @@ jest.unmock("react-relay")
 
 describe("ArtistInsightsAuctionResults", () => {
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
-  beforeEach(() => (mockEnvironment = createMockEnvironment()))
+  let getState: () => ArtworkFilterContextState
+
+  beforeEach(() => {
+    mockEnvironment = createMockEnvironment()
+    getState = () => ({
+      selectedFilters: [],
+      appliedFilters: [],
+      previouslyAppliedFilters: [],
+      applyFilters: false,
+      aggregations: [],
+      filterType: "auctionResult",
+      counts: {
+        total: null,
+        followedArtists: null,
+      },
+    })
+  })
 
   const TestRenderer = () => (
     <QueryRenderer<ArtistInsightsAuctionResultsTestsQuery>
@@ -28,7 +45,11 @@ describe("ArtistInsightsAuctionResults", () => {
       variables={{}}
       render={({ props }) => {
         if (props?.artist) {
-          return <ArtistInsightsAuctionResultsPaginationContainer artist={props.artist} />
+          return (
+            <ArtworkFilterContext.Provider value={{ state: getState(), dispatch: jest.fn() }}>
+              <ArtistInsightsAuctionResultsPaginationContainer artist={props.artist} />
+            </ArtworkFilterContext.Provider>
+          )
         }
         return null
       }}

--- a/src/lib/Components/Artist/ArtistShows/ArtistShows.tsx
+++ b/src/lib/Components/Artist/ArtistShows/ArtistShows.tsx
@@ -13,45 +13,41 @@ interface Props {
   artist: ArtistShows_artist
 }
 
-class Shows extends React.Component<Props> {
-  render() {
-    const currentShows = extractNodes(this.props.artist.currentShows)
-    const upcomingShows = extractNodes(this.props.artist.upcomingShows)
-    const currentAndUpcomingShows = [...currentShows, ...upcomingShows]
+const Shows: React.FC<Props> = ({ artist }) => {
+  const currentShows = extractNodes(artist.currentShows)
+  const upcomingShows = extractNodes(artist.upcomingShows)
+  const currentAndUpcomingShows = [...currentShows, ...upcomingShows]
 
-    const pastLargeShows = extractNodes(this.props.artist.pastLargeShows)
-    const pastSmallShows = extractNodes(this.props.artist.pastSmallShows)
-    const pastShows = pastLargeShows.length ? pastLargeShows : pastSmallShows
-    return (
-      <StickyTabPageScrollView>
-        <Stack spacing={3} py={2}>
-          {!!currentAndUpcomingShows.length && (
-            <View>
-              <SectionTitle title="Current & Upcoming Shows" />
-              <VariableSizeShowsList showSize="large" shows={currentAndUpcomingShows} />
-            </View>
-          )}
-          {!!pastShows.length && (
-            <View>
-              <SectionTitle title="Past Shows" />
-              {this.pastShowsList()}
-            </View>
-          )}
-        </Stack>
-      </StickyTabPageScrollView>
-    )
-  }
+  const pastLargeShows = extractNodes(artist.pastLargeShows)
+  const pastSmallShows = extractNodes(artist.pastSmallShows)
+  const pastShows = pastLargeShows.length ? pastLargeShows : pastSmallShows
 
-  pastShowsList() {
-    // TODO: Use `this.props.relay.getVariables().isPad` when this gets merged: https://github.com/facebook/relay/pull/1868
-    if (this.props.artist.pastLargeShows) {
-      return <VariableSizeShowsList showSize={"medium"} shows={extractNodes(this.props.artist.pastLargeShows)} />
+  const pastShowsList = () => {
+    // TODO: Use `relay.getVariables().isPad` when this gets merged: https://github.com/facebook/relay/pull/1868
+    if (artist.pastLargeShows) {
+      return <VariableSizeShowsList showSize={"medium"} shows={extractNodes(artist.pastLargeShows)} />
     } else {
-      return (
-        <SmallList shows={extractNodes(this.props.artist.pastSmallShows)} style={{ marginTop: -8, marginBottom: 50 }} />
-      )
+      return <SmallList shows={extractNodes(artist.pastSmallShows)} style={{ marginTop: -8, marginBottom: 50 }} />
     }
   }
+  return (
+    <StickyTabPageScrollView>
+      <Stack spacing={3} py={2}>
+        {!!currentAndUpcomingShows.length && (
+          <View>
+            <SectionTitle title="Current & Upcoming Shows" />
+            <VariableSizeShowsList showSize="large" shows={currentAndUpcomingShows} />
+          </View>
+        )}
+        {!!pastShows.length && (
+          <View>
+            <SectionTitle title="Past Shows" />
+            {pastShowsList()}
+          </View>
+        )}
+      </Stack>
+    </StickyTabPageScrollView>
+  )
 }
 
 export default createFragmentContainer(Shows, {

--- a/src/lib/Components/Artist/__tests__/ArtistHeader-tests.tsx
+++ b/src/lib/Components/Artist/__tests__/ArtistHeader-tests.tsx
@@ -1,18 +1,60 @@
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { ArtistHeaderTestsQuery } from "__generated__/ArtistHeaderTestsQuery.graphql"
 import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import { createMockEnvironment } from "relay-test-utils"
 
-import { ArtistHeaderFragmentContainer } from "../ArtistHeader"
+import { ArtistHeaderFragmentContainer } from "lib/Components/Artist/ArtistHeader"
+import { mockEnvironmentPayload } from "lib/tests/mockEnvironmentPayload"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { Sans } from "palette"
 
-it("renders without throwing an error", () => {
-  const artist = {
-    internalID: "some-id",
-    id: "marcel-duchamp",
-    name: "Marcel Duchamp",
-    nationality: "French",
-    birthday: "11/17/1992",
-    counts: {
-      follows: 22,
-    },
+jest.unmock("react-relay")
+
+describe("ArtistHeader", () => {
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => (mockEnvironment = createMockEnvironment()))
+
+  function TestRenderer() {
+    return (
+      <QueryRenderer<ArtistHeaderTestsQuery>
+        environment={mockEnvironment}
+        query={graphql`
+          query ArtistHeaderTestsQuery($artistID: String!) @relay_test_operation {
+            artist(id: $artistID) {
+              ...ArtistHeader_artist
+            }
+          }
+        `}
+        variables={{ artistID: "artist-id" }}
+        render={({ props }) => {
+          if (props?.artist) {
+            return <ArtistHeaderFragmentContainer artist={props.artist} />
+          }
+          return null
+        }}
+      />
+    )
   }
-  renderWithWrappers(<ArtistHeaderFragmentContainer artist={artist as any} />)
+
+  it("renders properly", () => {
+    const tree = renderWithWrappers(<TestRenderer />)
+
+    mockEnvironmentPayload(mockEnvironment, {
+      Artist: () => mockArtist,
+    })
+
+    expect(tree.root.findAllByType(Sans)[0].props.children).toMatch("Marcel Duchamp")
+  })
 })
+
+const mockArtist = {
+  internalID: "some-id",
+  id: "marcel-duchamp",
+  name: "Marcel Duchamp",
+  nationality: "French",
+  birthday: "11/17/1992",
+  counts: {
+    follows: 22,
+  },
+}

--- a/src/lib/Components/Artist/__tests__/ArtistHeader-tests.tsx
+++ b/src/lib/Components/Artist/__tests__/ArtistHeader-tests.tsx
@@ -1,7 +1,7 @@
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 
-import Header from "../ArtistHeader"
+import { ArtistHeaderFragmentContainer } from "../ArtistHeader"
 
 it("renders without throwing an error", () => {
   const artist = {
@@ -14,5 +14,5 @@ it("renders without throwing an error", () => {
       follows: 22,
     },
   }
-  renderWithWrappers(<Header artist={artist as any} />)
+  renderWithWrappers(<ArtistHeaderFragmentContainer artist={artist as any} />)
 })

--- a/src/lib/Components/ArtworkFilterOptions/SortOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/SortOptions.tsx
@@ -115,6 +115,7 @@ export const SortOptionsScreen: React.FC<SortOptionsScreenProps> = ({ navigator 
     artwork: [DEFAULT_ARTWORK_SORT, ...ORDERED_ARTWORK_SORTS],
     saleArtwork: ORDERED_SALE_ARTWORK_SORTS,
     showArtwork: [GALLERY_CURATED_ARTWORK_SORT, DEFAULT_ARTWORK_SORT, ...ORDERED_ARTWORK_SORTS],
+    auctionResult: [],
   }[filterType]
 
   const selectOption = (option: FilterData) => {

--- a/src/lib/Components/FilterModal/FilterModal.tsx
+++ b/src/lib/Components/FilterModal/FilterModal.tsx
@@ -427,9 +427,15 @@ export const FilterArtworkButton = styled(Flex)`
   box-shadow: 0px 3px 3px rgba(0, 0, 0, 0.12);
 `
 
-export const AnimatedArtworkFilterButton: React.FC<{ isVisible: boolean; onPress: () => void }> = ({
+interface AnimatedArtworkFilterButtonProps {
+  isVisible: boolean
+  onPress: () => void
+  text?: string
+}
+export const AnimatedArtworkFilterButton: React.FC<AnimatedArtworkFilterButtonProps> = ({
   isVisible,
   onPress,
+  text,
 }) => {
   const { state } = useContext(ArtworkFilterContext)
 
@@ -458,7 +464,7 @@ export const AnimatedArtworkFilterButton: React.FC<{ isVisible: boolean; onPress
       <FilterArtworkButton px="2" style={roundedButtonStyle}>
         <FilterIcon fill="white100" />
         <Sans size="3t" pl="1" py="1" color="white100" weight="medium">
-          Sort & Filter
+          {text || "Sort & Filter"}
         </Sans>
         {getFiltersCount() > 0 && (
           <>

--- a/src/lib/Components/FilterModal/FilterModal.tsx
+++ b/src/lib/Components/FilterModal/FilterModal.tsx
@@ -40,18 +40,26 @@ import { FancyModal } from "../FancyModal/FancyModal"
 interface FilterModalProps extends ViewProperties {
   closeModal?: () => void
   exitModal?: () => void
-  navigator?: NavigatorIOS
+  id: string
   initiallyAppliedFilters?: FilterArray
   isFilterArtworksModalVisible: boolean
-  id: string
-  slug: string
   mode: FilterModalMode
+  navigator?: NavigatorIOS
+  slug: string
+  title?: string
 }
 
-export const FilterModalNavigator: React.FC<FilterModalProps> = (props) => {
+export const FilterModalNavigator: React.FC<FilterModalProps> = ({
+  closeModal,
+  exitModal,
+  id,
+  isFilterArtworksModalVisible,
+  mode,
+  slug,
+  title = "Filter",
+}) => {
   const tracking = useTracking()
 
-  const { closeModal, exitModal, isFilterArtworksModalVisible, id, slug, mode } = props
   const { dispatch, state } = useContext(ArtworkFilterContext)
 
   const handleClosingModal = () => {
@@ -108,7 +116,7 @@ export const FilterModalNavigator: React.FC<FilterModalProps> = (props) => {
           navigationBarHidden={true}
           initialRoute={{
             component: FilterOptions,
-            passProps: { closeModal, id, slug, mode },
+            passProps: { closeModal, id, slug, mode, title },
             title: "",
           }}
           style={{ flex: 1 }}
@@ -205,20 +213,20 @@ export enum FilterModalMode {
   SaleArtworks = "SaleArtworks",
   Fair = "Fair",
   Show = "Show",
+  AuctionResults = "AuctionResults",
 }
 
 interface FilterOptionsProps {
   closeModal: () => void
-  navigator: NavigatorIOS
   id: string
-  slug: string
   mode: FilterModalMode
+  navigator: NavigatorIOS
+  slug: string
+  title: string
 }
 
-export const FilterOptions: React.FC<FilterOptionsProps> = (props) => {
+export const FilterOptions: React.FC<FilterOptionsProps> = ({ closeModal, id, mode, navigator, slug, title }) => {
   const tracking = useTracking()
-  const { closeModal, navigator, id, slug, mode } = props
-
   const { dispatch, state } = useContext(ArtworkFilterContext)
 
   const selectedOptions = useSelectedOptionsDisplay()
@@ -270,7 +278,7 @@ export const FilterOptions: React.FC<FilterOptionsProps> = (props) => {
       <Flex flexGrow={0} flexDirection="row" justifyContent="space-between">
         <Flex position="absolute" width="100%" height={67} justifyContent="center" alignItems="center">
           <Sans size="4" weight="medium">
-            Filter
+            {title}
           </Sans>
         </Flex>
         <Flex alignItems="flex-end" mt={0.5} mb={2}>
@@ -350,6 +358,9 @@ export const getStaticFilterOptionsByMode = (mode: FilterModalMode) => {
         filterOptionToDisplayConfigMap.viewAs,
         filterOptionToDisplayConfigMap.estimateRange,
       ]
+
+    case FilterModalMode.AuctionResults:
+      return []
 
     default:
       return [filterOptionToDisplayConfigMap.sortArtworks, filterOptionToDisplayConfigMap.waysToBuy]
@@ -435,7 +446,7 @@ interface AnimatedArtworkFilterButtonProps {
 export const AnimatedArtworkFilterButton: React.FC<AnimatedArtworkFilterButtonProps> = ({
   isVisible,
   onPress,
-  text,
+  text = "Sort & Filter",
 }) => {
   const { state } = useContext(ArtworkFilterContext)
 
@@ -464,7 +475,7 @@ export const AnimatedArtworkFilterButton: React.FC<AnimatedArtworkFilterButtonPr
       <FilterArtworkButton px="2" style={roundedButtonStyle}>
         <FilterIcon fill="white100" />
         <Sans size="3t" pl="1" py="1" color="white100" weight="medium">
-          {text || "Sort & Filter"}
+          {text}
         </Sans>
         {getFiltersCount() > 0 && (
           <>

--- a/src/lib/Components/FilterModal/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/FilterModal/__tests__/FilterModal-tests.tsx
@@ -655,8 +655,8 @@ describe("Applying filters on Artworks", () => {
   })
 })
 
-describe("Filter modal navigation flow", () => {
-  it("allows users to navigate forward to sort screen from filter screen", () => {
+describe("AnimatedArtworkFilterButton", () => {
+  it("Shows Sort & Filter when no text prop is available", () => {
     const tree = renderWithWrappers(
       <ArtworkFilterContext.Provider
         value={{
@@ -669,5 +669,20 @@ describe("Filter modal navigation flow", () => {
     )
 
     expect(tree.root.findAllByType(Sans)[0].props.children).toEqual("Sort & Filter")
+  })
+
+  it("Shows text when text prop is available", () => {
+    const tree = renderWithWrappers(
+      <ArtworkFilterContext.Provider
+        value={{
+          state,
+          dispatch: jest.fn(),
+        }}
+      >
+        <AnimatedArtworkFilterButton text="Filter Text" isVisible onPress={jest.fn()} />
+      </ArtworkFilterContext.Provider>
+    )
+
+    expect(tree.root.findAllByType(Sans)[0].props.children).toEqual("Filter Text")
   })
 })

--- a/src/lib/Components/FilterModal/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/FilterModal/__tests__/FilterModal-tests.tsx
@@ -204,6 +204,7 @@ describe("Filter modal navigation flow", () => {
           mode={FilterModalMode.Collection}
           closeModal={jest.fn()}
           navigator={mockNavigator as any}
+          title="Filter"
         />
       </ArtworkFilterContext.Provider>
     )
@@ -265,6 +266,7 @@ describe("Filter modal navigation flow", () => {
           mode={FilterModalMode.Collection}
           closeModal={jest.fn()}
           navigator={mockNavigator as any}
+          title="Filter"
         />
       </ArtworkFilterContext.Provider>
     )

--- a/src/lib/Components/FilterModal/__tests__/FilterTestHelper.tsx
+++ b/src/lib/Components/FilterModal/__tests__/FilterTestHelper.tsx
@@ -25,6 +25,7 @@ export const MockFilterScreen = ({ initialState }: InitialState) => {
           closeModal={closeModalMock}
           navigator={mockNavigator as any}
           mode={FilterModalMode.ArtistArtworks}
+          title="Filter"
         />
       </ArtworkFilterContext.Provider>
     </Theme>

--- a/src/lib/Scenes/Artist/Artist.tsx
+++ b/src/lib/Scenes/Artist/Artist.tsx
@@ -8,7 +8,7 @@ import {
 } from "__generated__/ArtistBelowTheFoldQuery.graphql"
 import { ArtistAboutContainer } from "lib/Components/Artist/ArtistAbout/ArtistAbout"
 import ArtistArtworks from "lib/Components/Artist/ArtistArtworks/ArtistArtworks"
-import ArtistHeader from "lib/Components/Artist/ArtistHeader"
+import { ArtistHeaderFragmentContainer } from "lib/Components/Artist/ArtistHeader"
 import { ArtistInsightsFragmentContainer } from "lib/Components/Artist/ArtistInsights/ArtistInsights"
 import ArtistShows from "lib/Components/Artist/ArtistShows/ArtistShows"
 import { HeaderTabsGridPlaceholder } from "lib/Components/HeaderTabGridPlaceholder"
@@ -35,29 +35,29 @@ export const Artist: React.FC<{
     (artistAboveTheFold.counts?.articles ?? 0) > 0 ||
     (artistAboveTheFold.counts?.related_artists ?? 0) > 0
 
-  if (displayAboutSection) {
-    tabs.push({
-      title: "About",
-      content: artistBelowTheFold ? <ArtistAboutContainer artist={artistBelowTheFold} /> : <LoadingPage />,
-    })
-  }
+  // if (displayAboutSection) {
+  //   tabs.push({
+  //     title: "About",
+  //     content: artistBelowTheFold ? <ArtistAboutContainer artist={artistBelowTheFold} /> : <LoadingPage />,
+  //   })
+  // }
 
-  if ((artistAboveTheFold.counts?.artworks ?? 0) > 0) {
-    tabs.push({
-      title: "Artworks",
-      initial: true,
-      content: <ArtistArtworks artist={artistAboveTheFold} />,
-    })
-  }
+  // if ((artistAboveTheFold.counts?.artworks ?? 0) > 0) {
+  //   tabs.push({
+  //     title: "Artworks",
+  //     initial: true,
+  //     content: <ArtistArtworks artist={artistAboveTheFold} />,
+  //   })
+  // }
 
   const isArtistInsightsEnabled = getCurrentEmissionState().options.AROptionsNewInsightsPage
 
-  if ((artistAboveTheFold.counts?.partner_shows ?? 0) > 0 && !isArtistInsightsEnabled) {
-    tabs.push({
-      title: "Shows",
-      content: artistBelowTheFold ? <ArtistShows artist={artistBelowTheFold} /> : <LoadingPage />,
-    })
-  }
+  // if ((artistAboveTheFold.counts?.partner_shows ?? 0) > 0 && !isArtistInsightsEnabled) {
+  //   tabs.push({
+  //     title: "Shows",
+  //     content: artistBelowTheFold ? <ArtistShows artist={artistBelowTheFold} /> : <LoadingPage />,
+  //   })
+  // }
 
   if (isArtistInsightsEnabled) {
     tabs.push({
@@ -90,7 +90,10 @@ export const Artist: React.FC<{
       }}
     >
       <Flex style={{ flex: 1 }}>
-        <StickyTabPage staticHeaderContent={<ArtistHeader artist={artistAboveTheFold!} />} tabs={tabs} />
+        <StickyTabPage
+          staticHeaderContent={<ArtistHeaderFragmentContainer artist={artistAboveTheFold!} />}
+          tabs={tabs}
+        />
       </Flex>
     </ProvideScreenTracking>
   )

--- a/src/lib/Scenes/Artist/Artist.tsx
+++ b/src/lib/Scenes/Artist/Artist.tsx
@@ -35,29 +35,29 @@ export const Artist: React.FC<{
     (artistAboveTheFold.counts?.articles ?? 0) > 0 ||
     (artistAboveTheFold.counts?.related_artists ?? 0) > 0
 
-  // if (displayAboutSection) {
-  //   tabs.push({
-  //     title: "About",
-  //     content: artistBelowTheFold ? <ArtistAboutContainer artist={artistBelowTheFold} /> : <LoadingPage />,
-  //   })
-  // }
+  if (displayAboutSection) {
+    tabs.push({
+      title: "About",
+      content: artistBelowTheFold ? <ArtistAboutContainer artist={artistBelowTheFold} /> : <LoadingPage />,
+    })
+  }
 
-  // if ((artistAboveTheFold.counts?.artworks ?? 0) > 0) {
-  //   tabs.push({
-  //     title: "Artworks",
-  //     initial: true,
-  //     content: <ArtistArtworks artist={artistAboveTheFold} />,
-  //   })
-  // }
+  if ((artistAboveTheFold.counts?.artworks ?? 0) > 0) {
+    tabs.push({
+      title: "Artworks",
+      initial: true,
+      content: <ArtistArtworks artist={artistAboveTheFold} />,
+    })
+  }
 
   const isArtistInsightsEnabled = getCurrentEmissionState().options.AROptionsNewInsightsPage
 
-  // if ((artistAboveTheFold.counts?.partner_shows ?? 0) > 0 && !isArtistInsightsEnabled) {
-  //   tabs.push({
-  //     title: "Shows",
-  //     content: artistBelowTheFold ? <ArtistShows artist={artistBelowTheFold} /> : <LoadingPage />,
-  //   })
-  // }
+  if ((artistAboveTheFold.counts?.partner_shows ?? 0) > 0 && !isArtistInsightsEnabled) {
+    tabs.push({
+      title: "Shows",
+      content: artistBelowTheFold ? <ArtistShows artist={artistBelowTheFold} /> : <LoadingPage />,
+    })
+  }
 
   if (isArtistInsightsEnabled) {
     tabs.push({

--- a/src/lib/Scenes/Artist/__tests__/Artist-tests.tsx
+++ b/src/lib/Scenes/Artist/__tests__/Artist-tests.tsx
@@ -1,5 +1,5 @@
 import ArtistArtworks from "lib/Components/Artist/ArtistArtworks/ArtistArtworks"
-import ArtistHeader from "lib/Components/Artist/ArtistHeader"
+import { ArtistHeaderFragmentContainer } from "lib/Components/Artist/ArtistHeader"
 import { ArtistInsights } from "lib/Components/Artist/ArtistInsights/ArtistInsights"
 import ArtistShows from "lib/Components/Artist/ArtistShows/ArtistShows"
 import { StickyTab } from "lib/Components/StickyTabPage/StickyTabPageTabBar"
@@ -61,7 +61,7 @@ describe("availableTabs", () => {
         }
       },
     })
-    expect(tree.root.findAllByType(ArtistHeader)).toHaveLength(1)
+    expect(tree.root.findAllByType(ArtistHeaderFragmentContainer)).toHaveLength(1)
     expect(tree.root.findAllByType(StickyTab)).toHaveLength(1)
     expect(extractText(tree.root)).toMatchInlineSnapshot(
       `"There aren’t any works available by the artist at this time. Follow to receive notifications when new works are added.Artworks"`
@@ -78,7 +78,7 @@ describe("availableTabs", () => {
         }
       },
     })
-    expect(tree.root.findAllByType(ArtistHeader)).toHaveLength(1)
+    expect(tree.root.findAllByType(ArtistHeaderFragmentContainer)).toHaveLength(1)
     expect(tree.root.findAllByType(StickyTab)).toHaveLength(1)
     expect(tree.root.findAllByType(ArtistAboutContainer)).toHaveLength(0)
     // it only shows below the fold

--- a/src/lib/Scenes/Artist/__tests__/Artist-tests.tsx
+++ b/src/lib/Scenes/Artist/__tests__/Artist-tests.tsx
@@ -63,8 +63,8 @@ describe("availableTabs", () => {
     })
     expect(tree.root.findAllByType(ArtistHeaderFragmentContainer)).toHaveLength(1)
     expect(tree.root.findAllByType(StickyTab)).toHaveLength(1)
-    expect(extractText(tree.root)).toMatchInlineSnapshot(
-      `"There aren’t any works available by the artist at this time. Follow to receive notifications when new works are added.Artworks"`
+    expect(extractText(tree.root)).toContain(
+      "There aren’t any works available by the artist at this time. Follow to receive notifications when new works are added"
     )
   })
 

--- a/src/lib/tests/renderWithWrappers.tsx
+++ b/src/lib/tests/renderWithWrappers.tsx
@@ -24,8 +24,8 @@ export const renderWithWrappers = (component: ReactElement) => {
   } catch (error) {
     if (error.message.includes("Element type is invalid")) {
       throw new Error(
-        'Error: Relay test component failed to render. Did you forget to add `jest.unmock("react-relay")` at the top ' +
-          "of your test?" +
+        'Error: Relay test component failed to render. This may happen if you forget to add `jest.unmock("react-relay")` at the top ' +
+          "of your test? or if the module you are testing is getting mocked in setup.js" +
           "\n\n" +
           error
       )

--- a/src/lib/utils/ArtworkFilter/ArtworkFiltersStore.tsx
+++ b/src/lib/utils/ArtworkFilter/ArtworkFiltersStore.tsx
@@ -252,7 +252,12 @@ export const reducer = (
 }
 
 const getSortDefaultValueByFilterType = (filterType: FilterType) => {
-  return { artwork: "-decayed_merch", saleArtwork: "position", showArtwork: "partner_show_position" }[filterType]
+  return {
+    artwork: "-decayed_merch",
+    saleArtwork: "position",
+    showArtwork: "partner_show_position",
+    auctionResult: "DATE_DESC",
+  }[filterType]
 }
 
 export const ParamDefaultValues = {
@@ -316,6 +321,11 @@ export const selectedOptionsUnion = ({
       paramName: FilterParamName.sort,
       paramValue: "partner_show_position",
       displayText: "Gallery Curated",
+    },
+    auctionResult: {
+      paramName: FilterParamName.sort,
+      paramValue: "DATE_DESC",
+      displayText: "Most recent sale date",
     },
   }[filterType]
 
@@ -423,7 +433,7 @@ export const ArtworkFilterGlobalStateProvider = ({ children }: any /* STRICTNESS
   return <ArtworkFilterContext.Provider value={{ state, dispatch }}>{children}</ArtworkFilterContext.Provider>
 }
 
-export type FilterType = "artwork" | "saleArtwork" | "showArtwork"
+export type FilterType = "artwork" | "saleArtwork" | "showArtwork" | "auctionResult"
 
 export interface FilterCounts {
   total: number | null

--- a/src/lib/utils/ArtworkFilter/FilterArtworksHelpers.ts
+++ b/src/lib/utils/ArtworkFilter/FilterArtworksHelpers.ts
@@ -95,11 +95,16 @@ const DEFAULT_SHOW_ARTWORKS_PARAMS = {
   sort: "partner_show_position",
 }
 
+const DEFAULT_AUCTION_RESULT_PARAMS = {
+  sort: "DATE_DESC",
+} as FilterParams
+
 const getDefaultParamsByType = (filterType: FilterType) => {
   return {
     artwork: DEFAULT_ARTWORKS_PARAMS,
     saleArtwork: DEFAULT_SALE_ARTWORKS_PARAMS,
     showArtwork: DEFAULT_SHOW_ARTWORKS_PARAMS,
+    auctionResult: DEFAULT_AUCTION_RESULT_PARAMS,
   }[filterType]
 }
 

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -104,7 +104,6 @@ mockedModule("./lib/Components/OpaqueImageView/OpaqueImageView.tsx", "AROpaqueIm
 // Artist tests
 mockedModule("./lib/Components/Artist/ArtistShows/ArtistShows.tsx", "ArtistShows")
 mockedModule("./lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx", "ArtistArtworks")
-mockedModule("./lib/Components/Artist/ArtistHeader.tsx", "ArtistHeader")
 
 // Gene tests
 mockedModule("./lib/Components/Gene/Header.tsx", "Header")


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-843]

### Description

**Add filtering to auctionResults**
- [x] Include showing the filter button depending on the scroll position
- [x] Show the filter modal on tap (empty for now)
- [x] Sett up GraphQL calls to pass down filter values as variables when a filter is applied

<!-- Implementation description -->


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-843]: https://artsyproduct.atlassian.net/browse/CX-843