### PR TITLE
fix: fix toast test, don't use button

### DIFF
--- a/src/lib/Components/Toast/__tests__/Toast-tests.tsx
+++ b/src/lib/Components/Toast/__tests__/Toast-tests.tsx
@@ -1,6 +1,7 @@
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
-import { Button, Flex } from "palette"
+import { Touchable } from "palette"
 import React from "react"
+import { Text } from "react-native"
 import { act } from "react-test-renderer"
 import { Toast } from "../Toast"
 import { useToast } from "../toastHook"
@@ -9,21 +10,28 @@ const TestRenderer: React.FC = () => {
   const toast = useToast()
 
   return (
-    <Flex>
-      <Button onPress={() => toast.show("Consider yourself toasted!", "middle")}>Toast me</Button>
-    </Flex>
+    <Touchable onPress={() => toast.show("Consider yourself toasted!", "middle")}>
+      <Text>Some button text</Text>
+    </Touchable>
   )
 }
 
-describe("Toasts", () => {
-  jest.useFakeTimers()
+describe("Toast", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+  })
 
-  it("renders a toast when", async () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it("renders a toast when show toast is called", async () => {
     const tree = renderWithWrappers(<TestRenderer />)
 
     expect(tree.root.findAllByType(Toast)).toHaveLength(0)
 
-    const buttonInstance = tree.root.findByType(Button)
+    const buttonInstance = tree.root.findByType(Touchable)
     act(() => buttonInstance.props.onPress())
 
     expect(tree.root.findAllByType(Toast)).toHaveLength(1)


### PR DESCRIPTION
The type of this PR is: **fix**

### Description

We are seeing intermittent test failures in Toast component.

Worked on in knowledge share with @artsy/collector-experience it looks like the problem is not with the Toast component but with some recent changes to the Button component here: https://github.com/artsy/eigen/pull/4591, 
Only theory which is kind of vague right now is the loading style now being passed is causing button component to animate which is causing the timer recursion issue but beyond that I am still unclear exactly what is going on. I didn't want to sink too much time into investigation so I just used a different component in this test.

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
