### PR TITLE
Add missing overlay page title to MO modal and remove cancel button in modal header

### DIFF
--- a/src/lib/Scenes/Inbox/Components/Conversations/MakeOfferModal.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/MakeOfferModal.tsx
@@ -30,15 +30,9 @@ export const MakeOfferModal: React.FC<MakeOfferModalProps> = ({ ...props }) => {
       }}
     >
       <View>
-        <FancyModalHeader
-          onLeftButtonPress={() => {
-            dismissModal()
-          }}
-          leftButtonText="Cancel"
-          rightButtonDisabled
-          rightButtonText=" "
-          hideBottomDivider
-        ></FancyModalHeader>
+        <FancyModalHeader rightButtonDisabled hideBottomDivider>
+          Make Offer with Artsy Pay
+        </FancyModalHeader>
         <Flex p={1.5}>
           <Text variant="largeTitle">Confirm Artwork</Text>
           <Text variant="small" color="black60">


### PR DESCRIPTION
# PURCHASE-2526

Make Offer (Initial View) - Title "Make Offer with Artsy Pay" is missing / Cancel link is in nav and should be ONLY the CTA (below "Confirm')

__Before:__
<img width="441" alt="Screen Shot 2021-04-01 at 3 56 32 PM" src="https://user-images.githubusercontent.com/5643895/113347431-2b906380-9303-11eb-9765-5ae820320609.png">

__After:__
<img width="442" alt="Screen Shot 2021-04-01 at 3 55 44 PM" src="https://user-images.githubusercontent.com/5643895/113350457-7d3aed00-9307-11eb-975e-9c6a6c0c2ad8.png">

