### PR TITLE
CTA/review offer button tweaks

### DIFF
--- a/src/__generated__/ComposerTestsQuery.graphql.ts
+++ b/src/__generated__/ComposerTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 2b1a7e1579b0b14d66165463ef370661 */
+/* @relayHash d55e56b4a15b93fb92988b7ecd444e47 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -70,6 +70,7 @@ fragment ReviewOfferButton_order on CommerceOrder {
   state
   stateReason
   stateExpiresAt
+  lastTransactionFailed
   ... on CommerceOfferOrder {
     lastOffer {
       fromParticipant
@@ -143,6 +144,12 @@ v7 = {
   "type": "String"
 },
 v8 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Boolean"
+},
+v9 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -345,6 +352,13 @@ return {
                             "name": "stateExpiresAt",
                             "storageKey": null
                           },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lastTransactionFailed",
+                            "storageKey": null
+                          },
                           (v3/*: any*/),
                           {
                             "kind": "InlineFragment",
@@ -440,7 +454,7 @@ return {
     ]
   },
   "params": {
-    "id": "2b1a7e1579b0b14d66165463ef370661",
+    "id": "d55e56b4a15b93fb92988b7ecd444e47",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "me": {
@@ -479,12 +493,7 @@ return {
         "me.conversation.items.item.artworkID": (v5/*: any*/),
         "me.conversation.items.item.href": (v7/*: any*/),
         "me.conversation.items.item.id": (v5/*: any*/),
-        "me.conversation.items.item.isOfferableFromInquiry": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Boolean"
-        },
+        "me.conversation.items.item.isOfferableFromInquiry": (v8/*: any*/),
         "me.conversation.items.item.slug": (v5/*: any*/),
         "me.conversation.orderConnection": {
           "enumValues": null,
@@ -508,7 +517,7 @@ return {
         "me.conversation.orderConnection.edges.node.__typename": (v6/*: any*/),
         "me.conversation.orderConnection.edges.node.id": (v5/*: any*/),
         "me.conversation.orderConnection.edges.node.internalID": (v5/*: any*/),
-        "me.conversation.orderConnection.edges.node.lastOffer": (v8/*: any*/),
+        "me.conversation.orderConnection.edges.node.lastOffer": (v9/*: any*/),
         "me.conversation.orderConnection.edges.node.lastOffer.createdAt": (v6/*: any*/),
         "me.conversation.orderConnection.edges.node.lastOffer.fromParticipant": {
           "enumValues": [
@@ -520,6 +529,7 @@ return {
           "type": "CommerceOrderParticipantEnum"
         },
         "me.conversation.orderConnection.edges.node.lastOffer.id": (v5/*: any*/),
+        "me.conversation.orderConnection.edges.node.lastTransactionFailed": (v8/*: any*/),
         "me.conversation.orderConnection.edges.node.offers": {
           "enumValues": null,
           "nullable": true,
@@ -532,7 +542,7 @@ return {
           "plural": true,
           "type": "CommerceOfferEdge"
         },
-        "me.conversation.orderConnection.edges.node.offers.edges.node": (v8/*: any*/),
+        "me.conversation.orderConnection.edges.node.offers.edges.node": (v9/*: any*/),
         "me.conversation.orderConnection.edges.node.offers.edges.node.id": (v5/*: any*/),
         "me.conversation.orderConnection.edges.node.offers.edges.node.internalID": (v5/*: any*/),
         "me.conversation.orderConnection.edges.node.state": {

--- a/src/__generated__/ConversationQuery.graphql.ts
+++ b/src/__generated__/ConversationQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash ba93b8867eb3b54e07ac3d1c3bdc0755 */
+/* @relayHash 2ac29bee5cc618e81daf18086b2352ef */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -249,6 +249,7 @@ fragment ReviewOfferButton_order on CommerceOrder {
   state
   stateReason
   stateExpiresAt
+  lastTransactionFailed
   ... on CommerceOfferOrder {
     lastOffer {
       fromParticipant
@@ -666,6 +667,13 @@ return {
                             "name": "stateExpiresAt",
                             "storageKey": null
                           },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lastTransactionFailed",
+                            "storageKey": null
+                          },
                           (v7/*: any*/),
                           {
                             "alias": null,
@@ -1022,7 +1030,7 @@ return {
     ]
   },
   "params": {
-    "id": "ba93b8867eb3b54e07ac3d1c3bdc0755",
+    "id": "2ac29bee5cc618e81daf18086b2352ef",
     "metadata": {},
     "name": "ConversationQuery",
     "operationKind": "query",

--- a/src/__generated__/ConversationTestsQuery.graphql.ts
+++ b/src/__generated__/ConversationTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 1d6868801ec331fe7af43eca311048c7 */
+/* @relayHash ef1eadf00e4c958d1e92576699fb23dc */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -249,6 +249,7 @@ fragment ReviewOfferButton_order on CommerceOrder {
   state
   stateReason
   stateExpiresAt
+  lastTransactionFailed
   ... on CommerceOfferOrder {
     lastOffer {
       fromParticipant
@@ -743,6 +744,13 @@ return {
                             "name": "stateExpiresAt",
                             "storageKey": null
                           },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lastTransactionFailed",
+                            "storageKey": null
+                          },
                           (v7/*: any*/),
                           {
                             "alias": null,
@@ -1099,7 +1107,7 @@ return {
     ]
   },
   "params": {
-    "id": "1d6868801ec331fe7af43eca311048c7",
+    "id": "ef1eadf00e4c958d1e92576699fb23dc",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "me": {
@@ -1257,6 +1265,7 @@ return {
         "me.conversation.orderConnection.edges.node.lastOffer.createdAt": (v19/*: any*/),
         "me.conversation.orderConnection.edges.node.lastOffer.fromParticipant": (v27/*: any*/),
         "me.conversation.orderConnection.edges.node.lastOffer.id": (v20/*: any*/),
+        "me.conversation.orderConnection.edges.node.lastTransactionFailed": (v24/*: any*/),
         "me.conversation.orderConnection.edges.node.offers": {
           "enumValues": null,
           "nullable": true,

--- a/src/__generated__/ReviewOfferButtonTestsQuery.graphql.ts
+++ b/src/__generated__/ReviewOfferButtonTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 42372e6c51863d84b99247b74649de8f */
+/* @relayHash 1e17508a96fe49bfd5c121283758c780 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -37,6 +37,7 @@ fragment ReviewOfferButton_order on CommerceOrder {
   state
   stateReason
   stateExpiresAt
+  lastTransactionFailed
   ... on CommerceOfferOrder {
     lastOffer {
       fromParticipant
@@ -182,6 +183,13 @@ return {
             "name": "stateExpiresAt",
             "storageKey": null
           },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "lastTransactionFailed",
+            "storageKey": null
+          },
           (v3/*: any*/),
           {
             "kind": "InlineFragment",
@@ -263,7 +271,7 @@ return {
     ]
   },
   "params": {
-    "id": "42372e6c51863d84b99247b74649de8f",
+    "id": "1e17508a96fe49bfd5c121283758c780",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "order": {
@@ -288,6 +296,12 @@ return {
           "type": "CommerceOrderParticipantEnum"
         },
         "order.lastOffer.id": (v5/*: any*/),
+        "order.lastTransactionFailed": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Boolean"
+        },
         "order.offers": {
           "enumValues": null,
           "nullable": true,

--- a/src/__generated__/ReviewOfferButton_order.graphql.ts
+++ b/src/__generated__/ReviewOfferButton_order.graphql.ts
@@ -11,6 +11,7 @@ export type ReviewOfferButton_order = {
     readonly state: CommerceOrderStateEnum;
     readonly stateReason: string | null;
     readonly stateExpiresAt: string | null;
+    readonly lastTransactionFailed: boolean | null;
     readonly lastOffer?: {
         readonly fromParticipant: CommerceOrderParticipantEnum | null;
         readonly createdAt: string;
@@ -66,6 +67,13 @@ return {
       "args": null,
       "kind": "ScalarField",
       "name": "stateExpiresAt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "lastTransactionFailed",
       "storageKey": null
     },
     {
@@ -145,5 +153,5 @@ return {
   "abstractKey": "__isCommerceOrder"
 };
 })();
-(node as any).hash = '00ab3377d074804382c5f8095a215c13';
+(node as any).hash = 'b9bef8d68539d767fe3ac1892dad8779';
 export default node;

--- a/src/lib/Scenes/Inbox/Components/Conversations/Composer.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/Composer.tsx
@@ -90,7 +90,7 @@ export default class Composer extends React.Component<Props, State> {
     // TODO: assumption is that there will be only 0/1 active (not pending or abandoned) order
     // and we will take the first without worrying about sort/order
     const orders = extractNodes(conversation.orderConnection)
-    const inactiveOrderStates = ["PENDING", "ABANDONED"]
+    const inactiveOrderStates = ["PENDING", "ABANDONED", "CANCELED"]
     const activeOrder = orders.filter((order) => {
       return !inactiveOrderStates.includes(order.state!)
     })[0]

--- a/src/lib/Scenes/Inbox/Components/Conversations/ReviewOfferButton.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/ReviewOfferButton.tsx
@@ -19,7 +19,7 @@ export const ReviewOfferButton: React.FC<ReviewOfferButtonProps> = ({ order }) =
     order.state === "ABANDONED" ||
     order.state === "PENDING" ||
     order.state === "CANCELED" ||
-    (order.state === "SUBMITTED" && order.lastOffer?.fromParticipant === "BUYER")
+    (order.state === "SUBMITTED" && order.lastOffer?.fromParticipant === "BUYER" && !order.lastTransactionFailed)
   ) {
     return null
   }

--- a/src/lib/Scenes/Inbox/Components/Conversations/ReviewOfferButton.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/ReviewOfferButton.tsx
@@ -1,4 +1,5 @@
 import { ReviewOfferButton_order } from "__generated__/ReviewOfferButton_order.graphql"
+import { OrderedColorFilters } from "lib/Components/ArtworkFilterOptions/ColorOptions"
 import { navigate } from "lib/navigation/navigate"
 import { extractNodes } from "lib/utils/extractNodes"
 import { useEventTiming } from "lib/utils/useEventTiming"
@@ -18,6 +19,7 @@ export const ReviewOfferButton: React.FC<ReviewOfferButtonProps> = ({ order }) =
     order.state == null ||
     order.state === "ABANDONED" ||
     order.state === "PENDING" ||
+    order.state === "CANCELED" ||
     (order.state === "SUBMITTED" && order.lastOffer?.fromParticipant === "BUYER")
   ) {
     return null
@@ -39,7 +41,7 @@ export const ReviewOfferButton: React.FC<ReviewOfferButtonProps> = ({ order }) =
 
     const { backgroundColor, message, subMessage, showMoneyIcon } = returnButtonMessaging({
       state: order.state,
-      stateReason: order.stateReason,
+      lastTransactionFailed: order.lastTransactionFailed,
       isCounter,
       lastOfferFromParticipant: order.lastOffer?.fromParticipant,
       hoursTillExpiration: hours,
@@ -98,6 +100,7 @@ export const ReviewOfferButtonFragmentContainer = createFragmentContainer(Review
       state
       stateReason
       stateExpiresAt
+      lastTransactionFailed
       ... on CommerceOfferOrder {
         lastOffer {
           fromParticipant

--- a/src/lib/Scenes/Inbox/Components/Conversations/ReviewOfferButton.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/ReviewOfferButton.tsx
@@ -1,5 +1,4 @@
 import { ReviewOfferButton_order } from "__generated__/ReviewOfferButton_order.graphql"
-import { OrderedColorFilters } from "lib/Components/ArtworkFilterOptions/ColorOptions"
 import { navigate } from "lib/navigation/navigate"
 import { extractNodes } from "lib/utils/extractNodes"
 import { useEventTiming } from "lib/utils/useEventTiming"

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/Composer-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/Composer-tests.tsx
@@ -238,7 +238,7 @@ describe("inquiry offer enabled", () => {
       expect(cta.findAllByType(Flex)[0].props).toEqual(expect.objectContaining({ bg: "green100" }))
     })
 
-    it("renders a red cta if the seller has rejected the buyer's offer", () => {
+    it("renders the MO button isntead of the cta if the seller has rejected the buyer's offer", () => {
       const tree = getWrapper({
         Conversation: () => ({
           items: [
@@ -267,14 +267,46 @@ describe("inquiry offer enabled", () => {
           },
         }),
       })
+      expect(tree.root.findAllByType(OpenInquiryModalButton).length).toEqual(1)
+      expect(tree.root.findAllByType(ReviewOfferButton).length).toEqual(0)
+    })
+    it("renders a red cta if the payment fails after an order is accepted", () => {
+      const tree = getWrapper({
+        Conversation: () => ({
+          items: [
+            {
+              item: {
+                __typename: "Artwork",
+                isOfferableFromInquiry: true,
+              },
+            },
+          ],
+          orderConnection: {
+            edges: [
+              {
+                node: {
+                  state: "SUBMITTED",
+                  lastTransactionFailed: true,
+                  lastOffer: {
+                    fromParticipant: "BUYER",
+                  },
+                  offers: {
+                    edges: [{}],
+                  },
+                },
+              },
+            ],
+          },
+        }),
+      })
       const cta = tree.root.findAllByType(ReviewOfferButton)[0]
       expect(cta).toBeDefined()
       expect(cta.children.length).toBe(1)
-      expect(extractText(cta)).toContain("Offer Declined")
+      expect(extractText(cta)).toContain("Payment Failed")
       expect(cta.findAllByType(Flex)[0].props).toEqual(expect.objectContaining({ bg: "red100" }))
     })
 
-    it("renders a black cta if the offer lapsed", () => {
+    it("renders the MO button instad of the cta if the offer lapsed", () => {
       const tree = getWrapper({
         Conversation: () => ({
           items: [
@@ -303,11 +335,8 @@ describe("inquiry offer enabled", () => {
           },
         }),
       })
-      const cta = tree.root.findAllByType(ReviewOfferButton)[0]
-      expect(cta).toBeDefined()
-      expect(cta.children.length).toBe(1)
-      expect(extractText(cta)).toContain("Counteroffer Expired")
-      expect(cta.findAllByType(Flex)[0].props).toEqual(expect.objectContaining({ bg: "black60" }))
+      expect(tree.root.findAllByType(OpenInquiryModalButton).length).toEqual(1)
+      expect(tree.root.findAllByType(ReviewOfferButton).length).toEqual(0)
     })
   })
 })

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/ReviewOfferButton-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/ReviewOfferButton-tests.tsx
@@ -139,7 +139,7 @@ describe("ReviewOfferButton", () => {
     })
 
     const text = extractText(wrapper.root)
-    expect(text).toContain("Offer Accepted")
+    expect(text).toContain("Payment Failed")
   })
 
   it("shows correct message and icon for received counteroffers", () => {

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/ReviewOfferButton-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/ReviewOfferButton-tests.tsx
@@ -53,7 +53,7 @@ describe("ReviewOfferButton", () => {
     expect(wrapper.root.findAllByType(ReviewOfferButton)).toHaveLength(1)
   })
 
-  it("shows correct message for rejected offers", () => {
+  it("doesn't render for rejected offers", () => {
     const wrapper = getWrapper({
       CommerceOrder: () => ({
         state: "CANCELED",
@@ -62,22 +62,22 @@ describe("ReviewOfferButton", () => {
     })
 
     const text = extractText(wrapper.root)
-    expect(text).toContain("Offer Declined")
-    expect(text).toContain("Tap to view")
-    expect(wrapper.root.findAllByType(MoneyFillIcon)).toHaveLength(1)
+    expect(text).not.toContain("Offer")
+    expect(text).not.toContain("Tap to view")
+    expect(wrapper.root.findAllByType(MoneyFillIcon)).toHaveLength(0)
   })
 
-  it("shows correct message for expired offers", () => {
+  it("doesn't render for expired offers", () => {
     const wrapper = getWrapper({
       CommerceOrder: () => ({
         state: "CANCELED",
         stateReason: "seller_lapsed",
       }),
     })
-
     const text = extractText(wrapper.root)
-    expect(text).toContain("Offer Expired")
-    expect(wrapper.root.findAllByType(MoneyFillIcon)).toHaveLength(1)
+    expect(text).not.toContain("Offer")
+    expect(text).not.toContain("Tap to view")
+    expect(wrapper.root.findAllByType(MoneyFillIcon)).toHaveLength(0)
   })
 
   it("doesn't render for pending orders", () => {

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/ReviewOfferButton-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/ReviewOfferButton-tests.tsx
@@ -130,6 +130,18 @@ describe("ReviewOfferButton", () => {
     expect(text).toContain("Offer Accepted")
   })
 
+  it("shows correct message for accepted offers where payment fails", () => {
+    const wrapper = getWrapper({
+      CommerceOrder: () => ({
+        state: "SUBMITTED",
+        lastTransactionFailed: true,
+      }),
+    })
+
+    const text = extractText(wrapper.root)
+    expect(text).toContain("Offer Accepted")
+  })
+
   it("shows correct message and icon for received counteroffers", () => {
     const wrapper = getWrapper({
       CommerceOrder: () => ({

--- a/src/lib/Scenes/Inbox/Components/Conversations/utils/returnButtonMessaging.ts
+++ b/src/lib/Scenes/Inbox/Components/Conversations/utils/returnButtonMessaging.ts
@@ -25,8 +25,7 @@ export const returnButtonMessaging = ({
     subMessage = `Expires in ${hoursTillExpiration}hr`
     showMoneyIcon = false
   } else if (state === "APPROVED" && lastOfferFromParticipant === "BUYER") {
-    message = `${offerType} Accepted - Please Confirm`
-    subMessage = `Expires in ${hoursTillExpiration}hr`
+    message = `${offerType} Accepted`
   } else if (lastTransactionFailed) {
     backgroundColor = "copper100"
     message = `Payment Failed`

--- a/src/lib/Scenes/Inbox/Components/Conversations/utils/returnButtonMessaging.ts
+++ b/src/lib/Scenes/Inbox/Components/Conversations/utils/returnButtonMessaging.ts
@@ -30,7 +30,7 @@ export const returnButtonMessaging = ({
     subMessage = `Expires in ${hoursTillExpiration}hr`
     showMoneyIcon = false
   } else if (state === "APPROVED" && lastOfferFromParticipant === "BUYER") {
-    message = `${offerType} Accepted`
+    message = `Congratulations! ${offerType} Accepted`
   }
 
   return {

--- a/src/lib/Scenes/Inbox/Components/Conversations/utils/returnButtonMessaging.ts
+++ b/src/lib/Scenes/Inbox/Components/Conversations/utils/returnButtonMessaging.ts
@@ -1,6 +1,6 @@
 interface ReturnButtonMessaging {
   state: string
-  stateReason: string | null
+  lastTransactionFailed: boolean | null
   isCounter: boolean
   lastOfferFromParticipant: string | null | undefined
   hoursTillExpiration?: string
@@ -8,7 +8,7 @@ interface ReturnButtonMessaging {
 
 export const returnButtonMessaging = ({
   state,
-  stateReason,
+  lastTransactionFailed,
   isCounter,
   lastOfferFromParticipant,
   hoursTillExpiration,
@@ -19,20 +19,21 @@ export const returnButtonMessaging = ({
   let backgroundColor = "green100"
   let showMoneyIcon = true
 
-  if (state === "CANCELED" && stateReason?.includes("seller_rejected")) {
-    message = `${offerType} Declined`
-    backgroundColor = "red100"
-  } else if (state === "CANCELED" && stateReason?.includes("_lapsed")) {
-    message = `${offerType} Expired`
-    backgroundColor = "black60"
-  } else if (state === "SUBMITTED" && lastOfferFromParticipant === "SELLER") {
+  if (state === "SUBMITTED" && lastOfferFromParticipant === "SELLER") {
     backgroundColor = "copper100"
     message = `${offerType} Received`
     subMessage = `Expires in ${hoursTillExpiration}hr`
     showMoneyIcon = false
   } else if (state === "APPROVED" && lastOfferFromParticipant === "BUYER") {
-    message = `${offerType} Accepted`
+    message = `${offerType} Accepted - Please Confirm`
+    subMessage = `Expires in ${hoursTillExpiration}hr`
+  } else if (lastTransactionFailed) {
+    backgroundColor = "copper100"
+    message = `Payment Failed`
+    subMessage = `Please update payment method`
+    showMoneyIcon = false
   }
+
   return {
     backgroundColor,
     message,

--- a/src/lib/Scenes/Inbox/Components/Conversations/utils/returnButtonMessaging.ts
+++ b/src/lib/Scenes/Inbox/Components/Conversations/utils/returnButtonMessaging.ts
@@ -19,18 +19,18 @@ export const returnButtonMessaging = ({
   let backgroundColor = "green100"
   let showMoneyIcon = true
 
-  if (state === "SUBMITTED" && lastOfferFromParticipant === "SELLER") {
+  if (lastTransactionFailed) {
+    backgroundColor = "red100"
+    message = `Payment Failed`
+    subMessage = `Please update payment method`
+    showMoneyIcon = false
+  } else if (state === "SUBMITTED" && lastOfferFromParticipant === "SELLER") {
     backgroundColor = "copper100"
     message = `${offerType} Received`
     subMessage = `Expires in ${hoursTillExpiration}hr`
     showMoneyIcon = false
   } else if (state === "APPROVED" && lastOfferFromParticipant === "BUYER") {
     message = `${offerType} Accepted`
-  } else if (lastTransactionFailed) {
-    backgroundColor = "copper100"
-    message = `Payment Failed`
-    subMessage = `Please update payment method`
-    showMoneyIcon = false
   }
 
   return {


### PR DESCRIPTION
# PURCHASE-2510

This PR contains the following: 

- hide banner and show MO button instead when offer is declined
- render failed payment CTA
- Update offer approved copy
- Make sure the button never renders when it shouldn't

* The refresh work is no longer included in this ticket


New failed payment state:
<img width="374" alt="Screen Shot 2021-03-25 at 12 51 00 PM" src="https://user-images.githubusercontent.com/5643895/112515093-58290600-8d6c-11eb-9001-df9a3d849233.png">

