### PR TITLE
fix(ArtistInsightsAuctionResults): show FilteredArtworkGridZeroState when no results are available 

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -7,6 +7,7 @@ upcoming:
   user_facing:
     - Refresh inbox automatically upon revisiting - erik, lily
     - Poll and refetch images when images are processing (my collection) - brian
+    - show FilteredArtworkGridZeroState when no results are available  - mounir
 
 
 releases:

--- a/src/__generated__/ArtistBelowTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtistBelowTheFoldQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash cf65fc45c703a6d9c56418738d7c2846 */
+/* @relayHash c366b30b3cf1ab44475f5bfd66f4e615 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -125,6 +125,7 @@ fragment ArtistConsignButton_artist on Artist {
 fragment ArtistInsightsAuctionResults_artist on Artist {
   birthday
   slug
+  id
   auctionResultsConnection(allowEmptyCreatedDates: true, earliestCreatedYear: 1000, first: 10, latestCreatedYear: 2050, sort: DATE_DESC) {
     createdYearRange {
       startAt
@@ -1187,7 +1188,7 @@ return {
     ]
   },
   "params": {
-    "id": "cf65fc45c703a6d9c56418738d7c2846",
+    "id": "c366b30b3cf1ab44475f5bfd66f4e615",
     "metadata": {},
     "name": "ArtistBelowTheFoldQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistInsightsAuctionResultsQuery.graphql.ts
+++ b/src/__generated__/ArtistInsightsAuctionResultsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash ab141f76ee3930bd7d661b94b0f40bde */
+/* @relayHash f9ac09471a7d8d52da1f6a48e9fcf235 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -51,6 +51,7 @@ query ArtistInsightsAuctionResultsQuery(
 fragment ArtistInsightsAuctionResults_artist_4szhbQ on Artist {
   birthday
   slug
+  id
   auctionResultsConnection(after: $cursor, allowEmptyCreatedDates: $allowEmptyCreatedDates, categories: $categories, earliestCreatedYear: $earliestCreatedYear, first: $count, latestCreatedYear: $latestCreatedYear, sizes: $sizes, sort: $sort) {
     createdYearRange {
       startAt
@@ -185,7 +186,14 @@ v7 = {
   "name": "sort",
   "variableName": "sort"
 },
-v8 = [
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v9 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -202,14 +210,7 @@ v8 = [
   (v5/*: any*/),
   (v6/*: any*/),
   (v7/*: any*/)
-],
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-};
+];
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -282,9 +283,10 @@ return {
             "name": "slug",
             "storageKey": null
           },
+          (v8/*: any*/),
           {
             "alias": null,
-            "args": (v8/*: any*/),
+            "args": (v9/*: any*/),
             "concreteType": "AuctionResultConnection",
             "kind": "LinkedField",
             "name": "auctionResultsConnection",
@@ -331,7 +333,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v9/*: any*/),
+                      (v8/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -537,7 +539,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v8/*: any*/),
+            "args": (v9/*: any*/),
             "filters": [
               "allowEmptyCreatedDates",
               "categories",
@@ -550,15 +552,14 @@ return {
             "key": "artist_auctionResultsConnection",
             "kind": "LinkedHandle",
             "name": "auctionResultsConnection"
-          },
-          (v9/*: any*/)
+          }
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "ab141f76ee3930bd7d661b94b0f40bde",
+    "id": "f9ac09471a7d8d52da1f6a48e9fcf235",
     "metadata": {},
     "name": "ArtistInsightsAuctionResultsQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistInsightsAuctionResultsTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistInsightsAuctionResultsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 571910566eb4e4a99ed1e07a9edf163c */
+/* @relayHash 636f8ce3c9e85f61af14866e6d35c859 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -29,6 +29,7 @@ query ArtistInsightsAuctionResultsTestsQuery {
 fragment ArtistInsightsAuctionResults_artist on Artist {
   birthday
   slug
+  id
   auctionResultsConnection(allowEmptyCreatedDates: true, earliestCreatedYear: 1000, first: 10, latestCreatedYear: 2050, sort: DATE_DESC) {
     createdYearRange {
       startAt
@@ -86,7 +87,14 @@ var v0 = [
     "value": "some-id"
   }
 ],
-v1 = [
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = [
   {
     "kind": "Literal",
     "name": "allowEmptyCreatedDates",
@@ -113,13 +121,6 @@ v1 = [
     "value": "DATE_DESC"
   }
 ],
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
 v3 = {
   "enumValues": null,
   "nullable": true,
@@ -205,9 +206,10 @@ return {
             "name": "slug",
             "storageKey": null
           },
+          (v1/*: any*/),
           {
             "alias": null,
-            "args": (v1/*: any*/),
+            "args": (v2/*: any*/),
             "concreteType": "AuctionResultConnection",
             "kind": "LinkedField",
             "name": "auctionResultsConnection",
@@ -254,7 +256,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v2/*: any*/),
+                      (v1/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -460,7 +462,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v1/*: any*/),
+            "args": (v2/*: any*/),
             "filters": [
               "allowEmptyCreatedDates",
               "categories",
@@ -473,15 +475,14 @@ return {
             "key": "artist_auctionResultsConnection",
             "kind": "LinkedHandle",
             "name": "auctionResultsConnection"
-          },
-          (v2/*: any*/)
+          }
         ],
         "storageKey": "artist(id:\"some-id\")"
       }
     ]
   },
   "params": {
-    "id": "571910566eb4e4a99ed1e07a9edf163c",
+    "id": "636f8ce3c9e85f61af14866e6d35c859",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artist": {

--- a/src/__generated__/ArtistInsightsAuctionResults_artist.graphql.ts
+++ b/src/__generated__/ArtistInsightsAuctionResults_artist.graphql.ts
@@ -7,6 +7,7 @@ import { FragmentRefs } from "relay-runtime";
 export type ArtistInsightsAuctionResults_artist = {
     readonly birthday: string | null;
     readonly slug: string;
+    readonly id: string;
     readonly auctionResultsConnection: {
         readonly createdYearRange: {
             readonly startAt: number | null;
@@ -30,7 +31,15 @@ export type ArtistInsightsAuctionResults_artist$key = {
 
 
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
   "argumentDefinitions": [
     {
       "defaultValue": true,
@@ -102,6 +111,7 @@ const node: ReaderFragment = {
       "name": "slug",
       "storageKey": null
     },
+    (v0/*: any*/),
     {
       "alias": "auctionResultsConnection",
       "args": [
@@ -182,13 +192,7 @@ const node: ReaderFragment = {
               "name": "node",
               "plural": false,
               "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "id",
-                  "storageKey": null
-                },
+                (v0/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -253,5 +257,6 @@ const node: ReaderFragment = {
   "type": "Artist",
   "abstractKey": null
 };
-(node as any).hash = '8084969a2b90f4c83c81e5d7a9d2efed';
+})();
+(node as any).hash = '55260af1dac80bc0b3f1ff6a1bef18c4';
 export default node;

--- a/src/__generated__/ArtistInsightsTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistInsightsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash a14197adb67bcdb4b3382028aa667c7f */
+/* @relayHash 807ecf087293f0495437e6e0510169d0 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -29,6 +29,7 @@ query ArtistInsightsTestsQuery {
 fragment ArtistInsightsAuctionResults_artist on Artist {
   birthday
   slug
+  id
   auctionResultsConnection(allowEmptyCreatedDates: true, earliestCreatedYear: 1000, first: 10, latestCreatedYear: 2050, sort: DATE_DESC) {
     createdYearRange {
       startAt
@@ -495,7 +496,7 @@ return {
     ]
   },
   "params": {
-    "id": "a14197adb67bcdb4b3382028aa667c7f",
+    "id": "807ecf087293f0495437e6e0510169d0",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artist": {

--- a/src/lib/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
@@ -1,12 +1,13 @@
 import { ArtistInsightsAuctionResults_artist } from "__generated__/ArtistInsightsAuctionResults_artist.graphql"
 import { ORDERED_AUCTION_RESULTS_SORTS } from "lib/Components/ArtworkFilterOptions/SortOptions"
+import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
 import Spinner from "lib/Components/Spinner"
 import { PAGE_SIZE } from "lib/data/constants"
 import { navigate } from "lib/navigation/navigate"
 import { ArtworkFilterContext } from "lib/utils/ArtworkFilter/ArtworkFiltersStore"
 import { filterArtworksParams } from "lib/utils/ArtworkFilter/FilterArtworksHelpers"
 import { extractNodes } from "lib/utils/extractNodes"
-import { Flex, Separator, Text } from "palette"
+import { Box, Flex, Separator, Text } from "palette"
 import React, { useCallback, useContext, useEffect, useState } from "react"
 import { FlatList } from "react-native"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
@@ -95,6 +96,14 @@ const ArtistInsightsAuctionResults: React.FC<Props> = ({ artist, relay }) => {
     })
   }, [])
 
+  if (!auctionResults.length) {
+    return (
+      <Box my="80px">
+        <FilteredArtworkGridZeroState id={artist.id} slug={artist.slug} />
+      </Box>
+    )
+  }
+
   return (
     <FlatList
       data={auctionResults}
@@ -146,6 +155,7 @@ export const ArtistInsightsAuctionResultsPaginationContainer = createPaginationC
       ) {
         birthday
         slug
+        id
         auctionResultsConnection(
           after: $cursor
           allowEmptyCreatedDates: $allowEmptyCreatedDates

--- a/src/lib/Components/Artist/ArtistInsights/__tests__/ArtistInsightsAuctionResults-tests.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/__tests__/ArtistInsightsAuctionResults-tests.tsx
@@ -1,4 +1,5 @@
 import { ArtistInsightsAuctionResultsTestsQuery } from "__generated__/ArtistInsightsAuctionResultsTestsQuery.graphql"
+import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
 import { extractText } from "lib/tests/extractText"
 import { mockEdges } from "lib/tests/mockEnvironmentPayload"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
@@ -70,5 +71,18 @@ describe("ArtistInsightsAuctionResults", () => {
     expect(tree.root.findAllByType(FlatList).length).toEqual(1)
     expect(tree.root.findAllByType(AuctionResultFragmentContainer).length).toEqual(5)
     expect(extractText(tree.root.findByType(SortMode))).toBe("Sorted by most recent sale date")
+  })
+
+  it("renders FilteredArtworkGridZeroState when no auction results are available", () => {
+    const tree = renderWithWrappers(<TestRenderer />)
+    mockEnvironmentPayload(mockEnvironment, {
+      Artist: () => ({
+        auctionResultsConnection: {
+          edges: [],
+        },
+      }),
+    })
+
+    expect(tree.root.findAllByType(FilteredArtworkGridZeroState).length).toEqual(1)
   })
 })


### PR DESCRIPTION

The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-967]

### Description
- show FilteredArtworkGridZeroState when no results are available

<img width="315" alt="Screenshot 2021-01-21 at 14 34 04" src="https://user-images.githubusercontent.com/11945712/105358379-65076d00-5bf6-11eb-870b-e3ff88ac55f9.png">


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-967]: https://artsyproduct.atlassian.net/browse/CX-967