### PR TITLE
fix: fix android share

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -8,6 +8,7 @@ upcoming:
     - Update filter params change tracking type for auction results - ole
     - Track a screen event when user lands on artist auction Results - ole
     - Fix android hardware back button in fancy modals - david
+    - Fix android share - brian, mounir, david, pavlos
   user_facing:
     - Add forgot password screen in new login - brian
     - Conversation-offer updates to CTA to allow multiple offers - erikdstock

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="net.artsy.app">
 
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-feature android:name="android.hardware.camera" android:required="false" />

--- a/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -133,7 +133,7 @@ export class ArtworkActions extends React.Component<ArtworkActionsProps> {
               </UtilButton>
             </TouchableWithoutFeedback>
           )}
-          <Touchable noFeedback haptic onPress={() => this.props.shareOnPress()}>
+          <Touchable haptic onPress={() => this.props.shareOnPress()}>
             <UtilButton>
               <Box mr={0.5}>
                 <ShareIcon />

--- a/src/lib/Scenes/Artwork/Components/ArtworkHeader.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworkHeader.tsx
@@ -39,6 +39,7 @@ export const ArtworkHeader: React.FC<ArtworkHeaderProps> = (props) => {
 
   const currentImage = (artwork.images ?? [])[currentImageIndex]
   const currentImageUrl = (currentImage?.url ?? "").replace(":version", "large")
+  const smallImageURL = (currentImage?.url ?? "").replace(":version", "small")
 
   const shareArtwork = async () => {
     trackEvent({
@@ -52,7 +53,7 @@ export const ArtworkHeader: React.FC<ArtworkHeaderProps> = (props) => {
 
     const resp = await RNFetchBlob.config({
       fileCache: true,
-    }).fetch("GET", currentImageUrl)
+    }).fetch("GET", smallImageURL)
 
     const base64RawData = await resp.base64()
     const base64Data = `data:image/png;base64,${base64RawData}`
@@ -60,8 +61,8 @@ export const ArtworkHeader: React.FC<ArtworkHeaderProps> = (props) => {
     try {
       const res = await Share.open({
         title: details.title,
-        urls: [base64Data, details.url],
-        message: details.message,
+        url: base64Data,
+        message: details.message + "\n" + details.url,
       })
       trackEvent(share(tracks.iosShare(res.app, artwork.internalID, artwork.slug)))
     } catch (err) {


### PR DESCRIPTION
The type of this PR is: **fix**

This PR resolves [CX-1276]

### Description

Fixes sharing on Android, we had 2 issues. 1 sharing was very slow because we were fetching a large image, 2 we were passing a non-base64 encoded url to urls array which was causing the base64 string to be shared instead of the image. 

- Fixes a small image instead
- Moves details url out of urls array and adds it to end of share message


### Screenshots

https://user-images.githubusercontent.com/49686530/115553878-e5804d00-a27b-11eb-8c86-eb96f58136ac.mp4


### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-1276]: https://artsyproduct.atlassian.net/browse/CX-1276