### PR TITLE
additions(haptics): make all haptics be the same, the stronger version

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -9,6 +9,8 @@ upcoming:
     - Add sharing on Instagram - pavlos
     - Fix a layout bug (double separator) in My Collection Artwork Details
     - Fix layout in My Collection artwork form AdditionalDetails screen - david
+    - Fix a layout bug - pavlos
+    - Add some more haptic feedback - annacarey, pavlos
     - Add auction result screen - adam
     - Add filter button and screen to the ArtistInsights AuctionResults - mounir
 

--- a/src/lib/Components/AnimatedBottomButton.tsx
+++ b/src/lib/Components/AnimatedBottomButton.tsx
@@ -40,7 +40,7 @@ export const AnimatedBottomButton: React.FC<AnimatedBottomButtonProps> = ({
 
   return (
     <BottomButtonContainer style={{ transform: [{ translateY: topOffset }] }}>
-      <Touchable haptic="selection" onPress={onPress} style={buttonStyles}>
+      <Touchable haptic onPress={onPress} style={buttonStyles}>
         {children}
       </Touchable>
     </BottomButtonContainer>

--- a/src/lib/Components/Artist/ArtistHeader.tsx
+++ b/src/lib/Components/Artist/ArtistHeader.tsx
@@ -138,7 +138,7 @@ export const ArtistHeader: React.FC<Props> = ({ artist, relay }) => {
               onPress={handleFollowChange}
               size="small"
               longestText="Following"
-              haptic="selection"
+              haptic
             >
               {artist.isFollowed ? "Following" : "Follow"}
             </Button>

--- a/src/lib/Components/ArtistListItem.tsx
+++ b/src/lib/Components/ArtistListItem.tsx
@@ -159,6 +159,7 @@ export class ArtistListItem extends React.Component<Props, State> {
                 size="small"
                 loading={isFollowedChanging}
                 longestText="Following"
+                haptic
               >
                 {is_followed ? "Following" : "Follow"}
               </Button>

--- a/src/lib/Components/Home/ArtistRails/ArtistCard.tsx
+++ b/src/lib/Components/Home/ArtistRails/ArtistCard.tsx
@@ -114,7 +114,7 @@ export class ArtistCard extends React.Component<Props, State> {
                 size="small"
                 block
                 loading={this.state.processingChange}
-                haptic="selection"
+                haptic
               >
                 {this.state.following ? "Following" : "Follow"}
               </Button>

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesMeta.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesMeta.tsx
@@ -90,7 +90,7 @@ export const ArtistSeriesMeta: React.FC<ArtistSeriesMetaProps> = ({ artistSeries
               <Touchable
                 onPress={() => followOrUnfollowArtist(artist)}
                 hitSlop={{ top: 20, left: 20, bottom: 20, right: 20 }}
-                haptic="selection"
+                haptic
                 noFeedback
               >
                 <Sans style={{ textDecorationLine: "underline" }} size="3">

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/BidButton.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/BidButton.tsx
@@ -96,7 +96,7 @@ export class BidButton extends React.Component<BidButtonProps> {
       <>
         {!registrationStatus && (
           <>
-            <Button width={100} block size="large" mt={1} onPress={() => this.redirectToRegister()} haptic="selection">
+            <Button width={100} block size="large" mt={1} onPress={() => this.redirectToRegister()} haptic>
               Register to bid
             </Button>
             {needsIdentityVerification && (
@@ -203,7 +203,7 @@ export class BidButton extends React.Component<BidButtonProps> {
 
       return (
         // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-        <Button width={100} size="large" block onPress={() => this.redirectToBid(incrementCents)} haptic="selection">
+        <Button width={100} size="large" block onPress={() => this.redirectToBid(incrementCents)} haptic>
           {hasBid ? "Increase max bid" : "Bid"}
         </Button>
       )

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/BuyNowButton.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/BuyNowButton.tsx
@@ -120,7 +120,7 @@ export class BuyNowButton extends React.Component<BuyNowButtonProps, State> {
         variant={variant}
         block
         width={100}
-        haptic="selection"
+        haptic
       >
         {variant && variant === "secondaryOutline" && artwork.saleMessage
           ? `Buy now ${artwork.saleMessage}`

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/CommercialButtons.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/CommercialButtons.tsx
@@ -3,6 +3,7 @@ import { CommercialButtons_me } from "__generated__/CommercialButtons_me.graphql
 import { AuctionTimerState } from "lib/Components/Bidding/Components/Timer"
 import { navigate } from "lib/navigation/navigate"
 import { getCurrentEmissionState } from "lib/store/GlobalStore"
+import { InquiryOptions } from "lib/utils/ArtworkInquiry/ArtworkInquiryTypes"
 import { Schema, Track, track as _track } from "lib/utils/track"
 import { Button, Spacer } from "palette"
 import React from "react"
@@ -11,7 +12,7 @@ import { BidButtonFragmentContainer } from "./BidButton"
 import { BuyNowButtonFragmentContainer } from "./BuyNowButton"
 import { InquiryButtonsFragmentContainer } from "./InquiryButtons"
 import { MakeOfferButtonFragmentContainer } from "./MakeOfferButton"
-import { InquiryOptions } from "lib/utils/ArtworkInquiry/ArtworkInquiryTypes"
+
 
 export interface CommercialButtonProps {
   artwork: CommercialButtons_artwork

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/CommercialButtons.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/CommercialButtons.tsx
@@ -83,7 +83,7 @@ export class CommercialButtons extends React.Component<CommercialButtonProps> {
       return <MakeOfferButtonFragmentContainer artwork={artwork} editionSetID={this.props.editionSetID} />
     } else if (isInquireable && !newFirstInquiry) {
       return (
-        <Button onPress={() => this.handleInquiry()} size="large" block width={100} haptic="selection">
+        <Button onPress={() => this.handleInquiry()} size="large" block width={100} haptic>
           Contact gallery
         </Button>
       )

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/CommercialButtons.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/CommercialButtons.tsx
@@ -11,6 +11,7 @@ import { BidButtonFragmentContainer } from "./BidButton"
 import { BuyNowButtonFragmentContainer } from "./BuyNowButton"
 import { InquiryButtonsFragmentContainer } from "./InquiryButtons"
 import { MakeOfferButtonFragmentContainer } from "./MakeOfferButton"
+import { InquiryOptions } from "lib/utils/ArtworkInquiry/ArtworkInquiryTypes"
 
 export interface CommercialButtonProps {
   artwork: CommercialButtons_artwork
@@ -84,7 +85,7 @@ export class CommercialButtons extends React.Component<CommercialButtonProps> {
     } else if (isInquireable && !newFirstInquiry) {
       return (
         <Button onPress={() => this.handleInquiry()} size="large" block width={100} haptic>
-          Contact gallery
+          {InquiryOptions.ContactGallery}
         </Button>
       )
     } else if (isInquireable && newFirstInquiry) {

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryButtons.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryButtons.tsx
@@ -55,6 +55,7 @@ const InquiryButtons: React.FC<InquiryButtonsProps> = ({ artwork }) => {
         size="large"
         block
         width={100}
+        haptic
       >
         {InquiryOptions.ContactGallery}
       </Button>

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/MakeOfferButton.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/MakeOfferButton.tsx
@@ -121,7 +121,7 @@ export class MakeOfferButton extends React.Component<MakeOfferButtonProps, State
         block
         width={100}
         variant={this.props.variant}
-        haptic="selection"
+        haptic
       >
         Make offer
       </Button>

--- a/src/lib/Scenes/Artwork/Components/ContextCard.tsx
+++ b/src/lib/Scenes/Artwork/Components/ContextCard.tsx
@@ -111,7 +111,7 @@ export class ContextCard extends React.Component<ContextCardProps, ContextCardSt
         size="small"
         longestText="Following"
         loading={isSaving}
-        haptic="selection"
+        haptic
       >
         {isFollowed ? "Following" : "Follow"}
       </Button>

--- a/src/lib/Scenes/Artwork/Components/FollowArtistButton.tsx
+++ b/src/lib/Scenes/Artwork/Components/FollowArtistButton.tsx
@@ -57,7 +57,7 @@ export class FollowArtistButton extends React.Component<Props> {
   render() {
     const followButtonText = this.props.artist.is_followed ? "Following" : "Follow"
     return (
-      <Touchable onPress={() => this.handleFollowArtist()} haptic="selection" noFeedback>
+      <Touchable onPress={() => this.handleFollowArtist()} haptic noFeedback>
         <Sans color="black60" weight="medium" size="3t">
           {followButtonText}
         </Sans>

--- a/src/lib/Scenes/Artwork/Components/PartnerCard.tsx
+++ b/src/lib/Scenes/Artwork/Components/PartnerCard.tsx
@@ -122,7 +122,7 @@ export class PartnerCard extends React.Component<Props, State> {
                   size="small"
                   longestText="Following"
                   loading={isFollowedChanging}
-                  haptic="selection"
+                  haptic
                 >
                   {partner!.profile.is_followed ? "Following" : "Follow"}
                 </Button>

--- a/src/lib/Scenes/Consignments/ConsignmentsHome/Components/Footer.tsx
+++ b/src/lib/Scenes/Consignments/ConsignmentsHome/Components/Footer.tsx
@@ -73,7 +73,7 @@ export const Footer: React.FC<FooterProps> = ({ onConsignPress }) => {
 
       <Spacer mb={3} />
 
-      <Button data-test-id="footer-cta" variant="primaryBlack" block onPress={handlePress} haptic="selection">
+      <Button data-test-id="footer-cta" variant="primaryBlack" block onPress={handlePress} haptic>
         <Sans size="3">Submit a work</Sans>
       </Button>
     </Box>

--- a/src/lib/Scenes/Consignments/ConsignmentsHome/Components/Header.tsx
+++ b/src/lib/Scenes/Consignments/ConsignmentsHome/Components/Header.tsx
@@ -33,7 +33,7 @@ export const Header: React.FC<HeaderProps> = ({ onConsignPress }) => {
 
       <Spacer mb={2} />
 
-      <Button data-test-id="header-cta" variant="primaryBlack" block onPress={handlePress} haptic="selection">
+      <Button data-test-id="header-cta" variant="primaryBlack" block onPress={handlePress} haptic>
         <Sans size="3" weight="medium">
           Submit a work
         </Sans>

--- a/src/lib/Scenes/Consignments/Screens/Overview.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Overview.tsx
@@ -279,11 +279,7 @@ export default class Overview extends React.Component<Props, State> {
               <Spacer mb={isPad ? 80 : 2} />
               <Flex justifyContent="center" alignItems="center" flexDirection="column">
                 {!!this.state.hasLoaded && (
-                  <Button
-                    onPress={canSubmit ? this.submitFinalSubmission : undefined}
-                    disabled={!canSubmit}
-                    haptic="selection"
-                  >
+                  <Button onPress={canSubmit ? this.submitFinalSubmission : undefined} disabled={!canSubmit} haptic>
                     Submit
                   </Button>
                 )}

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
@@ -77,7 +77,7 @@ export const MyCollectionArtwork: React.FC<MyCollectionArtworkProps> = ({ artwor
                 navigate("/consign/submission")
               }}
               data-test-id="SubmitButton"
-              haptic="selection"
+              haptic
             >
               Submit this work
             </Button>

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkFormModal/Screens/MyCollectionArtworkFormMain.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkFormModal/Screens/MyCollectionArtworkFormMain.tsx
@@ -86,7 +86,7 @@ export const MyCollectionArtworkFormMain: React.FC<StackScreenProps<ArtworkFormM
             block
             onPress={formik.handleSubmit}
             data-test-id="CompleteButton"
-            haptic="selection"
+            haptic
           >
             {modalType === "edit" ? "Save changes" : "Complete"}
           </Button>

--- a/src/lib/Scenes/Partner/Components/PartnerFollowButton.tsx
+++ b/src/lib/Scenes/Partner/Components/PartnerFollowButton.tsx
@@ -91,7 +91,7 @@ export class PartnerFollowButton extends React.Component<Props, State> {
         longestText="Following"
         loading={isFollowedChanging}
         size="small"
-        haptic="selection"
+        haptic
       >
         {partner.profile?.isFollowed ? "Following" : "Follow"}
       </Button>

--- a/src/lib/Scenes/Sale/Components/RegisterToBidButton.tsx
+++ b/src/lib/Scenes/Sale/Components/RegisterToBidButton.tsx
@@ -34,7 +34,7 @@ const RegisterToBidButton: React.FC<RegisterToBidButtonProps> = ({ me, sale, con
             )
             navigate(`/auction-registration/${sale.slug}`)
           }}
-          haptic="selection"
+          haptic
         >
           Register to bid
         </Button>

--- a/src/palette/elements/EntityHeader/EntityHeader.tsx
+++ b/src/palette/elements/EntityHeader/EntityHeader.tsx
@@ -14,10 +14,6 @@ interface EntityHeaderProps extends SpacerProps {
   FollowButton?: JSX.Element
 }
 
-/**
- * Component that is used as entity header that is paired with rich information about the entity.
- * Spec: zpl.io/aNoYM6d
- */
 export const EntityHeader: React.FC<EntityHeaderProps> = ({
   smallVariant,
   href,
@@ -35,19 +31,19 @@ export const EntityHeader: React.FC<EntityHeaderProps> = ({
   )
 
   const headerName = (
-    <Sans ellipsizeMode="tail" numberOfLines={1} size="3">
+    <Sans ellipsizeMode="tail" numberOfLines={1} size="3" style={{ flexShrink: 1 }}>
       {name}
     </Sans>
   )
 
   const headerMeta = meta && (
-    <Sans ellipsizeMode="tail" numberOfLines={1} size="2" color="black60">
+    <Sans ellipsizeMode="tail" numberOfLines={1} size="2" color="black60" style={{ flexShrink: 1 }}>
       {meta}
     </Sans>
   )
 
   return (
-    <Flex flexDirection="row" justifyContent="space-between" flexWrap="nowrap" {...remainderProps}>
+    <Flex flexDirection="row" flexWrap="nowrap" {...remainderProps}>
       {!!(imageUrl || initials) && (
         <Flex mr={1} justifyContent="center">
           <Avatar size="xs" src={imageUrl} initials={initials} />
@@ -66,7 +62,7 @@ export const EntityHeader: React.FC<EntityHeaderProps> = ({
         </Flex>
       ) : (
         <Flex justifyContent="space-between" width={0} flexGrow={1} flexDirection="row">
-          <Flex alignSelf="center">
+          <Flex alignSelf="center" flexShrink={1}>
             {headerName}
             {headerMeta}
           </Flex>


### PR DESCRIPTION
The type of this PR is: **TYPE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-550]

### Description

After the feedback in https://artsyproduct.atlassian.net/browse/CX-550?focusedCommentId=34269:
- made all haptics use the default strength, same as the "save work".
- fixed a small layout bug:
before:
<img width="467" alt="Screenshot 2021-01-12 at 12 16 12" src="https://user-images.githubusercontent.com/100233/104302562-da6d9200-54c0-11eb-85b6-f2d945dfa0db.png">
after:
<img width="382" alt="Screenshot 2021-01-12 at 12 15 37" src="https://user-images.githubusercontent.com/100233/104302582-e0637300-54c0-11eb-9e36-73bc72085897.png">
- added haptic on the contact gallery special case

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-550]: https://artsyproduct.atlassian.net/browse/CX-550