### PR TITLE
fix: set system navigation bar color to white on modals for android

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,7 +4,7 @@ upcoming:
   dev:
     -
   user_facing:
-    -
+    - Set system navigation bar color to white on modals for android - mounir
 
 releases:
   - version: 6.8.1

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -9,4 +9,12 @@
         <item name="android:windowLightNavigationBar">true</item>
     </style>
 
+    <style name="Theme.FullScreenDialog" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:navigationBarColor">#FFFFFF</item>
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1201]

### Description
- Set system navigation bar color to white on modals for android

![Group 1 (4)](https://user-images.githubusercontent.com/11945712/111316748-d0544500-8663-11eb-8820-f557fc66126f.png)

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1201]: https://artsyproduct.atlassian.net/browse/CX-1201