### PR TITLE
Pepopowitz/cx 1282 fix follow in artist rail

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -10,6 +10,7 @@ upcoming:
     - Add forgot password screen in new login - brian
     - Conversation-offer updates to CTA to allow multiple offers - erikdstock
     - Replace "All" option on multi-select filters with upper right-hand "Clear all"
+    - Fix infinite spinner on Android when following within an artist rail - pepopowitz
 
 releases:
   - version: 6.8.3

--- a/src/lib/NativeModules/Events.tsx
+++ b/src/lib/NativeModules/Events.tsx
@@ -1,7 +1,6 @@
 import { addBreadcrumb } from "@sentry/react-native"
+import { LegacyNativeModules } from "lib/NativeModules/LegacyNativeModules"
 import { getCurrentEmissionState } from "lib/store/GlobalStore"
-import { NativeModules } from "react-native"
-const { AREventsModule } = NativeModules
 
 export function postEvent(info: any) {
   if (__DEV__) {
@@ -13,7 +12,7 @@ export function postEvent(info: any) {
     category: "analytics",
   })
 
-  AREventsModule.postEvent(info)
+  LegacyNativeModules.AREventsModule.postEvent(info)
 }
 
 // Whether we have requested during the current session or not.
@@ -32,7 +31,7 @@ export function userHadMeaningfulInteraction() {
   if (launchCount % 20 === 2) {
     if (!hasRequested) {
       hasRequested = true
-      AREventsModule.requestAppStoreRating()
+      LegacyNativeModules.AREventsModule.requestAppStoreRating()
     }
   }
 }

--- a/src/lib/NativeModules/LegacyNativeModules.tsx
+++ b/src/lib/NativeModules/LegacyNativeModules.tsx
@@ -78,6 +78,10 @@ interface LegacyNativeModules {
     }
     triggerCameraModal(reactTag: number | null): Promise<void>
   }
+  AREventsModule: {
+    postEvent(info: any): void
+    requestAppStoreRating(): void
+  }
 }
 const LegacyNativeModulesIOS: LegacyNativeModules = AllNativeModules as any
 
@@ -122,4 +126,8 @@ export const LegacyNativeModules: LegacyNativeModules =
           requestPhotos: noop("requestPhotos"),
         },
         ARScreenPresenterModule,
+        AREventsModule: {
+          postEvent: noop("postEvent"),
+          requestAppStoreRating: noop("requestAppStoreRating"),
+        },
       }

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -204,6 +204,10 @@ function getNativeModules(): typeof LegacyNativeModules {
       popToRootOrScrollToTop: jest.fn(),
       presentModal: jest.fn(),
     },
+    AREventsModule: {
+      postEvent: jest.fn(),
+      requestAppStoreRating: jest.fn(),
+    },
   }
 }
 


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1282]

A collaboration with @brainbicycle 

### Description

Following/unfollowing an artist within an artist rail was giving an infinite spinner on Android, due to a native module call failing. 

This PR adds a new `AREventsModule` to `LegacyNativeModules` for branching based on platform, and replaces the existing calls to `NativeModules.AREventsModule` with calls to `LegacyNativeModules.AREventsModule`.

As a result, the follow button within an artist rail no longer spins infinitely: 


https://user-images.githubusercontent.com/1627089/114938631-f60c6f80-9e04-11eb-8dcd-64708e5c5ebb.mp4



### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1282]: https://artsyproduct.atlassian.net/browse/CX-1282