### PR TITLE
fix(analytics): uses internalID

### DIFF
--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -80,7 +80,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) 
         />
         <ArtworkFilterNavigator
           {...props}
-          id={artist.id}
+          id={artist.internalID}
           slug={artist.slug}
           isFilterArtworksModalVisible={isFilterArtworksModalVisible}
           exitModal={handleFilterArtworksModal}


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [FX-2716]

### Description

We were previously using `artist.id` which is a "globalID" for Relay. This PR switches it to using our `internalID` which corresponds with Gravity IDs.

![](https://static.damonzucconi.com/_capture/42eX2wLE.png)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2716]: https://artsyproduct.atlassian.net/browse/FX-2716