### PR TITLE
refactor: use react native fast image

### DIFF
--- a/Artsy/Categories/Apple/UIImageView+AsyncImageLoading.h
+++ b/Artsy/Categories/Apple/UIImageView+AsyncImageLoading.h
@@ -7,7 +7,7 @@
 
 - (void)ar_setImageWithURL:(NSURL *)url;
 
-- (void)ar_setImageWithURL:(NSURL *)url completed:(SDWebImageCompletionBlock)completed;
+- (void)ar_setImageWithURL:(NSURL *)url completed:(SDExternalCompletionBlock)completed;
 
 - (void)ar_setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder;
 

--- a/Artsy/View_Controllers/Live_Auctions/Views/LiveAuctionLotCollectionViewDataSource.swift
+++ b/Artsy/View_Controllers/Live_Auctions/Views/LiveAuctionLotCollectionViewDataSource.swift
@@ -7,7 +7,7 @@ class LiveAuctionLotCollectionViewDataSource: NSObject {
     static let CellClass = LiveAuctionLotImageCollectionViewCell.self
 
     let salesPerson: LiveAuctionsSalesPersonType
-    let imagePrefetcher = SDWebImagePrefetcher.shared()
+    let imagePrefetcher = SDWebImagePrefetcher.shared
 
     init(salesPerson: LiveAuctionsSalesPersonType) {
         self.salesPerson = salesPerson
@@ -20,7 +20,7 @@ class LiveAuctionLotCollectionViewDataSource: NSObject {
 
     func beginThumbnailPrecache() {
         let thumbnailURLs = (1..<salesPerson.lotCount).compactMap { return salesPerson.lotViewModelForIndex($0).urlForThumbnail }
-        imagePrefetcher?.prefetchURLs(thumbnailURLs)
+        imagePrefetcher.prefetchURLs(thumbnailURLs)
     }
 
     fileprivate func offsetForIndex(_ index: Int) -> Int {

--- a/Artsy/View_Controllers/Util/ARFeedImageLoader.m
+++ b/Artsy/View_Controllers/Util/ARFeedImageLoader.m
@@ -4,6 +4,7 @@
 
 #import "UIImage+ImageFromColor.h"
 #import "UIImageView+AsyncImageLoading.h"
+#import <SDWebImage/SDImageCache.h>
 
 // From the gravity source
 

--- a/Podfile
+++ b/Podfile
@@ -80,7 +80,7 @@ target 'Artsy' do
   pod 'AFNetworking', '~> 2.5', subspecs: %w[Reachability Serialization Security NSURLSession NSURLConnection]
   pod 'AFOAuth1Client', git: 'https://github.com/artsy/AFOAuth1Client.git', tag: '0.4.0-subspec-fix'
   pod 'AFNetworkActivityLogger'
-  pod 'SDWebImage', '>= 3.7.2' # 3.7.2 contains a fix that allows you to not force decoding each image, which uses lots of memory
+  pod 'SDWebImage', '5.8'
 
   # Core
   pod 'ARGenericTableViewController', git: 'https://github.com/artsy/ARGenericTableViewController.git'

--- a/Podfile
+++ b/Podfile
@@ -80,7 +80,7 @@ target 'Artsy' do
   pod 'AFNetworking', '~> 2.5', subspecs: %w[Reachability Serialization Security NSURLSession NSURLConnection]
   pod 'AFOAuth1Client', git: 'https://github.com/artsy/AFOAuth1Client.git', tag: '0.4.0-subspec-fix'
   pod 'AFNetworkActivityLogger'
-  pod 'SDWebImage', '5.8'
+  pod 'SDWebImage', '5.8.3'
 
   # Core
   pod 'ARGenericTableViewController', git: 'https://github.com/artsy/ARGenericTableViewController.git'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -199,6 +199,15 @@ PODS:
   - JLRoutes (2.0.0)
   - JSDecoupledAppDelegate (1.2.0)
   - JWTDecode (2.0.0)
+  - libwebp (1.1.0):
+    - libwebp/demux (= 1.1.0)
+    - libwebp/mux (= 1.1.0)
+    - libwebp/webp (= 1.1.0)
+  - libwebp/demux (1.1.0):
+    - libwebp/webp
+  - libwebp/mux (1.1.0):
+    - libwebp/demux
+  - libwebp/webp (1.1.0)
   - Mantle (1.5.6):
     - Mantle/extobjc (= 1.5.6)
   - Mantle/extobjc (1.5.6)
@@ -493,6 +502,10 @@ PODS:
     - React
   - RNCPicker (1.3.0):
     - React
+  - RNFastImage (8.3.4):
+    - React-Core
+    - SDWebImage (~> 5.8)
+    - SDWebImageWebPCoder (~> 0.6.1)
   - RNGestureHandler (1.8.0):
     - React
   - RNImageCropPicker (0.35.1):
@@ -525,6 +538,9 @@ PODS:
   - SDWebImage (5.8.0):
     - SDWebImage/Core (= 5.8.0)
   - SDWebImage/Core (5.8.0)
+  - SDWebImageWebPCoder (0.6.1):
+    - libwebp (~> 1.0)
+    - SDWebImage/Core (~> 5.7)
   - Sentry (4.4.3):
     - Sentry/Core (= 4.4.3)
   - Sentry/Core (4.4.3)
@@ -651,6 +667,7 @@ DEPENDENCIES:
   - "RNCAsyncStorage (from `node_modules/@react-native-community/async-storage`)"
   - "RNCMaskedView (from `node_modules/@react-native-community/masked-view`)"
   - "RNCPicker (from `node_modules/@react-native-community/picker`)"
+  - RNFastImage (from `node_modules/react-native-fast-image`)
   - RNGestureHandler (from `node_modules/react-native-gesture-handler`)
   - RNImageCropPicker (from `node_modules/react-native-image-crop-picker`)
   - RNLocalize (from `node_modules/react-native-localize`)
@@ -702,6 +719,7 @@ SPEC REPOS:
     - INTUAnimationEngine
     - JSDecoupledAppDelegate
     - JWTDecode
+    - libwebp
     - Mantle
     - Mapbox-iOS-SDK
     - MapboxMobileEvents
@@ -720,6 +738,7 @@ SPEC REPOS:
     - Quick
     - SailthruMobile
     - SDWebImage
+    - SDWebImageWebPCoder
     - Sentry
     - Specta
     - Starscream
@@ -836,6 +855,8 @@ EXTERNAL SOURCES:
     :path: "node_modules/@react-native-community/masked-view"
   RNCPicker:
     :path: "node_modules/@react-native-community/picker"
+  RNFastImage:
+    :path: node_modules/react-native-fast-image
   RNGestureHandler:
     :path: node_modules/react-native-gesture-handler
   RNImageCropPicker:
@@ -930,6 +951,7 @@ SPEC CHECKSUMS:
   JLRoutes: 63d64c28b26bcdeb5f5b29e436f75b8358e8d6d1
   JSDecoupledAppDelegate: 5905e144cbe6e0c889248eebbee6784510f315e1
   JWTDecode: 178e47e5d28d3abcff778bacced8342858cd6cb5
+  libwebp: 946cb3063cea9236285f7e9a8505d806d30e07f3
   Mantle: a197db93e0f1e36194b1fdbc078219a8492eaef2
   Mapbox-iOS-SDK: 2563ed87ead6ec08f1c2090873977b8a7be335a8
   MapboxMobileEvents: d0a581dedd8f47411cc65ea520b965e83914316e
@@ -979,6 +1001,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 3c304d1adfaea02ec732ac218801cb13897aa8c0
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNCPicker: 7d06ee91dff65b0bcd400ca00039051d5ddcb938
+  RNFastImage: d4870d58f5936111c56218dbd7fcfc18e65b58ff
   RNGestureHandler: 7a5833d0f788dbd107fbb913e09aa0c1ff333c39
   RNImageCropPicker: 16951bc02411f50c4d197488ed6406a23dc3b5f1
   RNLocalize: 41026b7c14878f1a1b381bc79f668f1fbf841adb
@@ -990,6 +1013,7 @@ SPEC CHECKSUMS:
   RNSVG: f6177f8d7c095fada7cfee2e4bb7388ba426064c
   SailthruMobile: df0a457a0be8cc9feaba16cc52deb527d89cab04
   SDWebImage: 84000f962cbfa70c07f19d2234cbfcf5d779b5dc
+  SDWebImageWebPCoder: d0dac55073088d24b2ac1b191a71a8f8d0adac21
   Sentry: 14bdd673870e8cf64932b149fad5bbbf39a9b390
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
   Starscream: f5da93fe6984c77b694366bf7299b7dc63a76f26

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -76,7 +76,7 @@ PODS:
     - React-RCTText (= 0.63.3)
     - RNSentry (= 1.3.2)
     - RNSVG (= 9.13.3)
-    - SDWebImage (< 4, >= 3.7.2)
+    - SDWebImage (= 5.8)
     - tipsi-stripe (= 7.5.0)
   - Expecta (1.0.6)
   - "Expecta+Snapshots (3.1.1)":
@@ -522,9 +522,9 @@ PODS:
   - SailthruMobile (11.0.1):
     - SailthruMobile/Extension (= 11.0.1)
   - SailthruMobile/Extension (11.0.1)
-  - SDWebImage (3.7.3):
-    - SDWebImage/Core (= 3.7.3)
-  - SDWebImage/Core (3.7.3)
+  - SDWebImage (5.8.0):
+    - SDWebImage/Core (= 5.8.0)
+  - SDWebImage/Core (5.8.0)
   - Sentry (4.4.3):
     - Sentry/Core (= 4.4.3)
   - Sentry/Core (4.4.3)
@@ -661,7 +661,7 @@ DEPENDENCIES:
   - RNShare (from `node_modules/react-native-share`)
   - RNSVG (from `node_modules/react-native-svg`)
   - SailthruMobile
-  - SDWebImage (>= 3.7.2)
+  - SDWebImage (= 5.8)
   - Specta
   - Starscream
   - SwiftyJSON
@@ -903,7 +903,7 @@ SPEC CHECKSUMS:
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   DoubleConversion: cde416483dac037923206447da6e1454df403714
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
-  Emission: cb9fd158eac9aa56e44a65b15e7a525c1ce11a48
+  Emission: 31be322563451bcfe9c435a75363b6e2c8b134e8
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   "Expecta+Snapshots": dcff217eef506dabd6dfdc7864ea2da321fafbb8
   Extraction: 2be993a17f8f8c4fac988ebecaed93a409181faf
@@ -989,7 +989,7 @@ SPEC CHECKSUMS:
   RNShare: fed99fd743f80ca255903c1da46fc9a6430efab6
   RNSVG: f6177f8d7c095fada7cfee2e4bb7388ba426064c
   SailthruMobile: df0a457a0be8cc9feaba16cc52deb527d89cab04
-  SDWebImage: 1d2b1a1efda1ade1b00b6f8498865f8ddedc8a84
+  SDWebImage: 84000f962cbfa70c07f19d2234cbfcf5d779b5dc
   Sentry: 14bdd673870e8cf64932b149fad5bbbf39a9b390
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
   Starscream: f5da93fe6984c77b694366bf7299b7dc63a76f26
@@ -1004,6 +1004,6 @@ SPEC CHECKSUMS:
   Yoga: 7d13633d129fd179e01b8953d38d47be90db185a
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 059f1c6c66d6afbb55df1080532345e3e4741a46
+PODFILE CHECKSUM: d624e1a94390c8f20e39596c2facf3ca885def32
 
 COCOAPODS: 1.7.5

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -76,7 +76,7 @@ PODS:
     - React-RCTText (= 0.63.3)
     - RNSentry (= 1.3.2)
     - RNSVG (= 9.13.3)
-    - SDWebImage (= 5.8)
+    - SDWebImage (= 5.8.3)
     - tipsi-stripe (= 7.5.0)
   - Expecta (1.0.6)
   - "Expecta+Snapshots (3.1.1)":
@@ -535,9 +535,9 @@ PODS:
   - SailthruMobile (11.0.1):
     - SailthruMobile/Extension (= 11.0.1)
   - SailthruMobile/Extension (11.0.1)
-  - SDWebImage (5.8.0):
-    - SDWebImage/Core (= 5.8.0)
-  - SDWebImage/Core (5.8.0)
+  - SDWebImage (5.8.3):
+    - SDWebImage/Core (= 5.8.3)
+  - SDWebImage/Core (5.8.3)
   - SDWebImageWebPCoder (0.6.1):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.7)
@@ -678,7 +678,7 @@ DEPENDENCIES:
   - RNShare (from `node_modules/react-native-share`)
   - RNSVG (from `node_modules/react-native-svg`)
   - SailthruMobile
-  - SDWebImage (= 5.8)
+  - SDWebImage (= 5.8.3)
   - Specta
   - Starscream
   - SwiftyJSON
@@ -924,7 +924,7 @@ SPEC CHECKSUMS:
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   DoubleConversion: cde416483dac037923206447da6e1454df403714
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
-  Emission: 31be322563451bcfe9c435a75363b6e2c8b134e8
+  Emission: 306da99e7fdcfa2b8c92c221f2fedcb813c2a434
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   "Expecta+Snapshots": dcff217eef506dabd6dfdc7864ea2da321fafbb8
   Extraction: 2be993a17f8f8c4fac988ebecaed93a409181faf
@@ -1012,7 +1012,7 @@ SPEC CHECKSUMS:
   RNShare: fed99fd743f80ca255903c1da46fc9a6430efab6
   RNSVG: f6177f8d7c095fada7cfee2e4bb7388ba426064c
   SailthruMobile: df0a457a0be8cc9feaba16cc52deb527d89cab04
-  SDWebImage: 84000f962cbfa70c07f19d2234cbfcf5d779b5dc
+  SDWebImage: 112503ec94a5a2a41869503844a15e8d8f1ead5c
   SDWebImageWebPCoder: d0dac55073088d24b2ac1b191a71a8f8d0adac21
   Sentry: 14bdd673870e8cf64932b149fad5bbbf39a9b390
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
@@ -1028,6 +1028,6 @@ SPEC CHECKSUMS:
   Yoga: 7d13633d129fd179e01b8953d38d47be90db185a
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: d624e1a94390c8f20e39596c2facf3ca885def32
+PODFILE CHECKSUM: 81889ba14c800b4ae098b0834072d3ce481292d1
 
 COCOAPODS: 1.7.5

--- a/emission/Emission.podspec
+++ b/emission/Emission.podspec
@@ -39,7 +39,7 @@ podspec = Pod::Spec.new do |s|
   s.dependency 'ISO8601DateFormatter'
 
   # To ensure a consistent image cache between app/lib
-  s.dependency 'SDWebImage', '>= 3.7.2', '< 4'
+  s.dependency 'SDWebImage', '5.8'
 
   # For custom animations in DeepZoomOverlay
   s.dependency 'INTUAnimationEngine'

--- a/emission/Emission.podspec
+++ b/emission/Emission.podspec
@@ -39,7 +39,7 @@ podspec = Pod::Spec.new do |s|
   s.dependency 'ISO8601DateFormatter'
 
   # To ensure a consistent image cache between app/lib
-  s.dependency 'SDWebImage', '5.8'
+  s.dependency 'SDWebImage', '5.8.3'
 
   # For custom animations in DeepZoomOverlay
   s.dependency 'INTUAnimationEngine'

--- a/emission/Pod/Classes/OpaqueImageViewComponent/AROpaqueImageView.m
+++ b/emission/Pod/Classes/OpaqueImageViewComponent/AROpaqueImageView.m
@@ -76,59 +76,59 @@ LoadImage(UIImage *image, CGSize destinationSize, CGFloat scaleFactor, UIColor *
 
 - (void)setImageURL:(NSURL *)imageURL;
 {
-  if ([_imageURL isEqual:imageURL]) {
-    return;
-  }
-
-  // This is a weak reference, so either an operation is in-flight and
-  // needs cancelling, or it will be nil and this is a no-op.
-  [self.downloadOperation cancel];
-
-  _imageURL = imageURL;
-  if (_imageURL == nil) {
-    return;
-  }
-
-  // TODO: Setting decompress to NO, because Eigen sets it to YES.
-  //      We need to send a PR to SDWebImage to disable decoding
-  //      with an option to the download method.
-  //
-  SDWebImageManager *manager = [SDWebImageManager sharedManager];
-
-  manager.imageCache.shouldDecompressImages = NO;
-  manager.imageDownloader.shouldDecompressImages = NO;
-
-  __weak typeof(self) weakSelf = self;
-  [manager cachedImageExistsForURL:self.imageURL completion:^(BOOL isInCache) {
-    if (!isInCache) {
-      self.backgroundColor = self.placeholderBackgroundColor;
-    }
-    self.downloadOperation = [manager downloadImageWithURL:self.imageURL
-                                                   options:self.highPriority ? SDWebImageHighPriority : 0
-                                                  progress:nil
-                                                 completed:^(UIImage *image,
-                                                             NSError *error,
-                                                             SDImageCacheType __,
-                                                             BOOL completed,
-                                                             NSURL *imageURL) {
-
-     __strong typeof(weakSelf) strongSelf = weakSelf;
-     // Only really assign if the URL we downloaded still matches `self.imageURL`.
-     if (strongSelf && [imageURL isEqual:strongSelf.imageURL]) {
-       if (strongSelf.failSilently && (error != nil || !completed)) {
-         return;
-       }
-       // The view might not yet be associated with a window, in which case
-       // -[UIView contentScaleFactor] would always return 1, so use screen instead.
-       CGFloat scaleFactor = [[UIScreen mainScreen] scale];
-       LoadImage(image, strongSelf.bounds.size, scaleFactor, strongSelf.placeholderBackgroundColor, strongSelf.highPriority, ^(UIImage *loadedImage) {
-         if ([imageURL isEqual:weakSelf.imageURL]) {
-           weakSelf.image = loadedImage;
-         }
-       });
-     }
-   }];
-  }];
+//  if ([_imageURL isEqual:imageURL]) {
+//    return;
+//  }
+//
+//  // This is a weak reference, so either an operation is in-flight and
+//  // needs cancelling, or it will be nil and this is a no-op.
+//  [self.downloadOperation cancel];
+//
+//  _imageURL = imageURL;
+//  if (_imageURL == nil) {
+//    return;
+//  }
+//
+//  // TODO: Setting decompress to NO, because Eigen sets it to YES.
+//  //      We need to send a PR to SDWebImage to disable decoding
+//  //      with an option to the download method.
+//  //
+//  SDWebImageManager *manager = [SDWebImageManager sharedManager];
+//
+//  manager.imageCache.shouldDecompressImages = NO;
+//  manager.imageDownloader.shouldDecompressImages = NO;
+//
+//  __weak typeof(self) weakSelf = self;
+//  [manager cachedImageExistsForURL:self.imageURL completion:^(BOOL isInCache) {
+//    if (!isInCache) {
+//      self.backgroundColor = self.placeholderBackgroundColor;
+//    }
+//    self.downloadOperation = [manager downloadImageWithURL:self.imageURL
+//                                                   options:self.highPriority ? SDWebImageHighPriority : 0
+//                                                  progress:nil
+//                                                 completed:^(UIImage *image,
+//                                                             NSError *error,
+//                                                             SDImageCacheType __,
+//                                                             BOOL completed,
+//                                                             NSURL *imageURL) {
+//
+//     __strong typeof(weakSelf) strongSelf = weakSelf;
+//     // Only really assign if the URL we downloaded still matches `self.imageURL`.
+//     if (strongSelf && [imageURL isEqual:strongSelf.imageURL]) {
+//       if (strongSelf.failSilently && (error != nil || !completed)) {
+//         return;
+//       }
+//       // The view might not yet be associated with a window, in which case
+//       // -[UIView contentScaleFactor] would always return 1, so use screen instead.
+//       CGFloat scaleFactor = [[UIScreen mainScreen] scale];
+//       LoadImage(image, strongSelf.bounds.size, scaleFactor, strongSelf.placeholderBackgroundColor, strongSelf.highPriority, ^(UIImage *loadedImage) {
+//         if ([imageURL isEqual:weakSelf.imageURL]) {
+//           weakSelf.image = loadedImage;
+//         }
+//       });
+//     }
+//   }];
+//  }];
 }
 
 @end

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "react": "16.13.1",
     "react-native": "0.63.3",
     "react-native-config": "https://github.com/artsy/react-native-config.git",
+    "react-native-fast-image": "^8.3.4",
     "react-native-gesture-handler": "^1.8.0",
     "react-native-haptic-feedback": "1.10.0",
     "react-native-hyperlink": "0.0.11",

--- a/src/lib/Components/OpaqueImageView/OpaqueImageView.tsx
+++ b/src/lib/Components/OpaqueImageView/OpaqueImageView.tsx
@@ -1,16 +1,8 @@
 import React from "react"
 
-import {
-  LayoutChangeEvent,
-  PixelRatio,
-  processColor,
-  requireNativeComponent,
-  StyleSheet,
-  View,
-  ViewProps,
-} from "react-native"
+import { LayoutChangeEvent, PixelRatio, processColor, StyleSheet, ViewProps } from "react-native"
 
-import colors from "lib/data/colors"
+import FastImage from "react-native-fast-image"
 import { createGeminiUrl } from "./createGeminiUrl"
 
 interface Props extends ViewProps {
@@ -63,12 +55,7 @@ interface State {
   width?: number
   height?: number
 }
-
-export default class OpaqueImageView extends React.Component<Props, State> {
-  static defaultProps: Props = {
-    placeholderBackgroundColor: colors["gray-regular"],
-  }
-
+export default class ArtsyImageView extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
 
@@ -97,6 +84,15 @@ export default class OpaqueImageView extends React.Component<Props, State> {
     }
   }
 
+  onLayout = (event: LayoutChangeEvent) => {
+    const { width, height } = event.nativeEvent.layout
+    const scale = PixelRatio.get()
+    this.setState({
+      width: width * scale,
+      height: height * scale,
+    })
+  }
+
   imageURL() {
     const { imageURL, useRawURL } = this.props
 
@@ -113,16 +109,7 @@ export default class OpaqueImageView extends React.Component<Props, State> {
       })
     }
 
-    return null
-  }
-
-  onLayout = (event: LayoutChangeEvent) => {
-    const { width, height } = event.nativeEvent.layout
-    const scale = PixelRatio.get()
-    this.setState({
-      width: width * scale,
-      height: height * scale,
-    })
+    return undefined
   }
 
   render() {
@@ -148,8 +135,18 @@ export default class OpaqueImageView extends React.Component<Props, State> {
       backgroundColorStyle = { backgroundColor: props.placeholderBackgroundColor }
     }
 
-    return <NativeOpaqueImageView style={[style, backgroundColorStyle]} {...remainderProps} />
+    const resolvedURL = isLaidOut ? this.imageURL() : undefined
+    // TODO: Fix `any` cast
+    return (
+      <FastImage
+        source={{
+          uri: resolvedURL,
+          priority: FastImage.priority.normal,
+        }}
+        onLayout={this.onLayout}
+        style={[style as any, backgroundColorStyle]}
+        {...remainderProps}
+      />
+    )
   }
 }
-
-const NativeOpaqueImageView = requireNativeComponent("AROpaqueImageView") as typeof View

--- a/yarn.lock
+++ b/yarn.lock
@@ -11152,6 +11152,11 @@ react-is@^17.0.1:
   version "1.3.3"
   resolved "https://github.com/artsy/react-native-config.git#83fda4898dc33b920166c246093792c12a384146"
 
+react-native-fast-image@^8.3.4:
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/react-native-fast-image/-/react-native-fast-image-8.3.4.tgz#79edca177e30311b19d59ff335625bcbe22650d7"
+  integrity sha512-LpzAdjUphihUpVEBn5fEv5AILe55rHav0YiZroPZ1rumKDhAl4u2cG01ku2Pb7l8sayjTsNu7FuURAlXUUDsow==
+
 react-native-gesture-handler@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.8.0.tgz#18f61f51da50320f938957b0ee79bc58f47449dc"


### PR DESCRIPTION
The type of this PR is: **Refactor**

This PR resolves [CX-882]

### Description

We are looking to replace our `ImageView` code which is currently backed by `SDWebImage` with the cross platform `react-native-fast-image` in preparation for Android. Complicated slightly by the fact that `react-native-fast-image` also uses a later version of `SDWebImage` and we use the library throughout codebase most notably in View in Room.

Co-authored in knowledge share by @artsy/collector-experience 

### TODO:

- [x] Install SDWebImage 5.8
- [x] Update usage in codebase to new api
- [x] Install react-native-fast-image
- [ ] Replace usage of AROpaqueImageView with react-native-fast-image
- [ ] Test View in Room and image rendering generally to make sure nothing is broken

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [ ] I have documented any follow-up work that this PR will require, or it does not require any.
- [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-882]: https://artsyproduct.atlassian.net/browse/CX-882