### PR TITLE
chore: update artist insights flag

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
   dev:
     - Add scripts and docs for android beta promotion - pavlos
     - Migrate feature flag infrastructure to easy-peasy - david
+    - Update artist insights flag and set readyToRelease to true - mounir
   user_facing:
     - Add custom ShareSheet and sharing to Instagram Stories - pavlos
     - MarketStats on auction results - pepopowitz, mounir

--- a/src/lib/Components/Artist/ArtistAbout/ArtistAbout.tsx
+++ b/src/lib/Components/Artist/ArtistAbout/ArtistAbout.tsx
@@ -31,7 +31,7 @@ export const ArtistAbout: React.FC<Props> = ({ artist }) => {
           <CaretButton text="Auction results" onPress={() => navigate(`/artist/${artist.slug}/auction-results`)} />
         )}
         <ArtistConsignButton artist={artist} />
-        {!!useFeatureFlag("AROptionsNewInsightsPage") && <ArtistAboutShowsFragmentContainer artist={artist} />}
+        {!!useFeatureFlag("AROptionsNewArtistInsightsPage") && <ArtistAboutShowsFragmentContainer artist={artist} />}
         {!!articles.length && <Articles articles={articles} />}
         {!!relatedArtists.length && <RelatedArtists artists={relatedArtists} />}
       </Stack>

--- a/src/lib/Components/Artist/ArtistAbout/__tests__/ArtistAbout-tests.tsx
+++ b/src/lib/Components/Artist/ArtistAbout/__tests__/ArtistAbout-tests.tsx
@@ -99,8 +99,8 @@ describe("ArtistAbout", () => {
   })
 
   describe("ArtistAboutShows", () => {
-    it("is shown when AROptionsNewInsightsPage is true", () => {
-      __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsNewInsightsPage: true })
+    it("is shown when AROptionsNewArtistInsightsPage is true", () => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsNewArtistInsightsPage: true })
 
       const tree = renderWithWrappers(<TestRenderer />)
 
@@ -109,8 +109,8 @@ describe("ArtistAbout", () => {
       expect(tree.root.findAllByType(ArtistAboutShowsFragmentContainer).length).toEqual(1)
     })
 
-    it("is hidden when AROptionsNewInsightsPage is false", () => {
-      __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsNewInsightsPage: false })
+    it("is hidden when AROptionsNewArtistInsightsPage is false", () => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsNewArtistInsightsPage: false })
 
       const tree = renderWithWrappers(<TestRenderer />)
 

--- a/src/lib/Components/Artist/ArtistAbout/__tests__/ArtistAboutShows-tests.tsx
+++ b/src/lib/Components/Artist/ArtistAbout/__tests__/ArtistAboutShows-tests.tsx
@@ -45,7 +45,7 @@ describe("ArtistAboutShows", () => {
   })
 
   it("returns nothing if the user has no past/running/upcoming events", () => {
-    __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsNewInsightsPage: false })
+    __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsNewArtistInsightsPage: false })
 
     const tree = renderWithWrappers(<TestRenderer />)
 
@@ -66,7 +66,7 @@ describe("ArtistAboutShows", () => {
   })
 
   it("returns list of shows if the user has past/running/upcoming events", () => {
-    __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsNewInsightsPage: false })
+    __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsNewArtistInsightsPage: false })
 
     const tree = renderWithWrappers(<TestRenderer />)
 
@@ -89,7 +89,7 @@ describe("ArtistAboutShows", () => {
 
   describe("See all past shows Button", () => {
     it("is visible when the user has past shows", () => {
-      __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsNewInsightsPage: false })
+      __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsNewArtistInsightsPage: false })
 
       const tree = renderWithWrappers(<TestRenderer />)
 
@@ -110,7 +110,7 @@ describe("ArtistAboutShows", () => {
     })
 
     it("is hidden when the user has no past shows", () => {
-      __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsNewInsightsPage: false })
+      __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsNewArtistInsightsPage: false })
 
       const tree = renderWithWrappers(<TestRenderer />)
 

--- a/src/lib/Scenes/Artist/Artist.tsx
+++ b/src/lib/Scenes/Artist/Artist.tsx
@@ -66,7 +66,7 @@ export const Artist: React.FC<{
     })
   }
 
-  if ((!isArtistInsightsEnabled && tabs.length === 0) || (isArtistInsightsEnabled && tabs.length === 1)) {
+  if (tabs.length === 0) {
     tabs.push({
       title: "Artworks",
       content: (

--- a/src/lib/Scenes/Artist/Artist.tsx
+++ b/src/lib/Scenes/Artist/Artist.tsx
@@ -50,7 +50,7 @@ export const Artist: React.FC<{
     })
   }
 
-  const isArtistInsightsEnabled = useFeatureFlag("AROptionsNewInsightsPage")
+  const isArtistInsightsEnabled = useFeatureFlag("AROptionsNewArtistInsightsPage")
 
   if ((artistAboveTheFold.counts?.partner_shows ?? 0) > 0 && !isArtistInsightsEnabled) {
     tabs.push({

--- a/src/lib/Scenes/Artist/__tests__/Artist-tests.tsx
+++ b/src/lib/Scenes/Artist/__tests__/Artist-tests.tsx
@@ -51,13 +51,16 @@ describe("availableTabs", () => {
     return <ArtistQueryRenderer artistID="ignored" environment={environment} isPad={false} />
   }
 
-  it("returns an empty state if artist has no metadata, shows, or works", async () => {
+  it("returns an empty state if artist has no metadata, shows, insights, or works", async () => {
     const tree = renderWithWrappers(<TestWrapper />)
     mockMostRecentOperation("ArtistAboveTheFoldQuery", {
       Artist() {
         return {
           has_metadata: false,
           counts: { articles: 0, related_artists: 0, artworks: 0, partner_shows: 0 },
+          auctionResultsConnection: {
+            totalCount: 0,
+          },
         }
       },
     })
@@ -68,13 +71,16 @@ describe("availableTabs", () => {
     )
   })
 
-  it("returns About tab if artist has metadata", async () => {
+  it("returns only About tab if artist has only metadata", async () => {
     const tree = renderWithWrappers(<TestWrapper />)
     mockMostRecentOperation("ArtistAboveTheFoldQuery", {
       Artist() {
         return {
           has_metadata: true,
           counts: { articles: 0, related_artists: 0, artworks: 0, partner_shows: 0 },
+          auctionResultsConnection: {
+            totalCount: 0,
+          },
         }
       },
     })
@@ -86,13 +92,16 @@ describe("availableTabs", () => {
     expect(tree.root.findAllByType(ArtistAboutContainer)).toHaveLength(1)
   })
 
-  it("returns About tab if artist has articles", async () => {
+  it("returns About tab if artist has only articles", async () => {
     const tree = renderWithWrappers(<TestWrapper />)
     mockMostRecentOperation("ArtistAboveTheFoldQuery", {
       Artist() {
         return {
           has_metadata: false,
           counts: { articles: 1, related_artists: 0, artworks: 0, partner_shows: 0 },
+          auctionResultsConnection: {
+            totalCount: 0,
+          },
         }
       },
     })

--- a/src/lib/Scenes/Artist/__tests__/Artist-tests.tsx
+++ b/src/lib/Scenes/Artist/__tests__/Artist-tests.tsx
@@ -101,7 +101,7 @@ describe("availableTabs", () => {
   })
 
   it("returns Shows tab if artist has shows", async () => {
-    __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsNewInsightsPage: false })
+    __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsNewArtistInsightsPage: false })
     const tree = renderWithWrappers(<TestWrapper />)
     mockMostRecentOperation("ArtistAboveTheFoldQuery", {
       Artist() {
@@ -115,8 +115,8 @@ describe("availableTabs", () => {
     expect(tree.root.findAllByType(ArtistShows)).toHaveLength(1)
   })
 
-  it("returns all three tabs if artist has metadata, works, and shows when AROptionsNewInsightsPage is false", async () => {
-    __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsNewInsightsPage: false })
+  it("returns all three tabs if artist has metadata, works, and shows when AROptionsNewArtistInsightsPage is false", async () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsNewArtistInsightsPage: false })
     const tree = renderWithWrappers(<TestWrapper />)
     mockMostRecentOperation("ArtistAboveTheFoldQuery", {
       Artist() {
@@ -133,8 +133,8 @@ describe("availableTabs", () => {
     expect(tree.root.findAllByType(ArtistInsights)).toHaveLength(0)
   })
 
-  it("returns two tabs if artist has metadata, works, and shows when AROptionsNewInsightsPage is true", async () => {
-    __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsNewInsightsPage: true })
+  it("returns two tabs if artist has metadata, works, and shows when AROptionsNewArtistInsightsPage is true", async () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsNewArtistInsightsPage: true })
     const tree = renderWithWrappers(<TestWrapper />)
     mockMostRecentOperation("ArtistAboveTheFoldQuery", {
       Artist() {
@@ -154,8 +154,8 @@ describe("availableTabs", () => {
     expect(tree.root.findAllByType(ArtistInsights)).toHaveLength(1)
   })
 
-  it("Hide Artist insights tab when AROptionsNewInsightsPage is true and there are no auction results", async () => {
-    __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsNewInsightsPage: true })
+  it("Hide Artist insights tab when AROptionsNewArtistInsightsPage is true and there are no auction results", async () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AROptionsNewArtistInsightsPage: true })
     const tree = renderWithWrappers(<TestWrapper />)
     mockMostRecentOperation("ArtistAboveTheFoldQuery", {
       Artist() {

--- a/src/lib/navigation/routes.tsx
+++ b/src/lib/navigation/routes.tsx
@@ -56,7 +56,7 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
     new RouteMatcher("/my-profile", "MyProfile"),
 
     new RouteMatcher("/artist/:artistID", "Artist"),
-    unsafe_getFeatureFlag("AROptionsNewInsightsPage")
+    unsafe_getFeatureFlag("AROptionsNewArtistInsightsPage")
       ? new RouteMatcher("/artist/:artistID/shows", "ArtistShows")
       : null,
     new RouteMatcher("/artwork/:artworkID", "Artwork"),

--- a/src/lib/store/features.ts
+++ b/src/lib/store/features.ts
@@ -40,11 +40,9 @@ export const features = defineFeatures({
     readyForRelease: true,
     echoFlagKey: "AROptionsNewFirstInquiry",
   },
-  AROptionsNewInsightsPage: {
-    readyForRelease: false,
-    echoFlagKey: "AROptionsNewInsightsPage",
-    showInAdminMenu: true,
-    description: "Show new Artist Insights tab",
+  AROptionsNewArtistInsightsPage: {
+    readyForRelease: true,
+    echoFlagKey: "AROptionsNewArtistInsightsPage",
   },
   AROptionsInquiryCheckout: {
     readyForRelease: false,


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1066]

### Description
- Update artist insights flag
- Set the ready to release to true
<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1066]: https://artsyproduct.atlassian.net/browse/CX-1066