### PR TITLE
fix: auction result text QA fixes

### DIFF
--- a/src/lib/Components/Lists/AuctionResult.tsx
+++ b/src/lib/Components/Lists/AuctionResult.tsx
@@ -21,7 +21,7 @@ const AuctionResult: React.FC<Props> = ({ auctionResult, onPress }) => {
 
   return (
     <Touchable underlayColor={color("black5")} onPress={onPress}>
-      <Flex height={100} py="2" px={2} flexDirection="row">
+      <Flex py="2" px={2} flexDirection="row">
         {/* Sale Artwork Thumbnail Image */}
         {!auctionResult.images?.thumbnail?.url ? (
           <Flex
@@ -51,14 +51,10 @@ const AuctionResult: React.FC<Props> = ({ auctionResult, onPress }) => {
         <Flex pl={15} flex={1} flexDirection="row" justifyContent="space-between">
           <Flex flex={3}>
             <Flex flexDirection="row" mb={0.5}>
-              <Text variant="subtitle" numberOfLines={1} style={{ flexShrink: 1 }}>
+              <Text variant="caption" ellipsizeMode="middle" numberOfLines={2} style={{ flexShrink: 1 }}>
                 {auctionResult.title}
+                {!!auctionResult.dateText && auctionResult.dateText !== "" && `, ${auctionResult.dateText}`}
               </Text>
-              {!!auctionResult.dateText && auctionResult.dateText !== "" && (
-                <Text variant="subtitle" numberOfLines={1}>
-                  , {auctionResult.dateText}
-                </Text>
-              )}
             </Flex>
             {!!auctionResult.mediumText && (
               <Text variant="small" color="black60" numberOfLines={1}>
@@ -79,7 +75,7 @@ const AuctionResult: React.FC<Props> = ({ auctionResult, onPress }) => {
           <Flex alignItems="flex-end" pl={15}>
             {!!auctionResult.priceRealized?.display && !!auctionResult.currency ? (
               <Flex alignItems="flex-end">
-                <Text variant="subtitle" fontWeight="bold" testID="price">
+                <Text variant="caption" fontWeight="bold" testID="price">
                   {(auctionResult.priceRealized?.display ?? "").replace(`${auctionResult.currency} `, "")}
                 </Text>
                 {!!auctionResult.performance?.mid && (

--- a/src/lib/Components/Lists/AuctionResult.tsx
+++ b/src/lib/Components/Lists/AuctionResult.tsx
@@ -84,7 +84,7 @@ const AuctionResult: React.FC<Props> = ({ auctionResult, onPress }) => {
               </Flex>
             ) : (
               <Flex alignItems="flex-end">
-                <Text variant="subtitle" fontWeight="bold" style={{ width: 100 }} textAlign="right" testID="price">
+                <Text variant="caption" fontWeight="bold" style={{ width: 100 }} textAlign="right" testID="price">
                   {auctionResult.boughtIn === true
                     ? "Bought in"
                     : isFromPastMonth


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-955]

### Description

- ~~Lighten the divider color~~
- Reduce the text size on the artwork title and price to “Caption” (Sans 3, or 14px)
- Extending the artwork title to 2 lines if needed and make sure to show the year

<img width="316" alt="Screenshot 2021-02-03 at 12 26 07" src="https://user-images.githubusercontent.com/11945712/106740688-0640eb00-661b-11eb-8605-c638ea09201a.png">


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-955]: https://artsyproduct.atlassian.net/browse/CX-955