### PR TITLE
fix(nav flow): hardware back button is closing modals when needed

### DIFF
--- a/src/lib/Components/Bidding/Screens/BidResult.tsx
+++ b/src/lib/Components/Bidding/Screens/BidResult.tsx
@@ -1,6 +1,6 @@
 import NavigatorIOS from "lib/utils/__legacy_do_not_use__navigator-ios-shim"
 import React from "react"
-import { View } from "react-native"
+import { BackHandler, NativeEventSubscription, View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 
 import { dismissModal, navigate } from "lib/navigation/navigate"
@@ -45,6 +45,18 @@ const Icons = {
 }
 
 export class BidResult extends React.Component<BidResultProps> {
+  backButtonListener?: NativeEventSubscription = undefined
+
+  componentDidMount = () => {
+    this.backButtonListener = BackHandler.addEventListener("hardwareBackPress", this.handleBackButton.bind(this))
+  }
+
+  componentWillUnmount = () => {
+    if (this.backButtonListener) {
+      this.backButtonListener.remove()
+    }
+  }
+
   onPressBidAgain = () => {
     // refetch bidder information so your registration status is up to date
     if (this.props.refreshBidderInfo) {
@@ -69,6 +81,15 @@ export class BidResult extends React.Component<BidResultProps> {
       navigate(url, { modal: true })
     } else {
       dismissModal()
+    }
+  }
+
+  handleBackButton = () => {
+    if (this.canBidAgain(this.props.bidderPositionResult.status)) {
+      return false
+    } else {
+      dismissModal()
+      return true
     }
   }
 

--- a/src/lib/Components/Bidding/Screens/BidResult.tsx
+++ b/src/lib/Components/Bidding/Screens/BidResult.tsx
@@ -52,9 +52,7 @@ export class BidResult extends React.Component<BidResultProps> {
   }
 
   componentWillUnmount = () => {
-    if (this.backButtonListener) {
-      this.backButtonListener.remove()
-    }
+    this.backButtonListener?.remove()
   }
 
   onPressBidAgain = () => {

--- a/src/lib/Components/Bidding/Screens/BidResult.tsx
+++ b/src/lib/Components/Bidding/Screens/BidResult.tsx
@@ -48,7 +48,7 @@ export class BidResult extends React.Component<BidResultProps> {
   backButtonListener?: NativeEventSubscription = undefined
 
   componentDidMount = () => {
-    this.backButtonListener = BackHandler.addEventListener("hardwareBackPress", this.handleBackButton.bind(this))
+    this.backButtonListener = BackHandler.addEventListener("hardwareBackPress", this.handleBackButton)
   }
 
   componentWillUnmount = () => {

--- a/src/lib/Components/Bidding/Screens/RegistrationResult.tsx
+++ b/src/lib/Components/Bidding/Screens/RegistrationResult.tsx
@@ -1,6 +1,6 @@
 import { Button, Sans, Theme } from "palette"
 import React from "react"
-import { View } from "react-native"
+import { BackHandler, NativeEventSubscription, View } from "react-native"
 import { blockRegex } from "simple-markdown"
 
 import { Icon20 } from "../Components/Icon"
@@ -106,6 +106,30 @@ const resultEnumToPageName = (result: RegistrationStatus) => {
     } as any) /* STRICTNESS_MIGRATION */
 )
 export class RegistrationResult extends React.Component<RegistrationResultProps> {
+  backButtonListener?: NativeEventSubscription = undefined
+
+  componentDidMount = () => {
+    this.backButtonListener = BackHandler.addEventListener("hardwareBackPress", this.handleBackButton.bind(this))
+  }
+
+  componentWillUnmount = () => {
+    if (this.backButtonListener) {
+      this.backButtonListener.remove()
+    }
+  }
+
+  handleBackButton = () => {
+    if (
+      this.props.status === RegistrationStatus.RegistrationStatusComplete ||
+      this.props.status === RegistrationStatus.RegistrationStatusPending
+    ) {
+      dismissModal()
+      return true
+    } else {
+      return false
+    }
+  }
+
   render() {
     const { status, needsIdentityVerification } = this.props
     let title: string

--- a/src/lib/Components/Bidding/Screens/RegistrationResult.tsx
+++ b/src/lib/Components/Bidding/Screens/RegistrationResult.tsx
@@ -113,9 +113,7 @@ export class RegistrationResult extends React.Component<RegistrationResultProps>
   }
 
   componentWillUnmount = () => {
-    if (this.backButtonListener) {
-      this.backButtonListener.remove()
-    }
+    this.backButtonListener?.remove()
   }
 
   handleBackButton = () => {

--- a/src/lib/Components/Bidding/Screens/RegistrationResult.tsx
+++ b/src/lib/Components/Bidding/Screens/RegistrationResult.tsx
@@ -109,7 +109,7 @@ export class RegistrationResult extends React.Component<RegistrationResultProps>
   backButtonListener?: NativeEventSubscription = undefined
 
   componentDidMount = () => {
-    this.backButtonListener = BackHandler.addEventListener("hardwareBackPress", this.handleBackButton.bind(this))
+    this.backButtonListener = BackHandler.addEventListener("hardwareBackPress", this.handleBackButton)
   }
 
   componentWillUnmount = () => {


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1191] [CX-1190]

### Description

Fixed this with @ds300 and @brainbicycle during bugbash.

When we show a "confirmation" screen, like bid success or registration success, then the android hw back button should take us all the way back, by just dismissing the modal.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1191]: https://artsyproduct.atlassian.net/browse/CX-1191
[CX-1190]: https://artsyproduct.atlassian.net/browse/CX-1190