### PR TITLE
fix: use native webview for checkout to share auth creds

### DIFF
--- a/Artsy/View_Controllers/Web_Browsing/ARInternalWebView.h
+++ b/Artsy/View_Controllers/Web_Browsing/ARInternalWebView.h
@@ -4,5 +4,6 @@
 
 @property (nonatomic, weak) UIViewController *webViewController;
 @property (nonatomic) NSString *route;
+@property (nonatomic, assign) BOOL showFullScreen;
 
 @end

--- a/Artsy/View_Controllers/Web_Browsing/ARInternalWebView.m
+++ b/Artsy/View_Controllers/Web_Browsing/ARInternalWebView.m
@@ -34,7 +34,9 @@
     ARInternalMobileWebViewController *webVC = [[ARInternalMobileWebViewController alloc] initWithURL:resolvedURL];
     UIViewController *parentVC = [self reactViewController];
     [parentVC ar_addModernChildViewController:webVC];
-    [self alignToView:parentVC.view];
+    if (self.showFullScreen) {
+        [self alignToView:parentVC.view];
+    }
     [webVC.view alignToView:self];
     self.webViewController = webVC;
 }

--- a/Artsy/View_Controllers/Web_Browsing/ARInternalWebViewManager.h
+++ b/Artsy/View_Controllers/Web_Browsing/ARInternalWebViewManager.h
@@ -2,4 +2,5 @@
 
 @interface ARInternalWebViewManager : RCTViewManager
 @property (nonatomic, strong, readwrite) NSString *route;
+@property (nonatomic, assign) BOOL showFullScreen;
 @end

--- a/Artsy/View_Controllers/Web_Browsing/ARInternalWebViewManager.m
+++ b/Artsy/View_Controllers/Web_Browsing/ARInternalWebViewManager.m
@@ -10,5 +10,6 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_VIEW_PROPERTY(route, NSString *)
+RCT_EXPORT_VIEW_PROPERTY(showFullScreen, BOOL)
 
 @end

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,6 +5,7 @@ upcoming:
     - Add scripts and docs for android beta promotion - pavlos
     - Migrate feature flag infrastructure to easy-peasy - david
     - Update artist insights flag and set readyToRelease to true - mounir
+    - use native webview to share auth creds in checkout - brian
   user_facing:
     - Add custom ShareSheet and sharing to Instagram Stories - pavlos
     - MarketStats on auction results - pepopowitz, mounir

--- a/src/lib/Components/ArtsyWebView.tsx
+++ b/src/lib/Components/ArtsyWebView.tsx
@@ -4,7 +4,7 @@ import React from "react"
 import WebView from "react-native-webview"
 import InternalWebView from "./InternalWebView"
 
-export const ArtsyWebView: React.FC<{ url: string }> = ({ url }) => {
+export const ArtsyWebView: React.FC<{ url: string; showFullScreen?: boolean }> = ({ url, showFullScreen }) => {
   const useReactNativeWebView = useFeatureFlag("AROptionsUseReactNativeWebView")
 
   const paddingTop = useScreenDimensions().safeAreaInsets.top
@@ -12,6 +12,6 @@ export const ArtsyWebView: React.FC<{ url: string }> = ({ url }) => {
   if (useReactNativeWebView) {
     return <WebView source={{ uri: url }} style={{ marginTop: paddingTop, flex: 1 }} />
   } else {
-    return <InternalWebView route={url} />
+    return <InternalWebView route={url} showFullScreen={showFullScreen ?? true} />
   }
 }

--- a/src/lib/Components/InternalWebView.tsx
+++ b/src/lib/Components/InternalWebView.tsx
@@ -1,8 +1,9 @@
 import React from "react"
-import { requireNativeComponent } from "react-native"
+import { requireNativeComponent, View } from "react-native"
 
 interface Props {
   route: string
+  showFullScreen?: boolean
 }
 
 /**
@@ -11,8 +12,8 @@ interface Props {
  */
 export default class InternalWebView extends React.Component<Props, any> {
   render() {
-    return <NativeInternalWebView {...this.props} />
+    return <NativeInternalWebView style={{ flex: 1 }} {...this.props} />
   }
 }
 
-const NativeInternalWebView = requireNativeComponent("ARInternalWebView")
+const NativeInternalWebView = requireNativeComponent("ARInternalWebView") as typeof View

--- a/src/lib/Scenes/Inbox/Screens/Checkout.tsx
+++ b/src/lib/Scenes/Inbox/Screens/Checkout.tsx
@@ -25,7 +25,7 @@ export const Checkout: React.FC<{ orderID: string }> = ({ orderID }) => {
         >
           Make Offer
         </FancyModalHeader>
-        <ArtsyWebView url={webCheckoutUrl} />
+        <ArtsyWebView url={webCheckoutUrl} showFullScreen={false} />
       </View>
     </KeyboardAvoidingView>
   )

--- a/src/lib/Scenes/Inbox/Screens/Checkout.tsx
+++ b/src/lib/Scenes/Inbox/Screens/Checkout.tsx
@@ -1,17 +1,13 @@
+import { ArtsyWebView } from "lib/Components/ArtsyWebView"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
-import Spinner from "lib/Components/Spinner"
 import { dismissModal } from "lib/navigation/navigate"
 import { getCurrentEmissionState } from "lib/store/GlobalStore"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
-import React, { useState } from "react"
+import React from "react"
 import { KeyboardAvoidingView, View } from "react-native"
-import WebView from "react-native-webview"
 
 export const Checkout: React.FC<{ orderID: string }> = ({ orderID }) => {
   const webCheckoutUrl = `${getCurrentEmissionState().webURL}/orders/${orderID}`
-  const paddingTop = useScreenDimensions().safeAreaInsets.top
-
-  const [isLoading, setLoading] = useState(false)
   return (
     <KeyboardAvoidingView
       behavior="padding"
@@ -29,17 +25,7 @@ export const Checkout: React.FC<{ orderID: string }> = ({ orderID }) => {
         >
           Make Offer
         </FancyModalHeader>
-        <WebView
-          onLoadStart={() => {
-            setLoading(true)
-          }}
-          onLoadEnd={() => {
-            setLoading(false)
-          }}
-          source={{ uri: webCheckoutUrl }}
-          style={{ marginTop: paddingTop, flex: 1 }}
-        />
-        {!!isLoading && <Spinner style={{ flex: 1, marginBottom: "60%" }} />}
+        <ArtsyWebView url={webCheckoutUrl} />
       </View>
     </KeyboardAvoidingView>
   )


### PR DESCRIPTION
The type of this PR is: **fix**

### Description

Use native webview rather than react-native-webview in order to share auth credentials and prevent users from being prompted to login in checkout flows.

- Adds a prop `showFullScreen` to native webview to allow showing header
- Replaces react-native-webview with our own native webview in Checkout

#### Before

https://user-images.githubusercontent.com/49686530/108123341-b24ef100-7073-11eb-865c-2c3b69095752.mp4


#### After 

https://user-images.githubusercontent.com/49686530/108123346-b418b480-7073-11eb-9f62-77f1d3aeaac1.mp4


### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
