### PR TITLE
fix: add camera permissions setup for android

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -10,6 +10,7 @@ upcoming:
     - Add link interception for react web views - david
     - Fix iOS modal presentation infra code - david
     - Enable sentry for android - brian, barry
+    - Add camera permissions to android manifest - brian
   user_facing:
     - Set system navigation bar color to white on modals for android - mounir
     - Fix UI for Inquiry message count on iPad - pavlos

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -141,6 +141,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 7
         versionName "1.0.0"
+        vectorDrawables.useSupportLibrary = true
 
         multiDexEnabled true
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
   package="net.artsy.app">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.front" android:required="false" />
 
     <application
       android:name=".MainApplication"


### PR DESCRIPTION
The type of this PR is: **fix**

This PR resolves [CX-1154]

### Description

Follow-up to https://github.com/artsy/eigen/pull/4535 which worked for selecting from library but missed some necessary permissions for using camera on Android.

Adds some camera permissions to the android manifest as per setup instructions here:
https://github.com/ivpusic/react-native-image-crop-picker#android


### Screenshots


https://user-images.githubusercontent.com/49686530/112543874-b9f96800-8d8c-11eb-81a1-efb8db35f350.mp4



### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-1154]: https://artsyproduct.atlassian.net/browse/CX-1154