### PR TITLE
fix: don't clear launch count on logout

### DIFF
--- a/Artsy/Constants/ARDefaults.m
+++ b/Artsy/Constants/ARDefaults.m
@@ -1,6 +1,7 @@
 #import "ARDefaults+SiteFeatures.h"
 #import "ARDefaults.h"
 #import "AROptions.h"
+#import "ARAnalyticsConstants.h"
 
 NSString *const ARUserIdentifierDefault = @"ARUserIdentifier";
 
@@ -45,8 +46,10 @@ NSString *const ARAugmentedRealityHasSuccessfullyRan = @"ARAugmentedRealityHasSu
 
 + (void)resetDefaults
 {
+    // Need to save launch count for analytics
+    NSInteger launchCount = [[NSUserDefaults standardUserDefaults] integerForKey:ARAnalyticsAppUsageCountProperty];
     [[NSUserDefaults standardUserDefaults] removePersistentDomainForName:[[NSBundle mainBundle] bundleIdentifier]];
+    [[NSUserDefaults standardUserDefaults] setInteger:launchCount forKey:ARAnalyticsAppUsageCountProperty];
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
-
 @end

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -2,7 +2,7 @@ upcoming:
   version: 6.8.2
   date: TBD
   dev:
-    -
+    - Fix first install event analytics - brian, mike
   user_facing:
     - Set system navigation bar color to white on modals for android - mounir
     - Fix change password screen title  - mounir


### PR DESCRIPTION
The type of this PR is: **fix**

This PR resolves [CX-1223]

### Description

We are overly aggressively clearing out all user defaults on logout, including launchCount. This is causing the first install analytics event to be fired more than once per device install. This PR saves the value and rewrites it to defaults on logout. This has been broken for a while we were just made aware of it recently due to the staging issue causing many logouts.

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-1223]: https://artsyproduct.atlassian.net/browse/CX-1223