### PR TITLE
fix: don't render retry view for market stats #trivial

### DIFF
--- a/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
@@ -192,6 +192,7 @@ export const MarketStatsQueryRenderer: React.FC<{
       render={renderWithPlaceholder({
         Container: MarketStatsFragmentContainer,
         renderPlaceholder: LoadingSkeleton,
+        renderFallback: () => null,
       })}
     />
   )


### PR DESCRIPTION
The type of this PR is: **fix**

### Description

Market Signals view is render the retry view when getting and error and rendering poorly, I think in this case we can just not show the module.

#### Before
![IMG_1046](https://user-images.githubusercontent.com/49686530/108218461-ac542100-7102-11eb-8d00-87faf2edb9a6.PNG)

#### After

![auction-results-no-error](https://user-images.githubusercontent.com/49686530/108218250-757e0b00-7102-11eb-9a24-2792338c2e61.png)




### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
