### PR TITLE
refactor: move rails on artist artwork tab to overview (about) tab

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -6,6 +6,8 @@ upcoming:
   user_facing:
     - Combine gallery and institution artwork filters - mdole
     - Allows multi-select filters to be searchable - damon
+    - Rename artist about tab to artist overview tab - iskounen
+    - Move rails on artist artwork tab to artist overview tab - iskounen
 
 releases:
   - version: 6.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -928,7 +928,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CocoaLumberjack: aa9dcab71bdf9eaf2a63bbd9ddc87863efe45457
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
-  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
+  DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
   Emission: bec9c8f604b13b12385835cd98d80a035dc41cc8
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
@@ -950,7 +950,7 @@ SPEC CHECKSUMS:
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   Forgeries: 64ced144ea8341d89a7eec9d1d7986f0f1366250
   FXBlurView: 5121730176fd52bcf7bffd0bd8c1485e8aabc3cb
-  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
+  glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   Interstellar: ab67502af03105f92100a043e178d188a1a437c9
   INTUAnimationEngine: 3a7d63738cd51af573d16848a771feedea7cc9f2
   ISO8601DateFormatter: 8311a2d4e265b269b2fed7ab4db685dcb0a7ccb2

--- a/src/__generated__/ArtistAboutTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistAboutTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash ec53f45facd78fca1a35d765c7cd7aec */
+/* @relayHash 619ca8565658a9cfd7dd411f10c95038 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -78,8 +78,24 @@ fragment ArtistAboutShows_artist on Artist {
 
 fragment ArtistAbout_artist on Artist {
   hasMetadata
+  internalID
   slug
   ...Biography_artist
+  ...ArtistSeriesMoreSeries_artist
+  ...ArtistNotableWorksRail_artist
+  notableWorks: filterArtworksConnection(sort: "-weighted_iconicity", first: 3) {
+    edges {
+      node {
+        id
+      }
+    }
+    id
+  }
+  ...ArtistCollectionsRail_artist
+  iconicCollections: marketingCollections(isFeaturedArtistContent: true, size: 16) {
+    ...ArtistCollectionsRail_collections
+    id
+  }
   ...ArtistConsignButton_artist
   ...ArtistAboutShows_artist
   related {
@@ -102,6 +118,30 @@ fragment ArtistAbout_artist on Artist {
   }
 }
 
+fragment ArtistCollectionsRail_artist on Artist {
+  internalID
+  slug
+}
+
+fragment ArtistCollectionsRail_collections on MarketingCollection {
+  slug
+  id
+  title
+  priceGuidance
+  artworksConnection(first: 3, aggregations: [TOTAL], sort: "-decayed_merch") {
+    edges {
+      node {
+        title
+        image {
+          url
+        }
+        id
+      }
+    }
+    id
+  }
+}
+
 fragment ArtistConsignButton_artist on Artist {
   targetSupply {
     isInMicrofunnel
@@ -113,6 +153,61 @@ fragment ArtistConsignButton_artist on Artist {
   image {
     cropped(width: 66, height: 66) {
       url
+    }
+  }
+}
+
+fragment ArtistNotableWorksRail_artist on Artist {
+  internalID
+  slug
+  filterArtworksConnection(sort: "-weighted_iconicity", first: 10) {
+    edges {
+      node {
+        id
+        image {
+          imageURL
+          aspectRatio
+        }
+        saleMessage
+        saleArtwork {
+          openingBid {
+            display
+          }
+          highestBid {
+            display
+          }
+          id
+        }
+        sale {
+          isClosed
+          isAuction
+          id
+        }
+        title
+        internalID
+        slug
+      }
+    }
+    id
+  }
+}
+
+fragment ArtistSeriesMoreSeries_artist on Artist {
+  internalID
+  slug
+  artistSeriesConnection(first: 4) {
+    totalCount
+    edges {
+      node {
+        slug
+        internalID
+        title
+        featured
+        artworksCountMessage
+        image {
+          url
+        }
+      }
     }
   }
 }
@@ -195,36 +290,91 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "slug",
+  "name": "internalID",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "slug",
   "storageKey": null
 },
 v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "title",
+  "storageKey": null
+},
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "url",
+    "storageKey": null
+  }
+],
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Image",
+  "kind": "LinkedField",
+  "name": "image",
+  "plural": false,
+  "selections": (v5/*: any*/),
+  "storageKey": null
+},
+v7 = {
   "kind": "Literal",
   "name": "first",
   "value": 10
 },
-v5 = {
+v8 = {
+  "kind": "Literal",
+  "name": "sort",
+  "value": "-weighted_iconicity"
+},
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v6 = {
+v10 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+],
+v11 = {
+  "kind": "Literal",
+  "name": "first",
+  "value": 3
+},
+v12 = [
+  (v9/*: any*/)
+],
+v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v7 = [
+v15 = [
   {
     "alias": null,
     "args": [
@@ -239,11 +389,11 @@ v7 = [
     "storageKey": "url(version:\"large\")"
   }
 ],
-v8 = [
-  (v3/*: any*/),
-  (v5/*: any*/)
+v16 = [
+  (v13/*: any*/),
+  (v9/*: any*/)
 ],
-v9 = [
+v17 = [
   {
     "alias": null,
     "args": null,
@@ -260,9 +410,9 @@ v9 = [
         "name": "node",
         "plural": false,
         "selections": [
-          (v5/*: any*/),
-          (v2/*: any*/),
-          (v6/*: any*/),
+          (v9/*: any*/),
+          (v3/*: any*/),
+          (v14/*: any*/),
           {
             "alias": "is_fair_booth",
             "args": null,
@@ -277,7 +427,7 @@ v9 = [
             "kind": "LinkedField",
             "name": "coverImage",
             "plural": false,
-            "selections": (v7/*: any*/),
+            "selections": (v15/*: any*/),
             "storageKey": null
           },
           {
@@ -287,7 +437,7 @@ v9 = [
             "name": "kind",
             "storageKey": null
           },
-          (v3/*: any*/),
+          (v13/*: any*/),
           {
             "alias": "exhibition_period",
             "args": null,
@@ -327,22 +477,20 @@ v9 = [
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v3/*: any*/)
+                  (v13/*: any*/)
                 ],
                 "type": "Partner",
                 "abstractKey": null
               },
               {
                 "kind": "InlineFragment",
-                "selections": (v8/*: any*/),
+                "selections": (v16/*: any*/),
                 "type": "ExternalPartner",
                 "abstractKey": null
               },
               {
                 "kind": "InlineFragment",
-                "selections": [
-                  (v5/*: any*/)
-                ],
+                "selections": (v12/*: any*/),
                 "type": "Node",
                 "abstractKey": "__isNode"
               }
@@ -364,7 +512,7 @@ v9 = [
                 "name": "city",
                 "storageKey": null
               },
-              (v5/*: any*/)
+              (v9/*: any*/)
             ],
             "storageKey": null
           }
@@ -375,73 +523,91 @@ v9 = [
     "storageKey": null
   }
 ],
-v10 = {
+v18 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Artist"
 },
-v11 = {
+v19 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v12 = {
+v20 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v13 = {
+v21 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
 },
-v14 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "ShowConnection"
-},
-v15 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": true,
-  "type": "ShowEdge"
-},
-v16 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Show"
-},
-v17 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Boolean"
-},
-v18 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Location"
-},
-v19 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "PartnerTypes"
-},
-v20 = {
+v22 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v21 = {
+v23 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "ShowConnection"
+},
+v24 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": true,
+  "type": "ShowEdge"
+},
+v25 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Show"
+},
+v26 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Boolean"
+},
+v27 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Location"
+},
+v28 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "PartnerTypes"
+},
+v29 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "FilterArtworksConnection"
+},
+v30 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": true,
+  "type": "FilterArtworksEdge"
+},
+v31 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Artwork"
+},
+v32 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -496,6 +662,7 @@ return {
             "storageKey": null
           },
           (v2/*: any*/),
+          (v3/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -509,6 +676,320 @@ return {
             "kind": "ScalarField",
             "name": "blurb",
             "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 4
+              }
+            ],
+            "concreteType": "ArtistSeriesConnection",
+            "kind": "LinkedField",
+            "name": "artistSeriesConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "totalCount",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ArtistSeriesEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ArtistSeries",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      (v2/*: any*/),
+                      (v4/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "featured",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "artworksCountMessage",
+                        "storageKey": null
+                      },
+                      (v6/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "artistSeriesConnection(first:4)"
+          },
+          {
+            "alias": null,
+            "args": [
+              (v7/*: any*/),
+              (v8/*: any*/)
+            ],
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v9/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "imageURL",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "aspectRatio",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "saleMessage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "kind": "LinkedField",
+                        "name": "saleArtwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkOpeningBid",
+                            "kind": "LinkedField",
+                            "name": "openingBid",
+                            "plural": false,
+                            "selections": (v10/*: any*/),
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkHighestBid",
+                            "kind": "LinkedField",
+                            "name": "highestBid",
+                            "plural": false,
+                            "selections": (v10/*: any*/),
+                            "storageKey": null
+                          },
+                          (v9/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "kind": "LinkedField",
+                        "name": "sale",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isClosed",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isAuction",
+                            "storageKey": null
+                          },
+                          (v9/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v4/*: any*/),
+                      (v2/*: any*/),
+                      (v3/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v9/*: any*/)
+            ],
+            "storageKey": "filterArtworksConnection(first:10,sort:\"-weighted_iconicity\")"
+          },
+          {
+            "alias": "notableWorks",
+            "args": [
+              (v11/*: any*/),
+              (v8/*: any*/)
+            ],
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": (v12/*: any*/),
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v9/*: any*/)
+            ],
+            "storageKey": "filterArtworksConnection(first:3,sort:\"-weighted_iconicity\")"
+          },
+          {
+            "alias": "iconicCollections",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "isFeaturedArtistContent",
+                "value": true
+              },
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 16
+              }
+            ],
+            "concreteType": "MarketingCollection",
+            "kind": "LinkedField",
+            "name": "marketingCollections",
+            "plural": true,
+            "selections": [
+              (v3/*: any*/),
+              (v9/*: any*/),
+              (v4/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "priceGuidance",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "aggregations",
+                    "value": [
+                      "TOTAL"
+                    ]
+                  },
+                  (v11/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "sort",
+                    "value": "-decayed_merch"
+                  }
+                ],
+                "concreteType": "FilterArtworksConnection",
+                "kind": "LinkedField",
+                "name": "artworksConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "FilterArtworksEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artwork",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v4/*: any*/),
+                          (v6/*: any*/),
+                          (v9/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v9/*: any*/)
+                ],
+                "storageKey": "artworksConnection(aggregations:[\"TOTAL\"],first:3,sort:\"-decayed_merch\")"
+              }
+            ],
+            "storageKey": "marketingCollections(isFeaturedArtistContent:true,size:16)"
           },
           {
             "alias": null,
@@ -535,14 +1016,7 @@ return {
             ],
             "storageKey": null
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "internalID",
-            "storageKey": null
-          },
-          (v3/*: any*/),
+          (v13/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -569,15 +1043,7 @@ return {
                 "kind": "LinkedField",
                 "name": "cropped",
                 "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "url",
-                    "storageKey": null
-                  }
-                ],
+                "selections": (v5/*: any*/),
                 "storageKey": "cropped(height:66,width:66)"
               }
             ],
@@ -586,7 +1052,7 @@ return {
           {
             "alias": "currentShows",
             "args": [
-              (v4/*: any*/),
+              (v7/*: any*/),
               {
                 "kind": "Literal",
                 "name": "status",
@@ -597,13 +1063,13 @@ return {
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
-            "selections": (v9/*: any*/),
+            "selections": (v17/*: any*/),
             "storageKey": "showsConnection(first:10,status:\"running\")"
           },
           {
             "alias": "upcomingShows",
             "args": [
-              (v4/*: any*/),
+              (v7/*: any*/),
               {
                 "kind": "Literal",
                 "name": "status",
@@ -614,17 +1080,13 @@ return {
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
-            "selections": (v9/*: any*/),
+            "selections": (v17/*: any*/),
             "storageKey": "showsConnection(first:10,status:\"upcoming\")"
           },
           {
             "alias": "pastShows",
             "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 3
-              },
+              (v11/*: any*/),
               {
                 "kind": "Literal",
                 "name": "status",
@@ -635,7 +1097,7 @@ return {
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
-            "selections": (v9/*: any*/),
+            "selections": (v17/*: any*/),
             "storageKey": "showsConnection(first:3,status:\"closed\")"
           },
           {
@@ -676,9 +1138,9 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
-                          (v6/*: any*/),
-                          (v3/*: any*/),
+                          (v9/*: any*/),
+                          (v14/*: any*/),
+                          (v13/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -711,7 +1173,7 @@ return {
                             "kind": "LinkedField",
                             "name": "image",
                             "plural": false,
-                            "selections": (v7/*: any*/),
+                            "selections": (v15/*: any*/),
                             "storageKey": null
                           }
                         ],
@@ -729,7 +1191,7 @@ return {
           {
             "alias": "articles",
             "args": [
-              (v4/*: any*/),
+              (v7/*: any*/),
               {
                 "kind": "Literal",
                 "name": "inEditorialFeed",
@@ -757,7 +1219,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/),
+                      (v9/*: any*/),
                       {
                         "alias": "thumbnail_title",
                         "args": null,
@@ -765,7 +1227,7 @@ return {
                         "name": "thumbnailTitle",
                         "storageKey": null
                       },
-                      (v6/*: any*/),
+                      (v14/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -773,7 +1235,7 @@ return {
                         "kind": "LinkedField",
                         "name": "author",
                         "plural": false,
-                        "selections": (v8/*: any*/),
+                        "selections": (v16/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -783,7 +1245,7 @@ return {
                         "kind": "LinkedField",
                         "name": "thumbnailImage",
                         "plural": false,
-                        "selections": (v7/*: any*/),
+                        "selections": (v15/*: any*/),
                         "storageKey": null
                       }
                     ],
@@ -795,17 +1257,17 @@ return {
             ],
             "storageKey": "articlesConnection(first:10,inEditorialFeed:true)"
           },
-          (v5/*: any*/)
+          (v9/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "ec53f45facd78fca1a35d765c7cd7aec",
+    "id": "619ca8565658a9cfd7dd411f10c95038",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "artist": (v10/*: any*/),
+        "artist": (v18/*: any*/),
         "artist.articles": {
           "enumValues": null,
           "nullable": true,
@@ -830,71 +1292,182 @@ return {
           "plural": false,
           "type": "Author"
         },
-        "artist.articles.edges.node.author.id": (v11/*: any*/),
-        "artist.articles.edges.node.author.name": (v12/*: any*/),
-        "artist.articles.edges.node.href": (v12/*: any*/),
-        "artist.articles.edges.node.id": (v11/*: any*/),
-        "artist.articles.edges.node.thumbnail_image": (v13/*: any*/),
-        "artist.articles.edges.node.thumbnail_image.url": (v12/*: any*/),
-        "artist.articles.edges.node.thumbnail_title": (v12/*: any*/),
-        "artist.bio": (v12/*: any*/),
-        "artist.blurb": (v12/*: any*/),
-        "artist.currentShows": (v14/*: any*/),
-        "artist.currentShows.edges": (v15/*: any*/),
-        "artist.currentShows.edges.node": (v16/*: any*/),
-        "artist.currentShows.edges.node.cover_image": (v13/*: any*/),
-        "artist.currentShows.edges.node.cover_image.url": (v12/*: any*/),
-        "artist.currentShows.edges.node.exhibition_period": (v12/*: any*/),
-        "artist.currentShows.edges.node.href": (v12/*: any*/),
-        "artist.currentShows.edges.node.id": (v11/*: any*/),
-        "artist.currentShows.edges.node.is_fair_booth": (v17/*: any*/),
-        "artist.currentShows.edges.node.kind": (v12/*: any*/),
-        "artist.currentShows.edges.node.location": (v18/*: any*/),
-        "artist.currentShows.edges.node.location.city": (v12/*: any*/),
-        "artist.currentShows.edges.node.location.id": (v11/*: any*/),
-        "artist.currentShows.edges.node.name": (v12/*: any*/),
-        "artist.currentShows.edges.node.partner": (v19/*: any*/),
-        "artist.currentShows.edges.node.partner.__isNode": (v20/*: any*/),
-        "artist.currentShows.edges.node.partner.__typename": (v20/*: any*/),
-        "artist.currentShows.edges.node.partner.id": (v11/*: any*/),
-        "artist.currentShows.edges.node.partner.name": (v12/*: any*/),
-        "artist.currentShows.edges.node.slug": (v11/*: any*/),
-        "artist.currentShows.edges.node.status": (v12/*: any*/),
-        "artist.currentShows.edges.node.status_update": (v12/*: any*/),
-        "artist.hasMetadata": (v17/*: any*/),
-        "artist.id": (v11/*: any*/),
-        "artist.image": (v13/*: any*/),
+        "artist.articles.edges.node.author.id": (v19/*: any*/),
+        "artist.articles.edges.node.author.name": (v20/*: any*/),
+        "artist.articles.edges.node.href": (v20/*: any*/),
+        "artist.articles.edges.node.id": (v19/*: any*/),
+        "artist.articles.edges.node.thumbnail_image": (v21/*: any*/),
+        "artist.articles.edges.node.thumbnail_image.url": (v20/*: any*/),
+        "artist.articles.edges.node.thumbnail_title": (v20/*: any*/),
+        "artist.artistSeriesConnection": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtistSeriesConnection"
+        },
+        "artist.artistSeriesConnection.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "ArtistSeriesEdge"
+        },
+        "artist.artistSeriesConnection.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtistSeries"
+        },
+        "artist.artistSeriesConnection.edges.node.artworksCountMessage": (v20/*: any*/),
+        "artist.artistSeriesConnection.edges.node.featured": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Boolean"
+        },
+        "artist.artistSeriesConnection.edges.node.image": (v21/*: any*/),
+        "artist.artistSeriesConnection.edges.node.image.url": (v20/*: any*/),
+        "artist.artistSeriesConnection.edges.node.internalID": (v19/*: any*/),
+        "artist.artistSeriesConnection.edges.node.slug": (v22/*: any*/),
+        "artist.artistSeriesConnection.edges.node.title": (v22/*: any*/),
+        "artist.artistSeriesConnection.totalCount": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Int"
+        },
+        "artist.bio": (v20/*: any*/),
+        "artist.blurb": (v20/*: any*/),
+        "artist.currentShows": (v23/*: any*/),
+        "artist.currentShows.edges": (v24/*: any*/),
+        "artist.currentShows.edges.node": (v25/*: any*/),
+        "artist.currentShows.edges.node.cover_image": (v21/*: any*/),
+        "artist.currentShows.edges.node.cover_image.url": (v20/*: any*/),
+        "artist.currentShows.edges.node.exhibition_period": (v20/*: any*/),
+        "artist.currentShows.edges.node.href": (v20/*: any*/),
+        "artist.currentShows.edges.node.id": (v19/*: any*/),
+        "artist.currentShows.edges.node.is_fair_booth": (v26/*: any*/),
+        "artist.currentShows.edges.node.kind": (v20/*: any*/),
+        "artist.currentShows.edges.node.location": (v27/*: any*/),
+        "artist.currentShows.edges.node.location.city": (v20/*: any*/),
+        "artist.currentShows.edges.node.location.id": (v19/*: any*/),
+        "artist.currentShows.edges.node.name": (v20/*: any*/),
+        "artist.currentShows.edges.node.partner": (v28/*: any*/),
+        "artist.currentShows.edges.node.partner.__isNode": (v22/*: any*/),
+        "artist.currentShows.edges.node.partner.__typename": (v22/*: any*/),
+        "artist.currentShows.edges.node.partner.id": (v19/*: any*/),
+        "artist.currentShows.edges.node.partner.name": (v20/*: any*/),
+        "artist.currentShows.edges.node.slug": (v19/*: any*/),
+        "artist.currentShows.edges.node.status": (v20/*: any*/),
+        "artist.currentShows.edges.node.status_update": (v20/*: any*/),
+        "artist.filterArtworksConnection": (v29/*: any*/),
+        "artist.filterArtworksConnection.edges": (v30/*: any*/),
+        "artist.filterArtworksConnection.edges.node": (v31/*: any*/),
+        "artist.filterArtworksConnection.edges.node.id": (v19/*: any*/),
+        "artist.filterArtworksConnection.edges.node.image": (v21/*: any*/),
+        "artist.filterArtworksConnection.edges.node.image.aspectRatio": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Float"
+        },
+        "artist.filterArtworksConnection.edges.node.image.imageURL": (v20/*: any*/),
+        "artist.filterArtworksConnection.edges.node.internalID": (v19/*: any*/),
+        "artist.filterArtworksConnection.edges.node.sale": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Sale"
+        },
+        "artist.filterArtworksConnection.edges.node.sale.id": (v19/*: any*/),
+        "artist.filterArtworksConnection.edges.node.sale.isAuction": (v26/*: any*/),
+        "artist.filterArtworksConnection.edges.node.sale.isClosed": (v26/*: any*/),
+        "artist.filterArtworksConnection.edges.node.saleArtwork": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtwork"
+        },
+        "artist.filterArtworksConnection.edges.node.saleArtwork.highestBid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkHighestBid"
+        },
+        "artist.filterArtworksConnection.edges.node.saleArtwork.highestBid.display": (v20/*: any*/),
+        "artist.filterArtworksConnection.edges.node.saleArtwork.id": (v19/*: any*/),
+        "artist.filterArtworksConnection.edges.node.saleArtwork.openingBid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkOpeningBid"
+        },
+        "artist.filterArtworksConnection.edges.node.saleArtwork.openingBid.display": (v20/*: any*/),
+        "artist.filterArtworksConnection.edges.node.saleMessage": (v20/*: any*/),
+        "artist.filterArtworksConnection.edges.node.slug": (v19/*: any*/),
+        "artist.filterArtworksConnection.edges.node.title": (v20/*: any*/),
+        "artist.filterArtworksConnection.id": (v19/*: any*/),
+        "artist.hasMetadata": (v26/*: any*/),
+        "artist.iconicCollections": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "MarketingCollection"
+        },
+        "artist.iconicCollections.artworksConnection": (v29/*: any*/),
+        "artist.iconicCollections.artworksConnection.edges": (v30/*: any*/),
+        "artist.iconicCollections.artworksConnection.edges.node": (v31/*: any*/),
+        "artist.iconicCollections.artworksConnection.edges.node.id": (v19/*: any*/),
+        "artist.iconicCollections.artworksConnection.edges.node.image": (v21/*: any*/),
+        "artist.iconicCollections.artworksConnection.edges.node.image.url": (v20/*: any*/),
+        "artist.iconicCollections.artworksConnection.edges.node.title": (v20/*: any*/),
+        "artist.iconicCollections.artworksConnection.id": (v19/*: any*/),
+        "artist.iconicCollections.id": (v19/*: any*/),
+        "artist.iconicCollections.priceGuidance": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Float"
+        },
+        "artist.iconicCollections.slug": (v22/*: any*/),
+        "artist.iconicCollections.title": (v22/*: any*/),
+        "artist.id": (v19/*: any*/),
+        "artist.image": (v21/*: any*/),
         "artist.image.cropped": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "CroppedImageUrl"
         },
-        "artist.image.cropped.url": (v20/*: any*/),
-        "artist.internalID": (v11/*: any*/),
-        "artist.name": (v12/*: any*/),
-        "artist.pastShows": (v14/*: any*/),
-        "artist.pastShows.edges": (v15/*: any*/),
-        "artist.pastShows.edges.node": (v16/*: any*/),
-        "artist.pastShows.edges.node.cover_image": (v13/*: any*/),
-        "artist.pastShows.edges.node.cover_image.url": (v12/*: any*/),
-        "artist.pastShows.edges.node.exhibition_period": (v12/*: any*/),
-        "artist.pastShows.edges.node.href": (v12/*: any*/),
-        "artist.pastShows.edges.node.id": (v11/*: any*/),
-        "artist.pastShows.edges.node.is_fair_booth": (v17/*: any*/),
-        "artist.pastShows.edges.node.kind": (v12/*: any*/),
-        "artist.pastShows.edges.node.location": (v18/*: any*/),
-        "artist.pastShows.edges.node.location.city": (v12/*: any*/),
-        "artist.pastShows.edges.node.location.id": (v11/*: any*/),
-        "artist.pastShows.edges.node.name": (v12/*: any*/),
-        "artist.pastShows.edges.node.partner": (v19/*: any*/),
-        "artist.pastShows.edges.node.partner.__isNode": (v20/*: any*/),
-        "artist.pastShows.edges.node.partner.__typename": (v20/*: any*/),
-        "artist.pastShows.edges.node.partner.id": (v11/*: any*/),
-        "artist.pastShows.edges.node.partner.name": (v12/*: any*/),
-        "artist.pastShows.edges.node.slug": (v11/*: any*/),
-        "artist.pastShows.edges.node.status": (v12/*: any*/),
-        "artist.pastShows.edges.node.status_update": (v12/*: any*/),
+        "artist.image.cropped.url": (v22/*: any*/),
+        "artist.internalID": (v19/*: any*/),
+        "artist.name": (v20/*: any*/),
+        "artist.notableWorks": (v29/*: any*/),
+        "artist.notableWorks.edges": (v30/*: any*/),
+        "artist.notableWorks.edges.node": (v31/*: any*/),
+        "artist.notableWorks.edges.node.id": (v19/*: any*/),
+        "artist.notableWorks.id": (v19/*: any*/),
+        "artist.pastShows": (v23/*: any*/),
+        "artist.pastShows.edges": (v24/*: any*/),
+        "artist.pastShows.edges.node": (v25/*: any*/),
+        "artist.pastShows.edges.node.cover_image": (v21/*: any*/),
+        "artist.pastShows.edges.node.cover_image.url": (v20/*: any*/),
+        "artist.pastShows.edges.node.exhibition_period": (v20/*: any*/),
+        "artist.pastShows.edges.node.href": (v20/*: any*/),
+        "artist.pastShows.edges.node.id": (v19/*: any*/),
+        "artist.pastShows.edges.node.is_fair_booth": (v26/*: any*/),
+        "artist.pastShows.edges.node.kind": (v20/*: any*/),
+        "artist.pastShows.edges.node.location": (v27/*: any*/),
+        "artist.pastShows.edges.node.location.city": (v20/*: any*/),
+        "artist.pastShows.edges.node.location.id": (v19/*: any*/),
+        "artist.pastShows.edges.node.name": (v20/*: any*/),
+        "artist.pastShows.edges.node.partner": (v28/*: any*/),
+        "artist.pastShows.edges.node.partner.__isNode": (v22/*: any*/),
+        "artist.pastShows.edges.node.partner.__typename": (v22/*: any*/),
+        "artist.pastShows.edges.node.partner.id": (v19/*: any*/),
+        "artist.pastShows.edges.node.partner.name": (v20/*: any*/),
+        "artist.pastShows.edges.node.slug": (v19/*: any*/),
+        "artist.pastShows.edges.node.status": (v20/*: any*/),
+        "artist.pastShows.edges.node.status_update": (v20/*: any*/),
         "artist.related": {
           "enumValues": null,
           "nullable": true,
@@ -913,51 +1486,51 @@ return {
           "plural": true,
           "type": "ArtistEdge"
         },
-        "artist.related.artists.edges.node": (v10/*: any*/),
+        "artist.related.artists.edges.node": (v18/*: any*/),
         "artist.related.artists.edges.node.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtistCounts"
         },
-        "artist.related.artists.edges.node.counts.artworks": (v21/*: any*/),
-        "artist.related.artists.edges.node.counts.forSaleArtworks": (v21/*: any*/),
-        "artist.related.artists.edges.node.href": (v12/*: any*/),
-        "artist.related.artists.edges.node.id": (v11/*: any*/),
-        "artist.related.artists.edges.node.image": (v13/*: any*/),
-        "artist.related.artists.edges.node.image.url": (v12/*: any*/),
-        "artist.related.artists.edges.node.name": (v12/*: any*/),
-        "artist.slug": (v11/*: any*/),
+        "artist.related.artists.edges.node.counts.artworks": (v32/*: any*/),
+        "artist.related.artists.edges.node.counts.forSaleArtworks": (v32/*: any*/),
+        "artist.related.artists.edges.node.href": (v20/*: any*/),
+        "artist.related.artists.edges.node.id": (v19/*: any*/),
+        "artist.related.artists.edges.node.image": (v21/*: any*/),
+        "artist.related.artists.edges.node.image.url": (v20/*: any*/),
+        "artist.related.artists.edges.node.name": (v20/*: any*/),
+        "artist.slug": (v19/*: any*/),
         "artist.targetSupply": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtistTargetSupply"
         },
-        "artist.targetSupply.isInMicrofunnel": (v17/*: any*/),
-        "artist.targetSupply.isTargetSupply": (v17/*: any*/),
-        "artist.upcomingShows": (v14/*: any*/),
-        "artist.upcomingShows.edges": (v15/*: any*/),
-        "artist.upcomingShows.edges.node": (v16/*: any*/),
-        "artist.upcomingShows.edges.node.cover_image": (v13/*: any*/),
-        "artist.upcomingShows.edges.node.cover_image.url": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.exhibition_period": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.href": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.id": (v11/*: any*/),
-        "artist.upcomingShows.edges.node.is_fair_booth": (v17/*: any*/),
-        "artist.upcomingShows.edges.node.kind": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.location": (v18/*: any*/),
-        "artist.upcomingShows.edges.node.location.city": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.location.id": (v11/*: any*/),
-        "artist.upcomingShows.edges.node.name": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.partner": (v19/*: any*/),
-        "artist.upcomingShows.edges.node.partner.__isNode": (v20/*: any*/),
-        "artist.upcomingShows.edges.node.partner.__typename": (v20/*: any*/),
-        "artist.upcomingShows.edges.node.partner.id": (v11/*: any*/),
-        "artist.upcomingShows.edges.node.partner.name": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.slug": (v11/*: any*/),
-        "artist.upcomingShows.edges.node.status": (v12/*: any*/),
-        "artist.upcomingShows.edges.node.status_update": (v12/*: any*/)
+        "artist.targetSupply.isInMicrofunnel": (v26/*: any*/),
+        "artist.targetSupply.isTargetSupply": (v26/*: any*/),
+        "artist.upcomingShows": (v23/*: any*/),
+        "artist.upcomingShows.edges": (v24/*: any*/),
+        "artist.upcomingShows.edges.node": (v25/*: any*/),
+        "artist.upcomingShows.edges.node.cover_image": (v21/*: any*/),
+        "artist.upcomingShows.edges.node.cover_image.url": (v20/*: any*/),
+        "artist.upcomingShows.edges.node.exhibition_period": (v20/*: any*/),
+        "artist.upcomingShows.edges.node.href": (v20/*: any*/),
+        "artist.upcomingShows.edges.node.id": (v19/*: any*/),
+        "artist.upcomingShows.edges.node.is_fair_booth": (v26/*: any*/),
+        "artist.upcomingShows.edges.node.kind": (v20/*: any*/),
+        "artist.upcomingShows.edges.node.location": (v27/*: any*/),
+        "artist.upcomingShows.edges.node.location.city": (v20/*: any*/),
+        "artist.upcomingShows.edges.node.location.id": (v19/*: any*/),
+        "artist.upcomingShows.edges.node.name": (v20/*: any*/),
+        "artist.upcomingShows.edges.node.partner": (v28/*: any*/),
+        "artist.upcomingShows.edges.node.partner.__isNode": (v22/*: any*/),
+        "artist.upcomingShows.edges.node.partner.__typename": (v22/*: any*/),
+        "artist.upcomingShows.edges.node.partner.id": (v19/*: any*/),
+        "artist.upcomingShows.edges.node.partner.name": (v20/*: any*/),
+        "artist.upcomingShows.edges.node.slug": (v19/*: any*/),
+        "artist.upcomingShows.edges.node.status": (v20/*: any*/),
+        "artist.upcomingShows.edges.node.status_update": (v20/*: any*/)
       }
     },
     "name": "ArtistAboutTestsQuery",

--- a/src/__generated__/ArtistAbout_artist.graphql.ts
+++ b/src/__generated__/ArtistAbout_artist.graphql.ts
@@ -6,7 +6,18 @@ import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type ArtistAbout_artist = {
     readonly hasMetadata: boolean | null;
+    readonly internalID: string;
     readonly slug: string;
+    readonly notableWorks: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly id: string;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly iconicCollections: ReadonlyArray<{
+        readonly " $fragmentRefs": FragmentRefs<"ArtistCollectionsRail_collections">;
+    } | null> | null;
     readonly related: {
         readonly artists: {
             readonly edges: ReadonlyArray<{
@@ -23,7 +34,7 @@ export type ArtistAbout_artist = {
             } | null;
         } | null> | null;
     } | null;
-    readonly " $fragmentRefs": FragmentRefs<"Biography_artist" | "ArtistConsignButton_artist" | "ArtistAboutShows_artist">;
+    readonly " $fragmentRefs": FragmentRefs<"Biography_artist" | "ArtistSeriesMoreSeries_artist" | "ArtistNotableWorksRail_artist" | "ArtistCollectionsRail_artist" | "ArtistConsignButton_artist" | "ArtistAboutShows_artist">;
     readonly " $refType": "ArtistAbout_artist";
 };
 export type ArtistAbout_artist$data = ArtistAbout_artist;
@@ -51,8 +62,93 @@ const node: ReaderFragment = {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
       "name": "slug",
       "storageKey": null
+    },
+    {
+      "alias": "notableWorks",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 3
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "-weighted_iconicity"
+        }
+      ],
+      "concreteType": "FilterArtworksConnection",
+      "kind": "LinkedField",
+      "name": "filterArtworksConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "FilterArtworksEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Artwork",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "id",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "filterArtworksConnection(first:3,sort:\"-weighted_iconicity\")"
+    },
+    {
+      "alias": "iconicCollections",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "isFeaturedArtistContent",
+          "value": true
+        },
+        {
+          "kind": "Literal",
+          "name": "size",
+          "value": 16
+        }
+      ],
+      "concreteType": "MarketingCollection",
+      "kind": "LinkedField",
+      "name": "marketingCollections",
+      "plural": true,
+      "selections": [
+        {
+          "args": null,
+          "kind": "FragmentSpread",
+          "name": "ArtistCollectionsRail_collections"
+        }
+      ],
+      "storageKey": "marketingCollections(isFeaturedArtistContent:true,size:16)"
     },
     {
       "alias": null,
@@ -166,6 +262,21 @@ const node: ReaderFragment = {
     {
       "args": null,
       "kind": "FragmentSpread",
+      "name": "ArtistSeriesMoreSeries_artist"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "ArtistNotableWorksRail_artist"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "ArtistCollectionsRail_artist"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
       "name": "ArtistConsignButton_artist"
     },
     {
@@ -177,5 +288,5 @@ const node: ReaderFragment = {
   "type": "Artist",
   "abstractKey": null
 };
-(node as any).hash = 'd3b7e4e4a3137cf53904b9efcb60c492';
+(node as any).hash = 'b90ade61430985fc3d4e157ac87167c8';
 export default node;

--- a/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash f2ad6c3651d33cc7a2814eeb2e27d87c */
+/* @relayHash ed9718c23f63d321712f8b4f1cf449b1 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -82,45 +82,6 @@ fragment ArtistArtworks_artist on Artist {
     }
     id
   }
-  ...ArtistCollectionsRail_artist
-  iconicCollections: marketingCollections(isFeaturedArtistContent: true, size: 16) {
-    ...ArtistCollectionsRail_collections
-    id
-  }
-  ...ArtistNotableWorksRail_artist
-  ...ArtistSeriesMoreSeries_artist
-  notableWorks: filterArtworksConnection(sort: "-weighted_iconicity", first: 3) {
-    edges {
-      node {
-        id
-      }
-    }
-    id
-  }
-}
-
-fragment ArtistCollectionsRail_artist on Artist {
-  internalID
-  slug
-}
-
-fragment ArtistCollectionsRail_collections on MarketingCollection {
-  slug
-  id
-  title
-  priceGuidance
-  artworksConnection(first: 3, aggregations: [TOTAL], sort: "-decayed_merch") {
-    edges {
-      node {
-        title
-        image {
-          url
-        }
-        id
-      }
-    }
-    id
-  }
 }
 
 fragment ArtistHeader_artist on Artist {
@@ -134,61 +95,6 @@ fragment ArtistHeader_artist on Artist {
   counts {
     artworks
     follows
-  }
-}
-
-fragment ArtistNotableWorksRail_artist on Artist {
-  internalID
-  slug
-  filterArtworksConnection(sort: "-weighted_iconicity", first: 10) {
-    edges {
-      node {
-        id
-        image {
-          imageURL
-          aspectRatio
-        }
-        saleMessage
-        saleArtwork {
-          openingBid {
-            display
-          }
-          highestBid {
-            display
-          }
-          id
-        }
-        sale {
-          isClosed
-          isAuction
-          id
-        }
-        title
-        internalID
-        slug
-      }
-    }
-    id
-  }
-}
-
-fragment ArtistSeriesMoreSeries_artist on Artist {
-  internalID
-  slug
-  artistSeriesConnection(first: 4) {
-    totalCount
-    edges {
-      node {
-        slug
-        internalID
-        title
-        featured
-        artworksCountMessage
-        image {
-          url
-        }
-      }
-    }
   }
 }
 
@@ -319,47 +225,36 @@ v8 = {
 v9 = {
   "alias": null,
   "args": null,
-  "kind": "ScalarField",
-  "name": "totalCount",
-  "storageKey": null
-},
-v10 = {
-  "alias": null,
-  "args": null,
   "concreteType": "AuctionResultConnection",
   "kind": "LinkedField",
   "name": "auctionResultsConnection",
   "plural": false,
   "selections": [
-    (v9/*: any*/)
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "totalCount",
+      "storageKey": null
+    }
   ],
   "storageKey": null
 },
-v11 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v12 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v13 = {
-  "kind": "Literal",
-  "name": "first",
-  "value": 10
-},
-v14 = {
-  "kind": "Literal",
-  "name": "sort",
-  "value": "-decayed_merch"
-},
-v15 = [
+v12 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -377,90 +272,23 @@ v15 = [
     "name": "dimensionRange",
     "value": "*-*"
   },
-  (v13/*: any*/),
-  (v14/*: any*/)
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  },
+  {
+    "kind": "Literal",
+    "name": "sort",
+    "value": "-decayed_merch"
+  }
 ],
-v16 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
-},
-v17 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "aspectRatio",
-  "storageKey": null
-},
-v18 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "title",
-  "storageKey": null
-},
-v19 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "saleMessage",
-  "storageKey": null
-},
-v20 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "isAuction",
-  "storageKey": null
-},
-v21 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "isClosed",
-  "storageKey": null
-},
-v22 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "display",
-    "storageKey": null
-  }
-],
-v23 = [
-  (v11/*: any*/)
-],
-v24 = {
-  "kind": "Literal",
-  "name": "first",
-  "value": 3
-},
-v25 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "Image",
-  "kind": "LinkedField",
-  "name": "image",
-  "plural": false,
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "url",
-      "storageKey": null
-    }
-  ],
-  "storageKey": null
-},
-v26 = {
-  "kind": "Literal",
-  "name": "sort",
-  "value": "-weighted_iconicity"
 };
 return {
   "fragment": {
@@ -495,7 +323,7 @@ return {
             ],
             "storageKey": null
           },
-          (v10/*: any*/),
+          (v9/*: any*/),
           {
             "args": null,
             "kind": "FragmentSpread",
@@ -552,7 +380,7 @@ return {
             ],
             "storageKey": null
           },
-          (v11/*: any*/),
+          (v10/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -560,7 +388,7 @@ return {
             "name": "isFollowed",
             "storageKey": null
           },
-          (v12/*: any*/),
+          (v11/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -577,7 +405,7 @@ return {
           },
           {
             "alias": "artworks",
-            "args": (v15/*: any*/),
+            "args": (v12/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -613,7 +441,7 @@ return {
                         "name": "count",
                         "storageKey": null
                       },
-                      (v12/*: any*/),
+                      (v11/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -643,8 +471,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v11/*: any*/),
-                      (v16/*: any*/)
+                      (v10/*: any*/),
+                      (v13/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -683,7 +511,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v11/*: any*/),
+              (v10/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -713,7 +541,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v16/*: any*/),
+                      (v13/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -731,7 +559,13 @@ return {
                             "name": "image",
                             "plural": false,
                             "selections": [
-                              (v17/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "aspectRatio",
+                                "storageKey": null
+                              },
                               {
                                 "alias": null,
                                 "args": [
@@ -748,7 +582,13 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v18/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "title",
+                            "storageKey": null
+                          },
                           {
                             "alias": null,
                             "args": null,
@@ -756,7 +596,13 @@ return {
                             "name": "date",
                             "storageKey": null
                           },
-                          (v19/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "saleMessage",
+                            "storageKey": null
+                          },
                           (v2/*: any*/),
                           {
                             "alias": null,
@@ -780,8 +626,20 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v20/*: any*/),
-                              (v21/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isAuction",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isClosed",
+                                "storageKey": null
+                              },
                               {
                                 "alias": null,
                                 "args": null,
@@ -796,7 +654,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v11/*: any*/)
+                              (v10/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -833,7 +691,15 @@ return {
                                 "kind": "LinkedField",
                                 "name": "currentBid",
                                 "plural": false,
-                                "selections": (v22/*: any*/),
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "display",
+                                    "storageKey": null
+                                  }
+                                ],
                                 "storageKey": null
                               },
                               {
@@ -843,7 +709,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v11/*: any*/)
+                              (v10/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -855,8 +721,8 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v12/*: any*/),
-                              (v11/*: any*/)
+                              (v11/*: any*/),
+                              (v10/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -865,7 +731,9 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v23/*: any*/),
+                        "selections": [
+                          (v10/*: any*/)
+                        ],
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -881,7 +749,7 @@ return {
           },
           {
             "alias": "artworks",
-            "args": (v15/*: any*/),
+            "args": (v12/*: any*/),
             "filters": [
               "sort",
               "additionalGeneIDs",
@@ -904,294 +772,14 @@ return {
             "kind": "LinkedHandle",
             "name": "filterArtworksConnection"
           },
-          {
-            "alias": "iconicCollections",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "isFeaturedArtistContent",
-                "value": true
-              },
-              {
-                "kind": "Literal",
-                "name": "size",
-                "value": 16
-              }
-            ],
-            "concreteType": "MarketingCollection",
-            "kind": "LinkedField",
-            "name": "marketingCollections",
-            "plural": true,
-            "selections": [
-              (v3/*: any*/),
-              (v11/*: any*/),
-              (v18/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "priceGuidance",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "aggregations",
-                    "value": [
-                      "TOTAL"
-                    ]
-                  },
-                  (v24/*: any*/),
-                  (v14/*: any*/)
-                ],
-                "concreteType": "FilterArtworksConnection",
-                "kind": "LinkedField",
-                "name": "artworksConnection",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "FilterArtworksEdge",
-                    "kind": "LinkedField",
-                    "name": "edges",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Artwork",
-                        "kind": "LinkedField",
-                        "name": "node",
-                        "plural": false,
-                        "selections": [
-                          (v18/*: any*/),
-                          (v25/*: any*/),
-                          (v11/*: any*/)
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  (v11/*: any*/)
-                ],
-                "storageKey": "artworksConnection(aggregations:[\"TOTAL\"],first:3,sort:\"-decayed_merch\")"
-              }
-            ],
-            "storageKey": "marketingCollections(isFeaturedArtistContent:true,size:16)"
-          },
-          {
-            "alias": null,
-            "args": [
-              (v13/*: any*/),
-              (v26/*: any*/)
-            ],
-            "concreteType": "FilterArtworksConnection",
-            "kind": "LinkedField",
-            "name": "filterArtworksConnection",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "FilterArtworksEdge",
-                "kind": "LinkedField",
-                "name": "edges",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Artwork",
-                    "kind": "LinkedField",
-                    "name": "node",
-                    "plural": false,
-                    "selections": [
-                      (v11/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "imageURL",
-                            "storageKey": null
-                          },
-                          (v17/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      (v19/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "SaleArtwork",
-                        "kind": "LinkedField",
-                        "name": "saleArtwork",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "SaleArtworkOpeningBid",
-                            "kind": "LinkedField",
-                            "name": "openingBid",
-                            "plural": false,
-                            "selections": (v22/*: any*/),
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "SaleArtworkHighestBid",
-                            "kind": "LinkedField",
-                            "name": "highestBid",
-                            "plural": false,
-                            "selections": (v22/*: any*/),
-                            "storageKey": null
-                          },
-                          (v11/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Sale",
-                        "kind": "LinkedField",
-                        "name": "sale",
-                        "plural": false,
-                        "selections": [
-                          (v21/*: any*/),
-                          (v20/*: any*/),
-                          (v11/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      (v18/*: any*/),
-                      (v2/*: any*/),
-                      (v3/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              (v11/*: any*/)
-            ],
-            "storageKey": "filterArtworksConnection(first:10,sort:\"-weighted_iconicity\")"
-          },
-          {
-            "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 4
-              }
-            ],
-            "concreteType": "ArtistSeriesConnection",
-            "kind": "LinkedField",
-            "name": "artistSeriesConnection",
-            "plural": false,
-            "selections": [
-              (v9/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "ArtistSeriesEdge",
-                "kind": "LinkedField",
-                "name": "edges",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "ArtistSeries",
-                    "kind": "LinkedField",
-                    "name": "node",
-                    "plural": false,
-                    "selections": [
-                      (v3/*: any*/),
-                      (v2/*: any*/),
-                      (v18/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "featured",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "artworksCountMessage",
-                        "storageKey": null
-                      },
-                      (v25/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              }
-            ],
-            "storageKey": "artistSeriesConnection(first:4)"
-          },
-          {
-            "alias": "notableWorks",
-            "args": [
-              (v24/*: any*/),
-              (v26/*: any*/)
-            ],
-            "concreteType": "FilterArtworksConnection",
-            "kind": "LinkedField",
-            "name": "filterArtworksConnection",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "FilterArtworksEdge",
-                "kind": "LinkedField",
-                "name": "edges",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Artwork",
-                    "kind": "LinkedField",
-                    "name": "node",
-                    "plural": false,
-                    "selections": (v23/*: any*/),
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              (v11/*: any*/)
-            ],
-            "storageKey": "filterArtworksConnection(first:3,sort:\"-weighted_iconicity\")"
-          },
-          (v10/*: any*/)
+          (v9/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "f2ad6c3651d33cc7a2814eeb2e27d87c",
+    "id": "ed9718c23f63d321712f8b4f1cf449b1",
     "metadata": {},
     "name": "ArtistAboveTheFoldQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistArtworksQuery.graphql.ts
+++ b/src/__generated__/ArtistArtworksQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 763e126746a52dc6378f103965c1a69d */
+/* @relayHash 5d6ec84c120e84c08901ae960f617659 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -91,100 +91,6 @@ fragment ArtistArtworks_artist_1qqVY9 on Artist {
       hasNextPage
     }
     id
-  }
-  ...ArtistCollectionsRail_artist
-  iconicCollections: marketingCollections(isFeaturedArtistContent: true, size: 16) {
-    ...ArtistCollectionsRail_collections
-    id
-  }
-  ...ArtistNotableWorksRail_artist
-  ...ArtistSeriesMoreSeries_artist
-  notableWorks: filterArtworksConnection(sort: "-weighted_iconicity", first: 3) {
-    edges {
-      node {
-        id
-      }
-    }
-    id
-  }
-}
-
-fragment ArtistCollectionsRail_artist on Artist {
-  internalID
-  slug
-}
-
-fragment ArtistCollectionsRail_collections on MarketingCollection {
-  slug
-  id
-  title
-  priceGuidance
-  artworksConnection(first: 3, aggregations: [TOTAL], sort: "-decayed_merch") {
-    edges {
-      node {
-        title
-        image {
-          url
-        }
-        id
-      }
-    }
-    id
-  }
-}
-
-fragment ArtistNotableWorksRail_artist on Artist {
-  internalID
-  slug
-  filterArtworksConnection(sort: "-weighted_iconicity", first: 10) {
-    edges {
-      node {
-        id
-        image {
-          imageURL
-          aspectRatio
-        }
-        saleMessage
-        saleArtwork {
-          openingBid {
-            display
-          }
-          highestBid {
-            display
-          }
-          id
-        }
-        sale {
-          isClosed
-          isAuction
-          id
-        }
-        title
-        internalID
-        slug
-      }
-    }
-    id
-  }
-}
-
-fragment ArtistSeriesMoreSeries_artist on Artist {
-  internalID
-  slug
-  artistSeriesConnection(first: 4) {
-    totalCount
-    edges {
-      node {
-        slug
-        internalID
-        title
-        featured
-        artworksCountMessage
-        image {
-          url
-        }
-      }
-    }
   }
 }
 
@@ -483,81 +389,6 @@ v37 = {
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
-},
-v38 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "aspectRatio",
-  "storageKey": null
-},
-v39 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "title",
-  "storageKey": null
-},
-v40 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "saleMessage",
-  "storageKey": null
-},
-v41 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "isAuction",
-  "storageKey": null
-},
-v42 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "isClosed",
-  "storageKey": null
-},
-v43 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "display",
-    "storageKey": null
-  }
-],
-v44 = [
-  (v33/*: any*/)
-],
-v45 = {
-  "kind": "Literal",
-  "name": "first",
-  "value": 3
-},
-v46 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "Image",
-  "kind": "LinkedField",
-  "name": "image",
-  "plural": false,
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "url",
-      "storageKey": null
-    }
-  ],
-  "storageKey": null
-},
-v47 = {
-  "kind": "Literal",
-  "name": "sort",
-  "value": "-weighted_iconicity"
 };
 return {
   "fragment": {
@@ -831,7 +662,13 @@ return {
                                 "name": "image",
                                 "plural": false,
                                 "selections": [
-                                  (v38/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "aspectRatio",
+                                    "storageKey": null
+                                  },
                                   {
                                     "alias": null,
                                     "args": [
@@ -848,7 +685,13 @@ return {
                                 ],
                                 "storageKey": null
                               },
-                              (v39/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "title",
+                                "storageKey": null
+                              },
                               {
                                 "alias": null,
                                 "args": null,
@@ -856,7 +699,13 @@ return {
                                 "name": "date",
                                 "storageKey": null
                               },
-                              (v40/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "saleMessage",
+                                "storageKey": null
+                              },
                               (v35/*: any*/),
                               {
                                 "alias": null,
@@ -880,8 +729,20 @@ return {
                                 "name": "sale",
                                 "plural": false,
                                 "selections": [
-                                  (v41/*: any*/),
-                                  (v42/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isAuction",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isClosed",
+                                    "storageKey": null
+                                  },
                                   {
                                     "alias": null,
                                     "args": null,
@@ -933,7 +794,15 @@ return {
                                     "kind": "LinkedField",
                                     "name": "currentBid",
                                     "plural": false,
-                                    "selections": (v43/*: any*/),
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "display",
+                                        "storageKey": null
+                                      }
+                                    ],
                                     "storageKey": null
                                   },
                                   {
@@ -965,7 +834,9 @@ return {
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v44/*: any*/),
+                            "selections": [
+                              (v33/*: any*/)
+                            ],
                             "type": "Node",
                             "abstractKey": "__isNode"
                           }
@@ -1003,300 +874,6 @@ return {
                 "key": "ArtistArtworksGrid_artworks",
                 "kind": "LinkedHandle",
                 "name": "filterArtworksConnection"
-              },
-              {
-                "alias": "iconicCollections",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "isFeaturedArtistContent",
-                    "value": true
-                  },
-                  {
-                    "kind": "Literal",
-                    "name": "size",
-                    "value": 16
-                  }
-                ],
-                "concreteType": "MarketingCollection",
-                "kind": "LinkedField",
-                "name": "marketingCollections",
-                "plural": true,
-                "selections": [
-                  (v34/*: any*/),
-                  (v33/*: any*/),
-                  (v39/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "priceGuidance",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": [
-                      {
-                        "kind": "Literal",
-                        "name": "aggregations",
-                        "value": [
-                          "TOTAL"
-                        ]
-                      },
-                      (v45/*: any*/),
-                      {
-                        "kind": "Literal",
-                        "name": "sort",
-                        "value": "-decayed_merch"
-                      }
-                    ],
-                    "concreteType": "FilterArtworksConnection",
-                    "kind": "LinkedField",
-                    "name": "artworksConnection",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "FilterArtworksEdge",
-                        "kind": "LinkedField",
-                        "name": "edges",
-                        "plural": true,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "Artwork",
-                            "kind": "LinkedField",
-                            "name": "node",
-                            "plural": false,
-                            "selections": [
-                              (v39/*: any*/),
-                              (v46/*: any*/),
-                              (v33/*: any*/)
-                            ],
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v33/*: any*/)
-                    ],
-                    "storageKey": "artworksConnection(aggregations:[\"TOTAL\"],first:3,sort:\"-decayed_merch\")"
-                  }
-                ],
-                "storageKey": "marketingCollections(isFeaturedArtistContent:true,size:16)"
-              },
-              {
-                "alias": null,
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "first",
-                    "value": 10
-                  },
-                  (v47/*: any*/)
-                ],
-                "concreteType": "FilterArtworksConnection",
-                "kind": "LinkedField",
-                "name": "filterArtworksConnection",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "FilterArtworksEdge",
-                    "kind": "LinkedField",
-                    "name": "edges",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Artwork",
-                        "kind": "LinkedField",
-                        "name": "node",
-                        "plural": false,
-                        "selections": [
-                          (v33/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "Image",
-                            "kind": "LinkedField",
-                            "name": "image",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "imageURL",
-                                "storageKey": null
-                              },
-                              (v38/*: any*/)
-                            ],
-                            "storageKey": null
-                          },
-                          (v40/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "SaleArtwork",
-                            "kind": "LinkedField",
-                            "name": "saleArtwork",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "SaleArtworkOpeningBid",
-                                "kind": "LinkedField",
-                                "name": "openingBid",
-                                "plural": false,
-                                "selections": (v43/*: any*/),
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "SaleArtworkHighestBid",
-                                "kind": "LinkedField",
-                                "name": "highestBid",
-                                "plural": false,
-                                "selections": (v43/*: any*/),
-                                "storageKey": null
-                              },
-                              (v33/*: any*/)
-                            ],
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "Sale",
-                            "kind": "LinkedField",
-                            "name": "sale",
-                            "plural": false,
-                            "selections": [
-                              (v42/*: any*/),
-                              (v41/*: any*/),
-                              (v33/*: any*/)
-                            ],
-                            "storageKey": null
-                          },
-                          (v39/*: any*/),
-                          (v35/*: any*/),
-                          (v34/*: any*/)
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  (v33/*: any*/)
-                ],
-                "storageKey": "filterArtworksConnection(first:10,sort:\"-weighted_iconicity\")"
-              },
-              {
-                "alias": null,
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "first",
-                    "value": 4
-                  }
-                ],
-                "concreteType": "ArtistSeriesConnection",
-                "kind": "LinkedField",
-                "name": "artistSeriesConnection",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "totalCount",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "ArtistSeriesEdge",
-                    "kind": "LinkedField",
-                    "name": "edges",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "ArtistSeries",
-                        "kind": "LinkedField",
-                        "name": "node",
-                        "plural": false,
-                        "selections": [
-                          (v34/*: any*/),
-                          (v35/*: any*/),
-                          (v39/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "featured",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "artworksCountMessage",
-                            "storageKey": null
-                          },
-                          (v46/*: any*/)
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": "artistSeriesConnection(first:4)"
-              },
-              {
-                "alias": "notableWorks",
-                "args": [
-                  (v45/*: any*/),
-                  (v47/*: any*/)
-                ],
-                "concreteType": "FilterArtworksConnection",
-                "kind": "LinkedField",
-                "name": "filterArtworksConnection",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "FilterArtworksEdge",
-                    "kind": "LinkedField",
-                    "name": "edges",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Artwork",
-                        "kind": "LinkedField",
-                        "name": "node",
-                        "plural": false,
-                        "selections": (v44/*: any*/),
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  (v33/*: any*/)
-                ],
-                "storageKey": "filterArtworksConnection(first:3,sort:\"-weighted_iconicity\")"
               }
             ],
             "type": "Artist",
@@ -1308,7 +885,7 @@ return {
     ]
   },
   "params": {
-    "id": "763e126746a52dc6378f103965c1a69d",
+    "id": "5d6ec84c120e84c08901ae960f617659",
     "metadata": {},
     "name": "ArtistArtworksQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistArtworks_artist.graphql.ts
+++ b/src/__generated__/ArtistArtworks_artist.graphql.ts
@@ -25,17 +25,6 @@ export type ArtistArtworks_artist = {
         } | null> | null;
         readonly " $fragmentRefs": FragmentRefs<"InfiniteScrollArtworksGrid_connection">;
     } | null;
-    readonly iconicCollections: ReadonlyArray<{
-        readonly " $fragmentRefs": FragmentRefs<"ArtistCollectionsRail_collections">;
-    } | null> | null;
-    readonly notableWorks: {
-        readonly edges: ReadonlyArray<{
-            readonly node: {
-                readonly id: string;
-            } | null;
-        } | null> | null;
-    } | null;
-    readonly " $fragmentRefs": FragmentRefs<"ArtistCollectionsRail_artist" | "ArtistNotableWorksRail_artist" | "ArtistSeriesMoreSeries_artist">;
     readonly " $refType": "ArtistArtworks_artist";
 };
 export type ArtistArtworks_artist$data = ArtistArtworks_artist;
@@ -377,98 +366,11 @@ return {
         }
       ],
       "storageKey": null
-    },
-    {
-      "alias": "iconicCollections",
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "isFeaturedArtistContent",
-          "value": true
-        },
-        {
-          "kind": "Literal",
-          "name": "size",
-          "value": 16
-        }
-      ],
-      "concreteType": "MarketingCollection",
-      "kind": "LinkedField",
-      "name": "marketingCollections",
-      "plural": true,
-      "selections": [
-        {
-          "args": null,
-          "kind": "FragmentSpread",
-          "name": "ArtistCollectionsRail_collections"
-        }
-      ],
-      "storageKey": "marketingCollections(isFeaturedArtistContent:true,size:16)"
-    },
-    {
-      "alias": "notableWorks",
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "first",
-          "value": 3
-        },
-        {
-          "kind": "Literal",
-          "name": "sort",
-          "value": "-weighted_iconicity"
-        }
-      ],
-      "concreteType": "FilterArtworksConnection",
-      "kind": "LinkedField",
-      "name": "filterArtworksConnection",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "FilterArtworksEdge",
-          "kind": "LinkedField",
-          "name": "edges",
-          "plural": true,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "concreteType": "Artwork",
-              "kind": "LinkedField",
-              "name": "node",
-              "plural": false,
-              "selections": [
-                (v0/*: any*/)
-              ],
-              "storageKey": null
-            }
-          ],
-          "storageKey": null
-        }
-      ],
-      "storageKey": "filterArtworksConnection(first:3,sort:\"-weighted_iconicity\")"
-    },
-    {
-      "args": null,
-      "kind": "FragmentSpread",
-      "name": "ArtistCollectionsRail_artist"
-    },
-    {
-      "args": null,
-      "kind": "FragmentSpread",
-      "name": "ArtistNotableWorksRail_artist"
-    },
-    {
-      "args": null,
-      "kind": "FragmentSpread",
-      "name": "ArtistSeriesMoreSeries_artist"
     }
   ],
   "type": "Artist",
   "abstractKey": null
 };
 })();
-(node as any).hash = '262484ed0c4e5645ad1087a2c7c91d03';
+(node as any).hash = 'fb68935c4b08f9db352db34e64d5ba35';
 export default node;

--- a/src/__generated__/ArtistBelowTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtistBelowTheFoldQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash d8b1ed776483ef39f65eda97f4c8d293 */
+/* @relayHash 5e8d852a3526af22fc87bce04145e7aa */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -82,8 +82,24 @@ fragment ArtistAboutShows_artist on Artist {
 
 fragment ArtistAbout_artist on Artist {
   hasMetadata
+  internalID
   slug
   ...Biography_artist
+  ...ArtistSeriesMoreSeries_artist
+  ...ArtistNotableWorksRail_artist
+  notableWorks: filterArtworksConnection(sort: "-weighted_iconicity", first: 3) {
+    edges {
+      node {
+        id
+      }
+    }
+    id
+  }
+  ...ArtistCollectionsRail_artist
+  iconicCollections: marketingCollections(isFeaturedArtistContent: true, size: 16) {
+    ...ArtistCollectionsRail_collections
+    id
+  }
   ...ArtistConsignButton_artist
   ...ArtistAboutShows_artist
   related {
@@ -103,6 +119,30 @@ fragment ArtistAbout_artist on Artist {
         id
       }
     }
+  }
+}
+
+fragment ArtistCollectionsRail_artist on Artist {
+  internalID
+  slug
+}
+
+fragment ArtistCollectionsRail_collections on MarketingCollection {
+  slug
+  id
+  title
+  priceGuidance
+  artworksConnection(first: 3, aggregations: [TOTAL], sort: "-decayed_merch") {
+    edges {
+      node {
+        title
+        image {
+          url
+        }
+        id
+      }
+    }
+    id
   }
 }
 
@@ -154,6 +194,61 @@ fragment ArtistInsights_artist on Artist {
   internalID
   slug
   ...ArtistInsightsAuctionResults_artist
+}
+
+fragment ArtistNotableWorksRail_artist on Artist {
+  internalID
+  slug
+  filterArtworksConnection(sort: "-weighted_iconicity", first: 10) {
+    edges {
+      node {
+        id
+        image {
+          imageURL
+          aspectRatio
+        }
+        saleMessage
+        saleArtwork {
+          openingBid {
+            display
+          }
+          highestBid {
+            display
+          }
+          id
+        }
+        sale {
+          isClosed
+          isAuction
+          id
+        }
+        title
+        internalID
+        slug
+      }
+    }
+    id
+  }
+}
+
+fragment ArtistSeriesMoreSeries_artist on Artist {
+  internalID
+  slug
+  artistSeriesConnection(first: 4) {
+    totalCount
+    edges {
+      node {
+        slug
+        internalID
+        title
+        featured
+        artworksCountMessage
+        image {
+          url
+        }
+      }
+    }
+  }
 }
 
 fragment ArtistShow_show on Show {
@@ -314,43 +409,106 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "slug",
+  "name": "internalID",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "internalID",
+  "name": "slug",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "totalCount",
   "storageKey": null
 },
 v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "title",
+  "storageKey": null
+},
+v6 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "url",
+    "storageKey": null
+  }
+],
+v7 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Image",
+  "kind": "LinkedField",
+  "name": "image",
+  "plural": false,
+  "selections": (v6/*: any*/),
+  "storageKey": null
+},
+v8 = {
   "kind": "Literal",
   "name": "first",
   "value": 10
 },
-v6 = {
+v9 = {
+  "kind": "Literal",
+  "name": "sort",
+  "value": "-weighted_iconicity"
+},
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "aspectRatio",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "display",
+  "storageKey": null
+},
+v13 = [
+  (v12/*: any*/)
+],
+v14 = {
+  "kind": "Literal",
+  "name": "first",
+  "value": 3
+},
+v15 = [
+  (v10/*: any*/)
+],
+v16 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v8 = [
+v18 = [
   {
     "alias": null,
     "args": [
@@ -365,18 +523,18 @@ v8 = [
     "storageKey": "url(version:\"large\")"
   }
 ],
-v9 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v10 = [
-  (v4/*: any*/),
-  (v6/*: any*/)
+v20 = [
+  (v16/*: any*/),
+  (v10/*: any*/)
 ],
-v11 = [
+v21 = [
   {
     "alias": null,
     "args": null,
@@ -393,9 +551,9 @@ v11 = [
         "name": "node",
         "plural": false,
         "selections": [
-          (v6/*: any*/),
-          (v2/*: any*/),
-          (v7/*: any*/),
+          (v10/*: any*/),
+          (v3/*: any*/),
+          (v17/*: any*/),
           {
             "alias": "is_fair_booth",
             "args": null,
@@ -410,7 +568,7 @@ v11 = [
             "kind": "LinkedField",
             "name": "coverImage",
             "plural": false,
-            "selections": (v8/*: any*/),
+            "selections": (v18/*: any*/),
             "storageKey": null
           },
           {
@@ -420,7 +578,7 @@ v11 = [
             "name": "kind",
             "storageKey": null
           },
-          (v4/*: any*/),
+          (v16/*: any*/),
           {
             "alias": "exhibition_period",
             "args": null,
@@ -450,26 +608,24 @@ v11 = [
             "name": "partner",
             "plural": false,
             "selections": [
-              (v9/*: any*/),
+              (v19/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v4/*: any*/)
+                  (v16/*: any*/)
                 ],
                 "type": "Partner",
                 "abstractKey": null
               },
               {
                 "kind": "InlineFragment",
-                "selections": (v10/*: any*/),
+                "selections": (v20/*: any*/),
                 "type": "ExternalPartner",
                 "abstractKey": null
               },
               {
                 "kind": "InlineFragment",
-                "selections": [
-                  (v6/*: any*/)
-                ],
+                "selections": (v15/*: any*/),
                 "type": "Node",
                 "abstractKey": "__isNode"
               }
@@ -491,7 +647,7 @@ v11 = [
                 "name": "city",
                 "storageKey": null
               },
-              (v6/*: any*/)
+              (v10/*: any*/)
             ],
             "storageKey": null
           }
@@ -502,12 +658,12 @@ v11 = [
     "storageKey": null
   }
 ],
-v12 = {
+v22 = {
   "kind": "Literal",
   "name": "status",
   "value": "closed"
 },
-v13 = [
+v23 = [
   {
     "kind": "Literal",
     "name": "allowEmptyCreatedDates",
@@ -518,7 +674,7 @@ v13 = [
     "name": "earliestCreatedYear",
     "value": 1000
   },
-  (v5/*: any*/),
+  (v8/*: any*/),
   {
     "kind": "Literal",
     "name": "latestCreatedYear",
@@ -530,13 +686,13 @@ v13 = [
     "value": "DATE_DESC"
   }
 ],
-v14 = [
+v24 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 20
   },
-  (v12/*: any*/)
+  (v22/*: any*/)
 ];
 return {
   "fragment": {
@@ -597,6 +753,7 @@ return {
             "storageKey": null
           },
           (v2/*: any*/),
+          (v3/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -610,6 +767,308 @@ return {
             "kind": "ScalarField",
             "name": "blurb",
             "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 4
+              }
+            ],
+            "concreteType": "ArtistSeriesConnection",
+            "kind": "LinkedField",
+            "name": "artistSeriesConnection",
+            "plural": false,
+            "selections": [
+              (v4/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ArtistSeriesEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ArtistSeries",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      (v2/*: any*/),
+                      (v5/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "featured",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "artworksCountMessage",
+                        "storageKey": null
+                      },
+                      (v7/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "artistSeriesConnection(first:4)"
+          },
+          {
+            "alias": null,
+            "args": [
+              (v8/*: any*/),
+              (v9/*: any*/)
+            ],
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v10/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "imageURL",
+                            "storageKey": null
+                          },
+                          (v11/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "saleMessage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "SaleArtwork",
+                        "kind": "LinkedField",
+                        "name": "saleArtwork",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkOpeningBid",
+                            "kind": "LinkedField",
+                            "name": "openingBid",
+                            "plural": false,
+                            "selections": (v13/*: any*/),
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "SaleArtworkHighestBid",
+                            "kind": "LinkedField",
+                            "name": "highestBid",
+                            "plural": false,
+                            "selections": (v13/*: any*/),
+                            "storageKey": null
+                          },
+                          (v10/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "kind": "LinkedField",
+                        "name": "sale",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isClosed",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isAuction",
+                            "storageKey": null
+                          },
+                          (v10/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v5/*: any*/),
+                      (v2/*: any*/),
+                      (v3/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v10/*: any*/)
+            ],
+            "storageKey": "filterArtworksConnection(first:10,sort:\"-weighted_iconicity\")"
+          },
+          {
+            "alias": "notableWorks",
+            "args": [
+              (v14/*: any*/),
+              (v9/*: any*/)
+            ],
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": (v15/*: any*/),
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v10/*: any*/)
+            ],
+            "storageKey": "filterArtworksConnection(first:3,sort:\"-weighted_iconicity\")"
+          },
+          {
+            "alias": "iconicCollections",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "isFeaturedArtistContent",
+                "value": true
+              },
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 16
+              }
+            ],
+            "concreteType": "MarketingCollection",
+            "kind": "LinkedField",
+            "name": "marketingCollections",
+            "plural": true,
+            "selections": [
+              (v3/*: any*/),
+              (v10/*: any*/),
+              (v5/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "priceGuidance",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "aggregations",
+                    "value": [
+                      "TOTAL"
+                    ]
+                  },
+                  (v14/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "sort",
+                    "value": "-decayed_merch"
+                  }
+                ],
+                "concreteType": "FilterArtworksConnection",
+                "kind": "LinkedField",
+                "name": "artworksConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "FilterArtworksEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artwork",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v5/*: any*/),
+                          (v7/*: any*/),
+                          (v10/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v10/*: any*/)
+                ],
+                "storageKey": "artworksConnection(aggregations:[\"TOTAL\"],first:3,sort:\"-decayed_merch\")"
+              }
+            ],
+            "storageKey": "marketingCollections(isFeaturedArtistContent:true,size:16)"
           },
           {
             "alias": null,
@@ -636,8 +1095,7 @@ return {
             ],
             "storageKey": null
           },
-          (v3/*: any*/),
-          (v4/*: any*/),
+          (v16/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -664,15 +1122,7 @@ return {
                 "kind": "LinkedField",
                 "name": "cropped",
                 "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "url",
-                    "storageKey": null
-                  }
-                ],
+                "selections": (v6/*: any*/),
                 "storageKey": "cropped(height:66,width:66)"
               }
             ],
@@ -681,7 +1131,7 @@ return {
           {
             "alias": "currentShows",
             "args": [
-              (v5/*: any*/),
+              (v8/*: any*/),
               {
                 "kind": "Literal",
                 "name": "status",
@@ -692,13 +1142,13 @@ return {
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
-            "selections": (v11/*: any*/),
+            "selections": (v21/*: any*/),
             "storageKey": "showsConnection(first:10,status:\"running\")"
           },
           {
             "alias": "upcomingShows",
             "args": [
-              (v5/*: any*/),
+              (v8/*: any*/),
               {
                 "kind": "Literal",
                 "name": "status",
@@ -709,24 +1159,20 @@ return {
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
-            "selections": (v11/*: any*/),
+            "selections": (v21/*: any*/),
             "storageKey": "showsConnection(first:10,status:\"upcoming\")"
           },
           {
             "alias": "pastShows",
             "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 3
-              },
-              (v12/*: any*/)
+              (v14/*: any*/),
+              (v22/*: any*/)
             ],
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
-            "selections": (v11/*: any*/),
+            "selections": (v21/*: any*/),
             "storageKey": "showsConnection(first:3,status:\"closed\")"
           },
           {
@@ -767,9 +1213,9 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v6/*: any*/),
-                          (v7/*: any*/),
-                          (v4/*: any*/),
+                          (v10/*: any*/),
+                          (v17/*: any*/),
+                          (v16/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -802,7 +1248,7 @@ return {
                             "kind": "LinkedField",
                             "name": "image",
                             "plural": false,
-                            "selections": (v8/*: any*/),
+                            "selections": (v18/*: any*/),
                             "storageKey": null
                           }
                         ],
@@ -820,7 +1266,7 @@ return {
           {
             "alias": "articles",
             "args": [
-              (v5/*: any*/),
+              (v8/*: any*/),
               {
                 "kind": "Literal",
                 "name": "inEditorialFeed",
@@ -848,7 +1294,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
+                      (v10/*: any*/),
                       {
                         "alias": "thumbnail_title",
                         "args": null,
@@ -856,7 +1302,7 @@ return {
                         "name": "thumbnailTitle",
                         "storageKey": null
                       },
-                      (v7/*: any*/),
+                      (v17/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -864,7 +1310,7 @@ return {
                         "kind": "LinkedField",
                         "name": "author",
                         "plural": false,
-                        "selections": (v10/*: any*/),
+                        "selections": (v20/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -874,7 +1320,7 @@ return {
                         "kind": "LinkedField",
                         "name": "thumbnailImage",
                         "plural": false,
-                        "selections": (v8/*: any*/),
+                        "selections": (v18/*: any*/),
                         "storageKey": null
                       }
                     ],
@@ -886,7 +1332,7 @@ return {
             ],
             "storageKey": "articlesConnection(first:10,inEditorialFeed:true)"
           },
-          (v6/*: any*/),
+          (v10/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -896,7 +1342,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v13/*: any*/),
+            "args": (v23/*: any*/),
             "concreteType": "AuctionResultConnection",
             "kind": "LinkedField",
             "name": "auctionResultsConnection",
@@ -927,13 +1373,7 @@ return {
                 ],
                 "storageKey": null
               },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "totalCount",
-                "storageKey": null
-              },
+              (v4/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -950,8 +1390,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
-                      (v3/*: any*/),
+                      (v10/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1009,13 +1449,7 @@ return {
                                 "name": "width",
                                 "storageKey": null
                               },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "aspectRatio",
-                                "storageKey": null
-                              }
+                              (v11/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -1087,13 +1521,7 @@ return {
                         "name": "priceRealized",
                         "plural": false,
                         "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "display",
-                            "storageKey": null
-                          },
+                          (v12/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1111,14 +1539,8 @@ return {
                         "name": "saleDate",
                         "storageKey": null
                       },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "title",
-                        "storageKey": null
-                      },
-                      (v9/*: any*/)
+                      (v5/*: any*/),
+                      (v19/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -1162,7 +1584,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v13/*: any*/),
+            "args": (v23/*: any*/),
             "filters": [
               "allowEmptyCreatedDates",
               "categories",
@@ -1183,12 +1605,12 @@ return {
             "selections": [
               {
                 "alias": "pastSmallShows",
-                "args": (v14/*: any*/),
+                "args": (v24/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
-                "selections": (v11/*: any*/),
+                "selections": (v21/*: any*/),
                 "storageKey": "showsConnection(first:20,status:\"closed\")"
               }
             ]
@@ -1200,12 +1622,12 @@ return {
             "selections": [
               {
                 "alias": "pastLargeShows",
-                "args": (v14/*: any*/),
+                "args": (v24/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
-                "selections": (v11/*: any*/),
+                "selections": (v21/*: any*/),
                 "storageKey": "showsConnection(first:20,status:\"closed\")"
               }
             ]
@@ -1216,7 +1638,7 @@ return {
     ]
   },
   "params": {
-    "id": "d8b1ed776483ef39f65eda97f4c8d293",
+    "id": "5e8d852a3526af22fc87bce04145e7aa",
     "metadata": {},
     "name": "ArtistBelowTheFoldQuery",
     "operationKind": "query",

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistCollectionsRail.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistCollectionsRail.tsx
@@ -1,4 +1,4 @@
-import { ArtistArtworks_artist } from "__generated__/ArtistArtworks_artist.graphql"
+import { ArtistAbout_artist } from "__generated__/ArtistAbout_artist.graphql"
 import { ArtistCollectionsRail_artist } from "__generated__/ArtistCollectionsRail_artist.graphql"
 import { GenericArtistSeriesRail } from "lib/Components/GenericArtistSeriesRail"
 import { SectionTitle } from "lib/Components/SectionTitle"
@@ -9,7 +9,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components/native"
 
 interface ArtistCollectionsRailProps {
-  collections: ArtistArtworks_artist["iconicCollections"]
+  collections: ArtistAbout_artist["iconicCollections"]
   artist: ArtistCollectionsRail_artist
 }
 
@@ -35,7 +35,7 @@ export const ArtistCollectionsRail: React.FC<ArtistCollectionsRailProps> = (prop
 }
 
 const ArtistSeriesRailWrapper = styled(Box)`
-  margin: 0px -20px 20px -40px;
+  margin: 0 -20px 20px -40px;
 `
 
 export const ArtistCollectionsRailFragmentContainer = createFragmentContainer(ArtistCollectionsRail, {

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistNotableWorksRail.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistNotableWorksRail.tsx
@@ -99,7 +99,7 @@ export const ArtistNotableWorksRailFragmentContainer = createFragmentContainer(A
     fragment ArtistNotableWorksRail_artist on Artist {
       internalID
       slug
-      # this should match the notableWorks query in ArtistArtworks
+      # this should match the notableWorks query in ArtistAbout
       filterArtworksConnection(sort: "-weighted_iconicity", first: 10) {
         edges {
           node {

--- a/src/lib/Components/GenericArtistSeriesRail.tsx
+++ b/src/lib/Components/GenericArtistSeriesRail.tsx
@@ -1,4 +1,4 @@
-import { ArtistArtworks_artist } from "__generated__/ArtistArtworks_artist.graphql"
+import { ArtistAbout_artist } from "__generated__/ArtistAbout_artist.graphql"
 import { ArtistCollectionsRail_collections } from "__generated__/ArtistCollectionsRail_collections.graphql"
 import { CollectionArtistSeriesRail_collectionGroup } from "__generated__/CollectionArtistSeriesRail_collectionGroup.graphql"
 import {
@@ -20,7 +20,7 @@ import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
 
 interface GenericArtistSeriesRailProps {
-  collections: CollectionArtistSeriesRail_collectionGroup["members"] | ArtistArtworks_artist["iconicCollections"]
+  collections: CollectionArtistSeriesRail_collectionGroup["members"] | ArtistAbout_artist["iconicCollections"]
   contextScreenOwnerType: Schema.OwnerEntityTypes.Collection | Schema.OwnerEntityTypes.Artist
   contextScreenOwnerId: string
   contextScreenOwnerSlug: string
@@ -118,11 +118,11 @@ export const GenericArtistSeriesRail: React.FC<GenericArtistSeriesRailProps> = (
 }
 
 export const GenericArtistSeriesMeta = styled(Sans)`
-  margin: 0px 15px;
+  margin: 0 15px;
 `
 
 export const GenericArtistSeriesTitle = styled(Sans)`
-  margin: 15px 15px 0px 15px;
+  margin: 15px 15px 0 15px;
 `
 
 const MetadataContainer = styled(View)`

--- a/src/lib/Scenes/Artist/Artist.tsx
+++ b/src/lib/Scenes/Artist/Artist.tsx
@@ -37,7 +37,7 @@ export const Artist: React.FC<{
 
   if (displayAboutSection) {
     tabs.push({
-      title: "About",
+      title: "Overview",
       content: artistBelowTheFold ? <ArtistAboutContainer artist={artistBelowTheFold} /> : <LoadingPage />,
     })
   }


### PR DESCRIPTION
- The type of this PR is: Refactor
- This PR resolves [FX-2904]

### Description

This PR changes the title of the artist "About" tab to "Overview" and moves the rails from the "Artworks" tab to "Overview".  These rails include the _Artist Series_, _Notable Works_, and _Iconic Collections_ rails. This is done in preparation of removing the "Sort & Filter" pill and moving it to the sticky header to increase usage of filters.

These rails can now be found below the _Biography_ section and above the consignments call-to-action in the same order.

<img width="718" alt="Screen Shot 2021-05-03 at 9 32 20 AM" src="https://user-images.githubusercontent.com/44589599/116882690-bad6b280-abf2-11eb-8212-8a91874826f3.png">


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2904]: https://artsyproduct.atlassian.net/browse/FX-2904