### PR TITLE
chore: release prep 6.7.8

### DIFF
--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,5 +1,6 @@
 This update includes a number of improvements and bug fixes, including:
 
-• Watched lots are now available under my bids in the Inbox tab
+• Auction Results and Market Signals now available on Insights tab of artist pages
+• Artworks can now be shared to Instagram Stories
 
 Have feedback? Email us at support@artsy.net


### PR DESCRIPTION
The type of this PR is: **chore**

### Description

Updates release notes ahead of 6.7.8 submission.