### PR TITLE
fix(CX-1356): Palette button disabled state on iOS

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -30,6 +30,7 @@ upcoming:
     - Fix and Release new multiselect "Colors" filter - ole
     - Release artwork filter style updates - iskounen
     - Restrict Android phones to portrait mode - adamb
+    - Fix palette button disabled state on iOS - mounir
 
 releases:
   - version: 6.8.3

--- a/src/palette/elements/Button/Button.tsx
+++ b/src/palette/elements/Button/Button.tsx
@@ -5,7 +5,7 @@ import Haptic, { HapticFeedbackTypes } from "react-native-haptic-feedback"
 // @ts-ignore
 import { animated, Spring } from "react-spring/renderprops-native.cjs"
 import styled from "styled-components/native"
-import { SansSize } from "../../Theme"
+import { SansSize, themeProps } from "../../Theme"
 import { Box, BoxProps } from "../Box"
 import { Flex } from "../Flex"
 import { Spinner } from "../Spinner"
@@ -69,6 +69,10 @@ export interface ButtonBaseProps extends BoxProps {
  * @param variant
  */
 export function getColorsForVariant(variant: ButtonVariant, disabled: boolean = false) {
+  const {
+    colors: { black100, white100, red100 },
+  } = themeProps
+
   const opacity = disabled ? "0.1" : "1"
   const black100WithOpacity = `rgba(0, 0, 0, ${opacity})`
   const black10WithOpacity = `rgba(229, 229, 229, ${opacity})`
@@ -84,11 +88,13 @@ export function getColorsForVariant(variant: ButtonVariant, disabled: boolean = 
           backgroundColor: black100WithOpacity,
           borderColor: black100WithOpacity,
           color: whiteWithOpacity,
+          textColor: white100,
         },
         hover: {
           backgroundColor: purple100WithOpacity,
           borderColor: purple100WithOpacity,
           color: whiteWithOpacity,
+          textColor: white100,
         },
       }
     case "primaryWhite":
@@ -97,11 +103,13 @@ export function getColorsForVariant(variant: ButtonVariant, disabled: boolean = 
           backgroundColor: whiteWithOpacity,
           borderColor: whiteWithOpacity,
           color: black100WithOpacity,
+          textColor: black100,
         },
         hover: {
           backgroundColor: purple100WithOpacity,
           borderColor: purple100WithOpacity,
           color: whiteWithOpacity,
+          textColor: white100,
         },
       }
     case "secondaryGray":
@@ -110,11 +118,13 @@ export function getColorsForVariant(variant: ButtonVariant, disabled: boolean = 
           backgroundColor: black10WithOpacity,
           borderColor: black10WithOpacity,
           color: black100WithOpacity,
+          textColor: black100,
         },
         hover: {
           backgroundColor: black30WithOpacity,
           borderColor: black30WithOpacity,
           color: black100WithOpacity,
+          textColor: black100,
         },
       }
     case "secondaryOutline":
@@ -123,11 +133,13 @@ export function getColorsForVariant(variant: ButtonVariant, disabled: boolean = 
           backgroundColor: whiteWithOpacity,
           borderColor: black10WithOpacity,
           color: black100WithOpacity,
+          textColor: black100,
         },
         hover: {
           backgroundColor: whiteWithOpacity,
           borderColor: black100WithOpacity,
           color: black100WithOpacity,
+          textColor: black100,
         },
       }
     case "secondaryOutlineWarning":
@@ -136,11 +148,13 @@ export function getColorsForVariant(variant: ButtonVariant, disabled: boolean = 
           backgroundColor: whiteWithOpacity,
           borderColor: black10WithOpacity,
           color: red100WithOpacity,
+          textColor: red100,
         },
         hover: {
           backgroundColor: whiteWithOpacity,
           borderColor: black100WithOpacity,
           color: black100WithOpacity,
+          textColor: black100,
         },
       }
     case "noOutline":
@@ -149,11 +163,13 @@ export function getColorsForVariant(variant: ButtonVariant, disabled: boolean = 
           backgroundColor: "rgba(0, 0, 0, 0)",
           borderColor: "rgba(0, 0, 0, 0)",
           color: black100WithOpacity,
+          textColor: black100,
         },
         hover: {
           backgroundColor: whiteWithOpacity,
           borderColor: black100WithOpacity,
           color: black100WithOpacity,
+          textColor: black100,
         },
       }
   }
@@ -274,7 +290,7 @@ export const Button: React.FC<ButtonProps> = (props) => {
                 {!loading ? (
                   <>
                     <VisibleTextContainer>
-                      <Sans weight="medium" color={loadingStyles.color || to.color} size={s.size}>
+                      <Sans weight="medium" color={loadingStyles.color || to.textColor} size={s.size}>
                         {children}
                       </Sans>
                     </VisibleTextContainer>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1356]

### Description
On iOS, the palette button disabled state looks broke. This was happening because of dropping the text opacity too much (0.1). This PR reverts those changes and removes the opacity same as it was before. 

<img width="921" alt="Screenshot 2021-04-26 at 10 17 41" src="https://user-images.githubusercontent.com/11945712/116051257-ac2f4f00-a678-11eb-8994-0b3465ae9fef.png">

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [xo] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1356]: https://artsyproduct.atlassian.net/browse/CX-1356