### PR TITLE
fix: use appJson for version remove legacy module #trivial

### DIFF
--- a/emission/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.m
+++ b/emission/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.m
@@ -49,14 +49,6 @@ RCT_EXPORT_METHOD(clearUserData:(RCTPromiseResolveBlock)completion reject:(RCTPr
     self.userDataClearer(completion);
 }
 
-- (NSDictionary *)constantsToExport
-{
-    return @{
-        @"appVersion" : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"],
-        @"buildVersion" : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"],
-    };
-}
-
 + (BOOL)requiresMainQueueSetup
 {
     return YES;

--- a/src/lib/NativeModules/LegacyNativeModules.tsx
+++ b/src/lib/NativeModules/LegacyNativeModules.tsx
@@ -20,8 +20,6 @@ const noop: any = (name: string) => () => console.warn(`method ${name} doesn't e
 
 interface LegacyNativeModules {
   ARTemporaryAPIModule: {
-    appVersion: string
-    buildVersion: string
     requestNotificationPermissions(): void
     fetchNotificationPermissions(callback: (error: any, result: PushAuthorizationStatus) => void): void
     markNotificationsRead(callback: (error?: Error) => any): void
@@ -117,8 +115,6 @@ export const LegacyNativeModules: LegacyNativeModules =
           setApplicationIconBadgeNumber: () => {
             console.log("TODO: make app icon badge work on android")
           },
-          appVersion: "appVersion",
-          buildVersion: "buildVersion",
           clearUserData: () => Promise.resolve(),
         },
         ARPHPhotoPickerModule: {

--- a/src/lib/Scenes/About/About.tsx
+++ b/src/lib/Scenes/About/About.tsx
@@ -1,17 +1,18 @@
 import { MenuItem } from "lib/Components/MenuItem"
 import { PageWithSimpleHeader } from "lib/Components/PageWithSimpleHeader"
-import { LegacyNativeModules } from "lib/NativeModules/LegacyNativeModules"
 import { navigate } from "lib/navigation/navigate"
+import { appJson } from "lib/utils/jsonFiles"
 import React from "react"
 import { ScrollView } from "react-native"
 
 export const About: React.FC<{}> = ({}) => {
+  const appVersion = appJson().version
   return (
     <PageWithSimpleHeader title="About">
       <ScrollView contentContainerStyle={{ paddingTop: 10 }}>
         <MenuItem title="Terms of Use" onPress={() => navigate("/terms", { modal: true })} />
         <MenuItem title="Privacy Policy" onPress={() => navigate("/privacy", { modal: true })} />
-        <MenuItem title="Version" disabled text={LegacyNativeModules.ARTemporaryAPIModule.appVersion} />
+        <MenuItem title="Version" disabled text={appVersion} />
       </ScrollView>
     </PageWithSimpleHeader>
   )

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -184,8 +184,6 @@ function getNativeModules(): typeof LegacyNativeModules {
       markNotificationsRead: jest.fn(),
       setApplicationIconBadgeNumber: jest.fn(),
       clearUserData: jest.fn(),
-      appVersion: "appVersion",
-      buildVersion: "buildVersion",
     },
     ARPHPhotoPickerModule: {
       requestPhotos: jest.fn(),


### PR DESCRIPTION
The type of this PR is: **fix**

### Description

Use app version for version display in about menu on Android and remove the native module that only supported iOS. 

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
