### PR TITLE
fix: fix conversation scrolling after the keyboard fix (PURCHASE-2516)

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -16,6 +16,7 @@ upcoming:
     - Fix message ordering in Inbox - starsirius
     - Converts multi-select filters to use checkboxes instead of toggles - damon
     - Add modal replacement api to android app - erik, david
+    - Fix conversation scrolling while supporting dismissing keyboard - starsirius
 
 releases:
   - version: 6.8.2

--- a/src/lib/Scenes/Inbox/Components/Conversations/Messages.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/Messages.tsx
@@ -145,7 +145,6 @@ export const Messages: React.FC<Props> = forwardRef((props, ref) => {
       keyExtractor={(group) => {
         return group[0].id
       }}
-      keyboardShouldPersistTaps="always"
       onEndReached={loadMore}
       onEndReachedThreshold={0.2}
       refreshControl={refreshControl}

--- a/src/lib/Scenes/Inbox/Screens/Conversation.tsx
+++ b/src/lib/Scenes/Inbox/Screens/Conversation.tsx
@@ -13,7 +13,7 @@ import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import { Schema, Track, track as _track } from "lib/utils/track"
 import { color, Flex, Text, Touchable } from "palette"
 import React from "react"
-import { Keyboard, TouchableWithoutFeedback, View } from "react-native"
+import { View } from "react-native"
 import Svg, { Path } from "react-native-svg"
 import { createFragmentContainer, graphql, QueryRenderer, RelayProp } from "react-relay"
 import styled from "styled-components/native"
@@ -167,45 +167,43 @@ export class Conversation extends React.Component<Props, State> {
           this.messages.scrollToLastMessage()
         }}
       >
-        <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()}>
-          <Container>
-            <Header>
-              <Flex flexDirection="row" alignSelf="stretch" mx={2}>
-                <HeaderTextContainer>
-                  <Text variant="mediumText">{partnerName}</Text>
-                  <PlaceholderView />
-                </HeaderTextContainer>
-                <Touchable
-                  onPress={() => {
-                    this.props.navigator.push({
-                      component: ConversationDetailsQueryRenderer,
-                      title: "",
-                      passProps: {
-                        conversationID: this.props.me?.conversation?.internalID,
-                      },
-                    })
-                  }}
-                >
-                  <Svg width={28} height={28} viewBox="0 0 28 28">
-                    <Path
-                      d="M6.5 21.5V6.5H16L16 21.5H6.5ZM17.5 21.5H21.5V6.5H17.5L17.5 21.5ZM5 5.5C5 5.22386 5.22386 5 5.5 5H22.5C22.7761 5 23 5.22386 23 5.5V22.5C23 22.7761 22.7761 23 22.5 23H5.5C5.22386 23 5 22.7761 5 22.5V5.5Z"
-                      fill={color("black100")}
-                      fillRule="evenodd"
-                    />
-                  </Svg>
-                </Touchable>
-              </Flex>
-            </Header>
-            {!this.state.isConnected && <ConnectivityBanner />}
-            <Messages
-              componentRef={(messages) => (this.messages = messages)}
-              conversation={conversation as any}
-              onDataFetching={(loading) => {
-                this.setState({ fetchingData: loading })
-              }}
-            />
-          </Container>
-        </TouchableWithoutFeedback>
+        <Container>
+          <Header>
+            <Flex flexDirection="row" alignSelf="stretch" mx={2}>
+              <HeaderTextContainer>
+                <Text variant="mediumText">{partnerName}</Text>
+                <PlaceholderView />
+              </HeaderTextContainer>
+              <Touchable
+                onPress={() => {
+                  this.props.navigator.push({
+                    component: ConversationDetailsQueryRenderer,
+                    title: "",
+                    passProps: {
+                      conversationID: this.props.me?.conversation?.internalID,
+                    },
+                  })
+                }}
+              >
+                <Svg width={28} height={28} viewBox="0 0 28 28">
+                  <Path
+                    d="M6.5 21.5V6.5H16L16 21.5H6.5ZM17.5 21.5H21.5V6.5H17.5L17.5 21.5ZM5 5.5C5 5.22386 5.22386 5 5.5 5H22.5C22.7761 5 23 5.22386 23 5.5V22.5C23 22.7761 22.7761 23 22.5 23H5.5C5.22386 23 5 22.7761 5 22.5V5.5Z"
+                    fill={color("black100")}
+                    fillRule="evenodd"
+                  />
+                </Svg>
+              </Touchable>
+            </Flex>
+          </Header>
+          {!this.state.isConnected && <ConnectivityBanner />}
+          <Messages
+            componentRef={(messages) => (this.messages = messages)}
+            conversation={conversation as any}
+            onDataFetching={(loading) => {
+              this.setState({ fetchingData: loading })
+            }}
+          />
+        </Container>
       </ComposerFragmentContainer>
     )
   }

--- a/src/lib/Scenes/Inbox/Screens/__tests__/Conversation-tests.tsx
+++ b/src/lib/Scenes/Inbox/Screens/__tests__/Conversation-tests.tsx
@@ -4,7 +4,6 @@ import Composer from "lib/Scenes/Inbox/Components/Conversations/Composer"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { Touchable } from "palette"
 import React from "react"
-import { Keyboard, TouchableWithoutFeedback } from "react-native"
 import "react-native"
 import { graphql, QueryRenderer } from "react-relay"
 import { act, ReactTestInstance } from "react-test-renderer"
@@ -94,17 +93,4 @@ it("clicking on detail link opens pushes detail screen into navigator", () => {
     passProps: { conversationID: "123" },
     title: "",
   })
-})
-
-it("tapping anywhere outside of the composer closes the keyboard", () => {
-  const conversation = getWrapper({
-    Conversation: () => ({
-      internalID: "123",
-    }),
-  })
-
-  jest.spyOn(Keyboard, "dismiss")
-
-  conversation.root.findAllByType(TouchableWithoutFeedback)[0].props.onPress()
-  expect(Keyboard.dismiss).toBeCalled()
 })


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [PURCHASE-2516]

### Description

We noticed the keyboard fix in https://github.com/artsy/eigen/pull/4592 caused the conversation screen to be not scrollable. This reverts the introduction of `TouchableWithoutFeedback` and, instead, uses `keyboardShouldPersistTaps` to dismiss the keyboard.

![dismiss-keyboard](https://user-images.githubusercontent.com/796573/113627881-1fbddd80-9632-11eb-8f02-a775f88635a6.gif)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[PURCHASE-2516]: https://artsyproduct.atlassian.net/browse/PURCHASE-2516