### PR TITLE
fix: use api key for beta deploy #trivial

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,7 +22,15 @@ app_json = JSON.parse(File.read(app_json_path))
 app_plist = "../Artsy/App_Resources/Artsy-Info.plist"
 sticker_plist = "../Artsy Stickers/Info.plist"
 
+
 lane :ship_beta_ios do
+  api_key = app_store_connect_api_key(
+    key_id: "B95P9K5S5V",
+    issuer_id: "69a6de72-31ba-47e3-e053-5b8c7c11a4d1",
+    key_content: ENV['ARTSY_APP_STORE_CONNECT_API_KEY_CONTENT'],
+    in_house: false,
+  )
+
   set_build_version_ios
 
   changelog_yaml = File.read('../CHANGELOG.yml')
@@ -146,11 +154,12 @@ lane :ship_beta_ios do
     demo_account_name: ENV['BETA_DEMO_ACCOUNT_NAME'],
     demo_account_password: ENV['BETA_DEMO_ACCOUNT_PWD']
   }
-  pilot beta_app_review_info: beta_app_review_info,
+  pilot(api_key: api_key,
+        beta_app_review_info: beta_app_review_info,
         changelog: beta_readme,
         itc_provider: 'ArtsyInc',
         distribute_external: true,
-        groups: ['Artsy']
+        groups: ['Artsy'])
 end
 
 lane :update_version_string do


### PR DESCRIPTION
The type of this PR is: **fix**

### Description

Apple has started enforcing 2fa on all accounts in App Store connect, and this broke our beta deploys. This PR uses an App Store connect api key rather than user password login. 

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
