### PR TITLE
fix: use api key for fastlane promote beta

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,9 +187,6 @@ jobs:
       - checkout
       - install-node
       - run:
-          name: Notify if new developer agreement
-          command: ./scripts/notify-if-new-license-agreement
-      - run:
           name: Deploy beta
           command: ./scripts/deploy-both
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -12,6 +12,7 @@ upcoming:
     - Validate CHANGELOG.yml - brian, pavlos, brian, adam, steven, david, mounir
     - Add increase/decrease icons - pepopowitz
     - Add android navigation infra - david, mounir
+    - Use api key in fastlane scripts - brian, mounir
   user_facing:
     - Added watched lots to MyBids - erik, ashley, christina
     - Refresh inbox automatically upon revisiting - erik, lily

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,7 +25,7 @@ sticker_plist = "../Artsy Stickers/Info.plist"
 
 lane :ship_beta_ios do
   api_key = app_store_connect_api_key(
-    key_id: "B95P9K5S5V",
+    key_id: '9U7GAZP7XS',
     issuer_id: "69a6de72-31ba-47e3-e053-5b8c7c11a4d1",
     key_content: ENV['ARTSY_APP_STORE_CONNECT_API_KEY_CONTENT'],
     in_house: false,
@@ -241,20 +241,43 @@ lane :ship_beta_android do
 end
 
 lane :promote_beta_ios do
-  client = Spaceship::Tunes.login(ENV['FASTLANE_USERNAME'], ENV['FASTLANE_PASSWORD'])
-  client.team_id = '479887'
-  app = Spaceship::Tunes::Application.find('net.artsy.artsy')
+  # There seems to be some delta between spaceship + deliver token format
+  token = Spaceship::ConnectAPI::Token.create(
+    key_id: '9U7GAZP7XS',
+    issuer_id: "69a6de72-31ba-47e3-e053-5b8c7c11a4d1",
+    key: ENV['ARTSY_APP_STORE_CONNECT_API_KEY_CONTENT'],
+    in_house: false
+  )
 
-  # app.builds are listed most recent last; we are assuming that we're shipping the most recent beta.
-  beta = app.builds.last
+  api_key = app_store_connect_api_key(
+    key_id: '9U7GAZP7XS',
+    issuer_id: "69a6de72-31ba-47e3-e053-5b8c7c11a4d1",
+    key_content: ENV['ARTSY_APP_STORE_CONNECT_API_KEY_CONTENT'],
+    in_house: false,
+  )
 
-  puts "Let's deliver beta #{beta.train_version} (#{beta.build_version}) with build number #{latest_testflight_build_number}."
+  Spaceship::ConnectAPI.token = token
+
+  app = Spaceship::ConnectAPI::App.find('net.artsy.artsy')
+  next_app_store_version = app.get_edit_app_store_version.version_string
+
+  # app.builds are listed most recent first; we are assuming that we're shipping the most recent beta.
+  latest_build = app.get_builds.first
+  build_number = latest_build.version
+
+
+  puts "Got next app version #{next_app_store_version}"
+  puts "Got build number #{build_number}"
+
+  puts "Let's deliver beta #{next_app_store_version} (#{build_number}) with build number #{build_number}."
   deliver(
-    build_number: latest_testflight_build_number,
+    api_key: api_key,
+    build_number: build_number,
     force: true, # Skip HTMl report verification
     skip_screenshots: true,
     skip_binary_upload: true,
     submit_for_review: true,
+    precheck_include_in_app_purchases: false,
     submission_information: {
       add_id_info_limits_tracking: true,
       add_id_info_serves_ads: false,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,7 +22,15 @@ app_json = JSON.parse(File.read(app_json_path))
 app_plist = "../Artsy/App_Resources/Artsy-Info.plist"
 sticker_plist = "../Artsy Stickers/Info.plist"
 
+
 lane :ship_beta_ios do
+  api_key = app_store_connect_api_key(
+    key_id: "B95P9K5S5V",
+    issuer_id: "69a6de72-31ba-47e3-e053-5b8c7c11a4d1",
+    key_content: ENV['ARTSY_APP_STORE_CONNECT_API_KEY_CONTENT'],
+    in_house: false,
+  )
+
   set_build_version_ios
 
   changelog_yaml = File.read('../CHANGELOG.yml')
@@ -146,11 +154,12 @@ lane :ship_beta_ios do
     demo_account_name: ENV['BETA_DEMO_ACCOUNT_NAME'],
     demo_account_password: ENV['BETA_DEMO_ACCOUNT_PWD']
   }
-  pilot beta_app_review_info: beta_app_review_info,
+  pilot(api_key: api_key,
+        beta_app_review_info: beta_app_review_info,
         changelog: beta_readme,
         itc_provider: 'ArtsyInc',
         distribute_external: true,
-        groups: ['Artsy']
+        groups: ['Artsy'])
 end
 
 lane :update_version_string do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -265,10 +265,6 @@ lane :promote_beta_ios do
   latest_build = app.get_builds.first
   build_number = latest_build.version
 
-
-  puts "Got next app version #{next_app_store_version}"
-  puts "Got build number #{build_number}"
-
   puts "Let's deliver beta #{next_app_store_version} (#{build_number}) with build number #{build_number}."
   deliver(
     api_key: api_key,
@@ -317,6 +313,8 @@ lane :promote_beta_ios do
 end
 
 lane :notify_if_new_license_agreement do
+  # TODO: This login method will no longer work for CI with 2fa being enforced
+  # Check spaceship docs for future support with api key
   client = Spaceship::Tunes.login(ENV['FASTLANE_USERNAME'], ENV['FASTLANE_PASSWORD'])
   client.team_id = '479887'
   messages = Spaceship::Tunes.client.fetch_program_license_agreement_messages


### PR DESCRIPTION
The type of this PR is: **fix**

### Description

Use new app store connect API Key auth for promote beta lane.
Also removes the check developer agreements step from our nightly builds because there is not a corresponding App Store connect api as far as I can tell so will fail when prompted for 2fa.

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
