### PR TITLE
fix: keyboard avoidance for iOS13 modals

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -13,6 +13,7 @@ upcoming:
     - Conversation-offer updates to CTA to allow multiple offers - erikdstock
     - Replace "All" option on multi-select filters with upper right-hand "Clear all"
     - Fix infinite spinner on Android when following within an artist rail - pepopowitz
+    - Fix iOS13 modal keyboard avoidance - david
     - Release multi-select time period filter - iskounen
     - Refine filter header typography, spacing & copy - damon
     - Fix renderWithLoadProgress on android - brian, mounir, pavlos

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -205,7 +205,7 @@ const InnerPageWrapper: React.FC<PageWrapperProps> = ({ fullBleed, isMainView, V
   }
   const isPresentedModally = viewProps.isPresentedModally
   return (
-    <ArtsyKeyboardAvoidingViewContext.Provider value={{ isVisible, isPresentedModally }}>
+    <ArtsyKeyboardAvoidingViewContext.Provider value={{ isVisible, isPresentedModally, bottomOffset: paddingBottom }}>
       <View style={{ flex: 1, paddingTop, paddingBottom }}>
         {isHydrated ? (
           <FadeIn style={{ flex: 1 }} slide={false}>

--- a/src/lib/Components/ArtsyKeyboardAvoidingView.tsx
+++ b/src/lib/Components/ArtsyKeyboardAvoidingView.tsx
@@ -20,15 +20,21 @@ interface State {
 export const ArtsyKeyboardAvoidingViewContext = React.createContext({
   isPresentedModally: false,
   isVisible: true,
+  /**
+   * bottom offset is used when the screen is presented modally to account for
+   * any extra padding at the bottom of the screen (i.e. added for safe area insets)
+   */
+  bottomOffset: 0,
 })
 
 export const ArtsyKeyboardAvoidingView: React.FC<{}> = ({ children }) => {
-  const { isPresentedModally, isVisible } = useContext(ArtsyKeyboardAvoidingViewContext)
+  const { isPresentedModally, isVisible, bottomOffset } = useContext(ArtsyKeyboardAvoidingViewContext)
 
   return (
     <KeyboardAvoidingView
       enabled={isVisible}
       mode={isPresentedModally ? "bottom-based" : "top-based"}
+      bottomOffset={bottomOffset}
       style={{ flex: 1 }}
     >
       {children}
@@ -49,7 +55,7 @@ export const ArtsyKeyboardAvoidingView: React.FC<{}> = ({ children }) => {
  * LICENSE file in the root directory of https://github.com/facebook/react-native
  */
 class KeyboardAvoidingView extends React.Component<
-  { enabled?: boolean; mode: "top-based" | "bottom-based" } & ViewProps,
+  { enabled?: boolean; mode: "top-based" | "bottom-based"; bottomOffset: number } & ViewProps,
   State
 > {
   _frame: LayoutRectangle | null = null
@@ -88,6 +94,8 @@ class KeyboardAvoidingView extends React.Component<
         if (Platform.OS === "android") {
           keyboardHeight -= ArtsyNativeModule.navigationBarHeight
         }
+
+        keyboardHeight -= this.props.bottomOffset
 
         return Math.max(keyboardHeight, 0)
       }

--- a/src/lib/Components/FancyModal/FancyModal.tsx
+++ b/src/lib/Components/FancyModal/FancyModal.tsx
@@ -42,7 +42,7 @@ export const FancyModal: React.FC<{
           up to the maximum 'top' value, and then add padding if the keyboard comes up any more.
           I'd imagine it would have an API like <FancyKeyboardAvoding height={sheetHeighht} maxHeight={screenHeight - (top + 10)}>
       */
-      <ArtsyKeyboardAvoidingViewContext.Provider value={{ isPresentedModally: true, isVisible: true }}>
+      <ArtsyKeyboardAvoidingViewContext.Provider value={{ isPresentedModally: true, isVisible: true, bottomOffset: 0 }}>
         <ArtsyKeyboardAvoidingView>{children}</ArtsyKeyboardAvoidingView>
       </ArtsyKeyboardAvoidingViewContext.Provider>
     ) : null,

--- a/src/lib/navigation/NavStack.tsx
+++ b/src/lib/navigation/NavStack.tsx
@@ -47,7 +47,7 @@ const ScreenWrapper: React.FC<{ route: Route<"", ScreenProps> }> = ({ route }) =
   return (
     <LegacyBackButtonContext.Provider value={{ updateShouldHideBackButton }}>
       <ProvideScreenDimensions>
-        <ArtsyKeyboardAvoidingViewContext.Provider value={{ isPresentedModally, isVisible }}>
+        <ArtsyKeyboardAvoidingViewContext.Provider value={{ isPresentedModally, isVisible, bottomOffset: 0 }}>
           <ScreenPadding
             isPresentedModally={isPresentedModally}
             isVisible={isVisible}


### PR DESCRIPTION
### Description

This is a follow-up to #4619

This fixes an issue where iOS 13+ pageSheet modals had too much bottom padding added when the keyboard is visible

![image](https://user-images.githubusercontent.com/1242537/115565762-91905b00-a2b1-11eb-9a19-0fbb7ff4132d.png)

No idea how I missed this before, I even posted a screenshot that showed this same screen working as expected in the original PR. 🤷🏼

Anyway this change makes perfect sense to me so I'm also confused how it was ever working for that screenshot. Maybe I had some weird simulator state.

I checked this on iOS 12 and android and everything there is still 👍🏼 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
