### PR TITLE
fix: adjust arrow padding #trivial

### DIFF
--- a/src/lib/Components/AuctionResult/AuctionResultMidEstimate.tsx
+++ b/src/lib/Components/AuctionResult/AuctionResultMidEstimate.tsx
@@ -15,10 +15,11 @@ export const AuctionResultsMidEstimate: React.FC<AuctionResultsMidEstimateProps>
 
   return (
     <Flex flexDirection="row" alignItems="center">
+      {/* Up arrow is heavier toward bottom so appears off center without padding */}
       {arrowDirection === "up" ? (
-        <IncreaseIcon bottom={"2px"} height={12} fill={color} />
+        <IncreaseIcon bottom={"1px"} height={12} fill={color} />
       ) : (
-        <DecreaseIcon bottom={"2px"} height={12} fill={color} />
+        <DecreaseIcon height={12} fill={color} />
       )}
       <Text variant="small" color={color}>
         {value.replace("-", "")} {shortDescription}


### PR DESCRIPTION
The type of this PR is: **fix**

This PR resolves [CX-1000]

### Description

Adjusts padding on arrow icons in auction lots to appear better centered.
This still appears ever so slightly off to me for certain numbers but I think it is mostly because the decrease icon is a little heavier towards the bottom and close to the numbers but let me know if needs adjustments.

### Screenshots

![Screen Shot 2021-02-04 at 1 13 14 PM](https://user-images.githubusercontent.com/49686530/106937068-525b6080-66eb-11eb-8130-aa1d6916fa5f.png)


### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
