### PR TITLE
fix: keyboard avoiding

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -11,6 +11,7 @@ upcoming:
     - Hide AdminMenu behind 7 taps of "Version" - pavlos
     - Use radio buttons for single-select filters behind feature flag - iskounen
     - Specify tracking screen owner in tab bar tracking - ole
+    - Fix keyboard avoidance - david
   user_facing:
     - Use toolbar style modal headers in consignments flow - brian
     - Add Onboarding welcome screen - mounir

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:launchMode="singleTask"
         android:exported="true"
-        android:windowSoftInputMode="adjustPan">
+        android:windowSoftInputMode="adjustResize">
       </activity>
 
       <activity

--- a/android/app/src/main/java/net/artsy/app/ArtsyNativeModule.java
+++ b/android/app/src/main/java/net/artsy/app/ArtsyNativeModule.java
@@ -1,24 +1,31 @@
 package net.artsy.app;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.graphics.Color;
+import android.graphics.Point;
 import android.os.Build;
+import android.view.Display;
+import android.view.KeyCharacterMap;
+import android.view.KeyEvent;
 import android.view.View;
+import android.view.ViewConfiguration;
 import android.view.Window;
-import android.view.WindowInsets;
 import android.view.WindowManager;
 
 import androidx.annotation.NonNull;
 
-import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import java.util.Map;
+
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
+import java.util.Map;
 
 
 public class ArtsyNativeModule extends ReactContextBaseJavaModule {
@@ -43,6 +50,7 @@ public class ArtsyNativeModule extends ReactContextBaseJavaModule {
     public Map<String, Object> getConstants() {
         final Map<String, Object> constants = new HashMap<>();
         constants.put("launchCount", ArtsyNativeModule.launchCount);
+        constants.put("navigationBarHeight", getNavigationBarSize(this.getReactApplicationContext()).y);
         return constants;
     }
 
@@ -109,5 +117,48 @@ public class ArtsyNativeModule extends ReactContextBaseJavaModule {
                 }
             }
         });
+    }
+
+    public static Point getNavigationBarSize(Context context) {
+        Point appUsableSize = getAppUsableScreenSize(context);
+        Point realScreenSize = getRealScreenSize(context);
+
+        // navigation bar on the side
+        if (appUsableSize.x < realScreenSize.x) {
+            return new Point(realScreenSize.x - appUsableSize.x, appUsableSize.y);
+        }
+
+        // navigation bar at the bottom
+        if (appUsableSize.y < realScreenSize.y) {
+            return new Point(appUsableSize.x, realScreenSize.y - appUsableSize.y);
+        }
+
+        // navigation bar is not present
+        return new Point();
+    }
+
+    public static Point getAppUsableScreenSize(Context context) {
+        WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+        Display display = windowManager.getDefaultDisplay();
+        Point size = new Point();
+        display.getSize(size);
+        return size;
+    }
+
+    public static Point getRealScreenSize(Context context) {
+        WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+        Display display = windowManager.getDefaultDisplay();
+        Point size = new Point();
+
+        if (Build.VERSION.SDK_INT >= 17) {
+            display.getRealSize(size);
+        } else if (Build.VERSION.SDK_INT >= 14) {
+            try {
+                size.x = (Integer) Display.class.getMethod("getRawWidth").invoke(display);
+                size.y = (Integer) Display.class.getMethod("getRawHeight").invoke(display);
+            } catch (IllegalAccessException e) {} catch (InvocationTargetException e) {} catch (NoSuchMethodException e) {}
+        }
+
+        return size;
     }
 }

--- a/src/lib/Components/ArtsyKeyboardAvoidingView.tsx
+++ b/src/lib/Components/ArtsyKeyboardAvoidingView.tsx
@@ -1,0 +1,166 @@
+import { ArtsyNativeModule } from "lib/NativeModules/ArtsyNativeModule"
+import React, { useContext } from "react"
+import {
+  Dimensions,
+  Keyboard,
+  KeyboardEvent,
+  LayoutAnimation,
+  LayoutRectangle,
+  Platform,
+  StatusBar,
+  StyleSheet,
+  View,
+  ViewProps,
+} from "react-native"
+
+interface State {
+  bottom: number
+}
+
+export const ArtsyKeyboardAvoidingViewContext = React.createContext({
+  isPresentedModally: false,
+  isVisible: true,
+})
+
+export const ArtsyKeyboardAvoidingView: React.FC<{}> = ({ children }) => {
+  const { isPresentedModally, isVisible } = useContext(ArtsyKeyboardAvoidingViewContext)
+
+  return (
+    <KeyboardAvoidingView
+      enabled={isVisible}
+      mode={isPresentedModally ? "bottom-based" : "top-based"}
+      style={{ flex: 1 }}
+    >
+      {children}
+    </KeyboardAvoidingView>
+  )
+}
+
+/**
+ * This code was mostly copied directly from 'react-native'
+ *
+ * The things we've changed are:
+ * - to allow for bottom-based keyboard height calculations for modals
+ * - to use measerInWindow to get the view offset, rather than the bounding box from onLayout
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of https://github.com/facebook/react-native
+ */
+class KeyboardAvoidingView extends React.Component<
+  { enabled?: boolean; mode: "top-based" | "bottom-based" } & ViewProps,
+  State
+> {
+  _frame: LayoutRectangle | null = null
+  _subscriptions: Array<{ remove(): void }> = []
+  _initialFrameHeight: number = 0
+
+  viewRef = React.createRef<View>()
+
+  constructor(props: any) {
+    super(props)
+    this.state = { bottom: 0 }
+  }
+
+  _relativeKeyboardHeight(keyboardFrame: KeyboardEvent["endCoordinates"]): number {
+    const frame = this._frame
+    if (!frame || !keyboardFrame) {
+      return 0
+    }
+
+    switch (this.props.mode) {
+      case "top-based": {
+        let keyboardY = keyboardFrame.screenY
+        // on android the View layout frame coords start at -statusBarHeight but the
+        // keyboard screenY starts at 0 so we need to offset it to match the View frame
+        if (Platform.OS === "android") {
+          keyboardY -= StatusBar.currentHeight ?? 0
+        }
+
+        // Calculate the displacement needed for the view such that it
+        // no longer overlaps with the keyboard
+        return Math.max(frame.y + frame.height - keyboardY, 0)
+      }
+      case "bottom-based": {
+        let keyboardHeight = Dimensions.get("screen").height - keyboardFrame.screenY
+
+        if (Platform.OS === "android") {
+          keyboardHeight -= ArtsyNativeModule.navigationBarHeight
+        }
+
+        return Math.max(keyboardHeight, 0)
+      }
+    }
+  }
+
+  _onKeyboardChange = (event: KeyboardEvent) => {
+    if (event == null) {
+      this.setState({ bottom: 0 })
+      return
+    }
+
+    const { duration, easing, endCoordinates } = event
+    const height = this._relativeKeyboardHeight(endCoordinates)
+
+    if (this.state.bottom === height) {
+      return
+    }
+
+    if (duration && easing) {
+      LayoutAnimation.configureNext({
+        // We have to pass the duration equal to minimal accepted duration defined here: RCTLayoutAnimation.m
+        duration: duration > 10 ? duration : 10,
+        update: {
+          duration: duration > 10 ? duration : 10,
+          type: LayoutAnimation.Types[easing] || "keyboard",
+        },
+      })
+    }
+    this.setState({ bottom: height })
+  }
+
+  _onLayout: ViewProps["onLayout"] = (event) => {
+    this._frame = event.nativeEvent.layout
+    this.viewRef.current?.measureInWindow((x, y) => {
+      this._frame!.x = x
+      this._frame!.y = y
+    })
+    if (!this._initialFrameHeight) {
+      // save the initial frame height, before the keyboard is visible
+      this._initialFrameHeight = this._frame.height
+    }
+  }
+
+  componentDidMount(): void {
+    if (Platform.OS === "ios") {
+      this._subscriptions = [Keyboard.addListener("keyboardWillChangeFrame", this._onKeyboardChange)]
+    } else {
+      this._subscriptions = [
+        Keyboard.addListener("keyboardDidHide", this._onKeyboardChange),
+        Keyboard.addListener("keyboardDidShow", this._onKeyboardChange),
+      ]
+    }
+  }
+
+  componentWillUnmount(): void {
+    this._subscriptions.forEach((subscription) => {
+      subscription.remove()
+    })
+  }
+
+  render() {
+    const { children, mode, enabled, style, ...props } = this.props
+    const bottomHeight = enabled ? this.state.bottom : 0
+    return (
+      <View
+        ref={this.viewRef}
+        style={StyleSheet.compose(style, { paddingBottom: bottomHeight })}
+        onLayout={this._onLayout}
+        {...props}
+      >
+        {children}
+      </View>
+    )
+  }
+}

--- a/src/lib/Components/ArtsyReactWebView.tsx
+++ b/src/lib/Components/ArtsyReactWebView.tsx
@@ -6,9 +6,10 @@ import { getCurrentEmissionState, GlobalStore, useEnvironment } from "lib/store/
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { parse as parseQueryString } from "query-string"
 import React, { useEffect, useRef, useState } from "react"
-import { KeyboardAvoidingView, Platform, View } from "react-native"
+import { Platform, View } from "react-native"
 import WebView, { WebViewProps } from "react-native-webview"
 import { parse as parseURL } from "url"
+import { ArtsyKeyboardAvoidingView } from "./ArtsyKeyboardAvoidingView"
 import { FancyModalHeader } from "./FancyModal/FancyModalHeader"
 
 export interface ArtsyWebViewConfig {
@@ -38,11 +39,7 @@ export const ArtsyReactWebViewPage: React.FC<
 
   return (
     <View style={{ flex: 1, paddingTop }}>
-      <KeyboardAvoidingView
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
-        keyboardVerticalOffset={useScreenDimensions().safeAreaInsets.top}
-        style={{ flex: 1 }}
-      >
+      <ArtsyKeyboardAvoidingView>
         <FancyModalHeader
           useXButton={isPresentedModally && !canGoBack}
           onLeftButtonPress={() => {
@@ -61,7 +58,7 @@ export const ArtsyReactWebViewPage: React.FC<
           allowWebViewInnerNavigation={allowWebViewInnerNavigation}
           onNavigationStateChange={mimicBrowserBackButton ? (ev) => setCanGoBack(ev.canGoBack) : undefined}
         />
-      </KeyboardAvoidingView>
+      </ArtsyKeyboardAvoidingView>
     </View>
   )
 }

--- a/src/lib/Components/Bidding/Screens/BillingAddress.tsx
+++ b/src/lib/Components/Bidding/Screens/BillingAddress.tsx
@@ -222,7 +222,11 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
               Add billing address
             </FancyModalHeader>
           </Theme>
-          <ScrollView ref={(scrollView) => (this.scrollView = scrollView as any)}>
+          <ScrollView
+            keyboardDismissMode="on-drag"
+            keyboardShouldPersistTaps="handled"
+            ref={(scrollView) => (this.scrollView = scrollView as any)}
+          >
             <Container>
               <StyledInput
                 {...this.defaultPropsForInput("fullName")}
@@ -232,8 +236,6 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 textContentType="name"
                 // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 onSubmitEditing={() => this.addressLine1.focus()}
-                onLayout={({ nativeEvent }) => (this.fullNameLayout = nativeEvent.layout)}
-                onFocus={() => this.scrollToPosition(this.fullNameLayout)}
               />
 
               <StyledInput
@@ -243,8 +245,6 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 textContentType="streetAddressLine1"
                 // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 onSubmitEditing={() => this.addressLine2.focus()}
-                onLayout={({ nativeEvent }) => (this.addressLine1Layout = nativeEvent.layout)}
-                onFocus={() => this.scrollToPosition(this.addressLine1Layout)}
               />
 
               <StyledInput
@@ -254,8 +254,6 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 textContentType="streetAddressLine2"
                 // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 onSubmitEditing={() => this.city.focus()}
-                onLayout={({ nativeEvent }) => (this.addressLine2Layout = nativeEvent.layout)}
-                onFocus={() => this.scrollToPosition(this.addressLine2Layout)}
               />
 
               <StyledInput
@@ -265,8 +263,6 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 textContentType="addressCity"
                 // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 onSubmitEditing={() => this.stateProvinceRegion.focus()}
-                onLayout={({ nativeEvent }) => (this.cityLayout = nativeEvent.layout)}
-                onFocus={() => this.scrollToPosition(this.cityLayout)}
               />
 
               <StyledInput
@@ -277,8 +273,6 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 onSubmitEditing={() => this.postalCode.focus()}
                 inputRef={(el) => (this.stateProvinceRegion = el)}
-                onLayout={({ nativeEvent }) => (this.stateProvinceRegionLayout = nativeEvent.layout)}
-                onFocus={() => this.scrollToPosition(this.stateProvinceRegionLayout)}
               />
 
               <StyledInput
@@ -288,8 +282,6 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 textContentType="postalCode"
                 // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
                 onSubmitEditing={() => this.phoneNumber.focus()}
-                onLayout={({ nativeEvent }) => (this.postalCodeLayout = nativeEvent.layout)}
-                onFocus={() => this.scrollToPosition(this.postalCodeLayout)}
               />
 
               <StyledInput
@@ -299,8 +291,6 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
                 keyboardType="phone-pad"
                 textContentType="telephoneNumber"
                 onSubmitEditing={() => this.presentSelectCountry()}
-                onLayout={({ nativeEvent }) => (this.phoneNumberLayout = nativeEvent.layout)}
-                onFocus={() => this.scrollToPosition(this.phoneNumberLayout)}
               />
 
               <Flex mb={4}>

--- a/src/lib/Components/Bidding/Screens/BillingAddress.tsx
+++ b/src/lib/Components/Bidding/Screens/BillingAddress.tsx
@@ -8,7 +8,6 @@ import {
   Dimensions,
   EmitterSubscription,
   Keyboard,
-  KeyboardAvoidingView,
   LayoutRectangle,
   Platform,
   ScrollView,
@@ -24,6 +23,7 @@ import { Container } from "../Components/Containers"
 import { Input, InputProps } from "../Components/Input"
 import { Address, Country } from "../types"
 
+import { ArtsyKeyboardAvoidingView } from "lib/Components/ArtsyKeyboardAvoidingView"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
 import { SelectCountry } from "./SelectCountry"
 
@@ -216,11 +216,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
 
     return (
       <BiddingThemeProvider>
-        <KeyboardAvoidingView
-          behavior={Platform.OS === "ios" ? "padding" : undefined}
-          keyboardVerticalOffset={this.verticalOffset}
-          style={{ flex: 1 }}
-        >
+        <ArtsyKeyboardAvoidingView>
           <Theme>
             <FancyModalHeader onLeftButtonPress={() => this.props.navigator?.pop()}>
               Add billing address
@@ -339,7 +335,7 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
               </Button>
             </Container>
           </ScrollView>
-        </KeyboardAvoidingView>
+        </ArtsyKeyboardAvoidingView>
       </BiddingThemeProvider>
     )
   }
@@ -363,10 +359,6 @@ export class BillingAddress extends React.Component<BillingAddressProps, Billing
     const windowHeight = Dimensions.get("window").height
 
     return Math.max(0, y - windowHeight + height + iOSAccessoryViewHeight + this.keyboardHeight + this.iPhoneXOffset)
-  }
-
-  private get verticalOffset() {
-    return this.iPhoneXOffset + 15
   }
 
   // TODO: Remove this once React Native has been updated

--- a/src/lib/Components/Bidding/Screens/CreditCardForm.tsx
+++ b/src/lib/Components/Bidding/Screens/CreditCardForm.tsx
@@ -5,7 +5,7 @@ import { ScrollView, View } from "react-native"
 // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import stripe, { StripeToken } from "tipsi-stripe"
 
-import BottomAlignedButtonWrapper from "lib/Components/Buttons/BottomAlignedButtonWrapper"
+import { BottomAlignedButtonWrapper } from "lib/Components/Buttons/BottomAlignedButtonWrapper"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
 import { BiddingThemeProvider } from "../Components/BiddingThemeProvider"
 import { Container } from "../Components/Containers"
@@ -92,8 +92,7 @@ export class CreditCardForm extends Component<CreditCardFormProps, CreditCardFor
     return (
       <BiddingThemeProvider>
         <BottomAlignedButtonWrapper
-          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-          onPress={this.state.valid ? () => this.tokenizeCardAndSubmit() : null}
+          onPress={this.state.valid ? () => this.tokenizeCardAndSubmit() : undefined}
           buttonComponent={buttonComponent}
         >
           <Theme>

--- a/src/lib/Components/Bidding/Screens/Registration.tsx
+++ b/src/lib/Components/Bidding/Screens/Registration.tsx
@@ -317,7 +317,10 @@ export class Registration extends React.Component<RegistrationProps, Registratio
 
     return (
       <BiddingThemeProvider>
-        <ScrollView contentContainerStyle={{ flexGrow: 1, justifyContent: "space-between" }}>
+        <ScrollView
+          contentContainerStyle={{ flexGrow: 1, justifyContent: "space-between" }}
+          keyboardDismissMode={"on-drag"}
+        >
           <View style={{ paddingTop: 20 }}>
             <Flex alignItems="center">
               <Timer

--- a/src/lib/Components/Buttons/BottomAlignedButtonWrapper.tsx
+++ b/src/lib/Components/Buttons/BottomAlignedButtonWrapper.tsx
@@ -1,29 +1,18 @@
-import { ICON_HEIGHT } from "lib/Scenes/BottomTabs/BottomTabsIcon"
 import React from "react"
-import { Dimensions, KeyboardAvoidingView, View } from "react-native"
+import { View } from "react-native"
+import { ArtsyKeyboardAvoidingView } from "../ArtsyKeyboardAvoidingView"
 
 export interface BottomAlignedProps extends React.Props<JSX.Element> {
-  onPress: () => void
-  verticalOffset?: number
+  onPress?: () => void
   buttonComponent: any
 }
 
-// TODO: Remove this once React Native has been updated
-const isPhoneX = Dimensions.get("window").height === 812 && Dimensions.get("window").width === 375
-const defaultVerticalOffset = isPhoneX ? 30 : 15
-
-const BottomAlignedButtonWrapper: React.FC<BottomAlignedProps> = (props) => (
-  <KeyboardAvoidingView
-    behavior="padding"
-    keyboardVerticalOffset={props.verticalOffset || defaultVerticalOffset + ICON_HEIGHT}
-    style={{ flex: 1 }}
-  >
+export const BottomAlignedButtonWrapper: React.FC<BottomAlignedProps> = (props) => (
+  <ArtsyKeyboardAvoidingView>
     <View key="space-eater" style={{ flexGrow: 1 }}>
       {props.children}
     </View>
 
     {props.buttonComponent}
-  </KeyboardAvoidingView>
+  </ArtsyKeyboardAvoidingView>
 )
-
-export default BottomAlignedButtonWrapper

--- a/src/lib/Components/FancyModal/FancyModal.tsx
+++ b/src/lib/Components/FancyModal/FancyModal.tsx
@@ -1,6 +1,7 @@
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import React, { useContext, useEffect, useRef, useState } from "react"
-import { KeyboardAvoidingView, Modal, Platform } from "react-native"
+import { Modal, Platform } from "react-native"
+import { ArtsyKeyboardAvoidingView, ArtsyKeyboardAvoidingViewContext } from "../ArtsyKeyboardAvoidingView"
 import { CARD_STACK_OVERLAY_HEIGHT, CARD_STACK_OVERLAY_Y_OFFSET } from "./FancyModalCard"
 import { FancyModalContext } from "./FancyModalContext"
 
@@ -41,13 +42,9 @@ export const FancyModal: React.FC<{
           up to the maximum 'top' value, and then add padding if the keyboard comes up any more.
           I'd imagine it would have an API like <FancyKeyboardAvoding height={sheetHeighht} maxHeight={screenHeight - (top + 10)}>
       */
-      <KeyboardAvoidingView
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
-        style={{ flex: 1 }}
-        keyboardVerticalOffset={screenHeight - height}
-      >
-        {children}
-      </KeyboardAvoidingView>
+      <ArtsyKeyboardAvoidingViewContext.Provider value={{ isPresentedModally: true, isVisible: true }}>
+        <ArtsyKeyboardAvoidingView>{children}</ArtsyKeyboardAvoidingView>
+      </ArtsyKeyboardAvoidingViewContext.Provider>
     ) : null,
     onBackgroundPressed,
   })

--- a/src/lib/NativeModules/ArtsyNativeModule.tsx
+++ b/src/lib/NativeModules/ArtsyNativeModule.tsx
@@ -1,4 +1,4 @@
-import { NativeModules, Platform } from "react-native"
+import { NativeModules, PixelRatio, Platform } from "react-native"
 import { LegacyNativeModules } from "./LegacyNativeModules"
 
 /**
@@ -29,4 +29,9 @@ export const ArtsyNativeModule = {
           console.error("setNavigationBarColor is unsupported on iOS")
         }
       : NativeModules.ArtsyNativeModule.setNavigationBarColor,
+  get navigationBarHeight() {
+    return Platform.OS === "ios"
+      ? 0
+      : NativeModules.ArtsyNativeModule.getConstants().navigationBarHeight / PixelRatio.get()
+  },
 }

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -11,7 +11,7 @@ import { LocationWithDetails } from "lib/utils/googleMaps"
 import { Schema } from "lib/utils/track"
 import { Box, color, Flex, Separator, space, Text } from "palette"
 import React, { useCallback, useContext, useEffect, useRef, useState } from "react"
-import { KeyboardAvoidingView, LayoutAnimation, Platform, ScrollView, TouchableOpacity } from "react-native"
+import { LayoutAnimation, ScrollView, TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql, RelayProp } from "react-relay"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
@@ -233,49 +233,47 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, ...props })
           </Text>
         </ErrorMessageFlex>
       )}
-      <KeyboardAvoidingView behavior="padding" style={{ flex: 1 }} enabled={Platform.OS === "android"}>
-        <ScrollView ref={scrollViewRef}>
-          <CollapsibleArtworkDetailsFragmentContainer artwork={artwork} />
-          <Box m={2}>
-            <Text variant="mediumText">What information are you looking for?</Text>
-            {
-              // NOTE: For now the inquiryQuestions field values are always present and therefore never null, so it is safe to destructure them
-              questions!.map((inquiryQuestion) => {
-                if (!inquiryQuestion) {
-                  return false
-                }
-                const { internalID: id, question } = inquiryQuestion
-                return id === InquiryQuestionIDs.Shipping ? (
-                  <InquiryQuestionOption
-                    key={id}
-                    id={id}
-                    question={question}
-                    setShippingModalVisibility={setShippingModalVisibility}
-                  />
-                ) : (
-                  <InquiryQuestionOption key={id} id={id} question={question} />
-                )
-              })
-            }
-          </Box>
-          <Box
-            mx={2}
-            mb={4}
-            onLayout={({ nativeEvent }) => {
-              setAddMessageYCoordinate(nativeEvent.layout.y)
-            }}
-          >
-            <TextArea
-              placeholder="Add a custom note..."
-              title="Add message"
-              value={state.message ? state.message : ""}
-              onChangeText={setMessage}
-              onFocus={scrollToInput}
-              style={{ justifyContent: "flex-start" }}
-            />
-          </Box>
-        </ScrollView>
-      </KeyboardAvoidingView>
+      <ScrollView ref={scrollViewRef}>
+        <CollapsibleArtworkDetailsFragmentContainer artwork={artwork} />
+        <Box m={2}>
+          <Text variant="mediumText">What information are you looking for?</Text>
+          {
+            // NOTE: For now the inquiryQuestions field values are always present and therefore never null, so it is safe to destructure them
+            questions!.map((inquiryQuestion) => {
+              if (!inquiryQuestion) {
+                return false
+              }
+              const { internalID: id, question } = inquiryQuestion
+              return id === InquiryQuestionIDs.Shipping ? (
+                <InquiryQuestionOption
+                  key={id}
+                  id={id}
+                  question={question}
+                  setShippingModalVisibility={setShippingModalVisibility}
+                />
+              ) : (
+                <InquiryQuestionOption key={id} id={id} question={question} />
+              )
+            })
+          }
+        </Box>
+        <Box
+          mx={2}
+          mb={4}
+          onLayout={({ nativeEvent }) => {
+            setAddMessageYCoordinate(nativeEvent.layout.y)
+          }}
+        >
+          <TextArea
+            placeholder="Add a custom note..."
+            title="Add message"
+            value={state.message ? state.message : ""}
+            onChangeText={setMessage}
+            onFocus={scrollToInput}
+            style={{ justifyContent: "flex-start" }}
+          />
+        </Box>
+      </ScrollView>
       <ShippingModal
         toggleVisibility={() => setShippingModalVisibility(!shippingModalVisibility)}
         modalIsVisible={shippingModalVisibility}

--- a/src/lib/Scenes/Consignments/Components/BottomAlignedButton.tsx
+++ b/src/lib/Scenes/Consignments/Components/BottomAlignedButton.tsx
@@ -1,8 +1,7 @@
-import { ICON_HEIGHT } from "lib/Scenes/BottomTabs/BottomTabsIcon"
-import { useScreenDimensions } from "lib/utils/useScreenDimensions"
+import { ArtsyKeyboardAvoidingView } from "lib/Components/ArtsyKeyboardAvoidingView"
 import { Box, Button, Separator, Spacer } from "palette"
 import React from "react"
-import { KeyboardAvoidingView, View } from "react-native"
+import { View } from "react-native"
 
 export interface BottomAlignedProps extends React.Props<JSX.Element> {
   onPress: () => void
@@ -19,11 +18,7 @@ export const BottomAlignedButton: React.FC<BottomAlignedProps> = ({
   disabled,
   showSeparator = true,
 }) => (
-  <KeyboardAvoidingView
-    behavior="padding"
-    keyboardVerticalOffset={useScreenDimensions().safeAreaInsets.top + ICON_HEIGHT}
-    style={{ flex: 1 }}
-  >
+  <ArtsyKeyboardAvoidingView>
     <View key="space-eater" style={{ flexGrow: 1 }}>
       {children}
     </View>
@@ -35,5 +30,5 @@ export const BottomAlignedButton: React.FC<BottomAlignedProps> = ({
       </Button>
     </Box>
     <Spacer mb={1} />
-  </KeyboardAvoidingView>
+  </ArtsyKeyboardAvoidingView>
 )

--- a/src/lib/Scenes/Inbox/Components/Conversations/Composer.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/Composer.tsx
@@ -1,18 +1,16 @@
 import { Composer_conversation } from "__generated__/Composer_conversation.graphql"
+import { ArtsyKeyboardAvoidingView } from "lib/Components/ArtsyKeyboardAvoidingView"
 import colors from "lib/data/colors"
 import { unsafe_getFeatureFlag } from "lib/store/GlobalStore"
 import { extractNodes } from "lib/utils/extractNodes"
 import { Schema, Track, track as _track } from "lib/utils/track"
-import { ScreenDimensionsContext } from "lib/utils/useScreenDimensions"
 import { Button, color, Flex, themeProps } from "palette"
 import React from "react"
-import { Dimensions, TextInput, TouchableWithoutFeedback } from "react-native"
+import { TextInput, TouchableWithoutFeedback } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components/native"
 import { OpenInquiryModalButton } from "./OpenInquiryModalButton"
 import { ReviewOfferButtonFragmentContainer as ReviewOfferButton } from "./ReviewOfferButton"
-
-const isPad = Dimensions.get("window").width > 700
 
 interface ContainerProps {
   active: boolean
@@ -26,11 +24,6 @@ const Container = styled.View`
   border-top-color: ${color("black10")};
   padding: 10px;
   background-color: ${(p: ContainerProps) => (p.active ? "white" : colors["gray-light"])};
-`
-
-const StyledKeyboardAvoidingView = styled.KeyboardAvoidingView`
-  flex: 1;
-  ${isPad ? "width: 708; align-self: center;" : ""};
 `
 
 interface Props {
@@ -123,35 +116,31 @@ export default class Composer extends React.Component<Props, State> {
     }
 
     return (
-      <ScreenDimensionsContext.Consumer>
-        {({ safeAreaInsets }) => (
-          <StyledKeyboardAvoidingView behavior="padding" keyboardVerticalOffset={safeAreaInsets.top}>
-            {this.props.children}
-            <Flex flexDirection="column">
-              {!this.state.active && CTA}
-              <Container active={this.state.active}>
-                <TextInput
-                  placeholder={"Type your message"}
-                  placeholderTextColor={colors["gray-semibold"]}
-                  keyboardAppearance={"dark"}
-                  onEndEditing={() => this.setState({ active: false })}
-                  onFocus={() => this.setState({ active: this.input.isFocused() })}
-                  onChangeText={(text) => this.setState({ text })}
-                  ref={(input) => (this.input = input)}
-                  style={inputStyles}
-                  multiline={true}
-                  value={this.state.text || undefined}
-                />
-                <TouchableWithoutFeedback disabled={disableSendButton} onPress={this.submitText.bind(this)}>
-                  <Button ml={1} disabled={!!disableSendButton}>
-                    Send
-                  </Button>
-                </TouchableWithoutFeedback>
-              </Container>
-            </Flex>
-          </StyledKeyboardAvoidingView>
-        )}
-      </ScreenDimensionsContext.Consumer>
+      <ArtsyKeyboardAvoidingView>
+        {this.props.children}
+        <Flex flexDirection="column">
+          {!this.state.active && CTA}
+          <Container active={this.state.active}>
+            <TextInput
+              placeholder={"Type your message"}
+              placeholderTextColor={colors["gray-semibold"]}
+              keyboardAppearance={"dark"}
+              onEndEditing={() => this.setState({ active: false })}
+              onFocus={() => this.setState({ active: this.input.isFocused() })}
+              onChangeText={(text) => this.setState({ text })}
+              ref={(input) => (this.input = input)}
+              style={inputStyles}
+              multiline={true}
+              value={this.state.text || undefined}
+            />
+            <TouchableWithoutFeedback disabled={disableSendButton} onPress={this.submitText.bind(this)}>
+              <Button ml={1} disabled={!!disableSendButton}>
+                Send
+              </Button>
+            </TouchableWithoutFeedback>
+          </Container>
+        </Flex>
+      </ArtsyKeyboardAvoidingView>
     )
   }
 }

--- a/src/lib/Scenes/Inbox/Screens/Checkout.tsx
+++ b/src/lib/Scenes/Inbox/Screens/Checkout.tsx
@@ -1,19 +1,15 @@
+import { ArtsyKeyboardAvoidingView } from "lib/Components/ArtsyKeyboardAvoidingView"
 import { ArtsyWebView } from "lib/Components/ArtsyWebView"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
 import { dismissModal } from "lib/navigation/navigate"
 import { useEnvironment } from "lib/store/GlobalStore"
-import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import React from "react"
-import { KeyboardAvoidingView, View } from "react-native"
+import { View } from "react-native"
 
 export const Checkout: React.FC<{ orderID: string; title: string }> = ({ orderID, title }) => {
   const webCheckoutUrl = `${useEnvironment().webURL}/orders/${orderID}`
   return (
-    <KeyboardAvoidingView
-      behavior="padding"
-      keyboardVerticalOffset={useScreenDimensions().safeAreaInsets.top}
-      style={{ flex: 1 }}
-    >
+    <ArtsyKeyboardAvoidingView>
       <View style={{ flex: 1, flexDirection: "column" }}>
         <FancyModalHeader
           onLeftButtonPress={() => {
@@ -27,6 +23,6 @@ export const Checkout: React.FC<{ orderID: string; title: string }> = ({ orderID
         </FancyModalHeader>
         <ArtsyWebView url={webCheckoutUrl} showFullScreen={false} />
       </View>
-    </KeyboardAvoidingView>
+    </ArtsyKeyboardAvoidingView>
   )
 }

--- a/src/lib/Scenes/MyAccount/Components/MyAccountFieldEditScreen.tsx
+++ b/src/lib/Scenes/MyAccount/Components/MyAccountFieldEditScreen.tsx
@@ -1,7 +1,7 @@
+import { ArtsyKeyboardAvoidingView } from "lib/Components/ArtsyKeyboardAvoidingView"
 import LoadingModal from "lib/Components/Modals/LoadingModal"
 import { PageWithSimpleHeader } from "lib/Components/PageWithSimpleHeader"
 import { goBack } from "lib/navigation/navigate"
-import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { Sans } from "palette"
 import React, { useImperativeHandle, useRef, useState } from "react"
 import {
@@ -10,8 +10,6 @@ import {
   AlertOptions,
   AlertStatic,
   Keyboard,
-  KeyboardAvoidingView,
-  Platform,
   ScrollView,
   TouchableOpacity,
   ViewStyle,
@@ -38,7 +36,6 @@ export const MyAccountFieldEditScreen = React.forwardRef<
   const [isSaving, setIsSaving] = useState<boolean>(false)
   const afterLoadingAlert = useRef<AlertArgs>()
   const scrollViewRef = useRef<ScrollView>(null)
-  const screen = useScreenDimensions()
 
   const doTheAlert: AlertStatic["alert"] = (...args) => {
     afterLoadingAlert.current = args
@@ -76,11 +73,7 @@ export const MyAccountFieldEditScreen = React.forwardRef<
   )
 
   return (
-    <KeyboardAvoidingView
-      behavior={Platform.OS === "ios" ? "padding" : undefined}
-      style={{ flex: 1 }}
-      keyboardVerticalOffset={screen.safeAreaInsets.top}
-    >
+    <ArtsyKeyboardAvoidingView>
       <PageWithSimpleHeader
         left={
           <TouchableOpacity onPress={goBack}>
@@ -122,7 +115,7 @@ export const MyAccountFieldEditScreen = React.forwardRef<
           {children}
         </ScrollView>
       </PageWithSimpleHeader>
-    </KeyboardAvoidingView>
+    </ArtsyKeyboardAvoidingView>
   )
 })
 

--- a/src/lib/Scenes/Onboarding/OldLogIn/LogIn.tsx
+++ b/src/lib/Scenes/Onboarding/OldLogIn/LogIn.tsx
@@ -1,8 +1,8 @@
 import { NavigationContainer } from "@react-navigation/native"
 import { createStackNavigator, TransitionPresets } from "@react-navigation/stack"
+import { ArtsyKeyboardAvoidingView } from "lib/Components/ArtsyKeyboardAvoidingView"
 import { ChevronIcon, Flex, Text } from "palette"
 import React from "react"
-import { KeyboardAvoidingView, Platform } from "react-native"
 import { SafeAreaView } from "react-native-safe-area-context"
 import { LogInEmail } from "./LogInEmail"
 import { LogInEnterPassword } from "./LogInEnterPassword"
@@ -15,7 +15,7 @@ export const LogIn = () => {
     <SafeAreaView style={{ flex: 1 }}>
       <NavigationContainer independent>
         <LogInStore.Provider>
-          <KeyboardAvoidingView behavior={Platform.select({ ios: "padding", default: undefined })} style={{ flex: 1 }}>
+          <ArtsyKeyboardAvoidingView>
             <StackNavigator.Navigator
               headerMode="screen"
               screenOptions={{
@@ -37,7 +37,7 @@ export const LogIn = () => {
                 component={LogInEnterPassword}
               />
             </StackNavigator.Navigator>
-          </KeyboardAvoidingView>
+          </ArtsyKeyboardAvoidingView>
         </LogInStore.Provider>
       </NavigationContainer>
     </SafeAreaView>

--- a/src/lib/Scenes/Onboarding/Onboarding.tsx
+++ b/src/lib/Scenes/Onboarding/Onboarding.tsx
@@ -1,9 +1,10 @@
 import { NavigationContainer } from "@react-navigation/native"
 import { createStackNavigator, TransitionPresets } from "@react-navigation/stack"
+import { ArtsyKeyboardAvoidingView } from "lib/Components/ArtsyKeyboardAvoidingView"
 import { useFeatureFlag } from "lib/store/GlobalStore"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import React from "react"
-import { KeyboardAvoidingView, View } from "react-native"
+import { View } from "react-native"
 import { LogIn } from "./OldLogIn/LogIn"
 import { OnboardingCreateAccount } from "./OnboardingCreateAccount"
 import { OnboardingForgotPassword } from "./OnboardingForgotPassword"
@@ -30,7 +31,7 @@ export const Onboarding = () => {
   return (
     <View style={{ flex: 1, paddingBottom: useScreenDimensions().safeAreaInsets.bottom }}>
       <NavigationContainer independent>
-        <KeyboardAvoidingView behavior="padding" style={{ flex: 1 }}>
+        <ArtsyKeyboardAvoidingView>
           <StackNavigator.Navigator
             headerMode="screen"
             screenOptions={{
@@ -50,7 +51,7 @@ export const Onboarding = () => {
             <StackNavigator.Screen name="OnboardingCreateAccount" component={OnboardingCreateAccount} />
             <StackNavigator.Screen name="OnboardingForgotPassword" component={OnboardingForgotPassword} />
           </StackNavigator.Navigator>
-        </KeyboardAvoidingView>
+        </ArtsyKeyboardAvoidingView>
       </NavigationContainer>
     </View>
   )

--- a/src/lib/Scenes/Search/Search.tsx
+++ b/src/lib/Scenes/Search/Search.tsx
@@ -1,9 +1,10 @@
+import { ArtsyKeyboardAvoidingView } from "lib/Components/ArtsyKeyboardAvoidingView"
 import { SearchInput } from "lib/Components/SearchInput"
 import { isPad } from "lib/utils/hardware"
 import { Schema } from "lib/utils/track"
 import { color, Flex, Spacer } from "palette"
 import React, { useState } from "react"
-import { KeyboardAvoidingView, Platform, ScrollView } from "react-native"
+import { Platform, ScrollView } from "react-native"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
 import { AutosuggestResults } from "./AutosuggestResults"
@@ -18,7 +19,7 @@ export const Search: React.FC = () => {
 
   return (
     <SearchContext.Provider value={searchProviderValues}>
-      <KeyboardAvoidingView style={{ flex: 1 }} behavior="padding" enabled>
+      <ArtsyKeyboardAvoidingView>
         <Flex p={2} pb={1} style={{ borderBottomWidth: 1, borderColor: color("black10") }}>
           <SearchInput
             ref={searchProviderValues.inputRef}
@@ -55,7 +56,7 @@ export const Search: React.FC = () => {
             <Spacer mb="40px" />
           </Scrollable>
         )}
-      </KeyboardAvoidingView>
+      </ArtsyKeyboardAvoidingView>
     </SearchContext.Provider>
   )
 }


### PR DESCRIPTION
This PR resolves [CX-1280] [CX-1295] [CX-1281]

### Description

This PR takes care of our keyboard avoidance woes by

- Replacing `android:windowSoftInputMode="adjustPan"` with `android:windowSoftInputMode="adjustResize"` in AndroidManifest.xml

  This was our main problem on Android. `"adjustPan"` causes the main activity to scroll away when the keyboard opens, which is not how any of our keyboard avoidance interactions should work.

- Creating a two-mode version of `KeyboardAvoidingView` which handles iOS 13+ modals and requires less babysitting.

  The react-native built-in `KeyboardAvoidingView` calculates the keyboard displacement based on the assumption that the top of the view is at the top of the screen. To account for situations where this is not true it provides the `keyboardVerticalOffset` prop. Unfortunately, it can be difficult or impossible to provide an accurate value for that prop, since it relies on the view hierarchy and whether or not the view is inside a ios 13 modal. We fix this in a couple of ways:

  - for modals we add a new mode that makes the assumption that the view's bottom is at the bottom of the screen, which is always true in modals, or at least easy to make true.
  - for non-modals we use `measureInWindow` to calculate the y-offset of the view relative to the window, rather than relative to the parent view. Then you should never need to provide an explicit `keyboardVerticalOffset` value.
  
  Our custom `KeyboardAvoidingView` also takes care of the fact that android view measurement coordinates are calculated relative to the status bar bottom, rather than the top of the screen, while the keyboard measurement coordinates are calculated relative to the top of the screen. 

  All of this is to say that, it should 'just work' wherever you put it, as long as in modals it touches the bottom of the screen. If we ever build UI where that's not the case we can add an 'bottomOffset' override prop.

- MyAccountFieldEditScreen

   ![image](https://user-images.githubusercontent.com/1242537/114164221-f39ca800-9922-11eb-91e9-c861e01cc60d.png)

- BottomAlignedButtonWrapper (used only in CreditCardForm in registration flow)
 
  ![image](https://user-images.githubusercontent.com/1242537/114164653-745ba400-9923-11eb-9247-003f125f7e11.png)

- BottomAlignedButton (used in the Consignments flow)

  ![image](https://user-images.githubusercontent.com/1242537/114165220-1f6c5d80-9924-11eb-90b9-f7f1de4e8211.png)

- ArtsyReactWebView

  ![image](https://user-images.githubusercontent.com/1242537/114166259-69097800-9925-11eb-898b-3d5fc4fae6c6.png)

- BillingAddress (registration flow)

  ![image](https://user-images.githubusercontent.com/1242537/114167010-5479af80-9926-11eb-9209-7bfcf0d4b517.png)

- FancyModal (affects InquiryModal, MyCollectionArtworkForm)

  ![image](https://user-images.githubusercontent.com/1242537/114171198-dae4c000-992b-11eb-86f5-c6db442dd2ae.png)

  ![image](https://user-images.githubusercontent.com/1242537/114171841-be955300-992c-11eb-88e2-134d5ed2c8da.png)

- Composer

  ![image](https://user-images.githubusercontent.com/1242537/114180323-f5249b00-9937-11eb-9577-41b5df57b389.png)

- Search
 
  ![image](https://user-images.githubusercontent.com/1242537/114181128-028e5500-9939-11eb-99b0-9de2ba2864f1.png)

- Onboarding

  ![image](https://user-images.githubusercontent.com/1242537/114182055-20a88500-993a-11eb-9d9f-756ca1578c71.png)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-1280]: https://artsyproduct.atlassian.net/browse/CX-1280
[CX-1295]: https://artsyproduct.atlassian.net/browse/CX-1295
[CX-1281]: https://artsyproduct.atlassian.net/browse/CX-1281