### PR TITLE
fix: prevent MakeOfferModal screen tracking from double firing

### DIFF
--- a/src/lib/Scenes/Inbox/Components/Conversations/MakeOfferModal.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/MakeOfferModal.tsx
@@ -31,65 +31,57 @@ export const MakeOfferModal: React.FC<MakeOfferModalProps> = ({ ...props }) => {
   }
 
   return (
-    <ProvideScreenTrackingWithCohesionSchema
-      info={{
-        action: ActionType.screen,
-        context_screen_owner_type: OwnerType.conversationMakeOfferConfirmArtwork,
-        context_screen_referrer_type: OwnerType.conversation,
-      }}
-    >
-      <View>
-        <FancyModalHeader rightButtonDisabled hideBottomDivider>
-          Make Offer with Artsy Pay
-        </FancyModalHeader>
-        <Flex p={1.5}>
-          <Text variant="largeTitle">Confirm Artwork</Text>
-          <Text variant="small" color="black60">
-            {" "}
-            Make sure the artwork below matches the intended work you're making an offer on.
-          </Text>
-          <BorderBox p={0} my={2}>
-            <CollapsibleArtworkDetails hasSeparator={false} artwork={artwork} />
-          </BorderBox>
-          {!!artwork.isEdition && artwork.editionSets!.length > 1 && (
-            <Flex mb={1}>
-              <Text color="black100" mb={1}>
-                {" "}
-                Which edition are you interested in?
-              </Text>
-              {artwork.editionSets?.map((edition) => (
-                <EditionSelectBox
-                  edition={edition!}
-                  selected={edition!.internalID === selectedEdition}
-                  onPress={selectEdition}
-                  key={`edition-set-${edition?.internalID}`}
-                />
-              ))}
-            </Flex>
-          )}
-          <InquiryMakeOfferButton
-            variant="primaryBlack"
-            buttonText="Confirm"
-            artwork={artwork}
-            disabled={!!artwork.isEdition && !selectedEdition}
-            editionSetID={selectedEdition ? selectedEdition : null}
-            conversationID={conversationID}
-          />
-          <Button
-            mt={1}
-            size="large"
-            variant="secondaryOutline"
-            block
-            width={100}
-            onPress={() => {
-              dismissModal()
-            }}
-          >
-            Cancel
-          </Button>
-        </Flex>
-      </View>
-    </ProvideScreenTrackingWithCohesionSchema>
+    <View>
+      <FancyModalHeader rightButtonDisabled hideBottomDivider>
+        Make Offer with Artsy Pay
+      </FancyModalHeader>
+      <Flex p={1.5}>
+        <Text variant="largeTitle">Confirm Artwork</Text>
+        <Text variant="small" color="black60">
+          {" "}
+          Make sure the artwork below matches the intended work you're making an offer on.
+        </Text>
+        <BorderBox p={0} my={2}>
+          <CollapsibleArtworkDetails hasSeparator={false} artwork={artwork} />
+        </BorderBox>
+        {!!artwork.isEdition && artwork.editionSets!.length > 1 && (
+          <Flex mb={1}>
+            <Text color="black100" mb={1}>
+              {" "}
+              Which edition are you interested in?
+            </Text>
+            {artwork.editionSets?.map((edition) => (
+              <EditionSelectBox
+                edition={edition!}
+                selected={edition!.internalID === selectedEdition}
+                onPress={selectEdition}
+                key={`edition-set-${edition?.internalID}`}
+              />
+            ))}
+          </Flex>
+        )}
+        <InquiryMakeOfferButton
+          variant="primaryBlack"
+          buttonText="Confirm"
+          artwork={artwork}
+          disabled={!!artwork.isEdition && !selectedEdition}
+          editionSetID={selectedEdition ? selectedEdition : null}
+          conversationID={conversationID}
+        />
+        <Button
+          mt={1}
+          size="large"
+          variant="secondaryOutline"
+          block
+          width={100}
+          onPress={() => {
+            dismissModal()
+          }}
+        >
+          Cancel
+        </Button>
+      </Flex>
+    </View>
   )
 }
 
@@ -126,21 +118,29 @@ export const MakeOfferModalQueryRenderer: React.FC<{
   conversationID: string
 }> = ({ artworkID, conversationID }) => {
   return (
-    <QueryRenderer<MakeOfferModalQuery>
-      environment={defaultEnvironment}
-      query={graphql`
-        query MakeOfferModalQuery($artworkID: String!) {
-          artwork(id: $artworkID) {
-            ...MakeOfferModal_artwork
-          }
-        }
-      `}
-      variables={{
-        artworkID,
+    <ProvideScreenTrackingWithCohesionSchema
+      info={{
+        action: ActionType.screen,
+        context_screen_owner_type: OwnerType.conversationMakeOfferConfirmArtwork,
+        context_screen_referrer_type: OwnerType.conversation,
       }}
-      render={renderWithLoadProgress<MakeOfferModalQueryResponse>(({ artwork }) => (
-        <MakeOfferModalFragmentContainer artwork={artwork!} conversationID={conversationID} />
-      ))}
-    />
+    >
+      <QueryRenderer<MakeOfferModalQuery>
+        environment={defaultEnvironment}
+        query={graphql`
+          query MakeOfferModalQuery($artworkID: String!) {
+            artwork(id: $artworkID) {
+              ...MakeOfferModal_artwork
+            }
+          }
+        `}
+        variables={{
+          artworkID,
+        }}
+        render={renderWithLoadProgress<MakeOfferModalQueryResponse>(({ artwork }) => (
+          <MakeOfferModalFragmentContainer artwork={artwork!} conversationID={conversationID} />
+        ))}
+      />
+    </ProvideScreenTrackingWithCohesionSchema>
   )
 }


### PR DESCRIPTION
The type of this PR is: **FIX**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [PURCHASE-2517]

### Description

<!-- Implementation description -->

**Issue:**
The screen track event was firing twice for `<MakeOfferModal>`. Once when you navigate to the view/modal and once when navigating away from the view. The second fire was not an expected behavior. 

The  `<MakeOfferModal>` was getting re-rendered. We aren't sure why this is happening but I scheduled more time with the mobile practice team to dig into this a bit more. 

**Fix:**
In the mean time we've moved the `<ProvideScreenTrackingWithCohesionSchema>`  component to wrap the QueryRenderer and this prevents the event from firing more than once.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [ ] I have documented any follow-up work that this PR will require, or it does not require any.
- [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[PURCHASE-2517]: https://artsyproduct.atlassian.net/browse/PURCHASE-2517