### PR TITLE
fix: don't remove node_module assets when bundling

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -11,6 +11,7 @@ upcoming:
     - Hide AdminMenu behind 7 taps of "Version" - pavlos
     - Use radio buttons for single-select filters behind feature flag - iskounen
     - Specify tracking screen owner in tab bar tracking - ole
+    - don't remove node_module assets when bundling - brian
   user_facing:
     - Use toolbar style modal headers in consignments flow - brian
     - Add Onboarding welcome screen - mounir

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "main": "index.ios.js",
   "scripts": {
-    "bundle-for-native-ci": "yarn generate-graphql-query-map && react-native bundle --platform=ios --dev=false --entry-file=index.tests.ios.js --bundle-output emission/Pod/Assets/Emission.js --sourcemap-output emission/Pod/Assets/Emission.js.map --assets-dest emission/Pod/Assets && rm -rf emission/Pod/Assets/assets/node_modules",
-    "bundle": "react-native bundle --platform=ios --dev=false --entry-file=index.ios.js --bundle-output emission/Pod/Assets/Emission.js --sourcemap-output emission/Pod/Assets/Emission.js.map --assets-dest emission/Pod/Assets && rm -rf emission/Pod/Assets/assets/node_modules",
+    "bundle-for-native-ci": "yarn generate-graphql-query-map && react-native bundle --platform=ios --dev=false --entry-file=index.tests.ios.js --bundle-output emission/Pod/Assets/Emission.js --sourcemap-output emission/Pod/Assets/Emission.js.map --assets-dest emission/Pod/Assets",
+    "bundle": "react-native bundle --platform=ios --dev=false --entry-file=index.ios.js --bundle-output emission/Pod/Assets/Emission.js --sourcemap-output emission/Pod/Assets/Emission.js.map --assets-dest emission/Pod/Assets",
     "ci:lint": "yarn lint --format json --out tslint-errors.json ",
     "ci:skip-native-if-possible": "node scripts/ci-skip-native-if-possible.js",
     "ci:test": "jest --outputFile test-results.json --json --ci --forceExit",


### PR DESCRIPTION
The type of this PR is: **fix**

This PR resolves [CX-1308]

### Description

Removes last step in our bundle script that removes node_module assets from the Pod assets directory which was causing these icons not to be found when using bundled emission in release builds. I am not clear why we were doing this in the first place, I found [this fairly ancient commit](https://github.com/artsy/eigen/commit/0e670329c82b89902dafbc7289d5347f7dbc27bb) that first added it but not totally clear on the problem it solved. The node module assets directory is pretty small and as far as I can tell these assets aren't being copied anywhere else.

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-1308]: https://artsyproduct.atlassian.net/browse/CX-1308