### PR TITLE
Link CTA to failed payment page

### DIFF
--- a/src/lib/Scenes/Inbox/Components/Conversations/ReviewOfferButton.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/ReviewOfferButton.tsx
@@ -31,7 +31,14 @@ export const ReviewOfferButton: React.FC<ReviewOfferButtonProps> = ({ conversati
   })
   const offerType = (offers?.edges?.length || []) > 1 ? "Counteroffer" : "Offer"
 
-  let ctaAttributes: { backgroundColor: Color; message: string; subMessage: string; Icon: React.FC<IconProps> }
+  let ctaAttributes: {
+    backgroundColor: Color
+    message: string
+    subMessage: string
+    Icon: React.FC<IconProps>
+    url: string
+    modalTitle: string
+  }
 
   switch (kind) {
     case "PAYMENT_FAILED": {
@@ -40,6 +47,8 @@ export const ReviewOfferButton: React.FC<ReviewOfferButtonProps> = ({ conversati
         message: "Payment Failed",
         subMessage: "Please update payment method",
         Icon: AlertCircleFillIcon,
+        url: `/orders/${orderID}/payment/new`,
+        modalTitle: "Retry Payment",
       }
       break
     }
@@ -50,6 +59,8 @@ export const ReviewOfferButton: React.FC<ReviewOfferButtonProps> = ({ conversati
         // TODO: what about <1 hr?
         subMessage: `Expires in ${hours}hr`,
         Icon: AlertCircleFillIcon,
+        url: `/orders/${orderID}`,
+        modalTitle: "Make Offer",
       }
       break
     }
@@ -59,6 +70,8 @@ export const ReviewOfferButton: React.FC<ReviewOfferButtonProps> = ({ conversati
         message: `Congratulations! ${offerType} Accepted`,
         subMessage: "Tap to view",
         Icon: MoneyFillIcon,
+        url: `/orders/${orderID}`,
+        modalTitle: "Make Offer",
       }
       break
     }
@@ -68,25 +81,25 @@ export const ReviewOfferButton: React.FC<ReviewOfferButtonProps> = ({ conversati
     }
   }
 
-  const { message, subMessage, backgroundColor, Icon } = ctaAttributes
+  const { message, subMessage, backgroundColor, Icon, url, modalTitle } = ctaAttributes
 
-  const navigateToConversation = () => {
+  const navigateToConversation = (path: string, title: string) => {
     trackEvent(
       tappedViewOffer({
         impulse_conversation_id: conversationID,
         cta: message,
       })
     )
-    navigate(`/orders/${orderID}`, {
+    navigate(path, {
       modal: true,
-      passProps: { orderID, title: "Make Offer" },
+      passProps: { orderID, title },
     })
   }
 
   return (
     <TouchableWithoutFeedback
       onPress={() => {
-        navigateToConversation()
+        navigateToConversation(url, modalTitle)
       }}
     >
       <Flex

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/ReviewOfferButton-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/ReviewOfferButton-tests.tsx
@@ -88,4 +88,15 @@ describe("ReviewOfferButton", () => {
       passProps: { orderID: "order-id", title: "Make Offer" },
     })
   })
+
+  it("tapping it opens the correct webview with the correct title for offers where payment fails", () => {
+    const wrapper = getWrapper("PAYMENT_FAILED", { offers: { edges: [{}, {}] } })
+
+    wrapper.root.findByType(TouchableWithoutFeedback).props.onPress()
+
+    expect(navigate).toHaveBeenCalledWith("/orders/order-id/payment/new", {
+      modal: true,
+      passProps: { orderID: "order-id", title: "Retry Payment" },
+    })
+  })
 })


### PR DESCRIPTION
# PURCHASE-2547

CTA should link to {orderID}/payment/new only in case of failed payment. Also changed modal header title in this case to be "Retry Payment" as per this discussion https://artsy.slack.com/archives/C9YNS4X32/p1618337020223300

<img width="438" alt="Screen Shot 2021-04-13 at 11 23 53 AM" src="https://user-images.githubusercontent.com/5643895/114601841-f6b9d000-9c63-11eb-93c4-668078075683.png">

