### PR TITLE
fix: year created design updates #trivial

### DIFF
--- a/src/lib/Components/ArtworkFilterOptions/YearOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/YearOptions.tsx
@@ -5,6 +5,7 @@ import { aggregationForFilter, FilterParamName } from "lib/utils/ArtworkFilter/F
 import { Box, CheckIcon, color, Flex, Separator, Text } from "palette"
 import React, { useContext, useState } from "react"
 import { TouchableOpacity, View } from "react-native"
+import Haptic from "react-native-haptic-feedback"
 import styled from "styled-components/native"
 import { FilterData } from "../../utils/ArtworkFilter/ArtworkFiltersStore"
 import { useScreenDimensions } from "../../utils/useScreenDimensions"
@@ -96,13 +97,16 @@ export const YearOptionsScreen: React.FC<YearOptionsScreenProps> = ({ navigation
       <FancyModalHeader onLeftButtonPress={navigation.goBack}>Year created</FancyModalHeader>
       <Flex flexGrow={1} py={2}>
         <YearText variant="text" mb={15} mx={2}>
-          {sliderValues[0]} - {sliderValues[1]}
+          {sliderValues[0]} – {sliderValues[1]}
         </YearText>
         <Flex alignItems="center" mx={2}>
           <MultiSlider
             values={[Number(sliderValues[0]), Number(sliderValues[1])]}
-            sliderLength={screenWidth - 60}
-            onValuesChange={setSliderValues}
+            sliderLength={screenWidth - 40}
+            onValuesChange={(values) => {
+              Haptic.trigger("impactLight")
+              setSliderValues(values)
+            }}
             onValuesChangeFinish={onValuesChangeFinish}
             min={artistEarliestCreatedYear}
             max={artistLatestCreatedYear}
@@ -141,10 +145,7 @@ interface OptionItemProps {
 }
 
 export const OptionItem = ({ onPress, text, selected }: OptionItemProps) => (
-  <TouchableOpacity
-    onPress={onPress}
-    style={{ borderTopWidth: 1, borderBottomWidth: 1, borderColor: color("black10") }}
-  >
+  <TouchableOpacity onPress={onPress}>
     <Flex flexGrow={1} justifyContent="space-between" flexDirection="row" height={60}>
       <Flex flexDirection="row" justifyContent="space-between" flexGrow={1} alignItems="center" pl={2} pr={2}>
         <Text variant="text">{text}</Text>
@@ -170,6 +171,4 @@ export const BlackCircle = styled(View)`
   top: 2;
   border-radius: 12;
   background-color: ${color("black100")};
-  border-width: 2;
-  border-color: ${color("white100")};
 `

--- a/src/lib/Components/ArtworkFilterOptions/YearOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/YearOptions.tsx
@@ -4,11 +4,12 @@ import { ArtworkFilterContext, useSelectedOptionsDisplay } from "lib/utils/Artwo
 import { aggregationForFilter, FilterParamName } from "lib/utils/ArtworkFilter/FilterArtworksHelpers"
 import { Box, CheckIcon, color, Flex, Separator, Text } from "palette"
 import React, { useContext, useState } from "react"
-import { TouchableOpacity, View } from "react-native"
+import { TouchableOpacity } from "react-native"
 import Haptic from "react-native-haptic-feedback"
 import styled from "styled-components/native"
 import { FilterData } from "../../utils/ArtworkFilter/ArtworkFiltersStore"
 import { useScreenDimensions } from "../../utils/useScreenDimensions"
+import { CircleWithBorder } from "../CircleWithBorder/CircleWithBorder"
 import { FancyModalHeader } from "../FancyModal/FancyModalHeader"
 import { FilterModalNavigationStack } from "../FilterModal"
 
@@ -113,7 +114,15 @@ export const YearOptionsScreen: React.FC<YearOptionsScreenProps> = ({ navigation
             step={1}
             allowOverlap
             snapped
-            customMarker={CustomMarker}
+            customMarker={() => (
+              <CircleWithBorder
+                borderWidth={2}
+                backgroundColor={color("black100")}
+                borderColor={color("white100")}
+                diameter={24}
+                top="2px"
+              />
+            )}
             selectedStyle={{
               backgroundColor: "black",
               height: 5,
@@ -161,14 +170,4 @@ export const OptionItem = ({ onPress, text, selected }: OptionItemProps) => (
 
 export const YearText = styled(Text)`
   margin-bottom: 15;
-`
-
-const CustomMarker = () => <BlackCircle />
-
-export const BlackCircle = styled(View)`
-  height: 24;
-  width: 24;
-  top: 2;
-  border-radius: 12;
-  background-color: ${color("black100")};
 `

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/YearOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/YearOptions-tests.tsx
@@ -66,7 +66,7 @@ describe("Year Options Screen", () => {
 
   it("renders propertly", () => {
     const tree = renderWithWrappers(<MockYearOptionsScreen initialState={state} />)
-    expect(extractText(tree.root.findAllByType(YearText)[0])).toEqual("2010 - 2021")
+    expect(extractText(tree.root.findAllByType(YearText)[0])).toEqual("2010 – 2021")
     expect(extractText(tree.root.findAllByType(OptionItem)[0])).toEqual(ALLOW_EMPTY_CREATED_DATES_FILTER.displayText)
   })
 

--- a/src/lib/Components/CircleWithBorder/CircleWithBorder.tsx
+++ b/src/lib/Components/CircleWithBorder/CircleWithBorder.tsx
@@ -1,0 +1,38 @@
+import { Flex, FlexProps } from "palette"
+import React from "react"
+
+interface CircleWithBorderProps extends FlexProps {
+  backgroundColor: string
+  borderColor: string
+  borderWidth: number
+  diameter: number
+}
+
+//  It seems like React Native has a bug on iOS that causes some of the background to bleed
+//  so using a circle within a circle as a workaround
+export const CircleWithBorder: React.FC<CircleWithBorderProps> = ({
+  backgroundColor,
+  diameter,
+  borderColor,
+  borderWidth,
+  ...wrapperProps
+}) => (
+  <Flex flex={1} justifyContent="center" alignItems="center" backgroundColor={borderColor} {...wrapperProps}>
+    <Flex
+      justifyContent="center"
+      alignItems="center"
+      borderRadius={diameter / 2}
+      width={diameter}
+      height={diameter}
+      backgroundColor={borderColor}
+    >
+      <Flex
+        borderRadius={(diameter - borderWidth) / 2}
+        width={diameter - 2 * borderWidth}
+        height={diameter - 2 * borderWidth}
+        margin={borderWidth}
+        backgroundColor={backgroundColor}
+      />
+    </Flex>
+  </Flex>
+)


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-999]

### Description
**Design adjustment for year created**
- Change hyphen between years to an "en-dash"
- Make toggle switches border radius black instead of grey
- Add haptic feedback on value change for slider ✨ (the only way to test this is on real device)
- Update double divider to single divider (1px) between the slider and the "Include lots without year created info"
- Decrease left-padding to be 20px when the slider is active


https://user-images.githubusercontent.com/11945712/107047596-472a3280-67c8-11eb-98b2-a817ac2f126d.mov



<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-999]: https://artsyproduct.atlassian.net/browse/CX-999