### PR TITLE
fix: fancy modal status bar

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -19,6 +19,7 @@ upcoming:
     - Add extra safety to extractNodes - david, mounir
     - Fix sailthru deeplinks causing crash - brian, barry, steven
     - Fix fancy modal height on android - mounir
+    - Fix fancy modal status bar color - mounir
 
 releases:
   - version: 6.8.0

--- a/src/lib/Components/FancyModal/FancyModal.tsx
+++ b/src/lib/Components/FancyModal/FancyModal.tsx
@@ -70,7 +70,7 @@ export const FancyModal: React.FC<{
   }, [visible])
 
   return (
-    <Modal transparent animated={false} visible={showingUnderlyingModal}>
+    <Modal transparent animated={false} visible={showingUnderlyingModal} statusBarTranslucent>
       <FancyModalContext.Provider value={context.nextLevel()}>{card.jsx}</FancyModalContext.Provider>
     </Modal>
   )


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1205]

### Description
- Fix fancy modal status bar
<img width="388" alt="Screenshot 2021-03-11 at 17 40 36" src="https://user-images.githubusercontent.com/11945712/110824458-5ef74980-8293-11eb-8926-331c7044908c.png">
<img width="392" alt="Screenshot 2021-03-11 at 17 43 21" src="https://user-images.githubusercontent.com/11945712/110824472-63bbfd80-8293-11eb-8b42-7d01509dc346.png">


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1205]: https://artsyproduct.atlassian.net/browse/CX-1205