### PR TITLE
feature: track artist insights screen views

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -6,6 +6,7 @@ upcoming:
     - Improve bottom tabs dev state management  - david, mounir
     - Refactor Filter Modals - mounir
     - Update filter params change tracking type for auction results - ole
+    - Track a screen event when user lands on artist auction Results - ole
   user_facing:
     - Add forgot password screen in new login - brian
     - Conversation-offer updates to CTA to allow multiple offers - erikdstock

--- a/src/lib/Components/Artist/ArtistInsights/ArtistInsights.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/ArtistInsights.tsx
@@ -2,10 +2,10 @@ import { OwnerType } from "@artsy/cohesion"
 import { ArtistInsights_artist } from "__generated__/ArtistInsights_artist.graphql"
 import { AnimatedArtworkFilterButton, ArtworkFilterNavigator, FilterModalMode } from "lib/Components/ArtworkFilter"
 import { ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
-import { useIsFocusedTab } from "lib/Components/StickyTabPage/StickyTabPage"
+import { useOnTabFocusedEffect } from "lib/Components/StickyTabPage/StickyTabPage"
 import { StickyTabPageScrollView } from "lib/Components/StickyTabPage/StickyTabPageScrollView"
 import { Schema } from "lib/utils/track"
-import React, { useCallback, useEffect, useRef, useState } from "react"
+import React, { useCallback, useRef, useState } from "react"
 import { FlatList, NativeScrollEvent, NativeSyntheticEvent, View } from "react-native"
 import { createFragmentContainer, graphql, RelayProp } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -37,7 +37,6 @@ export const ArtistInsights: React.FC<ArtistInsightsProps> = (props) => {
 
   const tracking = useTracking()
   const flatListRef = useRef<{ getNode(): FlatList<any> } | null>(null)
-  const isFocusedTab = useIsFocusedTab(tabIndex)
 
   const [isFilterButtonVisible, setIsFilterButtonVisible] = useState(false)
   const [isFilterModalVisible, setIsFilterModalVisible] = useState(false)
@@ -66,12 +65,10 @@ export const ArtistInsights: React.FC<ArtistInsightsProps> = (props) => {
     setIsFilterButtonVisible(false)
   }, [])
 
-  // Track screen event when artist insights tab becomes visible
-  useEffect(() => {
-    if (isFocusedTab) {
-      tracking.trackEvent(tracks.screen(artist.internalID, artist.slug))
-    }
-  }, [isFocusedTab])
+  // Track screen event when artist insights tab is focused
+  useOnTabFocusedEffect(() => {
+    tracking.trackEvent(tracks.screen(artist.internalID, artist.slug))
+  }, tabIndex)
 
   return (
     <ArtworkFiltersStoreProvider>

--- a/src/lib/Components/Artist/ArtistInsights/ArtistInsights.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/ArtistInsights.tsx
@@ -2,7 +2,7 @@ import { OwnerType } from "@artsy/cohesion"
 import { ArtistInsights_artist } from "__generated__/ArtistInsights_artist.graphql"
 import { AnimatedArtworkFilterButton, ArtworkFilterNavigator, FilterModalMode } from "lib/Components/ArtworkFilter"
 import { ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
-import { useStickyTabPageContext } from "lib/Components/StickyTabPage/SitckyTabPageContext"
+import { useIsFocusedTab } from "lib/Components/StickyTabPage/StickyTabPage"
 import { StickyTabPageScrollView } from "lib/Components/StickyTabPage/StickyTabPageScrollView"
 import { Schema } from "lib/utils/track"
 import React, { useCallback, useEffect, useRef, useState } from "react"
@@ -33,13 +33,11 @@ interface ViewToken {
 
 const FILTER_BUTTON_OFFSET = 50
 export const ArtistInsights: React.FC<ArtistInsightsProps> = (props) => {
-  const { activeTabIndex } = useStickyTabPageContext()
-  activeTabIndex.useUpdates()
-
   const { artist, relay, tabIndex } = props
 
   const tracking = useTracking()
   const flatListRef = useRef<{ getNode(): FlatList<any> } | null>(null)
+  const isFocusedTab = useIsFocusedTab(tabIndex)
 
   const [isFilterButtonVisible, setIsFilterButtonVisible] = useState(false)
   const [isFilterModalVisible, setIsFilterModalVisible] = useState(false)
@@ -70,10 +68,10 @@ export const ArtistInsights: React.FC<ArtistInsightsProps> = (props) => {
 
   // Track screen event when artist insights tab becomes visible
   useEffect(() => {
-    if (activeTabIndex.current === tabIndex) {
-      tracking.trackEvent(tracks.screen(artist.id, artist.slug))
+    if (isFocusedTab) {
+      tracking.trackEvent(tracks.screen(artist.internalID, artist.slug))
     }
-  }, [activeTabIndex.current])
+  }, [isFocusedTab])
 
   return (
     <ArtworkFiltersStoreProvider>
@@ -146,8 +144,8 @@ export const tracks = {
   },
   screen: (id: string, slug: string) => {
     return {
-      context_screen: Schema.PageNames.Auction,
-      context_screen_owner_type: Schema.OwnerEntityTypes.Auction,
+      context_screen: OwnerType.artistAuctionResults,
+      context_screen_owner_type: OwnerType.artistAuctionResults,
       context_screen_owner_id: id,
       context_screen_owner_slug: slug,
     }

--- a/src/lib/Components/Artist/ArtistInsights/ArtistInsights.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/ArtistInsights.tsx
@@ -2,10 +2,10 @@ import { OwnerType } from "@artsy/cohesion"
 import { ArtistInsights_artist } from "__generated__/ArtistInsights_artist.graphql"
 import { AnimatedArtworkFilterButton, ArtworkFilterNavigator, FilterModalMode } from "lib/Components/ArtworkFilter"
 import { ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
-import { StickyTabPageContext } from "lib/Components/StickyTabPage/SitckyTabPageContext"
+import { useStickyTabPageContext } from "lib/Components/StickyTabPage/SitckyTabPageContext"
 import { StickyTabPageScrollView } from "lib/Components/StickyTabPage/StickyTabPageScrollView"
 import { Schema } from "lib/utils/track"
-import React, { useCallback, useContext, useEffect, useRef, useState } from "react"
+import React, { useCallback, useEffect, useRef, useState } from "react"
 import { FlatList, NativeScrollEvent, NativeSyntheticEvent, View } from "react-native"
 import { createFragmentContainer, graphql, RelayProp } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -16,6 +16,7 @@ import { MarketStatsQueryRenderer } from "./MarketStats"
 interface ArtistInsightsProps {
   artist: ArtistInsights_artist
   relay: RelayProp
+  tabIndex: number
 }
 
 export interface ViewableItems {
@@ -32,9 +33,10 @@ interface ViewToken {
 
 const FILTER_BUTTON_OFFSET = 50
 export const ArtistInsights: React.FC<ArtistInsightsProps> = (props) => {
-  const value = useContext(StickyTabPageContext)
+  const { activeTabIndex } = useStickyTabPageContext()
+  activeTabIndex.useUpdates()
 
-  const { artist, relay } = props
+  const { artist, relay, tabIndex } = props
 
   const tracking = useTracking()
   const flatListRef = useRef<{ getNode(): FlatList<any> } | null>(null)
@@ -66,15 +68,12 @@ export const ArtistInsights: React.FC<ArtistInsightsProps> = (props) => {
     setIsFilterButtonVisible(false)
   }, [])
 
+  // Track screen event when artist insights tab becomes visible
   useEffect(() => {
-    console.log("===============")
-    console.log(value)
-    // if tab is visible
-    // if (activeTabIndex === 2) {
-    //   // trigger screentracking event
-    //   tracking.trackEvent(tracks.screen("artistId", "slug"))
-    // }
-  }, [])
+    if (activeTabIndex.current === tabIndex) {
+      tracking.trackEvent(tracks.screen(artist.id, artist.slug))
+    }
+  }, [activeTabIndex.current])
 
   return (
     <ArtworkFiltersStoreProvider>

--- a/src/lib/Components/Artist/ArtistInsights/ArtistInsights.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/ArtistInsights.tsx
@@ -2,9 +2,10 @@ import { OwnerType } from "@artsy/cohesion"
 import { ArtistInsights_artist } from "__generated__/ArtistInsights_artist.graphql"
 import { AnimatedArtworkFilterButton, ArtworkFilterNavigator, FilterModalMode } from "lib/Components/ArtworkFilter"
 import { ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
+import { StickyTabPageContext } from "lib/Components/StickyTabPage/SitckyTabPageContext"
 import { StickyTabPageScrollView } from "lib/Components/StickyTabPage/StickyTabPageScrollView"
 import { Schema } from "lib/utils/track"
-import React, { useCallback, useRef, useState } from "react"
+import React, { useCallback, useContext, useEffect, useRef, useState } from "react"
 import { FlatList, NativeScrollEvent, NativeSyntheticEvent, View } from "react-native"
 import { createFragmentContainer, graphql, RelayProp } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -31,6 +32,8 @@ interface ViewToken {
 
 const FILTER_BUTTON_OFFSET = 50
 export const ArtistInsights: React.FC<ArtistInsightsProps> = (props) => {
+  const value = useContext(StickyTabPageContext)
+
   const { artist, relay } = props
 
   const tracking = useTracking()
@@ -61,6 +64,16 @@ export const ArtistInsights: React.FC<ArtistInsightsProps> = (props) => {
       return
     }
     setIsFilterButtonVisible(false)
+  }, [])
+
+  useEffect(() => {
+    console.log("===============")
+    console.log(value)
+    // if tab is visible
+    // if (activeTabIndex === 2) {
+    //   // trigger screentracking event
+    //   tracking.trackEvent(tracks.screen("artistId", "slug"))
+    // }
   }, [])
 
   return (
@@ -130,6 +143,14 @@ export const tracks = {
       context_screen_owner_id: id,
       context_screen_owner_slug: slug,
       action_type: Schema.ActionTypes.Tap,
+    }
+  },
+  screen: (id: string, slug: string) => {
+    return {
+      context_screen: Schema.PageNames.Auction,
+      context_screen_owner_type: Schema.OwnerEntityTypes.Auction,
+      context_screen_owner_id: id,
+      context_screen_owner_slug: slug,
     }
   },
 }

--- a/src/lib/Components/Artist/ArtistInsights/__tests__/ArtistInsights-tests.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/__tests__/ArtistInsights-tests.tsx
@@ -42,17 +42,17 @@ describe("ArtistInsights", () => {
     expect(tree.findAllByType(ArtistInsightsAuctionResultsPaginationContainer).length).toEqual(1)
   })
 
-  it("tracks an auction page view when artist insights is current tab", async (done) => {
+  it("tracks an auction page view when artist insights is current tab", (done) => {
     renderWithWrappers(<TestRenderer tabIndex={0} />)
 
     mockEnvironmentPayload(mockEnvironment)
 
-    await setImmediate(() => {
+    setImmediate(() => {
       expect(trackEvent).toHaveBeenCalledWith({
-        context_screen: "Auction",
-        context_screen_owner_id: "id-1",
+        context_screen: "artistAuctionResults",
+        context_screen_owner_id: "internalID-1",
         context_screen_owner_slug: "slug-1",
-        context_screen_owner_type: "Auction",
+        context_screen_owner_type: "artistAuctionResults",
       })
 
       done()

--- a/src/lib/Components/Artist/ArtistInsights/__tests__/ArtistInsights-tests.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/__tests__/ArtistInsights-tests.tsx
@@ -2,10 +2,13 @@ import { ArtistInsightsTestsQuery } from "__generated__/ArtistInsightsTestsQuery
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
+import { useTracking } from "react-tracking"
 import { createMockEnvironment } from "relay-test-utils"
 import { mockEnvironmentPayload } from "../../../../tests/mockEnvironmentPayload"
 import { ArtistInsightsFragmentContainer } from "../ArtistInsights"
 import { ArtistInsightsAuctionResultsPaginationContainer } from "../ArtistInsightsAuctionResults"
+
+const trackEvent = useTracking().trackEvent
 
 jest.unmock("react-relay")
 
@@ -13,7 +16,7 @@ describe("ArtistInsights", () => {
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
   beforeEach(() => (mockEnvironment = createMockEnvironment()))
 
-  const TestRenderer = () => (
+  const TestRenderer = ({ tabIndex = 0 }) => (
     <QueryRenderer<ArtistInsightsTestsQuery>
       environment={mockEnvironment}
       query={graphql`
@@ -26,7 +29,7 @@ describe("ArtistInsights", () => {
       variables={{}}
       render={({ props }) => {
         if (props?.artist) {
-          return <ArtistInsightsFragmentContainer artist={props.artist} />
+          return <ArtistInsightsFragmentContainer artist={props.artist} tabIndex={tabIndex} />
         }
         return null
       }}
@@ -37,5 +40,22 @@ describe("ArtistInsights", () => {
     const tree = renderWithWrappers(<TestRenderer />).root
     mockEnvironmentPayload(mockEnvironment)
     expect(tree.findAllByType(ArtistInsightsAuctionResultsPaginationContainer).length).toEqual(1)
+  })
+
+  it("tracks an auction page view when artist insights is current tab", async (done) => {
+    renderWithWrappers(<TestRenderer tabIndex={0} />)
+
+    mockEnvironmentPayload(mockEnvironment)
+
+    await setImmediate(() => {
+      expect(trackEvent).toHaveBeenCalledWith({
+        context_screen: "Auction",
+        context_screen_owner_id: "id-1",
+        context_screen_owner_slug: "slug-1",
+        context_screen_owner_type: "Auction",
+      })
+
+      done()
+    })
   })
 })

--- a/src/lib/Components/StickyTabPage/StickyTabPage.tsx
+++ b/src/lib/Components/StickyTabPage/StickyTabPage.tsx
@@ -3,12 +3,12 @@ import { Schema } from "lib/utils/track"
 import { useGlobalState } from "lib/utils/useGlobalState"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { color } from "palette"
-import React, { useMemo, useRef, useState } from "react"
+import React, { useEffect, useMemo, useRef, useState } from "react"
 import { View } from "react-native"
 import Animated from "react-native-reanimated"
 import { useTracking } from "react-tracking"
 import { useAnimatedValue } from "./reanimatedHelpers"
-import { StickyTabPageContext } from "./SitckyTabPageContext"
+import { StickyTabPageContext, useStickyTabPageContext } from "./SitckyTabPageContext"
 import { SnappyHorizontalRail } from "./SnappyHorizontalRail"
 import { StickyTabPageFlatListContext } from "./StickyTabPageFlatList"
 import { StickyTabPageTabBar } from "./StickyTabPageTabBar"
@@ -117,6 +117,23 @@ export const StickyTabPage: React.FC<{
       </View>
     </StickyTabPageContext.Provider>
   )
+}
+
+export function useIsFocusedTab(tabIndex: number) {
+  const { activeTabIndex } = useStickyTabPageContext()
+  activeTabIndex.useUpdates()
+
+  const [isFocusedTab, setIsFocusedTab] = useState(false)
+
+  useEffect(() => {
+    if (activeTabIndex.current === tabIndex) {
+      setIsFocusedTab(true)
+    } else {
+      setIsFocusedTab(false)
+    }
+  }, [activeTabIndex.current])
+
+  return isFocusedTab
 }
 
 function useAutoCollapsingMeasuredView(content: React.ReactChild) {

--- a/src/lib/Components/StickyTabPage/StickyTabPage.tsx
+++ b/src/lib/Components/StickyTabPage/StickyTabPage.tsx
@@ -3,7 +3,7 @@ import { Schema } from "lib/utils/track"
 import { useGlobalState } from "lib/utils/useGlobalState"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { color } from "palette"
-import React, { useEffect, useMemo, useRef, useState } from "react"
+import React, { EffectCallback, useEffect, useMemo, useRef, useState } from "react"
 import { View } from "react-native"
 import Animated from "react-native-reanimated"
 import { useTracking } from "react-tracking"
@@ -119,21 +119,15 @@ export const StickyTabPage: React.FC<{
   )
 }
 
-export function useIsFocusedTab(tabIndex: number) {
+export function useOnTabFocusedEffect(effect: EffectCallback, tabIndex: number) {
   const { activeTabIndex } = useStickyTabPageContext()
   activeTabIndex.useUpdates()
 
-  const [isFocusedTab, setIsFocusedTab] = useState(false)
-
   useEffect(() => {
     if (activeTabIndex.current === tabIndex) {
-      setIsFocusedTab(true)
-    } else {
-      setIsFocusedTab(false)
+      effect()
     }
   }, [activeTabIndex.current])
-
-  return isFocusedTab
 }
 
 function useAutoCollapsingMeasuredView(content: React.ReactChild) {

--- a/src/lib/Components/StickyTabPage/StickyTabPage.tsx
+++ b/src/lib/Components/StickyTabPage/StickyTabPage.tsx
@@ -16,7 +16,7 @@ import { StickyTabPageTabBar } from "./StickyTabPageTabBar"
 interface TabProps {
   initial?: boolean
   title: string
-  content: JSX.Element
+  content: JSX.Element | ((tabIndex: number) => JSX.Element)
 }
 
 /**
@@ -96,7 +96,7 @@ export const StickyTabPage: React.FC<{
                       tabIsActive: Animated.eq(index, activeTabIndexNative),
                     }}
                   >
-                    {content}
+                    {typeof content === "function" ? content(index) : content}
                   </StickyTabPageFlatListContext.Provider>
                 </View>
               )

--- a/src/lib/Scenes/Artist/Artist.tsx
+++ b/src/lib/Scenes/Artist/Artist.tsx
@@ -62,7 +62,11 @@ export const Artist: React.FC<{
   if (isArtistInsightsEnabled && artistAboveTheFold?.auctionResultsConnection?.totalCount) {
     tabs.push({
       title: "Insights",
-      content: artistBelowTheFold ? <ArtistInsightsFragmentContainer artist={artistBelowTheFold} /> : <LoadingPage />,
+      content: artistBelowTheFold ? (
+        (tabIndex: number) => <ArtistInsightsFragmentContainer tabIndex={tabIndex} artist={artistBelowTheFold} />
+      ) : (
+        <LoadingPage />
+      ),
     })
   }
 


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1327]

### Description

When opening the Artist Insights Tab we track the following event: 

```
[Event tracked] {
  "context_screen": "artistAuctionResults",
  "context_screen_owner_type": "artistAuctionResults",
  "context_screen_owner_slug": "hunt-slonem",
  "context_screen_owner_id": "506b34214466170002001a46"
}
```

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434

[CX-1274]: https://artsyproduct.atlassian.net/browse/CX-1274

[CX-1327]: https://artsyproduct.atlassian.net/browse/CX-1327