### PR TITLE
fix: fancy modal border radius animating on non shrinking backgrounds

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -21,6 +21,7 @@ upcoming:
     - Fix sailthru deeplinks causing crash - brian, barry, steven
     - Fix fancy modal height on android - mounir
     - Fix fancy modal status bar color - mounir
+    - Fix fancy modal border radius animating on non shrinking backgrounds - mounir
 
 releases:
   - version: 6.8.0

--- a/src/lib/Components/FancyModal/FancyModalCard.tsx
+++ b/src/lib/Components/FancyModal/FancyModalCard.tsx
@@ -1,4 +1,5 @@
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
+import { compact } from "lodash"
 import React, { RefObject, useImperativeHandle, useRef } from "react"
 import { Animated, TouchableWithoutFeedback, View } from "react-native"
 
@@ -120,16 +121,17 @@ export const FancyModalCard = React.forwardRef<
 
         let totalYoffset = -scaleYOffset - (naturalTop - top)
 
-        if (isRootCard && perceivedDistanceFromTopOfStack === 0) {
+        const isNonFullScreenModal = isRootCard && perceivedDistanceFromTopOfStack === 0
+        if (isNonFullScreenModal) {
           totalYoffset = 0
         }
 
-        return [
+        return compact([
           createAnimation(backdropOpacity, 0.2),
-          createAnimation(borderRadius, BORDER_RADIUS),
+          !isNonFullScreenModal ? createAnimation(borderRadius, BORDER_RADIUS) : null,
           createAnimation(scale, levelScale),
           createAnimation(translateY, totalYoffset),
-        ]
+        ])
       },
     }),
     [props.height]


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1208]

### Description

- Fix fancy modal border radius animating on non shrinking backgrounds
Note: This happens also on iOS

**Before**

https://user-images.githubusercontent.com/11945712/110926364-97933380-8324-11eb-80a4-f5078f702fb4.mov



**After**

https://user-images.githubusercontent.com/11945712/110926269-76cade00-8324-11eb-9339-b12b3c7d1266.mov


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1208]: https://artsyproduct.atlassian.net/browse/CX-1208