### PR TITLE
feat(android): configure metaphysics + relay

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,10 +4,10 @@ upcoming:
   dev:
     - remove unused files and scripts - pavlos
     - Add basic log-in flow for android - david
+    - Configure metaphyiscs and relay for android - david
   user_facing:
     - Refresh inbox automatically upon revisiting - erik, lily
     - Poll and refetch images when images are processing (my collection) - brian
-
 
 releases:
   - version: 6.7.6

--- a/src/__generated__/AndroidAppQuery.graphql.ts
+++ b/src/__generated__/AndroidAppQuery.graphql.ts
@@ -1,0 +1,97 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash 714ac6ded0ecac33354c6bb6fbe322dd */
+
+import { ConcreteRequest } from "relay-runtime";
+export type AndroidAppQueryVariables = {};
+export type AndroidAppQueryResponse = {
+    readonly me: {
+        readonly name: string | null;
+    } | null;
+};
+export type AndroidAppQuery = {
+    readonly response: AndroidAppQueryResponse;
+    readonly variables: AndroidAppQueryVariables;
+};
+
+
+
+/*
+query AndroidAppQuery {
+  me {
+    name
+    id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AndroidAppQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          (v0/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "AndroidAppQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          (v0/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "714ac6ded0ecac33354c6bb6fbe322dd",
+    "metadata": {},
+    "name": "AndroidAppQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = '6306cd64f6035bc0b736347f094c6561';
+export default node;

--- a/src/lib/AndroidApp.tsx
+++ b/src/lib/AndroidApp.tsx
@@ -1,9 +1,12 @@
+import { AndroidAppQuery } from "__generated__/AndroidAppQuery.graphql"
 import { GlobalStore, GlobalStoreProvider } from "lib/store/GlobalStore"
 import { Button, Flex, Text, Theme } from "palette"
 import React from "react"
-import { View } from "react-native"
+import { ActivityIndicator, View } from "react-native"
+import { graphql, QueryRenderer } from "react-relay"
 import track from "react-tracking"
 import { LogIn } from "./LogIn/LogIn"
+import { defaultEnvironment } from "./relay/createEnvironment"
 
 const Main: React.FC<{}> = track()(({}) => {
   const isHydrated = GlobalStore.useAppState((state) => state.sessionState.isHydrated)
@@ -18,7 +21,9 @@ const Main: React.FC<{}> = track()(({}) => {
   }
   return (
     <Flex py="6" px="2">
-      <Text variant="largeTitle">Hello</Text>
+      <Text variant="largeTitle">
+        Hello <MyName />
+      </Text>
       <Text my="2">
         Your user id is <Text variant="mediumText">{authState.userID}</Text>
       </Text>
@@ -33,6 +38,32 @@ const Main: React.FC<{}> = track()(({}) => {
     </Flex>
   )
 })
+
+const MyName: React.FC = () => {
+  return (
+    <QueryRenderer<AndroidAppQuery>
+      environment={defaultEnvironment}
+      query={graphql`
+        query AndroidAppQuery {
+          me {
+            name
+          }
+        }
+      `}
+      render={(props) => {
+        if (props.props?.me) {
+          return <Text>{props.props.me.name}</Text>
+        }
+        if (props.error) {
+          console.error(props.error)
+          return <Text>{JSON.stringify(props.error)}</Text>
+        }
+        return <ActivityIndicator />
+      }}
+      variables={{}}
+    />
+  )
+}
 
 export const App = () => (
   <Theme>

--- a/src/lib/NativeModules/ArtsyNativeModules.tsx
+++ b/src/lib/NativeModules/ArtsyNativeModules.tsx
@@ -1,4 +1,5 @@
 import { NativeModules as AllNativeModules, Platform } from "react-native"
+import { getLocales, getTimeZone } from "react-native-localize"
 
 const noop: any = (name: string) => () => console.warn(`method ${name} doesn't exist on android yet`)
 
@@ -18,47 +19,12 @@ export const ArtsyNativeModules = Platform.select({
     ARCocoaConstantsModule: {
       UIApplicationOpenSettingsURLString: "UIApplicationOpenSettingsURLString",
       AREnabled: true,
-      CurrentLocale: "en_US",
-      LocalTimeZone: "",
+      CurrentLocale: getLocales()[0].languageTag,
+      LocalTimeZone: getTimeZone(),
     },
 
     ARNotificationsManager: {
-      nativeState: {
-        userAgent: "Jest Unit Tests",
-        env: "test",
-        authenticationToken: "authenticationToken",
-        onboardingState: "complete",
-        gravityURL: "gravityURL",
-        launchCount: 1,
-        metaphysicsURL: "metaphysicsURL",
-        deviceId: "testDevice",
-        predictionURL: "predictionURL",
-        webURL: "webURL",
-        sentryDSN: "sentryDSN",
-        stripePublishableKey: "stripePublishableKey",
-        userID: "userID",
-        options: {
-          AROptionsBidManagement: false,
-          AROptionsEnableMyCollection: false,
-          AROptionsLotConditionReport: false,
-          AROptionsPriceTransparency: false,
-          AROptionsViewingRooms: false,
-          AROptionsNewSalePage: false,
-          AREnableViewingRooms: false,
-          AROptionsArtistSeries: false,
-          ipad_vir: false,
-          iphone_vir: false,
-          ARDisableReactNativeBidFlow: false,
-          AREnableNewPartnerView: false,
-          AROptionsNewFirstInquiry: false,
-          AROptionsUseReactNativeWebView: false,
-          AROptionsNewFairPage: false,
-          AROptionsNewInsightsPage: false,
-          AROptionsInquiryCheckout: false,
-        },
-        legacyFairSlugs: ["some-fairs-slug", "some-other-fair-slug"],
-        legacyFairProfileSlugs: [],
-      },
+      nativeState: null as any,
       postNotificationName: noop("postNotificationName"),
       didFinishBootstrapping: () => null,
     },

--- a/src/lib/NativeModules/GraphQLQueryCache.ts
+++ b/src/lib/NativeModules/GraphQLQueryCache.ts
@@ -1,67 +1,33 @@
-import _ from "lodash"
-import { NativeModules } from "react-native"
-let { ARGraphQLQueryCache } = NativeModules
-
-function stableSerialize(val: any): string {
-  if (_.isPlainObject(val)) {
-    return `{${Object.keys(val as object)
-      .sort()
-      .map((k) => `${JSON.stringify(k)}:${stableSerialize(val[k])}`)
-      .join(",")}}`
-  } else if (_.isArray(val)) {
-    return `[${val.map(stableSerialize).join(",")}]`
-  } else {
-    return JSON.stringify(val)
-  }
-}
-
-export function requestFingerprint(queryID: string, variables: object) {
-  return stableSerialize({ [queryID]: variables })
-}
-
-if (!ARGraphQLQueryCache) {
-  let cache: {
-    [requestFingerprint: string]: {
-      response: string
-      expires: number
-    }
-  } = {}
-  ARGraphQLQueryCache = {
-    _setResponseForQueryIDWithVariables(response: string, queryID: string, variables: object, ttl: number) {
-      if (ttl === 0) {
-        // default should be one day according to objc code
-        ttl = 60 * 60 * 24
-      }
-      cache[requestFingerprint(queryID, variables)] = { response, expires: Date.now() + ttl * 1000 }
-    },
-    _responseForQueryIDWithVariables(queryID: string, variables: object) {
-      const result = cache[requestFingerprint(queryID, variables)]
-      if (result && result.expires < Date.now()) {
-        return null
-      }
-      return Promise.resolve(result?.response ?? null)
-    },
-    _clearQueryIDWithVariables(queryID: string, variables: object) {
-      delete cache[requestFingerprint(queryID, variables)]
-    },
-    _clearAll() {
-      cache = {}
-    },
-  }
-}
+import * as RelayCache from "lib/relay/RelayCache"
+import { NativeModules, Platform } from "react-native"
+const { ARGraphQLQueryCache } = NativeModules
 
 export function set(queryID: string, variables: object, response: string, ttl: number = 0): void {
+  if (Platform.OS !== "ios") {
+    RelayCache.set(queryID, variables, response, ttl)
+    return
+  }
   ARGraphQLQueryCache._setResponseForQueryIDWithVariables(response, queryID, variables, ttl)
 }
 
 export function get(queryID: string, variables: object): Promise<string | null> {
+  if (Platform.OS !== "ios") {
+    return RelayCache.get(queryID, variables)
+  }
   return ARGraphQLQueryCache._responseForQueryIDWithVariables(queryID, variables)
 }
 
 export function clear(queryID: string, variables: object): void {
+  if (Platform.OS !== "ios") {
+    RelayCache.clear(queryID, variables)
+    return
+  }
   ARGraphQLQueryCache._clearQueryIDWithVariables(queryID, variables)
 }
 
 export function clearAll(): void {
+  if (Platform.OS !== "ios") {
+    RelayCache.clearAll()
+  }
   ARGraphQLQueryCache._clearAll()
 }

--- a/src/lib/NativeModules/GraphQLQueryCache.ts
+++ b/src/lib/NativeModules/GraphQLQueryCache.ts
@@ -1,5 +1,54 @@
+import _ from "lodash"
 import { NativeModules } from "react-native"
-const { ARGraphQLQueryCache } = NativeModules
+let { ARGraphQLQueryCache } = NativeModules
+
+function stableSerialize(val: any): string {
+  if (_.isPlainObject(val)) {
+    return `{${Object.keys(val as object)
+      .sort()
+      .map((k) => `${JSON.stringify(k)}:${stableSerialize(val[k])}`)
+      .join(",")}}`
+  } else if (_.isArray(val)) {
+    return `[${val.map(stableSerialize).join(",")}]`
+  } else {
+    return JSON.stringify(val)
+  }
+}
+
+export function requestFingerprint(queryID: string, variables: object) {
+  return stableSerialize({ [queryID]: variables })
+}
+
+if (!ARGraphQLQueryCache) {
+  let cache: {
+    [requestFingerprint: string]: {
+      response: string
+      expires: number
+    }
+  } = {}
+  ARGraphQLQueryCache = {
+    _setResponseForQueryIDWithVariables(response: string, queryID: string, variables: object, ttl: number) {
+      if (ttl === 0) {
+        // default should be one day according to objc code
+        ttl = 60 * 60 * 24
+      }
+      cache[requestFingerprint(queryID, variables)] = { response, expires: Date.now() + ttl * 1000 }
+    },
+    _responseForQueryIDWithVariables(queryID: string, variables: object) {
+      const result = cache[requestFingerprint(queryID, variables)]
+      if (result && result.expires < Date.now()) {
+        return null
+      }
+      return Promise.resolve(result?.response ?? null)
+    },
+    _clearQueryIDWithVariables(queryID: string, variables: object) {
+      delete cache[requestFingerprint(queryID, variables)]
+    },
+    _clearAll() {
+      cache = {}
+    },
+  }
+}
 
 export function set(queryID: string, variables: object, response: string, ttl: number = 0): void {
   ARGraphQLQueryCache._setResponseForQueryIDWithVariables(response, queryID, variables, ttl)

--- a/src/lib/relay/RelayCache.ts
+++ b/src/lib/relay/RelayCache.ts
@@ -1,0 +1,67 @@
+import AsyncStorage from "@react-native-community/async-storage"
+import _ from "lodash"
+
+const CACHE_KEY_PREFIX = "RelayCache:"
+
+function stableSerialize(val: any): string {
+  if (_.isPlainObject(val)) {
+    return `{${Object.keys(val as object)
+      .sort()
+      .map((k) => `${JSON.stringify(k)}:${stableSerialize(val[k])}`)
+      .join(",")}}`
+  } else if (_.isArray(val)) {
+    return `[${val.map(stableSerialize).join(",")}]`
+  } else {
+    return JSON.stringify(val)
+  }
+}
+
+export function requestFingerprint(queryID: string, variables: object) {
+  return stableSerialize({ [queryID]: variables })
+}
+
+function cacheKey(queryID: string, variables: object) {
+  return CACHE_KEY_PREFIX + requestFingerprint(queryID, variables)
+}
+
+interface CacheRecord {
+  response: string
+  expires: number
+}
+
+export async function set(queryID: string, variables: object, response: string, ttlSeconds: number = 0) {
+  if (ttlSeconds === 0) {
+    // default should be one day according to objc code
+    ttlSeconds = 60 * 60 * 24
+  }
+  const record: CacheRecord = { response, expires: Date.now() + ttlSeconds * 1000 }
+  await AsyncStorage.setItem(cacheKey(queryID, variables), JSON.stringify(record))
+}
+
+export async function get(queryID: string, variables: object): Promise<string | null> {
+  const result = await AsyncStorage.getItem(cacheKey(queryID, variables))
+  if (!result) {
+    return null
+  }
+
+  try {
+    const record = JSON.parse(result) as CacheRecord
+    if (record.expires < Date.now()) {
+      await clear(queryID, variables)
+      return null
+    }
+    return record.response
+  } catch (_) {
+    return null
+  }
+}
+
+export async function clear(queryID: string, variables: object) {
+  await AsyncStorage.removeItem(cacheKey(queryID, variables))
+}
+
+export async function clearAll() {
+  const ks = await AsyncStorage.getAllKeys()
+  const cacheKeys = ks.filter((k) => k.startsWith(CACHE_KEY_PREFIX))
+  await AsyncStorage.multiRemove(cacheKeys)
+}

--- a/src/lib/relay/__tests__/RelayCache-tests.tsx
+++ b/src/lib/relay/__tests__/RelayCache-tests.tsx
@@ -1,0 +1,95 @@
+import AsyncStorage from "@react-native-community/async-storage"
+import { clear, clearAll, get, requestFingerprint, set } from "../RelayCache"
+
+describe(requestFingerprint, () => {
+  it("makes a fingerprint of a graphql request with a stable key ordering", () => {
+    const fingerprintA = requestFingerprint("myQueryID", { a: "A", b: "B", c: "C" })
+    const fingerprintB = requestFingerprint("myQueryID", { b: "B", c: "C", a: "A" })
+    expect(fingerprintA).toMatchInlineSnapshot(`"{\\"myQueryID\\":{\\"a\\":\\"A\\",\\"b\\":\\"B\\",\\"c\\":\\"C\\"}}"`)
+    expect(fingerprintA).toEqual(fingerprintB)
+  })
+  it("works with nested objects and arrays", () => {
+    expect(
+      requestFingerprint("myQueryID", {
+        a: "A",
+        b: ["banana", "bingo", { bratislava: true, bristol: null, brightonBeach: 345 }],
+        c: "C",
+      })
+    ).toMatchInlineSnapshot(
+      `"{\\"myQueryID\\":{\\"a\\":\\"A\\",\\"b\\":[\\"banana\\",\\"bingo\\",{\\"bratislava\\":true,\\"brightonBeach\\":345,\\"bristol\\":null}],\\"c\\":\\"C\\"}}"`
+    )
+  })
+  it("should produce valid json (implementation detail)", () => {
+    const data = {
+      b: ["banana", "bingo", { bratislava: true, bristol: null }],
+      a: "A",
+      c: "C",
+    }
+    expect(JSON.parse(requestFingerprint("myQueryID", data))).toEqual({
+      myQueryID: data,
+    })
+  })
+})
+
+describe("the cache", () => {
+  const currentTime = 1611234089917
+  const nowMock = jest.fn(() => currentTime)
+  const properNow = Date.now
+  beforeAll(() => {
+    Date.now = nowMock
+    jest.useFakeTimers()
+  })
+  afterAll(() => {
+    Date.now = properNow
+    jest.useRealTimers()
+  })
+  beforeEach(() => {
+    ;(AsyncStorage as any).__resetState()
+  })
+  it("saves queries in async storage", async () => {
+    set("myQueryID", { foo: "bar" }, "response!")
+    expect(await AsyncStorage.getAllKeys()).toMatchInlineSnapshot(`
+      Array [
+        "RelayCache:{\\"myQueryID\\":{\\"foo\\":\\"bar\\"}}",
+      ]
+    `)
+    set("mySecondQueryID", { lol: "rofl" }, "another response!")
+    expect(await AsyncStorage.getAllKeys()).toMatchInlineSnapshot(`
+      Array [
+        "RelayCache:{\\"myQueryID\\":{\\"foo\\":\\"bar\\"}}",
+        "RelayCache:{\\"mySecondQueryID\\":{\\"lol\\":\\"rofl\\"}}",
+      ]
+    `)
+
+    expect(await get("myQueryID", { foo: "bar" })).toBe("response!")
+    expect(await get("mySecondQueryID", { lol: "rofl" })).toBe("another response!")
+  })
+
+  it("respects ttl params", async () => {
+    // set ttl to 1 second
+    set("myQueryID", { foo: "bar" }, "response!", 1)
+    expect(await AsyncStorage.getAllKeys()).toHaveLength(1)
+    // wait 2 seconds
+    nowMock.mockReturnValueOnce(currentTime + 2000)
+    expect(await get("myQueryID", { foo: "bar" })).toBe(null)
+    expect(await AsyncStorage.getAllKeys()).toHaveLength(0)
+  })
+
+  it("allows removal", async () => {
+    set("myQueryID", { foo: "bar" }, "response!", 1)
+    expect(await AsyncStorage.getAllKeys()).toHaveLength(1)
+    clear("myQueryID", { foo: "bar" })
+    expect(await AsyncStorage.getAllKeys()).toHaveLength(0)
+  })
+
+  it("allows clearing the whole cache without impacting other things using AsyncStorage", async () => {
+    AsyncStorage.setItem("MyImportantItem", "hello")
+    set("myQueryID", { foo: "bar" }, "response!", 1)
+    set("mySecondQueryID", { lol: "rofl" }, "another response!")
+    expect(await AsyncStorage.getAllKeys()).toHaveLength(3)
+
+    await clearAll()
+
+    expect(await AsyncStorage.getAllKeys()).toEqual(["MyImportantItem"])
+  })
+})

--- a/src/lib/store/ConfigModel.ts
+++ b/src/lib/store/ConfigModel.ts
@@ -4,6 +4,8 @@ export interface ConfigModel {
   sessionState: {
     webURL: string
     gravityBaseURL: string
+    metaphysicsBaseURL: string
+    predictionBaseURL: string
     gravitySecret: string
     gravityKey: string
   }
@@ -12,6 +14,8 @@ export const ConfigModel: ConfigModel = {
   sessionState: {
     webURL: "https://staging.artsy.net",
     gravityBaseURL: "https://stagingapi.artsy.net",
+    metaphysicsBaseURL: "https://metaphysics-staging.artsy.net/v2",
+    predictionBaseURL: "https://live-staging.artsy.net",
     gravityKey: Config.ARTSY_API_CLIENT_KEY,
     gravitySecret: Config.ARTSY_API_CLIENT_SECRET,
   },

--- a/src/lib/store/GlobalStore.tsx
+++ b/src/lib/store/GlobalStore.tsx
@@ -1,6 +1,8 @@
 import { action, createStore, createTypedHooks, StoreProvider } from "easy-peasy"
 import { ArtsyNativeModules } from "lib/NativeModules/ArtsyNativeModules"
 import React from "react"
+import { Platform } from "react-native"
+import Config from "react-native-config"
 import { Action, Middleware } from "redux"
 import { GlobalStoreModel, GlobalStoreState } from "./GlobalStoreModel"
 import { EmissionOptions } from "./NativeModel"
@@ -103,8 +105,49 @@ export function useEmissionOption(key: keyof EmissionOptions) {
 }
 
 export function getCurrentEmissionState() {
-  // on initial load globalStoreInstance might be undefined
-  return globalStoreInstance?.getState().native.sessionState ?? ArtsyNativeModules.ARNotificationsManager.nativeState
+  const state = globalStoreInstance?.getState() ?? null
+  if (Platform.OS === "ios") {
+    return state?.native.sessionState ?? ArtsyNativeModules.ARNotificationsManager.nativeState
+  }
+
+  const androidData: GlobalStoreModel["native"]["sessionState"] = {
+    authenticationToken: state?.auth.userAccessToken!,
+    deviceId: "Android", // TODO: get better device info
+    env: "staging", // TODO: add production support
+    gravityURL: state?.config.sessionState.gravityBaseURL,
+    launchCount: 1, // TODO: add support for this somehow??
+    legacyFairProfileSlugs: [], // TODO: take from echo
+    legacyFairSlugs: [], // TODO: take from echo
+    metaphysicsURL: state?.config.sessionState.metaphysicsBaseURL,
+    onboardingState: "none", // not used on android
+    options: {
+      // TODO: store options in easy-peasy
+      AROptionsBidManagement: false,
+      AROptionsEnableMyCollection: false,
+      AROptionsLotConditionReport: false,
+      AROptionsPriceTransparency: false,
+      AROptionsViewingRooms: false,
+      AROptionsNewSalePage: false,
+      AREnableViewingRooms: false,
+      AROptionsArtistSeries: false,
+      ipad_vir: false,
+      iphone_vir: false,
+      ARDisableReactNativeBidFlow: false,
+      AREnableNewPartnerView: false,
+      AROptionsNewFirstInquiry: false,
+      AROptionsUseReactNativeWebView: false,
+      AROptionsNewFairPage: false,
+      AROptionsNewInsightsPage: false,
+      AROptionsInquiryCheckout: false,
+    },
+    predictionURL: state?.config.sessionState.predictionBaseURL,
+    sentryDSN: Config.SENTRY_STAGING_DSN,
+    stripePublishableKey: "stripePublishableKey", // TODO: take key from echo config
+    userAgent: "eigen android", // TODO: proper user agent
+    userID: state?.auth.userID!,
+    webURL: state?.config.sessionState.webURL,
+  }
+  return androidData
 }
 
 /**

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -364,6 +364,15 @@ jest.mock("@react-native-community/async-storage", () => {
 
 jest.mock("react-native-localize", () => ({
   getCountry: jest.fn(() => "US"),
+  getLocales() {
+    return [
+      { countryCode: "US", languageTag: "en-US", languageCode: "en", isRTL: false },
+      { countryCode: "FR", languageTag: "fr-FR", languageCode: "fr", isRTL: false },
+    ]
+  },
+  getTimeZone() {
+    return "America/New_York"
+  },
 }))
 
 jest.mock("react-native-reanimated", () => require("react-native-reanimated/mock"))

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -327,23 +327,20 @@ jest.mock("@react-native-community/async-storage", () => {
     __resetState() {
       state = {}
     },
-    setItem(key: string, val: any) {
+    async setItem(key: string, val: any) {
       state[key] = val
-      return Promise.resolve()
     },
-    getItem(key: string) {
-      return Promise.resolve(state[key])
+    async getItem(key: string) {
+      return state[key]
     },
-    removeItem(key: string) {
+    async removeItem(key: string) {
       delete state[key]
-      return Promise.resolve()
     },
-    clear() {
+    async clear() {
       state = {}
-      return Promise.resolve()
     },
-    getAllKeys() {
-      return Promise.resolve(Object.keys(state))
+    async getAllKeys() {
+      return Object.keys(state)
     },
     mergeItem() {
       throw new Error("mock version of mergeItem not yet implemented")
@@ -354,8 +351,10 @@ jest.mock("@react-native-community/async-storage", () => {
     multiMerge() {
       throw new Error("mock version of multiMerge not yet implemented")
     },
-    multiRemove() {
-      throw new Error("mock version of multiRemove not yet implemented")
+    async multiRemove(keys: string[]) {
+      keys.forEach((k) => {
+        delete state[k]
+      })
     },
     multiSet() {
       throw new Error("mock version of multiSet not yet implemented")


### PR DESCRIPTION
This PR resolves [CX-870]

### Description

<em>Note: This was originally supposed to be part of #4346 but I decided to split it into a separate PR.</em>

This PR makes metaphysics work on android, and sets up a new GraphQL cache based on `AsyncStorage` (since our current ios one is in obj-c). We can probably already replace the obj-c one but I'll leave that until after we've migrated the admin menu since there's an option there to clear the cache which I occasionally use at least.

I added a POC query renderer to the main android page to show the user's name

![image](https://user-images.githubusercontent.com/1242537/105358181-beb76980-5bed-11eb-87e9-df2322f9c670.png)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-870]: https://artsyproduct.atlassian.net/browse/CX-870