### PR TITLE
fix: move spacer into modal content #trivial

### DIFF
--- a/src/lib/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
@@ -109,6 +109,7 @@ const ArtistInsightsAuctionResults: React.FC<Props> = ({ artist, relay }) => {
 
   const renderAuctionResultsModal = () => (
     <>
+      <Spacer my={1} />
       <Text>
         These auction results bring together sale data from top auction houses around the world, including Christies,
         Sotheby’s, Phillips, Bonhams, and Heritage. Results are updated daily.

--- a/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
@@ -39,6 +39,7 @@ const MarketStats: React.FC<MarketStatsProps> = ({ priceInsightsConnection }) =>
 
   const renderInfoModal = () => (
     <ScrollView showsVerticalScrollIndicator={false}>
+      <Spacer my={1} />
       <Text>
         The following data points provide an overview of an artist’s auction market for a specific medium (e.g.,
         photography, painting) over the past 36 months.

--- a/src/lib/Components/Buttons/InfoButton.tsx
+++ b/src/lib/Components/Buttons/InfoButton.tsx
@@ -1,7 +1,7 @@
 import { FancyModal } from "lib/Components/FancyModal/FancyModal"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
 import { ScreenMargin } from "lib/Scenes/MyCollection/Components/ScreenMargin"
-import { Flex, InfoCircleIcon, Spacer, Text } from "palette"
+import { Flex, InfoCircleIcon, Text } from "palette"
 import React, { useState } from "react"
 import { TouchableOpacity } from "react-native"
 
@@ -54,7 +54,6 @@ export const InfoButton: React.FC<InfoButtonProps> = ({
         <FancyModalHeader useXButton={true} onLeftButtonPress={() => setModalVisible(false)}>
           {modalTitle ?? title}
         </FancyModalHeader>
-        <Spacer my={1} />
         <ScreenMargin>{modalContent}</ScreenMargin>
       </FancyModal>
     </>

--- a/src/lib/Scenes/AuctionResult/AuctionResult.tsx
+++ b/src/lib/Scenes/AuctionResult/AuctionResult.tsx
@@ -143,6 +143,7 @@ const AuctionResult: React.FC<Props> = ({ artist, auctionResult }) => {
 
   const renderRealizedPriceModal = () => (
     <>
+      <Spacer my={1} />
       <Text>
         The sale price includes the hammer price and buyer’s premium, as well as any other additional fees (e.g.,
         Artist’s Resale Rights).

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistAuctionResults.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistAuctionResults.tsx
@@ -35,6 +35,7 @@ const MyCollectionArtworkArtistAuctionResults: React.FC<MyCollectionArtworkArtis
           title={`Auction Results for ${props?.artwork?.artist?.name}`}
           modalContent={
             <>
+              <Spacer my={1} />
               <Text>
                 This data set includes the latest lots from auction sales at top commercial auction houses. Lots are
                 updated daily.

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistMarket.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistMarket.tsx
@@ -73,6 +73,7 @@ const MyCollectionArtworkArtistMarket: React.FC<MyCollectionArtworkArtistMarketP
         modalTitle="Artist Market Insights"
         modalContent={
           <>
+            <Spacer my={1} />
             <Text>
               These statistics are based on the last 36 months of auction sale data from top commercial auction houses.
             </Text>

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkDemandIndex.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkDemandIndex.tsx
@@ -32,6 +32,7 @@ const MyCollectionArtworkDemandIndex: React.FC<MyCollectionArtworkDemandIndexPro
         title="Demand index"
         modalContent={
           <>
+            <Spacer my={1} />
             <Text>
               Overall strength of demand for this artist and medium combination. Based on the last 36 months of auction
               sale data from top commercial auction houses.

--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkPriceEstimate.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkPriceEstimate.tsx
@@ -105,6 +105,7 @@ const MyCollectionArtworkPriceEstimate: React.FC<MyCollectionArtworkPriceEstimat
         subTitle={`Based on ${artsyQInventory} comparable works`}
         modalContent={
           <>
+            <Spacer my={1} />
             <Text>
               This is an estimated range based on artist, medium, and size (if provided). It is not an official
               evaluation of your exact artwork. This is based on the last 36 months of auction sale data from top


### PR DESCRIPTION
The type of this PR is: **fix**

This PR resolves [CX-997]

### Description

Moves spacer element outside of info button to allow scrollview content to behave nicely / not be clipped.


### Screenshots

![fix-scroll-padding](https://user-images.githubusercontent.com/49686530/106922931-8b8bd480-66db-11eb-8203-97e03d666598.gif)


### PR Checklist (tick all before merging)


- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-997]: https://artsyproduct.atlassian.net/browse/CX-997