### PR TITLE
fix: auction results more QA fixes

### DIFF
--- a/src/lib/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
@@ -111,8 +111,8 @@ const ArtistInsightsAuctionResults: React.FC<Props> = ({ artist, relay }) => {
     <>
       <Spacer my={1} />
       <Text>
-        These auction results bring together sale data from top auction houses around the world, including Christies,
-        Sotheby’s, Phillips, Bonhams, and Heritage. Results are updated daily.
+        These auction results bring together sale data from top auction houses around the world, including
+        Christie&rsquo;s, Sotheby&rsquo;s, Phillips, Bonhams, and Heritage. Results are updated daily.
       </Text>
       <Spacer mb={2} />
       <Text>

--- a/src/lib/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
@@ -168,7 +168,7 @@ const ArtistInsightsAuctionResults: React.FC<Props> = ({ artist, relay }) => {
               new Intl.NumberFormat().format(artist.auctionResultsConnection.totalCount)}{" "}
             {resultsString} {bullet} Sorted by {getSortDescription()?.toLowerCase()}
           </SortMode>
-          <Separator mt="2" />
+          <Separator borderColor={color("black5")} mt="2" />
         </Flex>
       )}
       ItemSeparatorComponent={() => (

--- a/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
@@ -57,7 +57,7 @@ const MarketStats: React.FC<MarketStatsProps> = ({ priceInsightsConnection }) =>
         other additional fees (e.g., Artist’s Resale Rights).
       </Text>
       <Spacer mb={2} />
-      <Text fontWeight={"bold"}>Yearly lots sold</Text>
+      <Text fontWeight={"bold"}>Average yearly lots sold</Text>
       <Spacer mb={1} />
       <Text>The average number of lots sold per year at auction over the past 36 months.</Text>
       <Spacer mb={2} />

--- a/src/lib/Components/ArtworkFilterOptions/YearOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/YearOptions.tsx
@@ -16,7 +16,7 @@ import { FilterModalNavigationStack } from "../FilterModal"
 interface YearOptionsScreenProps extends StackScreenProps<FilterModalNavigationStack, "YearOptionsScreen"> {}
 
 export const ALLOW_EMPTY_CREATED_DATES_FILTER: FilterData = {
-  displayText: "Include lots without year created info",
+  displayText: "Include lots without artwork date listed",
   paramName: FilterParamName.allowEmptyCreatedDates,
   paramValue: true,
 }

--- a/src/lib/Components/ArtworkGrids/FilteredArtworkGridZeroState.tsx
+++ b/src/lib/Components/ArtworkGrids/FilteredArtworkGridZeroState.tsx
@@ -19,7 +19,7 @@ export const FilteredArtworkGridZeroState: React.FC<ZeroStateProps> = (props) =>
 
   return (
     <Flex flexDirection="column" px={4}>
-      <ZeroStateMessage size="3">Unfortunately, there are no works that meet your criteria.</ZeroStateMessage>
+      <ZeroStateMessage size="3">No results found{"\n"}Please try another search.</ZeroStateMessage>
       <Flex m="0 auto" pt={2}>
         <Button
           size="medium"

--- a/src/lib/Components/AuctionResult/AuctionResultMidEstimate.tsx
+++ b/src/lib/Components/AuctionResult/AuctionResultMidEstimate.tsx
@@ -1,14 +1,19 @@
-import { DecreaseIcon, Flex, IncreaseIcon, Text } from "palette"
+import { DecreaseIcon, Flex, IncreaseIcon, Text, TextVariant } from "palette"
 import React from "react"
 
 interface AuctionResultsMidEstimateProps {
   value: string
   shortDescription: string
+  textVariant?: TextVariant
 }
 
 type ArrowDirections = "up" | "down"
 
-export const AuctionResultsMidEstimate: React.FC<AuctionResultsMidEstimateProps> = ({ value, shortDescription }) => {
+export const AuctionResultsMidEstimate: React.FC<AuctionResultsMidEstimateProps> = ({
+  value,
+  textVariant = "small",
+  shortDescription,
+}) => {
   const arrowDirection: ArrowDirections = value[0] !== "-" ? "up" : "down"
 
   const color = ratioColor(value)
@@ -21,7 +26,7 @@ export const AuctionResultsMidEstimate: React.FC<AuctionResultsMidEstimateProps>
       ) : (
         <DecreaseIcon height={12} fill={color} />
       )}
-      <Text variant="small" color={color}>
+      <Text variant={textVariant} color={color}>
         {value.replace("-", "")} {shortDescription}
       </Text>
     </Flex>

--- a/src/lib/Components/AuctionResult/AuctionResultMidEstimate.tsx
+++ b/src/lib/Components/AuctionResult/AuctionResultMidEstimate.tsx
@@ -27,7 +27,7 @@ export const AuctionResultsMidEstimate: React.FC<AuctionResultsMidEstimateProps>
         <DecreaseIcon height={12} fill={color} />
       )}
       <Text variant={textVariant} color={color}>
-        {value.replace("-", "")} {shortDescription}
+        {new Intl.NumberFormat().format(Number(value.replace(/%|-/gm, "")))}% {shortDescription}
       </Text>
     </Flex>
   )

--- a/src/lib/Components/Lists/AuctionResult.tsx
+++ b/src/lib/Components/Lists/AuctionResult.tsx
@@ -50,7 +50,7 @@ const AuctionResult: React.FC<Props> = ({ auctionResult, onPress }) => {
         {/* Sale Artwork Details */}
         <Flex pl={15} flex={1} flexDirection="row" justifyContent="space-between">
           <Flex flex={3}>
-            <Flex flexDirection="row" mb={0.5}>
+            <Flex flexDirection="row" mb={"3px"}>
               <Text variant="caption" ellipsizeMode="middle" numberOfLines={2} style={{ flexShrink: 1 }}>
                 {auctionResult.title}
                 {!!auctionResult.dateText && auctionResult.dateText !== "" && `, ${auctionResult.dateText}`}

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesArtworks-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesArtworks-tests.tsx
@@ -83,6 +83,6 @@ describe("Artist Series Artworks", () => {
 
     expect(tree.root.findAllByType(InfiniteScrollArtworksGridContainer)).toHaveLength(0)
     expect(tree.root.findAllByType(FilteredArtworkGridZeroState)).toHaveLength(1)
-    expect(extractText(tree.root)).toContain("Unfortunately, there are no works that meet your criteria.")
+    expect(extractText(tree.root)).toContain("No results found\nPlease try another search.Clear filtersClear filters")
   })
 })

--- a/src/lib/Scenes/AuctionResult/AuctionResult.tsx
+++ b/src/lib/Scenes/AuctionResult/AuctionResult.tsx
@@ -205,7 +205,11 @@ const AuctionResult: React.FC<Props> = ({ artist, auctionResult }) => {
             <>
               <Text variant="largeTitle" mb={0.5}>{`${auctionResult.priceRealized?.display}`}</Text>
               {!!auctionResult.performance?.mid && (
-                <AuctionResultsMidEstimate value={auctionResult.performance.mid} shortDescription="mid-estimate" />
+                <AuctionResultsMidEstimate
+                  textVariant="caption"
+                  value={auctionResult.performance.mid}
+                  shortDescription="mid-estimate"
+                />
               )}
             </>
           ) : (

--- a/src/lib/Scenes/AuctionResult/AuctionResult.tsx
+++ b/src/lib/Scenes/AuctionResult/AuctionResult.tsx
@@ -103,16 +103,16 @@ const AuctionResult: React.FC<Props> = ({ artist, auctionResult }) => {
     </Flex>
   )
   if (auctionResult.estimate?.display) {
-    details.push(makeRow("Estimate range", auctionResult.estimate?.display))
+    details.push(makeRow("Pre-sale estimate", auctionResult.estimate?.display))
   }
   if (auctionResult.mediumText) {
-    details.push(makeRow("Medium", capitalize(auctionResult.mediumText)))
+    details.push(makeRow("Materials", capitalize(auctionResult.mediumText)))
   }
   if (auctionResult.dimensionText) {
     details.push(makeRow("Dimensions", auctionResult.dimensionText))
   }
   if (auctionResult.dateText) {
-    details.push(makeRow("Year created", auctionResult.dateText))
+    details.push(makeRow("Artwork date", auctionResult.dateText))
   }
   if (auctionResult.saleDate) {
     details.push(

--- a/src/lib/Scenes/Collection/Screens/__tests__/CollectionArtworks-tests.tsx
+++ b/src/lib/Scenes/Collection/Screens/__tests__/CollectionArtworks-tests.tsx
@@ -78,7 +78,7 @@ describe("CollectionArtworks", () => {
     })
 
     expect(tree.root.findAllByType(FilteredArtworkGridZeroState)).toHaveLength(1)
-    expect(extractText(tree.root)).toContain("Unfortunately, there are no works that meet your criteria.")
+    expect(extractText(tree.root)).toContain("No results found\nPlease try another search.Clear filtersClear filters")
   })
 
   it("returns artworks", () => {

--- a/src/lib/Scenes/Fair/__tests__/FairArtworks-tests.tsx
+++ b/src/lib/Scenes/Fair/__tests__/FairArtworks-tests.tsx
@@ -93,6 +93,8 @@ describe("FairArtworks", () => {
     expect(wrapper.root.findAllByType(InfiniteScrollArtworksGridContainer)).toHaveLength(0)
     expect(wrapper.root.findAllByType(InfiniteScrollArtworksGridContainer)).toHaveLength(0)
     expect(wrapper.root.findAllByType(FilteredArtworkGridZeroState)).toHaveLength(1)
-    expect(extractText(wrapper.root)).toContain("Unfortunately, there are no works that meet your criteria.")
+    expect(extractText(wrapper.root)).toContain(
+      "No results found\nPlease try another search.Clear filtersClear filters"
+    )
   })
 })

--- a/src/lib/utils/ArtworkFilter/FilterArtworksHelpers.ts
+++ b/src/lib/utils/ArtworkFilter/FilterArtworksHelpers.ts
@@ -56,7 +56,7 @@ export enum FilterDisplayName {
   sort = "Sort by",
   timePeriod = "Time period",
   viewAs = "View as",
-  year = "Year created",
+  year = "Artwork date",
   waysToBuy = "Ways to buy",
 }
 


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-947] [CX-1022][CX-1024]

### Description
<details>
  <summary>Format big mid-estimate percentages!</summary>
  <img width="331" alt="Screenshot 2021-02-10 at 19 43 54" src="https://user-images.githubusercontent.com/11945712/107556133-53532d00-6bd8-11eb-9810-248e341b37f1.png">
</details>

___

<details>
  <summary>Reduce the space between the title and the medium+data+auction house</summary>
<img width="326" alt="Screenshot 2021-02-10 at 19 48 43" src="https://user-images.githubusercontent.com/11945712/107556750-189dc480-6bd9-11eb-971b-b93dce001c65.png">
</details>

___

<details>
  <summary>Reduce the space between the title and the medium+data+auction house</summary>
<img width="326" alt="Screenshot 2021-02-10 at 19 48 43" src="https://user-images.githubusercontent.com/11945712/107556750-189dc480-6bd9-11eb-971b-b93dce001c65.png">
</details>

___

<details>
  <summary>make mid estimate size bigger on auction result details</summary>

**After**
<img width="337" alt="Screenshot 2021-02-10 at 19 50 40" src="https://user-images.githubusercontent.com/11945712/107556979-54d12500-6bd9-11eb-8974-58fed440ddbb.png">

**Before**
<img width="337" alt="Screenshot 2021-02-10 at 19 50 59" src="https://user-images.githubusercontent.com/11945712/107556986-569ae880-6bd9-11eb-9860-1df6c2455687.png">

</details>

___

<details>
  <summary>make divider color lighter</summary>

**After**
<img width="341" alt="Screenshot 2021-02-10 at 19 53 14" src="https://user-images.githubusercontent.com/11945712/107557239-a37ebf00-6bd9-11eb-9884-82f1df25840a.png">

**Before**
<img width="331" alt="Screenshot 2021-02-10 at 19 53 00" src="https://user-images.githubusercontent.com/11945712/107557258-a8437300-6bd9-11eb-9b55-0f56b8897af5.png">

</details>

___

<details>
  <summary>Copy updates</summary>

**1. Change “Year created” → “Artwork date” on:**
    a. Details Page
    b. Filter sheet (menu option in list and title on filter panel when selected)
    c. On the “Artwork date” filter page, change “Include lots without year created info” → “Include lots without artwork date listed”

**2. On details page** 
    a. Change “Estimate range” → “Pre-sale estimate”
    b. On the details page, the estimate range should use an en dash (&ndash;) instead of a hyphen 
    c. Change “Medium” → “Materials” (this is text like “oil on paper”)
    d. Change “Year created” → “Artwork date” (Also noted in #1)

**3. On the auction results empty state, change copy to:**
    a. “No results found” <br> “Please try another search.”

**4. Info modal**
    a. The apostrophes in Christie’s and Sotheby’s should use a curly quote (&rsquo;) instead of a straight quote

**5. Market Signals module** 
    a. Change “Yearly lots sold” to “Average yearly lots sold”
</details>



<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-947]: https://artsyproduct.atlassian.net/browse/CX-947
[CX-1022]: https://artsyproduct.atlassian.net/browse/CX-1022
[CX-1024]: https://artsyproduct.atlassian.net/browse/CX-1024