### PR TITLE
chore: use isOfferableFromInquiry to conditionally render make offer button

### DIFF
--- a/src/__generated__/ConversationQuery.graphql.ts
+++ b/src/__generated__/ConversationQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash af022aaf5846304690e83d53e8bca0d8 */
+/* @relayHash 5d748adb621af109ac3562fca471eb8d */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -54,6 +54,7 @@ fragment Conversation_me on Me {
         ... on Artwork {
           href
           slug
+          isOfferableFromInquiry
         }
         ... on Show {
           href
@@ -385,6 +386,13 @@ return {
                         "selections": [
                           (v2/*: any*/),
                           (v3/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isOfferableFromInquiry",
+                            "storageKey": null
+                          },
                           (v4/*: any*/),
                           {
                             "alias": null,
@@ -709,7 +717,7 @@ return {
     ]
   },
   "params": {
-    "id": "af022aaf5846304690e83d53e8bca0d8",
+    "id": "5d748adb621af109ac3562fca471eb8d",
     "metadata": {},
     "name": "ConversationQuery",
     "operationKind": "query",

--- a/src/__generated__/Conversation_me.graphql.ts
+++ b/src/__generated__/Conversation_me.graphql.ts
@@ -11,6 +11,7 @@ export type Conversation_me = {
                 readonly __typename: "Artwork";
                 readonly href: string | null;
                 readonly slug: string;
+                readonly isOfferableFromInquiry: boolean | null;
             } | {
                 readonly __typename: "Show";
                 readonly href: string | null;
@@ -108,6 +109,13 @@ return {
                       "kind": "ScalarField",
                       "name": "slug",
                       "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "isOfferableFromInquiry",
+                      "storageKey": null
                     }
                   ],
                   "type": "Artwork",
@@ -204,5 +212,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '7416664765d5665693a643c35d881392';
+(node as any).hash = '14ee975eb276b28d515aa0d357d6e1cb';
 export default node;

--- a/src/lib/Scenes/Inbox/Components/Conversations/Composer.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/Composer.tsx
@@ -34,6 +34,7 @@ interface Props {
   onSubmit?: (text: string) => any
   value?: string
   artworkID?: string | null
+  isOfferableFromInquiry?: boolean | null
 }
 
 interface State {
@@ -92,7 +93,8 @@ export default class Composer extends React.Component<Props, State> {
     const disableSendButton = !(this.state.text && this.state.text.length) || this.props.disabled
 
     // GOTCHA: Don't copy this kind of feature flag code if you're working in a functional component. use `useFeatureFlag` instead
-    const showInquiryMakeOfferButton = unsafe_getFeatureFlag("AROptionsInquiryCheckout")
+    const showInquiryMakeOfferButton =
+      unsafe_getFeatureFlag("AROptionsInquiryCheckout") && this.props.isOfferableFromInquiry
     return (
       <ScreenDimensionsContext.Consumer>
         {({ safeAreaInsets }) => (

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/Composer-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/Composer-tests.tsx
@@ -56,7 +56,7 @@ describe("regarding the make offer button", () => {
   })
 
   it("doesn't render the inquiry make offer button if the artwork is not offerable", () => {
-    __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsInquiryCheckout: false })
+    __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsInquiryCheckout: true })
     const tree = renderWithWrappers(<Composer artworkID="123456" isOfferableFromInquiry={false} />)
     expect(tree.root.findAllByType(Button).length).toEqual(1)
   })

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/Composer-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/Composer-tests.tsx
@@ -37,9 +37,9 @@ describe("regarding the send button", () => {
 })
 
 describe("regarding the make offer button", () => {
-  it("renders the inquiry make offer button if inquiry checkout flag is true and artwork ID is  not null", () => {
+  it("renders the inquiry make offer button if inquiry checkout flag is true, artwork ID is not null, and isOfferableFromInquiry is true", () => {
     __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsInquiryCheckout: true })
-    const tree = renderWithWrappers(<Composer artworkID="12234" />)
+    const tree = renderWithWrappers(<Composer artworkID="12234" isOfferableFromInquiry={true} />)
     expect(tree.root.findAllByType(Button).length).toEqual(2)
   })
 
@@ -52,6 +52,12 @@ describe("regarding the make offer button", () => {
   it("doesn't render the inquiry make offer button if inquiry item is not an artwork", () => {
     __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsInquiryCheckout: false })
     const tree = renderWithWrappers(<Composer />)
+    expect(tree.root.findAllByType(Button).length).toEqual(1)
+  })
+
+  it("doesn't render the inquiry make offer button if the artwork is not offerable", () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsInquiryCheckout: false })
+    const tree = renderWithWrappers(<Composer artworkID="123456" isOfferableFromInquiry={false} />)
     expect(tree.root.findAllByType(Button).length).toEqual(1)
   })
 })

--- a/src/lib/Scenes/Inbox/Screens/Conversation.tsx
+++ b/src/lib/Scenes/Inbox/Screens/Conversation.tsx
@@ -141,11 +141,12 @@ export class Conversation extends React.Component<Props, State> {
     const conversation = this.props.me.conversation
     // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const partnerName = conversation.to.name
-
     const artworkSlug =
       conversation?.items?.[0]?.item && conversation?.items?.[0]?.item.__typename === "Artwork"
-        ? conversation?.items?.[0]?.item.slug
+        ? conversation?.items?.[0]?.item?.slug
         : null
+    const showOfferableInquiryButton =
+      conversation?.items?.[0]?.item?.__typename === "Artwork" && conversation?.items?.[0]?.item?.isOfferableFromInquiry
 
     return (
       <Composer
@@ -155,6 +156,7 @@ export class Conversation extends React.Component<Props, State> {
         // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         value={this.state.failedMessageText}
         artworkID={artworkSlug}
+        isOfferableFromInquiry={showOfferableInquiryButton}
         onSubmit={(text) => {
           this.setState({ sendingMessage: true, failedMessageText: null })
           sendConversationMessage(
@@ -224,6 +226,7 @@ export const ConversationFragmentContainer = createFragmentContainer(Conversatio
             ... on Artwork {
               href
               slug
+              isOfferableFromInquiry
             }
             ... on Show {
               href


### PR DESCRIPTION
The type of this PR is: **Chore**

This PR resolves [Purchase-2414]

### Description

This PR includes `isOfferableFromInquiry` in the artwork query for conversations to conditionally render the Make Offer button.

cc: @artsy/purchase-devs 

### PR Checklist (tick all before merging)

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [ ] I have documented any follow-up work that this PR will require, or it does not require any.
- [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
