### PR TITLE
fix: prevent CI setup script running for devs

### DIFF
--- a/scripts/download-fonts
+++ b/scripts/download-fonts
@@ -2,7 +2,10 @@
 set -euxo pipefail
 
 
-./scripts/setup-distribute-linux
+if test $CI = true
+then
+  ./scripts/setup-distribute-linux
+fi
 
 # Create fonts directory
 mkdir -p android/app/src/main/assets/fonts


### PR DESCRIPTION
### Description

Running `make artsy` was accidentally running the linux CI setup script, so this PR prevents that.

You'll need to reinstall the `aws` cli tool if you fell victim to this. https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-mac.html

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
