### PR TITLE
chore: enable hermes on android

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
   dev:
     - Migrate LoadFailureView to typescript - adam, brian, david, mounir, pavlos
     - Improve bottom tabs dev state management  - david, mounir
+    - Enable hermes on Android - david
   user_facing:
     - Adds inquiry checkout offer status CTA - lily
     - Update consignment photo selection flow for iOS 14 - brian

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -83,7 +83,7 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    enableHermes: false,  // clean and rebuild if changing
+    enableHermes: true,  // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"


### PR DESCRIPTION
This PR resolves [CX-1057]

### Description

This PR enabled hermes on Android. It all seems to work fine, I used it for a couple of days doing heavy infra work.

After merging devs will need to clean and rebuild the android app:

    cd android && ./gradlew clean & cd ../ && yarn android

I'll publicise this in #mobile-practice

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-1057]: https://artsyproduct.atlassian.net/browse/CX-1057