### PR TITLE
refactor: move artist artworks sort & filter button into header

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -14,6 +14,7 @@ upcoming:
     - Show loading spinner in all infinite scroll artowrk grids - ole
     - Fix missing bottom space on the Partner Artworks screen - ole
     - Animate welcome screen - mounir
+    - Move sort & filter button to artist artworks grid header - iskounen
 
 releases:
   - version: 6.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -693,7 +693,14 @@ DEPENDENCIES:
   - Yoga (from `./node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://cdn.cocoapods.org/:
+  https://github.com/artsy/Specs.git:
+    - Aerodramus
+    - "Artsy+UIColors"
+    - "Artsy+UIFonts"
+    - "Artsy+UILabels"
+    - Artsy-UIButtons
+    - Extraction
+  trunk:
     - "@react-native-mapbox-gl-mapbox-static"
     - AFNetworkActivityLogger
     - AFNetworking
@@ -751,13 +758,6 @@ SPEC REPOS:
     - "UIView+BooleanAnimations"
     - "XCTest+OHHTTPStubSuiteCleanUp"
     - YogaKit
-  https://github.com/artsy/Specs.git:
-    - Aerodramus
-    - "Artsy+UIColors"
-    - "Artsy+UIFonts"
-    - "Artsy+UILabels"
-    - Artsy-UIButtons
-    - Extraction
 
 EXTERNAL SOURCES:
   AFOAuth1Client:
@@ -928,7 +928,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CocoaLumberjack: aa9dcab71bdf9eaf2a63bbd9ddc87863efe45457
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
-  DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
+  DoubleConversion: cde416483dac037923206447da6e1454df403714
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
   Emission: bec9c8f604b13b12385835cd98d80a035dc41cc8
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
@@ -950,7 +950,7 @@ SPEC CHECKSUMS:
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   Forgeries: 64ced144ea8341d89a7eec9d1d7986f0f1366250
   FXBlurView: 5121730176fd52bcf7bffd0bd8c1485e8aabc3cb
-  glog: 1f3da668190260b06b429bb211bfbee5cd790c28
+  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   Interstellar: ab67502af03105f92100a043e178d188a1a437c9
   INTUAnimationEngine: 3a7d63738cd51af573d16848a771feedea7cc9f2
   ISO8601DateFormatter: 8311a2d4e265b269b2fed7ab4db685dcb0a7ccb2

--- a/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash ed9718c23f63d321712f8b4f1cf449b1 */
+/* @relayHash 39f313d86bb521fd3fe142652866ee3a */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -74,6 +74,9 @@ fragment ArtistArtworks_artist on Artist {
         __typename
       }
       cursor
+    }
+    counts {
+      total
     }
     ...InfiniteScrollArtworksGrid_connection
     pageInfo {
@@ -489,6 +492,24 @@ return {
               {
                 "alias": null,
                 "args": null,
+                "concreteType": "FilterArtworksCounts",
+                "kind": "LinkedField",
+                "name": "counts",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "total",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
                 "concreteType": "PageInfo",
                 "kind": "LinkedField",
                 "name": "pageInfo",
@@ -779,7 +800,7 @@ return {
     ]
   },
   "params": {
-    "id": "ed9718c23f63d321712f8b4f1cf449b1",
+    "id": "39f313d86bb521fd3fe142652866ee3a",
     "metadata": {},
     "name": "ArtistAboveTheFoldQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistArtworksQuery.graphql.ts
+++ b/src/__generated__/ArtistArtworksQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 5d6ec84c120e84c08901ae960f617659 */
+/* @relayHash a85461f8b26cea472b22e88705774342 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -84,6 +84,9 @@ fragment ArtistArtworks_artist_1qqVY9 on Artist {
         __typename
       }
       cursor
+    }
+    counts {
+      total
     }
     ...InfiniteScrollArtworksGrid_connection
     pageInfo {
@@ -592,6 +595,24 @@ return {
                   {
                     "alias": null,
                     "args": null,
+                    "concreteType": "FilterArtworksCounts",
+                    "kind": "LinkedField",
+                    "name": "counts",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "total",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
                     "concreteType": "PageInfo",
                     "kind": "LinkedField",
                     "name": "pageInfo",
@@ -885,7 +906,7 @@ return {
     ]
   },
   "params": {
-    "id": "5d6ec84c120e84c08901ae960f617659",
+    "id": "a85461f8b26cea472b22e88705774342",
     "metadata": {},
     "name": "ArtistArtworksQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistArtworks_artist.graphql.ts
+++ b/src/__generated__/ArtistArtworks_artist.graphql.ts
@@ -23,6 +23,9 @@ export type ArtistArtworks_artist = {
                 readonly id: string;
             } | null;
         } | null> | null;
+        readonly counts: {
+            readonly total: number | null;
+        } | null;
         readonly " $fragmentRefs": FragmentRefs<"InfiniteScrollArtworksGrid_connection">;
     } | null;
     readonly " $refType": "ArtistArtworks_artist";
@@ -337,6 +340,24 @@ return {
         {
           "alias": null,
           "args": null,
+          "concreteType": "FilterArtworksCounts",
+          "kind": "LinkedField",
+          "name": "counts",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "total",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
           "concreteType": "PageInfo",
           "kind": "LinkedField",
           "name": "pageInfo",
@@ -372,5 +393,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = 'fb68935c4b08f9db352db34e64d5ba35';
+(node as any).hash = '3d80f342e7522ee5ff08a1b8ae2f9431';
 export default node;

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -1,6 +1,6 @@
 import { OwnerType } from "@artsy/cohesion"
 import { ArtistArtworks_artist } from "__generated__/ArtistArtworks_artist.graphql"
-import { AnimatedArtworkFilterButton, ArtworkFilterNavigator, FilterModalMode } from "lib/Components/ArtworkFilter"
+import { ArtworkFilterNavigator, FilterModalMode } from "lib/Components/ArtworkFilter"
 import { filterArtworksParams } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworkFiltersStoreProvider, ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
@@ -11,7 +11,7 @@ import {
 import { StickyTabPageScrollView } from "lib/Components/StickyTabPage/StickyTabPageScrollView"
 import { PAGE_SIZE } from "lib/data/constants"
 import { Schema } from "lib/utils/track"
-import { Box, Spacer } from "palette"
+import { Box, FilterIcon, Flex, Spacer, Text, Touchable } from "palette"
 import React, { useEffect, useState } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -24,7 +24,6 @@ interface ArtworksGridProps extends InfiniteScrollGridProps {
 const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) => {
   const tracking = useTracking()
   const [isFilterArtworksModalVisible, setFilterArtworkModalVisible] = useState(false)
-  const [isArtworksGridVisible, setArtworksGridVisible] = useState(false)
 
   const handleFilterArtworksModal = () => {
     setFilterArtworkModalVisible(!isFilterArtworksModalVisible)
@@ -54,25 +53,10 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) 
     handleFilterArtworksModal()
   }
 
-  const onViewRef = React.useRef(({ viewableItems }: ViewableItems) => {
-    const artworksItem = (viewableItems! ?? []).find((viewableItem: ViewToken) => {
-      return viewableItem?.item === "filteredArtworks"
-    })
-    setArtworksGridVisible(artworksItem?.isViewable ?? false)
-  })
-
-  const viewConfigRef = React.useRef({ viewAreaCoveragePercentThreshold: 25 })
-
   return (
     <ArtworkFiltersStoreProvider>
       <StickyTabPageScrollView>
-        <ArtistArtworksContainer
-          {...props}
-          viewableItemsRef={onViewRef}
-          viewConfigRef={viewConfigRef}
-          artist={artist}
-          relay={relay}
-        />
+        <ArtistArtworksContainer {...props} artist={artist} relay={relay} openFilterModal={openFilterArtworksModal} />
         <ArtworkFilterNavigator
           {...props}
           id={artist.internalID}
@@ -83,34 +67,17 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) 
           mode={FilterModalMode.ArtistArtworks}
         />
       </StickyTabPageScrollView>
-      <AnimatedArtworkFilterButton isVisible={isArtworksGridVisible} onPress={openFilterArtworksModal} />
     </ArtworkFiltersStoreProvider>
   )
 }
-
-// Types related to showing filter button on scroll
-interface ViewableItems {
-  viewableItems?: ViewToken[]
+interface ArtistArtworksContainerProps {
+  openFilterModal: () => void
 }
 
-interface ViewToken {
-  item?: any
-  key?: string
-  index?: number | null
-  isViewable?: boolean
-  section?: any
-}
-
-interface ViewableItemRefs {
-  viewableItemsRef: React.MutableRefObject<(viewableItems: ViewableItems) => void>
-  viewConfigRef: React.MutableRefObject<{ viewAreaCoveragePercentThreshold: number }>
-}
-
-const ArtistArtworksContainer: React.FC<ArtworksGridProps & ViewableItemRefs> = ({
+const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContainerProps> = ({
   artist,
-  viewableItemsRef,
-  viewConfigRef,
   relay,
+  openFilterModal,
   ...props
 }) => {
   const tracking = useTracking()
@@ -121,7 +88,8 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ViewableItemRefs> = 
 
   const filterParams = filterArtworksParams(appliedFilters)
   const artworks = artist.artworks
-  const artworksTotal = artworks?.edges?.length
+  const artworksCount = artworks?.edges?.length
+  const artworksTotal = artworks?.counts?.total
 
   useEffect(() => {
     if (applyFilters) {
@@ -154,7 +122,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ViewableItemRefs> = 
   }
 
   const filteredArtworks = () => {
-    if (artworksTotal === 0) {
+    if (artworksCount === 0) {
       return (
         <Box mb="80px" pt={1}>
           <FilteredArtworkGridZeroState id={artist.id} slug={artist.slug} trackClear={trackClear} />
@@ -163,7 +131,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ViewableItemRefs> = 
     } else {
       return (
         <>
-          <Spacer mb={2} />
+          <Spacer mb={1} />
           <InfiniteScrollArtworksGrid
             connection={artist.artworks!}
             loadMore={relay.loadMore}
@@ -172,6 +140,25 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ViewableItemRefs> = 
             contextScreenOwnerType={OwnerType.artist}
             contextScreenOwnerId={artist.internalID}
             contextScreenOwnerSlug={artist.slug}
+            HeaderComponent={() => (
+              <Box backgroundColor="white" py={1}>
+                <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
+                  <Text variant="subtitle" color="black60">
+                    Showing {artworksTotal} works
+                  </Text>
+                  <Touchable haptic onPress={openFilterModal}>
+                    <Flex flexDirection="row">
+                      <FilterIcon fill="black100" width="20px" height="20px" />
+                      <Text variant="subtitle" color="black100">
+                        Sort & Filter
+                      </Text>
+                    </Flex>
+                  </Touchable>
+                </Flex>
+                <Spacer mb={1} />
+              </Box>
+            )}
+            stickyHeaderIndices={[0]}
           />
         </>
       )
@@ -238,6 +225,9 @@ export default createPaginationContainer(
             node {
               id
             }
+          }
+          counts {
+            total
           }
           ...InfiniteScrollArtworksGrid_connection
         }


### PR DESCRIPTION
- The type of this PR is: Refactor
- This PR resolves [FX-2880]

### Description

This PR adds a header component to the artist artworks grid that will contain the total number of works in the grid and a button to allow users to sort and filter the grid. The purpose of this change is to make the sort and filter action more prominent and encourage users to find art that they love.

![Simulator Screen Shot - iPhone 12 - 2021-05-05 at 07 50 02](https://user-images.githubusercontent.com/44589599/117136592-93a8ee00-ad76-11eb-8dc0-d5c576e30af2.png)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2880]: https://artsyproduct.atlassian.net/browse/FX-2880