### PR TITLE
feat: show minutes if less than one hour remaining until sale start

### DIFF
--- a/src/lib/utils/__tests__/saleTime-tests.ts
+++ b/src/lib/utils/__tests__/saleTime-tests.ts
@@ -20,6 +20,8 @@ const times = {
 
   present: "2020-09-04T19:00:00",
 
+  future01: "2020-09-04T15:01:00",
+  future10: "2020-09-04T15:43:00",
   future20: "2020-09-05T15:00:00",
   future30: "2020-09-09T15:00:00",
   future40: "2020-09-09T21:00:00",
@@ -52,6 +54,20 @@ const liveSaleImminentNY: Sale = {
 
 const liveSaleSoonNY: Sale = {
   startAt: times.future30,
+  liveStartAt: null,
+  endAt: null,
+  timeZone: timezones.ny,
+}
+
+const liveSaleReallySoonNY: Sale = {
+  startAt: times.future10,
+  liveStartAt: null,
+  endAt: null,
+  timeZone: timezones.ny,
+}
+
+const liveSaleInOneMinuteNY: Sale = {
+  startAt: times.future01,
   liveStartAt: null,
   endAt: null,
   timeZone: timezones.ny,
@@ -188,6 +204,7 @@ describe("#saleTime.relative", () => {
   it("shows the relative time for imminent sales", () => {
     expect(saleTime(liveSaleImminentNY).relative).toEqual("Starts in 4 hours")
     expect(saleTime(liveSaleSoonNY).relative).toEqual("Starts in 5 days")
+    expect(saleTime(liveSaleReallySoonNY).relative).toEqual("Starts in 43 minutes")
   })
 
   it("doesn't show the relative time for a non-imminent sale", () => {
@@ -210,6 +227,7 @@ describe("#saleTime.relative", () => {
 
   it("pluralises correctly", () => {
     expect(saleTime(liveSaleTomorrow).relative).toEqual("Starts in 1 day")
+    expect(saleTime(liveSaleInOneMinuteNY).relative).toEqual("Starts in 1 minute")
   })
 
   it("handles complete sales correctly", () => {

--- a/src/lib/utils/saleTime.ts
+++ b/src/lib/utils/saleTime.ts
@@ -99,8 +99,11 @@ const maybePluralise = (word: string, unit: number) => word + (unit === 1 ? "" :
 
 const starts = (now: moment.Moment, startDate: moment.Moment): string | null => {
   const hours = startDate.diff(now, "hours")
+  const minutes = startDate.diff(now, "minutes")
   const days = startDate.startOf("day").diff(now.startOf("day"), "days")
-  if (days < 1) {
+  if (minutes < 60) {
+    return `Starts in ${minutes} ${maybePluralise("minute", minutes)}`
+  } else if (days < 1) {
     return `Starts in ${hours} ${maybePluralise("hour", hours)}`
   } else if (days < 7) {
     return `Starts in ${days} ${maybePluralise("day", days)}`


### PR DESCRIPTION
The type of this PR is: **Feature**
cc: @DagmarK @artsy/purchase-devs 

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [Purchase-2427]

### Description

<!-- Implementation description -->

Old functionality: When the time to the start of an auction is less then an hour the view would display "starts in 0 hours". 

<img width="978" alt="0hours" src="https://user-images.githubusercontent.com/82033298/115872433-16aa7a00-a442-11eb-9902-f5a1f7d039bb.png">

Updated functionality: The view will display the remaining minutes. The code will switch to display minutes and not hours when (now - live_start_at < 60 min).

<img width="1052" alt="50sec" src="https://user-images.githubusercontent.com/82033298/115872741-70ab3f80-a442-11eb-87c2-b61d84a44efa.png">



### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434