### PR TITLE
feat: add a loading skeleton for Market Stats

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -28,7 +28,7 @@ upcoming:
     - Add extra bottom padding on artist insights auction results - mounir
     - Remove separator from last auction result - mounir
     - Show mid-estimate performance on auction results - mounir
-    - Loading skeleton for maret stats - pepopowitz
+    - Loading skeleton for market stats - pepopowitz
 
 releases:
   - version: 6.7.6

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -28,6 +28,7 @@ upcoming:
     - Add extra bottom padding on artist insights auction results - mounir
     - Remove separator from last auction result - mounir
     - Show mid-estimate performance on auction results - mounir
+    - Loading skeleton for maret stats - pepopowitz
 
 releases:
   - version: 6.7.6

--- a/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
@@ -3,6 +3,7 @@ import { MarketStatsQuery } from "__generated__/MarketStatsQuery.graphql"
 import { InfoButton } from "lib/Components/Buttons/InfoButton"
 import { Select } from "lib/Components/Select"
 import { formatLargeNumber } from "lib/utils/formatLargeNumber"
+import { PlaceholderBox, PlaceholderText } from "lib/utils/placeholders"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { DecreaseIcon, Flex, IncreaseIcon, Join, Spacer, Text } from "palette"
 import React, { useRef, useState } from "react"
@@ -187,7 +188,42 @@ export const MarketStatsQueryRenderer: React.FC<{
 }
 
 const LoadingSkeleton = () => {
-  return <Text>Loading!!!!</Text>
+  return (
+    <>
+      <Flex flexDirection="row" alignItems="center">
+        <Text variant="title" mr={0.5}>
+          Market Signals by Medium
+        </Text>
+      </Flex>
+      <Text variant="small" color="black60" my={0.5}>
+        Last 36 months
+      </Text>
+      <Spacer mb={0.5} />
+      <PlaceholderBox width="100%" height={40} />
+      <Flex flexDirection="row" flexWrap="wrap" mt={15}>
+        <Flex width="50%">
+          <Spacer mb={0.3} />
+          <PlaceholderText width={30} height={25} />
+          <Text variant="text">Yearly lots sold</Text>
+        </Flex>
+        <Flex width="50%">
+          <Spacer mb={0.3} />
+          <PlaceholderText width={60} height={25} />
+          <Text variant="text">Sell-through rate</Text>
+        </Flex>
+        <Flex width="50%" mt={2}>
+          <Spacer mb={0.3} />
+          <PlaceholderText width={50} height={25} />
+          <Text variant="text">Average sale price</Text>
+        </Flex>
+        <Flex width="50%" mt={2}>
+          <Spacer mb={0.3} />
+          <PlaceholderText width={70} height={25} />
+          <Text variant="text">Sale price over estimate</Text>
+        </Flex>
+      </Flex>
+    </>
+  )
 }
 
 export const tracks = {


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR partially resolves [CX-738]

### Description

Adds a proper loading skeleton for the Market Stats component, in case someone taps quickly to the Insights tab before the insights load. 

#### Video

Note: the skeleton toggle button in this video was temporarily added for local development. It's not included in the PR. 

https://user-images.githubusercontent.com/1627089/106810300-5f684900-6632-11eb-86c9-64a36a62c561.mp4

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-738]: https://artsyproduct.atlassian.net/browse/CX-738