### PR TITLE
chore: disable hermes, enable JSC with intl

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,7 +4,6 @@ upcoming:
   dev:
     - Migrate LoadFailureView to typescript - adam, brian, david, mounir, pavlos
     - Improve bottom tabs dev state management  - david, mounir
-    - Enable hermes on Android - david
   user_facing:
     - Adds inquiry checkout offer status CTA - lily
     - Update consignment photo selection flow for iOS 14 - brian

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -83,7 +83,7 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    enableHermes: true,  // clean and rebuild if changing
+    enableHermes: false,  // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"
@@ -114,7 +114,7 @@ def enableProguardInReleaseBuilds = false
  * give correct results when using with locales other than en-US.  Note that
  * this variant is about 6MiB larger per architecture than default.
  */
-def jscFlavor = 'org.webkit:android-jsc:+'
+def jscFlavor = 'org.webkit:android-jsc-intl:+'
 
 /**
  * Whether to enable the Hermes VM.


### PR DESCRIPTION
### Description

I didn't check thoroughly, it turns out Hermes doesn't support `Intl` yet 😭 but it's being developed now so maybe in a couple of RN releases we'll be able to switch. We could also switch earlier by replacing our current (very limited) `Intl` usage with lightweight npm packages for number/date formatting until Hermes `Intl` support drops. I'll bring that up at Knowledge Share on thursday.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
