### PR TITLE
feat: improve StickyScrollHeader props

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -23,6 +23,7 @@ releases:
       - More analytics for My Collection - brian
       - Points to Artsy forks only - ash
       - Fix crash on entering city guide - brian
+      - Simplify useStickyScrollheader - adam
     user_facing:
       - Fix logout alert not showing up on changing password - brian
       - Fix a layout bug (double separator) in My Collection Artwork Details

--- a/src/lib/Scenes/AuctionResult/AuctionResult.tsx
+++ b/src/lib/Scenes/AuctionResult/AuctionResult.tsx
@@ -22,15 +22,11 @@ interface Props {
 const AuctionResult: React.FC<Props> = ({ artist, auctionResult }) => {
   const { headerElement, scrollProps } = useStickyScrollHeader({
     header: (
-      <Flex backgroundColor="white">
-        <FancyModalHeader>
-          <Flex flex={1} pl={6} pr={4} pt={0.5} flexDirection="row">
-            <Text variant="subtitle" numberOfLines={1} style={{ flexShrink: 1 }}>
-              {auctionResult?.title}
-            </Text>
-            {!!auctionResult?.dateText && <Text variant="subtitle">, {auctionResult?.dateText}</Text>}
-          </Flex>
-        </FancyModalHeader>
+      <Flex flex={1} pl={6} pr={4} pt={0.5} flexDirection="row">
+        <Text variant="subtitle" numberOfLines={1} style={{ flexShrink: 1 }}>
+          {auctionResult?.title}
+        </Text>
+        {!!auctionResult?.dateText && <Text variant="subtitle">, {auctionResult?.dateText}</Text>}
       </Flex>
     ),
   })

--- a/src/lib/utils/useStickyScrollHeader.tsx
+++ b/src/lib/utils/useStickyScrollHeader.tsx
@@ -1,12 +1,19 @@
+import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
+import { Flex, Text } from "palette"
 import React, { useMemo, useRef } from "react"
 import { Animated, NativeScrollEvent, NativeSyntheticEvent } from "react-native"
 
+const DEFAULT_FADE_IN_START = 90
+const FADE_LENGTH = 10
+
 export const useStickyScrollHeader = ({
   header,
-  fadeInStart = 90,
-  fadeInEnd = 100,
+  headerText,
+  fadeInStart = DEFAULT_FADE_IN_START,
+  fadeInEnd,
 }: {
-  header: JSX.Element
+  header?: JSX.Element
+  headerText?: string
   fadeInStart?: number
   fadeInEnd?: number
 }) => {
@@ -17,6 +24,24 @@ export const useStickyScrollHeader = ({
   scrollAnim.addListener(({ value }) => {
     translateYNumber.current = value
   })
+  fadeInEnd = fadeInEnd || fadeInStart + FADE_LENGTH
+  header =
+    !header && !!headerText ? (
+      <Flex backgroundColor="white">
+        <FancyModalHeader>
+          <Flex flex={1} pt={0.5} flexDirection="row">
+            <Text variant="subtitle" numberOfLines={1} style={{ flexShrink: 1 }}>
+              {headerText}
+            </Text>
+          </Flex>
+        </FancyModalHeader>
+      </Flex>
+    ) : (
+      <Flex backgroundColor="white">
+        <FancyModalHeader>{header}</FancyModalHeader>
+      </Flex>
+    )
+
   const headerElement = useMemo(
     () => (
       <Animated.View
@@ -88,5 +113,6 @@ export const useStickyScrollHeader = ({
       onScrollEndDrag,
       scrollEventThreshold: 100,
     },
+    scrollAnim,
   }
 }

--- a/src/lib/utils/useStickyScrollHeader.tsx
+++ b/src/lib/utils/useStickyScrollHeader.tsx
@@ -24,7 +24,7 @@ export const useStickyScrollHeader = ({
   scrollAnim.addListener(({ value }) => {
     translateYNumber.current = value
   })
-  fadeInEnd = fadeInEnd || fadeInStart + FADE_LENGTH
+  const calculatedFadeInEnd: number = !!fadeInEnd ? fadeInEnd : fadeInStart + FADE_LENGTH
   header =
     !header && !!headerText ? (
       <Flex backgroundColor="white">
@@ -53,7 +53,7 @@ export const useStickyScrollHeader = ({
           top: 0,
           width: "100%",
           opacity: Animated.add(scrollAnim, snapAnim).interpolate({
-            inputRange: [fadeInStart, fadeInEnd],
+            inputRange: [fadeInStart, calculatedFadeInEnd],
             outputRange: [0, 1],
             extrapolate: "clamp",
           }),
@@ -79,9 +79,11 @@ export const useStickyScrollHeader = ({
   )
 
   const handleSnap = (offsetY: number) => {
-    if (offsetY > fadeInStart && offsetY < fadeInEnd) {
+    if (offsetY > fadeInStart && offsetY < calculatedFadeInEnd) {
       const toValue =
-        offsetY - fadeInStart < (fadeInEnd - fadeInStart) / 2 ? fadeInStart - offsetY : fadeInEnd - offsetY
+        offsetY - fadeInStart < (calculatedFadeInEnd - fadeInStart) / 2
+          ? fadeInStart - offsetY
+          : calculatedFadeInEnd - offsetY
       Animated.timing(snapAnim, {
         toValue,
         duration: 100,


### PR DESCRIPTION
The type of this PR is: Enhancement

### Description

Makes it easier to use StickyScrollHeader by allowing a simple string value for the header instead of a whole component. `useStickyScrollHeader` will then create the required component. Also, more versatile setting of `fadeInStart` value, with calculated `fadeInEnd`.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
