### PR TITLE
Failed payment notification

### DIFF
--- a/src/lib/Scenes/Inbox/Components/Conversations/Messages.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/Messages.tsx
@@ -60,9 +60,15 @@ export const Messages: React.FC<Props> = forwardRef((props, ref) => {
     .reduce<OrderEvent[]>((prev, order) => prev.concat(order.orderHistory), [])
     .map<OrderEventWithKey>((event, index) => ({ ...event, key: `event-${index}` }))
 
+  const orderEventsWithoutFailedPayment = allOrderEvents.filter((event, index) => {
+    if (!(event.state === "APPROVED" && allOrderEvents[index + 1] && allOrderEvents[index + 1].state === "SUBMITTED")) {
+      return event
+    }
+  })
+
   // Combine and group events/messages
   useEffect(() => {
-    const sortedMessages = sortBy([...allOrderEvents, ...allMessages], (message) =>
+    const sortedMessages = sortBy([...orderEventsWithoutFailedPayment, ...allMessages], (message) =>
       DateTime.fromISO(message.createdAt!)
     )
 


### PR DESCRIPTION
# PURCHASE-2542

_From the Jira ticket:_
Failed payment displayed as "offer accepted" in inline order history

When testing a failed payment scenario, failed transaction got displayed as “Offer Accepted” in the inline history. See the screenshot below for an example: I submitted the offer with a test card that’ll fail when capturing. I accepted partner’s counteroffer 2 times (both were failed) and they were displayed as accepted in the history.

------
In this PR I am filtering out `APPROVED` state change updates when they are followed by `SUBMITTED` updates because they only occur in this order when payment fails (order goes to approved state then is reverted to submitted state when payment fails). While this solution may not be ideal, it solves the problem, and after discussing with team members I couldn't come up with another way to filter these notifications without major changes (adding a reference to the order object to `CommerceOrderStateChangedEvent` so we could access `lastPaymentFailed`)

Github is being weird when I try and attach screenshots (connectivity issue?) - will try again later
