### PR TITLE
fix: Add missing keyboard provider offset

### DIFF
--- a/src/lib/Scenes/Onboarding/Onboarding.tsx
+++ b/src/lib/Scenes/Onboarding/Onboarding.tsx
@@ -31,7 +31,9 @@ export const Onboarding = () => {
   return (
     <View style={{ flex: 1, paddingBottom: useScreenDimensions().safeAreaInsets.bottom }}>
       <NavigationContainer independent>
-        <ArtsyKeyboardAvoidingViewContext.Provider value={{ isVisible: true, isPresentedModally: false }}>
+        <ArtsyKeyboardAvoidingViewContext.Provider
+          value={{ isVisible: true, isPresentedModally: false, bottomOffset: 0 }}
+        >
           <ArtsyKeyboardAvoidingView>
             <StackNavigator.Navigator
               headerMode="screen"


### PR DESCRIPTION
The type of this PR is: Fix

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->


### Description

This PR adds the missing `bottomOffset` value for the onboarding `ArtsyKeyboardAvoidingViewContext.Provider`.

Tests are failing after this PR got merged:

PR: https://github.com/artsy/eigen/pull/4647/files#diff-d9a1e624b572abd4693c1db5ec9a3d39412a622f2df268778919dfa5d1aaa515R34

Failing Build: https://app.circleci.com/pipelines/github/artsy/eigen/11253/workflows/4e00ce0f-a903-43f8-b381-78d661eedc16/jobs/32062

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434