### PR TITLE
CTA/Order Update Tweaks

### DIFF
--- a/src/lib/Scenes/Inbox/Components/Conversations/OrderUpdate.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/OrderUpdate.tsx
@@ -49,7 +49,7 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({ event }) => {
       <TimeSince style={{ alignSelf: "center" }} time={event.createdAt} exact mb={1} />
       <Flex px={2} justifyContent="center" flexDirection="row">
         <Flex flexDirection="row">
-          <Icon mt="3px" fill={color} />
+          <Icon mt="1px" fill={color} />
           <Flex flexDirection="column" pl={1}>
             <Text color={color} variant="small">
               {message}

--- a/src/lib/Scenes/Inbox/Components/Conversations/ReviewOfferButton.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/ReviewOfferButton.tsx
@@ -24,11 +24,13 @@ export const ReviewOfferButton: React.FC<ReviewOfferButtonProps> = ({ conversati
   const { internalID: orderID, offers } = activeOrder
   const { trackEvent } = useTracking()
 
-  const { hours } = useEventTiming({
+  const { hours, minutes } = useEventTiming({
     currentTime: DateTime.local().toString(),
     startAt: activeOrder.lastOffer?.createdAt,
     endAt: activeOrder.stateExpiresAt || undefined,
   })
+
+  const expiresIn = Number(hours) < 1 ? `${minutes}m` : `${hours}hr`
   const offerType = (offers?.edges?.length || []) > 1 ? "Counteroffer" : "Offer"
 
   let ctaAttributes: {
@@ -45,10 +47,10 @@ export const ReviewOfferButton: React.FC<ReviewOfferButtonProps> = ({ conversati
       ctaAttributes = {
         backgroundColor: "red100",
         message: "Payment Failed",
-        subMessage: "Please update payment method",
+        subMessage: "Unable to process payment for accepted offer. Update payment method.",
         Icon: AlertCircleFillIcon,
         url: `/orders/${orderID}/payment/new`,
-        modalTitle: "Retry Payment",
+        modalTitle: "Update Payment Details",
       }
       break
     }
@@ -56,11 +58,10 @@ export const ReviewOfferButton: React.FC<ReviewOfferButtonProps> = ({ conversati
       ctaAttributes = {
         backgroundColor: "copper100",
         message: `${offerType} Received`,
-        // TODO: what about <1 hr?
-        subMessage: `Expires in ${hours}hr`,
+        subMessage: `Expires in ${expiresIn}`,
         Icon: AlertCircleFillIcon,
         url: `/orders/${orderID}`,
-        modalTitle: "Make Offer",
+        modalTitle: "Review Offer",
       }
       break
     }
@@ -71,7 +72,7 @@ export const ReviewOfferButton: React.FC<ReviewOfferButtonProps> = ({ conversati
         subMessage: "Tap to view",
         Icon: MoneyFillIcon,
         url: `/orders/${orderID}`,
-        modalTitle: "Make Offer",
+        modalTitle: "Offer Accepted",
       }
       break
     }

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/ConversationCTA-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/ConversationCTA-tests.tsx
@@ -116,7 +116,7 @@ describe("ConversationCTA", () => {
       expectReviewOfferButton(wrapper, {
         bg: "red100",
         Icon: AlertCircleFillIcon,
-        strings: ["Payment Failed", "Please update payment method"],
+        strings: ["Payment Failed", "Unable to process payment for accepted offer. Update payment method."],
       })
     })
 

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/ReviewOfferButton-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/ReviewOfferButton-tests.tsx
@@ -1,6 +1,7 @@
 import { navigate } from "lib/navigation/navigate"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { DateTime } from "luxon"
 import { AlertCircleFillIcon } from "palette"
 import { MoneyFillIcon } from "palette/svgs/MoneyFillIcon"
 import React from "react"
@@ -72,7 +73,33 @@ describe("ReviewOfferButton", () => {
     expect(wrapper.root.findAllByType(AlertCircleFillIcon)).toHaveLength(1)
   })
 
-  it("tapping it opens the review offer webview and tracks event", () => {
+  it("shows correct expiration in minutes when there is less than 1 hour left", () => {
+    const expirationTime = DateTime.local().plus({ minutes: 31 })
+    console.warn("EXpiration", expirationTime)
+    const wrapper = getWrapper("OFFER_RECEIVED", {
+      offers: { edges: [{}, {}] },
+      stateExpiresAt: expirationTime.toString(),
+    })
+
+    const text = extractText(wrapper.root)
+    expect(text).toContain("Counteroffer Received")
+    expect(text).toContain("Expires in 30m")
+  })
+
+  it("shows correct expiration in hours when there is more than 1 hour left", () => {
+    const expirationTime = DateTime.local().plus({ hours: 11 })
+    console.warn("EXpiration", expirationTime)
+    const wrapper = getWrapper("OFFER_RECEIVED", {
+      offers: { edges: [{}, {}] },
+      stateExpiresAt: expirationTime.toString(),
+    })
+
+    const text = extractText(wrapper.root)
+    expect(text).toContain("Counteroffer Received")
+    expect(text).toContain("Expires in 10hr")
+  })
+
+  it("tapping it opens the review offer webview with the correct modal title and tracks event", () => {
     const wrapper = getWrapper("OFFER_RECEIVED", { offers: { edges: [{}, {}] } })
 
     wrapper.root.findByType(TouchableWithoutFeedback).props.onPress()
@@ -85,7 +112,7 @@ describe("ReviewOfferButton", () => {
     })
     expect(navigate).toHaveBeenCalledWith("/orders/order-id", {
       modal: true,
-      passProps: { orderID: "order-id", title: "Make Offer" },
+      passProps: { orderID: "order-id", title: "Review Offer" },
     })
   })
 
@@ -96,7 +123,7 @@ describe("ReviewOfferButton", () => {
 
     expect(navigate).toHaveBeenCalledWith("/orders/order-id/payment/new", {
       modal: true,
-      passProps: { orderID: "order-id", title: "Retry Payment" },
+      passProps: { orderID: "order-id", title: "Update Payment Details" },
     })
   })
 })

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/ReviewOfferButton-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/ReviewOfferButton-tests.tsx
@@ -53,7 +53,7 @@ describe("ReviewOfferButton", () => {
     const wrapper = getWrapper("PAYMENT_FAILED")
 
     const text = extractText(wrapper.root)
-    expect(text).toContain("Payment Failed")
+    expect(text).toContain("Unable to process payment for accepted offer. Update payment method.")
     expect(wrapper.root.findAllByType(AlertCircleFillIcon)).toHaveLength(1)
   })
 

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/ReviewOfferButton-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/ReviewOfferButton-tests.tsx
@@ -75,7 +75,6 @@ describe("ReviewOfferButton", () => {
 
   it("shows correct expiration in minutes when there is less than 1 hour left", () => {
     const expirationTime = DateTime.local().plus({ minutes: 31 })
-    console.warn("EXpiration", expirationTime)
     const wrapper = getWrapper("OFFER_RECEIVED", {
       offers: { edges: [{}, {}] },
       stateExpiresAt: expirationTime.toString(),
@@ -88,7 +87,6 @@ describe("ReviewOfferButton", () => {
 
   it("shows correct expiration in hours when there is more than 1 hour left", () => {
     const expirationTime = DateTime.local().plus({ hours: 11 })
-    console.warn("EXpiration", expirationTime)
     const wrapper = getWrapper("OFFER_RECEIVED", {
       offers: { edges: [{}, {}] },
       stateExpiresAt: expirationTime.toString(),


### PR DESCRIPTION
# PURCHASE-2580 and PURCHASE-2576

This PR addresses some small tweaks to the CTA copy and modal headers that Arvind requested, as well as a small alignment adjustments to the order update icon

- Icon next to copy in Inline message needs to be bumped up by a pixel. Not fully aligned
- Update modal header titles
- Update modal copy
- Handle countdowns under 1 hr (currently `hr` is hardcoded)

_Icon after adjustments:_
<img width="266" alt="Screen Shot 2021-04-16 at 1 04 57 PM" src="https://user-images.githubusercontent.com/5643895/115081186-e0b14700-9ed1-11eb-8524-5c395c952452.png">

_CTA with expiration in minutes:_
having uploading issues...DM me for screenshot

