### PR TITLE
Fix bugs caught on QA

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -32,6 +32,7 @@ upcoming:
     - Restrict Android phones to portrait mode - adamb
     - Fix palette button disabled state on iOS - mounir
     - Fix artwork filter apply button disabled logic - iskounen
+    - Fix Filter Artwork title text breaking - mounir
 
 releases:
   - version: 6.8.3

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -114,17 +114,13 @@ export const ArtworkFilterOptionsScreen: React.FC<
   return (
     <Flex style={{ flex: 1 }}>
       <Flex flexGrow={0} flexDirection="row" justifyContent="space-between" alignItems="center" height={space(6)}>
-        <Flex flex={1} alignItems="flex-start">
+        <Flex position="absolute" alignItems="flex-start">
           <CloseIconContainer hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }} onPress={handleTappingCloseIcon}>
             <CloseIcon fill="black100" />
           </CloseIconContainer>
         </Flex>
 
-        <Flex flex={1} alignItems="center">
-          <Text variant="mediumText">{title}</Text>
-        </Flex>
-
-        <Flex flex={1} alignItems="flex-end">
+        <Flex position="absolute" right={0} alignItems="flex-end">
           <ClearAllButton
             disabled={!isClearAllButtonEnabled}
             onPress={() => {
@@ -150,6 +146,10 @@ export const ArtworkFilterOptionsScreen: React.FC<
               Clear all
             </Text>
           </ClearAllButton>
+        </Flex>
+
+        <Flex flex={1} alignItems="center">
+          <Text variant="mediumText">{title}</Text>
         </Flex>
       </Flex>
 

--- a/src/palette/elements/Button/Button.tsx
+++ b/src/palette/elements/Button/Button.tsx
@@ -212,6 +212,7 @@ export const Button: React.FC<ButtonProps> = (props) => {
         backgroundColor: `rgba(0, 0, 0, ${opacity})`,
         color: color("white100"),
         borderWidth: 0,
+        textColor: "transparent",
       }
     }
 
@@ -219,6 +220,7 @@ export const Button: React.FC<ButtonProps> = (props) => {
       backgroundColor: `rgba(0, 0, 0, ${opacity})`,
       borderColor: `rgba(0, 0, 0, 0)`,
       color: color("white100"),
+      textColor: "transparent",
     }
   })()
 
@@ -287,20 +289,16 @@ export const Button: React.FC<ButtonProps> = (props) => {
                 style={{ ...springProps, ...loadingStyles, height: s.height }}
                 px={s.px}
               >
-                {!loading ? (
-                  <>
-                    <VisibleTextContainer>
-                      <Sans weight="medium" color={loadingStyles.color || to.textColor} size={s.size}>
-                        {children}
-                      </Sans>
-                    </VisibleTextContainer>
-                    <HiddenText role="presentation" weight="medium" size={s.size}>
-                      {longestText ? longestText : children}
-                    </HiddenText>
-                  </>
-                ) : (
-                  <Spinner size={size} color={spinnerColor} />
-                )}
+                <VisibleTextContainer>
+                  <Sans weight="medium" color={loadingStyles.textColor || to.textColor} size={s.size}>
+                    {children}
+                  </Sans>
+                </VisibleTextContainer>
+                <HiddenText role="presentation" weight="medium" size={s.size}>
+                  {longestText ? longestText : children}
+                </HiddenText>
+
+                {!!loading && <Spinner size={size} color={spinnerColor} />}
               </AnimatedContainer>
             </Flex>
           </TouchableWithoutFeedback>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1358]

### Description
- Fix auction results filter modal title
![Group 1 (6)](https://user-images.githubusercontent.com/11945712/116124712-f1796e00-a6c4-11eb-9c1c-f1a7e470809f.png)

___
- Fix palette button loading state
**Before**

https://user-images.githubusercontent.com/11945712/116124643-d73f9000-a6c4-11eb-9887-20299a391bf6.mov

**After**

https://user-images.githubusercontent.com/11945712/116124634-d4dd3600-a6c4-11eb-88f1-665bcae53014.mov


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1358]: https://artsyproduct.atlassian.net/browse/CX-1358