### PR TITLE
fix: Add yarn install to make flip_table script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,8 @@ flip_table:
 	@echo 'Clear build artefacts (╯ರ ~ ರ）╯︵ ┻━┻'
 	rm -rf emission/Pod/Assets/Emission*
 	rm -rf emission/Pod/Assets/assets
+	@echo 'Install node modules'
+	yarn install
 	@echo 'Reinstall dependencies ┬─┬ノ( º _ ºノ)'
 	$(MAKE) update_echo
 	bundle exec pod install --repo-update


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->




### Description

The `make flip_table` command was failing because node modules need to be installed before calling `yarn prettier`. This PR updates the script.

https://artsy.slack.com/archives/C02BAQ5K7/p1610750140007000

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [ ] I have documented any follow-up work that this PR will require, or it does not require any.
- [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434