### PR TITLE
chore: add a feature flag for the new artwork filters

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -11,6 +11,7 @@ upcoming:
     - Make auction screens mountable on android - barry, brian
     - Support deep links on android - adam, barry, brian, david, mounir, steven
     - Fix sticky tab page layout problems on android - david
+    - Add feature flag for new artwork filters - iskounen
   user_facing:
     - Adds inquiry checkout offer status CTA - lily
     - Update consignment photo selection flow for iOS 14 - brian

--- a/src/lib/store/config/features.ts
+++ b/src/lib/store/config/features.ts
@@ -86,4 +86,9 @@ export const features = defineFeatures({
     description: "Enable custom share sheet",
     showInAdminMenu: true,
   },
+  ARUseNewArtworkFilters: {
+    readyForRelease: false,
+    description: "Use new artwork filters",
+    showInAdminMenu: true,
+  },
 })


### PR DESCRIPTION
The type of this PR is: Feature (flag)

This PR addresses: [FX-2719](https://artsyproduct.atlassian.net/browse/FX-2719)

### Description

The FX team is adding a feature flag for the new filters that we will be adding to artwork grids.

Follow-up work pre-release: [FX-2720](https://artsyproduct.atlassian.net/browse/FX-2720)
Follow-up work post-release: [FX-2721](https://artsyproduct.atlassian.net/browse/FX-2721)

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
