### PR TITLE
fix(signout): await clearUserData

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -159,8 +159,8 @@ SOFTWARE.
         }];
     };
 
-    emission.APIModule.userDataClearer = ^() {
-        [ARUserManager logout];
+    emission.APIModule.userDataClearer = ^(RCTPromiseResolveBlock completion) {
+        [ARUserManager logoutWithCompletion:completion];
     };
 
 

--- a/Artsy/Networking/API_Modules/ARUserManager.h
+++ b/Artsy/Networking/API_Modules/ARUserManager.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <React/RCTBridgeModule.h>
 
 extern NSString *const ARUserSessionStartedNotification;
 
@@ -8,7 +9,7 @@ extern NSString *const ARUserSessionStartedNotification;
 
 + (ARUserManager *)sharedManager;
 
-+ (void)logout;
++ (void)logoutWithCompletion:(RCTPromiseResolveBlock)completion;
 + (void)clearUserData;
 
 + (BOOL)didCreateAccountThisSession;

--- a/Artsy/Networking/API_Modules/ARUserManager.m
+++ b/Artsy/Networking/API_Modules/ARUserManager.m
@@ -511,10 +511,11 @@ static BOOL ARUserManagerDisableSharedWebCredentials = NO;
     }
 }
 
-+ (void)logout
++ (void)logoutWithCompletion:(RCTResponseSenderBlock)completion
 {
     [ArtsyAPI deleteAPNTokenForCurrentDeviceWithCompletion:^ {
         [[self class] clearUserData];
+        completion(nil);
     }];
 }
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -16,6 +16,7 @@ upcoming:
     - Enable feature flags on android - mounir
     - Enable new onboarding feature flag - mounir
   user_facing:
+    - Fix sign out bug - david, mounir
     - Adds inquiry checkout offer status CTA - lily
     - Update consignment photo selection flow for iOS 14 - brian
     - Allow adding pricePaid info in my collection - barry, brian

--- a/emission/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.h
+++ b/emission/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.h
@@ -5,7 +5,7 @@ typedef void(^ARNotificationReadStatusAssigner)(RCTResponseSenderBlock block);
 
 typedef void(^ARNotificationPermissionsPrompter)();
 
-typedef void(^ARUserDataClearer)();
+typedef void(^ARUserDataClearer)(RCTPromiseResolveBlock completion);
 
 typedef void(^ARAugmentedRealityVIRPresenter)(NSString *imgUrl, CGFloat widthIn, CGFloat heightIn, NSString *artworkSlug, NSString *artworkId);
 

--- a/emission/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.m
+++ b/emission/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.m
@@ -44,9 +44,9 @@ RCT_EXPORT_METHOD(setApplicationIconBadgeNumber:(nonnull NSNumber *)count)
     });
 }
 
-RCT_EXPORT_METHOD(clearUserData)
+RCT_EXPORT_METHOD(clearUserData:(RCTPromiseResolveBlock)completion reject:(RCTPromiseRejectBlock) _reject)
 {
-    self.userDataClearer();
+    self.userDataClearer(completion);
 }
 
 - (NSDictionary *)constantsToExport

--- a/src/lib/NativeModules/LegacyNativeModules.tsx
+++ b/src/lib/NativeModules/LegacyNativeModules.tsx
@@ -26,7 +26,7 @@ interface LegacyNativeModules {
     fetchNotificationPermissions(callback: (error: any, result: PushAuthorizationStatus) => void): void
     markNotificationsRead(callback: (error?: Error) => any): void
     setApplicationIconBadgeNumber(n: number): void
-    clearUserData(): void
+    clearUserData(): Promise<void>
   }
   ARNotificationsManager: {
     nativeState: NativeState
@@ -119,7 +119,7 @@ export const LegacyNativeModules: LegacyNativeModules =
           },
           appVersion: "appVersion",
           buildVersion: "buildVersion",
-          clearUserData: () => null,
+          clearUserData: () => Promise.resolve(),
         },
         ARPHPhotoPickerModule: {
           requestPhotos: noop("requestPhotos"),

--- a/src/lib/relay/middlewares/checkAuthenticationMiddleware.ts
+++ b/src/lib/relay/middlewares/checkAuthenticationMiddleware.ts
@@ -26,7 +26,7 @@ export const checkAuthenticationMiddleware = (): Middleware => {
         }
         if (result.status === 401) {
           expiredTokens.add(authenticationToken)
-          GlobalStore.actions.signOut()
+          await GlobalStore.actions.signOut()
           // There is a race condition that prevents the onboarding slideshow from starting if we call an Alert
           // here synchronously, so we need to wait a few ticks.
           setTimeout(() => {

--- a/src/lib/store/GlobalStoreModel.ts
+++ b/src/lib/store/GlobalStoreModel.ts
@@ -55,7 +55,7 @@ export const GlobalStoreModel: GlobalStoreModel = {
     const existingConfig = store.getState().config
     const config = sanitize(existingConfig) as typeof existingConfig
     if (Platform.OS === "ios") {
-      LegacyNativeModules.ARTemporaryAPIModule.clearUserData()
+      await LegacyNativeModules.ARTemporaryAPIModule.clearUserData()
     }
     clearAll()
     actions.reset({ config })


### PR DESCRIPTION
Co-authored-by: Mounir Dhahri <mounir.dhahri@ensi-uma.tn>

This PR resolves [CX-1222]

### Description

This fixes a race condition where, upon sign out, the onboarding flow was being shown before the user data was being cleared.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-1222]: https://artsyproduct.atlassian.net/browse/CX-1222