### PR TITLE
feat: react web view cookies

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -6,6 +6,7 @@ upcoming:
     - Fix iOS modal presentation infra code - david
     - Fix first install event analytics - brian, mike
     - Set up basic react webview module - david
+    - Add cookie setup for react web views - david
     - Fix iOS modal presentation infra code - david
   user_facing:
     - Set system navigation bar color to white on modals for android - mounir

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -397,6 +397,8 @@ PODS:
     - react-native-config/App (= 1.3.3)
   - react-native-config/App (1.3.3):
     - React
+  - react-native-cookies (6.0.4):
+    - React-Core
   - react-native-geolocation (2.0.2):
     - React
   - react-native-mapbox-gl (8.1.0-rc.9):
@@ -424,8 +426,8 @@ PODS:
     - React
   - react-native-viewpager (4.2.2):
     - React-Core
-  - react-native-webview (10.8.3):
-    - React
+  - react-native-webview (11.3.1):
+    - React-Core
   - React-RCTActionSheet (0.63.3):
     - React-Core/RCTActionSheetHeaders (= 0.63.3)
   - React-RCTAnimation (0.63.3):
@@ -634,6 +636,7 @@ DEPENDENCIES:
   - React-jsinspector (from `./node_modules/react-native/ReactCommon/jsinspector`)
   - "react-native-cameraroll (from `node_modules/@react-native-community/cameraroll`)"
   - react-native-config (from `node_modules/react-native-config`)
+  - "react-native-cookies (from `node_modules/@react-native-cookies/cookies`)"
   - "react-native-geolocation (from `node_modules/@react-native-community/geolocation`)"
   - "react-native-mapbox-gl (from `node_modules/@react-native-mapbox-gl/maps`)"
   - "react-native-netinfo (from `node_modules/@react-native-community/netinfo`)"
@@ -801,6 +804,8 @@ EXTERNAL SOURCES:
     :path: "node_modules/@react-native-community/cameraroll"
   react-native-config:
     :path: node_modules/react-native-config
+  react-native-cookies:
+    :path: "node_modules/@react-native-cookies/cookies"
   react-native-geolocation:
     :path: "node_modules/@react-native-community/geolocation"
   react-native-mapbox-gl:
@@ -968,13 +973,14 @@ SPEC CHECKSUMS:
   React-jsinspector: 8e68ffbfe23880d3ee9bafa8be2777f60b25cbe2
   react-native-cameraroll: 463aff54e37cff27ea76eb792e6f1fa43b876320
   react-native-config: 47fd4132d931f84aca9c31f302c3c867a8560b11
+  react-native-cookies: 3b5b182d008b714fefc337df15b787f00385a598
   react-native-geolocation: c956aeb136625c23e0dce0467664af2c437888c9
   react-native-mapbox-gl: eeed4fa8fffea96f77a9eecbc63f88eddb0d2e58
   react-native-netinfo: a59d8426a8484f739fe3a95dd6ad5af1435db05f
   react-native-safe-area-context: b6e0e284002381d2ff29fa4fff42b4d8282e3c94
   react-native-view-shot: 4475fde003fe8a210053d1f98fb9e06c1d834e1c
   react-native-viewpager: ea945e2881ce9a4a8bcdc84de4ec65ff23c90f6e
-  react-native-webview: 598605cd213f5096e695f5b33fbee210a47e60ab
+  react-native-webview: 07fca3f4378bd6ea26254bf63119bfd70f4fabeb
   React-RCTActionSheet: 53ea72699698b0b47a6421cb1c8b4ab215a774aa
   React-RCTAnimation: 1befece0b5183c22ae01b966f5583f42e69a83c2
   React-RCTBlob: 0b284339cbe4b15705a05e2313a51c6d8b51fa40

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@react-native-community/netinfo": "4.6.1",
     "@react-native-community/picker": "1.3.0",
     "@react-native-community/viewpager": "^4.2.2",
+    "@react-native-cookies/cookies": "^6.0.4",
     "@react-native-mapbox-gl/maps": "8.1.0-rc.9",
     "@react-navigation/bottom-tabs": "^5.11.7",
     "@react-navigation/native": "^5.9.2",

--- a/src/lib/AndroidApp.tsx
+++ b/src/lib/AndroidApp.tsx
@@ -6,6 +6,7 @@ import { useCallback } from "react"
 import { Linking, UIManager, View } from "react-native"
 import track from "react-tracking"
 import { RelayEnvironmentProvider } from "relay-hooks"
+import { useWebViewCookies } from "./Components/ArtsyReactWebView"
 import { _FancyModalPageWrapper } from "./Components/FancyModal/FancyModalContext"
 import { useSentryConfig } from "./ErrorReporting"
 import { ModalStack } from "./navigation/ModalStack"
@@ -28,6 +29,7 @@ const Main: React.FC<{}> = track()(({}) => {
 
   useSentryConfig()
   useStripeConfig()
+  useWebViewCookies()
 
   useEffect(() => {
     Linking.getInitialURL().then((url) => {

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -70,7 +70,7 @@ import { ShowMoreInfoQueryRenderer, ShowQueryRenderer } from "./Scenes/Show"
 import { VanityURLEntityRenderer } from "./Scenes/VanityURL/VanityURLEntity"
 
 import { ActionSheetProvider } from "@expo/react-native-action-sheet"
-import { ArtsyReactWebView, useWebViewCookies } from "./Components/ArtsyReactWebView"
+import { ArtsyReactWebViewPage, useWebViewCookies } from "./Components/ArtsyReactWebView"
 import { ToastProvider } from "./Components/Toast/toastHook"
 import { RegistrationFlow } from "./Containers/RegistrationFlow"
 import { useSentryConfig } from "./ErrorReporting"
@@ -343,7 +343,7 @@ export const modules = defineModules({
   }),
   LocalDiscovery: nativeModule(),
   WebView: nativeModule(),
-  ReactWebView: reactModule(ArtsyReactWebView, {
+  ReactWebView: reactModule(ArtsyReactWebViewPage, {
     fullBleed: true,
     hasOwnModalCloseButton: true,
     hidesBackButton: true,

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -70,7 +70,7 @@ import { ShowMoreInfoQueryRenderer, ShowQueryRenderer } from "./Scenes/Show"
 import { VanityURLEntityRenderer } from "./Scenes/VanityURL/VanityURLEntity"
 
 import { ActionSheetProvider } from "@expo/react-native-action-sheet"
-import { ArtsyReactWebView } from "./Components/ArtsyReactWebView"
+import { ArtsyReactWebView, useWebViewCookies } from "./Components/ArtsyReactWebView"
 import { ToastProvider } from "./Components/Toast/toastHook"
 import { RegistrationFlow } from "./Containers/RegistrationFlow"
 import { useSentryConfig } from "./ErrorReporting"
@@ -403,6 +403,7 @@ const Main: React.FC<{}> = track()(({}) => {
 
   useSentryConfig()
   useStripeConfig()
+  useWebViewCookies()
 
   if (!isHydrated) {
     return <View />

--- a/src/lib/Components/ArtsyReactWebView.tsx
+++ b/src/lib/Components/ArtsyReactWebView.tsx
@@ -12,13 +12,27 @@ export interface ArtsyWebViewConfig {
   title?: string
 }
 
-export const ArtsyReactWebView: React.FC<
+export const ArtsyReactWebViewPage: React.FC<
   {
     url: string
     isPresentedModally?: boolean
   } & ArtsyWebViewConfig
 > = ({ url, title, isPresentedModally }) => {
   const paddingTop = useScreenDimensions().safeAreaInsets.top
+
+  return (
+    <View style={{ flex: 1, paddingTop }}>
+      <FancyModalHeader useXButton={isPresentedModally} onLeftButtonPress={goBack}>
+        {title}
+      </FancyModalHeader>
+      <ArtsyReactWebView url={url} />
+    </View>
+  )
+}
+
+export const ArtsyReactWebView: React.FC<{
+  url: string
+}> = ({ url }) => {
   const userAgent = getCurrentEmissionState().userAgent
 
   const ref = useRef<WebView>(null)
@@ -27,22 +41,17 @@ export const ArtsyReactWebView: React.FC<
   const uri = url.startsWith("/") ? webURL + url : url
 
   return (
-    <View style={{ flex: 1, paddingTop }}>
-      <FancyModalHeader useXButton={isPresentedModally} onLeftButtonPress={goBack}>
-        {title}
-      </FancyModalHeader>
-      <View style={{ flex: 1 }}>
-        <WebView
-          ref={ref}
-          source={{ uri }}
-          style={{ flex: 1 }}
-          userAgent={userAgent}
-          onLoadStart={() => setLoadProgress((p) => Math.max(0.02, p ?? 0))}
-          onLoadEnd={() => setLoadProgress(null)}
-          onLoadProgress={(e) => setLoadProgress(e.nativeEvent.progress)}
-        />
-        <ProgressBar loadProgress={loadProgress} />
-      </View>
+    <View style={{ flex: 1 }}>
+      <WebView
+        ref={ref}
+        source={{ uri }}
+        style={{ flex: 1 }}
+        userAgent={userAgent}
+        onLoadStart={() => setLoadProgress((p) => Math.max(0.02, p ?? 0))}
+        onLoadEnd={() => setLoadProgress(null)}
+        onLoadProgress={(e) => setLoadProgress(e.nativeEvent.progress)}
+      />
+      <ProgressBar loadProgress={loadProgress} />
     </View>
   )
 }

--- a/src/lib/Components/ArtsyReactWebView.tsx
+++ b/src/lib/Components/ArtsyReactWebView.tsx
@@ -4,7 +4,7 @@ import { goBack } from "lib/navigation/navigate"
 import { getCurrentEmissionState, GlobalStore, useEnvironment } from "lib/store/GlobalStore"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import React, { useEffect, useRef, useState } from "react"
-import { View } from "react-native"
+import { Platform, View } from "react-native"
 import WebView from "react-native-webview"
 import { FancyModalHeader } from "./FancyModal/FancyModalHeader"
 
@@ -84,8 +84,8 @@ export const __webViewTestUtils__ = __TEST__
   : null
 
 export function useWebViewCookies() {
-  const authenticationToken = GlobalStore.useAppState(
-    (store) => store.auth.userAccessToken ?? store.native.sessionState.authenticationToken
+  const authenticationToken = GlobalStore.useAppState((store) =>
+    Platform.OS === "ios" ? store.native.sessionState.authenticationToken : store.auth.userAccessToken
   )
   const webURL = useEnvironment().webURL
   const isMounted = useRef(false)
@@ -102,7 +102,7 @@ export function useWebViewCookies() {
         try {
           const res = await fetch(webURL, {
             method: "HEAD",
-            headers: { "X-Access-Token": authenticationToken },
+            headers: { "X-Access-Token": authenticationToken! },
           })
 
           if (res.status > 400) {

--- a/src/lib/Components/__tests__/ArtsyReactWebView-tests.tsx
+++ b/src/lib/Components/__tests__/ArtsyReactWebView-tests.tsx
@@ -70,8 +70,8 @@ describe(useWebViewCookies, () => {
     useWebViewCookies()
     return null
   }
-  it("tries to make an authenticated HEAD request to force to make sure we get the user's coookies", () => {
-    __globalStoreTestUtils__?.injectState({ auth: { userAccessToken: "userAccessToken" } })
+  it("tries to make an authenticated HEAD request to force and prediction to make sure we get the user's coookies", () => {
+    __globalStoreTestUtils__?.injectState({ native: { sessionState: { authenticationToken: "userAccessToken" } } })
     act(() => {
       renderWithWrappers(<Wrapper />)
     })
@@ -79,37 +79,41 @@ describe(useWebViewCookies, () => {
       method: "HEAD",
       headers: { "X-Access-Token": "userAccessToken" },
     })
+    expect(mockFetch).toHaveBeenCalledWith("https://live-staging.artsy.net", {
+      method: "HEAD",
+      headers: { "X-Access-Token": "userAccessToken" },
+    })
   })
   it("retries if it fails", async () => {
-    __globalStoreTestUtils__?.injectState({ auth: { userAccessToken: "userAccessToken" } })
+    __globalStoreTestUtils__?.injectState({ native: { sessionState: { authenticationToken: "userAccessToken" } } })
     mockFetch.mockReturnValue(Promise.resolve({ ok: false, status: 500 } as any))
     const tree = renderWithWrappers(<Wrapper />)
     await act(() => undefined)
-    expect(mockFetch).toHaveBeenCalledTimes(1)
-
-    jest.runOnlyPendingTimers()
     expect(mockFetch).toHaveBeenCalledTimes(2)
 
-    await act(() => undefined)
-    jest.runOnlyPendingTimers()
-    expect(mockFetch).toHaveBeenCalledTimes(3)
-
-    await act(() => undefined)
     jest.runOnlyPendingTimers()
     expect(mockFetch).toHaveBeenCalledTimes(4)
 
     await act(() => undefined)
     jest.runOnlyPendingTimers()
-    expect(mockFetch).toHaveBeenCalledTimes(5)
+    expect(mockFetch).toHaveBeenCalledTimes(6)
+
+    await act(() => undefined)
+    jest.runOnlyPendingTimers()
+    expect(mockFetch).toHaveBeenCalledTimes(8)
+
+    await act(() => undefined)
+    jest.runOnlyPendingTimers()
+    expect(mockFetch).toHaveBeenCalledTimes(10)
 
     tree.unmount()
 
     await act(() => undefined)
     jest.runOnlyPendingTimers()
-    expect(mockFetch).toHaveBeenCalledTimes(5)
+    expect(mockFetch).toHaveBeenCalledTimes(10)
 
     await act(() => undefined)
     jest.runOnlyPendingTimers()
-    expect(mockFetch).toHaveBeenCalledTimes(5)
+    expect(mockFetch).toHaveBeenCalledTimes(10)
   })
 })

--- a/src/lib/Components/__tests__/ArtsyReactWebView-tests.tsx
+++ b/src/lib/Components/__tests__/ArtsyReactWebView-tests.tsx
@@ -1,10 +1,11 @@
+import mockFetch from "jest-fetch-mock"
 import { goBack } from "lib/navigation/navigate"
 import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import WebView from "react-native-webview"
 import { act } from "react-test-renderer"
-import { __webViewTestUtils__, ArtsyReactWebView } from "../ArtsyReactWebView"
+import { __webViewTestUtils__, ArtsyReactWebView, useWebViewCookies } from "../ArtsyReactWebView"
 import { FancyModalHeader } from "../FancyModal/FancyModalHeader"
 
 describe(ArtsyReactWebView, () => {
@@ -52,5 +53,63 @@ describe(ArtsyReactWebView, () => {
   it("sets the user agent correctly", () => {
     const tree = renderWithWrappers(<ArtsyReactWebView url="https://staging.artsy.net/hello" />)
     expect(tree.root.findByType(WebView).props.userAgent).toBe("Jest Unit Tests")
+  })
+})
+
+describe(useWebViewCookies, () => {
+  beforeAll(() => {
+    jest.useFakeTimers()
+  })
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+  beforeEach(() => {
+    mockFetch.mockClear()
+  })
+  const Wrapper = () => {
+    useWebViewCookies()
+    return null
+  }
+  it("tries to make an authenticated HEAD request to force to make sure we get the user's coookies", () => {
+    __globalStoreTestUtils__?.injectState({ auth: { userAccessToken: "userAccessToken" } })
+    act(() => {
+      renderWithWrappers(<Wrapper />)
+    })
+    expect(mockFetch).toHaveBeenCalledWith("https://staging.artsy.net", {
+      method: "HEAD",
+      headers: { "X-Access-Token": "userAccessToken" },
+    })
+  })
+  it("retries if it fails", async () => {
+    __globalStoreTestUtils__?.injectState({ auth: { userAccessToken: "userAccessToken" } })
+    mockFetch.mockReturnValue(Promise.resolve({ ok: false, status: 500 } as any))
+    const tree = renderWithWrappers(<Wrapper />)
+    await act(() => undefined)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+
+    jest.runOnlyPendingTimers()
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+
+    await act(() => undefined)
+    jest.runOnlyPendingTimers()
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+
+    await act(() => undefined)
+    jest.runOnlyPendingTimers()
+    expect(mockFetch).toHaveBeenCalledTimes(4)
+
+    await act(() => undefined)
+    jest.runOnlyPendingTimers()
+    expect(mockFetch).toHaveBeenCalledTimes(5)
+
+    tree.unmount()
+
+    await act(() => undefined)
+    jest.runOnlyPendingTimers()
+    expect(mockFetch).toHaveBeenCalledTimes(5)
+
+    await act(() => undefined)
+    jest.runOnlyPendingTimers()
+    expect(mockFetch).toHaveBeenCalledTimes(5)
   })
 })

--- a/src/lib/Components/__tests__/ArtsyReactWebView-tests.tsx
+++ b/src/lib/Components/__tests__/ArtsyReactWebView-tests.tsx
@@ -5,32 +5,32 @@ import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import WebView from "react-native-webview"
 import { act } from "react-test-renderer"
-import { __webViewTestUtils__, ArtsyReactWebView, useWebViewCookies } from "../ArtsyReactWebView"
+import { __webViewTestUtils__, ArtsyReactWebViewPage, useWebViewCookies } from "../ArtsyReactWebView"
 import { FancyModalHeader } from "../FancyModal/FancyModalHeader"
 
-describe(ArtsyReactWebView, () => {
+describe(ArtsyReactWebViewPage, () => {
   it(`renders a WebView`, () => {
-    const tree = renderWithWrappers(<ArtsyReactWebView url="https://staging.artsy.net/hello" />)
+    const tree = renderWithWrappers(<ArtsyReactWebViewPage url="https://staging.artsy.net/hello" />)
     expect(tree.root.findByType(WebView).props.source.uri).toEqual("https://staging.artsy.net/hello")
   })
   it(`renders a back button normally`, () => {
-    const tree = renderWithWrappers(<ArtsyReactWebView url="https://staging.artsy.net/hello" />)
+    const tree = renderWithWrappers(<ArtsyReactWebViewPage url="https://staging.artsy.net/hello" />)
     expect(tree.root.findByType(FancyModalHeader).props.useXButton).toBeFalsy()
     expect(tree.root.findByType(FancyModalHeader).props.onLeftButtonPress).toBeTruthy()
   })
   it(`renders a close button when presented modally`, () => {
-    const tree = renderWithWrappers(<ArtsyReactWebView isPresentedModally url="https://staging.artsy.net/hello" />)
+    const tree = renderWithWrappers(<ArtsyReactWebViewPage isPresentedModally url="https://staging.artsy.net/hello" />)
     expect(tree.root.findByType(FancyModalHeader).props.useXButton).toBeTruthy()
     expect(tree.root.findByType(FancyModalHeader).props.onLeftButtonPress).toBeTruthy()
   })
   it("calls goBack when the close/back button is pressed", () => {
-    const tree = renderWithWrappers(<ArtsyReactWebView url="https://staging.artsy.net/hello" />)
+    const tree = renderWithWrappers(<ArtsyReactWebViewPage url="https://staging.artsy.net/hello" />)
     expect(goBack).not.toHaveBeenCalled()
     tree.root.findByType(FancyModalHeader).props.onLeftButtonPress()
     expect(goBack).toHaveBeenCalled()
   })
   it("has a progress bar that follows page load events", () => {
-    const tree = renderWithWrappers(<ArtsyReactWebView url="https://staging.artsy.net/hello" />)
+    const tree = renderWithWrappers(<ArtsyReactWebViewPage url="https://staging.artsy.net/hello" />)
     const getProgressBar = () => tree.root.findByType(__webViewTestUtils__?.ProgressBar!)
     expect(getProgressBar().children).toHaveLength(0)
     act(() => {
@@ -47,11 +47,11 @@ describe(ArtsyReactWebView, () => {
     expect(getProgressBar().children).toHaveLength(0)
   })
   it("sets the user agent correctly", () => {
-    const tree = renderWithWrappers(<ArtsyReactWebView url="https://staging.artsy.net/hello" />)
+    const tree = renderWithWrappers(<ArtsyReactWebViewPage url="https://staging.artsy.net/hello" />)
     expect(tree.root.findByType(WebView).props.userAgent).toBe("Jest Unit Tests")
   })
   it("sets the user agent correctly", () => {
-    const tree = renderWithWrappers(<ArtsyReactWebView url="https://staging.artsy.net/hello" />)
+    const tree = renderWithWrappers(<ArtsyReactWebViewPage url="https://staging.artsy.net/hello" />)
     expect(tree.root.findByType(WebView).props.userAgent).toBe("Jest Unit Tests")
   })
 })

--- a/src/lib/store/GlobalStoreModel.ts
+++ b/src/lib/store/GlobalStoreModel.ts
@@ -1,6 +1,7 @@
+import CookieManager from "@react-native-cookies/cookies"
 import { Action, action, createStore, State, thunk, Thunk, thunkOn, ThunkOn } from "easy-peasy"
 import { LegacyNativeModules } from "lib/NativeModules/LegacyNativeModules"
-import { clearAll } from "lib/relay/RelayCache"
+import * as RelayCache from "lib/relay/RelayCache"
 import { BottomTabsModel } from "lib/Scenes/BottomTabs/BottomTabsModel"
 import { MyCollectionModel } from "lib/Scenes/MyCollection/State/MyCollectionModel"
 import { SearchModel } from "lib/Scenes/Search/SearchModel"
@@ -57,7 +58,8 @@ export const GlobalStoreModel: GlobalStoreModel = {
     if (Platform.OS === "ios") {
       await LegacyNativeModules.ARTemporaryAPIModule.clearUserData()
     }
-    clearAll()
+    CookieManager.clearAll()
+    RelayCache.clearAll()
     actions.reset({ config })
   }),
   didRehydrate: thunkOn(

--- a/src/lib/store/__tests__/GlobalStoreModel-tests.ts
+++ b/src/lib/store/__tests__/GlobalStoreModel-tests.ts
@@ -1,3 +1,5 @@
+import Cookies from "@react-native-cookies/cookies"
+import { LegacyNativeModules } from "lib/NativeModules/LegacyNativeModules"
 import { __globalStoreTestUtils__, GlobalStore } from "../GlobalStore"
 import { CURRENT_APP_VERSION } from "../migration"
 
@@ -24,5 +26,21 @@ describe("GlobalStoreModel", () => {
     })
 
     expect(__globalStoreTestUtils__?.getCurrentState().search.recentSearches[0].props.displayLabel).toEqual("Banksy")
+  })
+  it("has a signOut action", async () => {
+    __globalStoreTestUtils__?.injectState({
+      sessionState: { isHydrated: true },
+      auth: {
+        userAccessToken: "user-access-token",
+        userID: "user-id",
+      },
+    })
+    expect(Cookies.clearAll).not.toHaveBeenCalled()
+    expect(LegacyNativeModules.ARTemporaryAPIModule.clearUserData).not.toHaveBeenCalled()
+    expect(__globalStoreTestUtils__?.getCurrentState().auth.userAccessToken).toBe("user-access-token")
+    await GlobalStore.actions.signOut()
+    expect(__globalStoreTestUtils__?.getCurrentState().auth.userAccessToken).toBe(null)
+    expect(LegacyNativeModules.ARTemporaryAPIModule.clearUserData).toHaveBeenCalledTimes(1)
+    expect(Cookies.clearAll).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -83,8 +83,14 @@ jest.mock("rn-fetch-blob", () => ({
   },
 }))
 
+jest.mock("@react-native-cookies/cookies", () => ({ clearAll: jest.fn() }))
+
+beforeEach(() => {
+  require("@react-native-cookies/cookies").clearAll.mockReset()
+})
+
 // tslint:disable-next-line:no-empty
-jest.mock("@sentry/react-native", () => ({ captureMessage() {}, init() {}, setUser() {} }))
+jest.mock("@sentry/react-native", () => ({ captureMessage() {}, init() {}, setUser() {}, addBreadcrumb() {} }))
 
 // Needing to mock react-native-scrollable-tab-view due to Flow issue
 jest.mock("react-native-scrollable-tab-view", () => jest.fn(() => null))

--- a/yarn.lock
+++ b/yarn.lock
@@ -2317,6 +2317,13 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/viewpager/-/viewpager-4.2.2.tgz#e05d618829c589284326896c806200af90ae0986"
   integrity sha512-XBAO/9gV0pb6VAqbaobdJp6slTgmf8TOAnIbERO1pKjIXoj2OrKYcma2VPB/02wzEzu7TE8jcbt3u6BT4fpXxA==
 
+"@react-native-cookies/cookies@^6.0.4":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@react-native-cookies/cookies/-/cookies-6.0.4.tgz#4914bfa1110361ec67281c6d7ce9fde6e3b1e7e8"
+  integrity sha512-VOZvNtxUsNmWV/H6/JqO/HPiNJQa5zvmPv3YnuK3uu9CcTEWsvTsq6VmvhJci4DTilI1e1/SF6z6yJwmscS+iw==
+  dependencies:
+    invariant "^2.2.4"
+
 "@react-native-mapbox-gl/maps@8.1.0-rc.9":
   version "8.1.0-rc.9"
   resolved "https://registry.yarnpkg.com/@react-native-mapbox-gl/maps/-/maps-8.1.0-rc.9.tgz#2c9a296e06dba695184adc7b63fe8835e75eff47"


### PR DESCRIPTION
This PR contributes towards [CX-436]

### Description

This PR adds user authentication for `react-native-webview` web views.

It does that by setting up shared cookies between `fetch` and `webkit` by making `HEAD` `fetch`  requests to force and prediction, including the user's access token in the `x-access-token` header. It does this whenever the access token changes, and we also clear the app's cookies when the user logs out.

### iOS
https://user-images.githubusercontent.com/1242537/112020112-ff692b80-8b27-11eb-8ab1-499b75374ff4.mp4

### Android
https://user-images.githubusercontent.com/1242537/112020157-03954900-8b28-11eb-9ea4-5ee5c1cf768a.mp4


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-436]: https://artsyproduct.atlassian.net/browse/CX-436