### PR TITLE
feat: listen for modal close events to refresh conversation

### DIFF
--- a/src/lib/Scenes/Inbox/Screens/Conversation.tsx
+++ b/src/lib/Scenes/Inbox/Screens/Conversation.tsx
@@ -93,7 +93,10 @@ export class Conversation extends React.Component<Props, State> {
   }
 
   handleModalDismissed = () => {
-    console.warn("modal dismissed...")
+    this.refetch()
+  }
+
+  refetch = () => {
     this.props.relay.refetch({})
   }
 

--- a/src/lib/Scenes/Inbox/Screens/Conversation.tsx
+++ b/src/lib/Scenes/Inbox/Screens/Conversation.tsx
@@ -2,6 +2,7 @@ import NetInfo from "@react-native-community/netinfo"
 import { Conversation_me } from "__generated__/Conversation_me.graphql"
 import { ConversationQuery } from "__generated__/ConversationQuery.graphql"
 import ConnectivityBanner from "lib/Components/ConnectivityBanner"
+import { navigationEvents } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { ComposerFragmentContainer } from "lib/Scenes/Inbox/Components/Conversations/Composer"
 import Messages from "lib/Scenes/Inbox/Components/Conversations/Messages"
@@ -76,15 +77,24 @@ export class Conversation extends React.Component<Props, State> {
   componentDidMount() {
     NetInfo.isConnected.addEventListener("connectionChange", this.handleConnectivityChange)
     this.maybeMarkLastMessageAsRead()
+    navigationEvents.addListener("modalDismissed", this.handleModalDismissed)
+    navigationEvents.addListener("goBack", this.handleModalDismissed)
   }
 
   componentWillUnmount() {
     NetInfo.isConnected.removeEventListener("connectionChange", this.handleConnectivityChange)
+    navigationEvents.removeListener("modalDismissed", this.handleModalDismissed)
+    navigationEvents.removeListener("goBack", this.handleModalDismissed)
   }
 
   // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   handleConnectivityChange = (isConnected) => {
     this.setState({ isConnected })
+  }
+
+  handleModalDismissed = () => {
+    console.warn("modal dismissed...")
+    this.props.relay.refetch({})
   }
 
   maybeMarkLastMessageAsRead() {

--- a/src/lib/Scenes/Inbox/Screens/__tests__/Conversation-tests.tsx
+++ b/src/lib/Scenes/Inbox/Screens/__tests__/Conversation-tests.tsx
@@ -1,5 +1,6 @@
 import { ConversationTestsQuery } from "__generated__/ConversationTestsQuery.graphql"
 import ConnectivityBanner from "lib/Components/ConnectivityBanner"
+import { navigationEvents } from "lib/navigation/navigate"
 import Composer from "lib/Scenes/Inbox/Components/Conversations/Composer"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { Touchable } from "palette"
@@ -93,4 +94,24 @@ it("clicking on detail link opens pushes detail screen into navigator", () => {
     passProps: { conversationID: "123" },
     title: "",
   })
+})
+
+it("handles a dismissed modal with modalDismiss event", () => {
+  const conversation = getWrapper()
+  const componentInstance = (conversation.root.findByType(Conversation).children[0] as ReactTestInstance).instance
+
+  jest.spyOn(componentInstance, "refetch")
+  navigationEvents.emit("modalDismissed")
+
+  expect(componentInstance.refetch).toHaveBeenCalled()
+})
+
+it("handles a dismissed modal with goBack event", () => {
+  const conversation = getWrapper()
+  const componentInstance = (conversation.root.findByType(Conversation).children[0] as ReactTestInstance).instance
+
+  jest.spyOn(componentInstance, "refetch")
+  navigationEvents.emit("goBack")
+
+  expect(componentInstance.refetch).toHaveBeenCalled()
 })

--- a/src/lib/navigation/navigate.ts
+++ b/src/lib/navigation/navigate.ts
@@ -1,4 +1,5 @@
 import { addBreadcrumb } from "@sentry/react-native"
+import { EventEmitter } from "events"
 import { AppModule, modules, ViewOptions } from "lib/AppRegistry"
 import { LegacyNativeModules } from "lib/NativeModules/LegacyNativeModules"
 import { GlobalStore, unsafe__getSelectedTab } from "lib/store/GlobalStore"
@@ -71,12 +72,16 @@ export async function navigate(url: string, options: { modal?: boolean; passProp
   }
 }
 
+export const navigationEvents = new EventEmitter()
+
 export function dismissModal() {
   LegacyNativeModules.ARScreenPresenterModule.dismissModal()
+  navigationEvents.emit("modalDismissed")
 }
 
 export function goBack() {
   LegacyNativeModules.ARScreenPresenterModule.goBack(unsafe__getSelectedTab())
+  navigationEvents.emit("goBack")
 }
 
 export function popParentViewController() {

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -217,6 +217,7 @@ jest.mock("lib/navigation/navigate", () => ({
   dismissModal: jest.fn(),
   navigateToEntity: jest.fn(),
   navigateToPartner: jest.fn(),
+  navigationEvents: new (require("events").EventEmitter)(),
   EntityType: { partner: "partner", fair: "fair" },
   SlugType: { partner: "partner", fair: "fair" },
 }))


### PR DESCRIPTION
Team effort with @xtina-starr @jo-rs @lilyfromseattle @ds300 
The type of this PR is: **feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [PURCHASE-2574]

### Description
After submitting an offer and closing the modal, the user lands back in the conversation chat with the make offer button still visible. This provides a confusing UX experience. This PR adds a new event emitters to listen for the modal dismiss event and refreshes the conversation view to the up-to-date state.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [ ] I have documented any follow-up work that this PR will require, or it does not require any.
- [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434

[PURCHASE-2574]: https://artsyproduct.atlassian.net/browse/PURCHASE-2574