### PR TITLE
fix: load all filter options at once

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -24,6 +24,7 @@ upcoming:
     - Fix fancy modal status bar color - mounir
     - Fix fancy modal border radius animating on non shrinking backgrounds - mounir
     - Allow users to scroll to bottom of multi select filters - iskounen
+    - Fix batched loading of artwork category filter options - iskounen
 
 releases:
   - version: 6.8.0

--- a/src/lib/Components/ArtworkFilterOptions/MultiSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/MultiSelectOption.tsx
@@ -50,7 +50,6 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
       <FancyModalHeader onLeftButtonPress={handleBackNavigation}>{filterHeaderText}</FancyModalHeader>
       <Flex flexGrow={1}>
         <FlatList<FilterData>
-          initialNumToRender={4}
           style={{ flex: 1 }}
           keyExtractor={(_item, index) => String(index)}
           data={filterOptions}

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/AdditionalGeneIDsOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/AdditionalGeneIDsOptions-tests.tsx
@@ -61,9 +61,19 @@ describe("AdditionalGeneIDsOptions Screen", () => {
 
   it("renders the options", () => {
     const tree = renderWithWrappers(<MockAdditionalGeneIDsOptionsScreen initialState={state} />)
-    expect(tree.root.findAllByType(OptionListItem)).toHaveLength(4) // initialNumToRender={4}
+    expect(tree.root.findAllByType(OptionListItem)).toHaveLength(9)
     const items = tree.root.findAllByType(OptionListItem)
-    expect(items.map(extractText)).toEqual(["All", "Prints", "Design", "Sculpture"])
+    expect(items.map(extractText)).toEqual([
+      "All",
+      "Prints",
+      "Design",
+      "Sculpture",
+      "Work on Paper",
+      "Painting",
+      "Drawing",
+      "Jewelry",
+      "Photography",
+    ])
   })
 
   it("displays the default text when no filter selected on the filter modal screen", () => {

--- a/src/lib/Components/ArtworkFilterOptions/__tests__/ArtistIDsArtworksOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/__tests__/ArtistIDsArtworksOptions-tests.tsx
@@ -105,9 +105,8 @@ describe("Artist options screen", () => {
     const tree = renderWithWrappers(
       <MockArtistScreen initialState={state} aggregations={mockAggregations} navigator={mockNavigator} />
     )
-    // Includes a button for each artist + one for followed artists,
-    // but our FlatList is configured to only show 4 in the initial render pass
-    expect(tree.root.findAllByType(FilterToggleButton)).toHaveLength(4)
+    // Includes a button for each artist + one for followed artists
+    expect(tree.root.findAllByType(FilterToggleButton)).toHaveLength(6)
   })
 
   describe("selecting an artist option", () => {


### PR DESCRIPTION
The type of this PR is: Bugfix

### Description

When a user opens the category filters on an artwork grid, they see 4 filter options load before the rest. This PR removes the `initialNumToRender` prop that controls this behavior on a `MultiSelectOption` component because it looks glitchy.


![multi-select-option-screen_lag](https://user-images.githubusercontent.com/44589599/110999505-75aea680-834e-11eb-9419-2a675a252e1f.gif)


### PR Checklist
<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
