### PR TITLE
chore: disable metaphysics-check job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -428,16 +428,16 @@ workflows:
     jobs:
       - deploy-nightly-beta
 
-  metaphysics-check:
-    triggers:
-      - schedule:
-          cron: "13 * * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - check-metaphysics-freshness
+  # metaphysics-check:
+  #   triggers:
+  #     - schedule:
+  #         cron: "13 * * * *"
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master
+  #   jobs:
+  #     - check-metaphysics-freshness
 
   promote:
     jobs:


### PR DESCRIPTION
This job is creating a lot of failure emails and we have had complaints. I'm going to switch it off for now. We should fix the stability issues and re-enable later.