### PR TITLE
fix: add '~' to sentry source path #trivial

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -106,7 +106,7 @@ lane :ship_beta_ios do
                          version: sentry_release_version,
                          dist: bundle_version,
                          file: 'emission/Pod/Assets/Emission.js',
-                         fileURL:'~/Emission.js'
+                         file_url:'~/Emission.js'
       puts "Uploaded Emission.js for #{project_slug}"
 
       sentry_upload_sourcemap auth_token: ENV['SentryUploadAuthKey'],
@@ -115,7 +115,6 @@ lane :ship_beta_ios do
                               version: sentry_release_version,
                               dist: bundle_version,
                               sourcemap: 'emission/Pod/Assets/Emission.js.map',
-                              fileURL:'~/Emission.js.map'
                               rewrite: true
       puts "Uploaded Emission.js.map for #{project_slug}"
     rescue StandardError => e

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -105,7 +105,8 @@ lane :ship_beta_ios do
                          project_slug: project_slug,
                          version: sentry_release_version,
                          dist: bundle_version,
-                         file: 'emission/Pod/Assets/Emission.js'
+                         file: 'emission/Pod/Assets/Emission.js',
+                         fileURL:'~/Emission.js'
       puts "Uploaded Emission.js for #{project_slug}"
 
       sentry_upload_sourcemap auth_token: ENV['SentryUploadAuthKey'],
@@ -114,6 +115,7 @@ lane :ship_beta_ios do
                               version: sentry_release_version,
                               dist: bundle_version,
                               sourcemap: 'emission/Pod/Assets/Emission.js.map',
+                              fileURL:'~/Emission.js.map'
                               rewrite: true
       puts "Uploaded Emission.js.map for #{project_slug}"
     rescue StandardError => e

--- a/src/lib/ErrorReporting.ts
+++ b/src/lib/ErrorReporting.ts
@@ -1,4 +1,4 @@
-import { init } from "@sentry/react-native"
+import { init, setRelease } from "@sentry/react-native"
 import Config from "react-native-config"
 import { ArtsyNativeModules } from "./NativeModules/ArtsyNativeModules"
 import { getCurrentEmissionState } from "./store/GlobalStore"
@@ -20,4 +20,5 @@ if (getCurrentEmissionState().sentryDSN) {
     dsn: getCurrentEmissionState().sentryDSN,
     release: sentryReleaseName,
   })
+  setRelease(sentryReleaseName)
 }


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [CX-956]

### Description

Follow-up to https://github.com/artsy/eigen/pull/4368 which correctly uploaded the artifacts to the right release but still weren't getting deobfuscated js code in errors. 
This
- adds a tilde '~' to the source file upload which is a special character in sentry to ignore protocol when matching sources to errors
- calls `setRelease` explicitly to workaround an issue in sentry lib that was not respecting release param in init call

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-956]: https://artsyproduct.atlassian.net/browse/CX-956