### PR TITLE
fix: remove feature flag from time period filter tests

### DIFF
--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/TimePeriodOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/TimePeriodOptions-tests.tsx
@@ -92,8 +92,6 @@ describe("TimePeriodOptions Screen", () => {
     }
 
     it("displays a comma-separated list of the selected filters on the filter modal screen", () => {
-      __globalStoreTestUtils__?.injectFeatureFlags({ ARUseImprovedArtworkFilters: true })
-
       const tree = renderWithWrappers(<MockFilterScreen initialState={state} />)
 
       const items = tree.root.findAllByType(FilterModalOptionListItem)
@@ -113,22 +111,6 @@ describe("TimePeriodOptions Screen", () => {
       expect(switches[0].props.value).toBe(true)
       expect(switches[1].props.value).toBe(false)
       expect(switches[2].props.value).toBe(false)
-    })
-  })
-
-  describe("when the 'All' option is selected", () => {
-    it("does not display 'All' on the filter modal screen", () => {
-      __globalStoreTestUtils__?.injectFeatureFlags({ ARUseImprovedArtworkFilters: true })
-
-      const tree = renderWithWrappers(<MockFilterScreen initialState={initialState} />)
-
-      const items = tree.root.findAllByType(FilterModalOptionListItem)
-      const item = items.find((i) => extractText(i).startsWith("Time period"))
-
-      expect(item).not.toBeUndefined()
-      if (item) {
-        expect(extractText(item)).not.toContain("All")
-      }
     })
   })
 })


### PR DESCRIPTION
The type of this PR is: Enhancement

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-2867]

### Description

Removes the `ARUseImprovedArtworkFilters` feature flag from time period filter tests that were missed in #4645 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434

[FX-2867]: https://artsyproduct.atlassian.net/browse/FX-2867