### PR TITLE
fix fast reload

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ end
 group :test do
   gem 'danger' # Stop saying 'you forgot to...', used only on Circle CI
   gem 'xcode-install' # To ensure we have the right SDK installed for running tests
-  gem 'nokogiri', '>= 1.10.4' # For CVE-2019-5477
+  gem 'nokogiri', '1.11.1' # For CVE-2019-5477
   gem 'second_curtain' # to upload snapshot fails
   gem 'xcpretty' # Makes CI readable
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,7 +239,7 @@ GEM
     netrc (0.11.0)
     nio4r (2.5.4)
     no_proxy_fix (0.1.2)
-    nokogiri (1.11.1-x86_64-darwin)
+    nokogiri (1.11.1)
       racc (~> 1.4)
     octokit (4.20.0)
       faraday (>= 0.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,7 @@ GEM
     memoist (0.16.2)
     mini_magick (4.11.0)
     mini_mime (1.0.2)
+    mini_portile2 (2.5.0)
     minitest (5.14.3)
     molinillo (0.6.6)
     multi_json (1.15.0)
@@ -240,6 +241,7 @@ GEM
     nio4r (2.5.4)
     no_proxy_fix (0.1.2)
     nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     octokit (4.20.0)
       faraday (>= 0.9)
@@ -312,7 +314,6 @@ GEM
 
 PLATFORMS
   ruby
-  x86_64-darwin-19
 
 DEPENDENCIES
   cocoapods (~> 1.7.2)
@@ -324,7 +325,7 @@ DEPENDENCIES
   fastlane-plugin-sentry
   json
   lowdown
-  nokogiri (>= 1.10.4)
+  nokogiri (= 1.11.1)
   psych
   second_curtain
   xcode-install

--- a/HACKS.md
+++ b/HACKS.md
@@ -88,3 +88,13 @@
 
   - Stop using nested navigation containers.
   - Fix `@react-navigation/core` properly upstream.
+
+- relay-compiler
+
+  There are two hacks here:
+
+  - We hack the output of the compiler to provide clickable links for error messages. Relay assumes that you put your
+    `__genearted__` folder in the root of your project, but we put it in `src`.
+  - We make sure that files which do not change are not overwritten. This prevents excessive reloading by metro.
+
+  We can remove these hacks when they don't matter anymore. Neither are liley to be fixed by facebook.

--- a/HACKS.md
+++ b/HACKS.md
@@ -94,7 +94,7 @@
   There are two hacks here:
 
   - We hack the output of the compiler to provide clickable links for error messages. Relay assumes that you put your
-    `__genearted__` folder in the root of your project, but we put it in `src`.
+    `__generated__` folder in the root of your project, but we put it in `src`.
   - We make sure that files which do not change are not overwritten. This prevents excessive reloading by metro.
 
   We can remove these hacks when they don't matter anymore. Neither are likely to be fixed by facebook.

--- a/HACKS.md
+++ b/HACKS.md
@@ -97,4 +97,4 @@
     `__genearted__` folder in the root of your project, but we put it in `src`.
   - We make sure that files which do not change are not overwritten. This prevents excessive reloading by metro.
 
-  We can remove these hacks when they don't matter anymore. Neither are liley to be fixed by facebook.
+  We can remove these hacks when they don't matter anymore. Neither are likely to be fixed by facebook.

--- a/patches/relay-compiler+10.0.1.patch
+++ b/patches/relay-compiler+10.0.1.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/relay-compiler/bin/relay-compiler b/node_modules/relay-compiler/bin/relay-compiler
-index 14d0619..6830169 100755
+index 14d0619..0f400f8 100755
 --- a/node_modules/relay-compiler/bin/relay-compiler
 +++ b/node_modules/relay-compiler/bin/relay-compiler
 @@ -291,7 +291,7 @@ function highlightSourceAtLocation(source, location) {
@@ -20,7 +20,23 @@ index 14d0619..6830169 100755
      Profiler.run('CodegenDirectory.writeFile', function () {
        _this2._addGenerated(filename);
  
-@@ -18128,10 +18128,11 @@ module.exports = function (tagFinder, getFileFilter) {
+@@ -2400,6 +2400,15 @@ var CodegenDirectory = /*#__PURE__*/function () {
+ 
+   _proto._writeFile = function _writeFile(filePath, content) {
+     if (!this.onlyValidate) {
++      // Don't overwrite files that have not changed
++      // This fixes an issue that was causing metro to HMR way too often
++      // on android, and to fall back to a full refresh instead of a fast reload on iOS
++      if (this._filesystem.existsSync(filePath)) {
++        const existing = this._filesystem.readFileSync(filePath, 'utf8').toString()
++        if (existing === content) {
++          return
++        }
++      }
+       this._filesystem.writeFileSync(filePath, content, 'utf8');
+     }
+   }
+@@ -18128,10 +18137,11 @@ module.exports = function (tagFinder, getFileFilter) {
  
      var astDefinitions = [];
      var sources = [];
@@ -35,7 +51,7 @@ index 14d0619..6830169 100755
        sources.push(source.body);
        astDefinitions.push.apply(astDefinitions, (0, _toConsumableArray2["default"])(ast.definitions));
      });
-@@ -18216,9 +18217,7 @@ function find(tagFinder, text, absPath) {
+@@ -18216,9 +18226,7 @@ function find(tagFinder, text, absPath) {
    tags.forEach(function (tag) {
      return validateTemplate(tag, moduleName, absPath);
    });

--- a/patches/relay-compiler+10.0.1.patch
+++ b/patches/relay-compiler+10.0.1.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/relay-compiler/bin/relay-compiler b/node_modules/relay-compiler/bin/relay-compiler
-index 14d0619..0f400f8 100755
+index 14d0619..0fc167e 100755
 --- a/node_modules/relay-compiler/bin/relay-compiler
 +++ b/node_modules/relay-compiler/bin/relay-compiler
 @@ -291,7 +291,7 @@ function highlightSourceAtLocation(source, location) {
@@ -36,7 +36,21 @@ index 14d0619..0f400f8 100755
        this._filesystem.writeFileSync(filePath, content, 'utf8');
      }
    }
-@@ -18128,10 +18137,11 @@ module.exports = function (tagFinder, getFileFilter) {
+@@ -8027,7 +8036,12 @@ function getRelayFileWriter(baseDir, languagePlugin, noFutureProofEnums, outputD
+         }
+ 
+         var data = JSON.stringify(object, null, 2);
+-        fs.writeFileSync(persistedQueryPath, data, 'utf8');
++        if (
++          !fs.existsSync(persistedQueryPath) ||
++          data !== fs.readFileSync(persistedQueryPath, 'utf8').toString()
++        ) {
++          fs.writeFileSync(persistedQueryPath, data, 'utf8');
++        }
+       }
+ 
+       return results;
+@@ -18128,10 +18142,11 @@ module.exports = function (tagFinder, getFileFilter) {
  
      var astDefinitions = [];
      var sources = [];
@@ -51,7 +65,7 @@ index 14d0619..0f400f8 100755
        sources.push(source.body);
        astDefinitions.push.apply(astDefinitions, (0, _toConsumableArray2["default"])(ast.definitions));
      });
-@@ -18216,9 +18226,7 @@ function find(tagFinder, text, absPath) {
+@@ -18216,9 +18231,7 @@ function find(tagFinder, text, absPath) {
    tags.forEach(function (tag) {
      return validateTemplate(tag, moduleName, absPath);
    });


### PR DESCRIPTION
### Description

This fixes the long-standing issue of metro's Fast Reload feature not working properly.

It turns out that relay rewrites all generated files every time you touch _any_ file in `src`, which in turn triggers a cascade of 'file updated' notifications to metro's Fast Reload service. On iOS this sudden influx seems to raise a flag, and instead of doing hundreds of Fast Reload operations it bails out and does one normal full reload. On android it doesn't bail out that way and instead just applies all the Fast Reload operations sequentially, which takes like 20s most of the time.

Anyway we can prevent the whole mess by making it so that relay only rewrites files that have actually changed.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
