### PR TITLE
fix(artist): show correct name + link to past shows

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -8,6 +8,7 @@ upcoming:
   user_facing:
     - Add auction result screen - adam
     - Add filter button and screen to the ArtistInsights AuctionResults - mounir
+    - Wire up `See all past shows` button - adam
 
 releases:
   - version: 6.7.5

--- a/src/__generated__/ArtistAboutShowsTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistAboutShowsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 7577822d85a8a9401515c5976318898a */
+/* @relayHash 137076c8f8a7ac61e6d52c76c3dec9b3 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -45,6 +45,8 @@ query ArtistAboutShowsTestsQuery(
 }
 
 fragment ArtistAboutShows_artist on Artist {
+  name
+  slug
   currentShows: showsConnection(status: "running", first: 10) {
     edges {
       node {
@@ -153,7 +155,14 @@ v6 = {
   "name": "name",
   "storageKey": null
 },
-v7 = [
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v8 = [
   {
     "alias": null,
     "args": null,
@@ -171,13 +180,7 @@ v7 = [
         "plural": false,
         "selections": [
           (v4/*: any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "slug",
-            "storageKey": null
-          },
+          (v7/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -312,61 +315,61 @@ v7 = [
     "storageKey": null
   }
 ],
-v8 = {
+v9 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "ShowConnection"
 },
-v9 = {
+v10 = {
   "enumValues": null,
   "nullable": true,
   "plural": true,
   "type": "ShowEdge"
 },
-v10 = {
+v11 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Show"
 },
-v11 = {
+v12 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
 },
-v12 = {
+v13 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v13 = {
+v14 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v14 = {
+v15 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v15 = {
+v16 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Location"
 },
-v16 = {
+v17 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "PartnerTypes"
 },
-v17 = {
+v18 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
@@ -445,6 +448,8 @@ return {
         "name": "artist",
         "plural": false,
         "selections": [
+          (v6/*: any*/),
+          (v7/*: any*/),
           {
             "alias": "currentShows",
             "args": (v3/*: any*/),
@@ -452,7 +457,7 @@ return {
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
-            "selections": (v7/*: any*/),
+            "selections": (v8/*: any*/),
             "storageKey": "showsConnection(first:10,status:\"running\")"
           },
           {
@@ -469,7 +474,7 @@ return {
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
-            "selections": (v7/*: any*/),
+            "selections": (v8/*: any*/),
             "storageKey": "showsConnection(first:10,status:\"upcoming\")"
           },
           {
@@ -490,7 +495,7 @@ return {
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
-            "selections": (v7/*: any*/),
+            "selections": (v8/*: any*/),
             "storageKey": "showsConnection(first:3,status:\"closed\")"
           },
           (v4/*: any*/)
@@ -500,7 +505,7 @@ return {
     ]
   },
   "params": {
-    "id": "7577822d85a8a9401515c5976318898a",
+    "id": "137076c8f8a7ac61e6d52c76c3dec9b3",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artist": {
@@ -509,73 +514,75 @@ return {
           "plural": false,
           "type": "Artist"
         },
-        "artist.currentShows": (v8/*: any*/),
-        "artist.currentShows.edges": (v9/*: any*/),
-        "artist.currentShows.edges.node": (v10/*: any*/),
-        "artist.currentShows.edges.node.cover_image": (v11/*: any*/),
-        "artist.currentShows.edges.node.cover_image.url": (v12/*: any*/),
-        "artist.currentShows.edges.node.exhibition_period": (v12/*: any*/),
-        "artist.currentShows.edges.node.href": (v12/*: any*/),
-        "artist.currentShows.edges.node.id": (v13/*: any*/),
-        "artist.currentShows.edges.node.is_fair_booth": (v14/*: any*/),
-        "artist.currentShows.edges.node.kind": (v12/*: any*/),
-        "artist.currentShows.edges.node.location": (v15/*: any*/),
-        "artist.currentShows.edges.node.location.city": (v12/*: any*/),
-        "artist.currentShows.edges.node.location.id": (v13/*: any*/),
-        "artist.currentShows.edges.node.name": (v12/*: any*/),
-        "artist.currentShows.edges.node.partner": (v16/*: any*/),
-        "artist.currentShows.edges.node.partner.__isNode": (v17/*: any*/),
-        "artist.currentShows.edges.node.partner.__typename": (v17/*: any*/),
-        "artist.currentShows.edges.node.partner.id": (v13/*: any*/),
-        "artist.currentShows.edges.node.partner.name": (v12/*: any*/),
-        "artist.currentShows.edges.node.slug": (v13/*: any*/),
-        "artist.currentShows.edges.node.status": (v12/*: any*/),
-        "artist.currentShows.edges.node.status_update": (v12/*: any*/),
-        "artist.id": (v13/*: any*/),
-        "artist.pastShows": (v8/*: any*/),
-        "artist.pastShows.edges": (v9/*: any*/),
-        "artist.pastShows.edges.node": (v10/*: any*/),
-        "artist.pastShows.edges.node.cover_image": (v11/*: any*/),
-        "artist.pastShows.edges.node.cover_image.url": (v12/*: any*/),
-        "artist.pastShows.edges.node.exhibition_period": (v12/*: any*/),
-        "artist.pastShows.edges.node.href": (v12/*: any*/),
-        "artist.pastShows.edges.node.id": (v13/*: any*/),
-        "artist.pastShows.edges.node.is_fair_booth": (v14/*: any*/),
-        "artist.pastShows.edges.node.kind": (v12/*: any*/),
-        "artist.pastShows.edges.node.location": (v15/*: any*/),
-        "artist.pastShows.edges.node.location.city": (v12/*: any*/),
-        "artist.pastShows.edges.node.location.id": (v13/*: any*/),
-        "artist.pastShows.edges.node.name": (v12/*: any*/),
-        "artist.pastShows.edges.node.partner": (v16/*: any*/),
-        "artist.pastShows.edges.node.partner.__isNode": (v17/*: any*/),
-        "artist.pastShows.edges.node.partner.__typename": (v17/*: any*/),
-        "artist.pastShows.edges.node.partner.id": (v13/*: any*/),
-        "artist.pastShows.edges.node.partner.name": (v12/*: any*/),
-        "artist.pastShows.edges.node.slug": (v13/*: any*/),
-        "artist.pastShows.edges.node.status": (v12/*: any*/),
-        "artist.pastShows.edges.node.status_update": (v12/*: any*/),
-        "artist.upcomingShows": (v8/*: any*/),
-        "artist.upcomingShows.edges": (v9/*: any*/),
-        "artist.upcomingShows.edges.node": (v10/*: any*/),
-        "artist.upcomingShows.edges.node.cover_image": (v11/*: any*/),
-        "artist.upcomingShows.edges.node.cover_image.url": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.exhibition_period": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.href": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.id": (v13/*: any*/),
-        "artist.upcomingShows.edges.node.is_fair_booth": (v14/*: any*/),
-        "artist.upcomingShows.edges.node.kind": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.location": (v15/*: any*/),
-        "artist.upcomingShows.edges.node.location.city": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.location.id": (v13/*: any*/),
-        "artist.upcomingShows.edges.node.name": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.partner": (v16/*: any*/),
-        "artist.upcomingShows.edges.node.partner.__isNode": (v17/*: any*/),
-        "artist.upcomingShows.edges.node.partner.__typename": (v17/*: any*/),
-        "artist.upcomingShows.edges.node.partner.id": (v13/*: any*/),
-        "artist.upcomingShows.edges.node.partner.name": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.slug": (v13/*: any*/),
-        "artist.upcomingShows.edges.node.status": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.status_update": (v12/*: any*/)
+        "artist.currentShows": (v9/*: any*/),
+        "artist.currentShows.edges": (v10/*: any*/),
+        "artist.currentShows.edges.node": (v11/*: any*/),
+        "artist.currentShows.edges.node.cover_image": (v12/*: any*/),
+        "artist.currentShows.edges.node.cover_image.url": (v13/*: any*/),
+        "artist.currentShows.edges.node.exhibition_period": (v13/*: any*/),
+        "artist.currentShows.edges.node.href": (v13/*: any*/),
+        "artist.currentShows.edges.node.id": (v14/*: any*/),
+        "artist.currentShows.edges.node.is_fair_booth": (v15/*: any*/),
+        "artist.currentShows.edges.node.kind": (v13/*: any*/),
+        "artist.currentShows.edges.node.location": (v16/*: any*/),
+        "artist.currentShows.edges.node.location.city": (v13/*: any*/),
+        "artist.currentShows.edges.node.location.id": (v14/*: any*/),
+        "artist.currentShows.edges.node.name": (v13/*: any*/),
+        "artist.currentShows.edges.node.partner": (v17/*: any*/),
+        "artist.currentShows.edges.node.partner.__isNode": (v18/*: any*/),
+        "artist.currentShows.edges.node.partner.__typename": (v18/*: any*/),
+        "artist.currentShows.edges.node.partner.id": (v14/*: any*/),
+        "artist.currentShows.edges.node.partner.name": (v13/*: any*/),
+        "artist.currentShows.edges.node.slug": (v14/*: any*/),
+        "artist.currentShows.edges.node.status": (v13/*: any*/),
+        "artist.currentShows.edges.node.status_update": (v13/*: any*/),
+        "artist.id": (v14/*: any*/),
+        "artist.name": (v13/*: any*/),
+        "artist.pastShows": (v9/*: any*/),
+        "artist.pastShows.edges": (v10/*: any*/),
+        "artist.pastShows.edges.node": (v11/*: any*/),
+        "artist.pastShows.edges.node.cover_image": (v12/*: any*/),
+        "artist.pastShows.edges.node.cover_image.url": (v13/*: any*/),
+        "artist.pastShows.edges.node.exhibition_period": (v13/*: any*/),
+        "artist.pastShows.edges.node.href": (v13/*: any*/),
+        "artist.pastShows.edges.node.id": (v14/*: any*/),
+        "artist.pastShows.edges.node.is_fair_booth": (v15/*: any*/),
+        "artist.pastShows.edges.node.kind": (v13/*: any*/),
+        "artist.pastShows.edges.node.location": (v16/*: any*/),
+        "artist.pastShows.edges.node.location.city": (v13/*: any*/),
+        "artist.pastShows.edges.node.location.id": (v14/*: any*/),
+        "artist.pastShows.edges.node.name": (v13/*: any*/),
+        "artist.pastShows.edges.node.partner": (v17/*: any*/),
+        "artist.pastShows.edges.node.partner.__isNode": (v18/*: any*/),
+        "artist.pastShows.edges.node.partner.__typename": (v18/*: any*/),
+        "artist.pastShows.edges.node.partner.id": (v14/*: any*/),
+        "artist.pastShows.edges.node.partner.name": (v13/*: any*/),
+        "artist.pastShows.edges.node.slug": (v14/*: any*/),
+        "artist.pastShows.edges.node.status": (v13/*: any*/),
+        "artist.pastShows.edges.node.status_update": (v13/*: any*/),
+        "artist.slug": (v14/*: any*/),
+        "artist.upcomingShows": (v9/*: any*/),
+        "artist.upcomingShows.edges": (v10/*: any*/),
+        "artist.upcomingShows.edges.node": (v11/*: any*/),
+        "artist.upcomingShows.edges.node.cover_image": (v12/*: any*/),
+        "artist.upcomingShows.edges.node.cover_image.url": (v13/*: any*/),
+        "artist.upcomingShows.edges.node.exhibition_period": (v13/*: any*/),
+        "artist.upcomingShows.edges.node.href": (v13/*: any*/),
+        "artist.upcomingShows.edges.node.id": (v14/*: any*/),
+        "artist.upcomingShows.edges.node.is_fair_booth": (v15/*: any*/),
+        "artist.upcomingShows.edges.node.kind": (v13/*: any*/),
+        "artist.upcomingShows.edges.node.location": (v16/*: any*/),
+        "artist.upcomingShows.edges.node.location.city": (v13/*: any*/),
+        "artist.upcomingShows.edges.node.location.id": (v14/*: any*/),
+        "artist.upcomingShows.edges.node.name": (v13/*: any*/),
+        "artist.upcomingShows.edges.node.partner": (v17/*: any*/),
+        "artist.upcomingShows.edges.node.partner.__isNode": (v18/*: any*/),
+        "artist.upcomingShows.edges.node.partner.__typename": (v18/*: any*/),
+        "artist.upcomingShows.edges.node.partner.id": (v14/*: any*/),
+        "artist.upcomingShows.edges.node.partner.name": (v13/*: any*/),
+        "artist.upcomingShows.edges.node.slug": (v14/*: any*/),
+        "artist.upcomingShows.edges.node.status": (v13/*: any*/),
+        "artist.upcomingShows.edges.node.status_update": (v13/*: any*/)
       }
     },
     "name": "ArtistAboutShowsTestsQuery",

--- a/src/__generated__/ArtistAboutShows_artist.graphql.ts
+++ b/src/__generated__/ArtistAboutShows_artist.graphql.ts
@@ -5,6 +5,8 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ArtistAboutShows_artist = {
+    readonly name: string | null;
+    readonly slug: string;
     readonly currentShows: {
         readonly edges: ReadonlyArray<{
             readonly node: {
@@ -88,6 +90,20 @@ return {
   "name": "ArtistAboutShows_artist",
   "selections": [
     {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
+    },
+    {
       "alias": "currentShows",
       "args": [
         (v0/*: any*/),
@@ -147,5 +163,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = 'e6580eebc2233e258a2006f1715bc570';
+(node as any).hash = 'aba257bd31058e7c06b62c1a320fa0c6';
 export default node;

--- a/src/__generated__/ArtistAboutTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistAboutTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash e679015ebad2a640cb7ab67dc70a6108 */
+/* @relayHash e7e03baa797b12533f132bdddfbb709e */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -48,6 +48,8 @@ fragment Articles_articles on Article {
 }
 
 fragment ArtistAboutShows_artist on Artist {
+  name
+  slug
   currentShows: showsConnection(status: "running", first: 10) {
     edges {
       node {
@@ -803,7 +805,7 @@ return {
     ]
   },
   "params": {
-    "id": "e679015ebad2a640cb7ab67dc70a6108",
+    "id": "e7e03baa797b12533f132bdddfbb709e",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artist": (v10/*: any*/),

--- a/src/__generated__/ArtistBelowTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtistBelowTheFoldQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash d589c76834a62464989078d46f7a56a9 */
+/* @relayHash 8fb1543c8793b338b8f74ac002eac646 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -52,6 +52,8 @@ fragment Articles_articles on Article {
 }
 
 fragment ArtistAboutShows_artist on Artist {
+  name
+  slug
   currentShows: showsConnection(status: "running", first: 10) {
     edges {
       node {
@@ -1128,7 +1130,7 @@ return {
     ]
   },
   "params": {
-    "id": "d589c76834a62464989078d46f7a56a9",
+    "id": "8fb1543c8793b338b8f74ac002eac646",
     "metadata": {},
     "name": "ArtistBelowTheFoldQuery",
     "operationKind": "query",

--- a/src/lib/Components/Artist/ArtistAbout/ArtistAboutShows.tsx
+++ b/src/lib/Components/Artist/ArtistAbout/ArtistAboutShows.tsx
@@ -1,4 +1,5 @@
 import { ArtistAboutShows_artist } from "__generated__/ArtistAboutShows_artist.graphql"
+import { navigate } from "lib/navigation/navigate"
 import { extractNodes } from "lib/utils/extractNodes"
 import { Button, Flex, Spacer, Text } from "palette"
 import React from "react"
@@ -29,7 +30,7 @@ const ArtistAboutShows: React.FC<Props> = ({ artist }) => {
     return (
       <Flex>
         <Text variant="subtitle" mb={1}>
-          Shows featuring Nicolas Party
+          Shows featuring {artist.name}
         </Text>
         <FlatList
           data={shownShows}
@@ -59,10 +60,7 @@ const ArtistAboutShows: React.FC<Props> = ({ artist }) => {
         {!!pastShows.length && (
           <Button
             variant={"secondaryGray"}
-            onPress={() => {
-              // We navigate to the past shows screen
-              console.log("do nothing")
-            }}
+            onPress={() => navigate(`/artist/${artist?.slug!}/shows`)}
             size="medium"
             block
           >
@@ -80,6 +78,8 @@ const ArtistAboutShows: React.FC<Props> = ({ artist }) => {
 export const ArtistAboutShowsFragmentContainer = createFragmentContainer(ArtistAboutShows, {
   artist: graphql`
     fragment ArtistAboutShows_artist on Artist {
+      name
+      slug
       currentShows: showsConnection(status: "running", first: 10) {
         edges {
           node {


### PR DESCRIPTION
The type of this PR is: Bugfix

This PR resolves [CX-932]

### Description

Previously the heading of the `Shows` section of the `About` tab of the `Artist` screen had the heading `Shows featuring Nicholas Parry`, no matter who the artist was. Also the `See all past shows` button didn't work. Now it does.

![image](https://user-images.githubusercontent.com/1815204/104196793-7e553000-5424-11eb-8221-def3e14bd0c6.png)


### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-932]: https://artsyproduct.atlassian.net/browse/CX-932