### PR TITLE
fix: fix os version check in modal header

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -17,6 +17,7 @@ upcoming:
     - Fix change password screen title  - mounir
     - Enable experimental layout animation on android - mounir
     - Group order updates with messages in an associated conversation - erik, lily
+    - Fix modal header on iOS 14 in consignments flow - brian
 
 releases:
   - version: 6.8.1

--- a/src/lib/Components/ModalHeader.tsx
+++ b/src/lib/Components/ModalHeader.tsx
@@ -1,10 +1,10 @@
 import { dismissModal } from "lib/navigation/navigate"
-import { useBackButtonTopPadding } from "lib/utils/platformUtil"
+import { osMajorVersion, useBackButtonTopPadding } from "lib/utils/platformUtil"
 import { CloseIcon, color, Touchable } from "palette"
 import React from "react"
 import { Platform, View } from "react-native"
 
-const isIOS13Plus = Platform.OS === "ios" && Number(Platform.Version) >= 13
+const isIOS13Plus = Platform.OS === "ios" && osMajorVersion() >= 13
 
 export const ModalHeader: React.FC = () => {
   return (

--- a/src/lib/utils/__tests__/hardware-tests.ts
+++ b/src/lib/utils/__tests__/hardware-tests.ts
@@ -14,7 +14,7 @@ beforeEach(() => {
 })
 
 import { Dimensions, Platform } from "react-native"
-import { isPad, osMajorVersion, truncatedTextLimit } from "../hardware"
+import { isPad, truncatedTextLimit } from "../hardware"
 
 describe(isPad, () => {
   it("returns true if device is an iPad", () => {
@@ -67,19 +67,5 @@ describe(truncatedTextLimit, () => {
   it("returns 140 if device is not an iPad", () => {
     ;(Platform as any).isPad = false
     expect(truncatedTextLimit()).toBe(140)
-  })
-})
-
-describe(osMajorVersion, () => {
-  it("returns the correct version when version is a string", () => {
-    ;(Platform as any).Version = "12"
-    const version = osMajorVersion()
-    expect(version).toEqual(12)
-  })
-
-  it("returns the correct version when version is a number", () => {
-    ;(Platform as any).Version = 15
-    const version = osMajorVersion()
-    expect(version).toEqual(15)
   })
 })

--- a/src/lib/utils/__tests__/platformUtil-tests.ts
+++ b/src/lib/utils/__tests__/platformUtil-tests.ts
@@ -1,16 +1,33 @@
+jest.mock("react-native", () => ({
+  Platform: {
+    isPad: true,
+    OS: "ios",
+  },
+}))
+
+jest.mock("react-native-safe-area-context", () => ({
+  // workaround import issue in tests
+  useSafeAreaInsets: jest.fn(),
+}))
+
+beforeEach(() => {
+  Platform.OS = "ios"
+  ;(Platform as any).isPad = false
+})
+
 import { Platform } from "react-native"
 import { osMajorVersion } from "../platformUtil"
 
 describe(osMajorVersion, () => {
   it("returns the correct version when version is a string", () => {
-    ;(Platform as any).Version = "12"
+    ;(Platform as any).Version = "14.4.1"
     const version = osMajorVersion()
-    expect(version).toEqual(12)
+    expect(version).toEqual(14)
   })
 
   it("returns the correct version when version is a number", () => {
-    ;(Platform as any).Version = 15
+    ;(Platform as any).Version = 43
     const version = osMajorVersion()
-    expect(version).toEqual(15)
+    expect(version).toEqual(43)
   })
 })

--- a/src/lib/utils/__tests__/platformUtil-tests.ts
+++ b/src/lib/utils/__tests__/platformUtil-tests.ts
@@ -1,0 +1,16 @@
+import { Platform } from "react-native"
+import { osMajorVersion } from "../platformUtil"
+
+describe(osMajorVersion, () => {
+  it("returns the correct version when version is a string", () => {
+    ;(Platform as any).Version = "12"
+    const version = osMajorVersion()
+    expect(version).toEqual(12)
+  })
+
+  it("returns the correct version when version is a number", () => {
+    ;(Platform as any).Version = 15
+    const version = osMajorVersion()
+    expect(version).toEqual(15)
+  })
+})

--- a/src/lib/utils/hardware.ts
+++ b/src/lib/utils/hardware.ts
@@ -16,12 +16,4 @@ export const isPad = () => {
   return portraitWidthInches > 3.5
 }
 
-export const osMajorVersion = () => {
-  if (typeof (Platform.Version === "string")) {
-    return parseInt(Platform.Version as string, 10)
-  } else {
-    return Platform.Version as number
-  }
-}
-
 export const truncatedTextLimit = () => (isPad() ? 320 : 140)

--- a/src/lib/utils/platformUtil.ts
+++ b/src/lib/utils/platformUtil.ts
@@ -10,3 +10,11 @@ export const useBackButtonTopPadding = () => {
     return 13 + useSafeAreaInsets().top
   }
 }
+
+export const osMajorVersion = () => {
+  if (typeof (Platform.Version === "string")) {
+    return parseInt(Platform.Version as string, 10)
+  } else {
+    return Platform.Version as number
+  }
+}

--- a/src/lib/utils/requestPhotos.ts
+++ b/src/lib/utils/requestPhotos.ts
@@ -2,7 +2,7 @@ import { ActionSheetOptions } from "@expo/react-native-action-sheet"
 import { LegacyNativeModules } from "lib/NativeModules/LegacyNativeModules"
 import { Platform } from "react-native"
 import ImagePicker, { Image } from "react-native-image-crop-picker"
-import { osMajorVersion } from "./hardware"
+import { osMajorVersion } from "./platformUtil"
 
 export async function requestPhotos(): Promise<Image[]> {
   if (Platform.OS === "ios" && osMajorVersion() >= 14) {


### PR DESCRIPTION
The type of this PR is: **fix**

This PR resolves [CX-1268]

### Description

Our os version check in the consignments flow was faulty and trying to coerce a version string "14.4.1" into a number which resulted in NaN. This uses an osMajorVersion util instead that parse the version correctly, also moved this to platfromUtil file because it feels like it fits there a bit better.


### Screenshots

![consignments](https://user-images.githubusercontent.com/49686530/112532348-1b1a3f00-8d7f-11eb-86ec-f6b4b00ed359.jpeg)

### PR Checklist (tick all before merging)


- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-1268]: https://artsyproduct.atlassian.net/browse/CX-1268