### PR TITLE
fix: suppress deepZoom taps on Android

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -25,6 +25,7 @@ upcoming:
     - Updates filter styling - damon
     - Hide push notifications section in settings for Android - ole
     - Rename the category filter to medium - iskounen
+    - Suppress artwork deep-zoom taps on Android - pepopowitz
 
 releases:
   - version: 6.8.2

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarouselEmbedded.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/ImageCarouselEmbedded.tsx
@@ -2,7 +2,7 @@ import * as Sentry from "@sentry/react-native"
 import { isPad } from "lib/utils/hardware"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import React, { useCallback, useContext } from "react"
-import { FlatList, NativeScrollEvent, NativeSyntheticEvent } from "react-native"
+import { FlatList, NativeScrollEvent, NativeSyntheticEvent, Platform } from "react-native"
 import { findClosestIndex, getMeasurements } from "./geometry"
 import { ImageCarouselContext, ImageDescriptor } from "./ImageCarouselContext"
 import { ImageWithLoadingState } from "./ImageWithLoadingState"
@@ -46,7 +46,9 @@ export const ImageCarouselEmbedded: React.FC<ImageCarouselEmbeddedProps> = ({ ca
   )
 
   const goFullScreen = useCallback(() => {
-    dispatch({ type: "TAPPED_TO_GO_FULL_SCREEN" })
+    if (Platform.OS === "ios") {
+      dispatch({ type: "TAPPED_TO_GO_FULL_SCREEN" })
+    }
   }, [dispatch])
 
   // this exists as a hack to get onPress functionality while the flat list is still coming to a stop after a swipe.

--- a/src/lib/Scenes/Artwork/Components/ImageCarousel/__tests__/ImageCarouselEmbedded-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/ImageCarousel/__tests__/ImageCarouselEmbedded-tests.tsx
@@ -2,6 +2,7 @@
 import { mount } from "enzyme"
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import React from "react"
+import { Platform } from "react-native"
 import { ImageCarouselContext, useNewImageCarouselContext } from "../ImageCarouselContext"
 import { ImageCarouselEmbedded } from "../ImageCarouselEmbedded"
 import { ImageWithLoadingState } from "../ImageWithLoadingState"
@@ -62,5 +63,20 @@ describe("ImageCarouselEmbedded", () => {
     expect(context.fullScreenState.current).toBe("none")
     carousel.find(ImageWithLoadingState).at(0).props().onPress()
     expect(context.fullScreenState.current).toBe("none")
+  })
+  describe("deepZoom on Android", () => {
+    beforeAll(() => {
+      Platform.OS = "android"
+    })
+    afterAll(() => {
+      Platform.OS = "ios"
+    })
+
+    it("suppresses fullScreen when you tap an image with deepZoom because it would fail", () => {
+      const carousel = mount(<Mock />)
+      expect(context.fullScreenState.current).toBe("none")
+      carousel.find(ImageWithLoadingState).at(0).props().onPress()
+      expect(context.fullScreenState.current).toBe("none")
+    })
   })
 })


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR resolves [CX-1275]

### Description

Tapping an artwork to view it in deep-zoom fails on Android (see linked JIRA ticket). This PR suppresses deep-zoom taps on Android so that the user doesn't see an error. 


https://user-images.githubusercontent.com/1627089/114219025-c6a2c200-992f-11eb-9eb2-d3664b603048.mp4


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-1275]: https://artsyproduct.atlassian.net/browse/CX-1275