### PR TITLE
fix: add safety valve in extractNodes

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -15,6 +15,7 @@ upcoming:
     - Update consignment photo selection flow for iOS 14 - brian
     - Allow adding pricePaid info in my collection - barry, brian
     - Adds inquiry make offer button - lily
+    - Add extra safety to extractNodes - david, mounir
 
 releases:
   - version: 6.8.0

--- a/src/lib/utils/__tests__/extractNodes-tests.ts
+++ b/src/lib/utils/__tests__/extractNodes-tests.ts
@@ -16,5 +16,6 @@ describe(extractNodes, () => {
     expect(extractNodes(null)).toEqual([])
     expect(extractNodes({ edges: null })).toEqual([])
     expect(extractNodes({ edges: [] })).toEqual([])
+    expect(extractNodes({ edges: [null] })).toEqual([])
   })
 })

--- a/src/lib/utils/extractNodes.ts
+++ b/src/lib/utils/extractNodes.ts
@@ -2,5 +2,8 @@ export function extractNodes<Node extends object, T = Node>(
   connection: { readonly edges?: ReadonlyArray<{ readonly node?: Node | null } | null> | null } | undefined | null,
   mapper?: (node: Node) => T
 ): T[] {
-  return connection?.edges?.map((edge) => (mapper ? (mapper(edge?.node!) as any) : edge?.node!)) ?? []
+  return (
+    connection?.edges?.map((edge) => (mapper ? (mapper(edge?.node!) as any) : edge?.node!)).filter((x) => x != null) ??
+    []
+  )
 }


### PR DESCRIPTION
We had some bug reports about favourites disappearing, and we saw that metaphysics was returning `null` as node values for a shows connection, which should not be happening. We'll fix that separately, and try to add some tooling in metaphyiscs to prevent it happening again. But in case it does happen again in the future we can add this extra helper in `extractNodes` to filter out null/undefined.

Slack context: https://artsy.slack.com/archives/C01B2P6LJUU/p1615324641014600

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
