### PR TITLE
feat: POC for an OAuth login flow within the android app [NO NOT MERGE]

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -142,6 +142,10 @@ android {
         versionCode 7
         versionName "1.0.0"
 
+        manifestPlaceholders = [
+          appAuthRedirectScheme: 'artsy'
+        ]
+
         multiDexEnabled true
 
         buildConfigField "String", "GITCommitRev", '"c77772ee1"'

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "query-string": "4.3.4",
     "react": "16.13.1",
     "react-native": "0.63.3",
+    "react-native-app-auth": "^6.1.0",
     "react-native-config": "https://github.com/artsy/react-native-config.git",
     "react-native-gesture-handler": "^1.8.0",
     "react-native-haptic-feedback": "1.10.0",

--- a/src/lib/AndroidApp.tsx
+++ b/src/lib/AndroidApp.tsx
@@ -1,11 +1,12 @@
 import { GlobalStore, GlobalStoreProvider } from "lib/store/GlobalStore"
-import { Theme } from "palette"
+import { Button, Flex, Theme } from "palette"
 import React, { useEffect } from "react"
 import { Linking, View } from "react-native"
+import { authorize } from "react-native-app-auth"
+import Config from "react-native-config"
 import track from "react-tracking"
 import { RelayEnvironmentProvider } from "relay-hooks"
 import { _FancyModalPageWrapper } from "./Components/FancyModal/FancyModalContext"
-import { LogIn } from "./LogIn/LogIn"
 import { ModalStack } from "./navigation/ModalStack"
 import { navigate } from "./navigation/navigate"
 import { defaultEnvironment } from "./relay/createEnvironment"
@@ -16,6 +17,20 @@ import { ProvideScreenDimensions } from "./utils/useScreenDimensions"
 const Main: React.FC<{}> = track()(({}) => {
   const isHydrated = GlobalStore.useAppState((state) => state.sessionState.isHydrated)
   const isLoggedIn = GlobalStore.useAppState((state) => !!state.auth.userAccessToken)
+
+  const config = {
+    issuer: "https://stagingapi.artsy.net",
+    serviceConfiguration: {
+      authorizationEndpoint: "https://stagingapi.artsy.net/oauth2/authorize",
+      tokenEndpoint: "https://stagingapi.artsy.net/oauth2/access_token",
+    },
+    clientId: Config.ARTSY_API_CLIENT_KEY,
+    redirectUrl: "artsy://oauth/callback",
+    scopes: ["offline_access"],
+    usePKCE: false,
+    skipCodeExchange: false,
+    useNonce: false,
+  }
 
   useEffect(() => {
     // TODO: handle opening the app from deep link (Linking.getInitialURL)
@@ -29,7 +44,26 @@ const Main: React.FC<{}> = track()(({}) => {
     return <View></View>
   }
   if (!isLoggedIn) {
-    return <LogIn></LogIn>
+    return (
+      <View>
+        <Flex p="2" pt="1">
+          <Button
+            block
+            onPress={async () => {
+              try {
+                const result = await authorize(config)
+                console.log(result)
+                // result includes accessToken, accessTokenExpirationDate and refreshToken
+              } catch (error) {
+                console.log(error)
+              }
+            }}
+          >
+            Login to Artsy
+          </Button>
+        </Flex>
+      </View>
+    )
   }
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -11391,6 +11391,19 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
+react-native-app-auth@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-app-auth/-/react-native-app-auth-6.1.0.tgz#c299ea320810a1f74f40d789a7f004428bb36f0f"
+  integrity sha512-VIUAXuyqKnXpMWH8eyM9w380WNlAYSQBKYDn1eZ0hQRptMLAFIXzm0RA5887EVUlPT9CqbAJMwUMpS+uVPD8rw==
+  dependencies:
+    invariant "2.2.4"
+    react-native-base64 "0.0.2"
+
+react-native-base64@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-base64/-/react-native-base64-0.0.2.tgz#c28463c2c6779ac3ec5fdd12979ebc8c5f9b410a"
+  integrity sha512-Fu/J1a2y0X22EJDWqJR2oEa1fpP4gTFjYxk8ElJdt1Yak3HOXmFJ7EohLVHU2DaQkgmKfw8qb7u/48gpzveRbg==
+
 "react-native-config@https://github.com/artsy/react-native-config.git":
   version "1.3.3"
   resolved "https://github.com/artsy/react-native-config.git#83fda4898dc33b920166c246093792c12a384146"


### PR DESCRIPTION
Looks like Gravity does not currently accept the `artsy` URL scheme so I was
blocked there.

#FutureFriday #FF

https://github.com/artsy/gravity/blob/master/app/models/util/url_validation.rb#L8

- [x] Initiate OAuth handshake
- [ ] Support artsy://oauth/callback redirect URI within Gravity
- [ ] Receive OAuth authorization code
- [ ] Exchange OAuth authorization code for access token
- [ ] Store access token into config
- [ ] Support logout with access explicit access token expiration

The type of this PR is: **Enhancement**

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-]

### Description

Spike on supporting an OAuth login flow within the Android app.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [ ] I have documented any follow-up work that this PR will require, or it does not require any.
- [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434