### PR TITLE
chore: adds 10px of space to center inq chk header text

### DIFF
--- a/src/lib/Scenes/Inbox/Screens/Conversation.tsx
+++ b/src/lib/Scenes/Inbox/Screens/Conversation.tsx
@@ -32,10 +32,11 @@ const Header = styled.View`
 // This makes it really easy to style the HeaderTextContainer with space-between
 const PlaceholderView = View
 
-const HeaderTextContainer = styled.View`
+const HeaderTextContainer = styled(Flex)`
   flex-direction: row;
   justify-content: center;
   flex-grow: 1;
+  justify-content: space-between;
 `
 
 interface Props {
@@ -170,22 +171,24 @@ export class Conversation extends React.Component<Props, State> {
           <Header>
             <Flex flexDirection="row" alignSelf="stretch" mx={2}>
               <HeaderTextContainer>
-                <Text variant="mediumText">{partnerName}</Text>
                 <PlaceholderView />
+                <Text ml={1} variant="mediumText">
+                  {partnerName}
+                </Text>
+                <Touchable
+                  onPress={() => {
+                    this.props.navigator.push({
+                      component: ConversationDetailsQueryRenderer,
+                      title: "",
+                      passProps: {
+                        conversationID: this.props.me?.conversation?.internalID,
+                      },
+                    })
+                  }}
+                >
+                  <InfoCircleIcon />
+                </Touchable>
               </HeaderTextContainer>
-              <Touchable
-                onPress={() => {
-                  this.props.navigator.push({
-                    component: ConversationDetailsQueryRenderer,
-                    title: "",
-                    passProps: {
-                      conversationID: this.props.me?.conversation?.internalID,
-                    },
-                  })
-                }}
-              >
-                <InfoCircleIcon />
-              </Touchable>
             </Flex>
           </Header>
           {!this.state.isConnected && <ConnectivityBanner />}


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This commit should have been included in https://github.com/artsy/eigen/pull/4612.



<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [PURCHASE-2558]

### Description

<!-- Implementation description -->

I did a visual QA of the inquiry checkout header with @ArvindLall and we opted to add these small tweaks to the header text to center it on the screen. The back button creates a bit of asymmetry that we are fixing here.
### PR Checklist (tick all before merging)

<img width="447" alt="Screen Shot 2021-04-08 at 1 25 48 PM" src="https://user-images.githubusercontent.com/10385964/114081699-e330f280-987a-11eb-97a4-01a920881de3.png">
*The border has been removed, its there to use with Photoshop for centering properly.*

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434