### PR TITLE
bugfix(styling): Input scrolling and title header spacing

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -12,6 +12,7 @@ upcoming:
     - Add forgot password screen in new login - brian
     - Conversation-offer updates to CTA to allow multiple offers - erikdstock
     - Replace "All" option on multi-select filters with upper right-hand "Clear all"
+    - Fix input text scrolling and header title spacing - pavlos, david, mounir, brian, thomas
     - Fix infinite spinner on Android when following within an artist rail - pepopowitz
     - Release multi-select time period filter - iskounen
     - Refine filter header typography, spacing & copy - damon

--- a/src/lib/Components/Bidding/Components/Input.tsx
+++ b/src/lib/Components/Bidding/Components/Input.tsx
@@ -52,7 +52,7 @@ export class Input extends Component<InputProps, InputState> {
       <TextInput
         border={1}
         borderColor={this.state.borderColor}
-        fontSize={3}
+        fontSize={2}
         p={3}
         textAlignVertical="center"
         {...this.props}

--- a/src/lib/Components/FancyModal/FancyModalHeader.tsx
+++ b/src/lib/Components/FancyModal/FancyModalHeader.tsx
@@ -34,7 +34,7 @@ export const FancyModalHeader: React.FC<FancyModalHeaderProps> = ({
   return (
     <Flex>
       <Container alignItems="center" justifyContent="center">
-        <Flex flex={1} alignItems="flex-start">
+        <Flex position="absolute" left={0} alignItems="flex-start">
           {!!onLeftButtonPress && (
             <LeftButtonContainer
               hitSlop={{ top: space(1), bottom: space(1), left: space(1), right: space(1) }}
@@ -45,13 +45,7 @@ export const FancyModalHeader: React.FC<FancyModalHeaderProps> = ({
           )}
         </Flex>
 
-        <Flex flex={1} alignItems="center">
-          <Text variant="mediumText" color="black100">
-            {children}
-          </Text>
-        </Flex>
-
-        <Flex flex={1} alignItems="flex-end">
+        <Flex position="absolute" right={0} alignItems="flex-end">
           {!!onRightButtonPress && (
             <RightButtonContainer
               hitSlop={{ top: space(1), bottom: space(1), left: space(1), right: space(1) }}
@@ -66,6 +60,12 @@ export const FancyModalHeader: React.FC<FancyModalHeaderProps> = ({
               )}
             </RightButtonContainer>
           )}
+        </Flex>
+
+        <Flex position="absolute" left={0} right={0} alignItems="center" pointerEvents="none">
+          <Text variant="mediumText" color="black100">
+            {children}
+          </Text>
         </Flex>
       </Container>
 

--- a/src/lib/Components/Input/Input.tsx
+++ b/src/lib/Components/Input/Input.tsx
@@ -192,9 +192,9 @@ const StyledInput = styled(TextInput)`
   position: absolute;
   left: 10;
   right: 10;
-  top: 12; /* to center the text nicely */
-  bottom: -30;
-  padding-bottom: 40;
+  /* background-color: lightblue; */
+  top: 6; /* to center the text nicely */
+  padding-bottom: 30;
 
   /* to center the text */
   font-family: ${fontFamily.sans.regular.normal};

--- a/src/lib/Components/Input/Input.tsx
+++ b/src/lib/Components/Input/Input.tsx
@@ -192,8 +192,7 @@ const StyledInput = styled(TextInput)`
   position: absolute;
   left: 10;
   right: 10;
-  /* background-color: lightblue; */
-  top: 6; /* to center the text nicely */
+  top: ${Platform.OS === "ios" ? 12 : 6}; /* to center the text nicely */
   padding-bottom: 30;
 
   /* to center the text */


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1187]

### Description

Fixed these during Android Bug Bash, together with @ds300, @MounirDhahri, @brainbicycle, @thomasmeerschwam.

<!-- Implementation description -->

- Header not breaking:
<img width="519" alt="Screenshot 2021-04-21 at 13 54 54" src="https://user-images.githubusercontent.com/100233/115559805-ef21a900-a2ab-11eb-9a48-c2ad4c6730d4.png">

And InputText on "New card" and "Billing Address" screens don't scroll anymore like the ticket video.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1187]: https://artsyproduct.atlassian.net/browse/CX-1187