### PR TITLE
chore: update where and when we display the iconic collections rail for an artist

### DIFF
--- a/src/__generated__/ArtistAboutTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistAboutTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash e7e03baa797b12533f132bdddfbb709e */
+/* @relayHash cf0e0472d825ab2c462e22425908f882 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -83,6 +83,11 @@ fragment ArtistAbout_artist on Artist {
   ...Biography_artist
   ...ArtistConsignButton_artist
   ...ArtistAboutShows_artist
+  ...ArtistCollectionsRail_artist
+  iconicCollections: marketingCollections(isFeaturedArtistContent: true, size: 16) {
+    ...ArtistCollectionsRail_collections
+    id
+  }
   related {
     artists: artistsConnection(first: 16) {
       edges {
@@ -100,6 +105,30 @@ fragment ArtistAbout_artist on Artist {
         id
       }
     }
+  }
+}
+
+fragment ArtistCollectionsRail_artist on Artist {
+  internalID
+  slug
+}
+
+fragment ArtistCollectionsRail_collections on MarketingCollection {
+  slug
+  id
+  title
+  priceGuidance
+  artworksConnection(first: 3, aggregations: [TOTAL], sort: "-decayed_merch") {
+    edges {
+      node {
+        title
+        image {
+          url
+        }
+        id
+      }
+    }
+    id
   }
 }
 
@@ -206,26 +235,35 @@ v3 = {
   "name": "name",
   "storageKey": null
 },
-v4 = {
+v4 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "url",
+    "storageKey": null
+  }
+],
+v5 = {
   "kind": "Literal",
   "name": "first",
   "value": 10
 },
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v7 = [
+v8 = [
   {
     "alias": null,
     "args": [
@@ -240,11 +278,11 @@ v7 = [
     "storageKey": "url(version:\"large\")"
   }
 ],
-v8 = [
-  (v3/*: any*/),
-  (v5/*: any*/)
-],
 v9 = [
+  (v3/*: any*/),
+  (v6/*: any*/)
+],
+v10 = [
   {
     "alias": null,
     "args": null,
@@ -261,9 +299,9 @@ v9 = [
         "name": "node",
         "plural": false,
         "selections": [
-          (v5/*: any*/),
-          (v2/*: any*/),
           (v6/*: any*/),
+          (v2/*: any*/),
+          (v7/*: any*/),
           {
             "alias": "is_fair_booth",
             "args": null,
@@ -278,7 +316,7 @@ v9 = [
             "kind": "LinkedField",
             "name": "coverImage",
             "plural": false,
-            "selections": (v7/*: any*/),
+            "selections": (v8/*: any*/),
             "storageKey": null
           },
           {
@@ -335,14 +373,14 @@ v9 = [
               },
               {
                 "kind": "InlineFragment",
-                "selections": (v8/*: any*/),
+                "selections": (v9/*: any*/),
                 "type": "ExternalPartner",
                 "abstractKey": null
               },
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v5/*: any*/)
+                  (v6/*: any*/)
                 ],
                 "type": "Node",
                 "abstractKey": "__isNode"
@@ -365,7 +403,7 @@ v9 = [
                 "name": "city",
                 "storageKey": null
               },
-              (v5/*: any*/)
+              (v6/*: any*/)
             ],
             "storageKey": null
           }
@@ -376,73 +414,85 @@ v9 = [
     "storageKey": null
   }
 ],
-v10 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Artist"
-},
 v11 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "ID"
+  "kind": "Literal",
+  "name": "first",
+  "value": 3
 },
 v12 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "String"
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "title",
+  "storageKey": null
 },
 v13 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Image"
+  "type": "Artist"
 },
 v14 = {
   "enumValues": null,
-  "nullable": true,
+  "nullable": false,
   "plural": false,
-  "type": "ShowConnection"
+  "type": "ID"
 },
 v15 = {
   "enumValues": null,
   "nullable": true,
-  "plural": true,
-  "type": "ShowEdge"
+  "plural": false,
+  "type": "String"
 },
 v16 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Show"
+  "type": "Image"
 },
 v17 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Boolean"
+  "type": "ShowConnection"
 },
 v18 = {
   "enumValues": null,
   "nullable": true,
-  "plural": false,
-  "type": "Location"
+  "plural": true,
+  "type": "ShowEdge"
 },
 v19 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "PartnerTypes"
+  "type": "Show"
 },
 v20 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Boolean"
+},
+v21 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Location"
+},
+v22 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "PartnerTypes"
+},
+v23 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v21 = {
+v24 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -577,15 +627,7 @@ return {
                 "kind": "LinkedField",
                 "name": "cropped",
                 "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "url",
-                    "storageKey": null
-                  }
-                ],
+                "selections": (v4/*: any*/),
                 "storageKey": "cropped(height:66,width:66)"
               }
             ],
@@ -594,7 +636,7 @@ return {
           {
             "alias": "currentShows",
             "args": [
-              (v4/*: any*/),
+              (v5/*: any*/),
               {
                 "kind": "Literal",
                 "name": "status",
@@ -605,13 +647,13 @@ return {
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
-            "selections": (v9/*: any*/),
+            "selections": (v10/*: any*/),
             "storageKey": "showsConnection(first:10,status:\"running\")"
           },
           {
             "alias": "upcomingShows",
             "args": [
-              (v4/*: any*/),
+              (v5/*: any*/),
               {
                 "kind": "Literal",
                 "name": "status",
@@ -622,17 +664,13 @@ return {
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
-            "selections": (v9/*: any*/),
+            "selections": (v10/*: any*/),
             "storageKey": "showsConnection(first:10,status:\"upcoming\")"
           },
           {
             "alias": "pastShows",
             "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 3
-              },
+              (v11/*: any*/),
               {
                 "kind": "Literal",
                 "name": "status",
@@ -643,8 +681,100 @@ return {
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
-            "selections": (v9/*: any*/),
+            "selections": (v10/*: any*/),
             "storageKey": "showsConnection(first:3,status:\"closed\")"
+          },
+          {
+            "alias": "iconicCollections",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "isFeaturedArtistContent",
+                "value": true
+              },
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 16
+              }
+            ],
+            "concreteType": "MarketingCollection",
+            "kind": "LinkedField",
+            "name": "marketingCollections",
+            "plural": true,
+            "selections": [
+              (v2/*: any*/),
+              (v6/*: any*/),
+              (v12/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "priceGuidance",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "aggregations",
+                    "value": [
+                      "TOTAL"
+                    ]
+                  },
+                  (v11/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "sort",
+                    "value": "-decayed_merch"
+                  }
+                ],
+                "concreteType": "FilterArtworksConnection",
+                "kind": "LinkedField",
+                "name": "artworksConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "FilterArtworksEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artwork",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v12/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "kind": "LinkedField",
+                            "name": "image",
+                            "plural": false,
+                            "selections": (v4/*: any*/),
+                            "storageKey": null
+                          },
+                          (v6/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v6/*: any*/)
+                ],
+                "storageKey": "artworksConnection(aggregations:[\"TOTAL\"],first:3,sort:\"-decayed_merch\")"
+              }
+            ],
+            "storageKey": "marketingCollections(isFeaturedArtistContent:true,size:16)"
           },
           {
             "alias": null,
@@ -684,8 +814,8 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
                           (v6/*: any*/),
+                          (v7/*: any*/),
                           (v3/*: any*/),
                           {
                             "alias": null,
@@ -719,7 +849,7 @@ return {
                             "kind": "LinkedField",
                             "name": "image",
                             "plural": false,
-                            "selections": (v7/*: any*/),
+                            "selections": (v8/*: any*/),
                             "storageKey": null
                           }
                         ],
@@ -737,7 +867,7 @@ return {
           {
             "alias": "articles",
             "args": [
-              (v4/*: any*/)
+              (v5/*: any*/)
             ],
             "concreteType": "ArticleConnection",
             "kind": "LinkedField",
@@ -760,7 +890,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/),
+                      (v6/*: any*/),
                       {
                         "alias": "thumbnail_title",
                         "args": null,
@@ -768,7 +898,7 @@ return {
                         "name": "thumbnailTitle",
                         "storageKey": null
                       },
-                      (v6/*: any*/),
+                      (v7/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -776,7 +906,7 @@ return {
                         "kind": "LinkedField",
                         "name": "author",
                         "plural": false,
-                        "selections": (v8/*: any*/),
+                        "selections": (v9/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -786,7 +916,7 @@ return {
                         "kind": "LinkedField",
                         "name": "thumbnailImage",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v8/*: any*/),
                         "storageKey": null
                       }
                     ],
@@ -798,17 +928,17 @@ return {
             ],
             "storageKey": "articlesConnection(first:10)"
           },
-          (v5/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "e7e03baa797b12533f132bdddfbb709e",
+    "id": "cf0e0472d825ab2c462e22425908f882",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "artist": (v10/*: any*/),
+        "artist": (v13/*: any*/),
         "artist.articles": {
           "enumValues": null,
           "nullable": true,
@@ -833,72 +963,110 @@ return {
           "plural": false,
           "type": "Author"
         },
-        "artist.articles.edges.node.author.id": (v11/*: any*/),
-        "artist.articles.edges.node.author.name": (v12/*: any*/),
-        "artist.articles.edges.node.href": (v12/*: any*/),
-        "artist.articles.edges.node.id": (v11/*: any*/),
-        "artist.articles.edges.node.thumbnail_image": (v13/*: any*/),
-        "artist.articles.edges.node.thumbnail_image.url": (v12/*: any*/),
-        "artist.articles.edges.node.thumbnail_title": (v12/*: any*/),
-        "artist.bio": (v12/*: any*/),
-        "artist.blurb": (v12/*: any*/),
-        "artist.currentShows": (v14/*: any*/),
-        "artist.currentShows.edges": (v15/*: any*/),
-        "artist.currentShows.edges.node": (v16/*: any*/),
-        "artist.currentShows.edges.node.cover_image": (v13/*: any*/),
-        "artist.currentShows.edges.node.cover_image.url": (v12/*: any*/),
-        "artist.currentShows.edges.node.exhibition_period": (v12/*: any*/),
-        "artist.currentShows.edges.node.href": (v12/*: any*/),
-        "artist.currentShows.edges.node.id": (v11/*: any*/),
-        "artist.currentShows.edges.node.is_fair_booth": (v17/*: any*/),
-        "artist.currentShows.edges.node.kind": (v12/*: any*/),
-        "artist.currentShows.edges.node.location": (v18/*: any*/),
-        "artist.currentShows.edges.node.location.city": (v12/*: any*/),
-        "artist.currentShows.edges.node.location.id": (v11/*: any*/),
-        "artist.currentShows.edges.node.name": (v12/*: any*/),
-        "artist.currentShows.edges.node.partner": (v19/*: any*/),
-        "artist.currentShows.edges.node.partner.__isNode": (v20/*: any*/),
-        "artist.currentShows.edges.node.partner.__typename": (v20/*: any*/),
-        "artist.currentShows.edges.node.partner.id": (v11/*: any*/),
-        "artist.currentShows.edges.node.partner.name": (v12/*: any*/),
-        "artist.currentShows.edges.node.slug": (v11/*: any*/),
-        "artist.currentShows.edges.node.status": (v12/*: any*/),
-        "artist.currentShows.edges.node.status_update": (v12/*: any*/),
-        "artist.hasMetadata": (v17/*: any*/),
-        "artist.id": (v11/*: any*/),
-        "artist.image": (v13/*: any*/),
+        "artist.articles.edges.node.author.id": (v14/*: any*/),
+        "artist.articles.edges.node.author.name": (v15/*: any*/),
+        "artist.articles.edges.node.href": (v15/*: any*/),
+        "artist.articles.edges.node.id": (v14/*: any*/),
+        "artist.articles.edges.node.thumbnail_image": (v16/*: any*/),
+        "artist.articles.edges.node.thumbnail_image.url": (v15/*: any*/),
+        "artist.articles.edges.node.thumbnail_title": (v15/*: any*/),
+        "artist.bio": (v15/*: any*/),
+        "artist.blurb": (v15/*: any*/),
+        "artist.currentShows": (v17/*: any*/),
+        "artist.currentShows.edges": (v18/*: any*/),
+        "artist.currentShows.edges.node": (v19/*: any*/),
+        "artist.currentShows.edges.node.cover_image": (v16/*: any*/),
+        "artist.currentShows.edges.node.cover_image.url": (v15/*: any*/),
+        "artist.currentShows.edges.node.exhibition_period": (v15/*: any*/),
+        "artist.currentShows.edges.node.href": (v15/*: any*/),
+        "artist.currentShows.edges.node.id": (v14/*: any*/),
+        "artist.currentShows.edges.node.is_fair_booth": (v20/*: any*/),
+        "artist.currentShows.edges.node.kind": (v15/*: any*/),
+        "artist.currentShows.edges.node.location": (v21/*: any*/),
+        "artist.currentShows.edges.node.location.city": (v15/*: any*/),
+        "artist.currentShows.edges.node.location.id": (v14/*: any*/),
+        "artist.currentShows.edges.node.name": (v15/*: any*/),
+        "artist.currentShows.edges.node.partner": (v22/*: any*/),
+        "artist.currentShows.edges.node.partner.__isNode": (v23/*: any*/),
+        "artist.currentShows.edges.node.partner.__typename": (v23/*: any*/),
+        "artist.currentShows.edges.node.partner.id": (v14/*: any*/),
+        "artist.currentShows.edges.node.partner.name": (v15/*: any*/),
+        "artist.currentShows.edges.node.slug": (v14/*: any*/),
+        "artist.currentShows.edges.node.status": (v15/*: any*/),
+        "artist.currentShows.edges.node.status_update": (v15/*: any*/),
+        "artist.hasMetadata": (v20/*: any*/),
+        "artist.iconicCollections": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "MarketingCollection"
+        },
+        "artist.iconicCollections.artworksConnection": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "FilterArtworksConnection"
+        },
+        "artist.iconicCollections.artworksConnection.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "FilterArtworksEdge"
+        },
+        "artist.iconicCollections.artworksConnection.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "artist.iconicCollections.artworksConnection.edges.node.id": (v14/*: any*/),
+        "artist.iconicCollections.artworksConnection.edges.node.image": (v16/*: any*/),
+        "artist.iconicCollections.artworksConnection.edges.node.image.url": (v15/*: any*/),
+        "artist.iconicCollections.artworksConnection.edges.node.title": (v15/*: any*/),
+        "artist.iconicCollections.artworksConnection.id": (v14/*: any*/),
+        "artist.iconicCollections.id": (v14/*: any*/),
+        "artist.iconicCollections.priceGuidance": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Float"
+        },
+        "artist.iconicCollections.slug": (v23/*: any*/),
+        "artist.iconicCollections.title": (v23/*: any*/),
+        "artist.id": (v14/*: any*/),
+        "artist.image": (v16/*: any*/),
         "artist.image.cropped": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "CroppedImageUrl"
         },
-        "artist.image.cropped.url": (v20/*: any*/),
-        "artist.internalID": (v11/*: any*/),
-        "artist.isDisplayAuctionLink": (v17/*: any*/),
-        "artist.name": (v12/*: any*/),
-        "artist.pastShows": (v14/*: any*/),
-        "artist.pastShows.edges": (v15/*: any*/),
-        "artist.pastShows.edges.node": (v16/*: any*/),
-        "artist.pastShows.edges.node.cover_image": (v13/*: any*/),
-        "artist.pastShows.edges.node.cover_image.url": (v12/*: any*/),
-        "artist.pastShows.edges.node.exhibition_period": (v12/*: any*/),
-        "artist.pastShows.edges.node.href": (v12/*: any*/),
-        "artist.pastShows.edges.node.id": (v11/*: any*/),
-        "artist.pastShows.edges.node.is_fair_booth": (v17/*: any*/),
-        "artist.pastShows.edges.node.kind": (v12/*: any*/),
-        "artist.pastShows.edges.node.location": (v18/*: any*/),
-        "artist.pastShows.edges.node.location.city": (v12/*: any*/),
-        "artist.pastShows.edges.node.location.id": (v11/*: any*/),
-        "artist.pastShows.edges.node.name": (v12/*: any*/),
-        "artist.pastShows.edges.node.partner": (v19/*: any*/),
-        "artist.pastShows.edges.node.partner.__isNode": (v20/*: any*/),
-        "artist.pastShows.edges.node.partner.__typename": (v20/*: any*/),
-        "artist.pastShows.edges.node.partner.id": (v11/*: any*/),
-        "artist.pastShows.edges.node.partner.name": (v12/*: any*/),
-        "artist.pastShows.edges.node.slug": (v11/*: any*/),
-        "artist.pastShows.edges.node.status": (v12/*: any*/),
-        "artist.pastShows.edges.node.status_update": (v12/*: any*/),
+        "artist.image.cropped.url": (v23/*: any*/),
+        "artist.internalID": (v14/*: any*/),
+        "artist.isDisplayAuctionLink": (v20/*: any*/),
+        "artist.name": (v15/*: any*/),
+        "artist.pastShows": (v17/*: any*/),
+        "artist.pastShows.edges": (v18/*: any*/),
+        "artist.pastShows.edges.node": (v19/*: any*/),
+        "artist.pastShows.edges.node.cover_image": (v16/*: any*/),
+        "artist.pastShows.edges.node.cover_image.url": (v15/*: any*/),
+        "artist.pastShows.edges.node.exhibition_period": (v15/*: any*/),
+        "artist.pastShows.edges.node.href": (v15/*: any*/),
+        "artist.pastShows.edges.node.id": (v14/*: any*/),
+        "artist.pastShows.edges.node.is_fair_booth": (v20/*: any*/),
+        "artist.pastShows.edges.node.kind": (v15/*: any*/),
+        "artist.pastShows.edges.node.location": (v21/*: any*/),
+        "artist.pastShows.edges.node.location.city": (v15/*: any*/),
+        "artist.pastShows.edges.node.location.id": (v14/*: any*/),
+        "artist.pastShows.edges.node.name": (v15/*: any*/),
+        "artist.pastShows.edges.node.partner": (v22/*: any*/),
+        "artist.pastShows.edges.node.partner.__isNode": (v23/*: any*/),
+        "artist.pastShows.edges.node.partner.__typename": (v23/*: any*/),
+        "artist.pastShows.edges.node.partner.id": (v14/*: any*/),
+        "artist.pastShows.edges.node.partner.name": (v15/*: any*/),
+        "artist.pastShows.edges.node.slug": (v14/*: any*/),
+        "artist.pastShows.edges.node.status": (v15/*: any*/),
+        "artist.pastShows.edges.node.status_update": (v15/*: any*/),
         "artist.related": {
           "enumValues": null,
           "nullable": true,
@@ -917,51 +1085,51 @@ return {
           "plural": true,
           "type": "ArtistEdge"
         },
-        "artist.related.artists.edges.node": (v10/*: any*/),
+        "artist.related.artists.edges.node": (v13/*: any*/),
         "artist.related.artists.edges.node.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtistCounts"
         },
-        "artist.related.artists.edges.node.counts.artworks": (v21/*: any*/),
-        "artist.related.artists.edges.node.counts.forSaleArtworks": (v21/*: any*/),
-        "artist.related.artists.edges.node.href": (v12/*: any*/),
-        "artist.related.artists.edges.node.id": (v11/*: any*/),
-        "artist.related.artists.edges.node.image": (v13/*: any*/),
-        "artist.related.artists.edges.node.image.url": (v12/*: any*/),
-        "artist.related.artists.edges.node.name": (v12/*: any*/),
-        "artist.slug": (v11/*: any*/),
+        "artist.related.artists.edges.node.counts.artworks": (v24/*: any*/),
+        "artist.related.artists.edges.node.counts.forSaleArtworks": (v24/*: any*/),
+        "artist.related.artists.edges.node.href": (v15/*: any*/),
+        "artist.related.artists.edges.node.id": (v14/*: any*/),
+        "artist.related.artists.edges.node.image": (v16/*: any*/),
+        "artist.related.artists.edges.node.image.url": (v15/*: any*/),
+        "artist.related.artists.edges.node.name": (v15/*: any*/),
+        "artist.slug": (v14/*: any*/),
         "artist.targetSupply": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtistTargetSupply"
         },
-        "artist.targetSupply.isInMicrofunnel": (v17/*: any*/),
-        "artist.targetSupply.isTargetSupply": (v17/*: any*/),
-        "artist.upcomingShows": (v14/*: any*/),
-        "artist.upcomingShows.edges": (v15/*: any*/),
-        "artist.upcomingShows.edges.node": (v16/*: any*/),
-        "artist.upcomingShows.edges.node.cover_image": (v13/*: any*/),
-        "artist.upcomingShows.edges.node.cover_image.url": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.exhibition_period": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.href": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.id": (v11/*: any*/),
-        "artist.upcomingShows.edges.node.is_fair_booth": (v17/*: any*/),
-        "artist.upcomingShows.edges.node.kind": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.location": (v18/*: any*/),
-        "artist.upcomingShows.edges.node.location.city": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.location.id": (v11/*: any*/),
-        "artist.upcomingShows.edges.node.name": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.partner": (v19/*: any*/),
-        "artist.upcomingShows.edges.node.partner.__isNode": (v20/*: any*/),
-        "artist.upcomingShows.edges.node.partner.__typename": (v20/*: any*/),
-        "artist.upcomingShows.edges.node.partner.id": (v11/*: any*/),
-        "artist.upcomingShows.edges.node.partner.name": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.slug": (v11/*: any*/),
-        "artist.upcomingShows.edges.node.status": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.status_update": (v12/*: any*/)
+        "artist.targetSupply.isInMicrofunnel": (v20/*: any*/),
+        "artist.targetSupply.isTargetSupply": (v20/*: any*/),
+        "artist.upcomingShows": (v17/*: any*/),
+        "artist.upcomingShows.edges": (v18/*: any*/),
+        "artist.upcomingShows.edges.node": (v19/*: any*/),
+        "artist.upcomingShows.edges.node.cover_image": (v16/*: any*/),
+        "artist.upcomingShows.edges.node.cover_image.url": (v15/*: any*/),
+        "artist.upcomingShows.edges.node.exhibition_period": (v15/*: any*/),
+        "artist.upcomingShows.edges.node.href": (v15/*: any*/),
+        "artist.upcomingShows.edges.node.id": (v14/*: any*/),
+        "artist.upcomingShows.edges.node.is_fair_booth": (v20/*: any*/),
+        "artist.upcomingShows.edges.node.kind": (v15/*: any*/),
+        "artist.upcomingShows.edges.node.location": (v21/*: any*/),
+        "artist.upcomingShows.edges.node.location.city": (v15/*: any*/),
+        "artist.upcomingShows.edges.node.location.id": (v14/*: any*/),
+        "artist.upcomingShows.edges.node.name": (v15/*: any*/),
+        "artist.upcomingShows.edges.node.partner": (v22/*: any*/),
+        "artist.upcomingShows.edges.node.partner.__isNode": (v23/*: any*/),
+        "artist.upcomingShows.edges.node.partner.__typename": (v23/*: any*/),
+        "artist.upcomingShows.edges.node.partner.id": (v14/*: any*/),
+        "artist.upcomingShows.edges.node.partner.name": (v15/*: any*/),
+        "artist.upcomingShows.edges.node.slug": (v14/*: any*/),
+        "artist.upcomingShows.edges.node.status": (v15/*: any*/),
+        "artist.upcomingShows.edges.node.status_update": (v15/*: any*/)
       }
     },
     "name": "ArtistAboutTestsQuery",

--- a/src/__generated__/ArtistAbout_artist.graphql.ts
+++ b/src/__generated__/ArtistAbout_artist.graphql.ts
@@ -8,6 +8,9 @@ export type ArtistAbout_artist = {
     readonly hasMetadata: boolean | null;
     readonly isDisplayAuctionLink: boolean | null;
     readonly slug: string;
+    readonly iconicCollections: ReadonlyArray<{
+        readonly " $fragmentRefs": FragmentRefs<"ArtistCollectionsRail_collections">;
+    } | null> | null;
     readonly related: {
         readonly artists: {
             readonly edges: ReadonlyArray<{
@@ -24,7 +27,7 @@ export type ArtistAbout_artist = {
             } | null;
         } | null> | null;
     } | null;
-    readonly " $fragmentRefs": FragmentRefs<"Biography_artist" | "ArtistConsignButton_artist" | "ArtistAboutShows_artist">;
+    readonly " $fragmentRefs": FragmentRefs<"Biography_artist" | "ArtistConsignButton_artist" | "ArtistAboutShows_artist" | "ArtistCollectionsRail_artist">;
     readonly " $refType": "ArtistAbout_artist";
 };
 export type ArtistAbout_artist$data = ArtistAbout_artist;
@@ -61,6 +64,33 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "slug",
       "storageKey": null
+    },
+    {
+      "alias": "iconicCollections",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "isFeaturedArtistContent",
+          "value": true
+        },
+        {
+          "kind": "Literal",
+          "name": "size",
+          "value": 16
+        }
+      ],
+      "concreteType": "MarketingCollection",
+      "kind": "LinkedField",
+      "name": "marketingCollections",
+      "plural": true,
+      "selections": [
+        {
+          "args": null,
+          "kind": "FragmentSpread",
+          "name": "ArtistCollectionsRail_collections"
+        }
+      ],
+      "storageKey": "marketingCollections(isFeaturedArtistContent:true,size:16)"
     },
     {
       "alias": null,
@@ -175,10 +205,15 @@ const node: ReaderFragment = {
       "args": null,
       "kind": "FragmentSpread",
       "name": "ArtistAboutShows_artist"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "ArtistCollectionsRail_artist"
     }
   ],
   "type": "Artist",
   "abstractKey": null
 };
-(node as any).hash = 'c6d9d5446681e9c00f83659592d8ff3d';
+(node as any).hash = 'c9280af8a4694be8f7175608162912f5';
 export default node;

--- a/src/__generated__/ArtistBelowTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtistBelowTheFoldQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 949afa95c79a90ae72fd6e67ffe39c1f */
+/* @relayHash d4aa674cbc0a75c2d0cc69c1481a2131 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -87,6 +87,11 @@ fragment ArtistAbout_artist on Artist {
   ...Biography_artist
   ...ArtistConsignButton_artist
   ...ArtistAboutShows_artist
+  ...ArtistCollectionsRail_artist
+  iconicCollections: marketingCollections(isFeaturedArtistContent: true, size: 16) {
+    ...ArtistCollectionsRail_collections
+    id
+  }
   related {
     artists: artistsConnection(first: 16) {
       edges {
@@ -104,6 +109,30 @@ fragment ArtistAbout_artist on Artist {
         id
       }
     }
+  }
+}
+
+fragment ArtistCollectionsRail_artist on Artist {
+  internalID
+  slug
+}
+
+fragment ArtistCollectionsRail_collections on MarketingCollection {
+  slug
+  id
+  title
+  priceGuidance
+  artworksConnection(first: 3, aggregations: [TOTAL], sort: "-decayed_merch") {
+    edges {
+      node {
+        title
+        image {
+          url
+        }
+        id
+      }
+    }
+    id
   }
 }
 
@@ -332,26 +361,35 @@ v4 = {
   "name": "name",
   "storageKey": null
 },
-v5 = {
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "url",
+    "storageKey": null
+  }
+],
+v6 = {
   "kind": "Literal",
   "name": "first",
   "value": 10
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v8 = [
+v9 = [
   {
     "alias": null,
     "args": [
@@ -366,18 +404,18 @@ v8 = [
     "storageKey": "url(version:\"large\")"
   }
 ],
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v10 = [
-  (v4/*: any*/),
-  (v6/*: any*/)
-],
 v11 = [
+  (v4/*: any*/),
+  (v7/*: any*/)
+],
+v12 = [
   {
     "alias": null,
     "args": null,
@@ -394,9 +432,9 @@ v11 = [
         "name": "node",
         "plural": false,
         "selections": [
-          (v6/*: any*/),
-          (v2/*: any*/),
           (v7/*: any*/),
+          (v2/*: any*/),
+          (v8/*: any*/),
           {
             "alias": "is_fair_booth",
             "args": null,
@@ -411,7 +449,7 @@ v11 = [
             "kind": "LinkedField",
             "name": "coverImage",
             "plural": false,
-            "selections": (v8/*: any*/),
+            "selections": (v9/*: any*/),
             "storageKey": null
           },
           {
@@ -451,7 +489,7 @@ v11 = [
             "name": "partner",
             "plural": false,
             "selections": [
-              (v9/*: any*/),
+              (v10/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -462,14 +500,14 @@ v11 = [
               },
               {
                 "kind": "InlineFragment",
-                "selections": (v10/*: any*/),
+                "selections": (v11/*: any*/),
                 "type": "ExternalPartner",
                 "abstractKey": null
               },
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v6/*: any*/)
+                  (v7/*: any*/)
                 ],
                 "type": "Node",
                 "abstractKey": "__isNode"
@@ -492,7 +530,7 @@ v11 = [
                 "name": "city",
                 "storageKey": null
               },
-              (v6/*: any*/)
+              (v7/*: any*/)
             ],
             "storageKey": null
           }
@@ -503,12 +541,24 @@ v11 = [
     "storageKey": null
   }
 ],
-v12 = {
+v13 = {
+  "kind": "Literal",
+  "name": "first",
+  "value": 3
+},
+v14 = {
   "kind": "Literal",
   "name": "status",
   "value": "closed"
 },
-v13 = [
+v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "title",
+  "storageKey": null
+},
+v16 = [
   {
     "kind": "Literal",
     "name": "allowEmptyCreatedDates",
@@ -519,7 +569,7 @@ v13 = [
     "name": "earliestCreatedYear",
     "value": 1000
   },
-  (v5/*: any*/),
+  (v6/*: any*/),
   {
     "kind": "Literal",
     "name": "latestCreatedYear",
@@ -531,13 +581,13 @@ v13 = [
     "value": "DATE_DESC"
   }
 ],
-v14 = [
+v17 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 20
   },
-  (v12/*: any*/)
+  (v14/*: any*/)
 ];
 return {
   "fragment": {
@@ -672,15 +722,7 @@ return {
                 "kind": "LinkedField",
                 "name": "cropped",
                 "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "url",
-                    "storageKey": null
-                  }
-                ],
+                "selections": (v5/*: any*/),
                 "storageKey": "cropped(height:66,width:66)"
               }
             ],
@@ -689,7 +731,7 @@ return {
           {
             "alias": "currentShows",
             "args": [
-              (v5/*: any*/),
+              (v6/*: any*/),
               {
                 "kind": "Literal",
                 "name": "status",
@@ -700,13 +742,13 @@ return {
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
-            "selections": (v11/*: any*/),
+            "selections": (v12/*: any*/),
             "storageKey": "showsConnection(first:10,status:\"running\")"
           },
           {
             "alias": "upcomingShows",
             "args": [
-              (v5/*: any*/),
+              (v6/*: any*/),
               {
                 "kind": "Literal",
                 "name": "status",
@@ -717,25 +759,113 @@ return {
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
-            "selections": (v11/*: any*/),
+            "selections": (v12/*: any*/),
             "storageKey": "showsConnection(first:10,status:\"upcoming\")"
           },
           {
             "alias": "pastShows",
             "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 3
-              },
-              (v12/*: any*/)
+              (v13/*: any*/),
+              (v14/*: any*/)
             ],
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
-            "selections": (v11/*: any*/),
+            "selections": (v12/*: any*/),
             "storageKey": "showsConnection(first:3,status:\"closed\")"
+          },
+          {
+            "alias": "iconicCollections",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "isFeaturedArtistContent",
+                "value": true
+              },
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 16
+              }
+            ],
+            "concreteType": "MarketingCollection",
+            "kind": "LinkedField",
+            "name": "marketingCollections",
+            "plural": true,
+            "selections": [
+              (v2/*: any*/),
+              (v7/*: any*/),
+              (v15/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "priceGuidance",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "aggregations",
+                    "value": [
+                      "TOTAL"
+                    ]
+                  },
+                  (v13/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "sort",
+                    "value": "-decayed_merch"
+                  }
+                ],
+                "concreteType": "FilterArtworksConnection",
+                "kind": "LinkedField",
+                "name": "artworksConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "FilterArtworksEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artwork",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v15/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "kind": "LinkedField",
+                            "name": "image",
+                            "plural": false,
+                            "selections": (v5/*: any*/),
+                            "storageKey": null
+                          },
+                          (v7/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v7/*: any*/)
+                ],
+                "storageKey": "artworksConnection(aggregations:[\"TOTAL\"],first:3,sort:\"-decayed_merch\")"
+              }
+            ],
+            "storageKey": "marketingCollections(isFeaturedArtistContent:true,size:16)"
           },
           {
             "alias": null,
@@ -775,8 +905,8 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v6/*: any*/),
                           (v7/*: any*/),
+                          (v8/*: any*/),
                           (v4/*: any*/),
                           {
                             "alias": null,
@@ -810,7 +940,7 @@ return {
                             "kind": "LinkedField",
                             "name": "image",
                             "plural": false,
-                            "selections": (v8/*: any*/),
+                            "selections": (v9/*: any*/),
                             "storageKey": null
                           }
                         ],
@@ -828,7 +958,7 @@ return {
           {
             "alias": "articles",
             "args": [
-              (v5/*: any*/)
+              (v6/*: any*/)
             ],
             "concreteType": "ArticleConnection",
             "kind": "LinkedField",
@@ -851,7 +981,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
+                      (v7/*: any*/),
                       {
                         "alias": "thumbnail_title",
                         "args": null,
@@ -859,7 +989,7 @@ return {
                         "name": "thumbnailTitle",
                         "storageKey": null
                       },
-                      (v7/*: any*/),
+                      (v8/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -867,7 +997,7 @@ return {
                         "kind": "LinkedField",
                         "name": "author",
                         "plural": false,
-                        "selections": (v10/*: any*/),
+                        "selections": (v11/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -877,7 +1007,7 @@ return {
                         "kind": "LinkedField",
                         "name": "thumbnailImage",
                         "plural": false,
-                        "selections": (v8/*: any*/),
+                        "selections": (v9/*: any*/),
                         "storageKey": null
                       }
                     ],
@@ -889,7 +1019,7 @@ return {
             ],
             "storageKey": "articlesConnection(first:10)"
           },
-          (v6/*: any*/),
+          (v7/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -899,7 +1029,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v13/*: any*/),
+            "args": (v16/*: any*/),
             "concreteType": "AuctionResultConnection",
             "kind": "LinkedField",
             "name": "auctionResultsConnection",
@@ -953,7 +1083,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
+                      (v7/*: any*/),
                       (v3/*: any*/),
                       {
                         "alias": null,
@@ -1114,14 +1244,8 @@ return {
                         "name": "saleDate",
                         "storageKey": null
                       },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "title",
-                        "storageKey": null
-                      },
-                      (v9/*: any*/)
+                      (v15/*: any*/),
+                      (v10/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -1165,7 +1289,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v13/*: any*/),
+            "args": (v16/*: any*/),
             "filters": [
               "allowEmptyCreatedDates",
               "categories",
@@ -1186,12 +1310,12 @@ return {
             "selections": [
               {
                 "alias": "pastSmallShows",
-                "args": (v14/*: any*/),
+                "args": (v17/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
-                "selections": (v11/*: any*/),
+                "selections": (v12/*: any*/),
                 "storageKey": "showsConnection(first:20,status:\"closed\")"
               }
             ]
@@ -1203,12 +1327,12 @@ return {
             "selections": [
               {
                 "alias": "pastLargeShows",
-                "args": (v14/*: any*/),
+                "args": (v17/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
-                "selections": (v11/*: any*/),
+                "selections": (v12/*: any*/),
                 "storageKey": "showsConnection(first:20,status:\"closed\")"
               }
             ]
@@ -1219,7 +1343,7 @@ return {
     ]
   },
   "params": {
-    "id": "949afa95c79a90ae72fd6e67ffe39c1f",
+    "id": "d4aa674cbc0a75c2d0cc69c1481a2131",
     "metadata": {},
     "name": "ArtistBelowTheFoldQuery",
     "operationKind": "query",

--- a/src/lib/Components/Artist/ArtistAbout/ArtistAbout.tsx
+++ b/src/lib/Components/Artist/ArtistAbout/ArtistAbout.tsx
@@ -12,6 +12,7 @@ import { extractNodes } from "lib/utils/extractNodes"
 import { CaretButton } from "../../Buttons/CaretButton"
 import { Stack } from "../../Stack"
 import { StickyTabPageScrollView } from "../../StickyTabPage/StickyTabPageScrollView"
+import { ArtistCollectionsRailFragmentContainer } from "../ArtistArtworks/ArtistCollectionsRail"
 import { ArtistConsignButtonFragmentContainer as ArtistConsignButton } from "../ArtistConsignButton"
 import { ArtistAboutShowsFragmentContainer } from "./ArtistAboutShows"
 
@@ -26,6 +27,9 @@ export const ArtistAbout: React.FC<Props> = ({ artist }) => {
   return (
     <StickyTabPageScrollView>
       <Stack spacing={3} my={2}>
+        {!!artist.iconicCollections?.length && (
+          <ArtistCollectionsRailFragmentContainer collections={artist.iconicCollections} artist={artist} />
+        )}
         {!!artist.hasMetadata && <Biography artist={artist as any} />}
         {!!artist.isDisplayAuctionLink && (
           <CaretButton text="Auction results" onPress={() => navigate(`/artist/${artist.slug}/auction-results`)} />
@@ -48,6 +52,10 @@ export const ArtistAboutContainer = createFragmentContainer(ArtistAbout, {
       ...Biography_artist
       ...ArtistConsignButton_artist
       ...ArtistAboutShows_artist
+      ...ArtistCollectionsRail_artist
+      iconicCollections: marketingCollections(isFeaturedArtistContent: true, size: 16) {
+        ...ArtistCollectionsRail_collections
+      }
       related {
         artists: artistsConnection(first: 16) {
           edges {

--- a/src/lib/Components/Artist/ArtistAbout/__tests__/ArtistAbout-tests.tsx
+++ b/src/lib/Components/Artist/ArtistAbout/__tests__/ArtistAbout-tests.tsx
@@ -6,6 +6,7 @@ import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment } from "relay-test-utils"
+import { ArtistCollectionsRailFragmentContainer } from "../../ArtistArtworks/ArtistCollectionsRail"
 import Biography from "../../Biography"
 import { ArtistAboutContainer } from "../ArtistAbout"
 import { ArtistAboutShowsFragmentContainer } from "../ArtistAboutShows"
@@ -117,6 +118,22 @@ describe("ArtistAbout", () => {
       mockEnvironmentPayload(mockEnvironment)
 
       expect(tree.root.findAllByType(ArtistAboutShowsFragmentContainer).length).toEqual(0)
+    })
+  })
+
+  describe("the iconic collections rail", () => {
+    fit("is hidden when there are no collections that feature this artist", () => {
+      const tree = renderWithWrappers(<TestRenderer />)
+
+      mockEnvironmentPayload(mockEnvironment, {
+        MarketingCollection: (context) => {
+          if (context.alias === "iconicCollections") {
+            return []
+          }
+        },
+      })
+
+      expect(tree.root.findAllByType(ArtistCollectionsRailFragmentContainer).length).toEqual(0)
     })
   })
 })


### PR DESCRIPTION
The type of this PR is: Enhancement

This PR resolves [FX-2725]

### Description

1. Only show the Iconic Collections rail on the artist artworks tab if there are no artist series to show.
2. Always show the Iconic Collections rail on the artist about tab.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [ ] I have documented any follow-up work that this PR will require, or it does not require any.
- [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2725]: https://artsyproduct.atlassian.net/browse/FX-2725