### PR TITLE
feat(fx-2557): adds filter to partner artworks screen

### DIFF
--- a/src/__generated__/PartnerArtworkInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/PartnerArtworkInfiniteScrollGridQuery.graphql.ts
@@ -1,14 +1,24 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 0a6f46bae6de4786528e08b14a0e024d */
+/* @relayHash d516c9f709cabcbc6d92546dbe0e85c0 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type PartnerArtworkInfiniteScrollGridQueryVariables = {
-    id: string;
-    cursor?: string | null;
+    acquireable?: boolean | null;
+    attributionClass?: Array<string | null> | null;
+    color?: string | null;
     count: number;
+    cursor?: string | null;
+    dimensionRange?: string | null;
+    id: string;
+    inquireableOnly?: boolean | null;
+    majorPeriods?: Array<string | null> | null;
+    medium?: string | null;
+    offerable?: boolean | null;
+    priceRange?: string | null;
+    sort?: string | null;
 };
 export type PartnerArtworkInfiniteScrollGridQueryResponse = {
     readonly partner: {
@@ -24,12 +34,22 @@ export type PartnerArtworkInfiniteScrollGridQuery = {
 
 /*
 query PartnerArtworkInfiniteScrollGridQuery(
-  $id: String!
-  $cursor: String
+  $acquireable: Boolean
+  $attributionClass: [String]
+  $color: String
   $count: Int!
+  $cursor: String
+  $dimensionRange: String
+  $id: String!
+  $inquireableOnly: Boolean
+  $majorPeriods: [String]
+  $medium: String
+  $offerable: Boolean
+  $priceRange: String
+  $sort: String
 ) {
   partner(id: $id) {
-    ...PartnerArtwork_partner_1G22uz
+    ...PartnerArtwork_partner_1LBhko
     id
   }
 }
@@ -93,9 +113,18 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
   }
 }
 
-fragment PartnerArtwork_partner_1G22uz on Partner {
+fragment PartnerArtwork_partner_1LBhko on Partner {
   internalID
-  artworks: artworksConnection(sort: PARTNER_UPDATED_AT_DESC, first: $count, after: $cursor) {
+  slug
+  artworks: filterArtworksConnection(acquireable: $acquireable, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], attributionClass: $attributionClass, color: $color, dimensionRange: $dimensionRange, first: $count, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, priceRange: $priceRange, sort: $sort) {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
     edges {
       node {
         id
@@ -108,65 +137,198 @@ fragment PartnerArtwork_partner_1G22uz on Partner {
       endCursor
       hasNextPage
     }
+    id
   }
 }
 */
 
 const node: ConcreteRequest = (function(){
-var v0 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "count"
-},
-v1 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "cursor"
-},
-v2 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "id"
-},
-v3 = [
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "acquireable"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "attributionClass"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "color"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "count"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "cursor"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "dimensionRange"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "inquireableOnly"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "majorPeriods"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "medium"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "offerable"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "priceRange"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "sort"
+  }
+],
+v1 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
+v2 = {
+  "kind": "Variable",
+  "name": "acquireable",
+  "variableName": "acquireable"
+},
+v3 = {
+  "kind": "Variable",
+  "name": "attributionClass",
+  "variableName": "attributionClass"
+},
 v4 = {
+  "kind": "Variable",
+  "name": "color",
+  "variableName": "color"
+},
+v5 = {
+  "kind": "Variable",
+  "name": "dimensionRange",
+  "variableName": "dimensionRange"
+},
+v6 = {
+  "kind": "Variable",
+  "name": "inquireableOnly",
+  "variableName": "inquireableOnly"
+},
+v7 = {
+  "kind": "Variable",
+  "name": "majorPeriods",
+  "variableName": "majorPeriods"
+},
+v8 = {
+  "kind": "Variable",
+  "name": "medium",
+  "variableName": "medium"
+},
+v9 = {
+  "kind": "Variable",
+  "name": "offerable",
+  "variableName": "offerable"
+},
+v10 = {
+  "kind": "Variable",
+  "name": "priceRange",
+  "variableName": "priceRange"
+},
+v11 = {
+  "kind": "Variable",
+  "name": "sort",
+  "variableName": "sort"
+},
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v5 = [
+v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v14 = [
+  (v2/*: any*/),
   {
     "kind": "Variable",
     "name": "after",
     "variableName": "cursor"
   },
   {
+    "kind": "Literal",
+    "name": "aggregations",
+    "value": [
+      "COLOR",
+      "DIMENSION_RANGE",
+      "MAJOR_PERIOD",
+      "MEDIUM",
+      "PRICE_RANGE"
+    ]
+  },
+  (v3/*: any*/),
+  (v4/*: any*/),
+  (v5/*: any*/),
+  {
     "kind": "Variable",
     "name": "first",
     "variableName": "count"
   },
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "PARTNER_UPDATED_AT_DESC"
-  }
+  (v6/*: any*/),
+  (v7/*: any*/),
+  (v8/*: any*/),
+  (v9/*: any*/),
+  (v10/*: any*/),
+  (v11/*: any*/)
 ],
-v6 = {
+v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -175,18 +337,14 @@ v7 = {
 };
 return {
   "fragment": {
-    "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/),
-      (v2/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "PartnerArtworkInfiniteScrollGridQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": "Partner",
         "kind": "LinkedField",
         "name": "partner",
@@ -194,6 +352,9 @@ return {
         "selections": [
           {
             "args": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
               {
                 "kind": "Variable",
                 "name": "count",
@@ -203,7 +364,14 @@ return {
                 "kind": "Variable",
                 "name": "cursor",
                 "variableName": "cursor"
-              }
+              },
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              (v9/*: any*/),
+              (v10/*: any*/),
+              (v11/*: any*/)
             ],
             "kind": "FragmentSpread",
             "name": "PartnerArtwork_partner"
@@ -217,35 +385,76 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": [
-      (v2/*: any*/),
-      (v1/*: any*/),
-      (v0/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "PartnerArtworkInfiniteScrollGridQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": "Partner",
         "kind": "LinkedField",
         "name": "partner",
         "plural": false,
         "selections": [
-          (v4/*: any*/),
+          (v12/*: any*/),
+          (v13/*: any*/),
           {
             "alias": "artworks",
-            "args": (v5/*: any*/),
-            "concreteType": "ArtworkConnection",
+            "args": (v14/*: any*/),
+            "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
-            "name": "artworksConnection",
+            "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "ArtworkEdge",
+                "concreteType": "ArtworksAggregationResults",
+                "kind": "LinkedField",
+                "name": "aggregations",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "slice",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AggregationCount",
+                    "kind": "LinkedField",
+                    "name": "counts",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "count",
+                        "storageKey": null
+                      },
+                      (v15/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "value",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
                 "kind": "LinkedField",
                 "name": "edges",
                 "plural": true,
@@ -258,8 +467,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
-                      (v7/*: any*/)
+                      (v16/*: any*/),
+                      (v17/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -298,6 +507,7 @@ return {
                 ],
                 "storageKey": null
               },
+              (v16/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -327,7 +537,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v7/*: any*/),
+                      (v17/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -336,13 +546,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "slug",
-                            "storageKey": null
-                          },
+                          (v13/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -395,7 +599,7 @@ return {
                             "name": "saleMessage",
                             "storageKey": null
                           },
-                          (v4/*: any*/),
+                          (v12/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -446,7 +650,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v6/*: any*/)
+                              (v16/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -501,7 +705,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v6/*: any*/)
+                              (v16/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -513,14 +717,8 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "name",
-                                "storageKey": null
-                              },
-                              (v6/*: any*/)
+                              (v15/*: any*/),
+                              (v16/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -530,7 +728,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v6/*: any*/)
+                          (v16/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -547,23 +745,33 @@ return {
           },
           {
             "alias": "artworks",
-            "args": (v5/*: any*/),
+            "args": (v14/*: any*/),
             "filters": [
+              "acquireable",
+              "aggregations",
+              "attributionClass",
+              "color",
+              "dimensionRange",
+              "inquireableOnly",
+              "majorPeriods",
+              "medium",
+              "offerable",
+              "priceRange",
               "sort"
             ],
             "handle": "connection",
             "key": "Partner_artworks",
             "kind": "LinkedHandle",
-            "name": "artworksConnection"
+            "name": "filterArtworksConnection"
           },
-          (v6/*: any*/)
+          (v16/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "0a6f46bae6de4786528e08b14a0e024d",
+    "id": "d516c9f709cabcbc6d92546dbe0e85c0",
     "metadata": {},
     "name": "PartnerArtworkInfiniteScrollGridQuery",
     "operationKind": "query",
@@ -571,5 +779,5 @@ return {
   }
 };
 })();
-(node as any).hash = '1b25b93a29499e689fd4cbcc165f9e84';
+(node as any).hash = '07bae258d929897d4c852d053a8c265d';
 export default node;

--- a/src/__generated__/PartnerArtworkTestsQuery.graphql.ts
+++ b/src/__generated__/PartnerArtworkTestsQuery.graphql.ts
@@ -1,10 +1,11 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 79a88ff2a4904d2680d8fa81782d0fe8 */
+/* @relayHash 2500e2ecf289c7fb8f3c250b5516cf47 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 export type PartnerArtworkTestsQueryVariables = {};
 export type PartnerArtworkTestsQueryResponse = {
     readonly partner: {
@@ -14,7 +15,16 @@ export type PartnerArtworkTestsQueryResponse = {
 export type PartnerArtworkTestsQueryRawResponse = {
     readonly partner: ({
         readonly internalID: string;
+        readonly slug: string;
         readonly artworks: ({
+            readonly aggregations: ReadonlyArray<({
+                readonly slice: ArtworkAggregation | null;
+                readonly counts: ReadonlyArray<({
+                    readonly count: number;
+                    readonly name: string;
+                    readonly value: string;
+                }) | null> | null;
+            }) | null> | null;
             readonly edges: ReadonlyArray<({
                 readonly node: ({
                     readonly id: string;
@@ -62,7 +72,8 @@ export type PartnerArtworkTestsQueryRawResponse = {
                 readonly hasNextPage: boolean;
                 readonly startCursor?: string | null;
             };
-            readonly __isArtworkConnectionInterface: "ArtworkConnection";
+            readonly id: string;
+            readonly __isArtworkConnectionInterface: "FilterArtworksConnection";
         }) | null;
         readonly id: string;
     }) | null;
@@ -144,7 +155,16 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
 
 fragment PartnerArtwork_partner on Partner {
   internalID
-  artworks: artworksConnection(sort: PARTNER_UPDATED_AT_DESC, first: 10) {
+  slug
+  artworks: filterArtworksConnection(aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], dimensionRange: "*-*", first: 10, medium: "*", sort: "-partner_updated_at") {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
     edges {
       node {
         id
@@ -157,6 +177,7 @@ fragment PartnerArtwork_partner on Partner {
       endCursor
       hasNextPage
     }
+    id
   }
 }
 */
@@ -176,7 +197,30 @@ v1 = {
   "name": "internalID",
   "storageKey": null
 },
-v2 = [
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v3 = [
+  {
+    "kind": "Literal",
+    "name": "aggregations",
+    "value": [
+      "COLOR",
+      "DIMENSION_RANGE",
+      "MAJOR_PERIOD",
+      "MEDIUM",
+      "PRICE_RANGE"
+    ]
+  },
+  {
+    "kind": "Literal",
+    "name": "dimensionRange",
+    "value": "*-*"
+  },
   {
     "kind": "Literal",
     "name": "first",
@@ -184,18 +228,30 @@ v2 = [
   },
   {
     "kind": "Literal",
+    "name": "medium",
+    "value": "*"
+  },
+  {
+    "kind": "Literal",
     "name": "sort",
-    "value": "PARTNER_UPDATED_AT_DESC"
+    "value": "-partner_updated_at"
   }
 ],
-v3 = {
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -244,18 +300,63 @@ return {
         "plural": false,
         "selections": [
           (v1/*: any*/),
+          (v2/*: any*/),
           {
             "alias": "artworks",
-            "args": (v2/*: any*/),
-            "concreteType": "ArtworkConnection",
+            "args": (v3/*: any*/),
+            "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
-            "name": "artworksConnection",
+            "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "ArtworkEdge",
+                "concreteType": "ArtworksAggregationResults",
+                "kind": "LinkedField",
+                "name": "aggregations",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "slice",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AggregationCount",
+                    "kind": "LinkedField",
+                    "name": "counts",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "count",
+                        "storageKey": null
+                      },
+                      (v4/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "value",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
                 "kind": "LinkedField",
                 "name": "edges",
                 "plural": true,
@@ -268,8 +369,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
-                      (v4/*: any*/)
+                      (v5/*: any*/),
+                      (v6/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -308,6 +409,7 @@ return {
                 ],
                 "storageKey": null
               },
+              (v5/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -337,7 +439,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v4/*: any*/),
+                      (v6/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -346,13 +448,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "slug",
-                            "storageKey": null
-                          },
+                          (v2/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -456,7 +552,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v3/*: any*/)
+                              (v5/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -511,7 +607,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v3/*: any*/)
+                              (v5/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -523,14 +619,8 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "name",
-                                "storageKey": null
-                              },
-                              (v3/*: any*/)
+                              (v4/*: any*/),
+                              (v5/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -540,7 +630,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v3/*: any*/)
+                          (v5/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -553,27 +643,37 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "artworksConnection(first:10,sort:\"PARTNER_UPDATED_AT_DESC\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,medium:\"*\",sort:\"-partner_updated_at\")"
           },
           {
             "alias": "artworks",
-            "args": (v2/*: any*/),
+            "args": (v3/*: any*/),
             "filters": [
+              "acquireable",
+              "aggregations",
+              "attributionClass",
+              "color",
+              "dimensionRange",
+              "inquireableOnly",
+              "majorPeriods",
+              "medium",
+              "offerable",
+              "priceRange",
               "sort"
             ],
             "handle": "connection",
             "key": "Partner_artworks",
             "kind": "LinkedHandle",
-            "name": "artworksConnection"
+            "name": "filterArtworksConnection"
           },
-          (v3/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": "partner(id:\"anderson-fine-art-gallery-flickinger-collection\")"
       }
     ]
   },
   "params": {
-    "id": "79a88ff2a4904d2680d8fa81782d0fe8",
+    "id": "2500e2ecf289c7fb8f3c250b5516cf47",
     "metadata": {},
     "name": "PartnerArtworkTestsQuery",
     "operationKind": "query",

--- a/src/__generated__/PartnerArtwork_partner.graphql.ts
+++ b/src/__generated__/PartnerArtwork_partner.graphql.ts
@@ -4,9 +4,19 @@
 
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "MAJOR_PERIOD" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
 export type PartnerArtwork_partner = {
     readonly internalID: string;
+    readonly slug: string;
     readonly artworks: {
+        readonly aggregations: ReadonlyArray<{
+            readonly slice: ArtworkAggregation | null;
+            readonly counts: ReadonlyArray<{
+                readonly count: number;
+                readonly name: string;
+                readonly value: string;
+            } | null> | null;
+        } | null> | null;
         readonly edges: ReadonlyArray<{
             readonly node: {
                 readonly id: string;
@@ -27,6 +37,21 @@ export type PartnerArtwork_partner$key = {
 const node: ReaderFragment = {
   "argumentDefinitions": [
     {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "acquireable"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "attributionClass"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "color"
+    },
+    {
       "defaultValue": 10,
       "kind": "LocalArgument",
       "name": "count"
@@ -37,7 +62,37 @@ const node: ReaderFragment = {
       "name": "cursor"
     },
     {
-      "defaultValue": "PARTNER_UPDATED_AT_DESC",
+      "defaultValue": "*-*",
+      "kind": "LocalArgument",
+      "name": "dimensionRange"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "inquireableOnly"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "majorPeriods"
+    },
+    {
+      "defaultValue": "*",
+      "kind": "LocalArgument",
+      "name": "medium"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "offerable"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "priceRange"
+    },
+    {
+      "defaultValue": "-partner_updated_at",
       "kind": "LocalArgument",
       "name": "sort"
     }
@@ -65,15 +120,78 @@ const node: ReaderFragment = {
       "storageKey": null
     },
     {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
+    },
+    {
       "alias": "artworks",
       "args": [
+        {
+          "kind": "Variable",
+          "name": "acquireable",
+          "variableName": "acquireable"
+        },
+        {
+          "kind": "Literal",
+          "name": "aggregations",
+          "value": [
+            "COLOR",
+            "DIMENSION_RANGE",
+            "MAJOR_PERIOD",
+            "MEDIUM",
+            "PRICE_RANGE"
+          ]
+        },
+        {
+          "kind": "Variable",
+          "name": "attributionClass",
+          "variableName": "attributionClass"
+        },
+        {
+          "kind": "Variable",
+          "name": "color",
+          "variableName": "color"
+        },
+        {
+          "kind": "Variable",
+          "name": "dimensionRange",
+          "variableName": "dimensionRange"
+        },
+        {
+          "kind": "Variable",
+          "name": "inquireableOnly",
+          "variableName": "inquireableOnly"
+        },
+        {
+          "kind": "Variable",
+          "name": "majorPeriods",
+          "variableName": "majorPeriods"
+        },
+        {
+          "kind": "Variable",
+          "name": "medium",
+          "variableName": "medium"
+        },
+        {
+          "kind": "Variable",
+          "name": "offerable",
+          "variableName": "offerable"
+        },
+        {
+          "kind": "Variable",
+          "name": "priceRange",
+          "variableName": "priceRange"
+        },
         {
           "kind": "Variable",
           "name": "sort",
           "variableName": "sort"
         }
       ],
-      "concreteType": "ArtworkConnection",
+      "concreteType": "FilterArtworksConnection",
       "kind": "LinkedField",
       "name": "__Partner_artworks_connection",
       "plural": false,
@@ -81,7 +199,57 @@ const node: ReaderFragment = {
         {
           "alias": null,
           "args": null,
-          "concreteType": "ArtworkEdge",
+          "concreteType": "ArtworksAggregationResults",
+          "kind": "LinkedField",
+          "name": "aggregations",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "slice",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "AggregationCount",
+              "kind": "LinkedField",
+              "name": "counts",
+              "plural": true,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "count",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "name",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "value",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "FilterArtworksEdge",
           "kind": "LinkedField",
           "name": "edges",
           "plural": true,
@@ -158,5 +326,5 @@ const node: ReaderFragment = {
   "type": "Partner",
   "abstractKey": null
 };
-(node as any).hash = 'b27da342175e4f75b7de50768f5da346';
+(node as any).hash = 'a3d3c9fce966b742cea47d5d171eb8f8';
 export default node;

--- a/src/__generated__/PartnerQuery.graphql.ts
+++ b/src/__generated__/PartnerQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 76f97254d37e5e20faef10fa4d6856ab */
+/* @relayHash 8b88b1dea44778b59f195800c0a77c29 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -107,7 +107,16 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
 
 fragment PartnerArtwork_partner on Partner {
   internalID
-  artworks: artworksConnection(sort: PARTNER_UPDATED_AT_DESC, first: 10) {
+  slug
+  artworks: filterArtworksConnection(aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], dimensionRange: "*-*", first: 10, medium: "*", sort: "-partner_updated_at") {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
     edges {
       node {
         id
@@ -120,6 +129,7 @@ fragment PartnerArtwork_partner on Partner {
       endCursor
       hasNextPage
     }
+    id
   }
 }
 
@@ -341,11 +351,32 @@ v6 = {
   "value": 10
 },
 v7 = [
+  {
+    "kind": "Literal",
+    "name": "aggregations",
+    "value": [
+      "COLOR",
+      "DIMENSION_RANGE",
+      "MAJOR_PERIOD",
+      "MEDIUM",
+      "PRICE_RANGE"
+    ]
+  },
+  {
+    "kind": "Literal",
+    "name": "dimensionRange",
+    "value": "*-*"
+  },
   (v6/*: any*/),
   {
     "kind": "Literal",
+    "name": "medium",
+    "value": "*"
+  },
+  {
+    "kind": "Literal",
     "name": "sort",
-    "value": "PARTNER_UPDATED_AT_DESC"
+    "value": "-partner_updated_at"
   }
 ],
 v8 = {
@@ -414,9 +445,6 @@ v17 = {
   "abstractKey": "__isNode"
 },
 v18 = [
-  "sort"
-],
-v19 = [
   (v6/*: any*/),
   {
     "kind": "Literal",
@@ -424,7 +452,7 @@ v19 = [
     "value": "SORTABLE_ID_ASC"
   }
 ],
-v20 = {
+v19 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -438,29 +466,29 @@ v20 = {
   ],
   "storageKey": null
 },
-v21 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v22 = [
-  (v21/*: any*/)
+v21 = [
+  (v20/*: any*/)
 ],
-v23 = {
+v22 = {
   "kind": "Literal",
   "name": "status",
   "value": "CURRENT"
 },
-v24 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isDisplayable",
   "storageKey": null
 },
-v25 = [
+v24 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -477,18 +505,18 @@ v25 = [
     "value": "CLOSED"
   }
 ],
-v26 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "exhibitionPeriod",
   "storageKey": null
 },
-v27 = [
+v26 = [
   "status",
   "sort"
 ],
-v28 = [
+v27 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -499,7 +527,7 @@ v28 = [
     "name": "sort",
     "value": "END_AT_ASC"
   },
-  (v23/*: any*/)
+  (v22/*: any*/)
 ];
 return {
   "fragment": {
@@ -576,15 +604,59 @@ return {
           {
             "alias": "artworks",
             "args": (v7/*: any*/),
-            "concreteType": "ArtworkConnection",
+            "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
-            "name": "artworksConnection",
+            "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "ArtworkEdge",
+                "concreteType": "ArtworksAggregationResults",
+                "kind": "LinkedField",
+                "name": "aggregations",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "slice",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AggregationCount",
+                    "kind": "LinkedField",
+                    "name": "counts",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "count",
+                        "storageKey": null
+                      },
+                      (v5/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "value",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
                 "kind": "LinkedField",
                 "name": "edges",
                 "plural": true,
@@ -619,6 +691,7 @@ return {
                 ],
                 "storageKey": null
               },
+              (v2/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -821,16 +894,28 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "artworksConnection(first:10,sort:\"PARTNER_UPDATED_AT_DESC\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,medium:\"*\",sort:\"-partner_updated_at\")"
           },
           {
             "alias": "artworks",
             "args": (v7/*: any*/),
-            "filters": (v18/*: any*/),
+            "filters": [
+              "acquireable",
+              "aggregations",
+              "attributionClass",
+              "color",
+              "dimensionRange",
+              "inquireableOnly",
+              "majorPeriods",
+              "medium",
+              "offerable",
+              "priceRange",
+              "sort"
+            ],
             "handle": "connection",
             "key": "Partner_artworks",
             "kind": "LinkedHandle",
-            "name": "artworksConnection"
+            "name": "filterArtworksConnection"
           },
           (v5/*: any*/),
           {
@@ -842,13 +927,13 @@ return {
           },
           {
             "alias": "artists",
-            "args": (v19/*: any*/),
+            "args": (v18/*: any*/),
             "concreteType": "ArtistPartnerConnection",
             "kind": "LinkedField",
             "name": "artistsConnection",
             "plural": false,
             "selections": [
-              (v20/*: any*/),
+              (v19/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -912,7 +997,7 @@ return {
                         "kind": "LinkedField",
                         "name": "image",
                         "plural": false,
-                        "selections": (v22/*: any*/),
+                        "selections": (v21/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -947,8 +1032,10 @@ return {
           },
           {
             "alias": "artists",
-            "args": (v19/*: any*/),
-            "filters": (v18/*: any*/),
+            "args": (v18/*: any*/),
+            "filters": [
+              "sort"
+            ],
             "handle": "connection",
             "key": "Partner_artists",
             "kind": "LinkedHandle",
@@ -982,7 +1069,7 @@ return {
             "alias": "recentShows",
             "args": [
               (v6/*: any*/),
-              (v23/*: any*/)
+              (v22/*: any*/)
             ],
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
@@ -1006,7 +1093,7 @@ return {
                     "plural": false,
                     "selections": [
                       (v2/*: any*/),
-                      (v24/*: any*/)
+                      (v23/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1018,13 +1105,13 @@ return {
           },
           {
             "alias": "pastShows",
-            "args": (v25/*: any*/),
+            "args": (v24/*: any*/),
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
             "selections": [
-              (v20/*: any*/),
+              (v19/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1041,11 +1128,11 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v24/*: any*/),
+                      (v23/*: any*/),
                       (v2/*: any*/),
                       (v5/*: any*/),
                       (v4/*: any*/),
-                      (v26/*: any*/),
+                      (v25/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1054,7 +1141,7 @@ return {
                         "name": "coverImage",
                         "plural": false,
                         "selections": [
-                          (v21/*: any*/),
+                          (v20/*: any*/),
                           (v13/*: any*/)
                         ],
                         "storageKey": null
@@ -1073,8 +1160,8 @@ return {
           },
           {
             "alias": "pastShows",
-            "args": (v25/*: any*/),
-            "filters": (v27/*: any*/),
+            "args": (v24/*: any*/),
+            "filters": (v26/*: any*/),
             "handle": "connection",
             "key": "Partner_pastShows",
             "kind": "LinkedHandle",
@@ -1082,13 +1169,13 @@ return {
           },
           {
             "alias": "currentAndUpcomingShows",
-            "args": (v28/*: any*/),
+            "args": (v27/*: any*/),
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
             "selections": [
-              (v20/*: any*/),
+              (v19/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1105,12 +1192,12 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v24/*: any*/),
+                      (v23/*: any*/),
                       (v2/*: any*/),
                       (v3/*: any*/),
                       (v4/*: any*/),
                       (v5/*: any*/),
-                      (v26/*: any*/),
+                      (v25/*: any*/),
                       (v15/*: any*/),
                       {
                         "alias": null,
@@ -1119,7 +1206,7 @@ return {
                         "kind": "LinkedField",
                         "name": "images",
                         "plural": true,
-                        "selections": (v22/*: any*/),
+                        "selections": (v21/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -1156,7 +1243,7 @@ return {
                         "kind": "LinkedField",
                         "name": "coverImage",
                         "plural": false,
-                        "selections": (v22/*: any*/),
+                        "selections": (v21/*: any*/),
                         "storageKey": null
                       },
                       (v8/*: any*/)
@@ -1172,8 +1259,8 @@ return {
           },
           {
             "alias": "currentAndUpcomingShows",
-            "args": (v28/*: any*/),
-            "filters": (v27/*: any*/),
+            "args": (v27/*: any*/),
+            "filters": (v26/*: any*/),
             "handle": "connection",
             "key": "Partner_currentAndUpcomingShows",
             "kind": "LinkedHandle",
@@ -1203,7 +1290,7 @@ return {
     ]
   },
   "params": {
-    "id": "76f97254d37e5e20faef10fa4d6856ab",
+    "id": "8b88b1dea44778b59f195800c0a77c29",
     "metadata": {},
     "name": "PartnerQuery",
     "operationKind": "query",

--- a/src/__generated__/PartnerRefetchQuery.graphql.ts
+++ b/src/__generated__/PartnerRefetchQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 7d59e5afcf6c93f4114c126518951c52 */
+/* @relayHash 2b6746089f025938a356d853007393bc */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -108,7 +108,16 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
 
 fragment PartnerArtwork_partner on Partner {
   internalID
-  artworks: artworksConnection(sort: PARTNER_UPDATED_AT_DESC, first: 10) {
+  slug
+  artworks: filterArtworksConnection(aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], dimensionRange: "*-*", first: 10, medium: "*", sort: "-partner_updated_at") {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
     edges {
       node {
         id
@@ -121,6 +130,7 @@ fragment PartnerArtwork_partner on Partner {
       endCursor
       hasNextPage
     }
+    id
   }
 }
 
@@ -349,11 +359,32 @@ v7 = {
   "value": 10
 },
 v8 = [
+  {
+    "kind": "Literal",
+    "name": "aggregations",
+    "value": [
+      "COLOR",
+      "DIMENSION_RANGE",
+      "MAJOR_PERIOD",
+      "MEDIUM",
+      "PRICE_RANGE"
+    ]
+  },
+  {
+    "kind": "Literal",
+    "name": "dimensionRange",
+    "value": "*-*"
+  },
   (v7/*: any*/),
   {
     "kind": "Literal",
+    "name": "medium",
+    "value": "*"
+  },
+  {
+    "kind": "Literal",
     "name": "sort",
-    "value": "PARTNER_UPDATED_AT_DESC"
+    "value": "-partner_updated_at"
   }
 ],
 v9 = {
@@ -415,9 +446,6 @@ v17 = {
   "abstractKey": "__isNode"
 },
 v18 = [
-  "sort"
-],
-v19 = [
   (v7/*: any*/),
   {
     "kind": "Literal",
@@ -425,7 +453,7 @@ v19 = [
     "value": "SORTABLE_ID_ASC"
   }
 ],
-v20 = {
+v19 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -439,29 +467,29 @@ v20 = {
   ],
   "storageKey": null
 },
-v21 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v22 = [
-  (v21/*: any*/)
+v21 = [
+  (v20/*: any*/)
 ],
-v23 = {
+v22 = {
   "kind": "Literal",
   "name": "status",
   "value": "CURRENT"
 },
-v24 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isDisplayable",
   "storageKey": null
 },
-v25 = [
+v24 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -478,18 +506,18 @@ v25 = [
     "value": "CLOSED"
   }
 ],
-v26 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "exhibitionPeriod",
   "storageKey": null
 },
-v27 = [
+v26 = [
   "status",
   "sort"
 ],
-v28 = [
+v27 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -500,7 +528,7 @@ v28 = [
     "name": "sort",
     "value": "END_AT_ASC"
   },
-  (v23/*: any*/)
+  (v22/*: any*/)
 ];
 return {
   "fragment": {
@@ -581,15 +609,59 @@ return {
               {
                 "alias": "artworks",
                 "args": (v8/*: any*/),
-                "concreteType": "ArtworkConnection",
+                "concreteType": "FilterArtworksConnection",
                 "kind": "LinkedField",
-                "name": "artworksConnection",
+                "name": "filterArtworksConnection",
                 "plural": false,
                 "selections": [
                   {
                     "alias": null,
                     "args": null,
-                    "concreteType": "ArtworkEdge",
+                    "concreteType": "ArtworksAggregationResults",
+                    "kind": "LinkedField",
+                    "name": "aggregations",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slice",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "AggregationCount",
+                        "kind": "LinkedField",
+                        "name": "counts",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "count",
+                            "storageKey": null
+                          },
+                          (v6/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "value",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "FilterArtworksEdge",
                     "kind": "LinkedField",
                     "name": "edges",
                     "plural": true,
@@ -624,6 +696,7 @@ return {
                     ],
                     "storageKey": null
                   },
+                  (v3/*: any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
@@ -826,16 +899,28 @@ return {
                     "abstractKey": "__isArtworkConnectionInterface"
                   }
                 ],
-                "storageKey": "artworksConnection(first:10,sort:\"PARTNER_UPDATED_AT_DESC\")"
+                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,medium:\"*\",sort:\"-partner_updated_at\")"
               },
               {
                 "alias": "artworks",
                 "args": (v8/*: any*/),
-                "filters": (v18/*: any*/),
+                "filters": [
+                  "acquireable",
+                  "aggregations",
+                  "attributionClass",
+                  "color",
+                  "dimensionRange",
+                  "inquireableOnly",
+                  "majorPeriods",
+                  "medium",
+                  "offerable",
+                  "priceRange",
+                  "sort"
+                ],
                 "handle": "connection",
                 "key": "Partner_artworks",
                 "kind": "LinkedHandle",
-                "name": "artworksConnection"
+                "name": "filterArtworksConnection"
               },
               (v6/*: any*/),
               {
@@ -847,13 +932,13 @@ return {
               },
               {
                 "alias": "artists",
-                "args": (v19/*: any*/),
+                "args": (v18/*: any*/),
                 "concreteType": "ArtistPartnerConnection",
                 "kind": "LinkedField",
                 "name": "artistsConnection",
                 "plural": false,
                 "selections": [
-                  (v20/*: any*/),
+                  (v19/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -917,7 +1002,7 @@ return {
                             "kind": "LinkedField",
                             "name": "image",
                             "plural": false,
-                            "selections": (v22/*: any*/),
+                            "selections": (v21/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -952,8 +1037,10 @@ return {
               },
               {
                 "alias": "artists",
-                "args": (v19/*: any*/),
-                "filters": (v18/*: any*/),
+                "args": (v18/*: any*/),
+                "filters": [
+                  "sort"
+                ],
                 "handle": "connection",
                 "key": "Partner_artists",
                 "kind": "LinkedHandle",
@@ -987,7 +1074,7 @@ return {
                 "alias": "recentShows",
                 "args": [
                   (v7/*: any*/),
-                  (v23/*: any*/)
+                  (v22/*: any*/)
                 ],
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
@@ -1011,7 +1098,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v3/*: any*/),
-                          (v24/*: any*/)
+                          (v23/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -1023,13 +1110,13 @@ return {
               },
               {
                 "alias": "pastShows",
-                "args": (v25/*: any*/),
+                "args": (v24/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": [
-                  (v20/*: any*/),
+                  (v19/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1046,11 +1133,11 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v24/*: any*/),
+                          (v23/*: any*/),
                           (v3/*: any*/),
                           (v6/*: any*/),
                           (v5/*: any*/),
-                          (v26/*: any*/),
+                          (v25/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1059,7 +1146,7 @@ return {
                             "name": "coverImage",
                             "plural": false,
                             "selections": [
-                              (v21/*: any*/),
+                              (v20/*: any*/),
                               (v13/*: any*/)
                             ],
                             "storageKey": null
@@ -1078,8 +1165,8 @@ return {
               },
               {
                 "alias": "pastShows",
-                "args": (v25/*: any*/),
-                "filters": (v27/*: any*/),
+                "args": (v24/*: any*/),
+                "filters": (v26/*: any*/),
                 "handle": "connection",
                 "key": "Partner_pastShows",
                 "kind": "LinkedHandle",
@@ -1087,13 +1174,13 @@ return {
               },
               {
                 "alias": "currentAndUpcomingShows",
-                "args": (v28/*: any*/),
+                "args": (v27/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": [
-                  (v20/*: any*/),
+                  (v19/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1110,12 +1197,12 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v24/*: any*/),
+                          (v23/*: any*/),
                           (v3/*: any*/),
                           (v4/*: any*/),
                           (v5/*: any*/),
                           (v6/*: any*/),
-                          (v26/*: any*/),
+                          (v25/*: any*/),
                           (v15/*: any*/),
                           {
                             "alias": null,
@@ -1124,7 +1211,7 @@ return {
                             "kind": "LinkedField",
                             "name": "images",
                             "plural": true,
-                            "selections": (v22/*: any*/),
+                            "selections": (v21/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1161,7 +1248,7 @@ return {
                             "kind": "LinkedField",
                             "name": "coverImage",
                             "plural": false,
-                            "selections": (v22/*: any*/),
+                            "selections": (v21/*: any*/),
                             "storageKey": null
                           },
                           (v2/*: any*/)
@@ -1177,8 +1264,8 @@ return {
               },
               {
                 "alias": "currentAndUpcomingShows",
-                "args": (v28/*: any*/),
-                "filters": (v27/*: any*/),
+                "args": (v27/*: any*/),
+                "filters": (v26/*: any*/),
                 "handle": "connection",
                 "key": "Partner_currentAndUpcomingShows",
                 "kind": "LinkedHandle",
@@ -1212,7 +1299,7 @@ return {
     ]
   },
   "params": {
-    "id": "7d59e5afcf6c93f4114c126518951c52",
+    "id": "2b6746089f025938a356d853007393bc",
     "metadata": {},
     "name": "PartnerRefetchQuery",
     "operationKind": "query",

--- a/src/__generated__/VanityURLEntityQuery.graphql.ts
+++ b/src/__generated__/VanityURLEntityQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 5d3ab99350a52779596838f0d48aa6af */
+/* @relayHash 52fcf6a5020336a545051f7a20b65e12 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -393,7 +393,16 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
 
 fragment PartnerArtwork_partner on Partner {
   internalID
-  artworks: artworksConnection(sort: PARTNER_UPDATED_AT_DESC, first: 10) {
+  slug
+  artworks: filterArtworksConnection(aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], dimensionRange: "*-*", first: 10, medium: "*", sort: "-partner_updated_at") {
+    aggregations {
+      slice
+      counts {
+        count
+        name
+        value
+      }
+    }
     edges {
       node {
         id
@@ -406,6 +415,7 @@ fragment PartnerArtwork_partner on Partner {
       endCursor
       hasNextPage
     }
+    id
   }
 }
 
@@ -731,10 +741,20 @@ v19 = {
 },
 v20 = {
   "kind": "Literal",
+  "name": "dimensionRange",
+  "value": "*-*"
+},
+v21 = {
+  "kind": "Literal",
   "name": "first",
   "value": 30
 },
-v21 = [
+v22 = {
+  "kind": "Literal",
+  "name": "medium",
+  "value": "*"
+},
+v23 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -750,69 +770,87 @@ v21 = [
       "ARTIST"
     ]
   },
-  {
-    "kind": "Literal",
-    "name": "dimensionRange",
-    "value": "*-*"
-  },
   (v20/*: any*/),
-  {
-    "kind": "Literal",
-    "name": "medium",
-    "value": "*"
-  },
+  (v21/*: any*/),
+  (v22/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "-decayed_merch"
   }
 ],
-v22 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "cursor",
-  "storageKey": null
-},
-v23 = [
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "Artwork",
-    "kind": "LinkedField",
-    "name": "node",
-    "plural": false,
-    "selections": [
-      (v5/*: any*/),
-      (v2/*: any*/)
-    ],
-    "storageKey": null
-  },
-  (v22/*: any*/)
-],
 v24 = {
   "alias": null,
   "args": null,
-  "kind": "ScalarField",
-  "name": "endCursor",
+  "concreteType": "ArtworksAggregationResults",
+  "kind": "LinkedField",
+  "name": "aggregations",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slice",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AggregationCount",
+      "kind": "LinkedField",
+      "name": "counts",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "count",
+          "storageKey": null
+        },
+        (v15/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "value",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
   "storageKey": null
 },
 v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "hasNextPage",
+  "name": "cursor",
   "storageKey": null
 },
 v26 = {
   "alias": null,
   "args": null,
-  "concreteType": "PageInfo",
+  "concreteType": "FilterArtworksEdge",
   "kind": "LinkedField",
-  "name": "pageInfo",
-  "plural": false,
+  "name": "edges",
+  "plural": true,
   "selections": [
-    (v24/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Artwork",
+      "kind": "LinkedField",
+      "name": "node",
+      "plural": false,
+      "selections": [
+        (v5/*: any*/),
+        (v2/*: any*/)
+      ],
+      "storageKey": null
+    },
     (v25/*: any*/)
   ],
   "storageKey": null
@@ -821,24 +859,51 @@ v27 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "startCursor",
+  "name": "endCursor",
   "storageKey": null
 },
 v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "isAuction",
+  "name": "hasNextPage",
   "storageKey": null
 },
 v29 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "PageInfo",
+  "kind": "LinkedField",
+  "name": "pageInfo",
+  "plural": false,
+  "selections": [
+    (v27/*: any*/),
+    (v28/*: any*/)
+  ],
+  "storageKey": null
+},
+v30 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "startCursor",
+  "storageKey": null
+},
+v31 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isAuction",
+  "storageKey": null
+},
+v32 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v30 = {
+v33 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCounts",
@@ -856,7 +921,7 @@ v30 = {
   ],
   "storageKey": null
 },
-v31 = [
+v34 = [
   {
     "alias": null,
     "args": null,
@@ -865,26 +930,26 @@ v31 = [
     "storageKey": null
   }
 ],
-v32 = {
+v35 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCurrentBid",
   "kind": "LinkedField",
   "name": "currentBid",
   "plural": false,
-  "selections": (v31/*: any*/),
+  "selections": (v34/*: any*/),
   "storageKey": null
 },
-v33 = [
+v36 = [
   (v5/*: any*/)
 ],
-v34 = {
+v37 = {
   "kind": "InlineFragment",
-  "selections": (v33/*: any*/),
+  "selections": (v36/*: any*/),
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v35 = {
+v38 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -895,7 +960,7 @@ v35 = {
       "name": "pageInfo",
       "plural": false,
       "selections": [
-        (v27/*: any*/)
+        (v30/*: any*/)
       ],
       "storageKey": null
     },
@@ -962,8 +1027,8 @@ v35 = {
               "name": "sale",
               "plural": false,
               "selections": [
-                (v28/*: any*/),
-                (v29/*: any*/),
+                (v31/*: any*/),
+                (v32/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -984,8 +1049,8 @@ v35 = {
               "name": "saleArtwork",
               "plural": false,
               "selections": [
-                (v30/*: any*/),
-                (v32/*: any*/),
+                (v33/*: any*/),
+                (v35/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -1013,7 +1078,7 @@ v35 = {
           ],
           "storageKey": null
         },
-        (v34/*: any*/)
+        (v37/*: any*/)
       ],
       "storageKey": null
     }
@@ -1021,46 +1086,59 @@ v35 = {
   "type": "ArtworkConnectionInterface",
   "abstractKey": "__isArtworkConnectionInterface"
 },
-v36 = [
-  (v20/*: any*/),
+v39 = [
+  (v21/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "FEATURED_ASC"
   }
 ],
-v37 = [
+v40 = [
   (v9/*: any*/)
 ],
-v38 = [
+v41 = [
   (v5/*: any*/),
   (v15/*: any*/)
 ],
-v39 = [
+v42 = [
   "sort"
 ],
-v40 = {
+v43 = {
   "kind": "Literal",
   "name": "first",
   "value": 10
 },
-v41 = [
-  (v40/*: any*/),
+v44 = [
+  {
+    "kind": "Literal",
+    "name": "aggregations",
+    "value": [
+      "COLOR",
+      "DIMENSION_RANGE",
+      "MAJOR_PERIOD",
+      "MEDIUM",
+      "PRICE_RANGE"
+    ]
+  },
+  (v20/*: any*/),
+  (v43/*: any*/),
+  (v22/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
-    "value": "PARTNER_UPDATED_AT_DESC"
+    "value": "-partner_updated_at"
   }
 ],
-v42 = [
-  (v40/*: any*/),
+v45 = [
+  (v43/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "SORTABLE_ID_ASC"
   }
 ],
-v43 = {
+v46 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -1068,35 +1146,35 @@ v43 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v25/*: any*/),
-    (v27/*: any*/),
-    (v24/*: any*/)
+    (v28/*: any*/),
+    (v30/*: any*/),
+    (v27/*: any*/)
   ],
   "storageKey": null
 },
-v44 = {
+v47 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v45 = [
-  (v44/*: any*/)
+v48 = [
+  (v47/*: any*/)
 ],
-v46 = {
+v49 = {
   "kind": "Literal",
   "name": "status",
   "value": "CURRENT"
 },
-v47 = {
+v50 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isDisplayable",
   "storageKey": null
 },
-v48 = [
+v51 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -1113,11 +1191,11 @@ v48 = [
     "value": "CLOSED"
   }
 ],
-v49 = [
+v52 = [
   "status",
   "sort"
 ],
-v50 = [
+v53 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -1128,7 +1206,7 @@ v50 = [
     "name": "sort",
     "value": "END_AT_ASC"
   },
-  (v46/*: any*/)
+  (v49/*: any*/)
 ];
 return {
   "fragment": {
@@ -1628,66 +1706,14 @@ return {
               (v19/*: any*/),
               {
                 "alias": "fairArtworks",
-                "args": (v21/*: any*/),
+                "args": (v23/*: any*/),
                 "concreteType": "FilterArtworksConnection",
                 "kind": "LinkedField",
                 "name": "filterArtworksConnection",
                 "plural": false,
                 "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "ArtworksAggregationResults",
-                    "kind": "LinkedField",
-                    "name": "aggregations",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "slice",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "AggregationCount",
-                        "kind": "LinkedField",
-                        "name": "counts",
-                        "plural": true,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "count",
-                            "storageKey": null
-                          },
-                          (v15/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "value",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "FilterArtworksEdge",
-                    "kind": "LinkedField",
-                    "name": "edges",
-                    "plural": true,
-                    "selections": (v23/*: any*/),
-                    "storageKey": null
-                  },
+                  (v24/*: any*/),
+                  (v26/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1713,15 +1739,15 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v26/*: any*/),
+                  (v29/*: any*/),
                   (v5/*: any*/),
-                  (v35/*: any*/)
+                  (v38/*: any*/)
                 ],
                 "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,medium:\"*\",sort:\"-decayed_merch\")"
               },
               {
                 "alias": "fairArtworks",
-                "args": (v21/*: any*/),
+                "args": (v23/*: any*/),
                 "filters": [
                   "sort",
                   "medium",
@@ -1746,7 +1772,7 @@ return {
               },
               {
                 "alias": "exhibitors",
-                "args": (v36/*: any*/),
+                "args": (v39/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
@@ -1776,7 +1802,7 @@ return {
                             "kind": "LinkedField",
                             "name": "counts",
                             "plural": false,
-                            "selections": (v37/*: any*/),
+                            "selections": (v40/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1790,17 +1816,17 @@ return {
                               (v2/*: any*/),
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v38/*: any*/),
+                                "selections": (v41/*: any*/),
                                 "type": "Partner",
                                 "abstractKey": null
                               },
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v38/*: any*/),
+                                "selections": (v41/*: any*/),
                                 "type": "ExternalPartner",
                                 "abstractKey": null
                               },
-                              (v34/*: any*/)
+                              (v37/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1879,7 +1905,7 @@ return {
                                             "kind": "LinkedField",
                                             "name": "openingBid",
                                             "plural": false,
-                                            "selections": (v31/*: any*/),
+                                            "selections": (v34/*: any*/),
                                             "storageKey": null
                                           },
                                           {
@@ -1889,11 +1915,11 @@ return {
                                             "kind": "LinkedField",
                                             "name": "highestBid",
                                             "plural": false,
-                                            "selections": (v31/*: any*/),
+                                            "selections": (v34/*: any*/),
                                             "storageKey": null
                                           },
-                                          (v32/*: any*/),
-                                          (v30/*: any*/),
+                                          (v35/*: any*/),
+                                          (v33/*: any*/),
                                           (v5/*: any*/)
                                         ],
                                         "storageKey": null
@@ -1906,8 +1932,8 @@ return {
                                         "name": "sale",
                                         "plural": false,
                                         "selections": [
-                                          (v29/*: any*/),
-                                          (v28/*: any*/),
+                                          (v32/*: any*/),
+                                          (v31/*: any*/),
                                           (v19/*: any*/),
                                           (v5/*: any*/)
                                         ],
@@ -1929,18 +1955,18 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v22/*: any*/)
+                      (v25/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v26/*: any*/)
+                  (v29/*: any*/)
                 ],
                 "storageKey": "showsConnection(first:30,sort:\"FEATURED_ASC\")"
               },
               {
                 "alias": "exhibitors",
-                "args": (v36/*: any*/),
-                "filters": (v39/*: any*/),
+                "args": (v39/*: any*/),
+                "filters": (v42/*: any*/),
                 "handle": "connection",
                 "key": "FairExhibitorsQuery_exhibitors",
                 "kind": "LinkedHandle",
@@ -1986,35 +2012,40 @@ return {
               },
               {
                 "alias": "artworks",
-                "args": (v41/*: any*/),
-                "concreteType": "ArtworkConnection",
+                "args": (v44/*: any*/),
+                "concreteType": "FilterArtworksConnection",
                 "kind": "LinkedField",
-                "name": "artworksConnection",
+                "name": "filterArtworksConnection",
                 "plural": false,
                 "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "ArtworkEdge",
-                    "kind": "LinkedField",
-                    "name": "edges",
-                    "plural": true,
-                    "selections": (v23/*: any*/),
-                    "storageKey": null
-                  },
+                  (v24/*: any*/),
                   (v26/*: any*/),
-                  (v35/*: any*/)
+                  (v29/*: any*/),
+                  (v5/*: any*/),
+                  (v38/*: any*/)
                 ],
-                "storageKey": "artworksConnection(first:10,sort:\"PARTNER_UPDATED_AT_DESC\")"
+                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,medium:\"*\",sort:\"-partner_updated_at\")"
               },
               {
                 "alias": "artworks",
-                "args": (v41/*: any*/),
-                "filters": (v39/*: any*/),
+                "args": (v44/*: any*/),
+                "filters": [
+                  "acquireable",
+                  "aggregations",
+                  "attributionClass",
+                  "color",
+                  "dimensionRange",
+                  "inquireableOnly",
+                  "majorPeriods",
+                  "medium",
+                  "offerable",
+                  "priceRange",
+                  "sort"
+                ],
                 "handle": "connection",
                 "key": "Partner_artworks",
                 "kind": "LinkedHandle",
-                "name": "artworksConnection"
+                "name": "filterArtworksConnection"
               },
               (v15/*: any*/),
               {
@@ -2026,13 +2057,13 @@ return {
               },
               {
                 "alias": "artists",
-                "args": (v42/*: any*/),
+                "args": (v45/*: any*/),
                 "concreteType": "ArtistPartnerConnection",
                 "kind": "LinkedField",
                 "name": "artistsConnection",
                 "plural": false,
                 "selections": [
-                  (v43/*: any*/),
+                  (v46/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2096,7 +2127,7 @@ return {
                             "kind": "LinkedField",
                             "name": "image",
                             "plural": false,
-                            "selections": (v45/*: any*/),
+                            "selections": (v48/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -2106,14 +2137,14 @@ return {
                             "kind": "LinkedField",
                             "name": "counts",
                             "plural": false,
-                            "selections": (v37/*: any*/),
+                            "selections": (v40/*: any*/),
                             "storageKey": null
                           },
                           (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v22/*: any*/),
+                      (v25/*: any*/),
                       (v5/*: any*/)
                     ],
                     "storageKey": null
@@ -2123,8 +2154,8 @@ return {
               },
               {
                 "alias": "artists",
-                "args": (v42/*: any*/),
-                "filters": (v39/*: any*/),
+                "args": (v45/*: any*/),
+                "filters": (v42/*: any*/),
                 "handle": "connection",
                 "key": "Partner_artists",
                 "kind": "LinkedHandle",
@@ -2151,8 +2182,8 @@ return {
               {
                 "alias": "recentShows",
                 "args": [
-                  (v40/*: any*/),
-                  (v46/*: any*/)
+                  (v43/*: any*/),
+                  (v49/*: any*/)
                 ],
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
@@ -2176,7 +2207,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v5/*: any*/),
-                          (v47/*: any*/)
+                          (v50/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -2188,13 +2219,13 @@ return {
               },
               {
                 "alias": "pastShows",
-                "args": (v48/*: any*/),
+                "args": (v51/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": [
-                  (v43/*: any*/),
+                  (v46/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2211,7 +2242,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v47/*: any*/),
+                          (v50/*: any*/),
                           (v5/*: any*/),
                           (v15/*: any*/),
                           (v3/*: any*/),
@@ -2224,7 +2255,7 @@ return {
                             "name": "coverImage",
                             "plural": false,
                             "selections": [
-                              (v44/*: any*/),
+                              (v47/*: any*/),
                               (v16/*: any*/)
                             ],
                             "storageKey": null
@@ -2234,7 +2265,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v22/*: any*/)
+                      (v25/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -2243,8 +2274,8 @@ return {
               },
               {
                 "alias": "pastShows",
-                "args": (v48/*: any*/),
-                "filters": (v49/*: any*/),
+                "args": (v51/*: any*/),
+                "filters": (v52/*: any*/),
                 "handle": "connection",
                 "key": "Partner_pastShows",
                 "kind": "LinkedHandle",
@@ -2252,13 +2283,13 @@ return {
               },
               {
                 "alias": "currentAndUpcomingShows",
-                "args": (v50/*: any*/),
+                "args": (v53/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": [
-                  (v43/*: any*/),
+                  (v46/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2275,7 +2306,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v47/*: any*/),
+                          (v50/*: any*/),
                           (v5/*: any*/),
                           (v4/*: any*/),
                           (v3/*: any*/),
@@ -2289,7 +2320,7 @@ return {
                             "kind": "LinkedField",
                             "name": "images",
                             "plural": true,
-                            "selections": (v45/*: any*/),
+                            "selections": (v48/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -2309,10 +2340,10 @@ return {
                                 "type": "Partner",
                                 "abstractKey": null
                               },
-                              (v34/*: any*/),
+                              (v37/*: any*/),
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v33/*: any*/),
+                                "selections": (v36/*: any*/),
                                 "type": "ExternalPartner",
                                 "abstractKey": null
                               }
@@ -2326,14 +2357,14 @@ return {
                             "kind": "LinkedField",
                             "name": "coverImage",
                             "plural": false,
-                            "selections": (v45/*: any*/),
+                            "selections": (v48/*: any*/),
                             "storageKey": null
                           },
                           (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v22/*: any*/)
+                      (v25/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -2342,8 +2373,8 @@ return {
               },
               {
                 "alias": "currentAndUpcomingShows",
-                "args": (v50/*: any*/),
-                "filters": (v49/*: any*/),
+                "args": (v53/*: any*/),
+                "filters": (v52/*: any*/),
                 "handle": "connection",
                 "key": "Partner_currentAndUpcomingShows",
                 "kind": "LinkedHandle",
@@ -2371,14 +2402,14 @@ return {
             "type": "Partner",
             "abstractKey": null
           },
-          (v34/*: any*/)
+          (v37/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "5d3ab99350a52779596838f0d48aa6af",
+    "id": "52fcf6a5020336a545051f7a20b65e12",
     "metadata": {},
     "name": "VanityURLEntityQuery",
     "operationKind": "query",

--- a/src/lib/Components/FilterModal/FilterModal.tsx
+++ b/src/lib/Components/FilterModal/FilterModal.tsx
@@ -70,11 +70,12 @@ export interface FilterDisplayConfig {
 export enum FilterModalMode {
   ArtistArtworks = "ArtistArtworks",
   ArtistSeries = "ArtistSeries",
-  Collection = "Collection",
-  SaleArtworks = "SaleArtworks",
-  Fair = "Fair",
-  Show = "Show",
   AuctionResults = "AuctionResults",
+  Collection = "Collection",
+  Fair = "Fair",
+  Partner = "Partner",
+  SaleArtworks = "SaleArtworks",
+  Show = "Show",
 }
 
 interface FilterModalProps extends ViewProperties {
@@ -269,6 +270,15 @@ export const FilterModalNavigator: React.FC<FilterModalProps> = (props) => {
                     trackChangeFilters(
                       PageNames.AuctionResult,
                       OwnerEntityTypes.AuctionResult,
+                      appliedFiltersParams,
+                      changedFiltersParams(appliedFiltersParams, state.selectedFilters)
+                    )
+                    break
+
+                  case FilterModalMode.Partner:
+                    trackChangeFilters(
+                      PageNames.PartnerPage,
+                      OwnerEntityTypes.Partner,
                       appliedFiltersParams,
                       changedFiltersParams(appliedFiltersParams, state.selectedFilters)
                     )
@@ -482,6 +492,18 @@ export const getFilterScreenSortByMode = (mode: FilterModalMode) => (
       break
     case FilterModalMode.AuctionResults:
       sortOrder = AuctionResultsFiltersSorted
+      break
+    case FilterModalMode.Partner:
+      sortOrder = [
+        "sort",
+        "medium",
+        "attributionClass",
+        "priceRange",
+        "waysToBuy",
+        "dimensionRange",
+        "majorPeriods",
+        "color",
+      ]
       break
   }
 

--- a/src/lib/Scenes/Partner/Components/PartnerArtwork.tsx
+++ b/src/lib/Scenes/Partner/Components/PartnerArtwork.tsx
@@ -1,27 +1,56 @@
 import { PartnerArtwork_partner } from "__generated__/PartnerArtwork_partner.graphql"
 import { InfiniteScrollArtworksGridContainer as InfiniteScrollArtworksGrid } from "lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
+import { AnimatedArtworkFilterButton, FilterModalMode, FilterModalNavigator } from "lib/Components/FilterModal"
 import { StickyTabPageScrollView } from "lib/Components/StickyTabPage/StickyTabPageScrollView"
 import { TabEmptyState } from "lib/Components/TabEmptyState"
+import { useArtworkFilters } from "lib/utils/ArtworkFilter/useArtworkFilters"
 import { get } from "lib/utils/get"
 import { Spacer } from "palette"
-import React from "react"
+import React, { useState } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 
 export const PartnerArtwork: React.FC<{
   partner: PartnerArtwork_partner
   relay: RelayPaginationProp
 }> = ({ partner, relay }) => {
+  useArtworkFilters({ relay, aggregations: partner.artworks?.aggregations })
+
+  const [isFilterArtworksModalVisible, setIsFilterArtworksModalVisible] = useState(false)
+
   const artworks = get(partner, (p) => p.artworks)
 
   return (
-    <StickyTabPageScrollView>
-      <Spacer mb={2} />
-      {artworks ? (
-        <InfiniteScrollArtworksGrid connection={artworks} loadMore={relay.loadMore} hasMore={relay.hasMore} />
-      ) : (
-        <TabEmptyState text="There is no artwork from this gallery yet" />
-      )}
-    </StickyTabPageScrollView>
+    <>
+      <StickyTabPageScrollView>
+        <Spacer mb={2} />
+
+        {artworks ? (
+          <InfiniteScrollArtworksGrid connection={artworks} loadMore={relay.loadMore} hasMore={relay.hasMore} />
+        ) : (
+          <TabEmptyState text="There is no artwork from this gallery yet" />
+        )}
+      </StickyTabPageScrollView>
+
+      <AnimatedArtworkFilterButton
+        isVisible={true}
+        onPress={() => {
+          setIsFilterArtworksModalVisible(true)
+        }}
+      />
+
+      <FilterModalNavigator
+        isFilterArtworksModalVisible={isFilterArtworksModalVisible}
+        id={partner.internalID}
+        slug={partner.slug}
+        mode={FilterModalMode.Partner}
+        exitModal={() => {
+          setIsFilterArtworksModalVisible(false)
+        }}
+        closeModal={() => {
+          setIsFilterArtworksModalVisible(false)
+        }}
+      />
+    </>
   )
 }
 
@@ -31,14 +60,45 @@ export const PartnerArtworkFragmentContainer = createPaginationContainer(
     partner: graphql`
       fragment PartnerArtwork_partner on Partner
       @argumentDefinitions(
-        # 10 matche the PAGE_SIZE constant. This is required. See MX-316 for follow-up.
+        acquireable: { type: "Boolean" }
+        attributionClass: { type: "[String]" }
+        color: { type: "String" }
+        # 10 matches the PAGE_SIZE constant. This is required. See MX-316 for follow-up.
         count: { type: "Int", defaultValue: 10 }
         cursor: { type: "String" }
-        sort: { type: "ArtworkSorts", defaultValue: PARTNER_UPDATED_AT_DESC }
+        dimensionRange: { type: "String", defaultValue: "*-*" }
+        inquireableOnly: { type: "Boolean" }
+        majorPeriods: { type: "[String]" }
+        medium: { type: "String", defaultValue: "*" }
+        offerable: { type: "Boolean" }
+        priceRange: { type: "String" }
+        sort: { type: "String", defaultValue: "-partner_updated_at" }
       ) {
         internalID
-        artworks: artworksConnection(sort: $sort, first: $count, after: $cursor) @connection(key: "Partner_artworks") {
-          # TODO: Just to satisfy relay-compiler
+        slug
+        artworks: filterArtworksConnection(
+          acquireable: $acquireable
+          after: $cursor
+          aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]
+          attributionClass: $attributionClass
+          color: $color
+          dimensionRange: $dimensionRange
+          first: $count
+          inquireableOnly: $inquireableOnly
+          majorPeriods: $majorPeriods
+          medium: $medium
+          offerable: $offerable
+          priceRange: $priceRange
+          sort: $sort
+        ) @connection(key: "Partner_artworks") {
+          aggregations {
+            slice
+            counts {
+              count
+              name
+              value
+            }
+          }
           edges {
             node {
               id
@@ -53,17 +113,46 @@ export const PartnerArtworkFragmentContainer = createPaginationContainer(
     getConnectionFromProps(props) {
       return props.partner && props.partner.artworks
     },
-    getVariables(props, { count, cursor }) {
+    getVariables(props, { count, cursor }, fragmentVariables) {
       return {
+        ...fragmentVariables,
         id: props.partner.internalID,
         count,
         cursor,
       }
     },
     query: graphql`
-      query PartnerArtworkInfiniteScrollGridQuery($id: String!, $cursor: String, $count: Int!) {
+      query PartnerArtworkInfiniteScrollGridQuery(
+        $acquireable: Boolean
+        $attributionClass: [String]
+        $color: String
+        $count: Int!
+        $cursor: String
+        $dimensionRange: String
+        $id: String!
+        $inquireableOnly: Boolean
+        $majorPeriods: [String]
+        $medium: String
+        $offerable: Boolean
+        $priceRange: String
+        $sort: String
+      ) {
         partner(id: $id) {
-          ...PartnerArtwork_partner @arguments(count: $count, cursor: $cursor)
+          ...PartnerArtwork_partner
+            @arguments(
+              acquireable: $acquireable
+              attributionClass: $attributionClass
+              color: $color
+              count: $count
+              cursor: $cursor
+              dimensionRange: $dimensionRange
+              inquireableOnly: $inquireableOnly
+              majorPeriods: $majorPeriods
+              medium: $medium
+              offerable: $offerable
+              priceRange: $priceRange
+              sort: $sort
+            )
         }
       }
     `,

--- a/src/lib/Scenes/Partner/Partner.tsx
+++ b/src/lib/Scenes/Partner/Partner.tsx
@@ -4,6 +4,7 @@ import { HeaderTabsGridPlaceholder } from "lib/Components/HeaderTabGridPlacehold
 import { RetryErrorBoundary } from "lib/Components/RetryErrorBoundary"
 import { StickyTabPage } from "lib/Components/StickyTabPage/StickyTabPage"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
+import { ArtworkFilterGlobalStateProvider } from "lib/utils/ArtworkFilter/ArtworkFiltersStore"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { Schema, screenTrack } from "lib/utils/track"
 import React from "react"
@@ -38,7 +39,11 @@ class Partner extends React.Component<Props> {
           {
             title: "Artworks",
             initial: true,
-            content: <PartnerArtwork partner={partner} />,
+            content: (
+              <ArtworkFilterGlobalStateProvider>
+                <PartnerArtwork partner={partner} />
+              </ArtworkFilterGlobalStateProvider>
+            ),
           },
           {
             title: "Shows",

--- a/src/lib/Scenes/VanityURL/VanityURLEntity.tsx
+++ b/src/lib/Scenes/VanityURL/VanityURLEntity.tsx
@@ -23,7 +23,7 @@ const VanityURLEntity: React.FC<EntityProps> = ({ fairOrPartner, originalSlug })
   } else if (fairOrPartner.__typename === "Partner") {
     const { safeAreaInsets } = useScreenDimensions()
     return (
-      <View style={{ flex: 1, top: safeAreaInsets.top ?? 0 }}>
+      <View style={{ flex: 1, paddingTop: safeAreaInsets.top ?? 0 }}>
         <PartnerContainer partner={fairOrPartner} />
       </View>
     )

--- a/src/lib/utils/ArtworkFilter/useArtworkFilters.ts
+++ b/src/lib/utils/ArtworkFilter/useArtworkFilters.ts
@@ -1,0 +1,40 @@
+import { useContext, useEffect } from "react"
+import { RelayPaginationProp } from "react-relay"
+import { ArtworkFilterContext } from "./ArtworkFiltersStore"
+import { filterArtworksParams } from "./FilterArtworksHelpers"
+
+export const useArtworkFilters = ({
+  relay,
+  aggregations,
+}: { relay?: RelayPaginationProp; aggregations?: unknown } = {}) => {
+  const { dispatch, state } = useContext(ArtworkFilterContext)
+  const filterParams = filterArtworksParams(state.appliedFilters, state.filterType)
+
+  useEffect(() => {
+    if (!aggregations) {
+      return
+    }
+
+    dispatch({ type: "setAggregations", payload: aggregations })
+  }, [aggregations])
+
+  useEffect(() => {
+    if (relay && state.applyFilters) {
+      relay.refetchConnection(
+        30,
+        (error) => {
+          if (error) {
+            throw error
+          }
+        },
+        filterParams
+      )
+    }
+  }, [relay, state.appliedFilters, filterParams])
+
+  return {
+    dispatch,
+    state,
+    filterParams,
+  }
+}


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR resolves [FX-2557]

### Description

![](https://static.damonzucconi.com/_capture/dFtg3Fiv.gif)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2557]: https://artsyproduct.atlassian.net/browse/FX-2557