### PR TITLE
fix:use correct time zone for start of bidding on Auction More Info screen

### DIFF
--- a/src/lib/Scenes/SaleInfo/SaleInfo.tsx
+++ b/src/lib/Scenes/SaleInfo/SaleInfo.tsx
@@ -73,15 +73,17 @@ export const SaleInfo: React.FC<Props> = ({ sale, me }) => {
       return null
     }
 
+    const tz = moment.tz.guess(true)
+
     return (
       <Flex mb={1}>
         <Text variant="text" color="black" fontSize="size4" mt={25} fontWeight="500">
           Live bidding opens on
         </Text>
         <Text variant="text" color="black" fontSize="size4">
-          {`${moment(sale.liveStartAt).format("dddd, MMMM, D, YYYY")} at ${moment(sale.liveStartAt).format(
-            "h:mma"
-          )} ${moment.tz(sale.timeZone).zoneAbbr()}`}
+          {`${moment(sale.liveStartAt).format("dddd, MMMM, D, YYYY")} at ${moment(sale.liveStartAt)
+            .tz(tz)
+            .format("h:mma z")}`}
         </Text>
       </Flex>
     )


### PR DESCRIPTION
The type of this PR is: **bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1104]

### Description

Use the same timezone that the overview page uses.

#### overview screen

<img width="338" alt="Screen Shot 2021-02-24 at 10 22 59 PM" src="https://user-images.githubusercontent.com/19369/109098597-a1dfeb80-76ef-11eb-938a-1b0e39bfed2b.png">

#### more info screen

<img width="333" alt="Screen Shot 2021-02-24 at 10 23 14 PM" src="https://user-images.githubusercontent.com/19369/109098671-b4f2bb80-76ef-11eb-963c-cb886ba71ffd.png">

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1104]: https://artsyproduct.atlassian.net/browse/CX-1104