### PR TITLE
fix: fix incorrect message order when content is shorter than the scroll view (PURCHASE-2535)

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -12,6 +12,7 @@ upcoming:
     - Add splash screen to android - mounir
     - Support change system navigation bar color on android - mounir
     - Add ability for one modal to replace another and use it in inquiry checkout flow - erik, david
+    - Fix message ordering in Inbox - starsirius
 
 releases:
   - version: 6.8.2

--- a/src/lib/Scenes/Inbox/Components/Conversations/Messages.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/Messages.tsx
@@ -74,13 +74,6 @@ export const Messages: React.FC<Props> = forwardRef((props, ref) => {
   }, [allOrderEvents.length, allMessages.length])
 
   const flatList = useRef<FlatList>(null)
-  const [flatListHeight, setFlatListHeight] = useState(0)
-  const [contentHeight, setContentHeight] = useState(0)
-  const [shouldStickFirstMessageToTop, setShouldStickFirstMessageToTop] = useState(false)
-
-  useEffect(() => {
-    setShouldStickFirstMessageToTop(contentHeight < flatListHeight)
-  }, [contentHeight || flatListHeight])
 
   const loadMore = () => {
     if (!relay.hasMore() || relay.isLoading()) {
@@ -147,7 +140,7 @@ export const Messages: React.FC<Props> = forwardRef((props, ref) => {
           />
         )
       }}
-      inverted={!shouldStickFirstMessageToTop}
+      inverted={true}
       ref={flatList}
       keyExtractor={(group) => {
         return group[0].id
@@ -155,18 +148,9 @@ export const Messages: React.FC<Props> = forwardRef((props, ref) => {
       keyboardShouldPersistTaps="always"
       onEndReached={loadMore}
       onEndReachedThreshold={0.2}
-      onLayout={({
-        nativeEvent: {
-          layout: { height },
-        },
-      }) => {
-        setFlatListHeight(height)
-      }}
-      onContentSizeChange={(_width, height) => {
-        setContentHeight(height)
-      }}
       refreshControl={refreshControl}
       style={{ ...messagesStyles, paddingHorizontal: 10, flex: 0 }}
+      contentContainerStyle={{ justifyContent: "flex-end", flexGrow: 1 }}
       ListFooterComponent={<LoadingIndicator animating={fetchingMoreData} hidesWhenStopped />}
     />
   )


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [PURCHASE-2535]

### Description

We noticed in some cases the messages (including order events) would be displayed in the wrong order. It turns out we were only inverting the `FlatList` when the content is taller than the scroll view, and in cases the content is shorter, the messages were displayed in the wrong order.

This fixes it by always inverting the `FlatList` and uses flexbox `justifyContent` to align content to the top when the content is shorter than the scroll view. More details inline.

**Before**

![Screen Shot 2021-04-01 at 6 07 22 PM](https://user-images.githubusercontent.com/796573/113359451-cdb94700-9315-11eb-988a-e2ed1bdbf135.png)


**After**

![Screen Shot 2021-04-01 at 6 08 04 PM](https://user-images.githubusercontent.com/796573/113359457-d1e56480-9315-11eb-84be-53c86eb83484.png)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[PURCHASE-2535]: https://artsyproduct.atlassian.net/browse/PURCHASE-2535