### PR TITLE
feat(fx-2641): converts medium => additionalGeneIDs filter

### DIFF
--- a/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash a193922b716ef75bf880bb81a80e87cc */
+/* @relayHash 41348542f61c398d1e1859800a01a202 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -59,7 +59,7 @@ fragment ArtistArtworks_artist on Artist {
   id
   slug
   internalID
-  artworks: filterArtworksConnection(first: 10, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  artworks: filterArtworksConnection(first: 10, sort: "-decayed_merch", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -376,11 +376,6 @@ v15 = [
     "value": "*-*"
   },
   (v13/*: any*/),
-  {
-    "kind": "Literal",
-    "name": "medium",
-    "value": "*"
-  },
   (v14/*: any*/)
 ],
 v16 = {
@@ -880,14 +875,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,medium:\"*\",sort:\"-decayed_merch\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,sort:\"-decayed_merch\")"
           },
           {
             "alias": "artworks",
             "args": (v15/*: any*/),
             "filters": [
               "sort",
-              "medium",
+              "additionalGeneIDs",
               "priceRange",
               "color",
               "partnerID",
@@ -1192,7 +1187,7 @@ return {
     ]
   },
   "params": {
-    "id": "a193922b716ef75bf880bb81a80e87cc",
+    "id": "41348542f61c398d1e1859800a01a202",
     "metadata": {},
     "name": "ArtistAboveTheFoldQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistArtworksQuery.graphql.ts
+++ b/src/__generated__/ArtistArtworksQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 353c24cb19397d74957101b29a6369b8 */
+/* @relayHash 97c25020becf362a37274e1897a49cdd */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -10,7 +10,7 @@ export type ArtistArtworksQueryVariables = {
     count: number;
     cursor?: string | null;
     sort?: string | null;
-    medium?: string | null;
+    additionalGeneIDs?: Array<string | null> | null;
     priceRange?: string | null;
     color?: string | null;
     partnerID?: string | null;
@@ -40,7 +40,7 @@ query ArtistArtworksQuery(
   $count: Int!
   $cursor: String
   $sort: String
-  $medium: String
+  $additionalGeneIDs: [String]
   $priceRange: String
   $color: String
   $partnerID: ID
@@ -55,17 +55,17 @@ query ArtistArtworksQuery(
   node(id: $id) {
     __typename
     ... on Artist {
-      ...ArtistArtworks_artist_3FXTiz
+      ...ArtistArtworks_artist_4kOA9y
     }
     id
   }
 }
 
-fragment ArtistArtworks_artist_3FXTiz on Artist {
+fragment ArtistArtworks_artist_4kOA9y on Artist {
   id
   slug
   internalID
-  artworks: filterArtworksConnection(first: $count, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], attributionClass: $attributionClass) {
+  artworks: filterArtworksConnection(first: $count, after: $cursor, sort: $sort, additionalGeneIDs: $additionalGeneIDs, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], attributionClass: $attributionClass) {
     aggregations {
       slice
       counts {
@@ -250,52 +250,52 @@ var v0 = {
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "atAuction"
+  "name": "additionalGeneIDs"
 },
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "attributionClass"
+  "name": "atAuction"
 },
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "color"
+  "name": "attributionClass"
 },
 v4 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "count"
+  "name": "color"
 },
 v5 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "cursor"
+  "name": "count"
 },
 v6 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "dimensionRange"
+  "name": "cursor"
 },
 v7 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "id"
+  "name": "dimensionRange"
 },
 v8 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "inquireableOnly"
+  "name": "id"
 },
 v9 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "majorPeriods"
+  "name": "inquireableOnly"
 },
 v10 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "medium"
+  "name": "majorPeriods"
 },
 v11 = {
   "defaultValue": null,
@@ -331,38 +331,38 @@ v16 = {
 },
 v17 = {
   "kind": "Variable",
+  "name": "additionalGeneIDs",
+  "variableName": "additionalGeneIDs"
+},
+v18 = {
+  "kind": "Variable",
   "name": "atAuction",
   "variableName": "atAuction"
 },
-v18 = {
+v19 = {
   "kind": "Variable",
   "name": "attributionClass",
   "variableName": "attributionClass"
 },
-v19 = {
+v20 = {
   "kind": "Variable",
   "name": "color",
   "variableName": "color"
 },
-v20 = {
+v21 = {
   "kind": "Variable",
   "name": "dimensionRange",
   "variableName": "dimensionRange"
 },
-v21 = {
+v22 = {
   "kind": "Variable",
   "name": "inquireableOnly",
   "variableName": "inquireableOnly"
 },
-v22 = {
+v23 = {
   "kind": "Variable",
   "name": "majorPeriods",
   "variableName": "majorPeriods"
-},
-v23 = {
-  "kind": "Variable",
-  "name": "medium",
-  "variableName": "medium"
 },
 v24 = {
   "kind": "Variable",
@@ -414,6 +414,7 @@ v31 = {
 },
 v32 = [
   (v16/*: any*/),
+  (v17/*: any*/),
   {
     "kind": "Variable",
     "name": "after",
@@ -432,16 +433,15 @@ v32 = [
       "PRICE_RANGE"
     ]
   },
-  (v17/*: any*/),
   (v18/*: any*/),
   (v19/*: any*/),
   (v20/*: any*/),
+  (v21/*: any*/),
   {
     "kind": "Variable",
     "name": "first",
     "variableName": "count"
   },
-  (v21/*: any*/),
   (v22/*: any*/),
   (v23/*: any*/),
   (v24/*: any*/),
@@ -571,6 +571,7 @@ return {
                   (v17/*: any*/),
                   (v18/*: any*/),
                   (v19/*: any*/),
+                  (v20/*: any*/),
                   {
                     "kind": "Variable",
                     "name": "count",
@@ -581,7 +582,6 @@ return {
                     "name": "cursor",
                     "variableName": "cursor"
                   },
-                  (v20/*: any*/),
                   (v21/*: any*/),
                   (v22/*: any*/),
                   (v23/*: any*/),
@@ -607,21 +607,21 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v7/*: any*/),
-      (v4/*: any*/),
-      (v5/*: any*/),
-      (v14/*: any*/),
-      (v10/*: any*/),
-      (v13/*: any*/),
-      (v3/*: any*/),
-      (v12/*: any*/),
-      (v6/*: any*/),
-      (v9/*: any*/),
-      (v0/*: any*/),
       (v8/*: any*/),
+      (v5/*: any*/),
+      (v6/*: any*/),
+      (v14/*: any*/),
       (v1/*: any*/),
+      (v13/*: any*/),
+      (v4/*: any*/),
+      (v12/*: any*/),
+      (v7/*: any*/),
+      (v10/*: any*/),
+      (v0/*: any*/),
+      (v9/*: any*/),
+      (v2/*: any*/),
       (v11/*: any*/),
-      (v2/*: any*/)
+      (v3/*: any*/)
     ],
     "kind": "Operation",
     "name": "ArtistArtworksQuery",
@@ -950,7 +950,7 @@ return {
                 "args": (v32/*: any*/),
                 "filters": [
                   "sort",
-                  "medium",
+                  "additionalGeneIDs",
                   "priceRange",
                   "color",
                   "partnerID",
@@ -1272,7 +1272,7 @@ return {
     ]
   },
   "params": {
-    "id": "353c24cb19397d74957101b29a6369b8",
+    "id": "97c25020becf362a37274e1897a49cdd",
     "metadata": {},
     "name": "ArtistArtworksQuery",
     "operationKind": "query",
@@ -1280,5 +1280,5 @@ return {
   }
 };
 })();
-(node as any).hash = '847fa3cef271f76f7b28bb9612468eb2';
+(node as any).hash = '72b95c442bf71a622e3d5be207418c7b';
 export default node;

--- a/src/__generated__/ArtistArtworks_artist.graphql.ts
+++ b/src/__generated__/ArtistArtworks_artist.graphql.ts
@@ -64,6 +64,11 @@ return {
     {
       "defaultValue": null,
       "kind": "LocalArgument",
+      "name": "additionalGeneIDs"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
       "name": "atAuction"
     },
     {
@@ -100,11 +105,6 @@ return {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "majorPeriods"
-    },
-    {
-      "defaultValue": "*",
-      "kind": "LocalArgument",
-      "name": "medium"
     },
     {
       "defaultValue": null,
@@ -166,6 +166,11 @@ return {
           "variableName": "acquireable"
         },
         {
+          "kind": "Variable",
+          "name": "additionalGeneIDs",
+          "variableName": "additionalGeneIDs"
+        },
+        {
           "kind": "Literal",
           "name": "aggregations",
           "value": [
@@ -207,11 +212,6 @@ return {
           "kind": "Variable",
           "name": "majorPeriods",
           "variableName": "majorPeriods"
-        },
-        {
-          "kind": "Variable",
-          "name": "medium",
-          "variableName": "medium"
         },
         {
           "kind": "Variable",
@@ -451,5 +451,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = 'cf040c849c9f749decfafe2cbb0d4bde';
+(node as any).hash = '316610d38cfa740176494dabba63159e';
 export default node;

--- a/src/__generated__/ArtistSeriesArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash affc0967a8d5c824f9d8b7d72c68a359 */
+/* @relayHash a71b78dd21d9642aa7df73988602067f */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -10,7 +10,7 @@ export type ArtistSeriesArtworksInfiniteScrollGridQueryVariables = {
     count: number;
     cursor?: string | null;
     sort?: string | null;
-    medium?: string | null;
+    additionalGeneIDs?: Array<string | null> | null;
     priceRange?: string | null;
     color?: string | null;
     partnerID?: string | null;
@@ -39,7 +39,7 @@ query ArtistSeriesArtworksInfiniteScrollGridQuery(
   $id: ID!
   $cursor: String
   $sort: String
-  $medium: String
+  $additionalGeneIDs: [String]
   $priceRange: String
   $color: String
   $partnerID: ID
@@ -52,14 +52,14 @@ query ArtistSeriesArtworksInfiniteScrollGridQuery(
   $attributionClass: [String]
 ) {
   artistSeries(id: $id) {
-    ...ArtistSeriesArtworks_artistSeries_3FXTiz
+    ...ArtistSeriesArtworks_artistSeries_4kOA9y
   }
 }
 
-fragment ArtistSeriesArtworks_artistSeries_3FXTiz on ArtistSeries {
+fragment ArtistSeriesArtworks_artistSeries_4kOA9y on ArtistSeries {
   slug
   internalID
-  artistSeriesArtworks: filterArtworksConnection(first: 20, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], attributionClass: $attributionClass) {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, after: $cursor, sort: $sort, additionalGeneIDs: $additionalGeneIDs, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], attributionClass: $attributionClass) {
     aggregations {
       slice
       counts {
@@ -156,52 +156,52 @@ var v0 = {
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "atAuction"
+  "name": "additionalGeneIDs"
 },
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "attributionClass"
+  "name": "atAuction"
 },
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "color"
+  "name": "attributionClass"
 },
 v4 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "count"
+  "name": "color"
 },
 v5 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "cursor"
+  "name": "count"
 },
 v6 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "dimensionRange"
+  "name": "cursor"
 },
 v7 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "id"
+  "name": "dimensionRange"
 },
 v8 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "inquireableOnly"
+  "name": "id"
 },
 v9 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "majorPeriods"
+  "name": "inquireableOnly"
 },
 v10 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "medium"
+  "name": "majorPeriods"
 },
 v11 = {
   "defaultValue": null,
@@ -237,38 +237,38 @@ v16 = {
 },
 v17 = {
   "kind": "Variable",
+  "name": "additionalGeneIDs",
+  "variableName": "additionalGeneIDs"
+},
+v18 = {
+  "kind": "Variable",
   "name": "atAuction",
   "variableName": "atAuction"
 },
-v18 = {
+v19 = {
   "kind": "Variable",
   "name": "attributionClass",
   "variableName": "attributionClass"
 },
-v19 = {
+v20 = {
   "kind": "Variable",
   "name": "color",
   "variableName": "color"
 },
-v20 = {
+v21 = {
   "kind": "Variable",
   "name": "dimensionRange",
   "variableName": "dimensionRange"
 },
-v21 = {
+v22 = {
   "kind": "Variable",
   "name": "inquireableOnly",
   "variableName": "inquireableOnly"
 },
-v22 = {
+v23 = {
   "kind": "Variable",
   "name": "majorPeriods",
   "variableName": "majorPeriods"
-},
-v23 = {
-  "kind": "Variable",
-  "name": "medium",
-  "variableName": "medium"
 },
 v24 = {
   "kind": "Variable",
@@ -306,6 +306,7 @@ v29 = {
 },
 v30 = [
   (v16/*: any*/),
+  (v17/*: any*/),
   {
     "kind": "Variable",
     "name": "after",
@@ -324,16 +325,15 @@ v30 = [
       "PRICE_RANGE"
     ]
   },
-  (v17/*: any*/),
   (v18/*: any*/),
   (v19/*: any*/),
   (v20/*: any*/),
+  (v21/*: any*/),
   {
     "kind": "Literal",
     "name": "first",
     "value": 20
   },
-  (v21/*: any*/),
   (v22/*: any*/),
   (v23/*: any*/),
   (v24/*: any*/),
@@ -399,6 +399,7 @@ return {
               (v17/*: any*/),
               (v18/*: any*/),
               (v19/*: any*/),
+              (v20/*: any*/),
               {
                 "kind": "Variable",
                 "name": "count",
@@ -409,7 +410,6 @@ return {
                 "name": "cursor",
                 "variableName": "cursor"
               },
-              (v20/*: any*/),
               (v21/*: any*/),
               (v22/*: any*/),
               (v23/*: any*/),
@@ -431,21 +431,21 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v7/*: any*/),
-      (v4/*: any*/),
-      (v5/*: any*/),
-      (v14/*: any*/),
-      (v10/*: any*/),
-      (v13/*: any*/),
-      (v3/*: any*/),
-      (v12/*: any*/),
-      (v6/*: any*/),
-      (v9/*: any*/),
-      (v0/*: any*/),
       (v8/*: any*/),
+      (v5/*: any*/),
+      (v6/*: any*/),
+      (v14/*: any*/),
       (v1/*: any*/),
+      (v13/*: any*/),
+      (v4/*: any*/),
+      (v12/*: any*/),
+      (v7/*: any*/),
+      (v10/*: any*/),
+      (v0/*: any*/),
+      (v9/*: any*/),
+      (v2/*: any*/),
       (v11/*: any*/),
-      (v2/*: any*/)
+      (v3/*: any*/)
     ],
     "kind": "Operation",
     "name": "ArtistSeriesArtworksInfiniteScrollGridQuery",
@@ -827,7 +827,7 @@ return {
             "args": (v30/*: any*/),
             "filters": [
               "sort",
-              "medium",
+              "additionalGeneIDs",
               "priceRange",
               "color",
               "partnerID",
@@ -851,7 +851,7 @@ return {
     ]
   },
   "params": {
-    "id": "affc0967a8d5c824f9d8b7d72c68a359",
+    "id": "a71b78dd21d9642aa7df73988602067f",
     "metadata": {},
     "name": "ArtistSeriesArtworksInfiniteScrollGridQuery",
     "operationKind": "query",
@@ -859,5 +859,5 @@ return {
   }
 };
 })();
-(node as any).hash = '0c45653e45ae4bb81cff0a07553c36c7';
+(node as any).hash = 'dd294fbe178bce59de8df829d6774fce';
 export default node;

--- a/src/__generated__/ArtistSeriesArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworksTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 97396d53e8317450bbd85096ce63517b */
+/* @relayHash 0fcb402763f36997809340746cb9bfa5 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -28,7 +28,7 @@ query ArtistSeriesArtworksTestsQuery {
 fragment ArtistSeriesArtworks_artistSeries on ArtistSeries {
   slug
   internalID
-  artistSeriesArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -161,11 +161,6 @@ v3 = [
     "kind": "Literal",
     "name": "first",
     "value": 20
-  },
-  {
-    "kind": "Literal",
-    "name": "medium",
-    "value": "*"
   },
   {
     "kind": "Literal",
@@ -627,14 +622,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:20,medium:\"*\",sort:\"-decayed_merch\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:20,sort:\"-decayed_merch\")"
           },
           {
             "alias": "artistSeriesArtworks",
             "args": (v3/*: any*/),
             "filters": [
               "sort",
-              "medium",
+              "additionalGeneIDs",
               "priceRange",
               "color",
               "partnerID",
@@ -658,7 +653,7 @@ return {
     ]
   },
   "params": {
-    "id": "97396d53e8317450bbd85096ce63517b",
+    "id": "0fcb402763f36997809340746cb9bfa5",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artistSeries": {

--- a/src/__generated__/ArtistSeriesArtworks_artistSeries.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworks_artistSeries.graphql.ts
@@ -47,6 +47,11 @@ const node: ReaderFragment = {
     {
       "defaultValue": null,
       "kind": "LocalArgument",
+      "name": "additionalGeneIDs"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
       "name": "atAuction"
     },
     {
@@ -83,11 +88,6 @@ const node: ReaderFragment = {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "majorPeriods"
-    },
-    {
-      "defaultValue": "*",
-      "kind": "LocalArgument",
-      "name": "medium"
     },
     {
       "defaultValue": null,
@@ -148,6 +148,11 @@ const node: ReaderFragment = {
           "variableName": "acquireable"
         },
         {
+          "kind": "Variable",
+          "name": "additionalGeneIDs",
+          "variableName": "additionalGeneIDs"
+        },
+        {
           "kind": "Literal",
           "name": "aggregations",
           "value": [
@@ -189,11 +194,6 @@ const node: ReaderFragment = {
           "kind": "Variable",
           "name": "majorPeriods",
           "variableName": "majorPeriods"
-        },
-        {
-          "kind": "Variable",
-          "name": "medium",
-          "variableName": "medium"
         },
         {
           "kind": "Variable",
@@ -369,5 +369,5 @@ const node: ReaderFragment = {
   "type": "ArtistSeries",
   "abstractKey": null
 };
-(node as any).hash = 'bd0cf8766f02c953535bece7f657c285';
+(node as any).hash = '86de307244f966207da8c7cb5beda338';
 export default node;

--- a/src/__generated__/ArtistSeriesQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 446887fc16401f30c58b8e24f7e21c52 */
+/* @relayHash dae771d42d8d7133b043da3633669216 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -32,7 +32,7 @@ query ArtistSeriesQuery(
 fragment ArtistSeriesArtworks_artistSeries on ArtistSeries {
   slug
   internalID
-  artistSeriesArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -276,11 +276,6 @@ v9 = [
     "kind": "Literal",
     "name": "first",
     "value": 20
-  },
-  {
-    "kind": "Literal",
-    "name": "medium",
-    "value": "*"
   },
   {
     "kind": "Literal",
@@ -731,14 +726,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:20,medium:\"*\",sort:\"-decayed_merch\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:20,sort:\"-decayed_merch\")"
           },
           {
             "alias": "artistSeriesArtworks",
             "args": (v9/*: any*/),
             "filters": [
               "sort",
-              "medium",
+              "additionalGeneIDs",
               "priceRange",
               "color",
               "partnerID",
@@ -839,7 +834,7 @@ return {
     ]
   },
   "params": {
-    "id": "446887fc16401f30c58b8e24f7e21c52",
+    "id": "dae771d42d8d7133b043da3633669216",
     "metadata": {},
     "name": "ArtistSeriesQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash a35a6b79b4f6fda1e7b93ba4a67c674a */
+/* @relayHash b40e419bf46b2d768b797f99b48b5b0c */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -28,7 +28,7 @@ query ArtistSeriesTestsQuery {
 fragment ArtistSeriesArtworks_artistSeries on ArtistSeries {
   slug
   internalID
-  artistSeriesArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -265,11 +265,6 @@ v8 = [
     "kind": "Literal",
     "name": "first",
     "value": 20
-  },
-  {
-    "kind": "Literal",
-    "name": "medium",
-    "value": "*"
   },
   {
     "kind": "Literal",
@@ -780,14 +775,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:20,medium:\"*\",sort:\"-decayed_merch\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:20,sort:\"-decayed_merch\")"
           },
           {
             "alias": "artistSeriesArtworks",
             "args": (v8/*: any*/),
             "filters": [
               "sort",
-              "medium",
+              "additionalGeneIDs",
               "priceRange",
               "color",
               "partnerID",
@@ -888,7 +883,7 @@ return {
     ]
   },
   "params": {
-    "id": "a35a6b79b4f6fda1e7b93ba4a67c674a",
+    "id": "b40e419bf46b2d768b797f99b48b5b0c",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artistSeries": (v10/*: any*/),

--- a/src/__generated__/CollectionArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/CollectionArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 3e382b3ba6e6a83689c3e6b601cd1504 */
+/* @relayHash c26ced8c297607bdbeeccbbbb3c86191 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -10,7 +10,7 @@ export type CollectionArtworksInfiniteScrollGridQueryVariables = {
     count: number;
     cursor?: string | null;
     sort?: string | null;
-    medium?: string | null;
+    additionalGeneIDs?: Array<string | null> | null;
     priceRange?: string | null;
     color?: string | null;
     partnerID?: string | null;
@@ -40,7 +40,7 @@ query CollectionArtworksInfiniteScrollGridQuery(
   $count: Int!
   $cursor: String
   $sort: String
-  $medium: String
+  $additionalGeneIDs: [String]
   $priceRange: String
   $color: String
   $partnerID: ID
@@ -53,7 +53,7 @@ query CollectionArtworksInfiniteScrollGridQuery(
   $attributionClass: [String]
 ) {
   marketingCollection(slug: $id) {
-    ...CollectionArtworks_collection_3FXTiz
+    ...CollectionArtworks_collection_4kOA9y
     id
   }
 }
@@ -93,11 +93,11 @@ fragment ArtworkGridItem_artwork on Artwork {
   }
 }
 
-fragment CollectionArtworks_collection_3FXTiz on MarketingCollection {
+fragment CollectionArtworks_collection_4kOA9y on MarketingCollection {
   isDepartment
   slug
   id
-  collectionArtworks: artworksConnection(first: $count, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], attributionClass: $attributionClass) {
+  collectionArtworks: artworksConnection(first: $count, after: $cursor, sort: $sort, additionalGeneIDs: $additionalGeneIDs, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], attributionClass: $attributionClass) {
     aggregations {
       slice
       counts {
@@ -159,52 +159,52 @@ var v0 = {
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "atAuction"
+  "name": "additionalGeneIDs"
 },
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "attributionClass"
+  "name": "atAuction"
 },
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "color"
+  "name": "attributionClass"
 },
 v4 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "count"
+  "name": "color"
 },
 v5 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "cursor"
+  "name": "count"
 },
 v6 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "dimensionRange"
+  "name": "cursor"
 },
 v7 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "id"
+  "name": "dimensionRange"
 },
 v8 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "inquireableOnly"
+  "name": "id"
 },
 v9 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "majorPeriods"
+  "name": "inquireableOnly"
 },
 v10 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "medium"
+  "name": "majorPeriods"
 },
 v11 = {
   "defaultValue": null,
@@ -240,38 +240,38 @@ v16 = {
 },
 v17 = {
   "kind": "Variable",
+  "name": "additionalGeneIDs",
+  "variableName": "additionalGeneIDs"
+},
+v18 = {
+  "kind": "Variable",
   "name": "atAuction",
   "variableName": "atAuction"
 },
-v18 = {
+v19 = {
   "kind": "Variable",
   "name": "attributionClass",
   "variableName": "attributionClass"
 },
-v19 = {
+v20 = {
   "kind": "Variable",
   "name": "color",
   "variableName": "color"
 },
-v20 = {
+v21 = {
   "kind": "Variable",
   "name": "dimensionRange",
   "variableName": "dimensionRange"
 },
-v21 = {
+v22 = {
   "kind": "Variable",
   "name": "inquireableOnly",
   "variableName": "inquireableOnly"
 },
-v22 = {
+v23 = {
   "kind": "Variable",
   "name": "majorPeriods",
   "variableName": "majorPeriods"
-},
-v23 = {
-  "kind": "Variable",
-  "name": "medium",
-  "variableName": "medium"
 },
 v24 = {
   "kind": "Variable",
@@ -309,6 +309,7 @@ v29 = {
 },
 v30 = [
   (v16/*: any*/),
+  (v17/*: any*/),
   {
     "kind": "Variable",
     "name": "after",
@@ -327,16 +328,15 @@ v30 = [
       "PRICE_RANGE"
     ]
   },
-  (v17/*: any*/),
   (v18/*: any*/),
   (v19/*: any*/),
   (v20/*: any*/),
+  (v21/*: any*/),
   {
     "kind": "Variable",
     "name": "first",
     "variableName": "count"
   },
-  (v21/*: any*/),
   (v22/*: any*/),
   (v23/*: any*/),
   (v24/*: any*/),
@@ -395,6 +395,7 @@ return {
               (v17/*: any*/),
               (v18/*: any*/),
               (v19/*: any*/),
+              (v20/*: any*/),
               {
                 "kind": "Variable",
                 "name": "count",
@@ -405,7 +406,6 @@ return {
                 "name": "cursor",
                 "variableName": "cursor"
               },
-              (v20/*: any*/),
               (v21/*: any*/),
               (v22/*: any*/),
               (v23/*: any*/),
@@ -427,21 +427,21 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v7/*: any*/),
-      (v4/*: any*/),
-      (v5/*: any*/),
-      (v14/*: any*/),
-      (v10/*: any*/),
-      (v13/*: any*/),
-      (v3/*: any*/),
-      (v12/*: any*/),
-      (v6/*: any*/),
-      (v9/*: any*/),
-      (v0/*: any*/),
       (v8/*: any*/),
+      (v5/*: any*/),
+      (v6/*: any*/),
+      (v14/*: any*/),
       (v1/*: any*/),
+      (v13/*: any*/),
+      (v4/*: any*/),
+      (v12/*: any*/),
+      (v7/*: any*/),
+      (v10/*: any*/),
+      (v0/*: any*/),
+      (v9/*: any*/),
+      (v2/*: any*/),
       (v11/*: any*/),
-      (v2/*: any*/)
+      (v3/*: any*/)
     ],
     "kind": "Operation",
     "name": "CollectionArtworksInfiniteScrollGridQuery",
@@ -836,7 +836,7 @@ return {
             "args": (v30/*: any*/),
             "filters": [
               "sort",
-              "medium",
+              "additionalGeneIDs",
               "priceRange",
               "color",
               "partnerID",
@@ -860,7 +860,7 @@ return {
     ]
   },
   "params": {
-    "id": "3e382b3ba6e6a83689c3e6b601cd1504",
+    "id": "c26ced8c297607bdbeeccbbbb3c86191",
     "metadata": {},
     "name": "CollectionArtworksInfiniteScrollGridQuery",
     "operationKind": "query",
@@ -868,5 +868,5 @@ return {
   }
 };
 })();
-(node as any).hash = '2f6d6cdf0adaf3f45970c89aae12790f';
+(node as any).hash = 'fe2eabc2bd3e868575b92df9e7a74bc5';
 export default node;

--- a/src/__generated__/CollectionArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/CollectionArtworksTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash b0f8c0290705184b39902087fb017619 */
+/* @relayHash cbfef6875bc750eb5f0f54076ef8f52e */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -65,7 +65,7 @@ fragment CollectionArtworks_collection on MarketingCollection {
   isDepartment
   slug
   id
-  collectionArtworks: artworksConnection(first: 10, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  collectionArtworks: artworksConnection(first: 10, sort: "-decayed_merch", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -163,11 +163,6 @@ v3 = [
     "kind": "Literal",
     "name": "first",
     "value": 10
-  },
-  {
-    "kind": "Literal",
-    "name": "medium",
-    "value": "*"
   },
   {
     "kind": "Literal",
@@ -641,14 +636,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "artworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,medium:\"*\",sort:\"-decayed_merch\")"
+            "storageKey": "artworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,sort:\"-decayed_merch\")"
           },
           {
             "alias": "collectionArtworks",
             "args": (v3/*: any*/),
             "filters": [
               "sort",
-              "medium",
+              "additionalGeneIDs",
               "priceRange",
               "color",
               "partnerID",
@@ -672,7 +667,7 @@ return {
     ]
   },
   "params": {
-    "id": "b0f8c0290705184b39902087fb017619",
+    "id": "cbfef6875bc750eb5f0f54076ef8f52e",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "marketingCollection": {

--- a/src/__generated__/CollectionArtworks_collection.graphql.ts
+++ b/src/__generated__/CollectionArtworks_collection.graphql.ts
@@ -56,6 +56,11 @@ return {
     {
       "defaultValue": null,
       "kind": "LocalArgument",
+      "name": "additionalGeneIDs"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
       "name": "atAuction"
     },
     {
@@ -92,11 +97,6 @@ return {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "majorPeriods"
-    },
-    {
-      "defaultValue": "*",
-      "kind": "LocalArgument",
-      "name": "medium"
     },
     {
       "defaultValue": null,
@@ -158,6 +158,11 @@ return {
           "variableName": "acquireable"
         },
         {
+          "kind": "Variable",
+          "name": "additionalGeneIDs",
+          "variableName": "additionalGeneIDs"
+        },
+        {
           "kind": "Literal",
           "name": "aggregations",
           "value": [
@@ -199,11 +204,6 @@ return {
           "kind": "Variable",
           "name": "majorPeriods",
           "variableName": "majorPeriods"
-        },
-        {
-          "kind": "Variable",
-          "name": "medium",
-          "variableName": "medium"
         },
         {
           "kind": "Variable",
@@ -374,5 +374,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '1e65e47708f32d93e8b7607980305c68';
+(node as any).hash = '7c4b5d90ca875995146f13e80ea32ed3';
 export default node;

--- a/src/__generated__/CollectionQuery.graphql.ts
+++ b/src/__generated__/CollectionQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash a82d868a38b7fcf72e35b477dcc84ab4 */
+/* @relayHash 461142dacd1209fa826a3efa97bb5ae4 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -113,7 +113,7 @@ fragment CollectionArtworks_collection on MarketingCollection {
   isDepartment
   slug
   id
-  collectionArtworks: artworksConnection(first: 10, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  collectionArtworks: artworksConnection(first: 10, sort: "-decayed_merch", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -343,11 +343,6 @@ v8 = [
     "kind": "Literal",
     "name": "first",
     "value": 10
-  },
-  {
-    "kind": "Literal",
-    "name": "medium",
-    "value": "*"
   },
   (v7/*: any*/)
 ],
@@ -879,14 +874,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "artworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,medium:\"*\",sort:\"-decayed_merch\")"
+            "storageKey": "artworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,sort:\"-decayed_merch\")"
           },
           {
             "alias": "collectionArtworks",
             "args": (v8/*: any*/),
             "filters": [
               "sort",
-              "medium",
+              "additionalGeneIDs",
               "priceRange",
               "color",
               "partnerID",
@@ -1146,7 +1141,7 @@ return {
     ]
   },
   "params": {
-    "id": "a82d868a38b7fcf72e35b477dcc84ab4",
+    "id": "461142dacd1209fa826a3efa97bb5ae4",
     "metadata": {},
     "name": "CollectionQuery",
     "operationKind": "query",

--- a/src/__generated__/CollectionTestsQuery.graphql.ts
+++ b/src/__generated__/CollectionTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 704736599bce43b8d3255c6a6de743ed */
+/* @relayHash 2c76bf9c872533bf4a0a3d510f573177 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -108,7 +108,7 @@ fragment CollectionArtworks_collection on MarketingCollection {
   isDepartment
   slug
   id
-  collectionArtworks: artworksConnection(first: 10, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  collectionArtworks: artworksConnection(first: 10, sort: "-decayed_merch", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -326,11 +326,6 @@ v7 = [
     "kind": "Literal",
     "name": "first",
     "value": 10
-  },
-  {
-    "kind": "Literal",
-    "name": "medium",
-    "value": "*"
   },
   (v6/*: any*/)
 ],
@@ -922,14 +917,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "artworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,medium:\"*\",sort:\"-decayed_merch\")"
+            "storageKey": "artworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,sort:\"-decayed_merch\")"
           },
           {
             "alias": "collectionArtworks",
             "args": (v7/*: any*/),
             "filters": [
               "sort",
-              "medium",
+              "additionalGeneIDs",
               "priceRange",
               "color",
               "partnerID",
@@ -1189,7 +1184,7 @@ return {
     ]
   },
   "params": {
-    "id": "704736599bce43b8d3255c6a6de743ed",
+    "id": "2c76bf9c872533bf4a0a3d510f573177",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "marketingCollection": {

--- a/src/__generated__/FairAllFollowedArtistsQuery.graphql.ts
+++ b/src/__generated__/FairAllFollowedArtistsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 40445c90220600398eec78a294e13bcb */
+/* @relayHash 0df3fb69e35272f5787c567d0ede52dc */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -98,7 +98,7 @@ fragment FairAllFollowedArtists_fairForFilters on Fair {
 fragment FairArtworks_fair_485l1x on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", includeArtworksByFollowedArtists: true, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", dimensionRange: "*-*", includeArtworksByFollowedArtists: true, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
     aggregations {
       slice
       counts {
@@ -212,11 +212,6 @@ v5 = [
     "kind": "Literal",
     "name": "includeArtworksByFollowedArtists",
     "value": true
-  },
-  {
-    "kind": "Literal",
-    "name": "medium",
-    "value": "*"
   },
   {
     "kind": "Literal",
@@ -673,14 +668,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,includeArtworksByFollowedArtists:true,medium:\"*\",sort:\"-decayed_merch\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,includeArtworksByFollowedArtists:true,sort:\"-decayed_merch\")"
           },
           {
             "alias": "fairArtworks",
             "args": (v5/*: any*/),
             "filters": [
               "sort",
-              "medium",
+              "additionalGeneIDs",
               "priceRange",
               "color",
               "partnerID",
@@ -751,7 +746,7 @@ return {
     ]
   },
   "params": {
-    "id": "40445c90220600398eec78a294e13bcb",
+    "id": "0df3fb69e35272f5787c567d0ede52dc",
     "metadata": {},
     "name": "FairAllFollowedArtistsQuery",
     "operationKind": "query",

--- a/src/__generated__/FairAllFollowedArtistsTestsQuery.graphql.ts
+++ b/src/__generated__/FairAllFollowedArtistsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 87da43180d6beb47aea3e3e519641a93 */
+/* @relayHash 16a11fd2cb771d7bed9c8a755c7787ae */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -98,7 +98,7 @@ fragment FairAllFollowedArtists_fairForFilters on Fair {
 fragment FairArtworks_fair_485l1x on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", includeArtworksByFollowedArtists: true, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", dimensionRange: "*-*", includeArtworksByFollowedArtists: true, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
     aggregations {
       slice
       counts {
@@ -212,11 +212,6 @@ v5 = [
     "kind": "Literal",
     "name": "includeArtworksByFollowedArtists",
     "value": true
-  },
-  {
-    "kind": "Literal",
-    "name": "medium",
-    "value": "*"
   },
   {
     "kind": "Literal",
@@ -762,14 +757,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,includeArtworksByFollowedArtists:true,medium:\"*\",sort:\"-decayed_merch\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,includeArtworksByFollowedArtists:true,sort:\"-decayed_merch\")"
           },
           {
             "alias": "fairArtworks",
             "args": (v5/*: any*/),
             "filters": [
               "sort",
-              "medium",
+              "additionalGeneIDs",
               "priceRange",
               "color",
               "partnerID",
@@ -840,7 +835,7 @@ return {
     ]
   },
   "params": {
-    "id": "87da43180d6beb47aea3e3e519641a93",
+    "id": "16a11fd2cb771d7bed9c8a755c7787ae",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "fair": (v11/*: any*/),

--- a/src/__generated__/FairArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/FairArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 322747e1630483a5f2b107977f8e6f87 */
+/* @relayHash 6bf26a868d9fbc9812153ce2d5e48f4c */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -10,7 +10,7 @@ export type FairArtworksInfiniteScrollGridQueryVariables = {
     count: number;
     cursor?: string | null;
     sort?: string | null;
-    medium?: string | null;
+    additionalGeneIDs?: Array<string | null> | null;
     priceRange?: string | null;
     color?: string | null;
     partnerID?: string | null;
@@ -41,7 +41,7 @@ query FairArtworksInfiniteScrollGridQuery(
   $id: String!
   $cursor: String
   $sort: String
-  $medium: String
+  $additionalGeneIDs: [String]
   $priceRange: String
   $color: String
   $partnerID: ID
@@ -56,7 +56,7 @@ query FairArtworksInfiniteScrollGridQuery(
   $attributionClass: [String]
 ) {
   fair(id: $id) {
-    ...FairArtworks_fair_1Fr0Af
+    ...FairArtworks_fair_BsKMG
     id
   }
 }
@@ -96,10 +96,10 @@ fragment ArtworkGridItem_artwork on Artwork {
   }
 }
 
-fragment FairArtworks_fair_1Fr0Af on Fair {
+fragment FairArtworks_fair_BsKMG on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, includeArtworksByFollowedArtists: $includeArtworksByFollowedArtists, artistIDs: $artistIDs, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], attributionClass: $attributionClass) {
+  fairArtworks: filterArtworksConnection(first: 30, after: $cursor, sort: $sort, additionalGeneIDs: $additionalGeneIDs, priceRange: $priceRange, color: $color, partnerID: $partnerID, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, includeArtworksByFollowedArtists: $includeArtworksByFollowedArtists, artistIDs: $artistIDs, aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], attributionClass: $attributionClass) {
     aggregations {
       slice
       counts {
@@ -162,62 +162,62 @@ var v0 = {
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "artistIDs"
+  "name": "additionalGeneIDs"
 },
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "atAuction"
+  "name": "artistIDs"
 },
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "attributionClass"
+  "name": "atAuction"
 },
 v4 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "color"
+  "name": "attributionClass"
 },
 v5 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "count"
+  "name": "color"
 },
 v6 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "cursor"
+  "name": "count"
 },
 v7 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "dimensionRange"
+  "name": "cursor"
 },
 v8 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "id"
+  "name": "dimensionRange"
 },
 v9 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "includeArtworksByFollowedArtists"
+  "name": "id"
 },
 v10 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "inquireableOnly"
+  "name": "includeArtworksByFollowedArtists"
 },
 v11 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "majorPeriods"
+  "name": "inquireableOnly"
 },
 v12 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "medium"
+  "name": "majorPeriods"
 },
 v13 = {
   "defaultValue": null,
@@ -253,48 +253,48 @@ v18 = {
 },
 v19 = {
   "kind": "Variable",
+  "name": "additionalGeneIDs",
+  "variableName": "additionalGeneIDs"
+},
+v20 = {
+  "kind": "Variable",
   "name": "artistIDs",
   "variableName": "artistIDs"
 },
-v20 = {
+v21 = {
   "kind": "Variable",
   "name": "atAuction",
   "variableName": "atAuction"
 },
-v21 = {
+v22 = {
   "kind": "Variable",
   "name": "attributionClass",
   "variableName": "attributionClass"
 },
-v22 = {
+v23 = {
   "kind": "Variable",
   "name": "color",
   "variableName": "color"
 },
-v23 = {
+v24 = {
   "kind": "Variable",
   "name": "dimensionRange",
   "variableName": "dimensionRange"
 },
-v24 = {
+v25 = {
   "kind": "Variable",
   "name": "includeArtworksByFollowedArtists",
   "variableName": "includeArtworksByFollowedArtists"
 },
-v25 = {
+v26 = {
   "kind": "Variable",
   "name": "inquireableOnly",
   "variableName": "inquireableOnly"
 },
-v26 = {
+v27 = {
   "kind": "Variable",
   "name": "majorPeriods",
   "variableName": "majorPeriods"
-},
-v27 = {
-  "kind": "Variable",
-  "name": "medium",
-  "variableName": "medium"
 },
 v28 = {
   "kind": "Variable",
@@ -332,6 +332,7 @@ v33 = {
 },
 v34 = [
   (v18/*: any*/),
+  (v19/*: any*/),
   {
     "kind": "Variable",
     "name": "after",
@@ -352,17 +353,16 @@ v34 = [
       "ARTIST"
     ]
   },
-  (v19/*: any*/),
   (v20/*: any*/),
   (v21/*: any*/),
   (v22/*: any*/),
   (v23/*: any*/),
+  (v24/*: any*/),
   {
     "kind": "Literal",
     "name": "first",
     "value": 30
   },
-  (v24/*: any*/),
   (v25/*: any*/),
   (v26/*: any*/),
   (v27/*: any*/),
@@ -432,6 +432,7 @@ return {
               (v20/*: any*/),
               (v21/*: any*/),
               (v22/*: any*/),
+              (v23/*: any*/),
               {
                 "kind": "Variable",
                 "name": "count",
@@ -442,7 +443,6 @@ return {
                 "name": "cursor",
                 "variableName": "cursor"
               },
-              (v23/*: any*/),
               (v24/*: any*/),
               (v25/*: any*/),
               (v26/*: any*/),
@@ -465,23 +465,23 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v8/*: any*/),
-      (v5/*: any*/),
+      (v9/*: any*/),
       (v6/*: any*/),
-      (v16/*: any*/),
-      (v12/*: any*/),
-      (v15/*: any*/),
-      (v4/*: any*/),
-      (v14/*: any*/),
       (v7/*: any*/),
-      (v11/*: any*/),
+      (v16/*: any*/),
+      (v1/*: any*/),
+      (v15/*: any*/),
+      (v5/*: any*/),
+      (v14/*: any*/),
+      (v8/*: any*/),
+      (v12/*: any*/),
       (v0/*: any*/),
+      (v11/*: any*/),
+      (v3/*: any*/),
+      (v13/*: any*/),
       (v10/*: any*/),
       (v2/*: any*/),
-      (v13/*: any*/),
-      (v9/*: any*/),
-      (v1/*: any*/),
-      (v3/*: any*/)
+      (v4/*: any*/)
     ],
     "kind": "Operation",
     "name": "FairArtworksInfiniteScrollGridQuery",
@@ -870,7 +870,7 @@ return {
             "args": (v34/*: any*/),
             "filters": [
               "sort",
-              "medium",
+              "additionalGeneIDs",
               "priceRange",
               "color",
               "partnerID",
@@ -897,7 +897,7 @@ return {
     ]
   },
   "params": {
-    "id": "322747e1630483a5f2b107977f8e6f87",
+    "id": "6bf26a868d9fbc9812153ce2d5e48f4c",
     "metadata": {},
     "name": "FairArtworksInfiniteScrollGridQuery",
     "operationKind": "query",
@@ -905,5 +905,5 @@ return {
   }
 };
 })();
-(node as any).hash = 'd3e376a72e3f56bdb9f63cbeabe97394';
+(node as any).hash = 'e5122e782ea1d4f454e9d5d5001fab2f';
 export default node;

--- a/src/__generated__/FairArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/FairArtworksTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash e0d266de8f2c5bc1b7018f935154e343 */
+/* @relayHash 9a5cc56bc80b3706c7db90a3b7fb2121 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -68,7 +68,7 @@ fragment ArtworkGridItem_artwork on Artwork {
 fragment FairArtworks_fair on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
     aggregations {
       slice
       counts {
@@ -176,11 +176,6 @@ v4 = [
     "kind": "Literal",
     "name": "first",
     "value": 30
-  },
-  {
-    "kind": "Literal",
-    "name": "medium",
-    "value": "*"
   },
   {
     "kind": "Literal",
@@ -649,14 +644,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,medium:\"*\",sort:\"-decayed_merch\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,sort:\"-decayed_merch\")"
           },
           {
             "alias": "fairArtworks",
             "args": (v4/*: any*/),
             "filters": [
               "sort",
-              "medium",
+              "additionalGeneIDs",
               "priceRange",
               "color",
               "partnerID",
@@ -683,7 +678,7 @@ return {
     ]
   },
   "params": {
-    "id": "e0d266de8f2c5bc1b7018f935154e343",
+    "id": "9a5cc56bc80b3706c7db90a3b7fb2121",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "fair": {

--- a/src/__generated__/FairArtworks_fair.graphql.ts
+++ b/src/__generated__/FairArtworks_fair.graphql.ts
@@ -48,6 +48,11 @@ const node: ReaderFragment = {
     {
       "defaultValue": null,
       "kind": "LocalArgument",
+      "name": "additionalGeneIDs"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
       "name": "artistIDs"
     },
     {
@@ -94,11 +99,6 @@ const node: ReaderFragment = {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "majorPeriods"
-    },
-    {
-      "defaultValue": "*",
-      "kind": "LocalArgument",
-      "name": "medium"
     },
     {
       "defaultValue": null,
@@ -159,6 +159,11 @@ const node: ReaderFragment = {
           "variableName": "acquireable"
         },
         {
+          "kind": "Variable",
+          "name": "additionalGeneIDs",
+          "variableName": "additionalGeneIDs"
+        },
+        {
           "kind": "Literal",
           "name": "aggregations",
           "value": [
@@ -212,11 +217,6 @@ const node: ReaderFragment = {
           "kind": "Variable",
           "name": "majorPeriods",
           "variableName": "majorPeriods"
-        },
-        {
-          "kind": "Variable",
-          "name": "medium",
-          "variableName": "medium"
         },
         {
           "kind": "Variable",
@@ -399,5 +399,5 @@ const node: ReaderFragment = {
   "type": "Fair",
   "abstractKey": null
 };
-(node as any).hash = 'e8b34b7dd5a4f2647e72d2507678b357';
+(node as any).hash = 'd9dcb34dfc33291539e7dc0e02d282d8';
 export default node;

--- a/src/__generated__/FairQuery.graphql.ts
+++ b/src/__generated__/FairQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 9466a18a3ed143b389f77319923a7102 */
+/* @relayHash f5fd7afde4121593124f033cefb58ec0 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -79,7 +79,7 @@ fragment ArtworkTileRailCard_artwork on Artwork {
 fragment FairArtworks_fair on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
     aggregations {
       slice
       counts {
@@ -524,11 +524,6 @@ v19 = [
     "value": "*-*"
   },
   (v18/*: any*/),
-  {
-    "kind": "Literal",
-    "name": "medium",
-    "value": "*"
-  },
   {
     "kind": "Literal",
     "name": "sort",
@@ -1386,14 +1381,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,medium:\"*\",sort:\"-decayed_merch\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,sort:\"-decayed_merch\")"
           },
           {
             "alias": "fairArtworks",
             "args": (v19/*: any*/),
             "filters": [
               "sort",
-              "medium",
+              "additionalGeneIDs",
               "priceRange",
               "color",
               "partnerID",
@@ -1626,7 +1621,7 @@ return {
     ]
   },
   "params": {
-    "id": "9466a18a3ed143b389f77319923a7102",
+    "id": "f5fd7afde4121593124f033cefb58ec0",
     "metadata": {},
     "name": "FairQuery",
     "operationKind": "query",

--- a/src/__generated__/FairTestsQuery.graphql.ts
+++ b/src/__generated__/FairTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 9c0d1103014846b72c4d8150b8830375 */
+/* @relayHash c5d34feb62ae3842af4204b698a0d71b */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -79,7 +79,7 @@ fragment ArtworkTileRailCard_artwork on Artwork {
 fragment FairArtworks_fair on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
     aggregations {
       slice
       counts {
@@ -524,11 +524,6 @@ v19 = [
     "value": "*-*"
   },
   (v18/*: any*/),
-  {
-    "kind": "Literal",
-    "name": "medium",
-    "value": "*"
-  },
   {
     "kind": "Literal",
     "name": "sort",
@@ -1500,14 +1495,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,medium:\"*\",sort:\"-decayed_merch\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,sort:\"-decayed_merch\")"
           },
           {
             "alias": "fairArtworks",
             "args": (v19/*: any*/),
             "filters": [
               "sort",
-              "medium",
+              "additionalGeneIDs",
               "priceRange",
               "color",
               "partnerID",
@@ -1740,7 +1735,7 @@ return {
     ]
   },
   "params": {
-    "id": "9c0d1103014846b72c4d8150b8830375",
+    "id": "c5d34feb62ae3842af4204b698a0d71b",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "fair": (v30/*: any*/),

--- a/src/__generated__/FilterModalTestsQuery.graphql.ts
+++ b/src/__generated__/FilterModalTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash dd46bea1243d1c1c50da29e95dedecf4 */
+/* @relayHash 2e9894a0095be926fa80b147f78d3ebf */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -136,7 +136,7 @@ fragment CollectionArtworks_collection on MarketingCollection {
   isDepartment
   slug
   id
-  collectionArtworks: artworksConnection(first: 10, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  collectionArtworks: artworksConnection(first: 10, sort: "-decayed_merch", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -234,11 +234,6 @@ v3 = [
     "kind": "Literal",
     "name": "first",
     "value": 10
-  },
-  {
-    "kind": "Literal",
-    "name": "medium",
-    "value": "*"
   },
   {
     "kind": "Literal",
@@ -712,14 +707,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "artworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,medium:\"*\",sort:\"-decayed_merch\")"
+            "storageKey": "artworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,sort:\"-decayed_merch\")"
           },
           {
             "alias": "collectionArtworks",
             "args": (v3/*: any*/),
             "filters": [
               "sort",
-              "medium",
+              "additionalGeneIDs",
               "priceRange",
               "color",
               "partnerID",
@@ -743,7 +738,7 @@ return {
     ]
   },
   "params": {
-    "id": "dd46bea1243d1c1c50da29e95dedecf4",
+    "id": "2e9894a0095be926fa80b147f78d3ebf",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "marketingCollection": {

--- a/src/__generated__/PartnerArtworkInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/PartnerArtworkInfiniteScrollGridQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash d516c9f709cabcbc6d92546dbe0e85c0 */
+/* @relayHash 94549f416051a7713e47046daca3a967 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -12,10 +12,10 @@ export type PartnerArtworkInfiniteScrollGridQueryVariables = {
     count: number;
     cursor?: string | null;
     dimensionRange?: string | null;
+    additionalGeneIDs?: Array<string | null> | null;
     id: string;
     inquireableOnly?: boolean | null;
     majorPeriods?: Array<string | null> | null;
-    medium?: string | null;
     offerable?: boolean | null;
     priceRange?: string | null;
     sort?: string | null;
@@ -40,16 +40,16 @@ query PartnerArtworkInfiniteScrollGridQuery(
   $count: Int!
   $cursor: String
   $dimensionRange: String
+  $additionalGeneIDs: [String]
   $id: String!
   $inquireableOnly: Boolean
   $majorPeriods: [String]
-  $medium: String
   $offerable: Boolean
   $priceRange: String
   $sort: String
 ) {
   partner(id: $id) {
-    ...PartnerArtwork_partner_1LBhko
+    ...PartnerArtwork_partner_2EkHq
     id
   }
 }
@@ -113,10 +113,10 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
   }
 }
 
-fragment PartnerArtwork_partner_1LBhko on Partner {
+fragment PartnerArtwork_partner_2EkHq on Partner {
   internalID
   slug
-  artworks: filterArtworksConnection(acquireable: $acquireable, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], attributionClass: $attributionClass, color: $color, dimensionRange: $dimensionRange, first: $count, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, medium: $medium, offerable: $offerable, priceRange: $priceRange, sort: $sort) {
+  artworks: filterArtworksConnection(acquireable: $acquireable, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], attributionClass: $attributionClass, color: $color, dimensionRange: $dimensionRange, additionalGeneIDs: $additionalGeneIDs, first: $count, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, offerable: $offerable, priceRange: $priceRange, sort: $sort) {
     aggregations {
       slice
       counts {
@@ -143,146 +143,145 @@ fragment PartnerArtwork_partner_1LBhko on Partner {
 */
 
 const node: ConcreteRequest = (function(){
-var v0 = [
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "acquireable"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "attributionClass"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "color"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "count"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "cursor"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "dimensionRange"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "id"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "inquireableOnly"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "majorPeriods"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "medium"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "offerable"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "priceRange"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "sort"
-  }
-],
-v1 = [
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "acquireable"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "additionalGeneIDs"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "attributionClass"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "color"
+},
+v4 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "count"
+},
+v5 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "cursor"
+},
+v6 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "dimensionRange"
+},
+v7 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "id"
+},
+v8 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "inquireableOnly"
+},
+v9 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "majorPeriods"
+},
+v10 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "offerable"
+},
+v11 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "priceRange"
+},
+v12 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "sort"
+},
+v13 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v2 = {
+v14 = {
   "kind": "Variable",
   "name": "acquireable",
   "variableName": "acquireable"
 },
-v3 = {
+v15 = {
+  "kind": "Variable",
+  "name": "additionalGeneIDs",
+  "variableName": "additionalGeneIDs"
+},
+v16 = {
   "kind": "Variable",
   "name": "attributionClass",
   "variableName": "attributionClass"
 },
-v4 = {
+v17 = {
   "kind": "Variable",
   "name": "color",
   "variableName": "color"
 },
-v5 = {
+v18 = {
   "kind": "Variable",
   "name": "dimensionRange",
   "variableName": "dimensionRange"
 },
-v6 = {
+v19 = {
   "kind": "Variable",
   "name": "inquireableOnly",
   "variableName": "inquireableOnly"
 },
-v7 = {
+v20 = {
   "kind": "Variable",
   "name": "majorPeriods",
   "variableName": "majorPeriods"
 },
-v8 = {
-  "kind": "Variable",
-  "name": "medium",
-  "variableName": "medium"
-},
-v9 = {
+v21 = {
   "kind": "Variable",
   "name": "offerable",
   "variableName": "offerable"
 },
-v10 = {
+v22 = {
   "kind": "Variable",
   "name": "priceRange",
   "variableName": "priceRange"
 },
-v11 = {
+v23 = {
   "kind": "Variable",
   "name": "sort",
   "variableName": "sort"
 },
-v12 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v13 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v14 = [
-  (v2/*: any*/),
+v26 = [
+  (v14/*: any*/),
+  (v15/*: any*/),
   {
     "kind": "Variable",
     "name": "after",
@@ -299,36 +298,35 @@ v14 = [
       "PRICE_RANGE"
     ]
   },
-  (v3/*: any*/),
-  (v4/*: any*/),
-  (v5/*: any*/),
+  (v16/*: any*/),
+  (v17/*: any*/),
+  (v18/*: any*/),
   {
     "kind": "Variable",
     "name": "first",
     "variableName": "count"
   },
-  (v6/*: any*/),
-  (v7/*: any*/),
-  (v8/*: any*/),
-  (v9/*: any*/),
-  (v10/*: any*/),
-  (v11/*: any*/)
+  (v19/*: any*/),
+  (v20/*: any*/),
+  (v21/*: any*/),
+  (v22/*: any*/),
+  (v23/*: any*/)
 ],
-v15 = {
+v27 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v16 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v17 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -337,14 +335,28 @@ v17 = {
 };
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/),
+      (v3/*: any*/),
+      (v4/*: any*/),
+      (v5/*: any*/),
+      (v6/*: any*/),
+      (v7/*: any*/),
+      (v8/*: any*/),
+      (v9/*: any*/),
+      (v10/*: any*/),
+      (v11/*: any*/),
+      (v12/*: any*/)
+    ],
     "kind": "Fragment",
     "metadata": null,
     "name": "PartnerArtworkInfiniteScrollGridQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v13/*: any*/),
         "concreteType": "Partner",
         "kind": "LinkedField",
         "name": "partner",
@@ -352,9 +364,10 @@ return {
         "selections": [
           {
             "args": [
-              (v2/*: any*/),
-              (v3/*: any*/),
-              (v4/*: any*/),
+              (v14/*: any*/),
+              (v15/*: any*/),
+              (v16/*: any*/),
+              (v17/*: any*/),
               {
                 "kind": "Variable",
                 "name": "count",
@@ -365,13 +378,12 @@ return {
                 "name": "cursor",
                 "variableName": "cursor"
               },
-              (v5/*: any*/),
-              (v6/*: any*/),
-              (v7/*: any*/),
-              (v8/*: any*/),
-              (v9/*: any*/),
-              (v10/*: any*/),
-              (v11/*: any*/)
+              (v18/*: any*/),
+              (v19/*: any*/),
+              (v20/*: any*/),
+              (v21/*: any*/),
+              (v22/*: any*/),
+              (v23/*: any*/)
             ],
             "kind": "FragmentSpread",
             "name": "PartnerArtwork_partner"
@@ -385,23 +397,37 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v2/*: any*/),
+      (v3/*: any*/),
+      (v4/*: any*/),
+      (v5/*: any*/),
+      (v6/*: any*/),
+      (v1/*: any*/),
+      (v7/*: any*/),
+      (v8/*: any*/),
+      (v9/*: any*/),
+      (v10/*: any*/),
+      (v11/*: any*/),
+      (v12/*: any*/)
+    ],
     "kind": "Operation",
     "name": "PartnerArtworkInfiniteScrollGridQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v13/*: any*/),
         "concreteType": "Partner",
         "kind": "LinkedField",
         "name": "partner",
         "plural": false,
         "selections": [
-          (v12/*: any*/),
-          (v13/*: any*/),
+          (v24/*: any*/),
+          (v25/*: any*/),
           {
             "alias": "artworks",
-            "args": (v14/*: any*/),
+            "args": (v26/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -437,7 +463,7 @@ return {
                         "name": "count",
                         "storageKey": null
                       },
-                      (v15/*: any*/),
+                      (v27/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -467,8 +493,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v16/*: any*/),
-                      (v17/*: any*/)
+                      (v28/*: any*/),
+                      (v29/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -507,7 +533,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v16/*: any*/),
+              (v28/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -537,7 +563,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v17/*: any*/),
+                      (v29/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -546,7 +572,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v13/*: any*/),
+                          (v25/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -599,7 +625,7 @@ return {
                             "name": "saleMessage",
                             "storageKey": null
                           },
-                          (v12/*: any*/),
+                          (v24/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -650,7 +676,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v16/*: any*/)
+                              (v28/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -705,7 +731,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v16/*: any*/)
+                              (v28/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -717,8 +743,8 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v15/*: any*/),
-                              (v16/*: any*/)
+                              (v27/*: any*/),
+                              (v28/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -728,7 +754,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v16/*: any*/)
+                          (v28/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -745,16 +771,16 @@ return {
           },
           {
             "alias": "artworks",
-            "args": (v14/*: any*/),
+            "args": (v26/*: any*/),
             "filters": [
               "acquireable",
               "aggregations",
               "attributionClass",
               "color",
               "dimensionRange",
+              "additionalGeneIDs",
               "inquireableOnly",
               "majorPeriods",
-              "medium",
               "offerable",
               "priceRange",
               "sort"
@@ -764,14 +790,14 @@ return {
             "kind": "LinkedHandle",
             "name": "filterArtworksConnection"
           },
-          (v16/*: any*/)
+          (v28/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "d516c9f709cabcbc6d92546dbe0e85c0",
+    "id": "94549f416051a7713e47046daca3a967",
     "metadata": {},
     "name": "PartnerArtworkInfiniteScrollGridQuery",
     "operationKind": "query",
@@ -779,5 +805,5 @@ return {
   }
 };
 })();
-(node as any).hash = '07bae258d929897d4c852d053a8c265d';
+(node as any).hash = '22ae079a63aaed89398049e310404d44';
 export default node;

--- a/src/__generated__/PartnerArtworkTestsQuery.graphql.ts
+++ b/src/__generated__/PartnerArtworkTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 2500e2ecf289c7fb8f3c250b5516cf47 */
+/* @relayHash 06f66dea309ba0701eb846eb8c41e413 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -156,7 +156,7 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
 fragment PartnerArtwork_partner on Partner {
   internalID
   slug
-  artworks: filterArtworksConnection(aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], dimensionRange: "*-*", first: 10, medium: "*", sort: "-partner_updated_at") {
+  artworks: filterArtworksConnection(aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], dimensionRange: "*-*", first: 10, sort: "-partner_updated_at") {
     aggregations {
       slice
       counts {
@@ -225,11 +225,6 @@ v3 = [
     "kind": "Literal",
     "name": "first",
     "value": 10
-  },
-  {
-    "kind": "Literal",
-    "name": "medium",
-    "value": "*"
   },
   {
     "kind": "Literal",
@@ -643,7 +638,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,medium:\"*\",sort:\"-partner_updated_at\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,sort:\"-partner_updated_at\")"
           },
           {
             "alias": "artworks",
@@ -654,9 +649,9 @@ return {
               "attributionClass",
               "color",
               "dimensionRange",
+              "additionalGeneIDs",
               "inquireableOnly",
               "majorPeriods",
-              "medium",
               "offerable",
               "priceRange",
               "sort"
@@ -673,7 +668,7 @@ return {
     ]
   },
   "params": {
-    "id": "2500e2ecf289c7fb8f3c250b5516cf47",
+    "id": "06f66dea309ba0701eb846eb8c41e413",
     "metadata": {},
     "name": "PartnerArtworkTestsQuery",
     "operationKind": "query",

--- a/src/__generated__/PartnerArtwork_partner.graphql.ts
+++ b/src/__generated__/PartnerArtwork_partner.graphql.ts
@@ -44,6 +44,11 @@ const node: ReaderFragment = {
     {
       "defaultValue": null,
       "kind": "LocalArgument",
+      "name": "additionalGeneIDs"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
       "name": "attributionClass"
     },
     {
@@ -75,11 +80,6 @@ const node: ReaderFragment = {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "majorPeriods"
-    },
-    {
-      "defaultValue": "*",
-      "kind": "LocalArgument",
-      "name": "medium"
     },
     {
       "defaultValue": null,
@@ -135,6 +135,11 @@ const node: ReaderFragment = {
           "variableName": "acquireable"
         },
         {
+          "kind": "Variable",
+          "name": "additionalGeneIDs",
+          "variableName": "additionalGeneIDs"
+        },
+        {
           "kind": "Literal",
           "name": "aggregations",
           "value": [
@@ -169,11 +174,6 @@ const node: ReaderFragment = {
           "kind": "Variable",
           "name": "majorPeriods",
           "variableName": "majorPeriods"
-        },
-        {
-          "kind": "Variable",
-          "name": "medium",
-          "variableName": "medium"
         },
         {
           "kind": "Variable",
@@ -326,5 +326,5 @@ const node: ReaderFragment = {
   "type": "Partner",
   "abstractKey": null
 };
-(node as any).hash = 'a3d3c9fce966b742cea47d5d171eb8f8';
+(node as any).hash = '9b2ebf026165e0508e7452e1aff0f5ec';
 export default node;

--- a/src/__generated__/PartnerQuery.graphql.ts
+++ b/src/__generated__/PartnerQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 8b88b1dea44778b59f195800c0a77c29 */
+/* @relayHash 40f205d039ce3c8e64369a5bb25cc0e5 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -108,7 +108,7 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
 fragment PartnerArtwork_partner on Partner {
   internalID
   slug
-  artworks: filterArtworksConnection(aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], dimensionRange: "*-*", first: 10, medium: "*", sort: "-partner_updated_at") {
+  artworks: filterArtworksConnection(aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], dimensionRange: "*-*", first: 10, sort: "-partner_updated_at") {
     aggregations {
       slice
       counts {
@@ -368,11 +368,6 @@ v7 = [
     "value": "*-*"
   },
   (v6/*: any*/),
-  {
-    "kind": "Literal",
-    "name": "medium",
-    "value": "*"
-  },
   {
     "kind": "Literal",
     "name": "sort",
@@ -894,7 +889,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,medium:\"*\",sort:\"-partner_updated_at\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,sort:\"-partner_updated_at\")"
           },
           {
             "alias": "artworks",
@@ -905,9 +900,9 @@ return {
               "attributionClass",
               "color",
               "dimensionRange",
+              "additionalGeneIDs",
               "inquireableOnly",
               "majorPeriods",
-              "medium",
               "offerable",
               "priceRange",
               "sort"
@@ -1290,7 +1285,7 @@ return {
     ]
   },
   "params": {
-    "id": "8b88b1dea44778b59f195800c0a77c29",
+    "id": "40f205d039ce3c8e64369a5bb25cc0e5",
     "metadata": {},
     "name": "PartnerQuery",
     "operationKind": "query",

--- a/src/__generated__/PartnerRefetchQuery.graphql.ts
+++ b/src/__generated__/PartnerRefetchQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 2b6746089f025938a356d853007393bc */
+/* @relayHash ee5938bb907da6c82d5118f9a537ad6e */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -109,7 +109,7 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
 fragment PartnerArtwork_partner on Partner {
   internalID
   slug
-  artworks: filterArtworksConnection(aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], dimensionRange: "*-*", first: 10, medium: "*", sort: "-partner_updated_at") {
+  artworks: filterArtworksConnection(aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], dimensionRange: "*-*", first: 10, sort: "-partner_updated_at") {
     aggregations {
       slice
       counts {
@@ -376,11 +376,6 @@ v8 = [
     "value": "*-*"
   },
   (v7/*: any*/),
-  {
-    "kind": "Literal",
-    "name": "medium",
-    "value": "*"
-  },
   {
     "kind": "Literal",
     "name": "sort",
@@ -899,7 +894,7 @@ return {
                     "abstractKey": "__isArtworkConnectionInterface"
                   }
                 ],
-                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,medium:\"*\",sort:\"-partner_updated_at\")"
+                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,sort:\"-partner_updated_at\")"
               },
               {
                 "alias": "artworks",
@@ -910,9 +905,9 @@ return {
                   "attributionClass",
                   "color",
                   "dimensionRange",
+                  "additionalGeneIDs",
                   "inquireableOnly",
                   "majorPeriods",
-                  "medium",
                   "offerable",
                   "priceRange",
                   "sort"
@@ -1299,7 +1294,7 @@ return {
     ]
   },
   "params": {
-    "id": "2b6746089f025938a356d853007393bc",
+    "id": "ee5938bb907da6c82d5118f9a537ad6e",
     "metadata": {},
     "name": "PartnerRefetchQuery",
     "operationKind": "query",

--- a/src/__generated__/ShowArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/ShowArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 0559d18617f36d00f4b6f561120c8e41 */
+/* @relayHash f2324a933932b6d75c43aeab28c9f69c */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -10,7 +10,7 @@ export type ShowArtworksInfiniteScrollGridQueryVariables = {
     count: number;
     cursor?: string | null;
     sort?: string | null;
-    medium?: string | null;
+    additionalGeneIDs?: Array<string | null> | null;
     priceRange?: string | null;
     color?: string | null;
     dimensionRange?: string | null;
@@ -38,7 +38,7 @@ query ShowArtworksInfiniteScrollGridQuery(
   $id: String!
   $cursor: String
   $sort: String
-  $medium: String
+  $additionalGeneIDs: [String]
   $priceRange: String
   $color: String
   $dimensionRange: String
@@ -50,7 +50,7 @@ query ShowArtworksInfiniteScrollGridQuery(
   $attributionClass: [String]
 ) {
   show(id: $id) {
-    ...ShowArtworks_show_3IiyVu
+    ...ShowArtworks_show_3mnOQ1
     id
   }
 }
@@ -114,10 +114,10 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
   }
 }
 
-fragment ShowArtworks_show_3IiyVu on Show {
+fragment ShowArtworks_show_3mnOQ1 on Show {
   slug
   internalID
-  showArtworks: filterArtworksConnection(first: 30, after: $cursor, sort: $sort, medium: $medium, priceRange: $priceRange, color: $color, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], attributionClass: $attributionClass) {
+  showArtworks: filterArtworksConnection(first: 30, after: $cursor, sort: $sort, additionalGeneIDs: $additionalGeneIDs, priceRange: $priceRange, color: $color, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], attributionClass: $attributionClass) {
     aggregations {
       slice
       counts {
@@ -155,52 +155,52 @@ var v0 = {
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "atAuction"
+  "name": "additionalGeneIDs"
 },
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "attributionClass"
+  "name": "atAuction"
 },
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "color"
+  "name": "attributionClass"
 },
 v4 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "count"
+  "name": "color"
 },
 v5 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "cursor"
+  "name": "count"
 },
 v6 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "dimensionRange"
+  "name": "cursor"
 },
 v7 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "id"
+  "name": "dimensionRange"
 },
 v8 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "inquireableOnly"
+  "name": "id"
 },
 v9 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "majorPeriods"
+  "name": "inquireableOnly"
 },
 v10 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "medium"
+  "name": "majorPeriods"
 },
 v11 = {
   "defaultValue": null,
@@ -231,38 +231,38 @@ v15 = {
 },
 v16 = {
   "kind": "Variable",
+  "name": "additionalGeneIDs",
+  "variableName": "additionalGeneIDs"
+},
+v17 = {
+  "kind": "Variable",
   "name": "atAuction",
   "variableName": "atAuction"
 },
-v17 = {
+v18 = {
   "kind": "Variable",
   "name": "attributionClass",
   "variableName": "attributionClass"
 },
-v18 = {
+v19 = {
   "kind": "Variable",
   "name": "color",
   "variableName": "color"
 },
-v19 = {
+v20 = {
   "kind": "Variable",
   "name": "dimensionRange",
   "variableName": "dimensionRange"
 },
-v20 = {
+v21 = {
   "kind": "Variable",
   "name": "inquireableOnly",
   "variableName": "inquireableOnly"
 },
-v21 = {
+v22 = {
   "kind": "Variable",
   "name": "majorPeriods",
   "variableName": "majorPeriods"
-},
-v22 = {
-  "kind": "Variable",
-  "name": "medium",
-  "variableName": "medium"
 },
 v23 = {
   "kind": "Variable",
@@ -295,6 +295,7 @@ v27 = {
 },
 v28 = [
   (v15/*: any*/),
+  (v16/*: any*/),
   {
     "kind": "Variable",
     "name": "after",
@@ -311,16 +312,15 @@ v28 = [
       "PRICE_RANGE"
     ]
   },
-  (v16/*: any*/),
   (v17/*: any*/),
   (v18/*: any*/),
   (v19/*: any*/),
+  (v20/*: any*/),
   {
     "kind": "Literal",
     "name": "first",
     "value": 30
   },
-  (v20/*: any*/),
   (v21/*: any*/),
   (v22/*: any*/),
   (v23/*: any*/),
@@ -384,6 +384,7 @@ return {
               (v16/*: any*/),
               (v17/*: any*/),
               (v18/*: any*/),
+              (v19/*: any*/),
               {
                 "kind": "Variable",
                 "name": "count",
@@ -394,7 +395,6 @@ return {
                 "name": "cursor",
                 "variableName": "cursor"
               },
-              (v19/*: any*/),
               (v20/*: any*/),
               (v21/*: any*/),
               (v22/*: any*/),
@@ -415,20 +415,20 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v7/*: any*/),
-      (v4/*: any*/),
-      (v5/*: any*/),
-      (v13/*: any*/),
-      (v10/*: any*/),
-      (v12/*: any*/),
-      (v3/*: any*/),
-      (v6/*: any*/),
-      (v9/*: any*/),
-      (v0/*: any*/),
       (v8/*: any*/),
+      (v5/*: any*/),
+      (v6/*: any*/),
+      (v13/*: any*/),
       (v1/*: any*/),
+      (v12/*: any*/),
+      (v4/*: any*/),
+      (v7/*: any*/),
+      (v10/*: any*/),
+      (v0/*: any*/),
+      (v9/*: any*/),
+      (v2/*: any*/),
       (v11/*: any*/),
-      (v2/*: any*/)
+      (v3/*: any*/)
     ],
     "kind": "Operation",
     "name": "ShowArtworksInfiniteScrollGridQuery",
@@ -810,7 +810,7 @@ return {
             "args": (v28/*: any*/),
             "filters": [
               "sort",
-              "medium",
+              "additionalGeneIDs",
               "priceRange",
               "color",
               "dimensionRange",
@@ -834,7 +834,7 @@ return {
     ]
   },
   "params": {
-    "id": "0559d18617f36d00f4b6f561120c8e41",
+    "id": "f2324a933932b6d75c43aeab28c9f69c",
     "metadata": {},
     "name": "ShowArtworksInfiniteScrollGridQuery",
     "operationKind": "query",
@@ -842,5 +842,5 @@ return {
   }
 };
 })();
-(node as any).hash = '4e086ee0a8ba4eaf348b248c966a5a5b';
+(node as any).hash = 'f43980d86a1d42a3f42a07e2463c20a1';
 export default node;

--- a/src/__generated__/ShowArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/ShowArtworksTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash a18dae78b377778745117c2f5e67b8d4 */
+/* @relayHash 3d32e5c1e9160ef29b2474f9d23b6051 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -92,7 +92,7 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
 fragment ShowArtworks_show on Show {
   slug
   internalID
-  showArtworks: filterArtworksConnection(first: 30, sort: "partner_show_position", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  showArtworks: filterArtworksConnection(first: 30, sort: "partner_show_position", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -171,11 +171,6 @@ v4 = [
     "kind": "Literal",
     "name": "first",
     "value": 30
-  },
-  {
-    "kind": "Literal",
-    "name": "medium",
-    "value": "*"
   },
   {
     "kind": "Literal",
@@ -637,14 +632,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:30,medium:\"*\",sort:\"partner_show_position\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:30,sort:\"partner_show_position\")"
           },
           {
             "alias": "showArtworks",
             "args": (v4/*: any*/),
             "filters": [
               "sort",
-              "medium",
+              "additionalGeneIDs",
               "priceRange",
               "color",
               "dimensionRange",
@@ -668,7 +663,7 @@ return {
     ]
   },
   "params": {
-    "id": "a18dae78b377778745117c2f5e67b8d4",
+    "id": "3d32e5c1e9160ef29b2474f9d23b6051",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "show": {

--- a/src/__generated__/ShowArtworks_show.graphql.ts
+++ b/src/__generated__/ShowArtworks_show.graphql.ts
@@ -47,6 +47,11 @@ const node: ReaderFragment = {
     {
       "defaultValue": null,
       "kind": "LocalArgument",
+      "name": "additionalGeneIDs"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
       "name": "atAuction"
     },
     {
@@ -83,11 +88,6 @@ const node: ReaderFragment = {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "majorPeriods"
-    },
-    {
-      "defaultValue": "*",
-      "kind": "LocalArgument",
-      "name": "medium"
     },
     {
       "defaultValue": null,
@@ -143,6 +143,11 @@ const node: ReaderFragment = {
           "variableName": "acquireable"
         },
         {
+          "kind": "Variable",
+          "name": "additionalGeneIDs",
+          "variableName": "additionalGeneIDs"
+        },
+        {
           "kind": "Literal",
           "name": "aggregations",
           "value": [
@@ -182,11 +187,6 @@ const node: ReaderFragment = {
           "kind": "Variable",
           "name": "majorPeriods",
           "variableName": "majorPeriods"
-        },
-        {
-          "kind": "Variable",
-          "name": "medium",
-          "variableName": "medium"
         },
         {
           "kind": "Variable",
@@ -357,5 +357,5 @@ const node: ReaderFragment = {
   "type": "Show",
   "abstractKey": null
 };
-(node as any).hash = 'fc989d065d6210929db6be2d63d09bff';
+(node as any).hash = '0f5feeacff64eba79e8accb253635254';
 export default node;

--- a/src/__generated__/ShowQuery.graphql.ts
+++ b/src/__generated__/ShowQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 2210c19ff996768865b7da34a0eb78a3 */
+/* @relayHash a766e14baa264bd8580e53a1cd499043 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -97,7 +97,7 @@ fragment ShowArtworksEmptyState_show on Show {
 fragment ShowArtworks_show on Show {
   slug
   internalID
-  showArtworks: filterArtworksConnection(first: 30, sort: "partner_show_position", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  showArtworks: filterArtworksConnection(first: 30, sort: "partner_show_position", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -392,11 +392,6 @@ v14 = [
     "kind": "Literal",
     "name": "first",
     "value": 30
-  },
-  {
-    "kind": "Literal",
-    "name": "medium",
-    "value": "*"
   },
   {
     "kind": "Literal",
@@ -1183,14 +1178,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:30,medium:\"*\",sort:\"partner_show_position\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:30,sort:\"partner_show_position\")"
           },
           {
             "alias": "showArtworks",
             "args": (v14/*: any*/),
             "filters": [
               "sort",
-              "medium",
+              "additionalGeneIDs",
               "priceRange",
               "color",
               "dimensionRange",
@@ -1240,7 +1235,7 @@ return {
     ]
   },
   "params": {
-    "id": "2210c19ff996768865b7da34a0eb78a3",
+    "id": "a766e14baa264bd8580e53a1cd499043",
     "metadata": {},
     "name": "ShowQuery",
     "operationKind": "query",

--- a/src/__generated__/ShowTestsQuery.graphql.ts
+++ b/src/__generated__/ShowTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash f445dd1a38261254b5b00fc36d0d9851 */
+/* @relayHash bba942b2dc2cf6860a4df3c00dc10573 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -97,7 +97,7 @@ fragment ShowArtworksEmptyState_show on Show {
 fragment ShowArtworks_show on Show {
   slug
   internalID
-  showArtworks: filterArtworksConnection(first: 30, sort: "partner_show_position", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  showArtworks: filterArtworksConnection(first: 30, sort: "partner_show_position", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -392,11 +392,6 @@ v14 = [
     "kind": "Literal",
     "name": "first",
     "value": 30
-  },
-  {
-    "kind": "Literal",
-    "name": "medium",
-    "value": "*"
   },
   {
     "kind": "Literal",
@@ -1237,14 +1232,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:30,medium:\"*\",sort:\"partner_show_position\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:30,sort:\"partner_show_position\")"
           },
           {
             "alias": "showArtworks",
             "args": (v14/*: any*/),
             "filters": [
               "sort",
-              "medium",
+              "additionalGeneIDs",
               "priceRange",
               "color",
               "dimensionRange",
@@ -1294,7 +1289,7 @@ return {
     ]
   },
   "params": {
-    "id": "f445dd1a38261254b5b00fc36d0d9851",
+    "id": "bba942b2dc2cf6860a4df3c00dc10573",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "show": {

--- a/src/__generated__/VanityURLEntityQuery.graphql.ts
+++ b/src/__generated__/VanityURLEntityQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash df0e0c527837bbceaad780b3690f622e */
+/* @relayHash 3a1774cbdda70445c7d3746d06fb8e4a */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -99,7 +99,7 @@ fragment ArtworkTileRailCard_artwork on Artwork {
 fragment FairArtworks_fair on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", medium: "*", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, GALLERY, INSTITUTION, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
     aggregations {
       slice
       counts {
@@ -767,11 +767,6 @@ v22 = [
   },
   (v20/*: any*/),
   (v21/*: any*/),
-  {
-    "kind": "Literal",
-    "name": "medium",
-    "value": "*"
-  },
   {
     "kind": "Literal",
     "name": "sort",
@@ -1741,14 +1736,14 @@ return {
                   (v5/*: any*/),
                   (v37/*: any*/)
                 ],
-                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,medium:\"*\",sort:\"-decayed_merch\")"
+                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,sort:\"-decayed_merch\")"
               },
               {
                 "alias": "fairArtworks",
                 "args": (v22/*: any*/),
                 "filters": [
                   "sort",
-                  "medium",
+                  "additionalGeneIDs",
                   "priceRange",
                   "color",
                   "partnerID",
@@ -2407,7 +2402,7 @@ return {
     ]
   },
   "params": {
-    "id": "df0e0c527837bbceaad780b3690f622e",
+    "id": "3a1774cbdda70445c7d3746d06fb8e4a",
     "metadata": {},
     "name": "VanityURLEntityQuery",
     "operationKind": "query",

--- a/src/__generated__/VanityURLEntityQuery.graphql.ts
+++ b/src/__generated__/VanityURLEntityQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 52fcf6a5020336a545051f7a20b65e12 */
+/* @relayHash df0e0c527837bbceaad780b3690f622e */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -394,7 +394,7 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
 fragment PartnerArtwork_partner on Partner {
   internalID
   slug
-  artworks: filterArtworksConnection(aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], dimensionRange: "*-*", first: 10, medium: "*", sort: "-partner_updated_at") {
+  artworks: filterArtworksConnection(aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], dimensionRange: "*-*", first: 10, sort: "-partner_updated_at") {
     aggregations {
       slice
       counts {
@@ -749,12 +749,7 @@ v21 = {
   "name": "first",
   "value": 30
 },
-v22 = {
-  "kind": "Literal",
-  "name": "medium",
-  "value": "*"
-},
-v23 = [
+v22 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -772,14 +767,18 @@ v23 = [
   },
   (v20/*: any*/),
   (v21/*: any*/),
-  (v22/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "medium",
+    "value": "*"
+  },
   {
     "kind": "Literal",
     "name": "sort",
     "value": "-decayed_merch"
   }
 ],
-v24 = {
+v23 = {
   "alias": null,
   "args": null,
   "concreteType": "ArtworksAggregationResults",
@@ -823,14 +822,14 @@ v24 = {
   ],
   "storageKey": null
 },
-v25 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v26 = {
+v25 = {
   "alias": null,
   "args": null,
   "concreteType": "FilterArtworksEdge",
@@ -851,25 +850,25 @@ v26 = {
       ],
       "storageKey": null
     },
-    (v25/*: any*/)
+    (v24/*: any*/)
   ],
   "storageKey": null
 },
-v27 = {
+v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endCursor",
   "storageKey": null
 },
-v28 = {
+v27 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "hasNextPage",
   "storageKey": null
 },
-v29 = {
+v28 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -877,33 +876,33 @@ v29 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v27/*: any*/),
-    (v28/*: any*/)
+    (v26/*: any*/),
+    (v27/*: any*/)
   ],
   "storageKey": null
 },
-v30 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startCursor",
   "storageKey": null
 },
-v31 = {
+v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isAuction",
   "storageKey": null
 },
-v32 = {
+v31 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v33 = {
+v32 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCounts",
@@ -921,7 +920,7 @@ v33 = {
   ],
   "storageKey": null
 },
-v34 = [
+v33 = [
   {
     "alias": null,
     "args": null,
@@ -930,26 +929,26 @@ v34 = [
     "storageKey": null
   }
 ],
-v35 = {
+v34 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCurrentBid",
   "kind": "LinkedField",
   "name": "currentBid",
   "plural": false,
-  "selections": (v34/*: any*/),
+  "selections": (v33/*: any*/),
   "storageKey": null
 },
-v36 = [
+v35 = [
   (v5/*: any*/)
 ],
-v37 = {
+v36 = {
   "kind": "InlineFragment",
-  "selections": (v36/*: any*/),
+  "selections": (v35/*: any*/),
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v38 = {
+v37 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -960,7 +959,7 @@ v38 = {
       "name": "pageInfo",
       "plural": false,
       "selections": [
-        (v30/*: any*/)
+        (v29/*: any*/)
       ],
       "storageKey": null
     },
@@ -1027,8 +1026,8 @@ v38 = {
               "name": "sale",
               "plural": false,
               "selections": [
+                (v30/*: any*/),
                 (v31/*: any*/),
-                (v32/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -1049,8 +1048,8 @@ v38 = {
               "name": "saleArtwork",
               "plural": false,
               "selections": [
-                (v33/*: any*/),
-                (v35/*: any*/),
+                (v32/*: any*/),
+                (v34/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -1078,7 +1077,7 @@ v38 = {
           ],
           "storageKey": null
         },
-        (v37/*: any*/)
+        (v36/*: any*/)
       ],
       "storageKey": null
     }
@@ -1086,7 +1085,7 @@ v38 = {
   "type": "ArtworkConnectionInterface",
   "abstractKey": "__isArtworkConnectionInterface"
 },
-v39 = [
+v38 = [
   (v21/*: any*/),
   {
     "kind": "Literal",
@@ -1094,22 +1093,22 @@ v39 = [
     "value": "FEATURED_ASC"
   }
 ],
-v40 = [
+v39 = [
   (v9/*: any*/)
 ],
-v41 = [
+v40 = [
   (v5/*: any*/),
   (v15/*: any*/)
 ],
-v42 = [
+v41 = [
   "sort"
 ],
-v43 = {
+v42 = {
   "kind": "Literal",
   "name": "first",
   "value": 10
 },
-v44 = [
+v43 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -1122,23 +1121,22 @@ v44 = [
     ]
   },
   (v20/*: any*/),
-  (v43/*: any*/),
-  (v22/*: any*/),
+  (v42/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "-partner_updated_at"
   }
 ],
-v45 = [
-  (v43/*: any*/),
+v44 = [
+  (v42/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "SORTABLE_ID_ASC"
   }
 ],
-v46 = {
+v45 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -1146,35 +1144,35 @@ v46 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v28/*: any*/),
-    (v30/*: any*/),
-    (v27/*: any*/)
+    (v27/*: any*/),
+    (v29/*: any*/),
+    (v26/*: any*/)
   ],
   "storageKey": null
 },
-v47 = {
+v46 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v48 = [
-  (v47/*: any*/)
+v47 = [
+  (v46/*: any*/)
 ],
-v49 = {
+v48 = {
   "kind": "Literal",
   "name": "status",
   "value": "CURRENT"
 },
-v50 = {
+v49 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isDisplayable",
   "storageKey": null
 },
-v51 = [
+v50 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -1191,11 +1189,11 @@ v51 = [
     "value": "CLOSED"
   }
 ],
-v52 = [
+v51 = [
   "status",
   "sort"
 ],
-v53 = [
+v52 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -1206,7 +1204,7 @@ v53 = [
     "name": "sort",
     "value": "END_AT_ASC"
   },
-  (v49/*: any*/)
+  (v48/*: any*/)
 ];
 return {
   "fragment": {
@@ -1706,14 +1704,14 @@ return {
               (v19/*: any*/),
               {
                 "alias": "fairArtworks",
-                "args": (v23/*: any*/),
+                "args": (v22/*: any*/),
                 "concreteType": "FilterArtworksConnection",
                 "kind": "LinkedField",
                 "name": "filterArtworksConnection",
                 "plural": false,
                 "selections": [
-                  (v24/*: any*/),
-                  (v26/*: any*/),
+                  (v23/*: any*/),
+                  (v25/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1739,15 +1737,15 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v29/*: any*/),
+                  (v28/*: any*/),
                   (v5/*: any*/),
-                  (v38/*: any*/)
+                  (v37/*: any*/)
                 ],
                 "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"GALLERY\",\"INSTITUTION\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,medium:\"*\",sort:\"-decayed_merch\")"
               },
               {
                 "alias": "fairArtworks",
-                "args": (v23/*: any*/),
+                "args": (v22/*: any*/),
                 "filters": [
                   "sort",
                   "medium",
@@ -1772,7 +1770,7 @@ return {
               },
               {
                 "alias": "exhibitors",
-                "args": (v39/*: any*/),
+                "args": (v38/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
@@ -1802,7 +1800,7 @@ return {
                             "kind": "LinkedField",
                             "name": "counts",
                             "plural": false,
-                            "selections": (v40/*: any*/),
+                            "selections": (v39/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1816,17 +1814,17 @@ return {
                               (v2/*: any*/),
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v41/*: any*/),
+                                "selections": (v40/*: any*/),
                                 "type": "Partner",
                                 "abstractKey": null
                               },
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v41/*: any*/),
+                                "selections": (v40/*: any*/),
                                 "type": "ExternalPartner",
                                 "abstractKey": null
                               },
-                              (v37/*: any*/)
+                              (v36/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1905,7 +1903,7 @@ return {
                                             "kind": "LinkedField",
                                             "name": "openingBid",
                                             "plural": false,
-                                            "selections": (v34/*: any*/),
+                                            "selections": (v33/*: any*/),
                                             "storageKey": null
                                           },
                                           {
@@ -1915,11 +1913,11 @@ return {
                                             "kind": "LinkedField",
                                             "name": "highestBid",
                                             "plural": false,
-                                            "selections": (v34/*: any*/),
+                                            "selections": (v33/*: any*/),
                                             "storageKey": null
                                           },
-                                          (v35/*: any*/),
-                                          (v33/*: any*/),
+                                          (v34/*: any*/),
+                                          (v32/*: any*/),
                                           (v5/*: any*/)
                                         ],
                                         "storageKey": null
@@ -1932,8 +1930,8 @@ return {
                                         "name": "sale",
                                         "plural": false,
                                         "selections": [
-                                          (v32/*: any*/),
                                           (v31/*: any*/),
+                                          (v30/*: any*/),
                                           (v19/*: any*/),
                                           (v5/*: any*/)
                                         ],
@@ -1955,18 +1953,18 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v25/*: any*/)
+                      (v24/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v29/*: any*/)
+                  (v28/*: any*/)
                 ],
                 "storageKey": "showsConnection(first:30,sort:\"FEATURED_ASC\")"
               },
               {
                 "alias": "exhibitors",
-                "args": (v39/*: any*/),
-                "filters": (v42/*: any*/),
+                "args": (v38/*: any*/),
+                "filters": (v41/*: any*/),
                 "handle": "connection",
                 "key": "FairExhibitorsQuery_exhibitors",
                 "kind": "LinkedHandle",
@@ -2012,32 +2010,32 @@ return {
               },
               {
                 "alias": "artworks",
-                "args": (v44/*: any*/),
+                "args": (v43/*: any*/),
                 "concreteType": "FilterArtworksConnection",
                 "kind": "LinkedField",
                 "name": "filterArtworksConnection",
                 "plural": false,
                 "selections": [
-                  (v24/*: any*/),
-                  (v26/*: any*/),
-                  (v29/*: any*/),
+                  (v23/*: any*/),
+                  (v25/*: any*/),
+                  (v28/*: any*/),
                   (v5/*: any*/),
-                  (v38/*: any*/)
+                  (v37/*: any*/)
                 ],
-                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,medium:\"*\",sort:\"-partner_updated_at\")"
+                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,sort:\"-partner_updated_at\")"
               },
               {
                 "alias": "artworks",
-                "args": (v44/*: any*/),
+                "args": (v43/*: any*/),
                 "filters": [
                   "acquireable",
                   "aggregations",
                   "attributionClass",
                   "color",
                   "dimensionRange",
+                  "additionalGeneIDs",
                   "inquireableOnly",
                   "majorPeriods",
-                  "medium",
                   "offerable",
                   "priceRange",
                   "sort"
@@ -2057,13 +2055,13 @@ return {
               },
               {
                 "alias": "artists",
-                "args": (v45/*: any*/),
+                "args": (v44/*: any*/),
                 "concreteType": "ArtistPartnerConnection",
                 "kind": "LinkedField",
                 "name": "artistsConnection",
                 "plural": false,
                 "selections": [
-                  (v46/*: any*/),
+                  (v45/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2127,7 +2125,7 @@ return {
                             "kind": "LinkedField",
                             "name": "image",
                             "plural": false,
-                            "selections": (v48/*: any*/),
+                            "selections": (v47/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -2137,14 +2135,14 @@ return {
                             "kind": "LinkedField",
                             "name": "counts",
                             "plural": false,
-                            "selections": (v40/*: any*/),
+                            "selections": (v39/*: any*/),
                             "storageKey": null
                           },
                           (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v25/*: any*/),
+                      (v24/*: any*/),
                       (v5/*: any*/)
                     ],
                     "storageKey": null
@@ -2154,8 +2152,8 @@ return {
               },
               {
                 "alias": "artists",
-                "args": (v45/*: any*/),
-                "filters": (v42/*: any*/),
+                "args": (v44/*: any*/),
+                "filters": (v41/*: any*/),
                 "handle": "connection",
                 "key": "Partner_artists",
                 "kind": "LinkedHandle",
@@ -2182,8 +2180,8 @@ return {
               {
                 "alias": "recentShows",
                 "args": [
-                  (v43/*: any*/),
-                  (v49/*: any*/)
+                  (v42/*: any*/),
+                  (v48/*: any*/)
                 ],
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
@@ -2207,7 +2205,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v5/*: any*/),
-                          (v50/*: any*/)
+                          (v49/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -2219,13 +2217,13 @@ return {
               },
               {
                 "alias": "pastShows",
-                "args": (v51/*: any*/),
+                "args": (v50/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": [
-                  (v46/*: any*/),
+                  (v45/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2242,7 +2240,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v50/*: any*/),
+                          (v49/*: any*/),
                           (v5/*: any*/),
                           (v15/*: any*/),
                           (v3/*: any*/),
@@ -2255,7 +2253,7 @@ return {
                             "name": "coverImage",
                             "plural": false,
                             "selections": [
-                              (v47/*: any*/),
+                              (v46/*: any*/),
                               (v16/*: any*/)
                             ],
                             "storageKey": null
@@ -2265,7 +2263,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v25/*: any*/)
+                      (v24/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -2274,8 +2272,8 @@ return {
               },
               {
                 "alias": "pastShows",
-                "args": (v51/*: any*/),
-                "filters": (v52/*: any*/),
+                "args": (v50/*: any*/),
+                "filters": (v51/*: any*/),
                 "handle": "connection",
                 "key": "Partner_pastShows",
                 "kind": "LinkedHandle",
@@ -2283,13 +2281,13 @@ return {
               },
               {
                 "alias": "currentAndUpcomingShows",
-                "args": (v53/*: any*/),
+                "args": (v52/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": [
-                  (v46/*: any*/),
+                  (v45/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2306,7 +2304,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v50/*: any*/),
+                          (v49/*: any*/),
                           (v5/*: any*/),
                           (v4/*: any*/),
                           (v3/*: any*/),
@@ -2320,7 +2318,7 @@ return {
                             "kind": "LinkedField",
                             "name": "images",
                             "plural": true,
-                            "selections": (v48/*: any*/),
+                            "selections": (v47/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -2340,10 +2338,10 @@ return {
                                 "type": "Partner",
                                 "abstractKey": null
                               },
-                              (v37/*: any*/),
+                              (v36/*: any*/),
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v36/*: any*/),
+                                "selections": (v35/*: any*/),
                                 "type": "ExternalPartner",
                                 "abstractKey": null
                               }
@@ -2357,14 +2355,14 @@ return {
                             "kind": "LinkedField",
                             "name": "coverImage",
                             "plural": false,
-                            "selections": (v48/*: any*/),
+                            "selections": (v47/*: any*/),
                             "storageKey": null
                           },
                           (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v25/*: any*/)
+                      (v24/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -2373,8 +2371,8 @@ return {
               },
               {
                 "alias": "currentAndUpcomingShows",
-                "args": (v53/*: any*/),
-                "filters": (v52/*: any*/),
+                "args": (v52/*: any*/),
+                "filters": (v51/*: any*/),
                 "handle": "connection",
                 "key": "Partner_currentAndUpcomingShows",
                 "kind": "LinkedHandle",
@@ -2402,14 +2400,14 @@ return {
             "type": "Partner",
             "abstractKey": null
           },
-          (v37/*: any*/)
+          (v36/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "52fcf6a5020336a545051f7a20b65e12",
+    "id": "df0e0c527837bbceaad780b3690f622e",
     "metadata": {},
     "name": "VanityURLEntityQuery",
     "operationKind": "query",

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -266,7 +266,7 @@ export default createPaginationContainer(
         count: { type: "Int", defaultValue: 10 }
         cursor: { type: "String" }
         sort: { type: "String", defaultValue: "-decayed_merch" }
-        medium: { type: "String", defaultValue: "*" }
+        additionalGeneIDs: { type: "[String]" }
         priceRange: { type: "String" }
         color: { type: "String" }
         partnerID: { type: "ID" }
@@ -285,7 +285,7 @@ export default createPaginationContainer(
           first: $count
           after: $cursor
           sort: $sort
-          medium: $medium
+          additionalGeneIDs: $additionalGeneIDs
           priceRange: $priceRange
           color: $color
           partnerID: $partnerID
@@ -353,7 +353,7 @@ export default createPaginationContainer(
         $count: Int!
         $cursor: String
         $sort: String
-        $medium: String
+        $additionalGeneIDs: [String]
         $priceRange: String
         $color: String
         $partnerID: ID
@@ -372,7 +372,7 @@ export default createPaginationContainer(
                 count: $count
                 cursor: $cursor
                 sort: $sort
-                medium: $medium
+                additionalGeneIDs: $additionalGeneIDs
                 color: $color
                 partnerID: $partnerID
                 priceRange: $priceRange

--- a/src/lib/Components/ArtworkFilterOptions/AdditionalGeneIDsOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/AdditionalGeneIDsOptions.tsx
@@ -1,0 +1,114 @@
+import { StackScreenProps } from "@react-navigation/stack"
+import { FilterData, ParamDefaultValues } from "lib/utils/ArtworkFilter/ArtworkFiltersStore"
+import { FilterDisplayName, FilterParamName } from "lib/utils/ArtworkFilter/FilterArtworksHelpers"
+import { useArtworkFiltersAggregation } from "lib/utils/ArtworkFilter/useArtworkFilters"
+import React, { useState } from "react"
+import { FilterModalNavigationStack } from "../FilterModal"
+import { MultiSelectOptionScreen } from "./MultiSelectOption"
+
+const DEFAULT_OPTION: FilterData = {
+  displayText: "All",
+  paramValue: ParamDefaultValues.additionalGeneIDs,
+  paramName: FilterParamName.additionalGeneIDs,
+}
+
+interface AdditionalGeneIDsOptionsScreenProps
+  extends StackScreenProps<FilterModalNavigationStack, "AdditionalGeneIDsOptionsScreen"> {}
+
+export const AdditionalGeneIDsOptionsScreen: React.FC<AdditionalGeneIDsOptionsScreenProps> = ({ navigation }) => {
+  // Uses the medium aggregations
+  const { aggregation } = useArtworkFiltersAggregation({ paramName: FilterParamName.medium })
+
+  // But updates the additionalGeneIDs option
+  const { dispatch, selectedOption } = useArtworkFiltersAggregation({ paramName: FilterParamName.additionalGeneIDs })
+
+  const [nextOptions, setNextOptions] = useState<string[]>((selectedOption?.paramValue as string[]) ?? [])
+
+  const filterOptions: FilterData[] = [
+    DEFAULT_OPTION,
+    ...(aggregation?.counts ?? []).map(({ name: displayText, value: paramValue, count }) => {
+      return {
+        paramName: FilterParamName.additionalGeneIDs,
+        displayText,
+        paramValue,
+        count,
+      }
+    }),
+  ]
+
+  const booleanFilterOptions: FilterData[] = filterOptions.map((option) => {
+    if (option.displayText === DEFAULT_OPTION.displayText) {
+      return { ...option, paramValue: nextOptions.length === 0 }
+    }
+
+    return { ...option, paramValue: nextOptions.includes(option.paramValue as string) }
+  })
+
+  const handleSelect = (option: FilterData, updatedValue: boolean) => {
+    if (updatedValue) {
+      setNextOptions((prev) => {
+        let next = []
+
+        // If the `All` toggle is selected; reset the filters to the default value (`[]`)
+        if (option.displayText === DEFAULT_OPTION.displayText) {
+          next = ParamDefaultValues.additionalGeneIDs
+        } else {
+          // Otherwise append it
+          next = [
+            ...prev,
+            (aggregation?.counts ?? []).find(({ name }) => {
+              return name === option.displayText
+            })?.value as string,
+          ]
+        }
+
+        dispatch({
+          type: "selectFilters",
+          payload: {
+            displayText: option.displayText,
+            paramValue: next,
+            paramName: option.paramName,
+          },
+        })
+
+        return next
+      })
+    } else {
+      setNextOptions((prev) => {
+        let next = prev.filter((value) => {
+          return (
+            value !==
+            ((aggregation?.counts ?? []).find(({ name }) => {
+              return name === option.displayText
+            })?.value as string)
+          )
+        })
+
+        // If nothing is selected toggle the default value (`[]`)
+        if (next.length === 0) {
+          next = ParamDefaultValues.additionalGeneIDs
+        }
+
+        dispatch({
+          type: "selectFilters",
+          payload: {
+            displayText: option.displayText,
+            paramValue: next,
+            paramName: option.paramName,
+          },
+        })
+
+        return next
+      })
+    }
+  }
+
+  return (
+    <MultiSelectOptionScreen
+      onSelect={handleSelect}
+      filterHeaderText={FilterDisplayName.additionalGeneIDs}
+      filterOptions={booleanFilterOptions}
+      navigation={navigation}
+    />
+  )
+}

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/AdditionalGeneIDsOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/AdditionalGeneIDsOptions-tests.tsx
@@ -6,15 +6,32 @@ import { extractText } from "../../../../lib/tests/extractText"
 import { renderWithWrappers } from "../../../../lib/tests/renderWithWrappers"
 import { FilterParamName, InitialState } from "../../../../lib/utils/ArtworkFilter/FilterArtworksHelpers"
 import {
+  Aggregations,
   ArtworkFilterContext,
   ArtworkFilterContextState,
   reducer,
 } from "../../../utils/ArtworkFilter/ArtworkFiltersStore"
-import { AttributionClassOptionsScreen } from "../AttributionClassOptions"
+import { AdditionalGeneIDsOptionsScreen } from "../AdditionalGeneIDsOptions"
 import { OptionListItem } from "../MultiSelectOption"
 import { getEssentialProps } from "./helper"
 
-describe("AttributionClassOptions Screen", () => {
+const MOCK_AGGREGATIONS: Aggregations = [
+  {
+    slice: "MEDIUM",
+    counts: [
+      { name: "Prints", count: 2956, value: "prints" },
+      { name: "Design", count: 513, value: "design" },
+      { name: "Sculpture", count: 277, value: "sculpture" },
+      { name: "Work on Paper", count: 149, value: "work-on-paper" },
+      { name: "Painting", count: 145, value: "painting" },
+      { name: "Drawing", count: 83, value: "drawing" },
+      { name: "Jewelry", count: 9, value: "jewelry" },
+      { name: "Photography", count: 4, value: "photography" },
+    ],
+  },
+]
+
+describe("AdditionalGeneIDsOptions Screen", () => {
   let state: ArtworkFilterContextState
 
   beforeEach(() => {
@@ -23,7 +40,7 @@ describe("AttributionClassOptions Screen", () => {
       appliedFilters: [],
       previouslyAppliedFilters: [],
       applyFilters: false,
-      aggregations: [],
+      aggregations: MOCK_AGGREGATIONS,
       filterType: "artwork",
       counts: {
         total: null,
@@ -32,37 +49,24 @@ describe("AttributionClassOptions Screen", () => {
     }
   })
 
-  const MockAttributionClassOptionsScreen = ({ initialState }: InitialState) => {
+  const MockAdditionalGeneIDsOptionsScreen = ({ initialState }: InitialState) => {
     const [filterState, dispatch] = React.useReducer(reducer, initialState)
 
     return (
       <ArtworkFilterContext.Provider value={{ state: filterState, dispatch }}>
-        <AttributionClassOptionsScreen {...getEssentialProps()} />
+        <AdditionalGeneIDsOptionsScreen {...getEssentialProps()} />
       </ArtworkFilterContext.Provider>
     )
   }
 
   it("renders the options", () => {
-    const tree = renderWithWrappers(<MockAttributionClassOptionsScreen initialState={state} />)
-    expect(tree.root.findAllByType(OptionListItem)).toHaveLength(4)
+    const tree = renderWithWrappers(<MockAdditionalGeneIDsOptionsScreen initialState={state} />)
+    expect(tree.root.findAllByType(OptionListItem)).toHaveLength(4) // initialNumToRender={4}
     const items = tree.root.findAllByType(OptionListItem)
-    expect(items.map(extractText)).toEqual(["Unique", "Limited Edition", "Open Edition", "Unknown Edition"])
+    expect(items.map(extractText)).toEqual(["All", "Prints", "Design", "Sculpture"])
   })
 
   it("displays the default text when no filter selected on the filter modal screen", () => {
-    state = {
-      selectedFilters: [],
-      appliedFilters: [],
-      previouslyAppliedFilters: [],
-      applyFilters: false,
-      aggregations: [],
-      filterType: "artwork",
-      counts: {
-        total: null,
-        followedArtists: null,
-      },
-    }
-
     const tree = renderWithWrappers(<MockFilterScreen initialState={state} />)
     const items = tree.root.findAllByType(FilterModalOptionListItem)
     expect(extractText(items[items.length - 1])).toContain("All")
@@ -73,14 +77,14 @@ describe("AttributionClassOptions Screen", () => {
       selectedFilters: [
         {
           displayText: "Unique",
-          paramName: FilterParamName.attributionClass,
-          paramValue: ["unique", "unknown edition"],
+          paramName: FilterParamName.additionalGeneIDs,
+          paramValue: ["prints", "sculpture"],
         },
       ],
       appliedFilters: [],
       previouslyAppliedFilters: [],
       applyFilters: false,
-      aggregations: [],
+      aggregations: MOCK_AGGREGATIONS,
       filterType: "artwork",
       counts: {
         total: null,
@@ -91,7 +95,7 @@ describe("AttributionClassOptions Screen", () => {
     const tree = renderWithWrappers(<MockFilterScreen initialState={state} />)
     const items = tree.root.findAllByType(FilterModalOptionListItem)
 
-    expect(extractText(items[1])).toContain("Unique, Unknown edition")
+    expect(extractText(items[1])).toContain("Prints, Sculpture")
   })
 
   it("toggles selected filters 'ON' and unselected filters 'OFF", () => {
@@ -99,14 +103,14 @@ describe("AttributionClassOptions Screen", () => {
       selectedFilters: [
         {
           displayText: "Unique",
-          paramName: FilterParamName.attributionClass,
-          paramValue: ["unique", "unknown edition"],
+          paramName: FilterParamName.additionalGeneIDs,
+          paramValue: ["prints", "sculpture"],
         },
       ],
       appliedFilters: [],
       previouslyAppliedFilters: [],
       applyFilters: false,
-      aggregations: [],
+      aggregations: MOCK_AGGREGATIONS,
       filterType: "artwork",
       counts: {
         total: null,
@@ -114,11 +118,11 @@ describe("AttributionClassOptions Screen", () => {
       },
     }
 
-    const tree = renderWithWrappers(<MockAttributionClassOptionsScreen initialState={initialState} />)
+    const tree = renderWithWrappers(<MockAdditionalGeneIDsOptionsScreen initialState={initialState} />)
     const switches = tree.root.findAllByType(Switch)
 
-    expect(switches[0].props.value).toBe(true)
-    expect(switches[1].props.value).toBe(false)
+    expect(switches[0].props.value).toBe(false)
+    expect(switches[1].props.value).toBe(true)
     expect(switches[2].props.value).toBe(false)
     expect(switches[3].props.value).toBe(true)
   })

--- a/src/lib/Components/FilterModal/FilterModal.tsx
+++ b/src/lib/Components/FilterModal/FilterModal.tsx
@@ -24,6 +24,7 @@ import { FlatList, TouchableOpacity, View, ViewProperties } from "react-native"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
 import { AnimatedBottomButton } from "../AnimatedBottomButton"
+import { AdditionalGeneIDsOptionsScreen } from "../ArtworkFilterOptions/AdditionalGeneIDsOptions"
 import { ArtistIDsOptionsScreen } from "../ArtworkFilterOptions/ArtistIDsOptionsScreen"
 import { AttributionClassOptionsScreen } from "../ArtworkFilterOptions/AttributionClassOptions"
 import { CategoriesOptionsScreen } from "../ArtworkFilterOptions/CategoriesOptions"
@@ -44,11 +45,12 @@ import { YearOptionsScreen } from "../ArtworkFilterOptions/YearOptions"
 import { FancyModal } from "../FancyModal/FancyModal"
 
 export type FilterScreen =
+  | "additionalGeneIDs"
   | "artistIDs"
   | "artistsIFollow"
   | "attributionClass"
-  | "color"
   | "categories"
+  | "color"
   | "dimensionRange"
   | "estimateRange"
   | "gallery"
@@ -56,11 +58,11 @@ export type FilterScreen =
   | "majorPeriods"
   | "medium"
   | "priceRange"
-  | "sort"
   | "sizes"
+  | "sort"
   | "viewAs"
-  | "year"
   | "waysToBuy"
+  | "year"
 
 export interface FilterDisplayConfig {
   filterType: FilterScreen
@@ -94,9 +96,11 @@ interface FilterModalProps extends ViewProperties {
 // see src/lib/Scenes/MyCollection/Screens/ArtworkFormModal/MyCollectionArtworkFormModal.tsx#L35
 // tslint:disable-next-line:interface-over-type-literal
 export type FilterModalNavigationStack = {
+  AdditionalGeneIDsOptionsScreen: undefined
   ArtistIDsOptionsScreen: undefined
-  ColorOptionsScreen: undefined
   AttributionClassOptionsScreen: undefined
+  CategoriesOptionsScreen: undefined
+  ColorOptionsScreen: undefined
   EstimateRangeOptionsScreen: undefined
   FilterOptionsScreen: FilterOptionsScreenParams
   GalleryOptionsScreen: undefined
@@ -108,9 +112,8 @@ export type FilterModalNavigationStack = {
   SortOptionsScreen: undefined
   TimePeriodOptionsScreen: undefined
   ViewAsOptionsScreen: undefined
-  YearOptionsScreen: undefined
   WaysToBuyOptionsScreen: undefined
-  CategoriesOptionsScreen: undefined
+  YearOptionsScreen: undefined
 }
 
 const Stack = createStackNavigator<FilterModalNavigationStack>()
@@ -208,6 +211,7 @@ export const FilterModalNavigator: React.FC<FilterModalProps> = (props) => {
             <Stack.Screen name="ColorOptionsScreen" component={ColorOptionsScreen} />
             <Stack.Screen name="EstimateRangeOptionsScreen" component={EstimateRangeOptionsScreen} />
             <Stack.Screen name="GalleryOptionsScreen" component={GalleryOptionsScreen} />
+            <Stack.Screen name="AdditionalGeneIDsOptionsScreen" component={AdditionalGeneIDsOptionsScreen} />
             <Stack.Screen name="InstitutionOptionsScreen" component={InstitutionOptionsScreen} />
             <Stack.Screen name="MediumOptionsScreen" component={MediumOptionsScreen} />
             <Stack.Screen name="PriceRangeOptionsScreen" component={PriceRangeOptionsScreen} />
@@ -663,7 +667,7 @@ const filterKeyFromAggregation: Record<AggregationName, FilterParamName | string
   GALLERY: "gallery",
   INSTITUTION: "institution",
   MAJOR_PERIOD: FilterParamName.timePeriod,
-  MEDIUM: FilterParamName.medium,
+  MEDIUM: FilterParamName.additionalGeneIDs,
   PRICE_RANGE: FilterParamName.priceRange,
   FOLLOWED_ARTISTS: "artistsIFollow",
   ARTIST: "artistIDs",
@@ -672,6 +676,11 @@ const filterKeyFromAggregation: Record<AggregationName, FilterParamName | string
 }
 
 export const filterOptionToDisplayConfigMap: Record<string, FilterDisplayConfig> = {
+  additionalGeneIDs: {
+    displayText: FilterDisplayName.additionalGeneIDs,
+    filterType: "additionalGeneIDs",
+    ScreenComponent: "AdditionalGeneIDsOptionsScreen",
+  },
   artistIDs: {
     displayText: FilterDisplayName.artistIDs,
     filterType: "artistIDs",
@@ -757,6 +766,7 @@ export const filterOptionToDisplayConfigMap: Record<string, FilterDisplayConfig>
 const CollectionFiltersSorted: FilterScreen[] = [
   "sort",
   "medium",
+  "additionalGeneIDs",
   "attributionClass",
   "priceRange",
   "waysToBuy",
@@ -769,6 +779,7 @@ const CollectionFiltersSorted: FilterScreen[] = [
 const ArtistArtworksFiltersSorted: FilterScreen[] = [
   "sort",
   "medium",
+  "additionalGeneIDs",
   "attributionClass",
   "priceRange",
   "waysToBuy",
@@ -781,6 +792,7 @@ const ArtistArtworksFiltersSorted: FilterScreen[] = [
 const ArtistSeriesFiltersSorted: FilterScreen[] = [
   "sort",
   "medium",
+  "additionalGeneIDs",
   "attributionClass",
   "priceRange",
   "waysToBuy",
@@ -795,6 +807,7 @@ const FairFiltersSorted: FilterScreen[] = [
   "artistIDs",
   "artistsIFollow",
   "medium",
+  "additionalGeneIDs",
   "attributionClass",
   "priceRange",
   "waysToBuy",
@@ -804,6 +817,13 @@ const FairFiltersSorted: FilterScreen[] = [
   "gallery",
   "institution",
 ]
-const SaleArtworksFiltersSorted: FilterScreen[] = ["sort", "viewAs", "estimateRange", "artistIDs", "medium"]
+const SaleArtworksFiltersSorted: FilterScreen[] = [
+  "sort",
+  "viewAs",
+  "estimateRange",
+  "artistIDs",
+  "medium",
+  "additionalGeneIDs",
+]
 
 const AuctionResultsFiltersSorted: FilterScreen[] = ["sort", "categories", "sizes", "year"]

--- a/src/lib/Components/FilterModal/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/FilterModal/__tests__/FilterModal-tests.tsx
@@ -238,7 +238,7 @@ describe("Filter modal navigation flow", () => {
 
     act(() => instance.props.onPress())
 
-    expect(navigateMock).toBeCalledWith("MediumOptionsScreen")
+    expect(navigateMock).toBeCalledWith("AdditionalGeneIDsOptionsScreen")
   })
 
   it("allows users to exit filter modal screen when selecting close icon", () => {
@@ -270,7 +270,13 @@ describe("Filter modal states", () => {
 
   it("displays the currently selected medium option on the filter screen", () => {
     state = {
-      selectedFilters: [{ displayText: "Performance art", paramName: FilterParamName.medium }],
+      selectedFilters: [
+        {
+          displayText: "Performance Art",
+          paramValue: ["performance-art"],
+          paramName: FilterParamName.additionalGeneIDs,
+        },
+      ],
       appliedFilters: [],
       previouslyAppliedFilters: [],
       applyFilters: false,
@@ -283,7 +289,8 @@ describe("Filter modal states", () => {
     }
 
     const filterScreen = mount(<MockFilterScreen initialState={state} />)
-    expect(filterScreen.find(CurrentOption).at(1).text()).toEqual("Performance art")
+
+    expect(filterScreen.find(CurrentOption).at(1).text()).toEqual("Performance Art")
   })
 
   it("displays the filter screen apply button correctly when no filters are selected", () => {
@@ -324,7 +331,7 @@ describe("Filter modal states", () => {
   it("displays selected filters on the Filter modal", () => {
     state = {
       selectedFilters: [
-        { displayText: "Drawing", paramName: FilterParamName.medium },
+        { displayText: "Drawing", paramValue: ["drawing"], paramName: FilterParamName.additionalGeneIDs },
         { displayText: "Price (low to high)", paramName: FilterParamName.sort },
         { displayText: "$10,000-20,000", paramName: FilterParamName.priceRange },
         {
@@ -522,6 +529,7 @@ describe("Applying filters on Artworks", () => {
     expect(env.mock.getMostRecentOperation().request.variables).toMatchInlineSnapshot(`
       Object {
         "acquireable": false,
+        "additionalGeneIDs": null,
         "atAuction": false,
         "attributionClass": null,
         "color": null,
@@ -531,7 +539,6 @@ describe("Applying filters on Artworks", () => {
         "id": "street-art-now",
         "inquireableOnly": false,
         "majorPeriods": null,
-        "medium": "*",
         "offerable": false,
         "partnerID": null,
         "priceRange": "*-*",

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
@@ -93,7 +93,7 @@ export const ArtistSeriesArtworksFragmentContainer = createPaginationContainer(
         count: { type: "Int", defaultValue: 20 }
         cursor: { type: "String" }
         sort: { type: "String", defaultValue: "-decayed_merch" }
-        medium: { type: "String", defaultValue: "*" }
+        additionalGeneIDs: { type: "[String]" }
         priceRange: { type: "String" }
         color: { type: "String" }
         partnerID: { type: "ID" }
@@ -111,7 +111,7 @@ export const ArtistSeriesArtworksFragmentContainer = createPaginationContainer(
           first: 20
           after: $cursor
           sort: $sort
-          medium: $medium
+          additionalGeneIDs: $additionalGeneIDs
           priceRange: $priceRange
           color: $color
           partnerID: $partnerID
@@ -171,7 +171,7 @@ export const ArtistSeriesArtworksFragmentContainer = createPaginationContainer(
         $count: Int!
         $cursor: String
         $sort: String
-        $medium: String
+        $additionalGeneIDs: [String]
         $priceRange: String
         $color: String
         $partnerID: ID
@@ -189,7 +189,7 @@ export const ArtistSeriesArtworksFragmentContainer = createPaginationContainer(
               count: $count
               cursor: $cursor
               sort: $sort
-              medium: $medium
+              additionalGeneIDs: $additionalGeneIDs
               color: $color
               partnerID: $partnerID
               priceRange: $priceRange

--- a/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -102,7 +102,7 @@ export const CollectionArtworksFragmentContainer = createPaginationContainer(
         count: { type: "Int", defaultValue: 10 }
         cursor: { type: "String" }
         sort: { type: "String", defaultValue: "-decayed_merch" }
-        medium: { type: "String", defaultValue: "*" }
+        additionalGeneIDs: { type: "[String]" }
         priceRange: { type: "String" }
         color: { type: "String" }
         partnerID: { type: "ID" }
@@ -121,7 +121,7 @@ export const CollectionArtworksFragmentContainer = createPaginationContainer(
           first: $count
           after: $cursor
           sort: $sort
-          medium: $medium
+          additionalGeneIDs: $additionalGeneIDs
           priceRange: $priceRange
           color: $color
           partnerID: $partnerID
@@ -173,7 +173,7 @@ export const CollectionArtworksFragmentContainer = createPaginationContainer(
         $count: Int!
         $cursor: String
         $sort: String
-        $medium: String
+        $additionalGeneIDs: [String]
         $priceRange: String
         $color: String
         $partnerID: ID
@@ -191,7 +191,7 @@ export const CollectionArtworksFragmentContainer = createPaginationContainer(
               count: $count
               cursor: $cursor
               sort: $sort
-              medium: $medium
+              additionalGeneIDs: $additionalGeneIDs
               color: $color
               partnerID: $partnerID
               priceRange: $priceRange

--- a/src/lib/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/lib/Scenes/Fair/Components/FairArtworks.tsx
@@ -114,7 +114,7 @@ export const FairArtworksFragmentContainer = createPaginationContainer(
         count: { type: "Int", defaultValue: 30 }
         cursor: { type: "String" }
         sort: { type: "String", defaultValue: "-decayed_merch" }
-        medium: { type: "String", defaultValue: "*" }
+        additionalGeneIDs: { type: "[String]" }
         priceRange: { type: "String" }
         color: { type: "String" }
         partnerID: { type: "ID" }
@@ -134,7 +134,7 @@ export const FairArtworksFragmentContainer = createPaginationContainer(
           first: 30
           after: $cursor
           sort: $sort
-          medium: $medium
+          additionalGeneIDs: $additionalGeneIDs
           priceRange: $priceRange
           color: $color
           partnerID: $partnerID
@@ -207,7 +207,7 @@ export const FairArtworksFragmentContainer = createPaginationContainer(
         $count: Int!
         $cursor: String
         $sort: String
-        $medium: String
+        $additionalGeneIDs: [String]
         $priceRange: String
         $color: String
         $partnerID: ID
@@ -227,7 +227,7 @@ export const FairArtworksFragmentContainer = createPaginationContainer(
               count: $count
               cursor: $cursor
               sort: $sort
-              medium: $medium
+              additionalGeneIDs: $additionalGeneIDs
               color: $color
               partnerID: $partnerID
               priceRange: $priceRange

--- a/src/lib/Scenes/Partner/Components/PartnerArtwork.tsx
+++ b/src/lib/Scenes/Partner/Components/PartnerArtwork.tsx
@@ -67,9 +67,9 @@ export const PartnerArtworkFragmentContainer = createPaginationContainer(
         count: { type: "Int", defaultValue: 10 }
         cursor: { type: "String" }
         dimensionRange: { type: "String", defaultValue: "*-*" }
+        additionalGeneIDs: { type: "[String]" }
         inquireableOnly: { type: "Boolean" }
         majorPeriods: { type: "[String]" }
-        medium: { type: "String", defaultValue: "*" }
         offerable: { type: "Boolean" }
         priceRange: { type: "String" }
         sort: { type: "String", defaultValue: "-partner_updated_at" }
@@ -83,10 +83,10 @@ export const PartnerArtworkFragmentContainer = createPaginationContainer(
           attributionClass: $attributionClass
           color: $color
           dimensionRange: $dimensionRange
+          additionalGeneIDs: $additionalGeneIDs
           first: $count
           inquireableOnly: $inquireableOnly
           majorPeriods: $majorPeriods
-          medium: $medium
           offerable: $offerable
           priceRange: $priceRange
           sort: $sort
@@ -129,10 +129,10 @@ export const PartnerArtworkFragmentContainer = createPaginationContainer(
         $count: Int!
         $cursor: String
         $dimensionRange: String
+        $additionalGeneIDs: [String]
         $id: String!
         $inquireableOnly: Boolean
         $majorPeriods: [String]
-        $medium: String
         $offerable: Boolean
         $priceRange: String
         $sort: String
@@ -146,9 +146,9 @@ export const PartnerArtworkFragmentContainer = createPaginationContainer(
               count: $count
               cursor: $cursor
               dimensionRange: $dimensionRange
+              additionalGeneIDs: $additionalGeneIDs
               inquireableOnly: $inquireableOnly
               majorPeriods: $majorPeriods
-              medium: $medium
               offerable: $offerable
               priceRange: $priceRange
               sort: $sort

--- a/src/lib/Scenes/Show/Components/ShowArtworks.tsx
+++ b/src/lib/Scenes/Show/Components/ShowArtworks.tsx
@@ -106,7 +106,7 @@ export const ShowArtworksPaginationContainer = createPaginationContainer(
         count: { type: "Int", defaultValue: 30 }
         cursor: { type: "String" }
         sort: { type: "String", defaultValue: "partner_show_position" }
-        medium: { type: "String", defaultValue: "*" }
+        additionalGeneIDs: { type: "[String]" }
         priceRange: { type: "String" }
         color: { type: "String" }
         dimensionRange: { type: "String", defaultValue: "*-*" }
@@ -123,7 +123,7 @@ export const ShowArtworksPaginationContainer = createPaginationContainer(
           first: 30
           after: $cursor
           sort: $sort
-          medium: $medium
+          additionalGeneIDs: $additionalGeneIDs
           priceRange: $priceRange
           color: $color
           dimensionRange: $dimensionRange
@@ -178,7 +178,7 @@ export const ShowArtworksPaginationContainer = createPaginationContainer(
         $count: Int!
         $cursor: String
         $sort: String
-        $medium: String
+        $additionalGeneIDs: [String]
         $priceRange: String
         $color: String
         $dimensionRange: String
@@ -195,7 +195,7 @@ export const ShowArtworksPaginationContainer = createPaginationContainer(
               count: $count
               cursor: $cursor
               sort: $sort
-              medium: $medium
+              additionalGeneIDs: $additionalGeneIDs
               color: $color
               priceRange: $priceRange
               dimensionRange: $dimensionRange

--- a/src/lib/utils/ArtworkFilter/ArtworkFiltersStore.tsx
+++ b/src/lib/utils/ArtworkFilter/ArtworkFiltersStore.tsx
@@ -271,6 +271,7 @@ export const ParamDefaultValues = {
   dimensionRange: "*-*",
   earliestCreatedYear: undefined,
   estimateRange: "",
+  additionalGeneIDs: [],
   includeArtworksByFollowedArtists: false,
   inquireableOnly: false,
   latestCreatedYear: undefined,
@@ -285,7 +286,8 @@ export const ParamDefaultValues = {
   viewAs: ViewAsValues.Grid,
 }
 
-const defaultCommonFilterOptions: Record<FilterParamName, string | boolean | undefined | string[]> = {
+// const defaultCommonFilterOptions: Record<FilterParamName, string | boolean | undefined | string[]> = {
+const defaultCommonFilterOptions = {
   acquireable: ParamDefaultValues.acquireable,
   allowEmptyCreatedDates: ParamDefaultValues.allowEmptyCreatedDates,
   artistIDs: ParamDefaultValues.artistIDs,
@@ -293,6 +295,7 @@ const defaultCommonFilterOptions: Record<FilterParamName, string | boolean | und
   attributionClass: ParamDefaultValues.attributionClass,
   categories: ParamDefaultValues.categories,
   color: ParamDefaultValues.color,
+  additionalGeneIDs: ParamDefaultValues.additionalGeneIDs,
   dimensionRange: ParamDefaultValues.dimensionRange,
   earliestCreatedYear: ParamDefaultValues.earliestCreatedYear,
   estimateRange: ParamDefaultValues.estimateRange,
@@ -545,11 +548,13 @@ export type AggregationName =
   | "earliestCreatedYear"
   | "latestCreatedYear"
 
+export interface Aggregation {
+  count: number
+  value: string
+  name: string
+}
+
 export type Aggregations = Array<{
   slice: AggregationName
-  counts: Array<{
-    count: number
-    value: string
-    name: string
-  }>
+  counts: Aggregation[]
 }>

--- a/src/lib/utils/ArtworkFilter/FilterArtworksHelpers.ts
+++ b/src/lib/utils/ArtworkFilter/FilterArtworksHelpers.ts
@@ -6,26 +6,27 @@ import {
   FilterCounts,
   FilterType,
 } from "lib/utils/ArtworkFilter/ArtworkFiltersStore"
-import { capitalize, compact, forOwn, groupBy, sortBy } from "lodash"
+import { capitalize, compact, forOwn, groupBy, lowerCase, sortBy, startCase } from "lodash"
 
 // General filter types and objects
 export enum FilterParamName {
-  artistIDs = "artistIDs",
+  additionalGeneIDs = "additionalGeneIDs",
   allowEmptyCreatedDates = "allowEmptyCreatedDates",
+  artistIDs = "artistIDs",
   artistsIFollow = "includeArtworksByFollowedArtists",
   attributionClass = "attributionClass",
   categories = "categories",
   color = "color",
   earliestCreatedYear = "earliestCreatedYear",
-  latestCreatedYear = "latestCreatedYear",
   estimateRange = "estimateRange",
   gallery = "partnerID",
   institution = "partnerID",
+  latestCreatedYear = "latestCreatedYear",
   medium = "medium",
   priceRange = "priceRange",
   size = "dimensionRange",
-  sort = "sort",
   sizes = "sizes",
+  sort = "sort",
   timePeriod = "majorPeriods",
   viewAs = "viewAs",
   waysToBuyBid = "atAuction",
@@ -41,11 +42,12 @@ export type FilterParams = {
 
 export enum FilterDisplayName {
   // artist = "Artists",
+  additionalGeneIDs = "Category",
   artistIDs = "Artists",
   artistsIFollow = "Artist",
   attributionClass = "Rarity",
-  color = "Color",
   categories = "Medium",
+  color = "Color",
   estimateRange = "Price/estimate range",
   gallery = "Gallery",
   institution = "Institution",
@@ -56,8 +58,8 @@ export enum FilterDisplayName {
   sort = "Sort by",
   timePeriod = "Time period",
   viewAs = "View as",
-  year = "Artwork date",
   waysToBuy = "Ways to buy",
+  year = "Artwork date",
 }
 
 export enum ViewAsValues {
@@ -171,6 +173,19 @@ export const changedFiltersParams = (currentFilterParams: FilterParams, selected
 }
 
 /**
+ * NOTE: I am not happy this exists — but right now we can only dispatch arrays of paramValues
+ */
+const humanizeSlug = (input: string) => {
+  return (
+    startCase(input)
+      // Downcase insignficant words
+      .replace(/(\s\w{2}\s)/g, (match) => lowerCase(match))
+      // Replace humanized symbols
+      .replace(/\sSlash\s/g, "/")
+  )
+}
+
+/**
  * Formats the display for the Filter Modal "home" screen.
  */
 export const selectedOption = ({
@@ -185,6 +200,22 @@ export const selectedOption = ({
   aggregations: Aggregations
 }) => {
   const multiSelectedOptions = selectedOptions.filter((option) => option.paramValue === true)
+
+  if (filterScreen === "additionalGeneIDs") {
+    const additionalGeneIDsOption = selectedOptions.find((option) => {
+      return option.paramName === FilterParamName.additionalGeneIDs
+    })
+
+    if (
+      additionalGeneIDsOption?.paramValue &&
+      Array.isArray(additionalGeneIDsOption?.paramValue) &&
+      additionalGeneIDsOption?.paramValue.length > 0
+    ) {
+      return additionalGeneIDsOption?.paramValue.map(humanizeSlug).join(", ")
+    }
+
+    return "All"
+  }
 
   if (filterScreen === "attributionClass") {
     const selectedAttributionClassOption = selectedOptions.find((option) => {

--- a/src/lib/utils/ArtworkFilter/useArtworkFilters.ts
+++ b/src/lib/utils/ArtworkFilter/useArtworkFilters.ts
@@ -1,7 +1,7 @@
 import { useContext, useEffect } from "react"
 import { RelayPaginationProp } from "react-relay"
-import { ArtworkFilterContext } from "./ArtworkFiltersStore"
-import { filterArtworksParams } from "./FilterArtworksHelpers"
+import { ArtworkFilterContext, selectedOptionsUnion } from "./ArtworkFiltersStore"
+import { aggregationForFilter, filterArtworksParams, FilterParamName } from "./FilterArtworksHelpers"
 
 export const useArtworkFilters = ({
   relay,
@@ -19,7 +19,7 @@ export const useArtworkFilters = ({
   }, [aggregations])
 
   useEffect(() => {
-    if (relay && state.applyFilters) {
+    if (relay !== undefined && state.applyFilters) {
       relay.refetchConnection(
         30,
         (error) => {
@@ -36,5 +36,26 @@ export const useArtworkFilters = ({
     dispatch,
     state,
     filterParams,
+  }
+}
+
+export const useArtworkFiltersAggregation = ({ paramName }: { paramName: FilterParamName }) => {
+  const { dispatch, state } = useContext(ArtworkFilterContext)
+
+  const aggregation = aggregationForFilter(paramName, state.aggregations)
+
+  const selectedOptions = selectedOptionsUnion({
+    selectedFilters: state.selectedFilters,
+    previouslyAppliedFilters: state.previouslyAppliedFilters,
+    filterType: state.filterType,
+  })
+
+  const selectedOption = selectedOptions.find((option) => option.paramName === paramName)!
+
+  return {
+    dispatch,
+    state,
+    aggregation,
+    selectedOption,
   }
 }


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR resolves [FX-2641]

### Description

So this... works. It just feels obviously incorrect. I want to be able to dispatch a filter select without having to shovel everything into a single value; rather support multiple selected filters on the same param. Right now, if I wanted to merge this I'd have to write a humanization function to turn the selected values into readable labels (currently they are the values; which are slugs). This is, of course, insane. Send help.

<img src="https://static.damonzucconi.com/_capture/dITYTo5D.gif" width="300">

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2641]: https://artsyproduct.atlassian.net/browse/FX-2641