### PR TITLE
chore: Add early success task to android circle job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,13 +38,14 @@ commands:
           name: "Generate initial checksum manifests"
           command: |
             mkdir .manifests
-            scripts/generate-manifest.js .manifests/native_code '^Podfile' '^Makefile' '^Gemfile' '^emission/' '^Artsy' '^patches/react-native' '^\.env\.example'
             scripts/generate-manifest.js .manifests/node_modules '^yarn\.lock$' '^patches/'
             scripts/generate-manifest.js .manifests/js_transform '^\.manifests/node_modules' '^babel\.config\.js' '^relay\.config\.js' '^jest\.config\.js'
             scripts/generate-manifest.js .manifests/js_bundle '^\.manifests/js_transform' '^data/' '^index\.ios\.js' '^src/(?!.*(__tests__|__mocks__|__fixtures__))'
             scripts/generate-manifest.js .manifests/js_test_results '^\.manifests/js_transform' '^data/' '^src/'
             ls -lR emission > .manifests/emission_pod_file_list
             scripts/generate-manifest.js .manifests/cocoapods '^Podfile' '^Gemfile' '^\.manifests/emission_pod_file_list'
+            scripts/generate-manifest.js .manifests/native_code '^\.manifests/node_modules' '^Podfile' '^Makefile' '^Gemfile' '^emission/' '^Artsy' '^patches/react-native' '^\.env\.example'
+            scripts/generate-manifest.js .manifests/android_native '^\.manifests/node_modules' '^android/' '^patches/react-native' '^\.env\.example'
   setup-env-file:
     steps:
       - run:
@@ -339,13 +340,26 @@ jobs:
           at: .
       - install-node
       - setup-env-file
+      - restore_cache:
+          keys:
+            - v6-test-success-{{ checksum "../workspace/.manifests/android_native" }}
+      - run:
+          name: Quit early if possible
+          command: |
+            if test $CIRCLE_BRANCH != beta-android && ls build-success.log
+            then
+              circleci step halt
+            fi
       - install-node-modules
       - install-gems
       - build-app-android
-
       - run:
-          name: Danger
-          command: bundle exec danger --danger_id=circle --dangerfile=Dangerfile.circle.rb --verbose
+          name: Save success file
+          command: echo yes > 'build-success.log'
+      - save_cache:
+          key: v6-test-success-{{ checksum "../workspace/.manifests/android_native" }}
+          paths:
+            - build-success.log
 
       - await-previous-builds:
           branch: beta-android


### PR DESCRIPTION
### Description

This adds a short-circuiting step to the android build task on circle-ci. It stops if nothing which affects the android app build has changed.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
