### PR TITLE
fix: hide push notifications section in android

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -21,6 +21,7 @@ upcoming:
     - Add modal replacement api to android app - erik, david
     - Fix conversation scrolling while supporting dismissing keyboard - starsirius
     - Updates filter styling - damon
+    - Hide push notifications section in settings for Android - ole
 
 releases:
   - version: 6.8.2

--- a/src/lib/Scenes/MyProfile/MyProfile.tsx
+++ b/src/lib/Scenes/MyProfile/MyProfile.tsx
@@ -11,7 +11,7 @@ import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { times } from "lodash"
 import { Flex, Join, Sans, Separator, Spacer } from "palette"
 import React, { useCallback, useRef, useState } from "react"
-import { Alert, FlatList, RefreshControl, ScrollView } from "react-native"
+import { Alert, FlatList, Platform, RefreshControl, ScrollView } from "react-native"
 import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
 import { SmallTileRailContainer } from "../Home/Components/SmallTileRail"
 
@@ -20,6 +20,7 @@ const MyProfile: React.FC<{ me: MyProfile_me; relay: RelayRefetchProp }> = ({ me
 
   const recentlySavedArtworks = extractNodes(me.followsAndSaves?.artworksConnection)
   const shouldDisplayMyCollection = me.labFeatures?.includes("My Collection")
+  const shouldDisplayPushNotifications = Platform.OS === "ios"
   const [isRefreshing, setIsRefreshing] = useState(false)
   const onRefresh = useCallback(() => {
     setIsRefreshing(true)
@@ -47,7 +48,9 @@ const MyProfile: React.FC<{ me: MyProfile_me; relay: RelayRefetchProp }> = ({ me
       <SectionHeading title="Account Settings" />
       <MenuItem title="Account" onPress={() => navigate("my-account")} />
       <MenuItem title="Payment" onPress={() => navigate("my-profile/payment")} />
-      <MenuItem title="Push notifications" onPress={() => navigate("my-profile/push-notifications")} />
+      {!!shouldDisplayPushNotifications && (
+        <MenuItem title="Push notifications" onPress={() => navigate("my-profile/push-notifications")} />
+      )}
       <MenuItem
         title="Send feedback"
         onPress={() => presentEmailComposer("support@artsy.net", "Feedback from the Artsy app")}

--- a/src/lib/Scenes/MyProfile/__tests__/MyProfile-tests.tsx
+++ b/src/lib/Scenes/MyProfile/__tests__/MyProfile-tests.tsx
@@ -4,6 +4,7 @@ import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 
 import { extractText } from "lib/tests/extractText"
+import { Platform } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
 import { act } from "react-test-renderer"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
@@ -62,5 +63,17 @@ describe(MyProfileQueryRenderer, () => {
   it("doesn't render MyCollections app if feature flag is not on", () => {
     const tree = getWrapper()
     expect(extractText(tree.root)).not.toContain("My Collection")
+  })
+
+  it("renders push notifications on iOS", () => {
+    Platform.OS = "ios"
+    const tree = getWrapper()
+    expect(extractText(tree.root)).toContain("Push notifications")
+  })
+
+  it("doesn't render push notifications on Android", () => {
+    Platform.OS = "android"
+    const tree = getWrapper()
+    expect(extractText(tree.root)).not.toContain("Push notifications")
   })
 })


### PR DESCRIPTION
The type of this PR is: Bugfix

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1273]

### Description

Since we are not supporting push notifications for Android v1 we should hide this section of the profile menu. 

| iOS | Android |
| --- | ---|
|![image](https://user-images.githubusercontent.com/4691889/114021770-59305c00-9871-11eb-8032-965520f16164.png)|![image](https://user-images.githubusercontent.com/4691889/114021935-8a109100-9871-11eb-87f5-af0377d9c844.png)|


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1273]: https://artsyproduct.atlassian.net/browse/CX-1273