### PR TITLE
fix:round buyer's premium correctly on SaleInfo screen

### DIFF
--- a/src/lib/Scenes/SaleInfo/SaleInfo.tsx
+++ b/src/lib/Scenes/SaleInfo/SaleInfo.tsx
@@ -124,6 +124,8 @@ export const SaleInfo: React.FC<Props> = ({ sale, me }) => {
   )
 }
 
+const makePercent = (value: number) => parseFloat((value * 100).toFixed(5))
+
 const createPremiumDisplay = (props: { sale: SaleInfo_sale }) => {
   return props.sale.buyersPremium?.map((item, index) => (
     <BuyersPremiumItem sale={props.sale} currentValue={item} index={index} key={index} />
@@ -144,7 +146,7 @@ const BuyersPremiumItem: React.FC<BuyersPremiumItemProps> = (props) => {
 
   const buyersPremium = props.sale.buyersPremium
   const amount = props.currentValue?.amount
-  const percent = (props.currentValue?.percent || 0) * 100 + "%"
+  const percent = makePercent(props.currentValue?.percent || 0) + "%"
   const listLength = props.sale.buyersPremium?.length || 0
 
   const nextValue = !!buyersPremium ? buyersPremium[props.index + 1] : null
@@ -172,7 +174,7 @@ const BuyersPremium: React.FC<{ sale: SaleInfo_sale }> = (props) => {
   }
 
   if (buyersPremium.length === 1) {
-    premiumDisplay = <Text variant="text">{(buyersPremium[0]?.percent || 0) * 100}% on the hammer price</Text>
+    premiumDisplay = <Text variant="text">{makePercent(buyersPremium[0]?.percent || 0)}% on the hammer price</Text>
   } else {
     premiumDisplay = createPremiumDisplay(props)
   }


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1239]

### Description

Added a rounding function similar to the one in [Force](https://github.com/artsy/force/pull/2248/files#diff-b7eb4d941f9c0f248da97443ea83094b82fd13992ac463479766d91f4d74f410R6).

<img width="372" alt="Screen Shot 2021-03-24 at 5 17 00 PM" src="https://user-images.githubusercontent.com/19369/112384420-c914e300-8cc4-11eb-9d24-528826fc8e8d.png">


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1239]: https://artsyproduct.atlassian.net/browse/CX-1239