### PR TITLE
fix: update broken analytics link in preferred_practices.md

### DIFF
--- a/docs/preferred_practices.md
+++ b/docs/preferred_practices.md
@@ -117,7 +117,7 @@ _Most_ interactions are made through a "SwitchBoard" to open links. Other intera
 
 #### Follow the tracking docs and examples
 
-See our docs on implementing analytics [here](./docs/analytics_and_tracking.md)
+See our docs on implementing analytics [here](./analytics_and_tracking.md)
 
 ### Miscellaneous
 


### PR DESCRIPTION
The type of this PR is: Documentation

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

This PR fixes a broken link to the analytics docs in `preferred_practices.md`

[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434