### PR TITLE
fix: move separator to market stats module #trivial

### DIFF
--- a/src/lib/Components/Artist/ArtistInsights/ArtistInsights.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/ArtistInsights.tsx
@@ -3,8 +3,6 @@ import { ArtistInsights_artist } from "__generated__/ArtistInsights_artist.graph
 import { AnimatedArtworkFilterButton, FilterModalMode, FilterModalNavigator } from "lib/Components/FilterModal"
 import { StickyTabPageScrollView } from "lib/Components/StickyTabPage/StickyTabPageScrollView"
 import { ArtworkFilterGlobalStateProvider } from "lib/utils/ArtworkFilter/ArtworkFiltersStore"
-import { useScreenDimensions } from "lib/utils/useScreenDimensions"
-import { Join, Separator } from "palette"
 import React, { useCallback, useState } from "react"
 import { NativeScrollEvent, NativeSyntheticEvent } from "react-native"
 import { createFragmentContainer, graphql, RelayProp } from "react-relay"
@@ -63,10 +61,8 @@ export const ArtistInsights: React.FC<ArtistInsightsProps> = (props) => {
         contentContainerStyle={{ paddingTop: 20, paddingBottom: 60 }}
         onScrollEndDrag={onScrollEndDrag}
       >
-        <Join separator={<Separator my={2} ml={-2} width={useScreenDimensions().width} />}>
-          <MarketStatsQueryRenderer artistInternalID={artist.internalID} relay={relay} />
-          <ArtistInsightsAuctionResultsPaginationContainer artist={artist} />
-        </Join>
+        <MarketStatsQueryRenderer artistInternalID={artist.internalID} relay={relay} />
+        <ArtistInsightsAuctionResultsPaginationContainer artist={artist} />
       </StickyTabPageScrollView>
       <FilterModalNavigator
         isFilterArtworksModalVisible={isFilterModalVisible}
@@ -77,7 +73,6 @@ export const ArtistInsights: React.FC<ArtistInsightsProps> = (props) => {
         closeModal={closeFilterModal}
         title="Filter auction results"
       />
-
       <AnimatedArtworkFilterButton
         isVisible={isFilterButtonVisible}
         onPress={openFilterModal}

--- a/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
@@ -5,7 +5,8 @@ import { Select } from "lib/Components/Select"
 import { formatLargeNumber } from "lib/utils/formatLargeNumber"
 import { PlaceholderBox, PlaceholderText } from "lib/utils/placeholders"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
-import { DecreaseIcon, Flex, IncreaseIcon, Join, Spacer, Text } from "palette"
+import { useScreenDimensions } from "lib/utils/useScreenDimensions"
+import { DecreaseIcon, Flex, IncreaseIcon, Join, Separator, Spacer, Text } from "palette"
 import React, { useRef, useState } from "react"
 import { ScrollView } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer, RelayProp } from "react-relay"
@@ -144,6 +145,7 @@ const MarketStats: React.FC<MarketStatsProps> = ({ priceInsightsConnection }) =>
           <Text variant="text">Sale price over estimate</Text>
         </Flex>
       </Flex>
+      <Separator my={2} ml={-2} width={useScreenDimensions().width} />
     </>
   )
 }


### PR DESCRIPTION
The type of this PR is: **fix**

This PR resolves [CX-1002]

### Description

Moves markets stats + auction results out of Join component and instead adds separator at end of market stats to avoid showing separator when Market Stats is not present.

### Screenshots

![no-separator](https://user-images.githubusercontent.com/49686530/106934680-68b3ed00-66e8-11eb-9013-39a5879bdd5c.png)

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-1002]: https://artsyproduct.atlassian.net/browse/CX-1002