### PR TITLE
fix: android back button in fancy modals

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -7,6 +7,7 @@ upcoming:
     - Refactor Filter Modals - mounir
     - Update filter params change tracking type for auction results - ole
     - Track a screen event when user lands on artist auction Results - ole
+    - Fix android hardware back button in fancy modals - david
   user_facing:
     - Add forgot password screen in new login - brian
     - Conversation-offer updates to CTA to allow multiple offers - erikdstock

--- a/src/lib/Components/FancyModal/FancyModal.tsx
+++ b/src/lib/Components/FancyModal/FancyModal.tsx
@@ -67,7 +67,13 @@ export const FancyModal: React.FC<{
   }, [visible])
 
   return (
-    <Modal transparent animated={false} visible={showingUnderlyingModal} statusBarTranslucent>
+    <Modal
+      transparent
+      animated={false}
+      visible={showingUnderlyingModal}
+      statusBarTranslucent
+      onRequestClose={onBackgroundPressed}
+    >
       <FancyModalContext.Provider value={context.nextLevel()}>{card.jsx}</FancyModalContext.Provider>
     </Modal>
   )


### PR DESCRIPTION


This PR resolves [CX-1192]

### Description

This PR makes the android back button dismiss fancy modals.

https://user-images.githubusercontent.com/1242537/115209519-96a8ab00-a0f5-11eb-8084-da140e8fdb46.mp4


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-1192]: https://artsyproduct.atlassian.net/browse/CX-1192