### PR TITLE
feat(fx-2565): attribution class artworks filter

### DIFF
--- a/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
@@ -897,7 +897,8 @@ return {
               "inquireableOnly",
               "atAuction",
               "offerable",
-              "aggregations"
+              "aggregations",
+              "attributionClass"
             ],
             "handle": "connection",
             "key": "ArtistArtworksGrid_artworks",

--- a/src/__generated__/ArtistArtworksQuery.graphql.ts
+++ b/src/__generated__/ArtistArtworksQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash aaff65bec8c5345db126ae7bec44748b */
+/* @relayHash 353c24cb19397d74957101b29a6369b8 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -20,6 +20,7 @@ export type ArtistArtworksQueryVariables = {
     inquireableOnly?: boolean | null;
     atAuction?: boolean | null;
     offerable?: boolean | null;
+    attributionClass?: Array<string | null> | null;
 };
 export type ArtistArtworksQueryResponse = {
     readonly node: {
@@ -49,21 +50,22 @@ query ArtistArtworksQuery(
   $inquireableOnly: Boolean
   $atAuction: Boolean
   $offerable: Boolean
+  $attributionClass: [String]
 ) {
   node(id: $id) {
     __typename
     ... on Artist {
-      ...ArtistArtworks_artist_3m6HS0
+      ...ArtistArtworks_artist_3FXTiz
     }
     id
   }
 }
 
-fragment ArtistArtworks_artist_3m6HS0 on Artist {
+fragment ArtistArtworks_artist_3FXTiz on Artist {
   id
   slug
   internalID
-  artworks: filterArtworksConnection(first: $count, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  artworks: filterArtworksConnection(first: $count, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], attributionClass: $attributionClass) {
     aggregations {
       slice
       counts {
@@ -253,155 +255,165 @@ v1 = {
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "color"
+  "name": "attributionClass"
 },
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "count"
+  "name": "color"
 },
 v4 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "cursor"
+  "name": "count"
 },
 v5 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "dimensionRange"
+  "name": "cursor"
 },
 v6 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "id"
+  "name": "dimensionRange"
 },
 v7 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "inquireableOnly"
+  "name": "id"
 },
 v8 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "majorPeriods"
+  "name": "inquireableOnly"
 },
 v9 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "medium"
+  "name": "majorPeriods"
 },
 v10 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "offerable"
+  "name": "medium"
 },
 v11 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "partnerID"
+  "name": "offerable"
 },
 v12 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "priceRange"
+  "name": "partnerID"
 },
 v13 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "priceRange"
+},
+v14 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "sort"
 },
-v14 = [
+v15 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v15 = {
+v16 = {
   "kind": "Variable",
   "name": "acquireable",
   "variableName": "acquireable"
 },
-v16 = {
+v17 = {
   "kind": "Variable",
   "name": "atAuction",
   "variableName": "atAuction"
 },
-v17 = {
+v18 = {
+  "kind": "Variable",
+  "name": "attributionClass",
+  "variableName": "attributionClass"
+},
+v19 = {
   "kind": "Variable",
   "name": "color",
   "variableName": "color"
 },
-v18 = {
+v20 = {
   "kind": "Variable",
   "name": "dimensionRange",
   "variableName": "dimensionRange"
 },
-v19 = {
+v21 = {
   "kind": "Variable",
   "name": "inquireableOnly",
   "variableName": "inquireableOnly"
 },
-v20 = {
+v22 = {
   "kind": "Variable",
   "name": "majorPeriods",
   "variableName": "majorPeriods"
 },
-v21 = {
+v23 = {
   "kind": "Variable",
   "name": "medium",
   "variableName": "medium"
 },
-v22 = {
+v24 = {
   "kind": "Variable",
   "name": "offerable",
   "variableName": "offerable"
 },
-v23 = {
+v25 = {
   "kind": "Variable",
   "name": "partnerID",
   "variableName": "partnerID"
 },
-v24 = {
+v26 = {
   "kind": "Variable",
   "name": "priceRange",
   "variableName": "priceRange"
 },
-v25 = {
+v27 = {
   "kind": "Variable",
   "name": "sort",
   "variableName": "sort"
 },
-v26 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v27 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v28 = {
+v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v29 = {
+v31 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v30 = [
-  (v15/*: any*/),
+v32 = [
+  (v16/*: any*/),
   {
     "kind": "Variable",
     "name": "after",
@@ -420,65 +432,66 @@ v30 = [
       "PRICE_RANGE"
     ]
   },
-  (v16/*: any*/),
   (v17/*: any*/),
   (v18/*: any*/),
+  (v19/*: any*/),
+  (v20/*: any*/),
   {
     "kind": "Variable",
     "name": "first",
     "variableName": "count"
   },
-  (v19/*: any*/),
-  (v20/*: any*/),
   (v21/*: any*/),
   (v22/*: any*/),
   (v23/*: any*/),
   (v24/*: any*/),
-  (v25/*: any*/)
+  (v25/*: any*/),
+  (v26/*: any*/),
+  (v27/*: any*/)
 ],
-v31 = {
+v33 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v32 = {
+v34 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "aspectRatio",
   "storageKey": null
 },
-v33 = {
+v35 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "title",
   "storageKey": null
 },
-v34 = {
+v36 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "saleMessage",
   "storageKey": null
 },
-v35 = {
+v37 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isAuction",
   "storageKey": null
 },
-v36 = {
+v38 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v37 = [
+v39 = [
   {
     "alias": null,
     "args": null,
@@ -487,15 +500,15 @@ v37 = [
     "storageKey": null
   }
 ],
-v38 = [
-  (v27/*: any*/)
+v40 = [
+  (v29/*: any*/)
 ],
-v39 = {
+v41 = {
   "kind": "Literal",
   "name": "first",
   "value": 3
 },
-v40 = {
+v42 = {
   "alias": null,
   "args": null,
   "concreteType": "Image",
@@ -513,7 +526,7 @@ v40 = {
   ],
   "storageKey": null
 },
-v41 = {
+v43 = {
   "kind": "Literal",
   "name": "sort",
   "value": "-weighted_iconicity"
@@ -534,7 +547,8 @@ return {
       (v10/*: any*/),
       (v11/*: any*/),
       (v12/*: any*/),
-      (v13/*: any*/)
+      (v13/*: any*/),
+      (v14/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -542,7 +556,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v14/*: any*/),
+        "args": (v15/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
@@ -553,9 +567,10 @@ return {
             "selections": [
               {
                 "args": [
-                  (v15/*: any*/),
                   (v16/*: any*/),
                   (v17/*: any*/),
+                  (v18/*: any*/),
+                  (v19/*: any*/),
                   {
                     "kind": "Variable",
                     "name": "count",
@@ -566,14 +581,14 @@ return {
                     "name": "cursor",
                     "variableName": "cursor"
                   },
-                  (v18/*: any*/),
-                  (v19/*: any*/),
                   (v20/*: any*/),
                   (v21/*: any*/),
                   (v22/*: any*/),
                   (v23/*: any*/),
                   (v24/*: any*/),
-                  (v25/*: any*/)
+                  (v25/*: any*/),
+                  (v26/*: any*/),
+                  (v27/*: any*/)
                 ],
                 "kind": "FragmentSpread",
                 "name": "ArtistArtworks_artist"
@@ -592,42 +607,43 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v6/*: any*/),
-      (v3/*: any*/),
-      (v4/*: any*/),
-      (v13/*: any*/),
-      (v9/*: any*/),
-      (v12/*: any*/),
-      (v2/*: any*/),
-      (v11/*: any*/),
-      (v5/*: any*/),
-      (v8/*: any*/),
-      (v0/*: any*/),
       (v7/*: any*/),
+      (v4/*: any*/),
+      (v5/*: any*/),
+      (v14/*: any*/),
+      (v10/*: any*/),
+      (v13/*: any*/),
+      (v3/*: any*/),
+      (v12/*: any*/),
+      (v6/*: any*/),
+      (v9/*: any*/),
+      (v0/*: any*/),
+      (v8/*: any*/),
       (v1/*: any*/),
-      (v10/*: any*/)
+      (v11/*: any*/),
+      (v2/*: any*/)
     ],
     "kind": "Operation",
     "name": "ArtistArtworksQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v14/*: any*/),
+        "args": (v15/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v26/*: any*/),
-          (v27/*: any*/),
+          (v28/*: any*/),
+          (v29/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
-              (v28/*: any*/),
-              (v29/*: any*/),
+              (v30/*: any*/),
+              (v31/*: any*/),
               {
                 "alias": "artworks",
-                "args": (v30/*: any*/),
+                "args": (v32/*: any*/),
                 "concreteType": "FilterArtworksConnection",
                 "kind": "LinkedField",
                 "name": "filterArtworksConnection",
@@ -663,7 +679,7 @@ return {
                             "name": "count",
                             "storageKey": null
                           },
-                          (v31/*: any*/),
+                          (v33/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -693,8 +709,8 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v27/*: any*/),
-                          (v26/*: any*/)
+                          (v29/*: any*/),
+                          (v28/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -733,7 +749,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v27/*: any*/),
+                  (v29/*: any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
@@ -763,7 +779,7 @@ return {
                         "name": "edges",
                         "plural": true,
                         "selections": [
-                          (v26/*: any*/),
+                          (v28/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -772,7 +788,7 @@ return {
                             "name": "node",
                             "plural": false,
                             "selections": [
-                              (v28/*: any*/),
+                              (v30/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -781,7 +797,7 @@ return {
                                 "name": "image",
                                 "plural": false,
                                 "selections": [
-                                  (v32/*: any*/),
+                                  (v34/*: any*/),
                                   {
                                     "alias": null,
                                     "args": [
@@ -798,7 +814,7 @@ return {
                                 ],
                                 "storageKey": null
                               },
-                              (v33/*: any*/),
+                              (v35/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -806,8 +822,8 @@ return {
                                 "name": "date",
                                 "storageKey": null
                               },
-                              (v34/*: any*/),
-                              (v29/*: any*/),
+                              (v36/*: any*/),
+                              (v31/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -830,8 +846,8 @@ return {
                                 "name": "sale",
                                 "plural": false,
                                 "selections": [
-                                  (v35/*: any*/),
-                                  (v36/*: any*/),
+                                  (v37/*: any*/),
+                                  (v38/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -846,7 +862,7 @@ return {
                                     "name": "endAt",
                                     "storageKey": null
                                   },
-                                  (v27/*: any*/)
+                                  (v29/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -883,7 +899,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "currentBid",
                                     "plural": false,
-                                    "selections": (v37/*: any*/),
+                                    "selections": (v39/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -893,7 +909,7 @@ return {
                                     "name": "lotLabel",
                                     "storageKey": null
                                   },
-                                  (v27/*: any*/)
+                                  (v29/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -905,8 +921,8 @@ return {
                                 "name": "partner",
                                 "plural": false,
                                 "selections": [
-                                  (v31/*: any*/),
-                                  (v27/*: any*/)
+                                  (v33/*: any*/),
+                                  (v29/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -915,7 +931,7 @@ return {
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v38/*: any*/),
+                            "selections": (v40/*: any*/),
                             "type": "Node",
                             "abstractKey": "__isNode"
                           }
@@ -931,7 +947,7 @@ return {
               },
               {
                 "alias": "artworks",
-                "args": (v30/*: any*/),
+                "args": (v32/*: any*/),
                 "filters": [
                   "sort",
                   "medium",
@@ -944,7 +960,8 @@ return {
                   "inquireableOnly",
                   "atAuction",
                   "offerable",
-                  "aggregations"
+                  "aggregations",
+                  "attributionClass"
                 ],
                 "handle": "connection",
                 "key": "ArtistArtworksGrid_artworks",
@@ -970,9 +987,9 @@ return {
                 "name": "marketingCollections",
                 "plural": true,
                 "selections": [
-                  (v28/*: any*/),
-                  (v27/*: any*/),
-                  (v33/*: any*/),
+                  (v30/*: any*/),
+                  (v29/*: any*/),
+                  (v35/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -990,7 +1007,7 @@ return {
                           "TOTAL"
                         ]
                       },
-                      (v39/*: any*/),
+                      (v41/*: any*/),
                       {
                         "kind": "Literal",
                         "name": "sort",
@@ -1018,16 +1035,16 @@ return {
                             "name": "node",
                             "plural": false,
                             "selections": [
-                              (v33/*: any*/),
-                              (v40/*: any*/),
-                              (v27/*: any*/)
+                              (v35/*: any*/),
+                              (v42/*: any*/),
+                              (v29/*: any*/)
                             ],
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
-                      (v27/*: any*/)
+                      (v29/*: any*/)
                     ],
                     "storageKey": "artworksConnection(aggregations:[\"TOTAL\"],first:3,sort:\"-decayed_merch\")"
                   }
@@ -1042,7 +1059,7 @@ return {
                     "name": "first",
                     "value": 10
                   },
-                  (v41/*: any*/)
+                  (v43/*: any*/)
                 ],
                 "concreteType": "FilterArtworksConnection",
                 "kind": "LinkedField",
@@ -1065,7 +1082,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v27/*: any*/),
+                          (v29/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1081,11 +1098,11 @@ return {
                                 "name": "imageURL",
                                 "storageKey": null
                               },
-                              (v32/*: any*/)
+                              (v34/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v34/*: any*/),
+                          (v36/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1101,7 +1118,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v37/*: any*/),
+                                "selections": (v39/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -1111,10 +1128,10 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v37/*: any*/),
+                                "selections": (v39/*: any*/),
                                 "storageKey": null
                               },
-                              (v27/*: any*/)
+                              (v29/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1126,22 +1143,22 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v36/*: any*/),
-                              (v35/*: any*/),
-                              (v27/*: any*/)
+                              (v38/*: any*/),
+                              (v37/*: any*/),
+                              (v29/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v33/*: any*/),
-                          (v29/*: any*/),
-                          (v28/*: any*/)
+                          (v35/*: any*/),
+                          (v31/*: any*/),
+                          (v30/*: any*/)
                         ],
                         "storageKey": null
                       }
                     ],
                     "storageKey": null
                   },
-                  (v27/*: any*/)
+                  (v29/*: any*/)
                 ],
                 "storageKey": "filterArtworksConnection(first:10,sort:\"-weighted_iconicity\")"
               },
@@ -1182,9 +1199,9 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v28/*: any*/),
-                          (v29/*: any*/),
-                          (v33/*: any*/),
+                          (v30/*: any*/),
+                          (v31/*: any*/),
+                          (v35/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1199,7 +1216,7 @@ return {
                             "name": "artworksCountMessage",
                             "storageKey": null
                           },
-                          (v40/*: any*/)
+                          (v42/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -1212,8 +1229,8 @@ return {
               {
                 "alias": "notableWorks",
                 "args": [
-                  (v39/*: any*/),
-                  (v41/*: any*/)
+                  (v41/*: any*/),
+                  (v43/*: any*/)
                 ],
                 "concreteType": "FilterArtworksConnection",
                 "kind": "LinkedField",
@@ -1235,13 +1252,13 @@ return {
                         "kind": "LinkedField",
                         "name": "node",
                         "plural": false,
-                        "selections": (v38/*: any*/),
+                        "selections": (v40/*: any*/),
                         "storageKey": null
                       }
                     ],
                     "storageKey": null
                   },
-                  (v27/*: any*/)
+                  (v29/*: any*/)
                 ],
                 "storageKey": "filterArtworksConnection(first:3,sort:\"-weighted_iconicity\")"
               }
@@ -1255,7 +1272,7 @@ return {
     ]
   },
   "params": {
-    "id": "aaff65bec8c5345db126ae7bec44748b",
+    "id": "353c24cb19397d74957101b29a6369b8",
     "metadata": {},
     "name": "ArtistArtworksQuery",
     "operationKind": "query",
@@ -1263,5 +1280,5 @@ return {
   }
 };
 })();
-(node as any).hash = 'c91ab0348740dea9e999f8fddd5d7162';
+(node as any).hash = '847fa3cef271f76f7b28bb9612468eb2';
 export default node;

--- a/src/__generated__/ArtistArtworks_artist.graphql.ts
+++ b/src/__generated__/ArtistArtworks_artist.graphql.ts
@@ -69,6 +69,11 @@ return {
     {
       "defaultValue": null,
       "kind": "LocalArgument",
+      "name": "attributionClass"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
       "name": "color"
     },
     {
@@ -177,6 +182,11 @@ return {
           "kind": "Variable",
           "name": "atAuction",
           "variableName": "atAuction"
+        },
+        {
+          "kind": "Variable",
+          "name": "attributionClass",
+          "variableName": "attributionClass"
         },
         {
           "kind": "Variable",
@@ -441,5 +451,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = 'ffec0f990becd80b4282c1ed737289a9';
+(node as any).hash = 'cf040c849c9f749decfafe2cbb0d4bde';
 export default node;

--- a/src/__generated__/ArtistSeriesArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 84f1ac67b9a3039085d44980e0d5c992 */
+/* @relayHash affc0967a8d5c824f9d8b7d72c68a359 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -20,6 +20,7 @@ export type ArtistSeriesArtworksInfiniteScrollGridQueryVariables = {
     inquireableOnly?: boolean | null;
     atAuction?: boolean | null;
     offerable?: boolean | null;
+    attributionClass?: Array<string | null> | null;
 };
 export type ArtistSeriesArtworksInfiniteScrollGridQueryResponse = {
     readonly artistSeries: {
@@ -48,16 +49,17 @@ query ArtistSeriesArtworksInfiniteScrollGridQuery(
   $inquireableOnly: Boolean
   $atAuction: Boolean
   $offerable: Boolean
+  $attributionClass: [String]
 ) {
   artistSeries(id: $id) {
-    ...ArtistSeriesArtworks_artistSeries_3m6HS0
+    ...ArtistSeriesArtworks_artistSeries_3FXTiz
   }
 }
 
-fragment ArtistSeriesArtworks_artistSeries_3m6HS0 on ArtistSeries {
+fragment ArtistSeriesArtworks_artistSeries_3FXTiz on ArtistSeries {
   slug
   internalID
-  artistSeriesArtworks: filterArtworksConnection(first: 20, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], attributionClass: $attributionClass) {
     aggregations {
       slice
       counts {
@@ -159,141 +161,151 @@ v1 = {
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "color"
+  "name": "attributionClass"
 },
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "count"
+  "name": "color"
 },
 v4 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "cursor"
+  "name": "count"
 },
 v5 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "dimensionRange"
+  "name": "cursor"
 },
 v6 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "id"
+  "name": "dimensionRange"
 },
 v7 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "inquireableOnly"
+  "name": "id"
 },
 v8 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "majorPeriods"
+  "name": "inquireableOnly"
 },
 v9 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "medium"
+  "name": "majorPeriods"
 },
 v10 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "offerable"
+  "name": "medium"
 },
 v11 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "partnerID"
+  "name": "offerable"
 },
 v12 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "priceRange"
+  "name": "partnerID"
 },
 v13 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "priceRange"
+},
+v14 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "sort"
 },
-v14 = [
+v15 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v15 = {
+v16 = {
   "kind": "Variable",
   "name": "acquireable",
   "variableName": "acquireable"
 },
-v16 = {
+v17 = {
   "kind": "Variable",
   "name": "atAuction",
   "variableName": "atAuction"
 },
-v17 = {
+v18 = {
+  "kind": "Variable",
+  "name": "attributionClass",
+  "variableName": "attributionClass"
+},
+v19 = {
   "kind": "Variable",
   "name": "color",
   "variableName": "color"
 },
-v18 = {
+v20 = {
   "kind": "Variable",
   "name": "dimensionRange",
   "variableName": "dimensionRange"
 },
-v19 = {
+v21 = {
   "kind": "Variable",
   "name": "inquireableOnly",
   "variableName": "inquireableOnly"
 },
-v20 = {
+v22 = {
   "kind": "Variable",
   "name": "majorPeriods",
   "variableName": "majorPeriods"
 },
-v21 = {
+v23 = {
   "kind": "Variable",
   "name": "medium",
   "variableName": "medium"
 },
-v22 = {
+v24 = {
   "kind": "Variable",
   "name": "offerable",
   "variableName": "offerable"
 },
-v23 = {
+v25 = {
   "kind": "Variable",
   "name": "partnerID",
   "variableName": "partnerID"
 },
-v24 = {
+v26 = {
   "kind": "Variable",
   "name": "priceRange",
   "variableName": "priceRange"
 },
-v25 = {
+v27 = {
   "kind": "Variable",
   "name": "sort",
   "variableName": "sort"
 },
-v26 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v27 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v28 = [
-  (v15/*: any*/),
+v30 = [
+  (v16/*: any*/),
   {
     "kind": "Variable",
     "name": "after",
@@ -312,37 +324,38 @@ v28 = [
       "PRICE_RANGE"
     ]
   },
-  (v16/*: any*/),
   (v17/*: any*/),
   (v18/*: any*/),
+  (v19/*: any*/),
+  (v20/*: any*/),
   {
     "kind": "Literal",
     "name": "first",
     "value": 20
   },
-  (v19/*: any*/),
-  (v20/*: any*/),
   (v21/*: any*/),
   (v22/*: any*/),
   (v23/*: any*/),
   (v24/*: any*/),
-  (v25/*: any*/)
+  (v25/*: any*/),
+  (v26/*: any*/),
+  (v27/*: any*/)
 ],
-v29 = {
+v31 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v30 = {
+v32 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v31 = {
+v33 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -365,7 +378,8 @@ return {
       (v10/*: any*/),
       (v11/*: any*/),
       (v12/*: any*/),
-      (v13/*: any*/)
+      (v13/*: any*/),
+      (v14/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -373,7 +387,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v14/*: any*/),
+        "args": (v15/*: any*/),
         "concreteType": "ArtistSeries",
         "kind": "LinkedField",
         "name": "artistSeries",
@@ -381,9 +395,10 @@ return {
         "selections": [
           {
             "args": [
-              (v15/*: any*/),
               (v16/*: any*/),
               (v17/*: any*/),
+              (v18/*: any*/),
+              (v19/*: any*/),
               {
                 "kind": "Variable",
                 "name": "count",
@@ -394,14 +409,14 @@ return {
                 "name": "cursor",
                 "variableName": "cursor"
               },
-              (v18/*: any*/),
-              (v19/*: any*/),
               (v20/*: any*/),
               (v21/*: any*/),
               (v22/*: any*/),
               (v23/*: any*/),
               (v24/*: any*/),
-              (v25/*: any*/)
+              (v25/*: any*/),
+              (v26/*: any*/),
+              (v27/*: any*/)
             ],
             "kind": "FragmentSpread",
             "name": "ArtistSeriesArtworks_artistSeries"
@@ -416,37 +431,38 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v6/*: any*/),
-      (v3/*: any*/),
-      (v4/*: any*/),
-      (v13/*: any*/),
-      (v9/*: any*/),
-      (v12/*: any*/),
-      (v2/*: any*/),
-      (v11/*: any*/),
-      (v5/*: any*/),
-      (v8/*: any*/),
-      (v0/*: any*/),
       (v7/*: any*/),
+      (v4/*: any*/),
+      (v5/*: any*/),
+      (v14/*: any*/),
+      (v10/*: any*/),
+      (v13/*: any*/),
+      (v3/*: any*/),
+      (v12/*: any*/),
+      (v6/*: any*/),
+      (v9/*: any*/),
+      (v0/*: any*/),
+      (v8/*: any*/),
       (v1/*: any*/),
-      (v10/*: any*/)
+      (v11/*: any*/),
+      (v2/*: any*/)
     ],
     "kind": "Operation",
     "name": "ArtistSeriesArtworksInfiniteScrollGridQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v14/*: any*/),
+        "args": (v15/*: any*/),
         "concreteType": "ArtistSeries",
         "kind": "LinkedField",
         "name": "artistSeries",
         "plural": false,
         "selections": [
-          (v26/*: any*/),
-          (v27/*: any*/),
+          (v28/*: any*/),
+          (v29/*: any*/),
           {
             "alias": "artistSeriesArtworks",
-            "args": (v28/*: any*/),
+            "args": (v30/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -482,7 +498,7 @@ return {
                         "name": "count",
                         "storageKey": null
                       },
-                      (v29/*: any*/),
+                      (v31/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -512,8 +528,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v30/*: any*/),
-                      (v31/*: any*/)
+                      (v32/*: any*/),
+                      (v33/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -570,7 +586,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v30/*: any*/),
+              (v32/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -600,7 +616,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v31/*: any*/),
+                      (v33/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -609,7 +625,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v26/*: any*/),
+                          (v28/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -662,7 +678,7 @@ return {
                             "name": "saleMessage",
                             "storageKey": null
                           },
-                          (v27/*: any*/),
+                          (v29/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -713,7 +729,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v30/*: any*/)
+                              (v32/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -768,7 +784,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v30/*: any*/)
+                              (v32/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -780,8 +796,8 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v29/*: any*/),
-                              (v30/*: any*/)
+                              (v31/*: any*/),
+                              (v32/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -791,7 +807,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v30/*: any*/)
+                          (v32/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -808,7 +824,7 @@ return {
           },
           {
             "alias": "artistSeriesArtworks",
-            "args": (v28/*: any*/),
+            "args": (v30/*: any*/),
             "filters": [
               "sort",
               "medium",
@@ -821,7 +837,8 @@ return {
               "inquireableOnly",
               "atAuction",
               "offerable",
-              "aggregations"
+              "aggregations",
+              "attributionClass"
             ],
             "handle": "connection",
             "key": "ArtistSeries_artistSeriesArtworks",
@@ -834,7 +851,7 @@ return {
     ]
   },
   "params": {
-    "id": "84f1ac67b9a3039085d44980e0d5c992",
+    "id": "affc0967a8d5c824f9d8b7d72c68a359",
     "metadata": {},
     "name": "ArtistSeriesArtworksInfiniteScrollGridQuery",
     "operationKind": "query",
@@ -842,5 +859,5 @@ return {
   }
 };
 })();
-(node as any).hash = '742a3d10392ece79bd222570677b8475';
+(node as any).hash = '0c45653e45ae4bb81cff0a07553c36c7';
 export default node;

--- a/src/__generated__/ArtistSeriesArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworksTestsQuery.graphql.ts
@@ -644,7 +644,8 @@ return {
               "inquireableOnly",
               "atAuction",
               "offerable",
-              "aggregations"
+              "aggregations",
+              "attributionClass"
             ],
             "handle": "connection",
             "key": "ArtistSeries_artistSeriesArtworks",

--- a/src/__generated__/ArtistSeriesArtworks_artistSeries.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworks_artistSeries.graphql.ts
@@ -52,6 +52,11 @@ const node: ReaderFragment = {
     {
       "defaultValue": null,
       "kind": "LocalArgument",
+      "name": "attributionClass"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
       "name": "color"
     },
     {
@@ -159,6 +164,11 @@ const node: ReaderFragment = {
           "kind": "Variable",
           "name": "atAuction",
           "variableName": "atAuction"
+        },
+        {
+          "kind": "Variable",
+          "name": "attributionClass",
+          "variableName": "attributionClass"
         },
         {
           "kind": "Variable",
@@ -359,5 +369,5 @@ const node: ReaderFragment = {
   "type": "ArtistSeries",
   "abstractKey": null
 };
-(node as any).hash = '39063bcc6423e451869bf45145b839ee';
+(node as any).hash = 'bd0cf8766f02c953535bece7f657c285';
 export default node;

--- a/src/__generated__/ArtistSeriesQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesQuery.graphql.ts
@@ -748,7 +748,8 @@ return {
               "inquireableOnly",
               "atAuction",
               "offerable",
-              "aggregations"
+              "aggregations",
+              "attributionClass"
             ],
             "handle": "connection",
             "key": "ArtistSeries_artistSeriesArtworks",

--- a/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
@@ -797,7 +797,8 @@ return {
               "inquireableOnly",
               "atAuction",
               "offerable",
-              "aggregations"
+              "aggregations",
+              "attributionClass"
             ],
             "handle": "connection",
             "key": "ArtistSeries_artistSeriesArtworks",

--- a/src/__generated__/CollectionArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/CollectionArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 7030c09bd4cd9bcb20627a027c2880a8 */
+/* @relayHash 3e382b3ba6e6a83689c3e6b601cd1504 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -20,6 +20,7 @@ export type CollectionArtworksInfiniteScrollGridQueryVariables = {
     inquireableOnly?: boolean | null;
     atAuction?: boolean | null;
     offerable?: boolean | null;
+    attributionClass?: Array<string | null> | null;
 };
 export type CollectionArtworksInfiniteScrollGridQueryResponse = {
     readonly marketingCollection: {
@@ -49,9 +50,10 @@ query CollectionArtworksInfiniteScrollGridQuery(
   $inquireableOnly: Boolean
   $atAuction: Boolean
   $offerable: Boolean
+  $attributionClass: [String]
 ) {
   marketingCollection(slug: $id) {
-    ...CollectionArtworks_collection_3m6HS0
+    ...CollectionArtworks_collection_3FXTiz
     id
   }
 }
@@ -91,11 +93,11 @@ fragment ArtworkGridItem_artwork on Artwork {
   }
 }
 
-fragment CollectionArtworks_collection_3m6HS0 on MarketingCollection {
+fragment CollectionArtworks_collection_3FXTiz on MarketingCollection {
   isDepartment
   slug
   id
-  collectionArtworks: artworksConnection(first: $count, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  collectionArtworks: artworksConnection(first: $count, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], attributionClass: $attributionClass) {
     aggregations {
       slice
       counts {
@@ -162,141 +164,151 @@ v1 = {
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "color"
+  "name": "attributionClass"
 },
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "count"
+  "name": "color"
 },
 v4 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "cursor"
+  "name": "count"
 },
 v5 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "dimensionRange"
+  "name": "cursor"
 },
 v6 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "id"
+  "name": "dimensionRange"
 },
 v7 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "inquireableOnly"
+  "name": "id"
 },
 v8 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "majorPeriods"
+  "name": "inquireableOnly"
 },
 v9 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "medium"
+  "name": "majorPeriods"
 },
 v10 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "offerable"
+  "name": "medium"
 },
 v11 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "partnerID"
+  "name": "offerable"
 },
 v12 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "priceRange"
+  "name": "partnerID"
 },
 v13 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "priceRange"
+},
+v14 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "sort"
 },
-v14 = [
+v15 = [
   {
     "kind": "Variable",
     "name": "slug",
     "variableName": "id"
   }
 ],
-v15 = {
+v16 = {
   "kind": "Variable",
   "name": "acquireable",
   "variableName": "acquireable"
 },
-v16 = {
+v17 = {
   "kind": "Variable",
   "name": "atAuction",
   "variableName": "atAuction"
 },
-v17 = {
+v18 = {
+  "kind": "Variable",
+  "name": "attributionClass",
+  "variableName": "attributionClass"
+},
+v19 = {
   "kind": "Variable",
   "name": "color",
   "variableName": "color"
 },
-v18 = {
+v20 = {
   "kind": "Variable",
   "name": "dimensionRange",
   "variableName": "dimensionRange"
 },
-v19 = {
+v21 = {
   "kind": "Variable",
   "name": "inquireableOnly",
   "variableName": "inquireableOnly"
 },
-v20 = {
+v22 = {
   "kind": "Variable",
   "name": "majorPeriods",
   "variableName": "majorPeriods"
 },
-v21 = {
+v23 = {
   "kind": "Variable",
   "name": "medium",
   "variableName": "medium"
 },
-v22 = {
+v24 = {
   "kind": "Variable",
   "name": "offerable",
   "variableName": "offerable"
 },
-v23 = {
+v25 = {
   "kind": "Variable",
   "name": "partnerID",
   "variableName": "partnerID"
 },
-v24 = {
+v26 = {
   "kind": "Variable",
   "name": "priceRange",
   "variableName": "priceRange"
 },
-v25 = {
+v27 = {
   "kind": "Variable",
   "name": "sort",
   "variableName": "sort"
 },
-v26 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v27 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v28 = [
-  (v15/*: any*/),
+v30 = [
+  (v16/*: any*/),
   {
     "kind": "Variable",
     "name": "after",
@@ -315,30 +327,31 @@ v28 = [
       "PRICE_RANGE"
     ]
   },
-  (v16/*: any*/),
   (v17/*: any*/),
   (v18/*: any*/),
+  (v19/*: any*/),
+  (v20/*: any*/),
   {
     "kind": "Variable",
     "name": "first",
     "variableName": "count"
   },
-  (v19/*: any*/),
-  (v20/*: any*/),
   (v21/*: any*/),
   (v22/*: any*/),
   (v23/*: any*/),
   (v24/*: any*/),
-  (v25/*: any*/)
+  (v25/*: any*/),
+  (v26/*: any*/),
+  (v27/*: any*/)
 ],
-v29 = {
+v31 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v30 = {
+v32 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -361,7 +374,8 @@ return {
       (v10/*: any*/),
       (v11/*: any*/),
       (v12/*: any*/),
-      (v13/*: any*/)
+      (v13/*: any*/),
+      (v14/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -369,7 +383,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v14/*: any*/),
+        "args": (v15/*: any*/),
         "concreteType": "MarketingCollection",
         "kind": "LinkedField",
         "name": "marketingCollection",
@@ -377,9 +391,10 @@ return {
         "selections": [
           {
             "args": [
-              (v15/*: any*/),
               (v16/*: any*/),
               (v17/*: any*/),
+              (v18/*: any*/),
+              (v19/*: any*/),
               {
                 "kind": "Variable",
                 "name": "count",
@@ -390,14 +405,14 @@ return {
                 "name": "cursor",
                 "variableName": "cursor"
               },
-              (v18/*: any*/),
-              (v19/*: any*/),
               (v20/*: any*/),
               (v21/*: any*/),
               (v22/*: any*/),
               (v23/*: any*/),
               (v24/*: any*/),
-              (v25/*: any*/)
+              (v25/*: any*/),
+              (v26/*: any*/),
+              (v27/*: any*/)
             ],
             "kind": "FragmentSpread",
             "name": "CollectionArtworks_collection"
@@ -412,27 +427,28 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v6/*: any*/),
-      (v3/*: any*/),
-      (v4/*: any*/),
-      (v13/*: any*/),
-      (v9/*: any*/),
-      (v12/*: any*/),
-      (v2/*: any*/),
-      (v11/*: any*/),
-      (v5/*: any*/),
-      (v8/*: any*/),
-      (v0/*: any*/),
       (v7/*: any*/),
+      (v4/*: any*/),
+      (v5/*: any*/),
+      (v14/*: any*/),
+      (v10/*: any*/),
+      (v13/*: any*/),
+      (v3/*: any*/),
+      (v12/*: any*/),
+      (v6/*: any*/),
+      (v9/*: any*/),
+      (v0/*: any*/),
+      (v8/*: any*/),
       (v1/*: any*/),
-      (v10/*: any*/)
+      (v11/*: any*/),
+      (v2/*: any*/)
     ],
     "kind": "Operation",
     "name": "CollectionArtworksInfiniteScrollGridQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v14/*: any*/),
+        "args": (v15/*: any*/),
         "concreteType": "MarketingCollection",
         "kind": "LinkedField",
         "name": "marketingCollection",
@@ -445,11 +461,11 @@ return {
             "name": "isDepartment",
             "storageKey": null
           },
-          (v26/*: any*/),
-          (v27/*: any*/),
+          (v28/*: any*/),
+          (v29/*: any*/),
           {
             "alias": "collectionArtworks",
-            "args": (v28/*: any*/),
+            "args": (v30/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "artworksConnection",
@@ -485,7 +501,7 @@ return {
                         "name": "value",
                         "storageKey": null
                       },
-                      (v29/*: any*/),
+                      (v31/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -533,8 +549,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v27/*: any*/),
-                      (v30/*: any*/)
+                      (v29/*: any*/),
+                      (v32/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -573,7 +589,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v27/*: any*/),
+              (v29/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -603,7 +619,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v30/*: any*/),
+                      (v32/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -612,7 +628,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v26/*: any*/),
+                          (v28/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -722,7 +738,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v27/*: any*/)
+                              (v29/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -777,7 +793,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v27/*: any*/)
+                              (v29/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -789,8 +805,8 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v29/*: any*/),
-                              (v27/*: any*/)
+                              (v31/*: any*/),
+                              (v29/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -800,7 +816,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v27/*: any*/)
+                          (v29/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -817,7 +833,7 @@ return {
           },
           {
             "alias": "collectionArtworks",
-            "args": (v28/*: any*/),
+            "args": (v30/*: any*/),
             "filters": [
               "sort",
               "medium",
@@ -830,7 +846,8 @@ return {
               "inquireableOnly",
               "atAuction",
               "offerable",
-              "aggregations"
+              "aggregations",
+              "attributionClass"
             ],
             "handle": "connection",
             "key": "Collection_collectionArtworks",
@@ -843,7 +860,7 @@ return {
     ]
   },
   "params": {
-    "id": "7030c09bd4cd9bcb20627a027c2880a8",
+    "id": "3e382b3ba6e6a83689c3e6b601cd1504",
     "metadata": {},
     "name": "CollectionArtworksInfiniteScrollGridQuery",
     "operationKind": "query",
@@ -851,5 +868,5 @@ return {
   }
 };
 })();
-(node as any).hash = '3a448a1d00ce86e1a6740d9ee2bdfe85';
+(node as any).hash = '2f6d6cdf0adaf3f45970c89aae12790f';
 export default node;

--- a/src/__generated__/CollectionArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/CollectionArtworksTestsQuery.graphql.ts
@@ -658,7 +658,8 @@ return {
               "inquireableOnly",
               "atAuction",
               "offerable",
-              "aggregations"
+              "aggregations",
+              "attributionClass"
             ],
             "handle": "connection",
             "key": "Collection_collectionArtworks",

--- a/src/__generated__/CollectionArtworks_collection.graphql.ts
+++ b/src/__generated__/CollectionArtworks_collection.graphql.ts
@@ -61,6 +61,11 @@ return {
     {
       "defaultValue": null,
       "kind": "LocalArgument",
+      "name": "attributionClass"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
       "name": "color"
     },
     {
@@ -169,6 +174,11 @@ return {
           "kind": "Variable",
           "name": "atAuction",
           "variableName": "atAuction"
+        },
+        {
+          "kind": "Variable",
+          "name": "attributionClass",
+          "variableName": "attributionClass"
         },
         {
           "kind": "Variable",
@@ -364,5 +374,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '6e5763406b3d8c291a27a8364fd47052';
+(node as any).hash = '1e65e47708f32d93e8b7607980305c68';
 export default node;

--- a/src/__generated__/CollectionQuery.graphql.ts
+++ b/src/__generated__/CollectionQuery.graphql.ts
@@ -896,7 +896,8 @@ return {
               "inquireableOnly",
               "atAuction",
               "offerable",
-              "aggregations"
+              "aggregations",
+              "attributionClass"
             ],
             "handle": "connection",
             "key": "Collection_collectionArtworks",

--- a/src/__generated__/CollectionTestsQuery.graphql.ts
+++ b/src/__generated__/CollectionTestsQuery.graphql.ts
@@ -939,7 +939,8 @@ return {
               "inquireableOnly",
               "atAuction",
               "offerable",
-              "aggregations"
+              "aggregations",
+              "attributionClass"
             ],
             "handle": "connection",
             "key": "Collection_collectionArtworks",

--- a/src/__generated__/FairAllFollowedArtistsQuery.graphql.ts
+++ b/src/__generated__/FairAllFollowedArtistsQuery.graphql.ts
@@ -692,7 +692,8 @@ return {
               "offerable",
               "includeArtworksByFollowedArtists",
               "artistIDs",
-              "aggregations"
+              "aggregations",
+              "attributionClass"
             ],
             "handle": "connection",
             "key": "Fair_fairArtworks",

--- a/src/__generated__/FairAllFollowedArtistsTestsQuery.graphql.ts
+++ b/src/__generated__/FairAllFollowedArtistsTestsQuery.graphql.ts
@@ -778,7 +778,8 @@ return {
               "offerable",
               "includeArtworksByFollowedArtists",
               "artistIDs",
-              "aggregations"
+              "aggregations",
+              "attributionClass"
             ],
             "handle": "connection",
             "key": "Fair_fairArtworks",

--- a/src/__generated__/FairArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/FairArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 03b97ede4e6c6504befa9f3be610866c */
+/* @relayHash 322747e1630483a5f2b107977f8e6f87 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -22,6 +22,7 @@ export type FairArtworksInfiniteScrollGridQueryVariables = {
     offerable?: boolean | null;
     includeArtworksByFollowedArtists?: boolean | null;
     artistIDs?: Array<string | null> | null;
+    attributionClass?: Array<string | null> | null;
 };
 export type FairArtworksInfiniteScrollGridQueryResponse = {
     readonly fair: {
@@ -52,9 +53,10 @@ query FairArtworksInfiniteScrollGridQuery(
   $offerable: Boolean
   $includeArtworksByFollowedArtists: Boolean
   $artistIDs: [String]
+  $attributionClass: [String]
 ) {
   fair(id: $id) {
-    ...FairArtworks_fair_17LhbE
+    ...FairArtworks_fair_1Fr0Af
     id
   }
 }
@@ -94,10 +96,10 @@ fragment ArtworkGridItem_artwork on Artwork {
   }
 }
 
-fragment FairArtworks_fair_17LhbE on Fair {
+fragment FairArtworks_fair_1Fr0Af on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, includeArtworksByFollowedArtists: $includeArtworksByFollowedArtists, artistIDs: $artistIDs, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+  fairArtworks: filterArtworksConnection(first: 30, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, includeArtworksByFollowedArtists: $includeArtworksByFollowedArtists, artistIDs: $artistIDs, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], attributionClass: $attributionClass) {
     aggregations {
       slice
       counts {
@@ -170,156 +172,166 @@ v2 = {
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "color"
+  "name": "attributionClass"
 },
 v4 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "count"
+  "name": "color"
 },
 v5 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "cursor"
+  "name": "count"
 },
 v6 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "dimensionRange"
+  "name": "cursor"
 },
 v7 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "id"
+  "name": "dimensionRange"
 },
 v8 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "includeArtworksByFollowedArtists"
+  "name": "id"
 },
 v9 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "inquireableOnly"
+  "name": "includeArtworksByFollowedArtists"
 },
 v10 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "majorPeriods"
+  "name": "inquireableOnly"
 },
 v11 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "medium"
+  "name": "majorPeriods"
 },
 v12 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "offerable"
+  "name": "medium"
 },
 v13 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "partnerID"
+  "name": "offerable"
 },
 v14 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "priceRange"
+  "name": "partnerID"
 },
 v15 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "priceRange"
+},
+v16 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "sort"
 },
-v16 = [
+v17 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v17 = {
+v18 = {
   "kind": "Variable",
   "name": "acquireable",
   "variableName": "acquireable"
 },
-v18 = {
+v19 = {
   "kind": "Variable",
   "name": "artistIDs",
   "variableName": "artistIDs"
 },
-v19 = {
+v20 = {
   "kind": "Variable",
   "name": "atAuction",
   "variableName": "atAuction"
 },
-v20 = {
+v21 = {
+  "kind": "Variable",
+  "name": "attributionClass",
+  "variableName": "attributionClass"
+},
+v22 = {
   "kind": "Variable",
   "name": "color",
   "variableName": "color"
 },
-v21 = {
+v23 = {
   "kind": "Variable",
   "name": "dimensionRange",
   "variableName": "dimensionRange"
 },
-v22 = {
+v24 = {
   "kind": "Variable",
   "name": "includeArtworksByFollowedArtists",
   "variableName": "includeArtworksByFollowedArtists"
 },
-v23 = {
+v25 = {
   "kind": "Variable",
   "name": "inquireableOnly",
   "variableName": "inquireableOnly"
 },
-v24 = {
+v26 = {
   "kind": "Variable",
   "name": "majorPeriods",
   "variableName": "majorPeriods"
 },
-v25 = {
+v27 = {
   "kind": "Variable",
   "name": "medium",
   "variableName": "medium"
 },
-v26 = {
+v28 = {
   "kind": "Variable",
   "name": "offerable",
   "variableName": "offerable"
 },
-v27 = {
+v29 = {
   "kind": "Variable",
   "name": "partnerID",
   "variableName": "partnerID"
 },
-v28 = {
+v30 = {
   "kind": "Variable",
   "name": "priceRange",
   "variableName": "priceRange"
 },
-v29 = {
+v31 = {
   "kind": "Variable",
   "name": "sort",
   "variableName": "sort"
 },
-v30 = {
+v32 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v31 = {
+v33 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v32 = [
-  (v17/*: any*/),
+v34 = [
+  (v18/*: any*/),
   {
     "kind": "Variable",
     "name": "after",
@@ -340,39 +352,40 @@ v32 = [
       "ARTIST"
     ]
   },
-  (v18/*: any*/),
   (v19/*: any*/),
   (v20/*: any*/),
   (v21/*: any*/),
+  (v22/*: any*/),
+  (v23/*: any*/),
   {
     "kind": "Literal",
     "name": "first",
     "value": 30
   },
-  (v22/*: any*/),
-  (v23/*: any*/),
   (v24/*: any*/),
   (v25/*: any*/),
   (v26/*: any*/),
   (v27/*: any*/),
   (v28/*: any*/),
-  (v29/*: any*/)
+  (v29/*: any*/),
+  (v30/*: any*/),
+  (v31/*: any*/)
 ],
-v33 = {
+v35 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v34 = {
+v36 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v35 = {
+v37 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -397,7 +410,8 @@ return {
       (v12/*: any*/),
       (v13/*: any*/),
       (v14/*: any*/),
-      (v15/*: any*/)
+      (v15/*: any*/),
+      (v16/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -405,7 +419,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v16/*: any*/),
+        "args": (v17/*: any*/),
         "concreteType": "Fair",
         "kind": "LinkedField",
         "name": "fair",
@@ -413,10 +427,11 @@ return {
         "selections": [
           {
             "args": [
-              (v17/*: any*/),
               (v18/*: any*/),
               (v19/*: any*/),
               (v20/*: any*/),
+              (v21/*: any*/),
+              (v22/*: any*/),
               {
                 "kind": "Variable",
                 "name": "count",
@@ -427,15 +442,15 @@ return {
                 "name": "cursor",
                 "variableName": "cursor"
               },
-              (v21/*: any*/),
-              (v22/*: any*/),
               (v23/*: any*/),
               (v24/*: any*/),
               (v25/*: any*/),
               (v26/*: any*/),
               (v27/*: any*/),
               (v28/*: any*/),
-              (v29/*: any*/)
+              (v29/*: any*/),
+              (v30/*: any*/),
+              (v31/*: any*/)
             ],
             "kind": "FragmentSpread",
             "name": "FairArtworks_fair"
@@ -450,39 +465,40 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v7/*: any*/),
-      (v4/*: any*/),
-      (v5/*: any*/),
-      (v15/*: any*/),
-      (v11/*: any*/),
-      (v14/*: any*/),
-      (v3/*: any*/),
-      (v13/*: any*/),
-      (v6/*: any*/),
-      (v10/*: any*/),
-      (v0/*: any*/),
-      (v9/*: any*/),
-      (v2/*: any*/),
-      (v12/*: any*/),
       (v8/*: any*/),
-      (v1/*: any*/)
+      (v5/*: any*/),
+      (v6/*: any*/),
+      (v16/*: any*/),
+      (v12/*: any*/),
+      (v15/*: any*/),
+      (v4/*: any*/),
+      (v14/*: any*/),
+      (v7/*: any*/),
+      (v11/*: any*/),
+      (v0/*: any*/),
+      (v10/*: any*/),
+      (v2/*: any*/),
+      (v13/*: any*/),
+      (v9/*: any*/),
+      (v1/*: any*/),
+      (v3/*: any*/)
     ],
     "kind": "Operation",
     "name": "FairArtworksInfiniteScrollGridQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v16/*: any*/),
+        "args": (v17/*: any*/),
         "concreteType": "Fair",
         "kind": "LinkedField",
         "name": "fair",
         "plural": false,
         "selections": [
-          (v30/*: any*/),
-          (v31/*: any*/),
+          (v32/*: any*/),
+          (v33/*: any*/),
           {
             "alias": "fairArtworks",
-            "args": (v32/*: any*/),
+            "args": (v34/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -518,7 +534,7 @@ return {
                         "name": "count",
                         "storageKey": null
                       },
-                      (v33/*: any*/),
+                      (v35/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -548,8 +564,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v34/*: any*/),
-                      (v35/*: any*/)
+                      (v36/*: any*/),
+                      (v37/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -613,7 +629,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v34/*: any*/),
+              (v36/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -643,7 +659,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v35/*: any*/),
+                      (v37/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -652,7 +668,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v30/*: any*/),
+                          (v32/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -705,7 +721,7 @@ return {
                             "name": "saleMessage",
                             "storageKey": null
                           },
-                          (v31/*: any*/),
+                          (v33/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -756,7 +772,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v34/*: any*/)
+                              (v36/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -811,7 +827,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v34/*: any*/)
+                              (v36/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -823,8 +839,8 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v33/*: any*/),
-                              (v34/*: any*/)
+                              (v35/*: any*/),
+                              (v36/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -834,7 +850,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v34/*: any*/)
+                          (v36/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -851,7 +867,7 @@ return {
           },
           {
             "alias": "fairArtworks",
-            "args": (v32/*: any*/),
+            "args": (v34/*: any*/),
             "filters": [
               "sort",
               "medium",
@@ -866,21 +882,22 @@ return {
               "offerable",
               "includeArtworksByFollowedArtists",
               "artistIDs",
-              "aggregations"
+              "aggregations",
+              "attributionClass"
             ],
             "handle": "connection",
             "key": "Fair_fairArtworks",
             "kind": "LinkedHandle",
             "name": "filterArtworksConnection"
           },
-          (v34/*: any*/)
+          (v36/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "03b97ede4e6c6504befa9f3be610866c",
+    "id": "322747e1630483a5f2b107977f8e6f87",
     "metadata": {},
     "name": "FairArtworksInfiniteScrollGridQuery",
     "operationKind": "query",
@@ -888,5 +905,5 @@ return {
   }
 };
 })();
-(node as any).hash = 'ac2989a8205bb776a050ebd1b18452e2';
+(node as any).hash = 'd3e376a72e3f56bdb9f63cbeabe97394';
 export default node;

--- a/src/__generated__/FairArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/FairArtworksTestsQuery.graphql.ts
@@ -668,7 +668,8 @@ return {
               "offerable",
               "includeArtworksByFollowedArtists",
               "artistIDs",
-              "aggregations"
+              "aggregations",
+              "attributionClass"
             ],
             "handle": "connection",
             "key": "Fair_fairArtworks",

--- a/src/__generated__/FairArtworks_fair.graphql.ts
+++ b/src/__generated__/FairArtworks_fair.graphql.ts
@@ -58,6 +58,11 @@ const node: ReaderFragment = {
     {
       "defaultValue": null,
       "kind": "LocalArgument",
+      "name": "attributionClass"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
       "name": "color"
     },
     {
@@ -177,6 +182,11 @@ const node: ReaderFragment = {
           "kind": "Variable",
           "name": "atAuction",
           "variableName": "atAuction"
+        },
+        {
+          "kind": "Variable",
+          "name": "attributionClass",
+          "variableName": "attributionClass"
         },
         {
           "kind": "Variable",
@@ -389,5 +399,5 @@ const node: ReaderFragment = {
   "type": "Fair",
   "abstractKey": null
 };
-(node as any).hash = 'cc94bd72722e068a2c69e5bd7ed86a60';
+(node as any).hash = 'e8b34b7dd5a4f2647e72d2507678b357';
 export default node;

--- a/src/__generated__/FairQuery.graphql.ts
+++ b/src/__generated__/FairQuery.graphql.ts
@@ -1405,7 +1405,8 @@ return {
               "offerable",
               "includeArtworksByFollowedArtists",
               "artistIDs",
-              "aggregations"
+              "aggregations",
+              "attributionClass"
             ],
             "handle": "connection",
             "key": "Fair_fairArtworks",

--- a/src/__generated__/FairTestsQuery.graphql.ts
+++ b/src/__generated__/FairTestsQuery.graphql.ts
@@ -1519,7 +1519,8 @@ return {
               "offerable",
               "includeArtworksByFollowedArtists",
               "artistIDs",
-              "aggregations"
+              "aggregations",
+              "attributionClass"
             ],
             "handle": "connection",
             "key": "Fair_fairArtworks",

--- a/src/__generated__/FilterModalTestsQuery.graphql.ts
+++ b/src/__generated__/FilterModalTestsQuery.graphql.ts
@@ -729,7 +729,8 @@ return {
               "inquireableOnly",
               "atAuction",
               "offerable",
-              "aggregations"
+              "aggregations",
+              "attributionClass"
             ],
             "handle": "connection",
             "key": "Collection_collectionArtworks",

--- a/src/__generated__/ShowArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/ShowArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 07df579ce69da95b2768e3fe7f435afb */
+/* @relayHash 0559d18617f36d00f4b6f561120c8e41 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -19,6 +19,7 @@ export type ShowArtworksInfiniteScrollGridQueryVariables = {
     inquireableOnly?: boolean | null;
     atAuction?: boolean | null;
     offerable?: boolean | null;
+    attributionClass?: Array<string | null> | null;
 };
 export type ShowArtworksInfiniteScrollGridQueryResponse = {
     readonly show: {
@@ -46,9 +47,10 @@ query ShowArtworksInfiniteScrollGridQuery(
   $inquireableOnly: Boolean
   $atAuction: Boolean
   $offerable: Boolean
+  $attributionClass: [String]
 ) {
   show(id: $id) {
-    ...ShowArtworks_show_R9odU
+    ...ShowArtworks_show_3IiyVu
     id
   }
 }
@@ -112,10 +114,10 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
   }
 }
 
-fragment ShowArtworks_show_R9odU on Show {
+fragment ShowArtworks_show_3IiyVu on Show {
   slug
   internalID
-  showArtworks: filterArtworksConnection(first: 30, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  showArtworks: filterArtworksConnection(first: 30, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], attributionClass: $attributionClass) {
     aggregations {
       slice
       counts {
@@ -158,131 +160,141 @@ v1 = {
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "color"
+  "name": "attributionClass"
 },
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "count"
+  "name": "color"
 },
 v4 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "cursor"
+  "name": "count"
 },
 v5 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "dimensionRange"
+  "name": "cursor"
 },
 v6 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "id"
+  "name": "dimensionRange"
 },
 v7 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "inquireableOnly"
+  "name": "id"
 },
 v8 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "majorPeriods"
+  "name": "inquireableOnly"
 },
 v9 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "medium"
+  "name": "majorPeriods"
 },
 v10 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "offerable"
+  "name": "medium"
 },
 v11 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "priceRange"
+  "name": "offerable"
 },
 v12 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "priceRange"
+},
+v13 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "sort"
 },
-v13 = [
+v14 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v14 = {
+v15 = {
   "kind": "Variable",
   "name": "acquireable",
   "variableName": "acquireable"
 },
-v15 = {
+v16 = {
   "kind": "Variable",
   "name": "atAuction",
   "variableName": "atAuction"
 },
-v16 = {
+v17 = {
+  "kind": "Variable",
+  "name": "attributionClass",
+  "variableName": "attributionClass"
+},
+v18 = {
   "kind": "Variable",
   "name": "color",
   "variableName": "color"
 },
-v17 = {
+v19 = {
   "kind": "Variable",
   "name": "dimensionRange",
   "variableName": "dimensionRange"
 },
-v18 = {
+v20 = {
   "kind": "Variable",
   "name": "inquireableOnly",
   "variableName": "inquireableOnly"
 },
-v19 = {
+v21 = {
   "kind": "Variable",
   "name": "majorPeriods",
   "variableName": "majorPeriods"
 },
-v20 = {
+v22 = {
   "kind": "Variable",
   "name": "medium",
   "variableName": "medium"
 },
-v21 = {
+v23 = {
   "kind": "Variable",
   "name": "offerable",
   "variableName": "offerable"
 },
-v22 = {
+v24 = {
   "kind": "Variable",
   "name": "priceRange",
   "variableName": "priceRange"
 },
-v23 = {
+v25 = {
   "kind": "Variable",
   "name": "sort",
   "variableName": "sort"
 },
-v24 = {
+v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v25 = {
+v27 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v26 = [
-  (v14/*: any*/),
+v28 = [
+  (v15/*: any*/),
   {
     "kind": "Variable",
     "name": "after",
@@ -299,36 +311,37 @@ v26 = [
       "PRICE_RANGE"
     ]
   },
-  (v15/*: any*/),
   (v16/*: any*/),
   (v17/*: any*/),
+  (v18/*: any*/),
+  (v19/*: any*/),
   {
     "kind": "Literal",
     "name": "first",
     "value": 30
   },
-  (v18/*: any*/),
-  (v19/*: any*/),
   (v20/*: any*/),
   (v21/*: any*/),
   (v22/*: any*/),
-  (v23/*: any*/)
+  (v23/*: any*/),
+  (v24/*: any*/),
+  (v25/*: any*/)
 ],
-v27 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v28 = {
+v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v29 = {
+v31 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -350,7 +363,8 @@ return {
       (v9/*: any*/),
       (v10/*: any*/),
       (v11/*: any*/),
-      (v12/*: any*/)
+      (v12/*: any*/),
+      (v13/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -358,7 +372,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v13/*: any*/),
+        "args": (v14/*: any*/),
         "concreteType": "Show",
         "kind": "LinkedField",
         "name": "show",
@@ -366,9 +380,10 @@ return {
         "selections": [
           {
             "args": [
-              (v14/*: any*/),
               (v15/*: any*/),
               (v16/*: any*/),
+              (v17/*: any*/),
+              (v18/*: any*/),
               {
                 "kind": "Variable",
                 "name": "count",
@@ -379,13 +394,13 @@ return {
                 "name": "cursor",
                 "variableName": "cursor"
               },
-              (v17/*: any*/),
-              (v18/*: any*/),
               (v19/*: any*/),
               (v20/*: any*/),
               (v21/*: any*/),
               (v22/*: any*/),
-              (v23/*: any*/)
+              (v23/*: any*/),
+              (v24/*: any*/),
+              (v25/*: any*/)
             ],
             "kind": "FragmentSpread",
             "name": "ShowArtworks_show"
@@ -400,36 +415,37 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v6/*: any*/),
-      (v3/*: any*/),
-      (v4/*: any*/),
-      (v12/*: any*/),
-      (v9/*: any*/),
-      (v11/*: any*/),
-      (v2/*: any*/),
-      (v5/*: any*/),
-      (v8/*: any*/),
-      (v0/*: any*/),
       (v7/*: any*/),
+      (v4/*: any*/),
+      (v5/*: any*/),
+      (v13/*: any*/),
+      (v10/*: any*/),
+      (v12/*: any*/),
+      (v3/*: any*/),
+      (v6/*: any*/),
+      (v9/*: any*/),
+      (v0/*: any*/),
+      (v8/*: any*/),
       (v1/*: any*/),
-      (v10/*: any*/)
+      (v11/*: any*/),
+      (v2/*: any*/)
     ],
     "kind": "Operation",
     "name": "ShowArtworksInfiniteScrollGridQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v13/*: any*/),
+        "args": (v14/*: any*/),
         "concreteType": "Show",
         "kind": "LinkedField",
         "name": "show",
         "plural": false,
         "selections": [
-          (v24/*: any*/),
-          (v25/*: any*/),
+          (v26/*: any*/),
+          (v27/*: any*/),
           {
             "alias": "showArtworks",
-            "args": (v26/*: any*/),
+            "args": (v28/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -465,7 +481,7 @@ return {
                         "name": "count",
                         "storageKey": null
                       },
-                      (v27/*: any*/),
+                      (v29/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -495,8 +511,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v28/*: any*/),
-                      (v29/*: any*/)
+                      (v30/*: any*/),
+                      (v31/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -553,7 +569,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v28/*: any*/),
+              (v30/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -583,7 +599,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v29/*: any*/),
+                      (v31/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -592,7 +608,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v24/*: any*/),
+                          (v26/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -645,7 +661,7 @@ return {
                             "name": "saleMessage",
                             "storageKey": null
                           },
-                          (v25/*: any*/),
+                          (v27/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -696,7 +712,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v28/*: any*/)
+                              (v30/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -751,7 +767,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v28/*: any*/)
+                              (v30/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -763,8 +779,8 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v27/*: any*/),
-                              (v28/*: any*/)
+                              (v29/*: any*/),
+                              (v30/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -774,7 +790,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v28/*: any*/)
+                          (v30/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -791,7 +807,7 @@ return {
           },
           {
             "alias": "showArtworks",
-            "args": (v26/*: any*/),
+            "args": (v28/*: any*/),
             "filters": [
               "sort",
               "medium",
@@ -803,21 +819,22 @@ return {
               "inquireableOnly",
               "atAuction",
               "offerable",
-              "aggregations"
+              "aggregations",
+              "attributionClass"
             ],
             "handle": "connection",
             "key": "Show_showArtworks",
             "kind": "LinkedHandle",
             "name": "filterArtworksConnection"
           },
-          (v28/*: any*/)
+          (v30/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "07df579ce69da95b2768e3fe7f435afb",
+    "id": "0559d18617f36d00f4b6f561120c8e41",
     "metadata": {},
     "name": "ShowArtworksInfiniteScrollGridQuery",
     "operationKind": "query",
@@ -825,5 +842,5 @@ return {
   }
 };
 })();
-(node as any).hash = '7197ffb906a44f38c2cbcd90b187f125';
+(node as any).hash = '4e086ee0a8ba4eaf348b248c966a5a5b';
 export default node;

--- a/src/__generated__/ShowArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/ShowArtworksTestsQuery.graphql.ts
@@ -653,7 +653,8 @@ return {
               "inquireableOnly",
               "atAuction",
               "offerable",
-              "aggregations"
+              "aggregations",
+              "attributionClass"
             ],
             "handle": "connection",
             "key": "Show_showArtworks",

--- a/src/__generated__/ShowArtworks_show.graphql.ts
+++ b/src/__generated__/ShowArtworks_show.graphql.ts
@@ -52,6 +52,11 @@ const node: ReaderFragment = {
     {
       "defaultValue": null,
       "kind": "LocalArgument",
+      "name": "attributionClass"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
       "name": "color"
     },
     {
@@ -152,6 +157,11 @@ const node: ReaderFragment = {
           "kind": "Variable",
           "name": "atAuction",
           "variableName": "atAuction"
+        },
+        {
+          "kind": "Variable",
+          "name": "attributionClass",
+          "variableName": "attributionClass"
         },
         {
           "kind": "Variable",
@@ -347,5 +357,5 @@ const node: ReaderFragment = {
   "type": "Show",
   "abstractKey": null
 };
-(node as any).hash = 'c3476fb9ec591998c89bec283403c6d0';
+(node as any).hash = 'fc989d065d6210929db6be2d63d09bff';
 export default node;

--- a/src/__generated__/ShowQuery.graphql.ts
+++ b/src/__generated__/ShowQuery.graphql.ts
@@ -1199,7 +1199,8 @@ return {
               "inquireableOnly",
               "atAuction",
               "offerable",
-              "aggregations"
+              "aggregations",
+              "attributionClass"
             ],
             "handle": "connection",
             "key": "Show_showArtworks",

--- a/src/__generated__/ShowTestsQuery.graphql.ts
+++ b/src/__generated__/ShowTestsQuery.graphql.ts
@@ -1253,7 +1253,8 @@ return {
               "inquireableOnly",
               "atAuction",
               "offerable",
-              "aggregations"
+              "aggregations",
+              "attributionClass"
             ],
             "handle": "connection",
             "key": "Show_showArtworks",

--- a/src/__generated__/VanityURLEntityQuery.graphql.ts
+++ b/src/__generated__/VanityURLEntityQuery.graphql.ts
@@ -1736,7 +1736,8 @@ return {
                   "offerable",
                   "includeArtworksByFollowedArtists",
                   "artistIDs",
-                  "aggregations"
+                  "aggregations",
+                  "attributionClass"
                 ],
                 "handle": "connection",
                 "key": "Fair_fairArtworks",

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -276,6 +276,7 @@ export default createPaginationContainer(
         inquireableOnly: { type: "Boolean" }
         atAuction: { type: "Boolean" }
         offerable: { type: "Boolean" }
+        attributionClass: { type: "[String]" }
       ) {
         id
         slug
@@ -295,6 +296,7 @@ export default createPaginationContainer(
           atAuction: $atAuction
           offerable: $offerable
           aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]
+          attributionClass: $attributionClass
         ) @connection(key: "ArtistArtworksGrid_artworks") {
           aggregations {
             slice
@@ -339,20 +341,10 @@ export default createPaginationContainer(
     },
     getVariables(props, { count, cursor }, fragmentVariables) {
       return {
+        ...fragmentVariables,
         id: props.artist.id,
         count,
         cursor,
-        sort: fragmentVariables.sort,
-        medium: fragmentVariables.medium,
-        color: fragmentVariables.color,
-        partnerID: fragmentVariables.partnerID,
-        priceRange: fragmentVariables.priceRange,
-        dimensionRange: fragmentVariables.dimensionRange,
-        majorPeriods: fragmentVariables.majorPeriods,
-        acquireable: fragmentVariables.acquireable,
-        inquireableOnly: fragmentVariables.inquireableOnly,
-        atAuction: fragmentVariables.atAuction,
-        offerable: fragmentVariables.offerable,
       }
     },
     query: graphql`
@@ -371,6 +363,7 @@ export default createPaginationContainer(
         $inquireableOnly: Boolean
         $atAuction: Boolean
         $offerable: Boolean
+        $attributionClass: [String]
       ) {
         node(id: $id) {
           ... on Artist {
@@ -389,6 +382,7 @@ export default createPaginationContainer(
                 inquireableOnly: $inquireableOnly
                 atAuction: $atAuction
                 offerable: $offerable
+                attributionClass: $attributionClass
               )
           }
         }

--- a/src/lib/Components/ArtworkFilterOptions/AttributionClassOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/AttributionClassOptions.tsx
@@ -1,0 +1,109 @@
+import { StackScreenProps } from "@react-navigation/stack"
+import {
+  ArtworkFilterContext,
+  FilterData,
+  useSelectedOptionsDisplay,
+} from "lib/utils/ArtworkFilter/ArtworkFiltersStore"
+import { FilterDisplayName, FilterParamName } from "lib/utils/ArtworkFilter/FilterArtworksHelpers"
+import React, { useContext, useState } from "react"
+import { FilterModalNavigationStack } from "../FilterModal"
+import { MultiSelectOptionScreen } from "./MultiSelectOption"
+
+interface AttributionClassOptionsScreenProps
+  extends StackScreenProps<FilterModalNavigationStack, "AttributionClassOptionsScreen"> {}
+
+export const ATTRIBUTION_CLASS_OPTIONS: FilterData[] = [
+  {
+    displayText: "Unique",
+    paramName: FilterParamName.attributionClass,
+    paramValue: "unique",
+  },
+  {
+    displayText: "Limited Edition",
+    paramName: FilterParamName.attributionClass,
+    paramValue: "limited edition",
+  },
+  {
+    displayText: "Open Edition",
+    paramName: FilterParamName.attributionClass,
+    paramValue: "open edition",
+  },
+  {
+    displayText: "Unknown Edition",
+    paramName: FilterParamName.attributionClass,
+    paramValue: "unknown edition",
+  },
+]
+
+export const AttributionClassOptionsScreen: React.FC<AttributionClassOptionsScreenProps> = ({ navigation }) => {
+  const { dispatch } = useContext(ArtworkFilterContext)
+
+  const selectedOptions = useSelectedOptionsDisplay()
+
+  const selectedAttributionClassOptions = selectedOptions.find((option) => {
+    return option.paramName === FilterParamName.attributionClass
+  })
+
+  const [nextOptions, setNextOptions] = useState<string[]>(
+    (selectedAttributionClassOptions?.paramValue as string[]) ?? []
+  )
+
+  const handleSelect = (option: FilterData, updatedValue: boolean) => {
+    if (updatedValue) {
+      setNextOptions((prev) => {
+        const next = [
+          ...prev,
+          ATTRIBUTION_CLASS_OPTIONS.find(({ displayText }) => {
+            return displayText === option.displayText
+          })?.paramValue as string,
+        ]
+
+        dispatch({
+          type: "selectFilters",
+          payload: {
+            displayText: option.displayText,
+            paramValue: next,
+            paramName: option.paramName,
+          },
+        })
+
+        return next
+      })
+    } else {
+      setNextOptions((prev) => {
+        const next = prev.filter((value) => {
+          return (
+            value !==
+            (ATTRIBUTION_CLASS_OPTIONS.find(({ displayText }) => {
+              return displayText === option.displayText
+            })?.paramValue as string)
+          )
+        })
+
+        dispatch({
+          type: "selectFilters",
+          payload: {
+            displayText: option.displayText,
+            paramValue: next,
+            paramName: option.paramName,
+          },
+        })
+
+        return next
+      })
+    }
+  }
+
+  const filterOptions = ATTRIBUTION_CLASS_OPTIONS.map((option) => {
+    return { ...option, paramValue: nextOptions.includes(option.paramValue as string) }
+  })
+
+  return (
+    <MultiSelectOptionScreen
+      onSelect={handleSelect}
+      filterHeaderText={FilterDisplayName.attributionClass}
+      filterOptions={filterOptions}
+      navigation={navigation}
+    />
+  )
+}

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/AttributionClassOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/AttributionClassOptions-tests.tsx
@@ -1,0 +1,125 @@
+import React from "react"
+import { Switch } from "react-native"
+import { OptionListItem as FilterModalOptionListItem } from "../../../../lib/Components/FilterModal"
+import { MockFilterScreen } from "../../../../lib/Components/FilterModal/__tests__/FilterTestHelper"
+import { extractText } from "../../../../lib/tests/extractText"
+import { renderWithWrappers } from "../../../../lib/tests/renderWithWrappers"
+import { FilterParamName, InitialState } from "../../../../lib/utils/ArtworkFilter/FilterArtworksHelpers"
+import {
+  ArtworkFilterContext,
+  ArtworkFilterContextState,
+  reducer,
+} from "../../../utils/ArtworkFilter/ArtworkFiltersStore"
+import { AttributionClassOptionsScreen } from "../AttributionClassOptions"
+import { OptionListItem } from "../MultiSelectOption"
+import { getEssentialProps } from "./helper"
+
+describe("Ways to Buy Options Screen", () => {
+  let state: ArtworkFilterContextState
+
+  beforeEach(() => {
+    state = {
+      selectedFilters: [],
+      appliedFilters: [],
+      previouslyAppliedFilters: [],
+      applyFilters: false,
+      aggregations: [],
+      filterType: "artwork",
+      counts: {
+        total: null,
+        followedArtists: null,
+      },
+    }
+  })
+
+  const MockAttributionClassOptionsScreen = ({ initialState }: InitialState) => {
+    const [filterState, dispatch] = React.useReducer(reducer, initialState)
+
+    return (
+      <ArtworkFilterContext.Provider value={{ state: filterState, dispatch }}>
+        <AttributionClassOptionsScreen {...getEssentialProps()} />
+      </ArtworkFilterContext.Provider>
+    )
+  }
+
+  it("renders the options", () => {
+    const tree = renderWithWrappers(<MockAttributionClassOptionsScreen initialState={state} />)
+    expect(tree.root.findAllByType(OptionListItem)).toHaveLength(4)
+    const items = tree.root.findAllByType(OptionListItem)
+    expect(items.map(extractText)).toEqual(["Unique", "Limited Edition", "Open Edition", "Unknown Edition"])
+  })
+
+  it("displays the default text when no filter selected on the filter modal screen", () => {
+    state = {
+      selectedFilters: [],
+      appliedFilters: [],
+      previouslyAppliedFilters: [],
+      applyFilters: false,
+      aggregations: [],
+      filterType: "artwork",
+      counts: {
+        total: null,
+        followedArtists: null,
+      },
+    }
+
+    const tree = renderWithWrappers(<MockFilterScreen initialState={state} />)
+    const items = tree.root.findAllByType(FilterModalOptionListItem)
+    expect(extractText(items[items.length - 1])).toContain("All")
+  })
+
+  it("displays all the selected filters on the filter modal screen", () => {
+    state = {
+      selectedFilters: [
+        {
+          displayText: "Unique",
+          paramName: FilterParamName.attributionClass,
+          paramValue: ["unique", "unknown edition"],
+        },
+      ],
+      appliedFilters: [],
+      previouslyAppliedFilters: [],
+      applyFilters: false,
+      aggregations: [],
+      filterType: "artwork",
+      counts: {
+        total: null,
+        followedArtists: null,
+      },
+    }
+
+    const tree = renderWithWrappers(<MockFilterScreen initialState={state} />)
+    const items = tree.root.findAllByType(FilterModalOptionListItem)
+
+    expect(extractText(items[1])).toContain("Unique, Unknown edition")
+  })
+
+  it("toggles selected filters 'ON' and unselected filters 'OFF", () => {
+    const initialState: ArtworkFilterContextState = {
+      selectedFilters: [
+        {
+          displayText: "Unique",
+          paramName: FilterParamName.attributionClass,
+          paramValue: ["unique", "unknown edition"],
+        },
+      ],
+      appliedFilters: [],
+      previouslyAppliedFilters: [],
+      applyFilters: false,
+      aggregations: [],
+      filterType: "artwork",
+      counts: {
+        total: null,
+        followedArtists: null,
+      },
+    }
+
+    const tree = renderWithWrappers(<MockAttributionClassOptionsScreen initialState={initialState} />)
+    const switches = tree.root.findAllByType(Switch)
+
+    expect(switches[0].props.value).toBe(true)
+    expect(switches[1].props.value).toBe(false)
+    expect(switches[2].props.value).toBe(false)
+    expect(switches[3].props.value).toBe(true)
+  })
+})

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/WaysToBuyOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/WaysToBuyOptions-tests.tsx
@@ -117,9 +117,8 @@ describe("Ways to Buy Options Screen", () => {
     }
 
     const tree = renderWithWrappers(<MockFilterScreen initialState={state} />)
-    const waysToBuyListItem = tree.root.findAllByType(FilterModalOptionListItem)[1]
 
-    expect(extractText(waysToBuyListItem)).toContain("Buy now, Inquire, Bid")
+    expect(extractText(tree.root)).toContain("Buy now, Inquire, Bid")
   })
 
   it("toggles selected filters 'ON' and unselected filters 'OFF", () => {

--- a/src/lib/Components/FilterModal/FilterModal.tsx
+++ b/src/lib/Components/FilterModal/FilterModal.tsx
@@ -24,6 +24,7 @@ import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
 import { AnimatedBottomButton } from "../AnimatedBottomButton"
 import { ArtistIDsOptionsScreen } from "../ArtworkFilterOptions/ArtistIDsOptionsScreen"
+import { AttributionClassOptionsScreen } from "../ArtworkFilterOptions/AttributionClassOptions"
 import { CategoriesOptionsScreen } from "../ArtworkFilterOptions/CategoriesOptions"
 import { ColorOption, ColorOptionsScreen } from "../ArtworkFilterOptions/ColorOptions"
 import { colorHexMap } from "../ArtworkFilterOptions/ColorSwatch"
@@ -44,6 +45,7 @@ import { FancyModal } from "../FancyModal/FancyModal"
 export type FilterScreen =
   | "artistIDs"
   | "artistsIFollow"
+  | "attributionClass"
   | "color"
   | "categories"
   | "dimensionRange"
@@ -92,6 +94,7 @@ interface FilterModalProps extends ViewProperties {
 export type FilterModalNavigationStack = {
   ArtistIDsOptionsScreen: undefined
   ColorOptionsScreen: undefined
+  AttributionClassOptionsScreen: undefined
   EstimateRangeOptionsScreen: undefined
   FilterOptionsScreen: FilterOptionsScreenParams
   GalleryOptionsScreen: undefined
@@ -188,6 +191,7 @@ export const FilterModalNavigator: React.FC<FilterModalProps> = (props) => {
           >
             <Stack.Screen name="FilterOptionsScreen" component={FilterOptionsScreen} initialParams={props} />
             <Stack.Screen name="ArtistIDsOptionsScreen" component={ArtistIDsOptionsScreen} />
+            <Stack.Screen name="AttributionClassOptionsScreen" component={AttributionClassOptionsScreen} />
             <Stack.Screen name="ColorOptionsScreen" component={ColorOptionsScreen} />
             <Stack.Screen name="EstimateRangeOptionsScreen" component={EstimateRangeOptionsScreen} />
             <Stack.Screen name="GalleryOptionsScreen" component={GalleryOptionsScreen} />
@@ -434,7 +438,11 @@ export const getStaticFilterOptionsByMode = (mode: FilterModalMode) => {
       ]
 
     default:
-      return [filterOptionToDisplayConfigMap.sort, filterOptionToDisplayConfigMap.waysToBuy]
+      return [
+        filterOptionToDisplayConfigMap.sort,
+        filterOptionToDisplayConfigMap.waysToBuy,
+        filterOptionToDisplayConfigMap.attributionClass,
+      ]
   }
 }
 
@@ -626,6 +634,11 @@ export const filterOptionToDisplayConfigMap: Record<string, FilterDisplayConfig>
     filterType: "artistIDs",
     ScreenComponent: "ArtistIDsOptionsScreen",
   },
+  attributionClass: {
+    displayText: FilterDisplayName.attributionClass,
+    filterType: "attributionClass",
+    ScreenComponent: "AttributionClassOptionsScreen",
+  },
   color: {
     displayText: FilterDisplayName.color,
     filterType: "color",
@@ -701,6 +714,7 @@ export const filterOptionToDisplayConfigMap: Record<string, FilterDisplayConfig>
 const CollectionFiltersSorted: FilterScreen[] = [
   "sort",
   "medium",
+  "attributionClass",
   "priceRange",
   "waysToBuy",
   "dimensionRange",
@@ -712,6 +726,7 @@ const CollectionFiltersSorted: FilterScreen[] = [
 const ArtistArtworksFiltersSorted: FilterScreen[] = [
   "sort",
   "medium",
+  "attributionClass",
   "priceRange",
   "waysToBuy",
   "gallery",
@@ -723,6 +738,7 @@ const ArtistArtworksFiltersSorted: FilterScreen[] = [
 const ArtistSeriesFiltersSorted: FilterScreen[] = [
   "sort",
   "medium",
+  "attributionClass",
   "priceRange",
   "waysToBuy",
   "dimensionRange",
@@ -736,6 +752,7 @@ const FairFiltersSorted: FilterScreen[] = [
   "artistIDs",
   "artistsIFollow",
   "medium",
+  "attributionClass",
   "priceRange",
   "waysToBuy",
   "dimensionRange",

--- a/src/lib/Components/FilterModal/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/FilterModal/__tests__/FilterModal-tests.tsx
@@ -351,13 +351,15 @@ describe("Filter modal states", () => {
 
     expect(filterScreen.find(CurrentOption).at(1).text()).toEqual("Drawing")
 
-    expect(filterScreen.find(CurrentOption).at(2).text()).toEqual("$10,000-20,000")
+    expect(filterScreen.find(CurrentOption).at(2).text()).toEqual("All")
 
-    expect(filterScreen.find(CurrentOption).at(3).text()).toEqual("Bid")
+    expect(filterScreen.find(CurrentOption).at(3).text()).toEqual("$10,000-20,000")
 
-    expect(filterScreen.find(CurrentOption).at(4).text()).toEqual("All")
+    expect(filterScreen.find(CurrentOption).at(4).text()).toEqual("Bid")
 
-    expect(filterScreen.find(CurrentOption)).toHaveLength(5)
+    expect(filterScreen.find(CurrentOption).at(5).text()).toEqual("All")
+
+    expect(filterScreen.find(CurrentOption)).toHaveLength(6)
   })
 })
 
@@ -391,13 +393,13 @@ describe("Clearing filters", () => {
 
     expect(filterScreen.find(CurrentOption).at(0).text()).toEqual("Price (low to high)")
 
-    expect(filterScreen.find(CurrentOption).at(3).text()).toEqual("Buy Now")
+    expect(filterScreen.find(CurrentOption).at(4).text()).toEqual("Buy Now")
 
     filterScreen.find(ClearAllButton).at(0).props().onPress()
 
     expect(filterScreen.find(CurrentOption).at(0).text()).toEqual("Default")
 
-    expect(filterScreen.find(CurrentOption).at(1).text()).toEqual("All")
+    expect(filterScreen.find(CurrentOption).at(4).text()).toEqual("All")
   })
 
   it("enables the apply button when clearing all if no other options are selected", () => {
@@ -521,6 +523,7 @@ describe("Applying filters on Artworks", () => {
       Object {
         "acquireable": false,
         "atAuction": false,
+        "attributionClass": null,
         "color": null,
         "count": 10,
         "cursor": null,

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
@@ -103,6 +103,7 @@ export const ArtistSeriesArtworksFragmentContainer = createPaginationContainer(
         inquireableOnly: { type: "Boolean" }
         atAuction: { type: "Boolean" }
         offerable: { type: "Boolean" }
+        attributionClass: { type: "[String]" }
       ) {
         slug
         internalID
@@ -121,6 +122,7 @@ export const ArtistSeriesArtworksFragmentContainer = createPaginationContainer(
           atAuction: $atAuction
           offerable: $offerable
           aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]
+          attributionClass: $attributionClass
         ) @connection(key: "ArtistSeries_artistSeriesArtworks") {
           aggregations {
             slice
@@ -179,6 +181,7 @@ export const ArtistSeriesArtworksFragmentContainer = createPaginationContainer(
         $inquireableOnly: Boolean
         $atAuction: Boolean
         $offerable: Boolean
+        $attributionClass: [String]
       ) {
         artistSeries(id: $id) {
           ...ArtistSeriesArtworks_artistSeries
@@ -196,6 +199,7 @@ export const ArtistSeriesArtworksFragmentContainer = createPaginationContainer(
               inquireableOnly: $inquireableOnly
               atAuction: $atAuction
               offerable: $offerable
+              attributionClass: $attributionClass
             )
         }
       }

--- a/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -112,6 +112,7 @@ export const CollectionArtworksFragmentContainer = createPaginationContainer(
         inquireableOnly: { type: "Boolean" }
         atAuction: { type: "Boolean" }
         offerable: { type: "Boolean" }
+        attributionClass: { type: "[String]" }
       ) {
         isDepartment
         slug
@@ -131,6 +132,7 @@ export const CollectionArtworksFragmentContainer = createPaginationContainer(
           atAuction: $atAuction
           offerable: $offerable
           aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]
+          attributionClass: $attributionClass
         ) @connection(key: "Collection_collectionArtworks") {
           aggregations {
             slice
@@ -163,17 +165,6 @@ export const CollectionArtworksFragmentContainer = createPaginationContainer(
         id: props.collection.slug,
         count,
         cursor,
-        sort: fragmentVariables.sort,
-        medium: fragmentVariables.medium,
-        color: fragmentVariables.color,
-        partnerID: fragmentVariables.partnerID,
-        priceRange: fragmentVariables.priceRange,
-        dimensionRange: fragmentVariables.dimensionRange,
-        majorPeriods: fragmentVariables.majorPeriods,
-        acquireable: fragmentVariables.acquireable,
-        inquireableOnly: fragmentVariables.inquireableOnly,
-        atAuction: fragmentVariables.atAuction,
-        offerable: fragmentVariables.offerable,
       }
     },
     query: graphql`
@@ -192,6 +183,7 @@ export const CollectionArtworksFragmentContainer = createPaginationContainer(
         $inquireableOnly: Boolean
         $atAuction: Boolean
         $offerable: Boolean
+        $attributionClass: [String]
       ) {
         marketingCollection(slug: $id) {
           ...CollectionArtworks_collection
@@ -209,6 +201,7 @@ export const CollectionArtworksFragmentContainer = createPaginationContainer(
               inquireableOnly: $inquireableOnly
               atAuction: $atAuction
               offerable: $offerable
+              attributionClass: $attributionClass
             )
         }
       }

--- a/src/lib/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/lib/Scenes/Fair/Components/FairArtworks.tsx
@@ -126,6 +126,7 @@ export const FairArtworksFragmentContainer = createPaginationContainer(
         offerable: { type: "Boolean" }
         includeArtworksByFollowedArtists: { type: "Boolean" }
         artistIDs: { type: "[String]" }
+        attributionClass: { type: "[String]" }
       ) {
         slug
         internalID
@@ -156,6 +157,7 @@ export const FairArtworksFragmentContainer = createPaginationContainer(
             FOLLOWED_ARTISTS
             ARTIST
           ]
+          attributionClass: $attributionClass
         ) @connection(key: "Fair_fairArtworks") {
           aggregations {
             slice
@@ -217,6 +219,7 @@ export const FairArtworksFragmentContainer = createPaginationContainer(
         $offerable: Boolean
         $includeArtworksByFollowedArtists: Boolean
         $artistIDs: [String]
+        $attributionClass: [String]
       ) {
         fair(id: $id) {
           ...FairArtworks_fair
@@ -236,6 +239,7 @@ export const FairArtworksFragmentContainer = createPaginationContainer(
               offerable: $offerable
               includeArtworksByFollowedArtists: $includeArtworksByFollowedArtists
               artistIDs: $artistIDs
+              attributionClass: $attributionClass
             )
         }
       }

--- a/src/lib/Scenes/Show/Components/ShowArtworks.tsx
+++ b/src/lib/Scenes/Show/Components/ShowArtworks.tsx
@@ -115,6 +115,7 @@ export const ShowArtworksPaginationContainer = createPaginationContainer(
         inquireableOnly: { type: "Boolean" }
         atAuction: { type: "Boolean" }
         offerable: { type: "Boolean" }
+        attributionClass: { type: "[String]" }
       ) {
         slug
         internalID
@@ -132,6 +133,7 @@ export const ShowArtworksPaginationContainer = createPaginationContainer(
           atAuction: $atAuction
           offerable: $offerable
           aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]
+          attributionClass: $attributionClass
         ) @connection(key: "Show_showArtworks") {
           aggregations {
             slice
@@ -185,6 +187,7 @@ export const ShowArtworksPaginationContainer = createPaginationContainer(
         $inquireableOnly: Boolean
         $atAuction: Boolean
         $offerable: Boolean
+        $attributionClass: [String]
       ) {
         show(id: $id) {
           ...ShowArtworks_show
@@ -201,6 +204,7 @@ export const ShowArtworksPaginationContainer = createPaginationContainer(
               inquireableOnly: $inquireableOnly
               atAuction: $atAuction
               offerable: $offerable
+              attributionClass: $attributionClass
             )
         }
       }

--- a/src/lib/utils/ArtworkFilter/ArtworkFiltersStore.tsx
+++ b/src/lib/utils/ArtworkFilter/ArtworkFiltersStore.tsx
@@ -265,6 +265,7 @@ export const ParamDefaultValues = {
   allowEmptyCreatedDates: true,
   artistIDs: [],
   atAuction: false,
+  attributionClass: undefined,
   categories: undefined,
   color: undefined,
   dimensionRange: "*-*",
@@ -289,6 +290,7 @@ const defaultCommonFilterOptions: Record<FilterParamName, string | boolean | und
   allowEmptyCreatedDates: ParamDefaultValues.allowEmptyCreatedDates,
   artistIDs: ParamDefaultValues.artistIDs,
   atAuction: ParamDefaultValues.atAuction,
+  attributionClass: ParamDefaultValues.attributionClass,
   categories: ParamDefaultValues.categories,
   color: ParamDefaultValues.color,
   dimensionRange: ParamDefaultValues.dimensionRange,
@@ -387,6 +389,7 @@ export const selectedOptionsUnion = ({
       paramValue: false,
       displayText: "Grid",
     },
+    { paramName: FilterParamName.attributionClass, paramValue: "", displayText: "All" },
   ]
 
   // First, naively attempt to union all of the existing filters. Give selectedFilters

--- a/src/lib/utils/ArtworkFilter/FilterArtworksHelpers.ts
+++ b/src/lib/utils/ArtworkFilter/FilterArtworksHelpers.ts
@@ -13,6 +13,7 @@ export enum FilterParamName {
   artistIDs = "artistIDs",
   allowEmptyCreatedDates = "allowEmptyCreatedDates",
   artistsIFollow = "includeArtworksByFollowedArtists",
+  attributionClass = "attributionClass",
   categories = "categories",
   color = "color",
   earliestCreatedYear = "earliestCreatedYear",
@@ -42,6 +43,7 @@ export enum FilterDisplayName {
   // artist = "Artists",
   artistIDs = "Artists",
   artistsIFollow = "Artist",
+  attributionClass = "Rarity",
   color = "Color",
   categories = "Medium",
   estimateRange = "Price/estimate range",
@@ -183,6 +185,22 @@ export const selectedOption = ({
   aggregations: Aggregations
 }) => {
   const multiSelectedOptions = selectedOptions.filter((option) => option.paramValue === true)
+
+  if (filterScreen === "attributionClass") {
+    const selectedAttributionClassOption = selectedOptions.find((option) => {
+      return option.paramName === FilterParamName.attributionClass
+    })
+
+    if (
+      selectedAttributionClassOption?.paramValue &&
+      Array.isArray(selectedAttributionClassOption?.paramValue) &&
+      selectedAttributionClassOption?.paramValue.length > 0
+    ) {
+      return selectedAttributionClassOption?.paramValue.map(capitalize).join(", ")
+    }
+
+    return "All"
+  }
 
   if (filterScreen === "categories") {
     const selectedCategoriesValues = selectedOptions.find((filter) => filter.paramName === FilterParamName.categories)

--- a/src/lib/utils/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
+++ b/src/lib/utils/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
@@ -1221,6 +1221,11 @@ describe("selectedOptionsUnion", () => {
           paramName: "viewAs",
           paramValue: false,
         },
+        {
+          displayText: "All",
+          paramName: "attributionClass",
+          paramValue: "",
+        },
       ])
     })
 
@@ -1312,6 +1317,11 @@ describe("selectedOptionsUnion", () => {
           displayText: "Grid",
           paramName: "viewAs",
           paramValue: false,
+        },
+        {
+          displayText: "All",
+          paramName: "attributionClass",
+          paramValue: "",
         },
       ])
     })
@@ -1414,6 +1424,11 @@ describe("selectedOptionsUnion", () => {
           displayText: "Grid",
           paramName: "viewAs",
           paramValue: false,
+        },
+        {
+          displayText: "All",
+          paramName: "attributionClass",
+          paramValue: "",
         },
       ])
     })
@@ -1528,6 +1543,11 @@ describe("selectedOptionsUnion", () => {
           paramName: "viewAs",
           paramValue: false,
         },
+        {
+          displayText: "All",
+          paramName: "attributionClass",
+          paramValue: "",
+        },
       ])
     })
 
@@ -1631,6 +1651,11 @@ describe("selectedOptionsUnion", () => {
           paramName: "viewAs",
           paramValue: false,
         },
+        {
+          displayText: "All",
+          paramName: "attributionClass",
+          paramValue: "",
+        },
       ])
     })
   })
@@ -1709,6 +1734,11 @@ describe("selectedOptionsUnion", () => {
           displayText: "Grid",
           paramName: "viewAs",
           paramValue: false,
+        },
+        {
+          displayText: "All",
+          paramName: "attributionClass",
+          paramValue: "",
         },
       ])
     })
@@ -1796,6 +1826,11 @@ describe("selectedOptionsUnion", () => {
           displayText: "Grid",
           paramName: "viewAs",
           paramValue: false,
+        },
+        {
+          displayText: "All",
+          paramName: "attributionClass",
+          paramValue: "",
         },
       ])
     })
@@ -1890,6 +1925,11 @@ describe("selectedOptionsUnion", () => {
           paramName: "viewAs",
           paramValue: false,
         },
+        {
+          displayText: "All",
+          paramName: "attributionClass",
+          paramValue: "",
+        },
       ])
     })
   })
@@ -1968,6 +2008,11 @@ describe("selectedOptionsUnion", () => {
           displayText: "Grid",
           paramName: "viewAs",
           paramValue: false,
+        },
+        {
+          displayText: "All",
+          paramName: "attributionClass",
+          paramValue: "",
         },
       ])
     })

--- a/src/lib/utils/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
+++ b/src/lib/utils/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
@@ -276,6 +276,11 @@ describe("filterArtworksParams helper", () => {
         paramValue: true,
         paramName: FilterParamName.artistsIFollow,
       },
+      {
+        displayText: "Rarity",
+        paramValue: ["unique", "unknown edition"],
+        paramName: FilterParamName.attributionClass,
+      },
     ]
     expect(filterArtworksParams(appliedFilters)).toEqual({
       sort: "-partner_updated_at",
@@ -288,6 +293,7 @@ describe("filterArtworksParams helper", () => {
       acquireable: true,
       offerable: false,
       includeArtworksByFollowedArtists: true,
+      attributionClass: ["unique", "unknown edition"],
     })
   })
 
@@ -561,6 +567,48 @@ describe("selectedOption", () => {
         expect(selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations: [] })).toEqual(
           "All artists I follow, 2 more"
         )
+      })
+
+      it("returns the correct value for no (all) attribution classes", () => {
+        expect(
+          selectedOption({
+            selectedOptions: [],
+            filterScreen: "attributionClass",
+            aggregations: [],
+          })
+        ).toEqual("All")
+      })
+
+      it("returns the correct value for a single attribution classes", () => {
+        expect(
+          selectedOption({
+            selectedOptions: [
+              {
+                displayText: "",
+                paramName: FilterParamName.attributionClass,
+                paramValue: ["unique"],
+              },
+            ],
+            filterScreen: "attributionClass",
+            aggregations: [],
+          })
+        ).toEqual("Unique")
+      })
+
+      it("returns the correct value for multiple attribution classes", () => {
+        expect(
+          selectedOption({
+            selectedOptions: [
+              {
+                displayText: "",
+                paramName: FilterParamName.attributionClass,
+                paramValue: ["unique", "unknown edition"],
+              },
+            ],
+            filterScreen: "attributionClass",
+            aggregations: [],
+          })
+        ).toEqual("Unique, Unknown edition")
       })
     })
 


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR resolves [FX-2565]

### Description

One slightly weird thing to note here is that this counts as a single filter, which it is; but I sort of had to fight against the way actions for the filters are structured to implement it because we wanted the multi-select.

![](https://static.damonzucconi.com/_capture/gl3h1YmUR2oN.gif)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2565]: https://artsyproduct.atlassian.net/browse/FX-2565