### PR TITLE
feat: release improved artwork filter style

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -26,6 +26,7 @@ upcoming:
     - Hides "Default" sort label behind feature flag - damon
     - Fix unable to load artist screen - adam, brian, david, thomas, jonathan, mounir
     - Fix and Release new multiselect "Colors" filter - ole
+    - Release artwork filter style updates - iskounen
 
 releases:
   - version: 6.8.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -920,7 +920,7 @@ SPEC CHECKSUMS:
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   CocoaLumberjack: aa9dcab71bdf9eaf2a63bbd9ddc87863efe45457
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
-  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
+  DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
   Emission: bec9c8f604b13b12385835cd98d80a035dc41cc8
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
@@ -942,7 +942,7 @@ SPEC CHECKSUMS:
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   Forgeries: 64ced144ea8341d89a7eec9d1d7986f0f1366250
   FXBlurView: 5121730176fd52bcf7bffd0bd8c1485e8aabc3cb
-  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
+  glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   Interstellar: ab67502af03105f92100a043e178d188a1a437c9
   INTUAnimationEngine: 3a7d63738cd51af573d16848a771feedea7cc9f2
   ISO8601DateFormatter: 8311a2d4e265b269b2fed7ab4db685dcb0a7ccb2

--- a/src/lib/Components/ArtworkFilter/ArtworkFilter.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilter.tsx
@@ -6,7 +6,6 @@ import {
   changedFiltersParams,
   FilterArray,
   filterArtworksParams,
-  FilterParamName,
   FilterParams,
 } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
@@ -27,7 +26,6 @@ import { TimePeriodOptionsScreen } from "lib/Components/ArtworkFilter/Filters/Ti
 import { ViewAsOptionsScreen } from "lib/Components/ArtworkFilter/Filters/ViewAsOptions"
 import { WaysToBuyOptionsScreen } from "lib/Components/ArtworkFilter/Filters/WaysToBuyOptions"
 import { YearOptionsScreen } from "lib/Components/ArtworkFilter/Filters/YearOptions"
-import { useFeatureFlag } from "lib/store/GlobalStore"
 import { OwnerEntityTypes, PageNames } from "lib/utils/track/schema"
 import _ from "lodash"
 import { Box, Button, Separator } from "palette"
@@ -88,7 +86,6 @@ const Stack = createStackNavigator<ArtworkFilterNavigationStack>()
 
 export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
   const tracking = useTracking()
-  const shouldUseImprovedArtworkFilters = useFeatureFlag("ARUseImprovedArtworkFilters")
   const { exitModal, id, mode, slug, closeModal } = props
 
   const appliedFiltersState = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
@@ -134,36 +131,6 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
       changed: changedParams,
       action_type: actionType,
     })
-  }
-
-  const getApplyButtonCount = () => {
-    let selectedFiltersSum = selectedFiltersState.length
-
-    // For Auction results, the earliestCreatedYear and latestCreatedYear filters behave like one
-    if (filterTypeState === "auctionResult") {
-      const hasEarliestCreatedYearFilterEnabled = !!selectedFiltersState.find(
-        (filter) => filter.paramName === FilterParamName.earliestCreatedYear
-      )
-      const hasLatestCreatedYearFilterEnabled = !!selectedFiltersState.find(
-        (filter) => filter.paramName === FilterParamName.latestCreatedYear
-      )
-      if (hasEarliestCreatedYearFilterEnabled && hasLatestCreatedYearFilterEnabled) {
-        --selectedFiltersSum
-      }
-    }
-
-    // For Sale Artworks, the artistsIDs and the includeArtworksByFollowedArtists filters behave like one
-    if (filterTypeState === "saleArtwork") {
-      const hasArtistsIFollow = !!selectedFiltersState.find(
-        (filter) => filter.paramName === FilterParamName.artistsIFollow
-      )
-      const hasArtistIDs = !!selectedFiltersState.find((filter) => filter.paramName === FilterParamName.artistIDs)
-
-      if (hasArtistIDs && hasArtistsIFollow) {
-        --selectedFiltersSum
-      }
-    }
-    return selectedFiltersSum > 0 ? `Apply (${selectedFiltersSum})` : "Apply"
   }
 
   const isApplyButtonEnabled =
@@ -292,7 +259,7 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
               variant="primaryBlack"
               size="large"
             >
-              {shouldUseImprovedArtworkFilters ? "Show results" : getApplyButtonCount()}
+              Show results
             </ApplyButton>
           </ApplyButtonContainer>
         </View>

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -162,7 +162,6 @@ export const ArtworkFilterOptionsScreen: React.FC<
         keyExtractor={(_item, index) => String(index)}
         data={sortedFilterOptions}
         style={{ flexGrow: 1 }}
-        ItemSeparatorComponent={() => (shouldUseImprovedArtworkFilters ? null : <Separator />)}
         renderItem={({ item }) => {
           const selectedCurrentOption = selectedOption({
             selectedOptions,

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -7,7 +7,6 @@ import {
 import { selectedOption } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworksFiltersStore, useSelectedOptionsDisplay } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { TouchableRow } from "lib/Components/TouchableRow"
-import { useFeatureFlag } from "lib/store/GlobalStore"
 import { Schema } from "lib/utils/track"
 import { OwnerEntityTypes, PageNames } from "lib/utils/track/schema"
 import _ from "lodash"
@@ -112,8 +111,6 @@ export const ArtworkFilterOptionsScreen: React.FC<
     closeModal()
   }
 
-  const shouldUseImprovedArtworkFilters = useFeatureFlag("ARUseImprovedArtworkFilters")
-
   return (
     <Flex style={{ flex: 1 }}>
       <Flex flexGrow={0} flexDirection="row" justifyContent="space-between" alignItems="center" height={space(6)}>
@@ -170,12 +167,8 @@ export const ArtworkFilterOptionsScreen: React.FC<
             aggregations: aggregationsState,
           })
 
-          // TODO: When unwinding the `ARUseImprovedArtworkFilters` flag; simply return `null`
-          // instead of `"All"` in the `selectedOption` function
           const currentOption =
-            shouldUseImprovedArtworkFilters && (selectedCurrentOption === "All" || selectedCurrentOption === "Default")
-              ? null
-              : selectedCurrentOption
+            selectedCurrentOption === "All" || selectedCurrentOption === "Default" ? null : selectedCurrentOption
 
           return (
             <TouchableRow onPress={() => navigateToNextFilterScreen(item.ScreenComponent)}>

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -167,6 +167,8 @@ export const ArtworkFilterOptionsScreen: React.FC<
             aggregations: aggregationsState,
           })
 
+          // TODO: When unwinding the `ARUseImprovedArtworkFilters` flag; simply return `null`
+          // instead of `"All"` in the `selectedOption` function
           const currentOption =
             selectedCurrentOption === "All" || selectedCurrentOption === "Default" ? null : selectedCurrentOption
 

--- a/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
@@ -1,11 +1,9 @@
 import { ParamListBase } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"
 import { FilterData } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
-import { FilterToggleButton } from "lib/Components/ArtworkFilter/Filters/FilterToggleButton"
 import { FancyModalHeader, FancyModalHeaderProps } from "lib/Components/FancyModal/FancyModalHeader"
 import { TouchableRow } from "lib/Components/TouchableRow"
-import { useFeatureFlag } from "lib/store/GlobalStore"
-import { Box, Check, Flex, Sans, Text } from "palette"
+import { Box, Check, Flex, Text } from "palette"
 import React from "react"
 import { FlatList } from "react-native"
 import styled from "styled-components/native"
@@ -48,8 +46,6 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
     }
   }
 
-  const shouldUseImprovedArtworkFilters = useFeatureFlag("ARUseImprovedArtworkFilters")
-
   return (
     <Flex flexGrow={1}>
       <FancyModalHeader onLeftButtonPress={handleBackNavigation} {...rest}>
@@ -64,39 +60,20 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
           renderItem={({ item }) => {
             return (
               <Box ml={0.5}>
-                {shouldUseImprovedArtworkFilters ? (
-                  <TouchableRow
-                    onPress={() => {
-                      const currentParamValue = item.paramValue as boolean
-                      onSelect(item, !currentParamValue)
-                    }}
-                  >
-                    <OptionListItem>
-                      <Text variant="caption" color="black100">
-                        {item.displayText}
-                      </Text>
-
-                      <Check selected={itemIsSelected(item)} disabled={itemIsDisabled(item)} />
-                    </OptionListItem>
-                  </TouchableRow>
-                ) : (
+                <TouchableRow
+                  onPress={() => {
+                    const currentParamValue = item.paramValue as boolean
+                    onSelect(item, !currentParamValue)
+                  }}
+                >
                   <OptionListItem>
-                    <Flex mb={0.5}>
-                      <Sans color="black100" size="3t">
-                        {item.displayText}
-                      </Sans>
-                    </Flex>
+                    <Text variant="caption" color="black100">
+                      {item.displayText}
+                    </Text>
 
-                    <FilterToggleButton
-                      onChange={() => {
-                        const currentParamValue = item.paramValue as boolean
-                        onSelect(item, !currentParamValue)
-                      }}
-                      value={itemIsSelected(item)}
-                      disabled={itemIsDisabled(item)}
-                    />
+                    <Check selected={itemIsSelected(item)} disabled={itemIsDisabled(item)} />
                   </OptionListItem>
-                )}
+                </TouchableRow>
               </Box>
             )
           }}

--- a/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
@@ -5,7 +5,7 @@ import { FilterToggleButton } from "lib/Components/ArtworkFilter/Filters/FilterT
 import { FancyModalHeader, FancyModalHeaderProps } from "lib/Components/FancyModal/FancyModalHeader"
 import { TouchableRow } from "lib/Components/TouchableRow"
 import { useFeatureFlag } from "lib/store/GlobalStore"
-import { Box, Check, Flex, Sans, Separator, Text } from "palette"
+import { Box, Check, Flex, Sans, Text } from "palette"
 import React from "react"
 import { FlatList } from "react-native"
 import styled from "styled-components/native"
@@ -61,7 +61,6 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
           style={{ flex: 1 }}
           keyExtractor={(_item, index) => String(index)}
           data={filterOptions}
-          ItemSeparatorComponent={shouldUseImprovedArtworkFilters ? null : Separator}
           renderItem={({ item }) => {
             return (
               <Box ml={0.5}>

--- a/src/lib/Components/ArtworkFilter/Filters/SingleSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/SingleSelectOption.tsx
@@ -4,7 +4,7 @@ import { FilterData } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
 import { TouchableRow } from "lib/Components/TouchableRow"
 import { useFeatureFlag } from "lib/store/GlobalStore"
-import { Box, CheckIcon, Flex, RadioDot, Separator, Text } from "palette"
+import { Box, CheckIcon, Flex, RadioDot, Text } from "palette"
 import React from "react"
 import { FlatList } from "react-native"
 import styled from "styled-components/native"
@@ -32,8 +32,6 @@ export const SingleSelectOptionScreen: React.FC<SingleSelectOptionScreenProps> =
     navigation.goBack()
   }
 
-  const shouldUseImprovedArtworkFilters = useFeatureFlag("ARUseImprovedArtworkFilters")
-
   return (
     <Flex flexGrow={1}>
       <FancyModalHeader onLeftButtonPress={handleBackNavigation}>{filterHeaderText}</FancyModalHeader>
@@ -44,7 +42,7 @@ export const SingleSelectOptionScreen: React.FC<SingleSelectOptionScreenProps> =
           ListHeaderComponent={ListHeaderComponent}
           keyExtractor={(_item, index) => String(index)}
           data={filterOptions}
-          ItemSeparatorComponent={shouldUseImprovedArtworkFilters ? null : Separator}
+          ItemSeparatorComponent={null}
           renderItem={({ item }) => (
             <ListItem
               item={item}

--- a/src/lib/Components/ArtworkFilter/Filters/SingleSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/SingleSelectOption.tsx
@@ -3,8 +3,7 @@ import { StackNavigationProp } from "@react-navigation/stack"
 import { FilterData } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
 import { TouchableRow } from "lib/Components/TouchableRow"
-import { useFeatureFlag } from "lib/store/GlobalStore"
-import { Box, CheckIcon, Flex, RadioDot, Text } from "palette"
+import { Flex, RadioDot, Text } from "palette"
 import React from "react"
 import { FlatList } from "react-native"
 import styled from "styled-components/native"
@@ -68,7 +67,6 @@ const ListItem = ({
   selectedOption: FilterData
   withExtraPadding: boolean
 }) => {
-  const shouldUseImprovedArtworkFilters = useFeatureFlag("ARUseImprovedArtworkFilters")
   const selected = item.displayText === selectedOption.displayText
 
   return (
@@ -84,15 +82,7 @@ const ListItem = ({
               </Text>
             )}
           </Text>
-          {shouldUseImprovedArtworkFilters ? (
-            <RadioDot selected={selected} />
-          ) : (
-            !!selected && (
-              <Box mb={0.1}>
-                <CheckIcon fill="black100" />
-              </Box>
-            )
-          )}
+          <RadioDot selected={selected} />
         </InnerOptionListItem>
       </OptionListItem>
     </TouchableRow>

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/AdditionalGeneIDsOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/AdditionalGeneIDsOptions-tests.tsx
@@ -71,10 +71,10 @@ describe("AdditionalGeneIDsOptions Screen", () => {
     ])
   })
 
-  it("displays the default text when no filter selected on the filter modal screen", () => {
+  it("does not display the default text when no filter selected on the filter modal screen", () => {
     const tree = renderWithWrappers(<MockFilterScreen initialState={initialState} />)
     const items = tree.root.findAllByType(FilterModalOptionListItem)
-    expect(extractText(items[items.length - 1])).toContain("All")
+    expect(extractText(items[items.length - 1])).not.toContain("All")
   })
 
   it("displays all the selected filters on the filter modal screen", () => {

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/AdditionalGeneIDsOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/AdditionalGeneIDsOptions-tests.tsx
@@ -5,8 +5,8 @@ import { ArtworkFiltersState, ArtworkFiltersStoreProvider } from "lib/Components
 import { RightButtonContainer } from "lib/Components/FancyModal/FancyModalHeader"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { Check } from "palette"
 import React from "react"
-import { Switch } from "react-native"
 import { AdditionalGeneIDsOptionsScreen } from "../AdditionalGeneIDsOptions"
 import { OptionListItem } from "../MultiSelectOption"
 import { getEssentialProps } from "./helper"
@@ -124,11 +124,11 @@ describe("AdditionalGeneIDsOptions Screen", () => {
     }
 
     const tree = renderWithWrappers(<MockAdditionalGeneIDsOptionsScreen initialData={injectedState} />)
-    const switches = tree.root.findAllByType(Switch)
+    const options = tree.root.findAllByType(Check)
 
-    expect(switches[0].props.value).toBe(true)
-    expect(switches[1].props.value).toBe(false)
-    expect(switches[2].props.value).toBe(true)
+    expect(options[0].props.selected).toBe(true)
+    expect(options[1].props.selected).toBe(false)
+    expect(options[2].props.selected).toBe(true)
   })
 
   it("clears all when clear button is tapped", () => {
@@ -152,17 +152,17 @@ describe("AdditionalGeneIDsOptions Screen", () => {
     }
 
     const tree = renderWithWrappers(<MockAdditionalGeneIDsOptionsScreen initialData={injectedState} />)
-    const switches = tree.root.findAllByType(Switch)
+    const options = tree.root.findAllByType(Check)
     const clear = tree.root.findByType(RightButtonContainer)
 
-    expect(switches[0].props.value).toBe(true)
-    expect(switches[1].props.value).toBe(false)
-    expect(switches[2].props.value).toBe(true)
+    expect(options[0].props.selected).toBe(true)
+    expect(options[1].props.selected).toBe(false)
+    expect(options[2].props.selected).toBe(true)
 
     clear.props.onPress()
 
-    expect(switches[0].props.value).toBe(false)
-    expect(switches[1].props.value).toBe(false)
-    expect(switches[2].props.value).toBe(false)
+    expect(options[0].props.selected).toBe(false)
+    expect(options[1].props.selected).toBe(false)
+    expect(options[2].props.selected).toBe(false)
   })
 })

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/AggregationOptionCommonValidation.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/AggregationOptionCommonValidation.tsx
@@ -3,7 +3,7 @@ import { ArtworkFiltersState, ArtworkFiltersStoreProvider } from "lib/Components
 import { TouchableRow } from "lib/Components/TouchableRow"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
-import { CheckIcon } from "palette"
+import { RadioDot } from "palette"
 import React from "react"
 import { act, ReactTestRenderer } from "react-test-renderer"
 import { ReactElement } from "simple-markdown"
@@ -22,7 +22,7 @@ export interface ValidationParams {
 export const sharedAggregateFilterValidation = (params: ValidationParams) => {
   const selectedFilterOption = (componentTree: ReactTestRenderer) => {
     const innerOptions = componentTree.root.findAllByType(InnerOptionListItem)
-    const selectedOption = innerOptions.filter((item) => item.findAllByType(CheckIcon).length > 0)[0]
+    const selectedOption = innerOptions.filter((item) => item.findByType(RadioDot).props.selected)[0]
     return selectedOption
   }
 
@@ -105,7 +105,7 @@ export const sharedAggregateFilterValidation = (params: ValidationParams) => {
           const tree = renderWithWrappers(<MockScreenWrapper />)
 
           const [firstOptionInstance, secondOptionInstance, thirdOptionInstance] = tree.root.findAllByType(TouchableRow)
-          const selectedOptionIconBeforePress = tree.root.findAllByType(CheckIcon)
+          const selectedOptionIconBeforePress = tree.root.findAllByType(RadioDot).filter((item) => item.props.selected)
 
           expect(selectedOptionIconBeforePress).toHaveLength(1)
 
@@ -113,7 +113,7 @@ export const sharedAggregateFilterValidation = (params: ValidationParams) => {
           act(() => secondOptionInstance.props.onPress())
           act(() => thirdOptionInstance.props.onPress())
 
-          const selectedOptionIconAfterPress = tree.root.findAllByType(CheckIcon)
+          const selectedOptionIconAfterPress = tree.root.findAllByType(RadioDot).filter((item) => item.props.selected)
 
           expect(selectedOptionIconAfterPress).toHaveLength(1)
         }

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/ArtistIDsArtworksOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/ArtistIDsArtworksOptions-tests.tsx
@@ -1,11 +1,12 @@
 import { Aggregations, FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworkFiltersState, ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
+import { TouchableRow } from "lib/Components/TouchableRow"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { Check } from "palette"
 import React from "react"
 import { act, ReactTestRenderer } from "react-test-renderer"
 import { ArtistIDsArtworksOptionsScreen } from "../ArtistIDsArtworksOptions"
-import { FilterToggleButton } from "../FilterToggleButton"
 import { OptionListItem } from "../MultiSelectOption"
 import { getEssentialProps } from "./helper"
 
@@ -56,7 +57,7 @@ describe("Artist options screen", () => {
   const selectedArtistOptions = (componentTree: ReactTestRenderer) => {
     const artistOptions = componentTree.root.findAllByType(OptionListItem)
     const selectedOptions = artistOptions.filter((item) => {
-      return item.findByType(FilterToggleButton).props.value === true
+      return item.findByType(Check).props.selected === true
     })
     return selectedOptions
   }
@@ -86,7 +87,7 @@ describe("Artist options screen", () => {
 
     // Includes a button for each artist + one for followed artists,
     // but our FlatList is configured to only show 4 in the initial render pass
-    expect(tree.root.findAllByType(FilterToggleButton)).toHaveLength(6)
+    expect(tree.root.findAllByType(Check)).toHaveLength(6)
   })
 
   describe("selecting an artist option", () => {
@@ -132,13 +133,13 @@ describe("Artist options screen", () => {
 
       const tree = renderWithWrappers(<MockArtistScreen initialData={injectedState} />)
 
-      const firstOptionInstance = tree.root.findAllByType(FilterToggleButton)[0] // Artists I follow
-      const secondOptionInstance = tree.root.findAllByType(FilterToggleButton)[1] // Artist 1
-      const thirdOptionInstance = tree.root.findAllByType(FilterToggleButton)[2] // Artist 2
+      const firstOptionInstance = tree.root.findAllByType(TouchableRow)[0] // Artists I follow
+      const secondOptionInstance = tree.root.findAllByType(TouchableRow)[1] // Artist 1
+      const thirdOptionInstance = tree.root.findAllByType(TouchableRow)[2] // Artist 2
 
-      act(() => firstOptionInstance.props.onChange())
-      act(() => secondOptionInstance.props.onChange())
-      act(() => thirdOptionInstance.props.onChange())
+      act(() => firstOptionInstance.props.onPress())
+      act(() => secondOptionInstance.props.onPress())
+      act(() => thirdOptionInstance.props.onPress())
 
       const selectedOptions = selectedArtistOptions(tree)
       expect(selectedOptions).toHaveLength(3)
@@ -169,12 +170,12 @@ describe("Artist options screen", () => {
 
       const tree = renderWithWrappers(<MockArtistScreen initialData={injectedState} />)
 
-      const secondOptionInstance = tree.root.findAllByType(FilterToggleButton)[2] // Artists I follow, Artist 1, Artist 2
+      const secondOptionInstance = tree.root.findAllByType(TouchableRow)[2] // Artists I follow, Artist 1, Artist 2
       const selectedOptionsBeforeTapping = selectedArtistOptions(tree)
       expect(selectedOptionsBeforeTapping).toHaveLength(1)
       expect(extractText(selectedOptionsBeforeTapping[0])).toEqual("Artist 2")
 
-      act(() => secondOptionInstance.props.onChange())
+      act(() => secondOptionInstance.props.onPress())
 
       const selectedOptions = selectedArtistOptions(tree)
       expect(selectedOptions).toHaveLength(0)
@@ -219,10 +220,10 @@ describe("Artist options screen", () => {
 
       const tree = renderWithWrappers(<MockArtistScreen initialData={injectedState} />)
 
-      expect(tree.root.findAllByType(FilterToggleButton)).toHaveLength(4)
+      expect(tree.root.findAllByType(Check)).toHaveLength(4)
 
       // Artists I followed option should be disabled
-      const firstOptionInstance = tree.root.findAllByType(FilterToggleButton)[0]
+      const firstOptionInstance = tree.root.findAllByType(Check)[0]
       expect(firstOptionInstance.props.disabled).toEqual(true)
     })
   })

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/AttributionClassOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/AttributionClassOptions-tests.tsx
@@ -26,7 +26,7 @@ describe("AttributionClassOptions Screen", () => {
     expect(items.map(extractText)).toEqual(["Unique", "Limited Edition", "Open Edition", "Unknown Edition"])
   })
 
-  it("displays the default text when no filter selected on the filter modal screen", () => {
+  it("does not display the default text when no filter selected on the filter modal screen", () => {
     const injectedState: ArtworkFiltersState = {
       selectedFilters: [],
       appliedFilters: [],
@@ -42,7 +42,7 @@ describe("AttributionClassOptions Screen", () => {
 
     const tree = renderWithWrappers(<MockFilterScreen initialState={injectedState} />)
     const items = tree.root.findAllByType(FilterModalOptionListItem)
-    expect(extractText(items[items.length - 1])).toContain("All")
+    expect(extractText(items[items.length - 1])).not.toContain("All")
   })
 
   it("displays all the selected filters on the filter modal screen", () => {

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/AttributionClassOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/AttributionClassOptions-tests.tsx
@@ -4,8 +4,8 @@ import { FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpe
 import { ArtworkFiltersState, ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { Check } from "palette"
 import React from "react"
-import { Switch } from "react-native"
 import { AttributionClassOptionsScreen } from "../AttributionClassOptions"
 import { OptionListItem } from "../MultiSelectOption"
 import { getEssentialProps } from "./helper"
@@ -93,11 +93,11 @@ describe("AttributionClassOptions Screen", () => {
 
     // TODO: Fix this test
     const tree = renderWithWrappers(<MockAttributionClassOptionsScreen initialData={injectedState} />)
-    const switches = tree.root.findAllByType(Switch)
+    const options = tree.root.findAllByType(Check)
 
-    expect(switches[0].props.value).toBe(true)
-    expect(switches[1].props.value).toBe(false)
-    expect(switches[2].props.value).toBe(false)
-    expect(switches[3].props.value).toBe(true)
+    expect(options[0].props.selected).toBe(true)
+    expect(options[1].props.selected).toBe(false)
+    expect(options[2].props.selected).toBe(false)
+    expect(options[3].props.selected).toBe(true)
   })
 })

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/PriceRangeOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/PriceRangeOptions-tests.tsx
@@ -2,7 +2,7 @@ import { Aggregations, FilterParamName } from "lib/Components/ArtworkFilter/Artw
 import { ArtworkFiltersState, ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
-import { Box } from "palette"
+import { RadioDot } from "palette"
 import React from "react"
 import { ReactTestRenderer } from "react-test-renderer"
 import { PriceRangeOptionsScreen } from "../PriceRangeOptions"
@@ -71,7 +71,7 @@ describe("Price Range Options Screen", () => {
 
   const selectedPriceRangeOption = (componentTree: ReactTestRenderer) => {
     const innerOptions = componentTree.root.findAllByType(InnerOptionListItem)
-    const selectedOption = innerOptions.filter((item) => item.findAllByType(Box).length > 0)[0]
+    const selectedOption = innerOptions.filter((item) => item.findByType(RadioDot).props.selected)[0]
     return selectedOption
   }
 

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/SortOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/SortOptions-tests.tsx
@@ -3,7 +3,7 @@ import { ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/Artwor
 import { ArtworkFiltersState } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
-import { Box, CheckIcon } from "palette"
+import { RadioDot } from "palette"
 import React from "react"
 import { ReactTestRenderer } from "react-test-renderer"
 import { InnerOptionListItem, OptionListItem } from "../SingleSelectOption"
@@ -32,7 +32,7 @@ describe("Sort Options Screen", () => {
 
   const selectedSortOption = (componentTree: ReactTestRenderer) => {
     const innerOptions = componentTree.root.findAllByType(InnerOptionListItem)
-    const selectedOption = innerOptions.filter((item) => item.findAllByType(Box).length > 0)[0]
+    const selectedOption = innerOptions.filter((item) => item.findByType(RadioDot).props.selected)[0]
     return selectedOption
   }
 
@@ -182,7 +182,7 @@ describe("Sort Options Screen", () => {
 
     const selectedRow = selectedSortOption(tree)
     expect(extractText(selectedRow)).toEqual("Price (high to low)")
-    expect(selectedRow.findAllByType(CheckIcon)).toHaveLength(1)
+    expect(selectedRow.findByType(RadioDot).props.selected).toEqual(true)
   })
 
   describe("filterType of showArtwork", () => {
@@ -205,7 +205,7 @@ describe("Sort Options Screen", () => {
       const selectedRow = selectedSortOption(tree)
 
       expect(extractText(selectedRow)).toEqual("Gallery Curated")
-      expect(selectedRow.findAllByType(CheckIcon)).toHaveLength(1)
+      expect(selectedRow.findByType(RadioDot).props.selected).toEqual(true)
     })
   })
 
@@ -229,7 +229,7 @@ describe("Sort Options Screen", () => {
       const selectedRow = selectedSortOption(tree)
 
       expect(extractText(selectedRow)).toEqual("Most recent sale date")
-      expect(selectedRow.findAllByType(CheckIcon)).toHaveLength(1)
+      expect(selectedRow.findByType(RadioDot).props.selected).toEqual(true)
     })
   })
 })

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/TimePeriodOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/TimePeriodOptions-tests.tsx
@@ -6,8 +6,8 @@ import { ArtworkFiltersState } from "lib/Components/ArtworkFilter/ArtworkFilterS
 import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { Check } from "palette"
 import React from "react"
-import { Switch } from "react-native"
 import { OptionListItem as MultiSelectOptionListItem } from "../MultiSelectOption"
 import { TimePeriodOptionsScreen } from "../TimePeriodOptions"
 import { getEssentialProps } from "./helper"
@@ -106,11 +106,11 @@ describe("TimePeriodOptions Screen", () => {
     it("toggles selected filters 'ON' and unselected filters 'OFF", async () => {
       const tree = renderWithWrappers(<MockTimePeriodOptionsScreen initialData={state} />)
 
-      const switches = tree.root.findAllByType(Switch)
+      const options = tree.root.findAllByType(Check)
 
-      expect(switches[0].props.value).toBe(true)
-      expect(switches[1].props.value).toBe(false)
-      expect(switches[2].props.value).toBe(false)
+      expect(options[0].props.selected).toBe(true)
+      expect(options[1].props.selected).toBe(false)
+      expect(options[2].props.selected).toBe(false)
     })
   })
 })

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/TimePeriodOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/TimePeriodOptions-tests.tsx
@@ -56,7 +56,7 @@ describe("TimePeriodOptions Screen", () => {
   }
 
   describe("before any filters are selected", () => {
-    it("displays 'All' in the filter modal screen", () => {
+    it("does not display 'All' in the filter modal screen", () => {
       const tree = renderWithWrappers(<MockFilterScreen initialState={initialState} />)
 
       const items = tree.root.findAllByType(FilterModalOptionListItem)
@@ -65,7 +65,7 @@ describe("TimePeriodOptions Screen", () => {
       expect(item).not.toBeUndefined()
 
       if (item) {
-        expect(extractText(item)).toContain("All")
+        expect(extractText(item)).not.toContain("All")
       }
     })
 

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/WaysToBuyOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/WaysToBuyOptions-tests.tsx
@@ -49,7 +49,7 @@ describe("Ways to Buy Options Screen", () => {
     expect(extractText(fourthListItem)).toBe("Inquire")
   })
 
-  it("displays the default text when no filter selected on the filter modal screen", () => {
+  it("does not display the default text when no filter selected on the filter modal screen", () => {
     const injectedState: ArtworkFiltersState = {
       selectedFilters: [],
       appliedFilters: [],
@@ -67,7 +67,7 @@ describe("Ways to Buy Options Screen", () => {
 
     const waysToBuyListItem = tree.root.findAllByType(FilterModalOptionListItem)[1]
 
-    expect(extractText(waysToBuyListItem)).toContain("All")
+    expect(extractText(waysToBuyListItem)).not.toContain("All")
   })
 
   it("displays all the selected filters on the filter modal screen", () => {

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/WaysToBuyOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/WaysToBuyOptions-tests.tsx
@@ -4,8 +4,8 @@ import { FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpe
 import { ArtworkFiltersState, ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { Check } from "palette"
 import React from "react"
-import { Switch } from "react-native"
 import { OptionListItem } from "../MultiSelectOption"
 import { WaysToBuyOptionsScreen } from "../WaysToBuyOptions"
 import { getEssentialProps } from "./helper"
@@ -126,15 +126,15 @@ describe("Ways to Buy Options Screen", () => {
     }
 
     const tree = renderWithWrappers(<MockWaysToBuyScreen initialData={injectedState} />)
-    const switches = tree.root.findAllByType(Switch)
+    const options = tree.root.findAllByType(Check)
 
-    expect(switches[0].props.value).toBe(true)
+    expect(options[0].props.selected).toBe(true)
 
-    expect(switches[1].props.value).toBe(false)
+    expect(options[1].props.selected).toBe(false)
 
-    expect(switches[2].props.value).toBe(false)
+    expect(options[2].props.selected).toBe(false)
 
-    expect(switches[3].props.value).toBe(false)
+    expect(options[3].props.selected).toBe(false)
   })
 
   it("it toggles applied filters 'ON' and unapplied filters 'OFF", () => {
@@ -164,14 +164,14 @@ describe("Ways to Buy Options Screen", () => {
     }
 
     const tree = renderWithWrappers(<MockWaysToBuyScreen initialData={injectedState} />)
-    const switches = tree.root.findAllByType(Switch)
+    const options = tree.root.findAllByType(Check)
 
-    expect(switches[0].props.value).toBe(false)
+    expect(options[0].props.selected).toBe(false)
 
-    expect(switches[1].props.value).toBe(false)
+    expect(options[1].props.selected).toBe(false)
 
-    expect(switches[2].props.value).toBe(false)
+    expect(options[2].props.selected).toBe(false)
 
-    expect(switches[3].props.value).toBe(true)
+    expect(options[3].props.selected).toBe(true)
   })
 })

--- a/src/lib/Components/ArtworkFilter/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/FilterModal-tests.tsx
@@ -394,34 +394,6 @@ describe("Clearing filters", () => {
     expect(filterModal.find(CurrentOption).at(1).text()).toEqual("All")
     expect(filterModal.find(ApplyButton).at(0).props().disabled).toEqual(false)
   })
-
-  it("the apply button shows the number of currently selected filters and its count resets after filters are applied", () => {
-    const injectedState: ArtworkFiltersState = {
-      selectedFilters: [
-        { displayText: "Price (high to low)", paramName: FilterParamName.sort },
-        { displayText: "Works on paper", paramName: FilterParamName.medium },
-      ],
-      appliedFilters: [{ displayText: "Recently added", paramName: FilterParamName.sort }],
-      previouslyAppliedFilters: [{ displayText: "Recently added", paramName: FilterParamName.sort }],
-      applyFilters: true,
-      aggregations: mockAggregations,
-      filterType: "artwork",
-      counts: {
-        total: null,
-        followedArtists: null,
-      },
-    }
-
-    const filterModal = mount(<MockFilterModalNavigator initialData={injectedState} />)
-    const applyButton = filterModal.find(ApplyButton)
-
-    expect(applyButton.text()).toContain("Apply (2)")
-
-    applyButton.props().onPress()
-
-    // After applying, we reset the selectedFilters
-    expect(applyButton.text()).toContain("Apply")
-  })
 })
 
 describe("Applying filters on Artworks", () => {

--- a/src/lib/Components/ArtworkFilter/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/FilterModal-tests.tsx
@@ -291,14 +291,14 @@ describe("Filter modal states", () => {
     expect(filterScreen.root.findByType(ApplyButton).props.disabled).toEqual(false)
   })
 
-  it("displays default filters on the Filter modal", () => {
+  it("does not display default filters on the Filter modal", () => {
     const filterScreen = mount(<MockFilterScreen initialState={initialState} />)
 
-    expect(filterScreen.find(CurrentOption).at(0).text()).toEqual("Default")
+    expect(filterScreen.find(CurrentOption).at(0).text()).not.toEqual("Default")
 
-    expect(filterScreen.find(CurrentOption).at(1).text()).toEqual("All")
+    expect(filterScreen.find(CurrentOption).at(1).text()).not.toEqual("All")
 
-    expect(filterScreen.find(CurrentOption).at(2).text()).toEqual("All")
+    expect(filterScreen.find(CurrentOption).at(2).text()).not.toEqual("All")
   })
 
   it("displays selected filters on the Filter modal", () => {
@@ -329,10 +329,10 @@ describe("Filter modal states", () => {
 
     expect(extractText(filterScreen.root.findAllByType(CurrentOption)[0])).toEqual("Price (low to high)")
     expect(extractText(filterScreen.root.findAllByType(CurrentOption)[1])).toEqual("Drawing")
-    expect(extractText(filterScreen.root.findAllByType(CurrentOption)[2])).toEqual("All")
+    expect(extractText(filterScreen.root.findAllByType(CurrentOption)[2])).toEqual("")
     expect(extractText(filterScreen.root.findAllByType(CurrentOption)[3])).toEqual("$10,000-20,000")
     expect(extractText(filterScreen.root.findAllByType(CurrentOption)[4])).toEqual("Bid")
-    expect(extractText(filterScreen.root.findAllByType(CurrentOption)[5])).toEqual("All")
+    expect(extractText(filterScreen.root.findAllByType(CurrentOption)[5])).toEqual("")
     expect(filterScreen.root.findAllByType(CurrentOption)).toHaveLength(6)
   })
 })
@@ -364,7 +364,7 @@ describe("Clearing filters", () => {
 
     filterScreen.root.findByType(ClearAllButton).props.onPress()
 
-    expect(extractText(filterScreen.root.findAllByType(CurrentOption)[0])).toEqual("Default")
+    expect(extractText(filterScreen.root.findAllByType(CurrentOption)[0])).toEqual("")
   })
 
   it("enables the apply button when clearing all if no other options are selected", () => {
@@ -390,8 +390,8 @@ describe("Clearing filters", () => {
 
     filterModal.update()
 
-    expect(filterModal.find(CurrentOption).at(0).text()).toEqual("Default")
-    expect(filterModal.find(CurrentOption).at(1).text()).toEqual("All")
+    expect(filterModal.find(CurrentOption).at(0).text()).toEqual("")
+    expect(filterModal.find(CurrentOption).at(1).text()).toEqual("")
     expect(filterModal.find(ApplyButton).at(0).props().disabled).toEqual(false)
   })
 })

--- a/src/lib/Components/TouchableRow.tsx
+++ b/src/lib/Components/TouchableRow.tsx
@@ -1,19 +1,10 @@
-import { useFeatureFlag } from "lib/store/GlobalStore"
 import { color, Touchable, TouchableProps } from "palette"
 import React from "react"
 
 export type TouchableRowProps = TouchableProps
 
-export const TouchableRow: React.FC<TouchableRowProps> = ({ children, ...rest }) => {
-  const shouldUseImprovedArtworkFilters = useFeatureFlag("ARUseImprovedArtworkFilters")
-
-  if (shouldUseImprovedArtworkFilters) {
-    return (
-      <Touchable underlayColor={color("black5")} {...rest}>
-        {children}
-      </Touchable>
-    )
-  }
-
-  return <Touchable {...rest}>{children}</Touchable>
-}
+export const TouchableRow: React.FC<TouchableRowProps> = ({ children, ...rest }) => (
+  <Touchable underlayColor={color("black5")} {...rest}>
+    {children}
+  </Touchable>
+)


### PR DESCRIPTION
The type of this PR is: Feature
This PR resolves [FX-2871]

### Description

This PR removes style changes to the artwork filter modal. (For Artsy engineers, the design specs can be found [here](https://www.figma.com/file/zG9cduJdOaTQAw886QcOwn/Filters?node-id=1376%3A15695).)

- The "Apply (N)" button now simply shows "Show results"
- The separator lines between rows have been removed
- Rows are highlighted when a user taps on them
- Default values "All" and "Default" are no longer shown
- Multi-select filters have changed from toggle switches to checkboxes
- Single-select filters have changed from check marks to radio buttons

#### Before

![before](https://user-images.githubusercontent.com/44589599/115787330-09cd4e00-a390-11eb-98d9-b4a3edda8011.gif)


#### After

![after](https://user-images.githubusercontent.com/44589599/115787335-0c2fa800-a390-11eb-875a-f7934c2296d4.gif)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2871]: https://artsyproduct.atlassian.net/browse/FX-2871