### PR TITLE
feat: add fonts to android

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,6 +173,9 @@ commands:
       - run:
           name: Build App
           command: ./scripts/ci-android
+      - run:
+          name: Download fonts from s3
+          command: ./scripts/download-fonts
       - save_cache:
           key: v1-app_build_android-{{ checksum ".manifests/app_build" }}
           paths:

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ buck-out/
 *.keystore
 !debug.keystore
 android-secret.json
+
+
+# Fonts
+android/app/src/main/assets/fonts

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -13,6 +13,7 @@ upcoming:
     - Dedupe currencies in auction results - pepopowitz
     - update support email - brian
     - Market stats formatting fixes - brian
+    - Add fonts to android - mounir, steven
 
 releases:
   - version: 6.7.7

--- a/scripts/download-fonts
+++ b/scripts/download-fonts
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+
+./scripts/setup-distribute-linux
+
+# Create fonts directory
+mkdir -p android/app/src/main/assets/fonts
+
+# Get fonts from eigen s3 bueck
+aws s3 cp s3://artsy-citadel/eigen/fonts.tar.gz android/app/src/main/assets/fonts
+
+# Extract fonts from the fonts directory
+cd android/app/src/main/assets/fonts
+tar -xvzf fonts.tar.gz
+rm fonts.tar.gz

--- a/scripts/setup-env-for-artsy
+++ b/scripts/setup-env-for-artsy
@@ -4,3 +4,6 @@ set -euxo pipefail
 
 touch .env.ci
 aws s3 cp s3://artsy-citadel/dev/.env.eigen .env.shared
+
+# Get the required fonts
+./scripts/download-fonts


### PR DESCRIPTION
Co-authored-by: Steven Hicks <steven.j.hicks@gmail.com>

The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1010]

### Description

![Group 1 (3)](https://user-images.githubusercontent.com/11945712/107801261-2467c300-6d60-11eb-84d5-e349b9fbc908.png)

- Uploaded the fonts to the Eigen s3 bucket and made sure it's only accessible by artsy engineers
- Added script to download fonts and extract them to the assets directory
- Upgraded CI script to download fonts before building the android app

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1010]: https://artsyproduct.atlassian.net/browse/CX-1010