### PR TITLE
feat: Add edition select for inquiry checkout

### DIFF
--- a/src/__generated__/MakeOfferModalQuery.graphql.ts
+++ b/src/__generated__/MakeOfferModalQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash e737622125978cf3c8147f7c7d82a27e */
+/* @relayHash a75746e6a1b8771a202701cf0522a330 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -74,6 +74,27 @@ fragment InquiryMakeOfferButton_artwork on Artwork {
 fragment MakeOfferModal_artwork on Artwork {
   ...CollapsibleArtworkDetails_artwork
   ...InquiryMakeOfferButton_artwork
+  internalID
+  isEdition
+  editionSets {
+    internalID
+    editionOf
+    isOfferableFromInquiry
+    listPrice {
+      __typename
+      ... on Money {
+        display
+      }
+      ... on PriceRange {
+        display
+      }
+    }
+    dimensions {
+      cm
+      in
+    }
+    id
+  }
 }
 */
 
@@ -96,15 +117,45 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v3 = [
+v4 = [
   {
     "alias": null,
     "args": null,
     "kind": "ScalarField",
     "name": "details",
+    "storageKey": null
+  }
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "in",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cm",
+  "storageKey": null
+},
+v7 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
     "storageKey": null
   }
 ];
@@ -181,13 +232,7 @@ return {
             ],
             "storageKey": null
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "internalID",
-            "storageKey": null
-          },
+          (v2/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -224,7 +269,7 @@ return {
                 "name": "name",
                 "storageKey": null
               },
-              (v2/*: any*/)
+              (v3/*: any*/)
             ],
             "storageKey": null
           },
@@ -263,7 +308,7 @@ return {
             "kind": "LinkedField",
             "name": "conditionDescription",
             "plural": false,
-            "selections": (v3/*: any*/),
+            "selections": (v4/*: any*/),
             "storageKey": null
           },
           {
@@ -273,7 +318,7 @@ return {
             "kind": "LinkedField",
             "name": "certificateOfAuthenticity",
             "plural": false,
-            "selections": (v3/*: any*/),
+            "selections": (v4/*: any*/),
             "storageKey": null
           },
           {
@@ -283,7 +328,7 @@ return {
             "kind": "LinkedField",
             "name": "framed",
             "plural": false,
-            "selections": (v3/*: any*/),
+            "selections": (v4/*: any*/),
             "storageKey": null
           },
           {
@@ -294,20 +339,8 @@ return {
             "name": "dimensions",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "in",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "cm",
-                "storageKey": null
-              }
+              (v5/*: any*/),
+              (v6/*: any*/)
             ],
             "storageKey": null
           },
@@ -318,7 +351,7 @@ return {
             "kind": "LinkedField",
             "name": "signatureInfo",
             "plural": false,
-            "selections": (v3/*: any*/),
+            "selections": (v4/*: any*/),
             "storageKey": null
           },
           {
@@ -328,14 +361,91 @@ return {
             "name": "artistNames",
             "storageKey": null
           },
-          (v2/*: any*/)
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isEdition",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "EditionSet",
+            "kind": "LinkedField",
+            "name": "editionSets",
+            "plural": true,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "editionOf",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isOfferableFromInquiry",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "listPrice",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": (v7/*: any*/),
+                    "type": "Money",
+                    "abstractKey": null
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": (v7/*: any*/),
+                    "type": "PriceRange",
+                    "abstractKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "dimensions",
+                "kind": "LinkedField",
+                "name": "dimensions",
+                "plural": false,
+                "selections": [
+                  (v6/*: any*/),
+                  (v5/*: any*/)
+                ],
+                "storageKey": null
+              },
+              (v3/*: any*/)
+            ],
+            "storageKey": null
+          },
+          (v3/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "e737622125978cf3c8147f7c7d82a27e",
+    "id": "a75746e6a1b8771a202701cf0522a330",
     "metadata": {},
     "name": "MakeOfferModalQuery",
     "operationKind": "query",

--- a/src/__generated__/MakeOfferModalTestsQuery.graphql.ts
+++ b/src/__generated__/MakeOfferModalTestsQuery.graphql.ts
@@ -1,0 +1,556 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash b5eba9e53aa06c9d23d44db5a24b18ce */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type MakeOfferModalTestsQueryVariables = {};
+export type MakeOfferModalTestsQueryResponse = {
+    readonly artwork: {
+        readonly " $fragmentRefs": FragmentRefs<"MakeOfferModal_artwork">;
+    } | null;
+};
+export type MakeOfferModalTestsQuery = {
+    readonly response: MakeOfferModalTestsQueryResponse;
+    readonly variables: MakeOfferModalTestsQueryVariables;
+};
+
+
+
+/*
+query MakeOfferModalTestsQuery {
+  artwork(id: "pumpkins") {
+    ...MakeOfferModal_artwork
+    id
+  }
+}
+
+fragment CollapsibleArtworkDetails_artwork on Artwork {
+  image {
+    url
+    width
+    height
+  }
+  internalID
+  title
+  date
+  saleMessage
+  attributionClass {
+    name
+    id
+  }
+  category
+  manufacturer
+  publisher
+  medium
+  conditionDescription {
+    details
+  }
+  certificateOfAuthenticity {
+    details
+  }
+  framed {
+    details
+  }
+  dimensions {
+    in
+    cm
+  }
+  signatureInfo {
+    details
+  }
+  artistNames
+}
+
+fragment InquiryMakeOfferButton_artwork on Artwork {
+  internalID
+}
+
+fragment MakeOfferModal_artwork on Artwork {
+  ...CollapsibleArtworkDetails_artwork
+  ...InquiryMakeOfferButton_artwork
+  internalID
+  isEdition
+  editionSets {
+    internalID
+    editionOf
+    isOfferableFromInquiry
+    listPrice {
+      __typename
+      ... on Money {
+        display
+      }
+      ... on PriceRange {
+        display
+      }
+    }
+    dimensions {
+      cm
+      in
+    }
+    id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "pumpkins"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "details",
+    "storageKey": null
+  }
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "in",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cm",
+  "storageKey": null
+},
+v6 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+],
+v7 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v8 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v9 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "ArtworkInfoRow"
+},
+v10 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "dimensions"
+},
+v11 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Boolean"
+},
+v12 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "MakeOfferModalTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "MakeOfferModal_artwork"
+          }
+        ],
+        "storageKey": "artwork(id:\"pumpkins\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "MakeOfferModalTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "url",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "width",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "height",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "title",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "date",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "saleMessage",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AttributionClass",
+            "kind": "LinkedField",
+            "name": "attributionClass",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "category",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "manufacturer",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "publisher",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "medium",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "conditionDescription",
+            "plural": false,
+            "selections": (v3/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "certificateOfAuthenticity",
+            "plural": false,
+            "selections": (v3/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "framed",
+            "plural": false,
+            "selections": (v3/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "dimensions",
+            "kind": "LinkedField",
+            "name": "dimensions",
+            "plural": false,
+            "selections": [
+              (v4/*: any*/),
+              (v5/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkInfoRow",
+            "kind": "LinkedField",
+            "name": "signatureInfo",
+            "plural": false,
+            "selections": (v3/*: any*/),
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "artistNames",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isEdition",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "EditionSet",
+            "kind": "LinkedField",
+            "name": "editionSets",
+            "plural": true,
+            "selections": [
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "editionOf",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isOfferableFromInquiry",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "listPrice",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": (v6/*: any*/),
+                    "type": "Money",
+                    "abstractKey": null
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": (v6/*: any*/),
+                    "type": "PriceRange",
+                    "abstractKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "dimensions",
+                "kind": "LinkedField",
+                "name": "dimensions",
+                "plural": false,
+                "selections": [
+                  (v5/*: any*/),
+                  (v4/*: any*/)
+                ],
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": "artwork(id:\"pumpkins\")"
+      }
+    ]
+  },
+  "params": {
+    "id": "b5eba9e53aa06c9d23d44db5a24b18ce",
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "artwork": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "artwork.artistNames": (v7/*: any*/),
+        "artwork.attributionClass": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "AttributionClass"
+        },
+        "artwork.attributionClass.id": (v8/*: any*/),
+        "artwork.attributionClass.name": (v7/*: any*/),
+        "artwork.category": (v7/*: any*/),
+        "artwork.certificateOfAuthenticity": (v9/*: any*/),
+        "artwork.certificateOfAuthenticity.details": (v7/*: any*/),
+        "artwork.conditionDescription": (v9/*: any*/),
+        "artwork.conditionDescription.details": (v7/*: any*/),
+        "artwork.date": (v7/*: any*/),
+        "artwork.dimensions": (v10/*: any*/),
+        "artwork.dimensions.cm": (v7/*: any*/),
+        "artwork.dimensions.in": (v7/*: any*/),
+        "artwork.editionSets": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "EditionSet"
+        },
+        "artwork.editionSets.dimensions": (v10/*: any*/),
+        "artwork.editionSets.dimensions.cm": (v7/*: any*/),
+        "artwork.editionSets.dimensions.in": (v7/*: any*/),
+        "artwork.editionSets.editionOf": (v7/*: any*/),
+        "artwork.editionSets.id": (v8/*: any*/),
+        "artwork.editionSets.internalID": (v8/*: any*/),
+        "artwork.editionSets.isOfferableFromInquiry": (v11/*: any*/),
+        "artwork.editionSets.listPrice": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ListPrice"
+        },
+        "artwork.editionSets.listPrice.__typename": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "String"
+        },
+        "artwork.editionSets.listPrice.display": (v7/*: any*/),
+        "artwork.framed": (v9/*: any*/),
+        "artwork.framed.details": (v7/*: any*/),
+        "artwork.id": (v8/*: any*/),
+        "artwork.image": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Image"
+        },
+        "artwork.image.height": (v12/*: any*/),
+        "artwork.image.url": (v7/*: any*/),
+        "artwork.image.width": (v12/*: any*/),
+        "artwork.internalID": (v8/*: any*/),
+        "artwork.isEdition": (v11/*: any*/),
+        "artwork.manufacturer": (v7/*: any*/),
+        "artwork.medium": (v7/*: any*/),
+        "artwork.publisher": (v7/*: any*/),
+        "artwork.saleMessage": (v7/*: any*/),
+        "artwork.signatureInfo": (v9/*: any*/),
+        "artwork.signatureInfo.details": (v7/*: any*/),
+        "artwork.title": (v7/*: any*/)
+      }
+    },
+    "name": "MakeOfferModalTestsQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = 'efadc2d19d925e83e12e60ad8a4333c9';
+export default node;

--- a/src/__generated__/MakeOfferModal_artwork.graphql.ts
+++ b/src/__generated__/MakeOfferModal_artwork.graphql.ts
@@ -5,6 +5,20 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type MakeOfferModal_artwork = {
+    readonly internalID: string;
+    readonly isEdition: boolean | null;
+    readonly editionSets: ReadonlyArray<{
+        readonly internalID: string;
+        readonly editionOf: string | null;
+        readonly isOfferableFromInquiry: boolean | null;
+        readonly listPrice: {
+            readonly display?: string | null;
+        } | null;
+        readonly dimensions: {
+            readonly cm: string | null;
+            readonly in: string | null;
+        } | null;
+    } | null> | null;
     readonly " $fragmentRefs": FragmentRefs<"CollapsibleArtworkDetails_artwork" | "InquiryMakeOfferButton_artwork">;
     readonly " $refType": "MakeOfferModal_artwork";
 };
@@ -16,12 +30,111 @@ export type MakeOfferModal_artwork$key = {
 
 
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v1 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+];
+return {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
   "name": "MakeOfferModal_artwork",
   "selections": [
+    (v0/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "isEdition",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "EditionSet",
+      "kind": "LinkedField",
+      "name": "editionSets",
+      "plural": true,
+      "selections": [
+        (v0/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "editionOf",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "isOfferableFromInquiry",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": null,
+          "kind": "LinkedField",
+          "name": "listPrice",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "InlineFragment",
+              "selections": (v1/*: any*/),
+              "type": "Money",
+              "abstractKey": null
+            },
+            {
+              "kind": "InlineFragment",
+              "selections": (v1/*: any*/),
+              "type": "PriceRange",
+              "abstractKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "dimensions",
+          "kind": "LinkedField",
+          "name": "dimensions",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cm",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "in",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
     {
       "args": null,
       "kind": "FragmentSpread",
@@ -36,5 +149,6 @@ const node: ReaderFragment = {
   "type": "Artwork",
   "abstractKey": null
 };
-(node as any).hash = 'd54124f26606c1349c3454a124991dbc';
+})();
+(node as any).hash = '043f135e7486062db6b928117562e2ec';
 export default node;

--- a/src/lib/Scenes/Inbox/Components/Conversations/EditionSelectBox.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/EditionSelectBox.tsx
@@ -67,7 +67,7 @@ export const EditionSelectBox: React.FC<Props> = ({ edition, selected, onPress }
           <Text color={available ? "black60" : "black30"}>{edition.editionOf}</Text>
         </Flex>
         {available ? (
-          <Text>{edition.listPrice?.display}</Text>
+          <Text>{edition.listPrice?.display || "Contact for price"}</Text>
         ) : (
           <Flex flexDirection="row" alignItems="baseline">
             <UnavailableIndicator />

--- a/src/lib/Scenes/Inbox/Components/Conversations/EditionSelectBox.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/EditionSelectBox.tsx
@@ -49,11 +49,7 @@ interface Props {
 }
 
 export const EditionSelectBox: React.FC<Props> = ({ edition, selected, onPress }) => {
-  const [available, setAvailable] = useState<boolean>(false)
-
-  useEffect(() => {
-    setAvailable(!!edition.listPrice?.display && !!edition.isOfferableFromInquiry)
-  }, [edition])
+  const available = !!edition.isOfferableFromInquiry
 
   return (
     <Touchable

--- a/src/lib/Scenes/Inbox/Components/Conversations/EditionSelectBox.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/EditionSelectBox.tsx
@@ -1,5 +1,5 @@
 import { BorderBox, color, Flex, Text, Touchable } from "palette"
-import React from "react"
+import React, { useEffect, useState } from "react"
 import { View } from "react-native"
 import styled from "styled-components/native"
 
@@ -49,7 +49,11 @@ interface Props {
 }
 
 export const EditionSelectBox: React.FC<Props> = ({ edition, selected, onPress }) => {
-  const available = !!edition.listPrice?.display && !!edition.isOfferableFromInquiry
+  const [available, setAvailable] = useState<boolean>(false)
+
+  useEffect(() => {
+    setAvailable(!!edition.listPrice?.display && !!edition.isOfferableFromInquiry)
+  }, [edition])
 
   return (
     <Touchable

--- a/src/lib/Scenes/Inbox/Components/Conversations/EditionSelectBox.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/EditionSelectBox.tsx
@@ -1,0 +1,80 @@
+import { BorderBox, color, Flex, Text, Touchable } from "palette"
+import React from "react"
+import { View } from "react-native"
+import styled from "styled-components/native"
+
+import { MakeOfferModal_artwork } from "__generated__/MakeOfferModal_artwork.graphql"
+
+const UnavailableIndicator = styled(View)`
+  height: 8px;
+  width: 8px;
+  border-radius: 4px;
+  background-color: ${color("red100")};
+  margin-right: 6px;
+`
+
+export const RadioButton: React.FC<{ selected: boolean }> = (props) => {
+  const { selected } = props
+  return (
+    <View
+      style={{
+        height: 20,
+        width: 20,
+        borderRadius: 10,
+        borderWidth: 2,
+        borderColor: selected ? color("black100") : color("black10"),
+        backgroundColor: selected ? color("black100") : color("white100"),
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {selected ? (
+        <View
+          style={{
+            height: 10,
+            width: 10,
+            borderRadius: 5,
+            backgroundColor: color("white100"),
+          }}
+        />
+      ) : null}
+    </View>
+  )
+}
+
+interface Props {
+  edition: NonNullable<NonNullable<MakeOfferModal_artwork["editionSets"]>[number]>
+  selected: boolean
+  onPress: (editionSetId: string, isAvailable: boolean) => void
+}
+
+export const EditionSelectBox: React.FC<Props> = ({ edition, selected, onPress }) => {
+  const available = !!edition.listPrice?.display && !!edition.isOfferableFromInquiry
+
+  return (
+    <Touchable
+      onPress={() => {
+        onPress(edition.internalID, available)
+      }}
+    >
+      <BorderBox p={2} my={0.5} flexDirection="row">
+        <RadioButton selected={selected} />
+        <Flex mx={1} flexGrow={1}>
+          <Text color={available ? "black100" : "black30"}>{edition.dimensions?.in}</Text>
+          <Text color={available ? "black60" : "black30"} variant="caption">
+            {edition.dimensions?.cm}
+          </Text>
+          <Text color={available ? "black60" : "black30"}>{edition.editionOf}</Text>
+        </Flex>
+        {available ? (
+          <Text>{edition.listPrice?.display}</Text>
+        ) : (
+          <Flex flexDirection="row" alignItems="baseline">
+            <UnavailableIndicator />
+            <Text>Unavailable</Text>
+          </Flex>
+        )}
+      </BorderBox>
+    </Touchable>
+  )
+}

--- a/src/lib/Scenes/Inbox/Components/Conversations/EditionSelectBox.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/EditionSelectBox.tsx
@@ -1,5 +1,5 @@
 import { BorderBox, color, Flex, Text, Touchable } from "palette"
-import React, { useEffect, useState } from "react"
+import React from "react"
 import { View } from "react-native"
 import styled from "styled-components/native"
 

--- a/src/lib/Scenes/Inbox/Components/Conversations/InquiryMakeOfferButton.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/InquiryMakeOfferButton.tsx
@@ -13,6 +13,7 @@ export interface InquiryMakeOfferButtonProps {
   editionSetID: string | null
   variant?: ButtonVariant
   buttonText?: string
+  disabled?: boolean
   conversationID: string
 }
 
@@ -118,6 +119,7 @@ export class InquiryMakeOfferButton extends React.Component<InquiryMakeOfferButt
         onPress={() => this.handleCreateInquiryOfferOrder()}
         loading={isCommittingCreateOfferOrderMutation}
         size="large"
+        disabled={this.props.disabled}
         block
         width={100}
         variant={this.props.variant}

--- a/src/lib/Scenes/Inbox/Components/Conversations/MakeOfferModal.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/MakeOfferModal.tsx
@@ -77,6 +77,7 @@ export const MakeOfferModal: React.FC<MakeOfferModalProps> = ({ ...props }) => {
             variant="primaryBlack"
             buttonText="Confirm"
             artwork={artwork}
+            disabled={!!artwork.isEdition && !selectedEdition}
             editionSetID={selectedEdition ? selectedEdition : null}
             conversationID={conversationID}
           />

--- a/src/lib/Scenes/Inbox/Components/Conversations/MakeOfferModal.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/MakeOfferModal.tsx
@@ -8,10 +8,12 @@ import { CollapsibleArtworkDetailsFragmentContainer as CollapsibleArtworkDetails
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import { ProvideScreenTrackingWithCohesionSchema } from "lib/utils/track"
 import { BorderBox, Button, Flex, Text } from "palette"
-import React from "react"
+import React, { useState } from "react"
 import { View } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import { InquiryMakeOfferButtonFragmentContainer as InquiryMakeOfferButton } from "./InquiryMakeOfferButton"
+
+import { EditionSelectBox } from "./EditionSelectBox"
 
 interface MakeOfferModalProps {
   artwork: MakeOfferModal_artwork
@@ -20,6 +22,13 @@ interface MakeOfferModalProps {
 
 export const MakeOfferModal: React.FC<MakeOfferModalProps> = ({ ...props }) => {
   const { artwork, conversationID } = props
+  const [selectedEdition, setSelectedEdition] = useState<string>()
+
+  const selectEdition = (editionSetID: string, isAvailable?: boolean) => {
+    if (isAvailable) {
+      setSelectedEdition(editionSetID)
+    }
+  }
 
   return (
     <ProvideScreenTrackingWithCohesionSchema
@@ -48,11 +57,27 @@ export const MakeOfferModal: React.FC<MakeOfferModalProps> = ({ ...props }) => {
           <BorderBox p={0} my={2}>
             <CollapsibleArtworkDetails hasSeparator={false} artwork={artwork} />
           </BorderBox>
+          {!!artwork.isEdition && artwork.editionSets!.length > 1 && (
+            <Flex mb={1}>
+              <Text color="black100" mb={1}>
+                {" "}
+                Which edition are you interested in?
+              </Text>
+              {artwork.editionSets?.map((edition) => (
+                <EditionSelectBox
+                  edition={edition!}
+                  selected={edition!.internalID === selectedEdition}
+                  onPress={selectEdition}
+                  key={`edition-set-${edition?.internalID}`}
+                />
+              ))}
+            </Flex>
+          )}
           <InquiryMakeOfferButton
             variant="primaryBlack"
             buttonText="Confirm"
             artwork={artwork}
-            editionSetID={null}
+            editionSetID={selectedEdition ? selectedEdition : null}
             conversationID={conversationID}
           />
           <Button
@@ -78,6 +103,25 @@ export const MakeOfferModalFragmentContainer = createFragmentContainer(MakeOffer
     fragment MakeOfferModal_artwork on Artwork {
       ...CollapsibleArtworkDetails_artwork
       ...InquiryMakeOfferButton_artwork
+      internalID
+      isEdition
+      editionSets {
+        internalID
+        editionOf
+        isOfferableFromInquiry
+        listPrice {
+          ... on Money {
+            display
+          }
+          ... on PriceRange {
+            display
+          }
+        }
+        dimensions {
+          cm
+          in
+        }
+      }
     }
   `,
 })

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/MakeOfferModal-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/MakeOfferModal-tests.tsx
@@ -1,0 +1,171 @@
+import {
+  MakeOfferModalTestsQuery,
+  MakeOfferModalTestsQueryResponse,
+} from "__generated__/MakeOfferModalTestsQuery.graphql"
+import { CollapsibleArtworkDetails } from "lib/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails"
+import { extractText } from "lib/tests/extractText"
+import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import { act, ReactTestInstance } from "react-test-renderer"
+import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { EditionSelectBox } from "../EditionSelectBox"
+import { InquiryMakeOfferButton } from "../InquiryMakeOfferButton"
+import { MakeOfferModalFragmentContainer } from "../MakeOfferModal"
+
+jest.unmock("react-relay")
+
+let env: ReturnType<typeof createMockEnvironment>
+
+const FakeApp = (props: MakeOfferModalTestsQueryResponse) => {
+  return <MakeOfferModalFragmentContainer artwork={props!.artwork!} conversationID={"test-conversation-id"} />
+}
+
+interface RenderComponentProps {
+  props: MakeOfferModalTestsQueryResponse | null
+  error: Error | null
+}
+
+const renderComponent = ({ props, error }: RenderComponentProps) => {
+  if (props?.artwork) {
+    return <FakeApp {...props} />
+  } else if (error) {
+    console.log(error)
+  }
+}
+
+interface TestRenderProps {
+  renderer: (props: RenderComponentProps) => JSX.Element | undefined
+}
+
+const TestRenderer = ({ renderer }: TestRenderProps) => {
+  return (
+    <QueryRenderer<MakeOfferModalTestsQuery>
+      environment={env}
+      query={graphql`
+        query MakeOfferModalTestsQuery @relay_test_operation {
+          artwork(id: "pumpkins") {
+            ...MakeOfferModal_artwork
+          }
+        }
+      `}
+      variables={{}}
+      render={renderer}
+    />
+  )
+}
+
+const mockResolver = {
+  Artwork: () => ({
+    title: "test-artwork",
+  }),
+}
+
+const mockEditionsResolver = {
+  Artwork: () => ({
+    title: "test-editions-artwork",
+    isEdition: true,
+    editionSets: [
+      {
+        internalID: "edition-1",
+        isOfferableFromInquiry: true,
+        listPrice: {
+          display: "€100",
+        },
+      },
+      {
+        internalID: "edition-2",
+        isOfferableFromInquiry: false,
+        listPrice: {
+          display: "€200",
+        },
+      },
+      {
+        internalID: "edition-3",
+        isOfferableFromInquiry: true,
+        listPrice: {
+          display: "€300",
+        },
+      },
+    ],
+  }),
+}
+
+const getWrapper = (mockResolvers = mockResolver, renderer = renderComponent) => {
+  const tree = renderWithWrappers(<TestRenderer renderer={renderer} />)
+  act(() => {
+    env.mock.resolveMostRecentOperation((operation) => {
+      return MockPayloadGenerator.generate(operation, mockResolvers)
+    })
+  })
+  return tree
+}
+
+beforeEach(() => {
+  env = createMockEnvironment()
+})
+
+describe("<MakeOfferModal />", () => {
+  it("renders the modal", () => {
+    const tree = getWrapper()
+    expect(extractText(tree.root)).toContain("Confirm Artwork")
+  })
+  it("displays the correct artwork", () => {
+    const wrapper = getWrapper()
+    const details = wrapper.root.findByType(CollapsibleArtworkDetails)
+    expect(details.props.artwork.title).toBe("test-artwork")
+  })
+  it("doesn't display edition checkboxes and can be confirmed", () => {
+    const wrapper = getWrapper()
+    const confirmBtn = wrapper.root.findByType(InquiryMakeOfferButton)
+    const editions = wrapper.root.findAllByType(EditionSelectBox)
+    expect(editions).toHaveLength(0)
+    expect(confirmBtn.props.disabled).not.toBeTruthy()
+  })
+  // EDITIONS
+  describe("when artwork is edition set", () => {
+    const tapOn = (edition: ReactTestInstance) => {
+      edition.props.onPress(edition.props.edition.internalID, edition.props.edition.isOfferableFromInquiry)
+    }
+    it("shows edition selection when it's an edition", () => {
+      const wrapper = getWrapper(mockEditionsResolver)
+      const editions = wrapper.root.findAllByType(EditionSelectBox)
+      expect(editions).toHaveLength(3)
+    })
+    it("disables the confirm button until an edition is selected", () => {
+      const wrapper = getWrapper(mockEditionsResolver)
+      const confirmBtn = wrapper.root.findByType(InquiryMakeOfferButton)
+      expect(confirmBtn.props.disabled).toBeTruthy()
+    })
+    it("shows unavailable editions as unavailable and doesn't allow selection", async () => {
+      const wrapper = getWrapper(mockEditionsResolver)
+      const selection = wrapper.root
+        .findAllByType(EditionSelectBox)
+        .find((edtn) => edtn.props.edition.internalID === "edition-2")!
+      const text = extractText(selection)
+      expect(text).toContain("Unavailable")
+      expect(text).not.toContain("€200")
+      tapOn(selection)
+      await flushPromiseQueue()
+      const confirmBtn = wrapper.root.findByType(InquiryMakeOfferButton)
+      expect(confirmBtn.props.disabled).toBeTruthy()
+      expect(confirmBtn.props.editionSetID).toBeNull()
+    })
+    it("allows the user to toggle between available editions and confirm", async () => {
+      const wrapper = getWrapper(mockEditionsResolver)
+      const editions = wrapper.root.findAllByType(EditionSelectBox)
+      const selection = editions.find((edtn) => edtn.props.edition.internalID === "edition-1")!
+      const selectionAlt = editions.find((edtn) => edtn.props.edition.internalID === "edition-3")!
+      tapOn(selection)
+      const confirmBtn = wrapper.root.findByType(InquiryMakeOfferButton)
+      await flushPromiseQueue()
+      expect(confirmBtn.props.disabled).not.toBeTruthy()
+      expect(confirmBtn.props.editionSetID).toBe("edition-1")
+      tapOn(selectionAlt)
+      await flushPromiseQueue()
+      expect(confirmBtn.props.disabled).not.toBeTruthy()
+      expect(confirmBtn.props.editionSetID).toBe("edition-3")
+    })
+  })
+})


### PR DESCRIPTION
The type of this PR is: Feature

This PR resolves [PURCHASE-2373]

### Description
User is now able to confirm edition set during inquiry checkout
![edition](https://user-images.githubusercontent.com/7117670/112907060-75076580-90ed-11eb-8b44-512f28181c68.gif)

@artsy/purchase-devs 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[PURCHASE-2373]: https://artsyproduct.atlassian.net/browse/PURCHASE-2373