### PR TITLE
fix: use 'show more' button on all artwork grids on android

### DIFF
--- a/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -7,7 +7,7 @@
 // 4. Update height of grid to encompass all items.
 
 import React from "react"
-import { Dimensions, LayoutChangeEvent, ScrollView, StyleSheet, View, ViewStyle } from "react-native"
+import { Dimensions, LayoutChangeEvent, Platform, ScrollView, StyleSheet, View, ViewStyle } from "react-native"
 import { createFragmentContainer, RelayPaginationProp } from "react-relay"
 
 import Artwork from "./ArtworkGridItem"
@@ -266,7 +266,8 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
 
   render() {
     const artworks = this.state.sectionDimension ? this.renderSections() : null
-    const { shouldAddPadding, autoFetch, hasMore, stickyHeaderIndices } = this.props
+    const { shouldAddPadding, hasMore, stickyHeaderIndices } = this.props
+    const autoFetch = Platform.OS === "android" ? false : this.props.autoFetch
     const boxPadding = shouldAddPadding ? 2 : 0
 
     return (


### PR DESCRIPTION
This PR resolves [CX-1189]

### Description

We have a custom UIScrollView extension on iOS that forwards scroll events to nested scroll views. This allows the `InifiniteScrollArtworksGrid` component to load more elements even though the user never actually causes the inner scroll view to scroll (i.e. the `contentInset` on the  `InifiniteScrollArtworksGrid`'s `ScrollView` component will always have y-offset 0, while the parent scroll view will be the one actually scrolling. And the parent scroll view is usually the main scroll view for whichever screen you're looking at)

Unfortunately we don't, and probably can't, and definitely shouldn't, have the same thing on Android. 

The 'right' solution IMO would be to refactor the infinite scroll artworks thing into a hook which returns elements that a flat list can render. However, that is a serious amount of design and refactoring work.

The 'dirty' solution would be to find some way to forward the events in react-land. Maybe we could add an imperative `loadMore` handle and make consumers add it to their parent scroll container's `onEndReached` callback. Again this is a fair amount of refactoring work, but less that the solution above.

The 'probably fine for an MVP' solution is to just make all artwork grids on android show the 'load more' button instead of responding to scroll events. That's what this PR does.

https://user-images.githubusercontent.com/1242537/112977495-0ad2dd00-914e-11eb-87de-5d045f2daac7.mp4

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-1189]: https://artsyproduct.atlassian.net/browse/CX-1189