### PR TITLE
fix: markets stats qa fixes

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -12,6 +12,7 @@ upcoming:
     - Convert cents to dollars in market stats - pepopowitz
     - Dedupe currencies in auction results - pepopowitz
     - update support email - brian
+    - Market stats formatting fixes - brian
 
 releases:
   - version: 6.7.7

--- a/src/__generated__/MarketStatsQuery.graphql.ts
+++ b/src/__generated__/MarketStatsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash c9d50c61559ce7b240dc4433a2563a2f */
+/* @relayHash 493670ff35fcfa2c2a856f7060338013 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -24,7 +24,7 @@ export type MarketStatsQuery = {
 query MarketStatsQuery(
   $artistInternalID: ID!
 ) {
-  priceInsightsConnection: priceInsights(artistId: $artistInternalID, sort: DEMAND_RANK_DESC) {
+  priceInsightsConnection: priceInsights(artistId: $artistInternalID, sort: ANNUAL_VALUE_SOLD_CENTS_DESC) {
     ...MarketStats_priceInsightsConnection
   }
 }
@@ -60,7 +60,7 @@ v1 = [
   {
     "kind": "Literal",
     "name": "sort",
-    "value": "DEMAND_RANK_DESC"
+    "value": "ANNUAL_VALUE_SOLD_CENTS_DESC"
   }
 ];
 return {
@@ -174,7 +174,7 @@ return {
     ]
   },
   "params": {
-    "id": "c9d50c61559ce7b240dc4433a2563a2f",
+    "id": "493670ff35fcfa2c2a856f7060338013",
     "metadata": {},
     "name": "MarketStatsQuery",
     "operationKind": "query",
@@ -182,5 +182,5 @@ return {
   }
 };
 })();
-(node as any).hash = '9d5ded2803382428ef7cb7ca0e062037';
+(node as any).hash = 'b8c04641b23e82c0ad5fb0e068f340a0';
 export default node;

--- a/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
@@ -180,7 +180,7 @@ export const MarketStatsQueryRenderer: React.FC<{
       variables={{ artistInternalID }}
       query={graphql`
         query MarketStatsQuery($artistInternalID: ID!) {
-          priceInsightsConnection: priceInsights(artistId: $artistInternalID, sort: DEMAND_RANK_DESC) {
+          priceInsightsConnection: priceInsights(artistId: $artistInternalID, sort: ANNUAL_VALUE_SOLD_CENTS_DESC) {
             ...MarketStats_priceInsightsConnection
           }
         }

--- a/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
@@ -91,6 +91,7 @@ const MarketStats: React.FC<MarketStatsProps> = ({ priceInsightsConnection }) =>
   } else if (actualMedianSaleOverEstimatePercentage > 0) {
     deltaIcon = <IncreaseIcon />
   }
+  const formattedMedianSaleOverEstimatePercentage = Math.abs(actualMedianSaleOverEstimatePercentage)
 
   const sellThroughRatePercentage = (selectedPriceInsight.sellThroughRate as number) * 100
   // show up to 2 decimal places
@@ -147,7 +148,7 @@ const MarketStats: React.FC<MarketStatsProps> = ({ priceInsightsConnection }) =>
           <Flex width="50%" flexDirection="row" alignItems="center">
             <Join separator={<Spacer mr={0.5} />}>
               {deltaIcon}
-              <Text variant="largeTitle">{actualMedianSaleOverEstimatePercentage}%</Text>
+              <Text variant="largeTitle">{formattedMedianSaleOverEstimatePercentage}%</Text>
             </Join>
           </Flex>
           <Text variant="text">Sale price over estimate</Text>

--- a/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
@@ -92,6 +92,10 @@ const MarketStats: React.FC<MarketStatsProps> = ({ priceInsightsConnection }) =>
     deltaIcon = <IncreaseIcon />
   }
 
+  const sellThroughRatePercentage = (selectedPriceInsight.sellThroughRate as number) * 100
+  // show up to 2 decimal places
+  const formattedSellThroughRate = Math.round(sellThroughRatePercentage * 100) / 100
+
   return (
     <>
       <Flex flexDirection="row" alignItems="center">
@@ -132,7 +136,7 @@ const MarketStats: React.FC<MarketStatsProps> = ({ priceInsightsConnection }) =>
           <Text variant="text">Yearly lots sold</Text>
         </Flex>
         <Flex width="50%">
-          <Text variant="largeTitle">{selectedPriceInsight.sellThroughRate}%</Text>
+          <Text variant="largeTitle">{formattedSellThroughRate}%</Text>
           <Text variant="text">Sell-through rate</Text>
         </Flex>
         <Flex width="50%" mt={2}>


### PR DESCRIPTION
The type of this PR is: **fix**

This PR resolves [CX-1050]
This PR resolves [CX-1051]
This PR resolves [CX-1053]

### Description

- Multiplies sell-through rate by 100 and displays at most 2 decimal places (doesn't display trailing 0s)
- Updates sort for market stats query to ANNUAL_VALUE_SOLD_CENTS_DESC
- Uses absolute value for sale price over estimate to avoid negative symbol (we already have down arrow)

### Screenshots

#### Before

<img width="429" alt="Screen Shot 2021-02-11 at 8 40 19 AM" src="https://user-images.githubusercontent.com/49686530/107643948-c7c3b580-6c44-11eb-99a5-9abfbda0cb72.png">

#### After
<img width="429" alt="Screen Shot 2021-02-11 at 8 44 58 AM" src="https://user-images.githubusercontent.com/49686530/107644464-77008c80-6c45-11eb-9f12-5be7adfbc9e5.png">


### Follow-ups

This is the quick fix but I am going to try to follow-up with moving some of this formatting to metaphysics and serving display values as strings to the app, if anyone wants to pair on that let me know!

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-1050]: https://artsyproduct.atlassian.net/browse/CX-1050
[CX-1051]: https://artsyproduct.atlassian.net/browse/CX-1051
[CX-1053]: https://artsyproduct.atlassian.net/browse/CX-1053