### PR TITLE
Keyboard fixes

### DIFF
--- a/src/lib/Scenes/Inbox/Components/Conversations/Composer.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/Composer.tsx
@@ -137,10 +137,7 @@ export default class Composer extends React.Component<Props, State> {
                   placeholderTextColor={colors["gray-semibold"]}
                   keyboardAppearance={"dark"}
                   onEndEditing={() => this.setState({ active: false })}
-                  onFocus={() => {
-                    console.warn("ON FOCUS", this.state.active)
-                    this.setState({ active: this.input.isFocused() })
-                  }}
+                  onFocus={() => this.setState({ active: this.input.isFocused() })}
                   onChangeText={(text) => this.setState({ text })}
                   ref={(input) => (this.input = input)}
                   style={inputStyles}

--- a/src/lib/Scenes/Inbox/Components/Conversations/Composer.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/Composer.tsx
@@ -43,6 +43,7 @@ interface Props {
 interface State {
   active: boolean
   text: string | null
+  hideCTA: boolean
 }
 
 const track: Track<Props, State, Schema.Entity> = _track as any
@@ -59,6 +60,7 @@ export default class Composer extends React.Component<Props, State> {
     this.state = {
       active: false,
       text: null,
+      hideCTA: false,
     }
   }
 
@@ -128,20 +130,22 @@ export default class Composer extends React.Component<Props, State> {
           <StyledKeyboardAvoidingView behavior="padding" keyboardVerticalOffset={safeAreaInsets.top}>
             {this.props.children}
             <Flex flexDirection="column">
-              {CTA}
+              {!this.state.active && CTA}
               <Container active={this.state.active}>
                 <TextInput
                   placeholder={"Type your message"}
                   placeholderTextColor={colors["gray-semibold"]}
                   keyboardAppearance={"dark"}
                   onEndEditing={() => this.setState({ active: false })}
-                  onFocus={() => this.setState({ active: this.input.isFocused() })}
+                  onFocus={() => {
+                    console.warn("ON FOCUS", this.state.active)
+                    this.setState({ active: this.input.isFocused() })
+                  }}
                   onChangeText={(text) => this.setState({ text })}
                   ref={(input) => (this.input = input)}
                   style={inputStyles}
                   multiline={true}
                   value={this.state.text || undefined}
-                  autoFocus={typeof jest === "undefined" /* TODO: https://github.com/facebook/jest/issues/3707 */}
                 />
                 <TouchableWithoutFeedback disabled={disableSendButton} onPress={this.submitText.bind(this)}>
                   <Button ml={1} disabled={!!disableSendButton}>

--- a/src/lib/Scenes/Inbox/Components/Conversations/Composer.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/Composer.tsx
@@ -43,7 +43,6 @@ interface Props {
 interface State {
   active: boolean
   text: string | null
-  hideCTA: boolean
 }
 
 const track: Track<Props, State, Schema.Entity> = _track as any
@@ -60,7 +59,6 @@ export default class Composer extends React.Component<Props, State> {
     this.state = {
       active: false,
       text: null,
-      hideCTA: false,
     }
   }
 

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/Composer-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/Composer-tests.tsx
@@ -134,7 +134,7 @@ describe("inquiry offer enabled", () => {
     expect(tree.root.findAllByType(OpenInquiryModalButton).length).toEqual(0)
   })
 
-  fit("does not render the inquiry make offer button or cta when the keyboard is visible", () => {
+  it("does not render the inquiry make offer button or cta when the keyboard is visible", () => {
     const tree = getWrapper({
       Conversation: () => ({
         items: [
@@ -148,34 +148,12 @@ describe("inquiry offer enabled", () => {
       }),
     })
     const input = tree.root.findByType(TextInput)
-    act(() => {
-      input.props.onFocus()
-    })
-    // input.props.onFocus()
-    expect(tree.root.findAllByType(OpenInquiryModalButton).length).toEqual(0)
-    expect(tree.root.findAllByType(ReviewOfferButton).length).toEqual(0)
-  })
 
-  it("hides the keyboard when outside is tapped", () => {
-    const tree = getWrapper({
-      Conversation: () => ({
-        items: [
-          {
-            item: {
-              __typename: "Artwork",
-              isOfferableFromInquiry: true,
-            },
-          },
-        ],
-      }),
-    })
-    const input = tree.root.findAllByType(TextInput)[0]
     input.props.onFocus()
-    expect(tree.root.findAllByType(OpenInquiryModalButton).length).toEqual(0)
 
-    const touchable = tree.root.findAllByType(TouchableWithoutFeedback)[0]
-    touchable.props.onPress()
-    expect(tree.root.findAllByType(OpenInquiryModalButton).length).toEqual(1)
+    setTimeout(() => {
+      expect(tree.root.findAllByType(OpenInquiryModalButton).length).toEqual(0)
+    }, 0)
   })
 
   describe("with associated orders (OrderCTAs)", () => {

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/Composer-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/Composer-tests.tsx
@@ -134,6 +134,50 @@ describe("inquiry offer enabled", () => {
     expect(tree.root.findAllByType(OpenInquiryModalButton).length).toEqual(0)
   })
 
+  fit("does not render the inquiry make offer button or cta when the keyboard is visible", () => {
+    const tree = getWrapper({
+      Conversation: () => ({
+        items: [
+          {
+            item: {
+              __typename: "Artwork",
+              isOfferableFromInquiry: true,
+            },
+          },
+        ],
+      }),
+    })
+    const input = tree.root.findByType(TextInput)
+    act(() => {
+      input.props.onFocus()
+    })
+    // input.props.onFocus()
+    expect(tree.root.findAllByType(OpenInquiryModalButton).length).toEqual(0)
+    expect(tree.root.findAllByType(ReviewOfferButton).length).toEqual(0)
+  })
+
+  it("hides the keyboard when outside is tapped", () => {
+    const tree = getWrapper({
+      Conversation: () => ({
+        items: [
+          {
+            item: {
+              __typename: "Artwork",
+              isOfferableFromInquiry: true,
+            },
+          },
+        ],
+      }),
+    })
+    const input = tree.root.findAllByType(TextInput)[0]
+    input.props.onFocus()
+    expect(tree.root.findAllByType(OpenInquiryModalButton).length).toEqual(0)
+
+    const touchable = tree.root.findAllByType(TouchableWithoutFeedback)[0]
+    touchable.props.onPress()
+    expect(tree.root.findAllByType(OpenInquiryModalButton).length).toEqual(1)
+  })
+
   describe("with associated orders (OrderCTAs)", () => {
     it("renders an empty CTA if there is an active order with a pending offer from the buyer", () => {
       const tree = getWrapper({

--- a/src/lib/Scenes/Inbox/Screens/Conversation.tsx
+++ b/src/lib/Scenes/Inbox/Screens/Conversation.tsx
@@ -13,7 +13,7 @@ import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import { Schema, Track, track as _track } from "lib/utils/track"
 import { color, Flex, Text, Touchable } from "palette"
 import React from "react"
-import { View } from "react-native"
+import { Keyboard, TouchableWithoutFeedback, View } from "react-native"
 import Svg, { Path } from "react-native-svg"
 import { createFragmentContainer, graphql, QueryRenderer, RelayProp } from "react-relay"
 import styled from "styled-components/native"
@@ -167,43 +167,45 @@ export class Conversation extends React.Component<Props, State> {
           this.messages.scrollToLastMessage()
         }}
       >
-        <Container>
-          <Header>
-            <Flex flexDirection="row" alignSelf="stretch" mx={2}>
-              <HeaderTextContainer>
-                <Text variant="mediumText">{partnerName}</Text>
-                <PlaceholderView />
-              </HeaderTextContainer>
-              <Touchable
-                onPress={() => {
-                  this.props.navigator.push({
-                    component: ConversationDetailsQueryRenderer,
-                    title: "",
-                    passProps: {
-                      conversationID: this.props.me?.conversation?.internalID,
-                    },
-                  })
-                }}
-              >
-                <Svg width={28} height={28} viewBox="0 0 28 28">
-                  <Path
-                    d="M6.5 21.5V6.5H16L16 21.5H6.5ZM17.5 21.5H21.5V6.5H17.5L17.5 21.5ZM5 5.5C5 5.22386 5.22386 5 5.5 5H22.5C22.7761 5 23 5.22386 23 5.5V22.5C23 22.7761 22.7761 23 22.5 23H5.5C5.22386 23 5 22.7761 5 22.5V5.5Z"
-                    fill={color("black100")}
-                    fillRule="evenodd"
-                  />
-                </Svg>
-              </Touchable>
-            </Flex>
-          </Header>
-          {!this.state.isConnected && <ConnectivityBanner />}
-          <Messages
-            componentRef={(messages) => (this.messages = messages)}
-            conversation={conversation as any}
-            onDataFetching={(loading) => {
-              this.setState({ fetchingData: loading })
-            }}
-          />
-        </Container>
+        <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()}>
+          <Container>
+            <Header>
+              <Flex flexDirection="row" alignSelf="stretch" mx={2}>
+                <HeaderTextContainer>
+                  <Text variant="mediumText">{partnerName}</Text>
+                  <PlaceholderView />
+                </HeaderTextContainer>
+                <Touchable
+                  onPress={() => {
+                    this.props.navigator.push({
+                      component: ConversationDetailsQueryRenderer,
+                      title: "",
+                      passProps: {
+                        conversationID: this.props.me?.conversation?.internalID,
+                      },
+                    })
+                  }}
+                >
+                  <Svg width={28} height={28} viewBox="0 0 28 28">
+                    <Path
+                      d="M6.5 21.5V6.5H16L16 21.5H6.5ZM17.5 21.5H21.5V6.5H17.5L17.5 21.5ZM5 5.5C5 5.22386 5.22386 5 5.5 5H22.5C22.7761 5 23 5.22386 23 5.5V22.5C23 22.7761 22.7761 23 22.5 23H5.5C5.22386 23 5 22.7761 5 22.5V5.5Z"
+                      fill={color("black100")}
+                      fillRule="evenodd"
+                    />
+                  </Svg>
+                </Touchable>
+              </Flex>
+            </Header>
+            {!this.state.isConnected && <ConnectivityBanner />}
+            <Messages
+              componentRef={(messages) => (this.messages = messages)}
+              conversation={conversation as any}
+              onDataFetching={(loading) => {
+                this.setState({ fetchingData: loading })
+              }}
+            />
+          </Container>
+        </TouchableWithoutFeedback>
       </ComposerFragmentContainer>
     )
   }

--- a/src/lib/Scenes/Inbox/Screens/__tests__/Conversation-tests.tsx
+++ b/src/lib/Scenes/Inbox/Screens/__tests__/Conversation-tests.tsx
@@ -4,6 +4,7 @@ import Composer from "lib/Scenes/Inbox/Components/Conversations/Composer"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { Touchable } from "palette"
 import React from "react"
+import { Keyboard, TouchableWithoutFeedback } from "react-native"
 import "react-native"
 import { graphql, QueryRenderer } from "react-relay"
 import { act, ReactTestInstance } from "react-test-renderer"
@@ -93,4 +94,17 @@ it("clicking on detail link opens pushes detail screen into navigator", () => {
     passProps: { conversationID: "123" },
     title: "",
   })
+})
+
+it("tapping anywhere outside of the composer closes the keyboard", () => {
+  const conversation = getWrapper({
+    Conversation: () => ({
+      internalID: "123",
+    }),
+  })
+
+  jest.spyOn(Keyboard, "dismiss")
+
+  conversation.root.findAllByType(TouchableWithoutFeedback)[0].props.onPress()
+  expect(Keyboard.dismiss).toBeCalled()
 })


### PR DESCRIPTION
I addressed several tickets in this PR, all related to the keyboard and semi-dependent on each other. I also added tap to close functionality to the keyboard - if there is an existing ticket for this please let me know

https://user-images.githubusercontent.com/5643895/113346241-96409f80-9301-11eb-8be7-5aec026dbc38.mov

. Shoutout to @ashleyjelks for test help!

# PURCHASE-2516
Within initial inquiry view, keyboard is expanded (showing) by default

https://www.notion.so/artsy/Within-initial-inquiry-view-keyboard-is-expanded-showing-by-default-499d5576f5dc4f01aa794f0f0ce31d85

# PURCHASE-2522
When the keyboard is active can the make offer button hide? And when the keyboard is hidden the button is back.

https://www.notion.so/artsy/When-the-keyboard-is-active-can-the-make-offer-button-hide-And-when-the-keyboard-is-hidden-the-butt-5d2caef9172f4d86abde4e32dfca4975