### PR TITLE
fix: address cache issue for make offer button

### DIFF
--- a/src/lib/Scenes/Inbox/Components/Conversations/OpenInquiryModalButton.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/OpenInquiryModalButton.tsx
@@ -63,6 +63,7 @@ export const OpenInquiryModalButtonQueryRenderer: React.FC<{
       variables={{
         artworkID,
       }}
+      cacheConfig={{ force: true }}
       render={({ props, error }): null | JSX.Element => {
         if (error) {
           throw new Error(error.message)


### PR DESCRIPTION
The type of this PR is: **FIX**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PURCHASE-2599]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [PURCHASE-2599]

### Description

<!-- Implementation description -->
This is follow up to the issue where a stale version of `isOfferableFromInquiry` was return. This PR fixes the cache issue that happens when a user goes out and come back to the conversation screen and the make offer button isn't update.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [ ] I have documented any follow-up work that this PR will require, or it does not require any.
- [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[PURCHASE-2599]: https://artsyproduct.atlassian.net/browse/PURCHASE-2599
[PURCHASE-2599]: https://artsyproduct.atlassian.net/browse/PURCHASE-2599