### PR TITLE
chore: make android app full-bleed

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
   dev:
     - Migrate LoadFailureView to typescript - adam, brian, david, mounir, pavlos
     - Improve bottom tabs dev state management  - david, mounir
+    - Make android app full-bleed - david
   user_facing:
     - Adds inquiry checkout offer status CTA - lily
     - Update consignment photo selection flow for iOS 14 - brian

--- a/android/app/src/main/java/net/artsy/app/MainActivity.java
+++ b/android/app/src/main/java/net/artsy/app/MainActivity.java
@@ -1,5 +1,12 @@
 package net.artsy.app;
 
+import android.graphics.Color;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.View;
+import android.view.WindowInsets;
+import android.view.WindowManager;
+
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactRootView;
@@ -24,5 +31,24 @@ public class MainActivity extends ReactActivity {
        return new RNGestureHandlerEnabledRootView(MainActivity.this);
       }
     };
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      getWindow().setStatusBarColor(Color.TRANSPARENT);
+      getWindow().setNavigationBarColor(Color.WHITE);
+      View decorView = getWindow().getDecorView();
+      decorView.setOnApplyWindowInsetsListener(
+        (v, insets) -> {
+          WindowInsets defaultInsets = v.onApplyWindowInsets(insets);
+          return defaultInsets.replaceSystemWindowInsets(
+                  defaultInsets.getSystemWindowInsetLeft(),
+                  0,
+                  defaultInsets.getSystemWindowInsetRight(),
+                  defaultInsets.getSystemWindowInsetBottom());
+        });
+    }
   }
 }

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -4,6 +4,9 @@
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:textColor">#000000</item>
+        <item name="colorPrimaryDark">#FFFFFF</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar">true</item>
     </style>
 
 </resources>

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "react-native-linear-gradient": "2.5.6",
     "react-native-localize": "^2.0.1",
     "react-native-reanimated": "^1.13.1",
-    "react-native-safe-area-context": "^3.1.8",
+    "react-native-safe-area-context": "^3.1.9",
     "react-native-screens": "^2.17.1",
     "react-native-scrollable-tab-view": "1.0.0",
     "react-native-share": "5.1.0",

--- a/src/lib/LogIn/LogIn.tsx
+++ b/src/lib/LogIn/LogIn.tsx
@@ -3,6 +3,7 @@ import { createStackNavigator, TransitionPresets } from "@react-navigation/stack
 import { ChevronIcon, Flex, Text } from "palette"
 import React from "react"
 import { KeyboardAvoidingView, Platform } from "react-native"
+import { SafeAreaView } from "react-native-safe-area-context"
 import { LogInEmail } from "./LogInEmail"
 import { LogInEnterPassword } from "./LogInEnterPassword"
 import { LogInStore } from "./LogInStore"
@@ -11,32 +12,34 @@ const StackNavigator = createStackNavigator()
 
 export const LogIn = () => {
   return (
-    <NavigationContainer independent>
-      <LogInStore.Provider>
-        <KeyboardAvoidingView behavior={Platform.select({ ios: "padding", default: undefined })} style={{ flex: 1 }}>
-          <StackNavigator.Navigator
-            headerMode="screen"
-            screenOptions={{
-              ...TransitionPresets.SlideFromRightIOS,
-            }}
-          >
-            <StackNavigator.Screen options={{ headerShown: false }} name="LogInEmail" component={LogInEmail} />
-            <StackNavigator.Screen
-              options={{
-                headerBackTitleVisible: false,
-                headerBackImage: () => (
-                  <Flex py="2" px="1">
-                    <ChevronIcon direction="left" />
-                  </Flex>
-                ),
-                headerTitle: () => <Text variant="mediumText">Step 2 of 2</Text>,
+    <SafeAreaView style={{ flex: 1 }}>
+      <NavigationContainer independent>
+        <LogInStore.Provider>
+          <KeyboardAvoidingView behavior={Platform.select({ ios: "padding", default: undefined })} style={{ flex: 1 }}>
+            <StackNavigator.Navigator
+              headerMode="screen"
+              screenOptions={{
+                ...TransitionPresets.SlideFromRightIOS,
               }}
-              name="LogInEnterPassword"
-              component={LogInEnterPassword}
-            />
-          </StackNavigator.Navigator>
-        </KeyboardAvoidingView>
-      </LogInStore.Provider>
-    </NavigationContainer>
+            >
+              <StackNavigator.Screen options={{ headerShown: false }} name="LogInEmail" component={LogInEmail} />
+              <StackNavigator.Screen
+                options={{
+                  headerBackTitleVisible: false,
+                  headerBackImage: () => (
+                    <Flex py="2" px="1">
+                      <ChevronIcon direction="left" />
+                    </Flex>
+                  ),
+                  headerTitle: () => <Text variant="mediumText">Step 2 of 2</Text>,
+                }}
+                name="LogInEnterPassword"
+                component={LogInEnterPassword}
+              />
+            </StackNavigator.Navigator>
+          </KeyboardAvoidingView>
+        </LogInStore.Provider>
+      </NavigationContainer>
+    </SafeAreaView>
   )
 }

--- a/src/lib/navigation/BackButton.tsx
+++ b/src/lib/navigation/BackButton.tsx
@@ -1,3 +1,4 @@
+import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { ChevronIcon } from "palette"
 import React from "react"
 import { Animated } from "react-native"
@@ -9,7 +10,7 @@ export const BackButton: React.FC<{ onPress?(): void }> = ({ onPress = goBack })
     <Animated.View
       style={{
         position: "absolute",
-        top: 13,
+        top: 13 + useScreenDimensions().safeAreaInsets.top,
         left: 10,
         backgroundColor: "white",
         width: 40,

--- a/src/lib/navigation/NavStack.tsx
+++ b/src/lib/navigation/NavStack.tsx
@@ -1,5 +1,6 @@
 import { NavigationContainer, NavigationContainerRef, Route, useNavigationState } from "@react-navigation/native"
 import { AppModule, modules } from "lib/AppRegistry"
+import { ProvideScreenDimensions, useScreenDimensions } from "lib/utils/useScreenDimensions"
 import React from "react"
 import { View } from "react-native"
 import { createNativeStackNavigator } from "react-native-screens/native-stack"
@@ -28,11 +29,18 @@ const ScreenWrapper: React.FC<{ route: Route<"", ScreenProps> }> = ({ route }) =
   const showBackButton = !isRootScreen && !module.options.hidesBackButton
 
   return (
-    <View style={{ flex: 1, backgroundColor: "white" }}>
-      <module.Component {...route.params.props} />
-      {!!showBackButton && <BackButton />}
-    </View>
+    <ProvideScreenDimensions>
+      <ScreenPadding fullBleed={!!module.options.fullBleed}>
+        <module.Component {...route.params.props} />
+        {!!showBackButton && <BackButton />}
+      </ScreenPadding>
+    </ProvideScreenDimensions>
   )
+}
+
+const ScreenPadding: React.FC<{ fullBleed: boolean }> = ({ fullBleed, children }) => {
+  const topInset = useScreenDimensions().safeAreaInsets.top
+  return <View style={{ flex: 1, backgroundColor: "white", paddingTop: fullBleed ? 0 : topInset }}>{children}</View>
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -11444,10 +11444,10 @@ react-native-reanimated@^1.13.1:
   dependencies:
     fbjs "^1.0.0"
 
-react-native-safe-area-context@^3.1.8:
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.1.8.tgz#7a9883aa0f38f9c77d4bef2b89e4e285bc1024a3"
-  integrity sha512-9gUlsDZ96QwT9AKzA6aVWM/NX5rlJgauZ9HgCDVzKbe29UQYT1740QJnnaI2GExmkFGp6o7ZLNhCXZW95eYVFA==
+react-native-safe-area-context@^3.1.9:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.1.9.tgz#48864ea976b0fa57142a2cc523e1fd3314e7247e"
+  integrity sha512-wmcGbdyE/vBSL5IjDPReoJUEqxkZsywZw5gPwsVUV1NBpw5eTIdnL6Y0uNKHE25Z661moxPHQz6kwAkYQyorxA==
 
 react-native-screens@^2.17.1:
   version "2.17.1"


### PR DESCRIPTION
### Description

We forgot to make the app full-bleed when setting it up. It's now blocking progress on the new header/back-button work, so here we go 🚀

![image](https://user-images.githubusercontent.com/1242537/109044172-fec8ab00-76c9-11eb-8242-4947a45f2889.png)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
