### PR TITLE
enhancement(DX): add easy "Quick Access" info

### DIFF
--- a/src/lib/Components/Lists/AuctionResultListItem.tsx
+++ b/src/lib/Components/Lists/AuctionResultListItem.tsx
@@ -1,6 +1,7 @@
 import { AuctionResultListItem_auctionResult } from "__generated__/AuctionResultListItem_auctionResult.graphql"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { auctionResultHasPrice, auctionResultText } from "lib/Scenes/AuctionResult/helpers"
+import { QAInfoFlex, QAInfoRow } from "lib/utils/QAInfo"
 import { capitalize } from "lodash"
 import moment from "moment"
 import { bullet, color, Flex, NoArtworkIcon, Text, Touchable } from "palette"
@@ -14,6 +15,12 @@ interface Props {
 }
 
 const AuctionResultListItem: React.FC<Props> = ({ auctionResult, onPress }) => {
+  const QAInfo: React.FC = () => (
+    <QAInfoFlex position="absolute" top={0} left={95}>
+      <QAInfoRow i={{ id: auctionResult.internalID }} />
+    </QAInfoFlex>
+  )
+
   return (
     <Touchable underlayColor={color("black5")} onPress={onPress}>
       <Flex py="2" px={2} flexDirection="row">
@@ -87,6 +94,7 @@ const AuctionResultListItem: React.FC<Props> = ({ auctionResult, onPress }) => {
           </Flex>
         </Flex>
       </Flex>
+      <QAInfo />
     </Touchable>
   )
 }

--- a/src/lib/Components/Lists/AuctionResultListItem.tsx
+++ b/src/lib/Components/Lists/AuctionResultListItem.tsx
@@ -1,7 +1,7 @@
 import { AuctionResultListItem_auctionResult } from "__generated__/AuctionResultListItem_auctionResult.graphql"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { auctionResultHasPrice, auctionResultText } from "lib/Scenes/AuctionResult/helpers"
-import { QAInfoPanel, QAInfoRow } from "lib/utils/QAInfo"
+import { QAInfoManualPanel, QAInfoRow } from "lib/utils/QAInfo"
 import { capitalize } from "lodash"
 import moment from "moment"
 import { bullet, color, Flex, NoArtworkIcon, Text, Touchable } from "palette"
@@ -16,9 +16,9 @@ interface Props {
 
 const AuctionResultListItem: React.FC<Props> = ({ auctionResult, onPress }) => {
   const QAInfo: React.FC = () => (
-    <QAInfoPanel position="absolute" top={0} left={95}>
+    <QAInfoManualPanel position="absolute" top={0} left={95}>
       <QAInfoRow i={{ id: auctionResult.internalID }} />
-    </QAInfoPanel>
+    </QAInfoManualPanel>
   )
 
   return (

--- a/src/lib/Components/Lists/AuctionResultListItem.tsx
+++ b/src/lib/Components/Lists/AuctionResultListItem.tsx
@@ -1,7 +1,7 @@
 import { AuctionResultListItem_auctionResult } from "__generated__/AuctionResultListItem_auctionResult.graphql"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { auctionResultHasPrice, auctionResultText } from "lib/Scenes/AuctionResult/helpers"
-import { QAInfoFlex, QAInfoRow } from "lib/utils/QAInfo"
+import { QAInfoPanel, QAInfoRow } from "lib/utils/QAInfo"
 import { capitalize } from "lodash"
 import moment from "moment"
 import { bullet, color, Flex, NoArtworkIcon, Text, Touchable } from "palette"
@@ -16,9 +16,9 @@ interface Props {
 
 const AuctionResultListItem: React.FC<Props> = ({ auctionResult, onPress }) => {
   const QAInfo: React.FC = () => (
-    <QAInfoFlex position="absolute" top={0} left={95}>
+    <QAInfoPanel position="absolute" top={0} left={95}>
       <QAInfoRow i={{ id: auctionResult.internalID }} />
-    </QAInfoFlex>
+    </QAInfoPanel>
   )
 
   return (

--- a/src/lib/Scenes/AuctionResult/AuctionResult.tsx
+++ b/src/lib/Scenes/AuctionResult/AuctionResult.tsx
@@ -6,6 +6,7 @@ import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
 import { navigate } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { PlaceholderBox } from "lib/utils/placeholders"
+import { QAInfoPanel, QAInfoRow } from "lib/utils/QAInfo"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { ProvideScreenTrackingWithCohesionSchema } from "lib/utils/track"
 import { useStickyScrollHeader } from "lib/utils/useStickyScrollHeader"
@@ -141,6 +142,13 @@ const AuctionResult: React.FC<Props> = ({ artist, auctionResult }) => {
     </>
   )
 
+  const QAInfo = () => (
+    <QAInfoPanel position="absolute" top={10} left={80}>
+      <QAInfoRow i={{ id: auctionResult.internalID }} />
+      <QAInfoRow i={{ title: auctionResult.title }} />
+    </QAInfoPanel>
+  )
+
   return (
     <ProvideScreenTrackingWithCohesionSchema info={tracks.screen(auctionResult.internalID) as any}>
       <Animated.ScrollView {...scrollProps}>
@@ -214,6 +222,7 @@ const AuctionResult: React.FC<Props> = ({ artist, auctionResult }) => {
           </Text>
           {details}
         </Box>
+        <QAInfo />
       </Animated.ScrollView>
       {headerElement}
     </ProvideScreenTrackingWithCohesionSchema>

--- a/src/lib/Scenes/AuctionResult/AuctionResult.tsx
+++ b/src/lib/Scenes/AuctionResult/AuctionResult.tsx
@@ -144,10 +144,10 @@ const AuctionResult: React.FC<Props> = ({ artist, auctionResult }) => {
 
   const QAInfo = () => (
     <QAInfoPanel
-      style={{ position: "absolute", top: 10, left: 80 }}
+      style={{ position: "absolute", top: 200, right: 40 }}
       info={[
         ["id", auctionResult.internalID],
-        ["boughtIn", `${auctionResult.boughtIn}`],
+        ["bought in", `${auctionResult.boughtIn}`],
         ["cents", `${auctionResult.priceRealized?.centsUSD}`],
       ]}
     />

--- a/src/lib/Scenes/AuctionResult/AuctionResult.tsx
+++ b/src/lib/Scenes/AuctionResult/AuctionResult.tsx
@@ -6,7 +6,7 @@ import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
 import { navigate } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { PlaceholderBox } from "lib/utils/placeholders"
-import { QAInfoPanel, QAInfoRow } from "lib/utils/QAInfo"
+import { QAInfoPanel } from "lib/utils/QAInfo"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { ProvideScreenTrackingWithCohesionSchema } from "lib/utils/track"
 import { useStickyScrollHeader } from "lib/utils/useStickyScrollHeader"
@@ -143,10 +143,14 @@ const AuctionResult: React.FC<Props> = ({ artist, auctionResult }) => {
   )
 
   const QAInfo = () => (
-    <QAInfoPanel position="absolute" top={10} left={80}>
-      <QAInfoRow i={{ id: auctionResult.internalID }} />
-      <QAInfoRow i={{ title: auctionResult.title }} />
-    </QAInfoPanel>
+    <QAInfoPanel
+      style={{ position: "absolute", top: 10, left: 80 }}
+      info={[
+        ["id", auctionResult.internalID],
+        ["boughtIn", `${auctionResult.boughtIn}`],
+        ["cents", `${auctionResult.priceRealized?.centsUSD}`],
+      ]}
+    />
   )
 
   return (

--- a/src/lib/store/config/features.ts
+++ b/src/lib/store/config/features.ts
@@ -96,4 +96,9 @@ export const features = defineFeatures({
     description: "Use new onboarding",
     showInAdminMenu: true,
   },
+  ARShowQuickAccessInfo: {
+    readyForRelease: false, // never. it's just for devs.
+    description: "Show quick access info",
+    showInAdminMenu: true,
+  },
 })

--- a/src/lib/utils/QAInfo.tsx
+++ b/src/lib/utils/QAInfo.tsx
@@ -45,7 +45,7 @@ export const QAInfoRow: React.FC<{ i: { [key: string]: string } }> = ({ i }) => 
           toast.show("Copied", "middle")
         }}
       >
-        <Text>{value}</Text>
+        <Text fontWeight="bold">{value}</Text>
       </Touchable>
     </Flex>
   )

--- a/src/lib/utils/QAInfo.tsx
+++ b/src/lib/utils/QAInfo.tsx
@@ -1,0 +1,37 @@
+import Clipboard from "@react-native-community/clipboard"
+import { useToast } from "lib/Components/Toast/toastHook"
+import { useFeatureFlag } from "lib/store/GlobalStore"
+import { color, Flex, FlexProps, Text, Touchable } from "palette"
+import React from "react"
+
+export const QAInfoFlex: React.FC<FlexProps> = (props) => {
+  const enabled = useFeatureFlag("ARShowQuickAccessInfo")
+  if (!enabled) {
+    return null
+  }
+
+  return <Flex borderColor="purple100" borderWidth={1} {...props} />
+}
+
+export const QAInfoRow: React.FC<{ i: { [key: string]: string } }> = ({ i }) => {
+  const toast = useToast()
+
+  const key = Object.keys(i)[0]
+  const value = i[key]
+
+  return (
+    <Flex flexDirection="row">
+      <Text>{key}: </Text>
+      <Touchable
+        underlayColor={color("black5")}
+        haptic
+        onPress={() => {
+          Clipboard.setString(value)
+          toast.show("Copied", "middle")
+        }}
+      >
+        <Text>{value}</Text>
+      </Touchable>
+    </Flex>
+  )
+}

--- a/src/lib/utils/QAInfo.tsx
+++ b/src/lib/utils/QAInfo.tsx
@@ -4,7 +4,7 @@ import { useFeatureFlag } from "lib/store/GlobalStore"
 import { color, Flex, FlexProps, Text, Touchable } from "palette"
 import React from "react"
 
-export const QAInfoFlex: React.FC<FlexProps> = (props) => {
+export const QAInfoPanel: React.FC<FlexProps> = (props) => {
   const enabled = useFeatureFlag("ARShowQuickAccessInfo")
   if (!enabled) {
     return null

--- a/src/lib/utils/QAInfo.tsx
+++ b/src/lib/utils/QAInfo.tsx
@@ -4,7 +4,22 @@ import { useFeatureFlag } from "lib/store/GlobalStore"
 import { color, Flex, FlexProps, Text, Touchable } from "palette"
 import React from "react"
 
-export const QAInfoPanel: React.FC<FlexProps> = (props) => {
+export const QAInfoPanel: React.FC<Omit<FlexProps, "children"> & { info: Array<[string, string]> }> = (props) => {
+  const enabled = useFeatureFlag("ARShowQuickAccessInfo")
+  if (!enabled) {
+    return null
+  }
+
+  return (
+    <QAInfoManualPanel {...props}>
+      {props.info.map(([key, value]) => (
+        <QAInfoRow i={{ [key]: value }} />
+      ))}
+    </QAInfoManualPanel>
+  )
+}
+
+export const QAInfoManualPanel: React.FC<FlexProps> = (props) => {
   const enabled = useFeatureFlag("ARShowQuickAccessInfo")
   if (!enabled) {
     return null


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

<!-- Implementation description -->

Often I need to find some `internalID` or some specific identifier or info for a screen. Usually it's either for:
- getting the info so I can query MP in the separate playground application, or
- simply for debugging.

I added a simple way to add panels for "Quick Access" info.

My idea is that eventually we could have this work similarly to the analytics debug banner, where each screen/list item can show the basic info we might need, in order to debug or query in MP or web etc.

This is how it looks, for my use today:
- Auction results list items, they all have their id.
<img width="398" alt="Screenshot 2021-03-16 at 20 58 35" src="https://user-images.githubusercontent.com/100233/111379463-137dda80-869b-11eb-8daf-d6def43a8593.png">
- Auction results screens, they all have their id and bought in and cents. (I only wanted id, but I added the other two as examples.)
<img width="387" alt="Screenshot 2021-03-16 at 20 58 43" src="https://user-images.githubusercontent.com/100233/111379575-35775d00-869b-11eb-9db0-8c0b3bf39458.png">


To see them, just enable the flag "Show Quick Access Info"! When you tap on a value, it will be copied to the clipboard! That's how I use it, I find the item I need, tap, and I have the id. Then I go to the graphql playground and paste the id and boom. (The simulator uses the same clipboard as macos, so that's easy, and I have this enabled for my phone and mac as well, so everything is supereasy to copy and paste from/to anywhere.)

To use them:
- Make a component called `QAInfo`
- Use `QAInfoPanel`
- List the things you want to show
- Tell the panel where to be
- Render it

For example, in the auctions result screen, I have `<QAInfoPanel position="absolute" top={0} left={95}>` to that it shows up at the top, below the title. It doesn't have to be super accurate, since this is just for us devs. Usually `position="absolute"` is all you need, plus some basic `top`/`bottom` and `left`/`right`.
Then `info` is a list of `[name, value]: [string, string]` tuples.

If we need a bit more control, we can use the `QAInfoManualPanel` which is just a Flex + the flag check, and then we can render whatever we want in there, or use the `QAInfoRow` to reuse the text rendering + clipboard functionality, like `<QAInfoRow i={{theKey: "theValue"}} />`.



### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
