### PR TITLE
fix: allow users to scroll to bottom of multis-elect filters

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -23,6 +23,7 @@ upcoming:
     - Fix fancy modal height on android - mounir
     - Fix fancy modal status bar color - mounir
     - Fix fancy modal border radius animating on non shrinking backgrounds - mounir
+    - Allow users to scroll to bottom of multi select filters - iskounen
 
 releases:
   - version: 6.8.0

--- a/src/lib/Components/ArtworkFilterOptions/MultiSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilterOptions/MultiSelectOption.tsx
@@ -51,6 +51,7 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
       <Flex flexGrow={1}>
         <FlatList<FilterData>
           initialNumToRender={4}
+          style={{ flex: 1 }}
           keyExtractor={(_item, index) => String(index)}
           data={filterOptions}
           ItemSeparatorComponent={Separator}


### PR DESCRIPTION
The type of this PR is: Bugfix

### Description

When a user scrolls to the bottom of a long multi-select filter (like the categories filter on an artwork grid) they are not able to keep the bottom 2 options in view long enough to select them before the snap to hide behind the "Apply" button.


![multi-select-opion-screen_scroll](https://user-images.githubusercontent.com/44589599/111000798-b6a7ba80-8350-11eb-9b5f-6c0da4be2e1b.gif)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
