### PR TITLE
feat: multi-selection time period filters

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -15,6 +15,7 @@ upcoming:
     - Add feature flag for new artwork filters - iskounen
     - Enable feature flags on android - mounir
     - Enable new onboarding feature flag - mounir
+    - Adds improved time period filter behind feature flag - iskounen, damon, devon, roop
   user_facing:
     - Adds inquiry checkout offer status CTA - lily
     - Update consignment photo selection flow for iOS 14 - brian

--- a/src/lib/Components/ArtworkFilterOptions/TimePeriodMultiOptions.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/TimePeriodMultiOptions.tsx
@@ -1,0 +1,126 @@
+import { StackScreenProps } from "@react-navigation/stack"
+import {
+  ArtworkFilterContext,
+  FilterData,
+  ParamDefaultValues,
+  useSelectedOptionsDisplay,
+} from "lib/utils/ArtworkFilter/ArtworkFiltersStore"
+import {
+  FilterDisplayName,
+  FilterParamName,
+  getDisplayNameForTimePeriod,
+} from "lib/utils/ArtworkFilter/FilterArtworksHelpers"
+import { useArtworkFiltersAggregation } from "lib/utils/ArtworkFilter/useArtworkFilters"
+import _ from "lodash"
+import React, { useContext, useState } from "react"
+import { FilterModalNavigationStack } from "../FilterModal"
+import { MultiSelectOptionScreen } from "./MultiSelectOption"
+
+interface TimePeriodOptionsScreenProps
+  extends StackScreenProps<FilterModalNavigationStack, "TimePeriodOptionsScreen"> {}
+
+export const TimePeriodMultiOptionsScreen: React.FC<TimePeriodOptionsScreenProps> = ({ navigation }) => {
+  const { dispatch } = useContext(ArtworkFilterContext)
+  const { aggregation } = useArtworkFiltersAggregation({ paramName: FilterParamName.timePeriod })
+
+  const DEFAULT_OPTION: FilterData = {
+    displayText: "All",
+    paramName: FilterParamName.timePeriod,
+    paramValue: ParamDefaultValues.majorPeriods,
+  }
+
+  const TIME_PERIOD_OPTIONS: FilterData[] = [
+    DEFAULT_OPTION,
+    ...(aggregation?.counts ?? []).map((c) => {
+      return {
+        displayText: getDisplayNameForTimePeriod(c.name),
+        paramName: FilterParamName.timePeriod,
+        paramValue: c.value,
+      }
+    }),
+  ]
+
+  const selectedOptions = useSelectedOptionsDisplay()
+
+  const selectedTimePeriodOptions = selectedOptions.find((option) => {
+    return option.paramName === FilterParamName.timePeriod
+  })
+
+  const [nextOptions, setNextOptions] = useState<string[]>((selectedTimePeriodOptions?.paramValue as string[]) ?? [])
+
+  const handleSelect = (option: FilterData, updatedValue: boolean) => {
+    if (updatedValue) {
+      setNextOptions((prev) => {
+        let next = []
+
+        // If the `All` toggle is selected; reset the filters to the default value (`[]`)
+        if (option.displayText === DEFAULT_OPTION.displayText) {
+          next = ParamDefaultValues.majorPeriods
+        } else {
+          // Otherwise append it
+          next = [
+            ...prev,
+            TIME_PERIOD_OPTIONS.find(({ displayText }) => {
+              return displayText === option.displayText
+            })?.paramValue as string,
+          ]
+        }
+
+        dispatch({
+          type: "selectFilters",
+          payload: {
+            displayText: option.displayText,
+            paramValue: next,
+            paramName: option.paramName,
+          },
+        })
+
+        return next
+      })
+    } else {
+      setNextOptions((prev) => {
+        let next = prev.filter((value) => {
+          return (
+            value !==
+            (TIME_PERIOD_OPTIONS.find(({ displayText }) => {
+              return displayText === option.displayText
+            })?.paramValue as string)
+          )
+        })
+
+        // If nothing is selected toggle the default value (`[]`)
+        if (next.length === 0) {
+          next = ParamDefaultValues.majorPeriods
+        }
+
+        dispatch({
+          type: "selectFilters",
+          payload: {
+            displayText: option.displayText,
+            paramValue: next,
+            paramName: option.paramName,
+          },
+        })
+
+        return next
+      })
+    }
+  }
+
+  const filterOptions = TIME_PERIOD_OPTIONS.map((option) => {
+    if (option.displayText === DEFAULT_OPTION.displayText) {
+      return { ...option, paramValue: nextOptions.length === 0 }
+    }
+
+    return { ...option, paramValue: nextOptions.includes(option.paramValue as string) }
+  })
+
+  return (
+    <MultiSelectOptionScreen
+      onSelect={handleSelect}
+      filterHeaderText={FilterDisplayName.timePeriod}
+      filterOptions={filterOptions}
+      navigation={navigation}
+    />
+  )
+}

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/TimePeriodMultiOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/TimePeriodMultiOptions-tests.tsx
@@ -1,0 +1,157 @@
+import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
+import React from "react"
+import { Switch } from "react-native"
+import { OptionListItem as FilterModalOptionListItem } from "../../../../lib/Components/FilterModal"
+import { MockFilterScreen } from "../../../../lib/Components/FilterModal/__tests__/FilterTestHelper"
+import { extractText } from "../../../../lib/tests/extractText"
+import { renderWithWrappers } from "../../../../lib/tests/renderWithWrappers"
+import { FilterParamName, InitialState } from "../../../../lib/utils/ArtworkFilter/FilterArtworksHelpers"
+import {
+  ArtworkFilterContext,
+  ArtworkFilterContextState,
+  reducer,
+} from "../../../utils/ArtworkFilter/ArtworkFiltersStore"
+import { OptionListItem as MultiSelectOptionListItem } from "../MultiSelectOption"
+import { TimePeriodMultiOptionsScreen } from "../TimePeriodMultiOptions"
+import { getEssentialProps } from "./helper"
+
+describe("TimePeriodMultiOptions Screen", () => {
+  const defaultState: ArtworkFilterContextState = {
+    aggregations: [
+      {
+        slice: "MAJOR_PERIOD",
+        counts: [
+          {
+            count: 100,
+            name: "2020",
+            value: "2020",
+          },
+          {
+            count: 200,
+            name: "2010",
+            value: "2010",
+          },
+          {
+            count: 50,
+            name: "In the year 2000!",
+            value: "In the year 2000!",
+          },
+        ],
+      },
+    ],
+    appliedFilters: [],
+    applyFilters: false,
+    counts: {
+      total: null,
+      followedArtists: null,
+    },
+    filterType: "artwork",
+    previouslyAppliedFilters: [],
+    selectedFilters: [],
+  }
+
+  const MockTimePeriodOptionsScreen = ({ initialState }: InitialState) => {
+    const [filterState, dispatch] = React.useReducer(reducer, initialState)
+
+    return (
+      <ArtworkFilterContext.Provider value={{ state: filterState, dispatch }}>
+        <TimePeriodMultiOptionsScreen {...getEssentialProps()} />
+      </ArtworkFilterContext.Provider>
+    )
+  }
+
+  describe("before any filters are selected", () => {
+    const state: ArtworkFilterContextState = defaultState
+
+    it("displays 'All' in the filter modal screen", () => {
+      const tree = renderWithWrappers(<MockFilterScreen initialState={state} />)
+      const items = tree.root.findAllByType(FilterModalOptionListItem)
+      const item = items.find((i) => extractText(i).startsWith("Time period"))
+
+      expect(item).not.toBeUndefined()
+      if (item) {
+        expect(extractText(item)).toContain("All")
+      }
+    })
+
+    it("renders all options present in the aggregation", () => {
+      const tree = renderWithWrappers(<MockTimePeriodOptionsScreen initialState={state} />)
+      expect(tree.root.findAllByType(MultiSelectOptionListItem)).toHaveLength(4)
+
+      const items = tree.root.findAllByType(MultiSelectOptionListItem)
+      expect(items.map(extractText)).toEqual(["All", "2020-today", "2010-2019", "In the year 2000!"])
+    })
+  })
+
+  describe("when filters are selected", () => {
+    const state: ArtworkFilterContextState = {
+      ...defaultState,
+      selectedFilters: [
+        {
+          displayText: "Foo",
+          paramName: FilterParamName.timePeriod,
+          paramValue: ["2020", "In the year 2000!"],
+        },
+      ],
+    }
+
+    it("displays a comma-separated list of the selected filters on the filter modal screen", () => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ ARUseNewArtworkFilters: true })
+
+      const tree = renderWithWrappers(<MockFilterScreen initialState={state} />)
+      const items = tree.root.findAllByType(FilterModalOptionListItem)
+      const item = items.find((i) => extractText(i).startsWith("Time period"))
+
+      expect(item).not.toBeUndefined()
+      if (item) {
+        expect(extractText(item)).toContain("2020-today, In the year 2000!")
+      }
+    })
+
+    it("toggles selected filters 'ON' and unselected filters 'OFF", () => {
+      const tree = renderWithWrappers(<MockTimePeriodOptionsScreen initialState={state} />)
+      const switches = tree.root.findAllByType(Switch)
+
+      expect(switches[0].props.value).toBe(false)
+      expect(switches[1].props.value).toBe(true)
+      expect(switches[2].props.value).toBe(false)
+      expect(switches[3].props.value).toBe(true)
+    })
+  })
+
+  describe("when the 'All' option is selected", () => {
+    const state: ArtworkFilterContextState = {
+      ...defaultState,
+      selectedFilters: [
+        {
+          displayText: "Foo",
+          paramName: FilterParamName.timePeriod,
+          paramValue: [],
+        },
+      ],
+    }
+
+    it("displays 'All' on the filter modal screen", () => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ ARUseNewArtworkFilters: true })
+
+      const tree = renderWithWrappers(<MockFilterScreen initialState={state} />)
+      const items = tree.root.findAllByType(FilterModalOptionListItem)
+      const item = items.find((i) => extractText(i).startsWith("Time period"))
+
+      expect(item).not.toBeUndefined()
+      if (item) {
+        expect(extractText(item)).toContain("All")
+      }
+    })
+
+    it("toggles the 'All' filter 'ON' and the other filters 'OFF", () => {
+      const tree = renderWithWrappers(<MockTimePeriodOptionsScreen initialState={state} />)
+      const switches = tree.root.findAllByType(Switch)
+
+      expect(switches[0].props.value).toBe(true)
+      expect(switches[1].props.value).toBe(false)
+      expect(switches[2].props.value).toBe(false)
+      expect(switches[3].props.value).toBe(false)
+    })
+  })
+})

--- a/src/lib/Components/FilterModal/FilterModal.tsx
+++ b/src/lib/Components/FilterModal/FilterModal.tsx
@@ -1,6 +1,7 @@
 import { ContextModule } from "@artsy/cohesion"
 import { NavigationContainer } from "@react-navigation/native"
 import { createStackNavigator, StackScreenProps, TransitionPresets } from "@react-navigation/stack"
+import { useFeatureFlag } from "lib/store/GlobalStore"
 import {
   AggregationName,
   ArtworkFilterContext,
@@ -38,6 +39,7 @@ import { PriceRangeOptionsScreen } from "../ArtworkFilterOptions/PriceRangeOptio
 import { SizeOptionsScreen } from "../ArtworkFilterOptions/SizeOptions"
 import { SizesOptionsScreen } from "../ArtworkFilterOptions/SizesOptions"
 import { SortOptionsScreen } from "../ArtworkFilterOptions/SortOptions"
+import { TimePeriodMultiOptionsScreen } from "../ArtworkFilterOptions/TimePeriodMultiOptions"
 import { TimePeriodOptionsScreen } from "../ArtworkFilterOptions/TimePeriodOptions"
 import { ViewAsOptionsScreen } from "../ArtworkFilterOptions/ViewAsOptions"
 import { WaysToBuyOptionsScreen } from "../ArtworkFilterOptions/WaysToBuyOptions"
@@ -121,6 +123,7 @@ const Stack = createStackNavigator<FilterModalNavigationStack>()
 export const FilterModalNavigator: React.FC<FilterModalProps> = (props) => {
   const tracking = useTracking()
   const { dispatch, state } = useContext(ArtworkFilterContext)
+  const useImprovedArtworkFilters = useFeatureFlag("ARUseNewArtworkFilters")
   const { exitModal, id, mode, slug, closeModal } = props
 
   const handleClosingModal = () => {
@@ -218,7 +221,10 @@ export const FilterModalNavigator: React.FC<FilterModalProps> = (props) => {
             <Stack.Screen name="SizeOptionsScreen" component={SizeOptionsScreen} />
             <Stack.Screen name="SizesOptionsScreen" component={SizesOptionsScreen} />
             <Stack.Screen name="SortOptionsScreen" component={SortOptionsScreen} />
-            <Stack.Screen name="TimePeriodOptionsScreen" component={TimePeriodOptionsScreen} />
+            <Stack.Screen
+              name="TimePeriodOptionsScreen"
+              component={useImprovedArtworkFilters ? TimePeriodMultiOptionsScreen : TimePeriodOptionsScreen}
+            />
             <Stack.Screen name="ViewAsOptionsScreen" component={ViewAsOptionsScreen} />
             <Stack.Screen
               name="YearOptionsScreen"

--- a/src/lib/Components/FilterModal/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/FilterModal/__tests__/FilterModal-tests.tsx
@@ -8,6 +8,7 @@ import { FilterModalTestsQuery } from "__generated__/FilterModalTestsQuery.graph
 import { mount } from "enzyme"
 import { CollectionFixture } from "lib/Scenes/Collection/Components/__fixtures__/CollectionFixture"
 import { CollectionArtworksFragmentContainer } from "lib/Scenes/Collection/Screens/CollectionArtworks"
+import { GlobalStoreProvider } from "lib/store/GlobalStore"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import {
   Aggregations,
@@ -294,7 +295,11 @@ describe("Filter modal states", () => {
   })
 
   it("displays the filter screen apply button correctly when no filters are selected", () => {
-    const filterScreen = mount(<MockFilterModalNavigator initialState={state} />)
+    const filterScreen = mount(
+      <GlobalStoreProvider>
+        <MockFilterModalNavigator initialState={state} />
+      </GlobalStoreProvider>
+    )
 
     expect(filterScreen.find(ApplyButton).props().disabled).toEqual(true)
   })
@@ -313,13 +318,21 @@ describe("Filter modal states", () => {
       },
     }
 
-    const filterScreen = mount(<MockFilterModalNavigator initialState={state} />)
+    const filterScreen = mount(
+      <GlobalStoreProvider>
+        <MockFilterModalNavigator initialState={state} />
+      </GlobalStoreProvider>
+    )
 
     expect(filterScreen.find(ApplyButton).props().disabled).toEqual(false)
   })
 
   it("displays default filters on the Filter modal", () => {
-    const filterScreen = mount(<MockFilterScreen initialState={state} />)
+    const filterScreen = mount(
+      <GlobalStoreProvider>
+        <MockFilterScreen initialState={state} />
+      </GlobalStoreProvider>
+    )
 
     expect(filterScreen.find(CurrentOption).at(0).text()).toEqual("Default")
 
@@ -423,7 +436,11 @@ describe("Clearing filters", () => {
       },
     }
 
-    const filterModal = mount(<MockFilterModalNavigator initialState={state} />)
+    const filterModal = mount(
+      <GlobalStoreProvider>
+        <MockFilterModalNavigator initialState={state} />
+      </GlobalStoreProvider>
+    )
 
     expect(filterModal.find(CurrentOption).at(0).text()).toEqual("Recently added")
     expect(filterModal.find(ApplyButton).props().disabled).toEqual(true)
@@ -454,7 +471,11 @@ describe("Clearing filters", () => {
       },
     }
 
-    const filterModal = mount(<MockFilterModalNavigator initialState={state} />)
+    const filterModal = mount(
+      <GlobalStoreProvider>
+        <MockFilterModalNavigator initialState={state} />
+      </GlobalStoreProvider>
+    )
     const applyButton = filterModal.find(ApplyButton)
 
     expect(applyButton.text()).toContain("Apply (2)")
@@ -566,7 +587,11 @@ describe("Applying filters on Artworks", () => {
       },
     }
 
-    const filterModal = mount(<MockFilterModalNavigator initialState={state} />)
+    const filterModal = mount(
+      <GlobalStoreProvider>
+        <MockFilterModalNavigator initialState={state} />
+      </GlobalStoreProvider>
+    )
     const applyButton = filterModal.find(ApplyButton)
 
     applyButton.props().onPress()

--- a/src/lib/utils/ArtworkFilter/ArtworkFiltersStore.tsx
+++ b/src/lib/utils/ArtworkFilter/ArtworkFiltersStore.tsx
@@ -262,6 +262,7 @@ const getSortDefaultValueByFilterType = (filterType: FilterType) => {
 
 export const ParamDefaultValues = {
   acquireable: false,
+  additionalGeneIDs: [],
   allowEmptyCreatedDates: true,
   artistIDs: [],
   atAuction: false,
@@ -271,11 +272,10 @@ export const ParamDefaultValues = {
   dimensionRange: "*-*",
   earliestCreatedYear: undefined,
   estimateRange: "",
-  additionalGeneIDs: [],
   includeArtworksByFollowedArtists: false,
   inquireableOnly: false,
   latestCreatedYear: undefined,
-  majorPeriods: undefined,
+  majorPeriods: [],
   medium: "*",
   offerable: false,
   partnerID: undefined,
@@ -356,7 +356,7 @@ export const selectedOptionsUnion = ({
       displayText: "All",
     },
     { paramName: FilterParamName.color, displayText: "All" },
-    { paramName: FilterParamName.timePeriod, paramValue: "*-*", displayText: "All" },
+    { paramName: FilterParamName.timePeriod, paramValue: [], displayText: "All" },
     {
       paramName: FilterParamName.waysToBuyBuy,
       paramValue: false,

--- a/src/lib/utils/ArtworkFilter/FilterArtworksHelpers.ts
+++ b/src/lib/utils/ArtworkFilter/FilterArtworksHelpers.ts
@@ -1,4 +1,5 @@
 import { FilterScreen } from "lib/Components/FilterModal"
+import { unsafe_getFeatureFlag } from "lib/store/GlobalStore"
 import {
   AggregationName,
   Aggregations,
@@ -199,6 +200,7 @@ export const selectedOption = ({
   filterType?: FilterType
   aggregations: Aggregations
 }) => {
+  const useImprovedArtworkFilters = unsafe_getFeatureFlag("ARUseNewArtworkFilters")
   const multiSelectedOptions = selectedOptions.filter((option) => option.paramValue === true)
 
   if (filterScreen === "additionalGeneIDs") {
@@ -258,6 +260,17 @@ export const selectedOption = ({
       }
       return `${firstSelectedSize}, ${numSelectedSizesToDisplay - 1} more`
     }
+    return "All"
+  }
+
+  if (useImprovedArtworkFilters && filterScreen === "majorPeriods") {
+    let selection = selectedOptions.find((filter) => filter.paramName === FilterParamName.timePeriod)?.paramValue
+
+    if (Array.isArray(selection) && selection.length > 0) {
+      selection = selection.map((s) => getDisplayNameForTimePeriod(s))
+      return selection.join(", ")
+    }
+
     return "All"
   }
 
@@ -384,4 +397,24 @@ export const aggregationForFilter = (filterKey: string, aggregations: Aggregatio
   const aggregationName = aggregationNameFromFilter[filterKey]
   const aggregation = aggregations!.find((value) => value.slice === aggregationName)
   return aggregation
+}
+
+export const getDisplayNameForTimePeriod = (aggregationName: string) => {
+  const DISPLAY_TEXT: Record<string, string> = {
+    "2020": "2020-today",
+    "2010": "2010-2019",
+    "2000": "2000-2009",
+    "1990": "1990-1999",
+    "1980": "1980-1989",
+    "1970": "1970-1979",
+    "1960": "1960-1969",
+    "1950": "1950-1959",
+    "1940": "1940-1949",
+    "1930": "1930-1939",
+    "1920": "1920-1929",
+    "1910": "1910-1919",
+    "1900": "1900-1909",
+  }
+
+  return DISPLAY_TEXT[aggregationName] ?? aggregationName
 }

--- a/src/lib/utils/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
+++ b/src/lib/utils/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
@@ -1184,7 +1184,7 @@ describe("selectedOptionsUnion", () => {
         {
           displayText: "All",
           paramName: "majorPeriods",
-          paramValue: "*-*",
+          paramValue: [],
         },
         {
           displayText: "Buy now",
@@ -1281,7 +1281,7 @@ describe("selectedOptionsUnion", () => {
         {
           displayText: "All",
           paramName: "majorPeriods",
-          paramValue: "*-*",
+          paramValue: [],
         },
         {
           displayText: "Buy now",
@@ -1388,7 +1388,7 @@ describe("selectedOptionsUnion", () => {
         {
           displayText: "All",
           paramName: "majorPeriods",
-          paramValue: "*-*",
+          paramValue: [],
         },
         {
           displayText: "Buy now",
@@ -1506,7 +1506,7 @@ describe("selectedOptionsUnion", () => {
         {
           displayText: "All",
           paramName: "majorPeriods",
-          paramValue: "*-*",
+          paramValue: [],
         },
         {
           displayText: "Buy now",
@@ -1614,7 +1614,7 @@ describe("selectedOptionsUnion", () => {
         {
           displayText: "All",
           paramName: "majorPeriods",
-          paramValue: "*-*",
+          paramValue: [],
         },
         {
           displayText: "Buy now",
@@ -1698,7 +1698,7 @@ describe("selectedOptionsUnion", () => {
         {
           displayText: "All",
           paramName: "majorPeriods",
-          paramValue: "*-*",
+          paramValue: [],
         },
         {
           displayText: "Buy now",
@@ -1795,7 +1795,7 @@ describe("selectedOptionsUnion", () => {
         {
           displayText: "All",
           paramName: "majorPeriods",
-          paramValue: "*-*",
+          paramValue: [],
         },
         {
           displayText: "Buy now",
@@ -1893,7 +1893,7 @@ describe("selectedOptionsUnion", () => {
         {
           displayText: "All",
           paramName: "majorPeriods",
-          paramValue: "*-*",
+          paramValue: [],
         },
         {
           displayText: "Buy now",
@@ -1972,7 +1972,7 @@ describe("selectedOptionsUnion", () => {
         {
           displayText: "All",
           paramName: "majorPeriods",
-          paramValue: "*-*",
+          paramValue: [],
         },
         {
           displayText: "Buy now",


### PR DESCRIPTION
The type of this PR is: Feature

This PR resolves [FX-2624]

This PR is the work of @dzucconi, @dblandin, and @anandaroop 

### Description

- Allows multiple selection of time period (a.k.a. major period) filters on artwork grids.

### Screenshots

<details><summary>Before</summary>

![before_time_options](https://user-images.githubusercontent.com/44589599/110417838-49e8a380-8064-11eb-84d4-79257228fe67.gif)

</details>
<details><summary>After</summary>

![after_time_options](https://user-images.githubusercontent.com/44589599/110417830-435a2c00-8064-11eb-8646-586371563010.gif)

</details>

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2624]: https://artsyproduct.atlassian.net/browse/FX-2624