### PR TITLE
fix: use artistAuctionResults instead of artistInsights for contextScreenOwnerType

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -11,6 +11,7 @@ upcoming:
     - Fix iOS modal presentation infra code - david
     - Enable sentry for android - brian, barry
     - Add camera permissions to android manifest - brian
+    - Use artistAuctionResults instead of artistInsights for artist insights - mounir
   user_facing:
     - Set system navigation bar color to white on modals for android - mounir
     - Fix UI for Inquiry message count on iPad - pavlos

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "cheerio": "0.22.0"
   },
   "dependencies": {
-    "@artsy/cohesion": "^1.73.0",
+    "@artsy/cohesion": "^1.80.1",
     "@artsy/palette-tokens": "^1.3.1",
     "@expo/react-native-action-sheet": "^3.8.0",
     "@ptomasroos/react-native-multi-slider": "^2.2.2",

--- a/src/lib/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
@@ -280,7 +280,7 @@ export const tracks = {
 
   tapAuctionResultsInfo: (): TappedInfoBubbleArgs => ({
     contextModule: ContextModule.auctionResults,
-    contextScreenOwnerType: OwnerType.artistInsights,
+    contextScreenOwnerType: OwnerType.artistAuctionResults,
     subject: "auctionResults",
   }),
 }

--- a/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/MarketStats.tsx
@@ -241,7 +241,7 @@ const LoadingSkeleton = () => {
 export const tracks = {
   tapMarketStatsInfo: (): TappedInfoBubbleArgs => ({
     contextModule: ContextModule.auctionResults,
-    contextScreenOwnerType: OwnerType.artistInsights,
+    contextScreenOwnerType: OwnerType.artistAuctionResults,
     subject: "artistMarketStatistics",
   }),
 }

--- a/src/lib/Components/Artist/ArtistInsights/__tests__/MarketStats-tests.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/__tests__/MarketStats-tests.tsx
@@ -104,7 +104,7 @@ describe("MarketStats", () => {
   })
 
   describe("tracking", () => {
-    it("tracks the correct event when info bubble is tapped", () => {
+    it.only("tracks the correct event when info bubble is tapped", () => {
       const tree = renderWithWrappers(<TestWrapper />).root
       mockEnvironmentPayload(environment)
 
@@ -114,7 +114,9 @@ describe("MarketStats", () => {
       expect(trackEvent).toHaveBeenCalledWith({
         action: "tappedInfoBubble",
         context_module: "auctionResults",
-        context_screen_owner_type: "artistInsights",
+        context_screen_owner_type: "artistAuctionResults",
+        context_screen_owner_id: undefined,
+        context_screen_owner_slug: undefined,
         subject: "artistMarketStatistics",
       })
     })

--- a/src/lib/Scenes/AuctionResult/AuctionResult.tsx
+++ b/src/lib/Scenes/AuctionResult/AuctionResult.tsx
@@ -355,7 +355,7 @@ export const tracks = {
 
   tapMarketStatsInfo: (): TappedInfoBubbleArgs => ({
     contextModule: ContextModule.auctionResult,
-    contextScreenOwnerType: OwnerType.artistInsights,
+    contextScreenOwnerType: OwnerType.artistAuctionResults,
     subject: "auctionResultSalePrice",
   }),
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/auto-config/-/auto-config-1.0.2.tgz#b79f6fd0d0bda0c5e0764ced55e014cf58174d6f"
   integrity sha512-mJyuKNDMYZcgc2oLIkvmpVIr1RexklV71JmU+to5qs3Y9pv5dsj4WHl8+wf9g74EQNOyhWH2SYMGBm1JoPYh/Q==
 
-"@artsy/cohesion@^1.73.0":
-  version "1.77.0"
-  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-1.77.0.tgz#e70ac743cad8b59a52620d4b3972d111c3715a7c"
-  integrity sha512-RNKZ6piJRRdWbRnvgEriyhZxx02HDjBYziG2oVIVlcLEd49e4sqoME2yOeJF+LVwv7SNvAFcaykJgMq1bwSaYg==
+"@artsy/cohesion@^1.80.1":
+  version "1.80.1"
+  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-1.80.1.tgz#f49e666b33fdaade9f648f16ef43702dcbdb2d93"
+  integrity sha512-Q+1yfPeU6ax0HGo9pqDr0fxTbWO2Awz/o/COsLS7gUGk60Fgthq5z1qMU7YsOfwN22wikAtmzsNKryatLJ3i5g==
 
 "@artsy/palette-tokens@^1.3.1":
   version "1.3.1"


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->


### Description
- Use `artistAuctionResults` instead of `artistInsights` for artist insights `contextScreenOwnerType`

Related cohesion changes PR: https://github.com/artsy/cohesion/pull/175

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434