### PR TITLE
fix: remove heritage from the market stats text #trivial

### DIFF
--- a/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
@@ -48,7 +48,7 @@ const MarketStats: React.FC<MarketStatsProps> = ({ priceInsightsConnection }) =>
       <Spacer mb={2} />
       <Text>
         These market signals bring together data from top auction houses around the world, including Christie’s,
-        Sotheby’s, Phillips, Bonhams, and Heritage.
+        Sotheby’s, Phillips and Bonhams.
       </Text>
       <Spacer mb={2} />
       <Text>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1018]

### Description
- Remove heritage from the market stats text

<img width="323" alt="Screenshot 2021-02-05 at 15 47 36" src="https://user-images.githubusercontent.com/11945712/107048663-7d1be680-67c9-11eb-9659-31d5b8d060c1.png">


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1018]: https://artsyproduct.atlassian.net/browse/CX-1018