### PR TITLE
fix: show correct arrows on MarketStats sale price over estimate

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -28,6 +28,7 @@ upcoming:
     - Remove separator from last auction result - mounir
     - Show mid-estimate performance on auction results - mounir
     - MarketStats on auction results - pepopowitz, mounir
+    - fix - show correct up/down arrows on Market Stats - pepopowitz
 
 releases:
   - version: 6.7.6

--- a/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
@@ -83,9 +83,9 @@ const MarketStats: React.FC<MarketStatsProps> = ({ priceInsightsConnection }) =>
 
   let deltaIcon: React.ReactNode
   const actualMedianSaleOverEstimatePercentage = selectedPriceInsight?.medianSaleOverEstimatePercentage || 0
-  if (actualMedianSaleOverEstimatePercentage < 100) {
+  if (actualMedianSaleOverEstimatePercentage < 0) {
     deltaIcon = <DecreaseIcon />
-  } else if (actualMedianSaleOverEstimatePercentage > 100) {
+  } else if (actualMedianSaleOverEstimatePercentage > 0) {
     deltaIcon = <IncreaseIcon />
   }
 

--- a/src/lib/Components/Artist/ArtistInsights/__tests__/MarketStats-tests.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/__tests__/MarketStats-tests.tsx
@@ -77,26 +77,26 @@ describe("MarketStats", () => {
       return tree
     }
 
-    it("displays down arrow when percentage is under 100", () => {
+    it("displays down arrow when percentage is negative", () => {
       const tree = renderWithOnePriceInsightNode({
-        medianSaleOverEstimatePercentage: 90,
+        medianSaleOverEstimatePercentage: -10,
       })
 
       expect(tree.findByType(DecreaseIcon)).toBeDefined()
     })
 
-    it("displays no arrow when percentage is 100", () => {
+    it("displays no arrow when percentage is 0", () => {
       const tree = renderWithOnePriceInsightNode({
-        medianSaleOverEstimatePercentage: 100,
+        medianSaleOverEstimatePercentage: 0,
       })
 
       expect(tree.findAllByType(DecreaseIcon).length).toEqual(0)
       expect(tree.findAllByType(IncreaseIcon).length).toEqual(0)
     })
 
-    it("displays up arrow when percentage is over 100", () => {
+    it("displays up arrow when percentage is positive", () => {
       const tree = renderWithOnePriceInsightNode({
-        medianSaleOverEstimatePercentage: 110,
+        medianSaleOverEstimatePercentage: 10,
       })
 
       expect(tree.findByType(IncreaseIcon)).toBeDefined()


### PR DESCRIPTION
The type of this PR is: **Bugfix**

Note: this PR is currently targeted against the branch from #4394 to maximize signal:noise. We can merge this into that branch first, or change the base on this PR after #4394 is merged.

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1003]

### Description

This updates the logic for displaying up/down arrows on the Market Stats module. 

Since the number showing is percentage _over_ median estimate, the icon displayed is: 

#### Up arrow if percentage is positive
![image](https://user-images.githubusercontent.com/1627089/106805186-ff6ea400-662b-11eb-83a2-669e27da1212.png)
#### Down arrow if percentage is negative
![image](https://user-images.githubusercontent.com/1627089/106805255-190feb80-662c-11eb-960d-d8ce0ed582c6.png)
#### No arrow if percentage is zero
![image](https://user-images.githubusercontent.com/1627089/106805332-32189c80-662c-11eb-932b-088f02107e06.png)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1003]: https://artsyproduct.atlassian.net/browse/CX-1003