### PR TITLE
chore(deprecated stuff): replace viewproperties to viewprops, textproperties to textprops, textinputproperties to textinputprops

### DIFF
--- a/src/lib/Components/Artist/Articles/Article.tsx
+++ b/src/lib/Components/Artist/Articles/Article.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
-import { StyleSheet, TouchableWithoutFeedback, View, ViewProperties } from "react-native"
+import { StyleSheet, TouchableWithoutFeedback, View, ViewProps } from "react-native"
 
 import ImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import fonts from "lib/data/fonts"
@@ -10,7 +10,7 @@ import { navigate } from "lib/navigation/navigate"
 import { Article_article } from "__generated__/Article_article.graphql"
 import { Sans, Spacer } from "palette"
 
-interface Props extends ViewProperties {
+interface Props extends ViewProps {
   article: Article_article
 }
 

--- a/src/lib/Components/Artist/ArtistShows/Metadata.tsx
+++ b/src/lib/Components/Artist/ArtistShows/Metadata.tsx
@@ -1,13 +1,13 @@
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
-import { View, ViewProperties } from "react-native"
+import { View, ViewProps } from "react-native"
 
 import { Metadata_show } from "__generated__/Metadata_show.graphql"
 import { capitalize } from "lodash"
 import { Sans } from "palette"
 
-interface Props extends ViewProperties {
+interface Props extends ViewProps {
   show: Metadata_show
 }
 

--- a/src/lib/Components/Artist/ArtistShows/SmallList.tsx
+++ b/src/lib/Components/Artist/ArtistShows/SmallList.tsx
@@ -1,12 +1,12 @@
 import React from "react"
-import { FlatList, StyleSheet, View, ViewProperties } from "react-native"
+import { FlatList, StyleSheet, View, ViewProps } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 
 import { ArtistShowFragmentContainer } from "./ArtistShow"
 
 import { SmallList_shows } from "__generated__/SmallList_shows.graphql"
 
-interface Props extends ViewProperties {
+interface Props extends ViewProps {
   shows: SmallList_shows
 }
 

--- a/src/lib/Components/ArtworkFilter/ArtworkFilter.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilter.tsx
@@ -34,13 +34,13 @@ import { OwnerEntityTypes, PageNames } from "lib/utils/track/schema"
 import _ from "lodash"
 import { Box, Button, Separator } from "palette"
 import React from "react"
-import { View, ViewProperties } from "react-native"
+import { View, ViewProps } from "react-native"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
 import { FancyModal } from "../FancyModal/FancyModal"
 import { ArtworkFilterOptionsScreen, FilterModalMode as ArtworkFilterMode } from "./ArtworkFilterOptionsScreen"
 
-interface ArtworkFilterProps extends ViewProperties {
+interface ArtworkFilterProps extends ViewProps {
   closeModal?: () => void
   exitModal?: () => void
   id: string

--- a/src/lib/Components/Bidding/Components/Animation/CssTransition.tsx
+++ b/src/lib/Components/Bidding/Components/Animation/CssTransition.tsx
@@ -1,7 +1,7 @@
 import React from "react"
-import { Animated, StyleProp, ViewProperties, ViewStyle } from "react-native"
+import { Animated, StyleProp, ViewProps, ViewStyle } from "react-native"
 
-interface CssTransitionProps extends ViewProperties {
+interface CssTransitionProps extends ViewProps {
   animate: string[]
   duration: number
 }

--- a/src/lib/Components/Bidding/Components/BackButton.tsx
+++ b/src/lib/Components/Bidding/Components/BackButton.tsx
@@ -1,10 +1,10 @@
 import NavigatorIOS from "lib/utils/__legacy_do_not_use__navigator-ios-shim"
 import { isPad } from "lib/utils/hardware"
 import React from "react"
-import { TouchableWithoutFeedback, ViewProperties } from "react-native"
+import { TouchableWithoutFeedback, ViewProps } from "react-native"
 import { Image } from "../Elements/Image"
 
-interface ContainerWithBackButtonProps extends ViewProperties {
+interface ContainerWithBackButtonProps extends ViewProps {
   navigator: NavigatorIOS
 }
 

--- a/src/lib/Components/Bidding/Components/Input.tsx
+++ b/src/lib/Components/Bidding/Components/Input.tsx
@@ -1,8 +1,7 @@
 import React, { Component } from "react"
-import { TextInputProperties } from "react-native"
 import { TextInput, TextInputProps } from "../Elements/TextInput"
 
-export interface InputProps extends TextInputProps, TextInputProperties {
+export interface InputProps extends TextInputProps {
   error?: boolean
   inputRef?: (component: any) => void
 }

--- a/src/lib/Components/Bidding/Elements/TextInput.tsx
+++ b/src/lib/Components/Bidding/Elements/TextInput.tsx
@@ -1,4 +1,4 @@
-import { TextInputProperties } from "react-native"
+import { TextInputProps as RNTextInputProps } from "react-native"
 import styled from "styled-components/native"
 import { borderColor, borders, color, flex, fontSize, height, space, width } from "styled-system"
 import { Fonts } from "../../../data/fonts"
@@ -22,7 +22,7 @@ export interface TextInputProps
     HeightProps,
     SpaceProps,
     WidthProps,
-    TextInputProperties {}
+    RNTextInputProps {}
 
 export const TextInput = styled.TextInput.attrs<TextInputProps>({})`
   font-family: "${Fonts.GaramondRegular}";

--- a/src/lib/Components/Bidding/Screens/ConfirmBid/index.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid/index.tsx
@@ -30,7 +30,7 @@ import { Schema, screenTrack, track } from "lib/utils/track"
 import { get, isEmpty } from "lodash"
 import { Box, Button, Serif, Theme } from "palette"
 import React from "react"
-import { Image, ScrollView, ViewProperties } from "react-native"
+import { Image, ScrollView, ViewProps } from "react-native"
 import { commitMutation, createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { PayloadError } from "relay-runtime"
 // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
@@ -40,7 +40,7 @@ type BidderPositionResult = NonNullable<
   NonNullable<ConfirmBidCreateBidderPositionMutationResponse["createBidderPosition"]>["result"]
 >
 
-export interface ConfirmBidProps extends ViewProperties {
+export interface ConfirmBidProps extends ViewProps {
   sale_artwork: ConfirmBid_sale_artwork
   me: ConfirmBid_me
   relay: RelayRefetchProp

--- a/src/lib/Components/Bidding/Screens/Registration.tsx
+++ b/src/lib/Components/Bidding/Screens/Registration.tsx
@@ -16,7 +16,7 @@ import { Schema, screenTrack } from "lib/utils/track"
 import { get, isEmpty } from "lodash"
 import { Box, Button, Sans, Serif } from "palette"
 import React from "react"
-import { ScrollView, View, ViewProperties } from "react-native"
+import { ScrollView, View, ViewProps } from "react-native"
 import { commitMutation, createFragmentContainer, graphql, QueryRenderer, RelayProp } from "react-relay"
 // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import stripe from "tipsi-stripe"
@@ -29,7 +29,7 @@ import { Flex } from "../Elements/Flex"
 import { Address, PaymentCardTextFieldParams, StripeToken } from "../types"
 import { RegistrationResult, RegistrationStatus } from "./RegistrationResult"
 
-export interface RegistrationProps extends ViewProperties {
+export interface RegistrationProps extends ViewProps {
   sale: Registration_sale
   me: Registration_me
   relay: RelayProp

--- a/src/lib/Components/Bidding/Screens/SelectMaxBid.tsx
+++ b/src/lib/Components/Bidding/Screens/SelectMaxBid.tsx
@@ -1,6 +1,6 @@
 import NavigatorIOS from "lib/utils/__legacy_do_not_use__navigator-ios-shim"
 import React from "react"
-import { ActivityIndicator, View, ViewProperties } from "react-native"
+import { ActivityIndicator, View, ViewProps } from "react-native"
 import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
 
 import { Schema, screenTrack } from "../../../utils/track"
@@ -20,7 +20,7 @@ import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import { ScreenDimensionsContext } from "lib/utils/useScreenDimensions"
 import { compact } from "lodash"
 
-interface SelectMaxBidProps extends ViewProperties {
+interface SelectMaxBidProps extends ViewProps {
   sale_artwork: SelectMaxBid_sale_artwork
   me: SelectMaxBid_me
   navigator: NavigatorIOS

--- a/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
+++ b/src/lib/Components/Home/ArtistRails/ArtistRail.tsx
@@ -3,7 +3,7 @@
 //       let Relay re-render the cards.
 
 import React, { useImperativeHandle, useRef, useState } from "react"
-import { FlatList, View, ViewProperties } from "react-native"
+import { FlatList, View, ViewProps } from "react-native"
 import { commitMutation, createFragmentContainer, fetchQuery, graphql, RelayProp } from "react-relay"
 
 import HomeAnalytics from "lib/Scenes/Home/homeAnalytics"
@@ -29,7 +29,7 @@ interface SuggestedArtist extends Pick<ArtistCard_artist, Exclude<keyof ArtistCa
   _disappearable: Disappearable | null
 }
 
-interface Props extends ViewProperties {
+interface Props extends ViewProps {
   relay: RelayProp
   rail: ArtistRail_rail
 }

--- a/src/lib/Components/Modal.tsx
+++ b/src/lib/Components/Modal.tsx
@@ -2,10 +2,10 @@ import { TextAlignProperty } from "csstype"
 import { theme } from "lib/Components/Bidding/Elements/Theme"
 import { Button, Sans } from "palette"
 import React from "react"
-import { Modal as RNModal, TouchableWithoutFeedback, View, ViewProperties } from "react-native"
+import { Modal as RNModal, TouchableWithoutFeedback, View, ViewProps } from "react-native"
 import styled from "styled-components/native"
 
-interface ModalProps extends ViewProperties {
+interface ModalProps extends ViewProps {
   headerText: string
   detailText: string
   visible?: boolean

--- a/src/lib/Components/Separator.tsx
+++ b/src/lib/Components/Separator.tsx
@@ -1,11 +1,11 @@
 import React from "react"
-import { Dimensions, StyleSheet, View, ViewProperties } from "react-native"
+import { Dimensions, StyleSheet, View, ViewProps } from "react-native"
 
 import colors from "lib/data/colors"
 
 const negativeMargin = Dimensions.get("window").width > 700 ? -40 : -20
 
-export default class Separator extends React.Component<ViewProperties, any> {
+export default class Separator extends React.Component<ViewProps, any> {
   render() {
     return <View style={[styles.separator, this.props.style]} />
   }

--- a/src/lib/Components/Spinner.tsx
+++ b/src/lib/Components/Spinner.tsx
@@ -7,10 +7,10 @@ import {
   requireNativeComponent,
   StyleSheet,
   View,
-  ViewProperties,
+  ViewProps,
 } from "react-native"
 
-interface SpinnerProps extends ViewProperties {
+interface SpinnerProps extends ViewProps {
   spinnerColor?: string
   size?: {
     width: number

--- a/src/lib/Components/StickyTabPage/StickyTabPageTabBar.tsx
+++ b/src/lib/Components/StickyTabPage/StickyTabPageTabBar.tsx
@@ -2,7 +2,7 @@ import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { compact } from "lodash"
 import { color, Sans, space } from "palette"
 import React, { useEffect, useRef, useState } from "react"
-import { Animated, LayoutRectangle, ScrollView, TouchableOpacity, View, ViewProperties } from "react-native"
+import { Animated, LayoutRectangle, ScrollView, TouchableOpacity, View, ViewProps } from "react-native"
 import { useStickyTabPageContext } from "./SitckyTabPageContext"
 
 export const TAB_BAR_HEIGHT = 48
@@ -95,7 +95,7 @@ export const StickyTabPageTabBar: React.FC<{ onTabPress?(tab: { label: string; i
 export const StickyTab: React.FC<{
   label: string
   active: boolean
-  onLayout: ViewProperties["onLayout"]
+  onLayout: ViewProps["onLayout"]
   onPress(): void
 }> = ({ label, active, onPress, onLayout }) => {
   return (

--- a/src/lib/Components/Text/Serif.tsx
+++ b/src/lib/Components/Text/Serif.tsx
@@ -1,7 +1,7 @@
 import React from "react"
-import { StyleSheet, Text, TextProperties } from "react-native"
+import { StyleSheet, Text, TextProps } from "react-native"
 
-export default class Serif extends React.Component<TextProperties, any> {
+export default class Serif extends React.Component<TextProps, any> {
   render() {
     const { children, style, ...props } = this.props
     return (

--- a/src/lib/Containers/Gene.tsx
+++ b/src/lib/Containers/Gene.tsx
@@ -10,7 +10,7 @@ import { Schema, Track, track as _track } from "lib/utils/track"
 import * as _ from "lodash"
 import { Box, Button, Sans } from "palette"
 import React from "react"
-import { Dimensions, StyleSheet, View, ViewProperties, ViewStyle } from "react-native"
+import { Dimensions, StyleSheet, View, ViewProps, ViewStyle } from "react-native"
 import { createPaginationContainer, graphql, QueryRenderer, RelayPaginationProp } from "react-relay"
 import { InfiniteScrollArtworksGridContainer as InfiniteScrollArtworksGrid } from "../Components/ArtworkGrids/InfiniteScrollArtworksGrid"
 import About from "../Components/Gene/About"
@@ -25,7 +25,7 @@ const TABS = {
   ABOUT: "About",
 }
 
-interface Props extends ViewProperties {
+interface Props extends ViewProps {
   medium: string
   price_range: string
   gene: Gene_gene

--- a/src/lib/Scenes/City/Components/AllEvents.tsx
+++ b/src/lib/Scenes/City/Components/AllEvents.tsx
@@ -4,13 +4,13 @@ import { Show } from "lib/Scenes/Map/types"
 import { isEqual } from "lodash"
 import { Box, Separator, Serif, Spacer, Theme } from "palette"
 import React from "react"
-import { FlatList, ViewProperties } from "react-native"
+import { FlatList, ViewProps } from "react-native"
 import { RelayProp } from "react-relay"
 import { BMWEventSection } from "./BMWEventSection"
 import { FairEventSection } from "./FairEventSection"
 import { SavedEventSection } from "./SavedEventSection"
 
-interface Props extends ViewProperties {
+interface Props extends ViewProps {
   buckets: BucketResults
   cityName: string
   citySlug: string

--- a/src/lib/Scenes/Collection/Components/FullFeaturedArtistList.tsx
+++ b/src/lib/Scenes/Collection/Components/FullFeaturedArtistList.tsx
@@ -6,10 +6,10 @@ import { defaultEnvironment } from "lib/relay/createEnvironment"
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import { Box } from "palette"
 import React from "react"
-import { Dimensions, FlatList, ViewProperties } from "react-native"
+import { Dimensions, FlatList, ViewProps } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 
-interface Props extends ViewProperties {
+interface Props extends ViewProps {
   collection: FullFeaturedArtistList_collection
 }
 

--- a/src/lib/Scenes/Consignments/Components/FormElements.tsx
+++ b/src/lib/Scenes/Consignments/Components/FormElements.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { ScrollView, View, ViewProperties } from "react-native"
+import { ScrollView, View, ViewProps } from "react-native"
 import { LargeHeadline } from "../Typography/index"
 
 /** A re-usable full-screen form with a scrollview */
@@ -13,7 +13,7 @@ export const Form: React.FC<{ title?: string }> = (props) => (
 )
 
 /** An individual row inside the form */
-export const Row: React.FC<ViewProperties> = ({ children, ...props }) => (
+export const Row: React.FC<ViewProps> = ({ children, ...props }) => (
   <View {...props} style={[props.style, { flexDirection: "row", paddingVertical: 6, alignItems: "center" }]}>
     {children}
   </View>

--- a/src/lib/Scenes/Consignments/Components/TextArea.tsx
+++ b/src/lib/Scenes/Consignments/Components/TextArea.tsx
@@ -2,10 +2,10 @@ import colors from "lib/data/colors"
 import fonts from "lib/data/fonts"
 import { color } from "palette"
 import React from "react"
-import { TextInputProperties, View, ViewProperties } from "react-native"
+import { TextInputProperties, View, ViewProps } from "react-native"
 import styled from "styled-components/native"
 
-export interface TextAreaProps extends ViewProperties {
+export interface TextAreaProps extends ViewProps {
   text?: TextInputProperties
 }
 

--- a/src/lib/Scenes/Consignments/Components/TextArea.tsx
+++ b/src/lib/Scenes/Consignments/Components/TextArea.tsx
@@ -2,11 +2,11 @@ import colors from "lib/data/colors"
 import fonts from "lib/data/fonts"
 import { color } from "palette"
 import React from "react"
-import { TextInputProperties, View, ViewProps } from "react-native"
+import { TextInputProps, View, ViewProps } from "react-native"
 import styled from "styled-components/native"
 
 export interface TextAreaProps extends ViewProps {
-  text?: TextInputProperties
+  text?: TextInputProps
 }
 
 interface State {

--- a/src/lib/Scenes/Consignments/Components/TextInput.tsx
+++ b/src/lib/Scenes/Consignments/Components/TextInput.tsx
@@ -7,13 +7,13 @@ import {
   ImageURISource,
   Text,
   TextInput,
-  TextInputProps,
+  TextInputProps as RNTextInputProps,
   View,
   ViewProps,
 } from "react-native"
 import styled from "styled-components/native"
 
-interface ReffableTextInputProps extends TextInputProps {
+interface ReffableTextInputProps extends RNTextInputProps {
   ref?: (component: any) => any
 }
 

--- a/src/lib/Scenes/Consignments/Components/TextInput.tsx
+++ b/src/lib/Scenes/Consignments/Components/TextInput.tsx
@@ -9,7 +9,7 @@ import {
   TextInput,
   TextInputProperties,
   View,
-  ViewProperties,
+  ViewProps,
 } from "react-native"
 import styled from "styled-components/native"
 
@@ -17,7 +17,7 @@ interface ReffableTextInputProps extends TextInputProperties {
   ref?: (component: any) => any
 }
 
-export interface TextInputProps extends ViewProperties {
+export interface TextInputProps extends ViewProps {
   searching?: boolean
   readonly?: boolean
   text?: ReffableTextInputProps

--- a/src/lib/Scenes/Consignments/Components/TextInput.tsx
+++ b/src/lib/Scenes/Consignments/Components/TextInput.tsx
@@ -7,13 +7,13 @@ import {
   ImageURISource,
   Text,
   TextInput,
-  TextInputProperties,
+  TextInputProps,
   View,
   ViewProps,
 } from "react-native"
 import styled from "styled-components/native"
 
-interface ReffableTextInputProps extends TextInputProperties {
+interface ReffableTextInputProps extends TextInputProps {
   ref?: (component: any) => any
 }
 

--- a/src/lib/Scenes/Consignments/Screens/Confirmation.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Confirmation.tsx
@@ -5,10 +5,10 @@ import NavigatorIOS from "lib/utils/__legacy_do_not_use__navigator-ios-shim"
 import { Schema, screenTrack } from "lib/utils/track"
 import { Box, Button, color, Flex, Sans, Spacer } from "palette"
 import React from "react"
-import { Alert, BackHandler, NativeEventSubscription, View, ViewProperties } from "react-native"
+import { Alert, BackHandler, NativeEventSubscription, View, ViewProps } from "react-native"
 import styled from "styled-components/native"
 
-interface Props extends ViewProperties {
+interface Props extends ViewProps {
   navigator: NavigatorIOS
   /** Used for testing, it's expected to be undefined in prod */
   initialState?: SubmissionTypes

--- a/src/lib/Scenes/Consignments/Screens/ConsignmentsArtist.tsx
+++ b/src/lib/Scenes/Consignments/Screens/ConsignmentsArtist.tsx
@@ -6,13 +6,13 @@ import { extractNodes } from "lib/utils/extractNodes"
 import { throttle } from "lodash"
 import { Theme } from "palette"
 import React from "react"
-import { Dimensions, View, ViewProperties } from "react-native"
+import { Dimensions, View, ViewProps } from "react-native"
 import { fetchQuery, graphql } from "react-relay"
 import { BottomAlignedButton } from "../Components/BottomAlignedButton"
 import { SearchResults } from "../Components/SearchResults"
 import { ArtistResult, ConsignmentSetup } from "../index"
 
-interface Props extends ConsignmentSetup, ViewProperties {
+interface Props extends ConsignmentSetup, ViewProps {
   navigator: NavigatorIOS
   updateWithArtist?: (result: ArtistResult) => void
 }

--- a/src/lib/Scenes/Consignments/Screens/Edition.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Edition.tsx
@@ -1,6 +1,6 @@
 import NavigatorIOS from "lib/utils/__legacy_do_not_use__navigator-ios-shim"
 import React from "react"
-import { LayoutAnimation, ViewProperties } from "react-native"
+import { LayoutAnimation, ViewProps } from "react-native"
 import Text from "../Components/TextInput"
 import Toggle from "../Components/Toggle"
 import { ConsignmentSetup } from "../index"
@@ -10,7 +10,7 @@ import { Flex, Sans, Spacer, Theme } from "palette"
 import { BottomAlignedButton } from "../Components/BottomAlignedButton"
 import { Form, Row } from "../Components/FormElements"
 
-interface Props extends ConsignmentSetup, ViewProperties {
+interface Props extends ConsignmentSetup, ViewProps {
   navigator: NavigatorIOS
   setup: ConsignmentSetup
   updateWithEdition?: (setup: ConsignmentSetup) => void

--- a/src/lib/Scenes/Consignments/Screens/Location.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Location.tsx
@@ -3,7 +3,7 @@ import { SearchResults } from "../Components/SearchResults"
 
 import NavigatorIOS from "lib/utils/__legacy_do_not_use__navigator-ios-shim"
 import { LocationIcon } from "palette"
-import { View, ViewProperties } from "react-native"
+import { View, ViewProps } from "react-native"
 import { ConsignmentSetup, LocationResult } from "../index"
 
 import { stringify } from "qs"
@@ -14,7 +14,7 @@ import { Dimensions } from "react-native"
 import Config from "react-native-config"
 import { BottomAlignedButton } from "../Components/BottomAlignedButton"
 
-interface Props extends ConsignmentSetup, ViewProperties {
+interface Props extends ConsignmentSetup, ViewProps {
   navigator: NavigatorIOS
   updateWithResult?: (city: string, state: string, country: string) => void
 }

--- a/src/lib/Scenes/Consignments/Screens/Metadata.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Metadata.tsx
@@ -6,14 +6,14 @@ import { Select } from "lib/Components/Select"
 import NavigatorIOS from "lib/utils/__legacy_do_not_use__navigator-ios-shim"
 import { ScreenDimensionsContext } from "lib/utils/useScreenDimensions"
 import { Sans } from "palette"
-import { ScrollView, View, ViewProperties } from "react-native"
+import { ScrollView, View, ViewProps } from "react-native"
 import { ConsignmentMetadata } from "../"
 import { BottomAlignedButton } from "../Components/BottomAlignedButton"
 import { Row } from "../Components/FormElements"
 import Text from "../Components/TextInput"
 import Toggle from "../Components/Toggle"
 
-interface Props extends ViewProperties {
+interface Props extends ViewProps {
   navigator: NavigatorIOS
   updateWithMetadata?: (result: ConsignmentMetadata) => void
   metadata: ConsignmentMetadata

--- a/src/lib/Scenes/Consignments/Screens/Provenance.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Provenance.tsx
@@ -2,12 +2,12 @@ import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
 import NavigatorIOS from "lib/utils/__legacy_do_not_use__navigator-ios-shim"
 import { Theme } from "palette"
 import React from "react"
-import { View, ViewProperties } from "react-native"
+import { View, ViewProps } from "react-native"
 import { BottomAlignedButton } from "../Components/BottomAlignedButton"
 import TextArea from "../Components/TextArea"
 import { ConsignmentSetup } from "../index"
 
-interface Props extends ConsignmentSetup, ViewProperties {
+interface Props extends ConsignmentSetup, ViewProps {
   navigator: NavigatorIOS
   updateWithProvenance?: (provenance: string) => void
 }

--- a/src/lib/Scenes/Consignments/Typography/index.tsx
+++ b/src/lib/Scenes/Consignments/Typography/index.tsx
@@ -1,10 +1,10 @@
 import React from "react"
-import { StyleSheet, Text, TextProperties, TextStyle } from "react-native"
+import { StyleSheet, Text, TextProps, TextStyle } from "react-native"
 
 import colors from "lib/data/colors"
 import fonts from "lib/data/fonts"
 
-const LargeHeadline: React.FC<TextProperties> = (props) => {
+const LargeHeadline: React.FC<TextProps> = (props) => {
   const children: string = (props as any).children
   const style = [styles.largeHeadlineDefault, props.style || {}, styles.largeHeadlineRequired]
   return (
@@ -14,7 +14,7 @@ const LargeHeadline: React.FC<TextProperties> = (props) => {
   )
 }
 
-const SmallHeadline: React.FC<TextProperties> = (props: TextProperties) => {
+const SmallHeadline: React.FC<TextProps> = (props) => {
   const children: string = (props as any).children
   const style = [styles.smallHeadlineDefault, props.style || {}, styles.smallHeadlineRequired]
   return (
@@ -24,7 +24,7 @@ const SmallHeadline: React.FC<TextProperties> = (props: TextProperties) => {
   )
 }
 
-const Subtitle: React.FC<TextProperties> = (props: TextProperties) => {
+const Subtitle: React.FC<TextProps> = (props) => {
   const children: string = (props as any).children
   const style = [styles.subtitleDefault, props.style || {}, styles.subtitleRequired]
   return (
@@ -34,7 +34,7 @@ const Subtitle: React.FC<TextProperties> = (props: TextProperties) => {
   )
 }
 
-const BodyText: React.FC<TextProperties> = (props: TextProperties) => {
+const BodyText: React.FC<TextProps> = (props) => {
   const children: string = (props as any).children
   const style = [styles.bodyDefault, props.style || {}, styles.bodyRequired]
   return (
@@ -44,7 +44,7 @@ const BodyText: React.FC<TextProperties> = (props: TextProperties) => {
   )
 }
 
-const SmallPrint: React.FC<TextProperties> = (props: TextProperties) => {
+const SmallPrint: React.FC<TextProps> = (props) => {
   const children: string = (props as any).children
   const style = [styles.smallPrintDefault, props.style || {}, styles.smallPrintRequired]
   return (

--- a/src/lib/Scenes/Fair/FairBMWArtActivation.tsx
+++ b/src/lib/Scenes/Fair/FairBMWArtActivation.tsx
@@ -7,12 +7,12 @@ import { BMWSponsorship } from "lib/Scenes/City/CityBMWSponsorship"
 import { Schema, screenTrack, track } from "lib/utils/track"
 import { Box, Text, Theme } from "palette"
 import React from "react"
-import { FlatList, ViewProperties } from "react-native"
+import { FlatList, ViewProps } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import { defaultEnvironment } from "../../relay/createEnvironment"
 import renderWithLoadProgress from "../../utils/renderWithLoadProgress"
 
-interface Props extends ViewProperties {
+interface Props extends ViewProps {
   fair: FairBMWArtActivation_fair
 }
 

--- a/src/lib/Scenes/Home/Home.tsx
+++ b/src/lib/Scenes/Home/Home.tsx
@@ -1,5 +1,5 @@
 import React, { createRef, RefObject, useEffect, useRef, useState } from "react"
-import { Alert, RefreshControl, View, ViewProperties } from "react-native"
+import { Alert, RefreshControl, View, ViewProps } from "react-native"
 import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
 
 import { ArtistRailFragmentContainer } from "lib/Components/Home/ArtistRails/ArtistRail"
@@ -27,7 +27,7 @@ import { ViewingRoomsHomeRail } from "../ViewingRoom/Components/ViewingRoomsHome
 import { HomeHeroContainer, HomeHeroPlaceholder } from "./Components/HomeHero"
 import { RailScrollRef } from "./Components/types"
 
-interface Props extends ViewProperties {
+interface Props extends ViewProps {
   homePage: Home_homePage
   me: Home_me
   featured: Home_featured

--- a/src/lib/Scenes/Inbox/Components/Typography/index.tsx
+++ b/src/lib/Scenes/Inbox/Components/Typography/index.tsx
@@ -1,10 +1,10 @@
 import React from "react"
-import { StyleSheet, Text, TextProperties, TextStyle } from "react-native"
+import { StyleSheet, Text, TextProps, TextStyle } from "react-native"
 
 import colors from "lib/data/colors"
 import fonts from "lib/data/fonts"
 
-const LargeHeadline: React.FC<TextProperties> = (props) => {
+const LargeHeadline: React.FC<TextProps> = (props) => {
   const children: string = (props as any).children
   const style = [styles.largeDefault, props.style || {}, styles.largeRequired]
   return (
@@ -14,7 +14,7 @@ const LargeHeadline: React.FC<TextProperties> = (props) => {
   )
 }
 
-const SmallHeadline: React.FC<TextProperties & { disabled?: boolean }> = (props) => {
+const SmallHeadline: React.FC<TextProps & { disabled?: boolean }> = (props) => {
   const children: string = (props as any).children
   const style = [styles.smallDefault, props.disabled && styles.disabled, props.style || {}, styles.smallRequired]
   return (
@@ -24,7 +24,7 @@ const SmallHeadline: React.FC<TextProperties & { disabled?: boolean }> = (props)
   )
 }
 
-const Subtitle: React.FC<TextProperties> = (props) => {
+const Subtitle: React.FC<TextProps> = (props) => {
   const children: string = (props as any).children
   const style = [styles.subtitleDefault, props.style || {}, styles.subtitleRequired]
   return (
@@ -34,7 +34,7 @@ const Subtitle: React.FC<TextProperties> = (props) => {
   )
 }
 
-const FromSignatureText: React.FC<TextProperties> = (props) => {
+const FromSignatureText: React.FC<TextProps> = (props) => {
   const children: string = (props as any).children
   const style = [styles.fromSignatureDefault, props.style || {}]
   return (
@@ -44,7 +44,7 @@ const FromSignatureText: React.FC<TextProperties> = (props) => {
   )
 }
 
-const MetadataText: React.FC<TextProperties> = (props) => {
+const MetadataText: React.FC<TextProps> = (props) => {
   const children: string = (props as any).children
   const style = [styles.metadataDefault, props.style || {}, styles.metadataRequired]
   return (
@@ -54,7 +54,7 @@ const MetadataText: React.FC<TextProperties> = (props) => {
   )
 }
 
-const PreviewText: React.FC<TextProperties> = (props) => {
+const PreviewText: React.FC<TextProps> = (props) => {
   const children: string = (props as any).children
   const style = [styles.bodyDefault, props.style || {}, styles.bodyRequired]
   return (
@@ -64,7 +64,7 @@ const PreviewText: React.FC<TextProperties> = (props) => {
   )
 }
 
-const BodyText: React.FC<TextProperties & { disabled?: boolean }> = (props) => {
+const BodyText: React.FC<TextProps & { disabled?: boolean }> = (props) => {
   const children: string = (props as any).children
   const style = [styles.bodyDefault, props.disabled && styles.disabled, props.style || {}, styles.bodyRequired]
   return (

--- a/src/lib/Scenes/Sales/Components/SectionHeader.tsx
+++ b/src/lib/Scenes/Sales/Components/SectionHeader.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { ViewProperties } from "react-native"
+import { ViewProps } from "react-native"
 import styled from "styled-components/native"
 
 import fonts from "lib/data/fonts"
@@ -18,7 +18,7 @@ const Title = styled.Text`
   text-align: left;
 `
 
-interface Props extends ViewProperties {
+interface Props extends ViewProps {
   title: string
 }
 

--- a/src/lib/utils/track/index.tsx
+++ b/src/lib/utils/track/index.tsx
@@ -153,7 +153,7 @@ export class ProvideScreenTrackingWithCohesionSchema extends React.Component<Pro
  *      ```ts
  *      import { screenTrack, Schema } from "lib/utils/track"
  *
- *      interface Props extends ViewProperties {
+ *      interface Props extends ViewProps {
  *        // [...]
  *      }
  *


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-]



### Description

I noticed that `ViewProperties`, `TextProperties` and `TextInputProperties` have been deprecated, so I thought I'll quickly replace them with the new thing, `*Props`.

Pretty easy change.


(My first PR that I think deserves a `chore` 😅.)

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434