### PR TITLE
fix: conditional installation of sentry-cli to avoid non-zero exit #trivial

### DIFF
--- a/scripts/setup-distribute-linux
+++ b/scripts/setup-distribute-linux
@@ -7,7 +7,14 @@ set -euxo pipefail
 # brew update
 # brew tap getsentry/tools
 # brew install sentry-cli
-curl -sL https://sentry.io/get-cli/ | bash
+if ! which sentry-cli;
+then
+  echo "installing sentry-cli"
+  curl -sL https://sentry.io/get-cli/ | bash
+else
+  echo "sentry-cli already installed"
+fi
+
 bundle exec fastlane update_plugins
 
 if ! which aws;


### PR DESCRIPTION
The type of this PR is: **fix**

### Description

Sentry cli installation fails with exit code 1 if already present, this checks first if the command is present and doesn't install if it is. 

