### PR TITLE
fix: improve bottom tabs dev state management

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,8 +3,9 @@ upcoming:
   date: TBD
   dev:
     - Migrate LoadFailureView to typescript - adam, brian, david, mounir, pavlos
+    - Improve bottom tabs dev state management  - david, mounir
   user_facing:
-    - 
+    -
 
 releases:
   - version: 6.7.8

--- a/src/lib/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/lib/Scenes/BottomTabs/BottomTabsModel.ts
@@ -1,6 +1,6 @@
 import { BottomTabsModelFetchCurrentUnreadConversationCountQuery } from "__generated__/BottomTabsModelFetchCurrentUnreadConversationCountQuery.graphql"
 import { Action, action, Thunk, thunk } from "easy-peasy"
-import { saveDevNavState } from "lib/navigation/useReloadedDevNavigationState"
+import { saveDevNavigationStateSelectedTab } from "lib/navigation/useReloadedDevNavigationState"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { GlobalStore } from "lib/store/GlobalStore"
 import { fetchQuery, graphql } from "react-relay"
@@ -51,6 +51,6 @@ export const BottomTabsModel: BottomTabsModel = {
   }),
   switchTab: action((state, tabType) => {
     state.sessionState.selectedTab = tabType
-    saveDevNavState(tabType)
+    saveDevNavigationStateSelectedTab(tabType)
   }),
 }

--- a/src/lib/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/lib/Scenes/BottomTabs/BottomTabsModel.ts
@@ -1,8 +1,6 @@
-import AsyncStorage from "@react-native-community/async-storage"
 import { BottomTabsModelFetchCurrentUnreadConversationCountQuery } from "__generated__/BottomTabsModelFetchCurrentUnreadConversationCountQuery.graphql"
 import { Action, action, Thunk, thunk } from "easy-peasy"
-import { ArtsyNativeModule } from "lib/NativeModules/ArtsyNativeModule"
-import { BOTTOM_NAV_STATE_STORAGE_KEY } from "lib/navigation/useReloadedDevNavigationState"
+import { saveDevNavState } from "lib/navigation/useReloadedDevNavigationState"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { GlobalStore } from "lib/store/GlobalStore"
 import { fetchQuery, graphql } from "react-relay"
@@ -53,27 +51,6 @@ export const BottomTabsModel: BottomTabsModel = {
   }),
   switchTab: action((state, tabType) => {
     state.sessionState.selectedTab = tabType
-    persistDevReloadState(tabType)
+    saveDevNavState(tabType)
   }),
-}
-
-// We want the selected tab state to persist across dev reloads, but not across app launches.
-// So every time we switch tab we'll also save the number of launches + the newly selected tab
-// and every time the store rehydrates we'll check whether the number of launches is the same as the last
-// time the app switched tab. if so, we reinstate the last selected tab.
-const launchCount = ArtsyNativeModule.launchCount
-
-function persistDevReloadState(tabType: BottomTabType) {
-  if (!__DEV__) {
-    return
-  }
-  setImmediate(() => {
-    AsyncStorage.setItem(
-      BOTTOM_NAV_STATE_STORAGE_KEY,
-      JSON.stringify({
-        launchCount,
-        selectedTab: tabType,
-      })
-    )
-  })
 }

--- a/src/lib/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/lib/Scenes/BottomTabs/BottomTabsModel.ts
@@ -1,10 +1,10 @@
 import AsyncStorage from "@react-native-community/async-storage"
 import { BottomTabsModelFetchCurrentUnreadConversationCountQuery } from "__generated__/BottomTabsModelFetchCurrentUnreadConversationCountQuery.graphql"
-import { Action, action, Thunk, thunk, thunkOn, ThunkOn } from "easy-peasy"
+import { Action, action, Thunk, thunk } from "easy-peasy"
 import { ArtsyNativeModule } from "lib/NativeModules/ArtsyNativeModule"
+import { BOTTOM_NAV_STATE_STORAGE_KEY } from "lib/navigation/useReloadedDevNavigationState"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { GlobalStore } from "lib/store/GlobalStore"
-import type { GlobalStoreModel } from "lib/store/GlobalStoreModel"
 import { fetchQuery, graphql } from "react-relay"
 import { BottomTabType } from "./BottomTabType"
 
@@ -19,7 +19,6 @@ export interface BottomTabsModel {
 
   switchTab: Action<BottomTabsModel, BottomTabType>
   setTabProps: Action<BottomTabsModel, { tab: BottomTabType; props: object | undefined }>
-  __dev__didRehydrate: ThunkOn<BottomTabsModel, {}, GlobalStoreModel>
 }
 
 export const BottomTabsModel: BottomTabsModel = {
@@ -56,14 +55,13 @@ export const BottomTabsModel: BottomTabsModel = {
     state.sessionState.selectedTab = tabType
     persistDevReloadState(tabType)
   }),
-  __dev__didRehydrate: thunkOn((_, storeActions) => storeActions.rehydrate, maybeHandleDevReload),
 }
 
 // We want the selected tab state to persist across dev reloads, but not across app launches.
 // So every time we switch tab we'll also save the number of launches + the newly selected tab
 // and every time the store rehydrates we'll check whether the number of launches is the same as the last
 // time the app switched tab. if so, we reinstate the last selected tab.
-const reloadStateKey = "__dev__reloadState"
+const launchCount = ArtsyNativeModule.launchCount
 
 function persistDevReloadState(tabType: BottomTabType) {
   if (!__DEV__) {
@@ -71,33 +69,11 @@ function persistDevReloadState(tabType: BottomTabType) {
   }
   setImmediate(() => {
     AsyncStorage.setItem(
-      reloadStateKey,
+      BOTTOM_NAV_STATE_STORAGE_KEY,
       JSON.stringify({
         launchCount,
         selectedTab: tabType,
       })
     )
   })
-}
-
-const launchCount = ArtsyNativeModule.launchCount
-
-async function maybeHandleDevReload() {
-  if (!__DEV__) {
-    return
-  }
-  const json = await AsyncStorage.getItem(reloadStateKey)
-  if (!json) {
-    return
-  }
-  try {
-    const { launchCount: previousLaunchCount, selectedTab } = JSON.parse(json)
-    if (launchCount === previousLaunchCount) {
-      GlobalStore.actions.bottomTabs.switchTab(selectedTab)
-    } else {
-      AsyncStorage.removeItem(reloadStateKey)
-    }
-  } catch (e) {
-    console.error("failed to handle dev reload state")
-  }
 }

--- a/src/lib/navigation/useReloadedDevNavigationState.ts
+++ b/src/lib/navigation/useReloadedDevNavigationState.ts
@@ -6,8 +6,6 @@ import { useEffect } from "react"
 
 const NAV_STATE_STORAGE_KEY = "ARDevNavState"
 
-export const BOTTOM_NAV_STATE_STORAGE_KEY = "__dev__reloadState"
-
 interface NavStateCache {
   launchCount: number
   stackStates: {
@@ -24,6 +22,8 @@ const currentCache: NavStateCache = {
   selectedTab: "home",
 }
 
+// On dev mode, if the app restarted because of a bundle reload/fast refresh,
+// We want to rehydrate the navigation state
 export async function loadDevNavigationStateCache(switchTabAction: (tabName: BottomTabType) => void) {
   if (!__DEV__) {
     return
@@ -35,7 +35,6 @@ export async function loadDevNavigationStateCache(switchTabAction: (tabName: Bot
       // only reinstate the navigation state cache for bundle reloads, not for app reboots
       if (parsedCache?.launchCount === currentCache.launchCount) {
         switchTabAction(parsedCache.selectedTab)
-
         reloadedCache = parsedCache
       }
     } catch (e) {
@@ -44,6 +43,8 @@ export async function loadDevNavigationStateCache(switchTabAction: (tabName: Bot
   }
 }
 
+// We want the navigation stack state to persist across dev reloads
+// So whenever we find out it changed, we save it
 export function useReloadedDevNavigationState(
   stackID: string | undefined,
   ref: React.RefObject<NavigationContainerRef>
@@ -65,8 +66,9 @@ export function useReloadedDevNavigationState(
   return reloadedCache?.stackStates[stackID]
 }
 
-// We want to save the selected Tab after the user switches tabs
-export async function saveDevNavState(selectedTab: BottomTabType) {
+// We want the selected tab state to persist across dev reloads
+// So we save it whenever the user switches tabs
+export async function saveDevNavigationStateSelectedTab(selectedTab: BottomTabType) {
   if (!__DEV__) {
     return
   }

--- a/src/lib/store/GlobalStore.tsx
+++ b/src/lib/store/GlobalStore.tsx
@@ -1,6 +1,6 @@
 import { action, createStore, createTypedHooks, StoreProvider } from "easy-peasy"
 import { LegacyNativeModules } from "lib/NativeModules/LegacyNativeModules"
-import { loadDevNavigationStateCache } from "lib/navigation/useReloadedDevNavigationState"
+import { loadDevNavigationStateCache, maybeHandleDevReload } from "lib/navigation/useReloadedDevNavigationState"
 import React from "react"
 import { Platform } from "react-native"
 import Config from "react-native-config"
@@ -48,6 +48,7 @@ function createGlobalStore() {
   if (!__TEST__) {
     unpersist().then(async (state) => {
       await loadDevNavigationStateCache()
+      await maybeHandleDevReload(store.getActions().bottomTabs.switchTab)
       store.getActions().rehydrate(state)
     })
   }

--- a/src/lib/store/GlobalStore.tsx
+++ b/src/lib/store/GlobalStore.tsx
@@ -1,6 +1,6 @@
 import { action, createStore, createTypedHooks, StoreProvider } from "easy-peasy"
 import { LegacyNativeModules } from "lib/NativeModules/LegacyNativeModules"
-import { loadDevNavigationStateCache, maybeHandleDevReload } from "lib/navigation/useReloadedDevNavigationState"
+import { loadDevNavigationStateCache } from "lib/navigation/useReloadedDevNavigationState"
 import React from "react"
 import { Platform } from "react-native"
 import Config from "react-native-config"
@@ -47,8 +47,7 @@ function createGlobalStore() {
 
   if (!__TEST__) {
     unpersist().then(async (state) => {
-      await loadDevNavigationStateCache()
-      await maybeHandleDevReload(store.getActions().bottomTabs.switchTab)
+      await loadDevNavigationStateCache(store.getActions().bottomTabs.switchTab)
       store.getActions().rehydrate(state)
     })
   }


### PR DESCRIPTION
Co-authored-by: David Sheldrick <djsheldrick@gmail.com>

The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves an issue we had with the bottoms tabs nav state management after Fast Refresh. 

### Description
The videos below show how the app behaves after updating the user name under my profile tab.

**Before**

https://user-images.githubusercontent.com/11945712/108498852-bebe8e00-72ad-11eb-8607-f56e517a6622.mov


**After**

https://user-images.githubusercontent.com/11945712/108498840-bc5c3400-72ad-11eb-80d6-ed0a552c14e2.mov


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434