### PR TITLE
feature: add react web view module

### DIFF
--- a/Artsy/App/ARScreenPresenterModule.m
+++ b/Artsy/App/ARScreenPresenterModule.m
@@ -84,6 +84,10 @@ RCT_EXPORT_METHOD(presentModal:(nonnull NSDictionary *)viewDescriptor           
     UIModalPresentationStyle modalPresentationStyle = [self getModalPresentationStyle:viewDescriptor[@"modalPresentationStyle"]];
     UIViewController *vc = [self getViewControllerForViewDescriptor:viewDescriptor];
 
+    if ([vc isKindOfClass:ARComponentViewController.class]) {
+        [((ARComponentViewController *)vc) setProperty:@(YES) forKey:@"isPresentedModally"];
+    }
+
     BOOL hasOwnModalCloseButton = viewDescriptor[@"hasOwnModalCloseButton"];
 
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -6,6 +6,7 @@ upcoming:
     - Fix iOS modal presentation infra code - david
     - Fix first install event analytics - brian, mike
 
+    - Fix iOS modal presentation infra code - david
   user_facing:
     - Set system navigation bar color to white on modals for android - mounir
     - Fix change password screen title  - mounir

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -5,7 +5,7 @@ upcoming:
     - Add QAInfo UI and flag - pavlos
     - Fix iOS modal presentation infra code - david
     - Fix first install event analytics - brian, mike
-
+    - Set up basic react webview module - david
     - Fix iOS modal presentation infra code - david
   user_facing:
     - Set system navigation bar color to white on modals for android - mounir

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "react-native-share": "5.1.0",
     "react-native-svg": "9.13.3",
     "react-native-view-shot": "^3.1.2",
-    "react-native-webview": "^10.8.3",
+    "react-native-webview": "^11.3.1",
     "react-relay": "^10.0.1",
     "react-spring": "8.0.23",
     "react-tracking": "7.2.1",

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -69,6 +69,7 @@ import { Search } from "./Scenes/Search"
 import { ShowMoreInfoQueryRenderer, ShowQueryRenderer } from "./Scenes/Show"
 import { VanityURLEntityRenderer } from "./Scenes/VanityURL/VanityURLEntity"
 
+import { ArtsyReactWebView } from "./Components/ArtsyReactWebView"
 import { ToastProvider } from "./Components/Toast/toastHook"
 import { RegistrationFlow } from "./Containers/RegistrationFlow"
 import { useSentryConfig } from "./ErrorReporting"
@@ -339,6 +340,11 @@ export const modules = defineModules({
   }),
   LocalDiscovery: nativeModule(),
   WebView: nativeModule(),
+  ReactWebView: reactModule(ArtsyReactWebView, {
+    fullBleed: true,
+    hasOwnModalCloseButton: true,
+    hidesBackButton: true,
+  }),
   MakeOfferModal: reactModule(MakeOfferModalQueryRenderer, {
     hasOwnModalCloseButton: true,
   }),

--- a/src/lib/Components/ArtsyReactWebView.tsx
+++ b/src/lib/Components/ArtsyReactWebView.tsx
@@ -1,0 +1,74 @@
+import { color } from "@artsy/palette-tokens"
+import { goBack } from "lib/navigation/navigate"
+import { getCurrentEmissionState, useEnvironment } from "lib/store/GlobalStore"
+import { useScreenDimensions } from "lib/utils/useScreenDimensions"
+import React, { useRef, useState } from "react"
+import { View } from "react-native"
+import WebView from "react-native-webview"
+import { FancyModalHeader } from "./FancyModal/FancyModalHeader"
+
+export interface ArtsyWebViewConfig {
+  title?: string
+}
+
+export const ArtsyReactWebView: React.FC<
+  {
+    url: string
+    isPresentedModally?: boolean
+  } & ArtsyWebViewConfig
+> = ({ url, title, isPresentedModally }) => {
+  const paddingTop = useScreenDimensions().safeAreaInsets.top
+  const userAgent = getCurrentEmissionState().userAgent
+
+  const ref = useRef<WebView>(null)
+  const [loadProgress, setLoadProgress] = useState<number | null>(null)
+  const webURL = useEnvironment().webURL
+  const uri = url.startsWith("/") ? webURL + url : url
+
+  return (
+    <View style={{ flex: 1, paddingTop }}>
+      <FancyModalHeader useXButton={isPresentedModally} onLeftButtonPress={goBack}>
+        {title}
+      </FancyModalHeader>
+      <View style={{ flex: 1 }}>
+        <WebView
+          ref={ref}
+          source={{ uri }}
+          style={{ flex: 1 }}
+          userAgent={userAgent}
+          onLoadStart={() => setLoadProgress((p) => Math.max(0.02, p ?? 0))}
+          onLoadEnd={() => setLoadProgress(null)}
+          onLoadProgress={(e) => setLoadProgress(e.nativeEvent.progress)}
+        />
+        <ProgressBar loadProgress={loadProgress} />
+      </View>
+    </View>
+  )
+}
+
+const ProgressBar: React.FC<{ loadProgress: number | null }> = ({ loadProgress }) => {
+  if (loadProgress === null) {
+    return null
+  }
+  const progressPercent = Math.max(loadProgress * 100, 2)
+  return (
+    <View
+      testID="progress-bar"
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: progressPercent + "%",
+        height: 2,
+        backgroundColor: color("purple100"),
+      }}
+    />
+  )
+}
+
+// tslint:disable-next-line:variable-name
+export const __webViewTestUtils__ = __TEST__
+  ? {
+      ProgressBar,
+    }
+  : null

--- a/src/lib/Components/ArtsyWebView.tsx
+++ b/src/lib/Components/ArtsyWebView.tsx
@@ -1,16 +1,13 @@
 import { useFeatureFlag } from "lib/store/GlobalStore"
-import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import React from "react"
-import WebView from "react-native-webview"
+import { ArtsyReactWebView } from "./ArtsyReactWebView"
 import InternalWebView from "./InternalWebView"
 
 export const ArtsyWebView: React.FC<{ url: string; showFullScreen?: boolean }> = ({ url, showFullScreen }) => {
   const useReactNativeWebView = useFeatureFlag("AROptionsUseReactNativeWebView")
 
-  const paddingTop = useScreenDimensions().safeAreaInsets.top
-
   if (useReactNativeWebView) {
-    return <WebView source={{ uri: url }} style={{ marginTop: paddingTop, flex: 1 }} />
+    return <ArtsyReactWebView url={url} />
   } else {
     return <InternalWebView route={url} showFullScreen={showFullScreen ?? true} />
   }

--- a/src/lib/Components/__tests__/ArtsyReactWebView-tests.tsx
+++ b/src/lib/Components/__tests__/ArtsyReactWebView-tests.tsx
@@ -1,0 +1,56 @@
+import { goBack } from "lib/navigation/navigate"
+import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import React from "react"
+import WebView from "react-native-webview"
+import { act } from "react-test-renderer"
+import { __webViewTestUtils__, ArtsyReactWebView } from "../ArtsyReactWebView"
+import { FancyModalHeader } from "../FancyModal/FancyModalHeader"
+
+describe(ArtsyReactWebView, () => {
+  it(`renders a WebView`, () => {
+    const tree = renderWithWrappers(<ArtsyReactWebView url="https://staging.artsy.net/hello" />)
+    expect(tree.root.findByType(WebView).props.source.uri).toEqual("https://staging.artsy.net/hello")
+  })
+  it(`renders a back button normally`, () => {
+    const tree = renderWithWrappers(<ArtsyReactWebView url="https://staging.artsy.net/hello" />)
+    expect(tree.root.findByType(FancyModalHeader).props.useXButton).toBeFalsy()
+    expect(tree.root.findByType(FancyModalHeader).props.onLeftButtonPress).toBeTruthy()
+  })
+  it(`renders a close button when presented modally`, () => {
+    const tree = renderWithWrappers(<ArtsyReactWebView isPresentedModally url="https://staging.artsy.net/hello" />)
+    expect(tree.root.findByType(FancyModalHeader).props.useXButton).toBeTruthy()
+    expect(tree.root.findByType(FancyModalHeader).props.onLeftButtonPress).toBeTruthy()
+  })
+  it("calls goBack when the close/back button is pressed", () => {
+    const tree = renderWithWrappers(<ArtsyReactWebView url="https://staging.artsy.net/hello" />)
+    expect(goBack).not.toHaveBeenCalled()
+    tree.root.findByType(FancyModalHeader).props.onLeftButtonPress()
+    expect(goBack).toHaveBeenCalled()
+  })
+  it("has a progress bar that follows page load events", () => {
+    const tree = renderWithWrappers(<ArtsyReactWebView url="https://staging.artsy.net/hello" />)
+    const getProgressBar = () => tree.root.findByType(__webViewTestUtils__?.ProgressBar!)
+    expect(getProgressBar().children).toHaveLength(0)
+    act(() => {
+      tree.root.findByType(WebView).props.onLoadStart()
+    })
+    expect(getProgressBar().children).toHaveLength(1)
+    act(() => {
+      tree.root.findByType(WebView).props.onLoadProgress({ nativeEvent: { progress: 0.5 } })
+    })
+    expect(getProgressBar().findByProps({ testID: "progress-bar" }).props.style.width).toBe("50%")
+    act(() => {
+      tree.root.findByType(WebView).props.onLoadEnd()
+    })
+    expect(getProgressBar().children).toHaveLength(0)
+  })
+  it("sets the user agent correctly", () => {
+    const tree = renderWithWrappers(<ArtsyReactWebView url="https://staging.artsy.net/hello" />)
+    expect(tree.root.findByType(WebView).props.userAgent).toBe("Jest Unit Tests")
+  })
+  it("sets the user agent correctly", () => {
+    const tree = renderWithWrappers(<ArtsyReactWebView url="https://staging.artsy.net/hello" />)
+    expect(tree.root.findByType(WebView).props.userAgent).toBe("Jest Unit Tests")
+  })
+})

--- a/src/lib/Scenes/VanityURL/VanityURLPossibleRedirect.tsx
+++ b/src/lib/Scenes/VanityURL/VanityURLPossibleRedirect.tsx
@@ -38,7 +38,7 @@ export const VanityURLPossibleRedirect: React.FC<{ slug: string }> = ({ slug }) 
           // not sure if we have any URLs in force that would trigger this, but better safe than sorry!
           goBack()
           navigate(response.url)
-        } else if (screen.module === "WebView") {
+        } else if (screen.module === "WebView" || screen.module === "ReactWebView") {
           // Test this with `artsy:///artsy-vanguard-2019` which force should redirect to /series/artsy-vanguard-2019
           setJSX(<ArtsyWebView url={response.url} />)
         } else if (screen.module === "VanityURLEntity" && slug === (screen.params as any).slug) {

--- a/src/lib/navigation/ModalStack.tsx
+++ b/src/lib/navigation/ModalStack.tsx
@@ -42,7 +42,7 @@ const ModalNavStack: React.FC<{ route: Route<"", { rootModuleName: AppModule; ro
       id={route.key}
       ref={ref}
       rootModuleName={route.params.rootModuleName}
-      rootModuleProps={route.params.rootModuleProps}
+      rootModuleProps={{ ...route.params.rootModuleProps, isPresentedModally: true }}
     />
   )
 }

--- a/src/lib/navigation/routes.tsx
+++ b/src/lib/navigation/routes.tsx
@@ -1,5 +1,6 @@
 import { AppModule } from "lib/AppRegistry"
-import { unsafe_getFeatureFlag } from "lib/store/GlobalStore"
+import { ArtsyWebViewConfig } from "lib/Components/ArtsyReactWebView"
+import { unsafe__getEnvironment, unsafe_getFeatureFlag } from "lib/store/GlobalStore"
 import { compact } from "lodash"
 import { parse as parseQueryString } from "query-string"
 import { parse } from "url"
@@ -12,8 +13,8 @@ export function matchRoute(
   const pathParts = parsed.pathname?.split(/\/+/).filter(Boolean) ?? []
   const queryParams: object = parsed.query ? parseQueryString(parsed.query) : {}
 
-  const domain = parsed.host || "artsy.net"
-  const routes = getDomainMap()[domain]
+  const domain = (parsed.host || parse(unsafe__getEnvironment().webURL).host) ?? "artsy.net"
+  const routes = getDomainMap()[domain as any]
 
   if (!routes) {
     // Unrecognized domain, let's send the user to Safari or whatever
@@ -38,9 +39,35 @@ export function matchRoute(
   console.error("Unhandled route", url)
   return {
     type: "match",
-    module: "WebView",
+    module: unsafe_getFeatureFlag("AROptionsUseReactNativeWebView") ? "ReactWebView" : "WebView",
     params: { url },
   }
+}
+
+export function webViewRoute(url: string, config?: ArtsyWebViewConfig) {
+  return new RouteMatcher(
+    url,
+    unsafe_getFeatureFlag("AROptionsUseReactNativeWebView") ? "ReactWebView" : "WebView",
+    (params) => ({
+      url: replaceParams(url, params),
+      ...config,
+    })
+  )
+}
+
+export function replaceParams(url: string, params: any) {
+  url = url.replace(/\*$/, params["*"])
+  let match = url.match(/:(\w+)/)
+  while (match) {
+    const key = match[1]
+    if (!(key in params)) {
+      console.error("[replaceParams]: something is very wrong", key, params)
+      return url
+    }
+    url = url.replace(":" + key, params[key])
+    match = url.match(/:(\w+)/)
+  }
+  return url
 }
 
 function getDomainMap(): Record<string, RouteMatcher[] | null> {
@@ -61,14 +88,10 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
       : null,
     new RouteMatcher("/artwork/:artworkID", "Artwork"),
     new RouteMatcher("/artwork/:artworkID/medium", "ArtworkMedium"),
-    new RouteMatcher("/artist/:artistID/auction-results", "WebView", ({ artistID }) => ({
-      url: `/artist/${artistID}/auction-results`,
-    })),
+    webViewRoute("/artist/:artistID/auction-results"),
     new RouteMatcher("/artist/:artistID/auction-result/:auctionResultInternalID", "AuctionResult"),
     new RouteMatcher("/artist/:artistID/artist-series", "FullArtistSeriesList"),
-    new RouteMatcher("/artist/:artistID/articles", "WebView", (params) => ({
-      url: "/artist/" + params.artistID + "/articles",
-    })),
+    webViewRoute("/artist/:artistID/articles"),
     new RouteMatcher("/artist/:artistID/*", "Artist"),
     // For artists in a gallery context, like https://artsy.net/spruth-magers/artist/astrid-klein . Until we have a native
     // version of the gallery profile/context, we will use the normal native artist view instead of showing a web view.
@@ -120,7 +143,7 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
     new RouteMatcher("/consign/submission", "ConsignmentsSubmissionForm"),
     new RouteMatcher("/collections/my-collection/marketing-landing", "SalesNotRootTabView"),
 
-    new RouteMatcher("/conditions-of-sale", "WebView", () => ({ url: "/conditions-of-sale" })),
+    webViewRoute("/conditions-of-sale"),
     new RouteMatcher("/artwork-classifications", "ArtworkAttributionClassFAQ"),
 
     new RouteMatcher("/partner-locations/:partnerID", "PartnerLocations"),
@@ -139,17 +162,18 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
     new RouteMatcher("/city-save/:citySlug", "CitySavedList"),
     new RouteMatcher("/auctions", "Auctions"),
     new RouteMatcher("/works-for-you", "WorksForYou"),
-    new RouteMatcher("/categories", "WebView", () => ({ url: "/categories" })),
-    new RouteMatcher("/privacy", "WebView", () => ({ url: "/privacy" })),
-    new RouteMatcher("/identity-verification-faq", "WebView", () => ({ url: "/identity-verification-faq" })),
-    new RouteMatcher("/terms", "WebView", () => ({ url: "/terms" })),
+    webViewRoute("/categories"),
+    webViewRoute("/privacy"),
+    webViewRoute("/identity-verification-faq"),
+    webViewRoute("/terms"),
+    webViewRoute("/buy-now-feature-faq"),
 
     new RouteMatcher("/city-bmw-list/:citySlug", "CityBMWList"),
-    new RouteMatcher("/:slug", "VanityURLEntity"),
     new RouteMatcher("/make-offer/:artworkID", "MakeOfferModal"),
     new RouteMatcher("/orders/:orderID", "Checkout"),
 
-    new RouteMatcher("/*", "WebView", (params) => ({ url: "/" + params["*"] })),
+    new RouteMatcher("/:slug", "VanityURLEntity"),
+    webViewRoute("/*"),
   ])
 
   const routesForDomain = {
@@ -158,6 +182,7 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
     "staging.artsy.net": artsyDotNet,
     "artsy.net": artsyDotNet,
     "www.artsy.net": artsyDotNet,
+    [parse(unsafe__getEnvironment().webURL).host ?? "artsy.net"]: artsyDotNet,
   }
 
   return routesForDomain

--- a/src/lib/store/GlobalStore.tsx
+++ b/src/lib/store/GlobalStore.tsx
@@ -141,7 +141,7 @@ export function getCurrentEmissionState() {
     deviceId: "Android", // TODO: get better device info
     launchCount: ArtsyNativeModule.launchCount,
     onboardingState: "none", // not used on android
-    userAgent: "eigen android", // TODO: proper user agent
+    userAgent: "Artsy-Mobile android", // TODO: proper user agent
     userID: state?.auth.userID!,
   }
   return androidData

--- a/src/lib/store/config/features.ts
+++ b/src/lib/store/config/features.ts
@@ -1,3 +1,5 @@
+import { Platform } from "react-native"
+
 export interface FeatureDescriptor {
   /**
    * Set readyForRelease to `true` when the feature is ready to be exposed outside of dev mode.
@@ -64,9 +66,9 @@ export const features = defineFeatures({
     echoFlagKey: "AREnableNewPartnerView",
   },
   AROptionsUseReactNativeWebView: {
-    readyForRelease: false,
+    readyForRelease: Platform.OS === "android",
     description: "Use react-native web views",
-    showInAdminMenu: true,
+    showInAdminMenu: Platform.OS !== "android",
   },
   AROptionsLotConditionReport: {
     readyForRelease: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11609,10 +11609,10 @@ react-native-view-shot@^3.1.2:
   resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-3.1.2.tgz#8c8e84c67a4bc8b603e697dbbd59dbc9b4f84825"
   integrity sha512-9u9fPtp6a52UMoZ/UCPrCjKZk8tnkI9To0Eh6yYnLKFEGkRZ7Chm6DqwDJbYJHeZrheCCopaD5oEOnRqhF4L2Q==
 
-react-native-webview@^10.8.3:
-  version "10.8.3"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-10.8.3.tgz#63245fdf39320dbbc67c26e1e305342a51f93d66"
-  integrity sha512-QV3dCGG8xsr/65Rpf2/Khno8fzkyyJKUZpn00y6Wd1hbYRqataZOesCm2ceZS21yXzLLGVHmQlB5/41h3K787Q==
+react-native-webview@^11.3.1:
+  version "11.3.1"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.3.1.tgz#acc87db56eca568fd561edecbd990e8252b882a5"
+  integrity sha512-qHvD2DVbUVSuRLU33RU4LbfISoJ3q5PWj4fuDcMgEYaEnlvOiOQqR/x5t9z4kdVZ83T+WG8ktp19F2uTCaOKRg==
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
This PR contributes towards [CX-436]

### Description

This PR

- adds a ReactWebView app module to use behind a feature flag while we transition to react-native-webview
- turns on the feature flag by default on Android.
- adds tooling in `routes.tsx` for making it easier to define web view routes
- gives Android a user agent that will let force know it's receiving requests from eigen.
- adds a `isPresentedModally` prop for screen components to receive.

Follow-up PRs will add support for navigation request interception, authentication, and so on.

#### Before

https://user-images.githubusercontent.com/1242537/111620184-4977a780-87de-11eb-8a3f-f78f7315a512.mp4

#### iOS, modal presentation

https://user-images.githubusercontent.com/1242537/111620211-51cfe280-87de-11eb-808c-03b4914abae9.mp4

#### iOS, stack presentation

https://user-images.githubusercontent.com/1242537/111621757-454c8980-87e0-11eb-8742-b0647a2c4895.mp4

#### Android, modal presentation

https://user-images.githubusercontent.com/1242537/111621509-fbfc3a00-87df-11eb-9c2c-30eb8c79053e.mp4

#### Android, stack presentation

https://user-images.githubusercontent.com/1242537/111623134-e425b580-87e1-11eb-8060-62fae52ec8dd.mp4

I have tested iOS 12 and things look good there too.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-436]: https://artsyproduct.atlassian.net/browse/CX-436