### PR TITLE
feat: [WatchedLot] Guard against null

### DIFF
--- a/src/lib/Scenes/MyBids/Components/WatchedLot.tsx
+++ b/src/lib/Scenes/MyBids/Components/WatchedLot.tsx
@@ -16,6 +16,10 @@ interface WatchedLotProps {
 
 export const WatchedLot: React.FC<WatchedLotProps> = ({ lot }) => {
   const { saleArtwork, lot: lotState } = lot
+  if (!lotState) {
+    return null
+  }
+
   const bidCount = lotState.bidCount
   const sellingPrice = lotState?.sellingPrice?.display
   const tracking = useTracking()


### PR DESCRIPTION
The type of this PR is: **Feature**

### Description

Follow-up to https://github.com/artsy/metaphysics/pull/3026 which guards against `null` watched lots (which should only ever happen in staging).  

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
