### PR TITLE
chore: use a different text variant for auction result nav title

### DIFF
--- a/src/lib/Scenes/AuctionResult/AuctionResult.tsx
+++ b/src/lib/Scenes/AuctionResult/AuctionResult.tsx
@@ -48,10 +48,10 @@ const AuctionResult: React.FC<Props> = ({ artist, auctionResult }) => {
   const { headerElement, scrollProps } = useStickyScrollHeader({
     header: (
       <Flex flex={1} pl={6} pr={4} pt={0.5} flexDirection="row">
-        <Text variant="subtitle" numberOfLines={1} style={{ flexShrink: 1 }}>
+        <Text variant="mediumText" numberOfLines={1} style={{ flexShrink: 1 }}>
           {auctionResult.title}
         </Text>
-        {!!auctionResult.dateText && <Text variant="subtitle">, {auctionResult.dateText}</Text>}
+        {!!auctionResult.dateText && <Text variant="mediumText">, {auctionResult.dateText}</Text>}
       </Flex>
     ),
   })


### PR DESCRIPTION
The type of this PR is: **UI nudge**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-995].

### Description

Uses the `mediumText` variant for the AuctionResult nav title

![image](https://user-images.githubusercontent.com/1627089/106813103-2f22a980-6636-11eb-9ee9-9f32c294fd1e.png)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-995]: https://artsyproduct.atlassian.net/browse/CX-995