### PR TITLE
feat(fx-2713): allows multi-select filters to be searchable

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -35,6 +35,7 @@ upcoming:
     - Fix artwork filter apply button disabled logic - iskounen
     - Fix Filter Artwork title text breaking - mounir
     - Combine gallery and institution artwork filters - mdole
+    - Allows multi-select filters to be searchable - damon
 
 releases:
   - version: 6.8.3

--- a/src/lib/Components/ArtworkFilter/Filters/GalleriesAndInstitutionsOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/GalleriesAndInstitutionsOptions.tsx
@@ -31,6 +31,7 @@ export const GalleriesAndInstitutionsOptionsScreen: React.FC<GalleriesAndInstitu
       filterHeaderText={FilterDisplayName.partnerIDs}
       filterOptions={filterOptions}
       navigation={navigation}
+      searchable
       {...(isActive ? { rightButtonText: "Clear", onRightButtonPress: handleClear } : {})}
     />
   )

--- a/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
@@ -2,9 +2,10 @@ import { ParamListBase } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"
 import { FilterData } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { FancyModalHeader, FancyModalHeaderProps } from "lib/Components/FancyModal/FancyModalHeader"
+import { SearchInput } from "lib/Components/SearchInput"
 import { TouchableRow } from "lib/Components/TouchableRow"
 import { Box, Check, Flex, Text } from "palette"
-import React from "react"
+import React, { useState } from "react"
 import { FlatList } from "react-native"
 import styled from "styled-components/native"
 
@@ -15,6 +16,8 @@ interface MultiSelectOptionScreenProps extends FancyModalHeaderProps {
   filterOptions: FilterData[]
   isSelected?: (item: FilterData) => boolean
   isDisabled?: (item: FilterData) => boolean
+  /** Utilize a search input to further filter results */
+  searchable?: boolean
 }
 
 export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = ({
@@ -24,6 +27,8 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
   navigation,
   isSelected,
   isDisabled,
+  children,
+  searchable,
   ...rest
 }) => {
   const handleBackNavigation = () => {
@@ -46,17 +51,37 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
     }
   }
 
+  const [query, setQuery] = useState("")
+
+  const filteredOptions = filterOptions.filter((option) =>
+    option.displayText.toLowerCase().includes(query.toLowerCase())
+  )
+
   return (
     <Flex flexGrow={1}>
       <FancyModalHeader onLeftButtonPress={handleBackNavigation} {...rest}>
         {filterHeaderText}
       </FancyModalHeader>
 
+      {!!searchable && (
+        <>
+          <Flex m={2}>
+            <SearchInput onChangeText={setQuery} placeholder="Filter results" />
+          </Flex>
+
+          {filteredOptions.length === 0 && (
+            <Flex my={1.5} mx={2} alignItems="center">
+              <Text variant="caption">No results</Text>
+            </Flex>
+          )}
+        </>
+      )}
+
       <Flex flexGrow={1}>
         <FlatList<FilterData>
           style={{ flex: 1 }}
           keyExtractor={(_item, index) => String(index)}
-          data={filterOptions}
+          data={filteredOptions}
           renderItem={({ item }) => {
             return (
               <Box ml={0.5}>

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/MultiSelectOption-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/MultiSelectOption-tests.tsx
@@ -1,0 +1,49 @@
+import { SearchInput } from "lib/Components/SearchInput"
+import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import React from "react"
+import { FilterData, FilterParamName } from "../../ArtworkFilterHelpers"
+import { MultiSelectOptionScreen } from "../MultiSelectOption"
+import { getEssentialProps } from "./helper"
+
+const EXAMPLE_FILTER_OPTIONS: FilterData[] = [
+  { displayText: "First Example", paramValue: "first-example", paramName: FilterParamName.partnerIDs },
+  { displayText: "Another One", paramValue: "another-one", paramName: FilterParamName.partnerIDs },
+  { displayText: "The Third", paramValue: "the-third", paramName: FilterParamName.partnerIDs },
+]
+
+describe("MultiSelectOption", () => {
+  it("renders the options", () => {
+    const tree = renderWithWrappers(
+      <MultiSelectOptionScreen filterOptions={EXAMPLE_FILTER_OPTIONS} searchable {...getEssentialProps()} />
+    )
+
+    expect(extractText(tree.root)).toEqual("First ExampleAnother OneThe Third")
+  })
+
+  describe("searchable", () => {
+    it("filters the options with searchable", () => {
+      const tree = renderWithWrappers(
+        <MultiSelectOptionScreen filterOptions={EXAMPLE_FILTER_OPTIONS} searchable {...getEssentialProps()} />
+      )
+
+      expect(extractText(tree.root)).toEqual("First ExampleAnother OneThe Third")
+
+      tree.root.findByType(SearchInput).props.onChangeText("another")
+
+      expect(extractText(tree.root)).toEqual("Another One")
+    })
+
+    it("displays a message indicating no results when nothing matches the search input", () => {
+      const tree = renderWithWrappers(
+        <MultiSelectOptionScreen filterOptions={EXAMPLE_FILTER_OPTIONS} searchable {...getEssentialProps()} />
+      )
+
+      expect(extractText(tree.root)).toEqual("First ExampleAnother OneThe Third")
+
+      tree.root.findByType(SearchInput).props.onChangeText("garbage")
+
+      expect(extractText(tree.root)).toEqual("No results")
+    })
+  })
+})


### PR DESCRIPTION
The type of this PR is: **Feature**


This PR resolves [FX-2713]

### Description

https://user-images.githubusercontent.com/112297/116305936-72427380-a772-11eb-9140-72af8b93cb16.mov

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2713]: https://artsyproduct.atlassian.net/browse/FX-2713