### PR TITLE
chore: rename the category filter to medium

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -21,6 +21,7 @@ upcoming:
     - Add modal replacement api to android app - erik, david
     - Fix conversation scrolling while supporting dismissing keyboard - starsirius
     - Updates filter styling - damon
+    - Rename the category filter to medium - iskounen
 
 releases:
   - version: 6.8.2

--- a/src/lib/utils/ArtworkFilter/FilterArtworksHelpers.ts
+++ b/src/lib/utils/ArtworkFilter/FilterArtworksHelpers.ts
@@ -44,7 +44,7 @@ export type FilterParams = {
 
 export enum FilterDisplayName {
   // artist = "Artists",
-  additionalGeneIDs = "Category",
+  additionalGeneIDs = "Medium",
   artistIDs = "Artists",
   artistsIFollow = "Artist",
   attributionClass = "Rarity",


### PR DESCRIPTION
The type of this PR is: Enhancement
This PR resolves [FX-2740]

### Description

Renames the Category filter on artwork grids to Medium.

<img width="552" alt="Screen Shot 2021-04-06 at 9 11 29 PM" src="https://user-images.githubusercontent.com/44589599/113797434-4574e080-971f-11eb-9cd7-ec1e74e1cf4f.png">


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2740]: https://artsyproduct.atlassian.net/browse/FX-2740