### PR TITLE
fix: Display correct sale date for auction results

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -13,6 +13,7 @@ upcoming:
     - Add filter button and screen to the ArtistInsights AuctionResults - mounir
     - Allow users to indicate works in MyCollection as editions without marking edition size or number - anna
     - Wire up `See all past shows` button - adam
+    - Display sale date correctly on auction results - pepopowitz, ana lisa
 
 releases:
   - version: 6.7.5

--- a/src/lib/Components/Lists/AuctionResult.tsx
+++ b/src/lib/Components/Lists/AuctionResult.tsx
@@ -61,7 +61,7 @@ const AuctionResult: React.FC<Props> = ({ auctionResult, onPress }) => {
             )}
 
             {!!auctionResult.saleDate && (
-              <Text variant="small" color="black60" numberOfLines={1}>
+              <Text variant="small" color="black60" numberOfLines={1} testID="saleInfo">
                 {moment(auctionResult.saleDate).utc().format("MMM D, YYYY")}
                 {` ${bullet} `}
                 {auctionResult.organization}
@@ -73,7 +73,7 @@ const AuctionResult: React.FC<Props> = ({ auctionResult, onPress }) => {
           <Flex alignItems="flex-end" pl={15}>
             {!!auctionResult.priceRealized?.display && !!auctionResult.currency ? (
               <Flex alignItems="flex-end">
-                <Text variant="subtitle" fontWeight="bold">
+                <Text variant="subtitle" fontWeight="bold" testID="price">
                   {(auctionResult.priceRealized?.display ?? "").replace(`${auctionResult.currency} `, "")}
                 </Text>
                 {!!ratio && (
@@ -93,7 +93,7 @@ const AuctionResult: React.FC<Props> = ({ auctionResult, onPress }) => {
               </Flex>
             ) : (
               <Flex alignItems="flex-end">
-                <Text variant="subtitle" fontWeight="bold" style={{ width: 70 }} textAlign="right">
+                <Text variant="subtitle" fontWeight="bold" style={{ width: 70 }} textAlign="right" testID="price">
                   {auctionResult.boughtIn === true
                     ? "Bought in"
                     : isFromPastMonth

--- a/src/lib/Components/Lists/AuctionResult.tsx
+++ b/src/lib/Components/Lists/AuctionResult.tsx
@@ -62,7 +62,7 @@ const AuctionResult: React.FC<Props> = ({ auctionResult, onPress }) => {
 
             {!!auctionResult.saleDate && (
               <Text variant="small" color="black60" numberOfLines={1}>
-                {moment(auctionResult.saleDate).format("MMM D, YYYY")}
+                {moment(auctionResult.saleDate).utc().format("MMM D, YYYY")}
                 {` ${bullet} `}
                 {auctionResult.organization}
               </Text>

--- a/src/lib/Components/Lists/__tests__/AuctionResult-tests.tsx
+++ b/src/lib/Components/Lists/__tests__/AuctionResult-tests.tsx
@@ -2,7 +2,6 @@ import { AuctionResultTestsQuery } from "__generated__/AuctionResultTestsQuery.g
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { extractNodes } from "lib/utils/extractNodes"
 import moment from "moment"
-import { Text } from "palette"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment } from "relay-test-utils"
@@ -62,7 +61,7 @@ describe("AuctionResults", () => {
       }),
     })
 
-    expect(tree.findAllByType(Text)[4].props.children).toBe("$one gazillion")
+    expect(tree.findByProps({ testID: "price" }).props.children).toBe("$one gazillion")
   })
 
   it("renders auction result when auction results are not available yet", () => {
@@ -84,7 +83,7 @@ describe("AuctionResults", () => {
       }),
     })
 
-    expect(tree.findAllByType(Text)[4].props.children).toBe("Awaiting results")
+    expect(tree.findByProps({ testID: "price" }).props.children).toBe("Awaiting results")
   })
 
   it("renders auction result when auction result is `bought in`", () => {
@@ -107,7 +106,7 @@ describe("AuctionResults", () => {
       }),
     })
 
-    expect(tree.findAllByType(Text)[4].props.children).toBe("Bought in")
+    expect(tree.findByProps({ testID: "price" }).props.children).toBe("Bought in")
   })
 
   it("renders sale date correctly", () => {
@@ -126,6 +125,6 @@ describe("AuctionResults", () => {
       }),
     })
 
-    expect(tree.findAllByType(Text)[3].props.children).toContain("Jan 12, 2021")
+    expect(tree.findByProps({ testID: "saleInfo" }).props.children).toContain("Jan 12, 2021")
   })
 })

--- a/src/lib/Components/Lists/__tests__/AuctionResult-tests.tsx
+++ b/src/lib/Components/Lists/__tests__/AuctionResult-tests.tsx
@@ -110,7 +110,7 @@ describe("AuctionResults", () => {
     expect(tree.findAllByType(Text)[4].props.children).toBe("Bought in")
   })
 
-  it("renders auction result when auction results are not available", () => {
+  it("renders sale date correctly", () => {
     const tree = renderWithWrappers(<TestRenderer />).root
     mockEnvironmentPayload(mockEnvironment, {
       Artist: () => ({
@@ -118,11 +118,7 @@ describe("AuctionResults", () => {
           edges: [
             {
               node: {
-                priceRealized: {
-                  display: null,
-                },
-                saleDate: moment().subtract(2, "months").toISOString(),
-                boughtIn: false,
+                saleDate: "2021-01-11T18:00:00-06:00",
               },
             },
           ],
@@ -130,6 +126,6 @@ describe("AuctionResults", () => {
       }),
     })
 
-    expect(tree.findAllByType(Text)[4].props.children).toBe("Not available")
+    expect(tree.findAllByType(Text)[3].props.children).toContain("Jan 12, 2021")
   })
 })

--- a/src/lib/Scenes/AuctionResult/AuctionResult.tsx
+++ b/src/lib/Scenes/AuctionResult/AuctionResult.tsx
@@ -53,12 +53,12 @@ const AuctionResult: React.FC<Props> = ({ artist, auctionResult }) => {
   const difference = getDifference()
 
   const stats = []
-  const makeRow = (label: string, value: string, fullWidth?: boolean) => (
+  const makeRow = (label: string, value: string, options?: { fullWidth?: boolean; testID?: string }) => (
     <Flex key={label} mb={1}>
       <Flex style={{ opacity: 0.5 }}>
         <Separator mb={1} />
       </Flex>
-      {fullWidth ? (
+      {options?.fullWidth ? (
         <Flex>
           <Text color="black60" mb={1}>
             {label}
@@ -69,7 +69,7 @@ const AuctionResult: React.FC<Props> = ({ artist, auctionResult }) => {
         <Flex flexDirection="row" justifyContent="space-between">
           <Text color="black60">{label}</Text>
           <Flex maxWidth="80%">
-            <Text pl={2} textAlign="right">
+            <Text pl={2} textAlign="right" testID={options?.testID}>
               {value}
             </Text>
           </Flex>
@@ -91,7 +91,7 @@ const AuctionResult: React.FC<Props> = ({ artist, auctionResult }) => {
     stats.push(makeRow("Year created", auctionResult.dateText))
   }
   if (auctionResult?.saleDate) {
-    stats.push(makeRow("Sale date", moment(auctionResult.saleDate).format("MMM D, YYYY")))
+    stats.push(makeRow("Sale date", moment(auctionResult.saleDate).utc().format("MMM D, YYYY"), { testID: "saleDate" }))
   }
   if (auctionResult?.organization) {
     stats.push(makeRow("Auction house", auctionResult.organization))
@@ -103,7 +103,7 @@ const AuctionResult: React.FC<Props> = ({ artist, auctionResult }) => {
     stats.push(makeRow("Sale location", auctionResult.location))
   }
   if (auctionResult?.description) {
-    stats.push(makeRow("Description", auctionResult.description, true))
+    stats.push(makeRow("Description", auctionResult.description, { fullWidth: true }))
   }
 
   const hasSalePrice = !!auctionResult?.priceRealized?.display && !!auctionResult.currency

--- a/src/lib/Scenes/AuctionResult/__tests__/AuctionResult-tests.tsx
+++ b/src/lib/Scenes/AuctionResult/__tests__/AuctionResult-tests.tsx
@@ -64,4 +64,13 @@ describe("AuctionResult", () => {
     expect(extractText(tree.root)).toContain("Bought in")
     expect(tree.root.findAllByProps({ testID: "ratio" })).toHaveLength(0)
   })
+
+  it("shows the correct sale date", () => {
+    const tree = renderAuctionResult({
+      AuctionResult: () => ({
+        saleDate: "2021-01-11T18:00:00-06:00",
+      }),
+    })
+    expect(extractText(tree.root.findByProps({ testID: "saleDate" }))).toContain("Jan 12, 2021")
+  })
 })


### PR DESCRIPTION
Collaboration with @The-Beez-Kneez!!!

The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-943]

### Description

The sale date is parsed as a local timestamp, so dates were getting nudged off by 1 (for those of us west of gmt). 

In this PR we convert to UTC before displaying them.

Auction result list: 

(The Andy Warhol "Wine Label" items were previously showing Dec 14)

![image](https://user-images.githubusercontent.com/1627089/104384529-3eab4880-54f7-11eb-8fa3-3596d92cf102.png)

Auction result detail:
(This was previously showing Dec 14)

![image](https://user-images.githubusercontent.com/1627089/104384645-67334280-54f7-11eb-93a5-cc6afcc05092.png)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-943]: https://artsyproduct.atlassian.net/browse/CX-943