### PR TITLE
[WIP] feat(FX-2907): Convert artist series filter to static button

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -4,6 +4,7 @@ upcoming:
   dev:
     - Add native modalDismissed event - lily & christina
     - Refactor filter event payloads to send JSON - roop
+    - Convert artist series filter to static button - mdole
   user_facing:
     - Combine gallery and institution artwork filters - mdole
     - Remove old login from android - adam, barry, david, jonathan, mounir, pavlos

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
@@ -6,7 +6,7 @@ import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/Filter
 import { InfiniteScrollArtworksGridContainer } from "lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
 import { ARTIST_SERIES_PAGE_SIZE } from "lib/data/constants"
 import { Schema } from "lib/utils/track"
-import { Box, Separator, Spacer } from "palette"
+import { Box, FilterIcon, Flex, Spacer, Text, Touchable } from "palette"
 import React, { useEffect } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -14,11 +14,12 @@ import { useTracking } from "react-tracking"
 interface ArtistSeriesArtworksProps {
   artistSeries: ArtistSeriesArtworks_artistSeries
   relay: RelayPaginationProp
+  openFilterModal: () => void
 }
 
 const PAGE_SIZE = 20
 
-export const ArtistSeriesArtworks: React.FC<ArtistSeriesArtworksProps> = ({ artistSeries, relay }) => {
+export const ArtistSeriesArtworks: React.FC<ArtistSeriesArtworksProps> = ({ artistSeries, relay, openFilterModal }) => {
   const setAggregationsAction = ArtworksFiltersStore.useStoreActions((state) => state.setAggregationsAction)
   const appliedFilters = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
   const applyFilters = ArtworksFiltersStore.useStoreState((state) => state.applyFilters)
@@ -57,18 +58,18 @@ export const ArtistSeriesArtworks: React.FC<ArtistSeriesArtworksProps> = ({ arti
     setAggregationsAction(artworks?.aggregations)
   }, [])
 
-  if ((artworks?.counts?.total ?? 0) === 0) {
+  const artworksTotal = artworks?.counts?.total
+
+  if ((artworksTotal ?? 0) === 0) {
     return (
       <Box>
-        <Separator mb={2} />
         <FilteredArtworkGridZeroState id={artistSeries.internalID} slug={artistSeries.slug} trackClear={trackClear} />
-        <Spacer mb={1} />
+        <Spacer mb={2} />
       </Box>
     )
   } else {
     return (
       <Box>
-        <Separator mb={2} />
         <InfiniteScrollArtworksGridContainer
           connection={artworks}
           loadMore={relay.loadMore}
@@ -78,6 +79,25 @@ export const ArtistSeriesArtworks: React.FC<ArtistSeriesArtworksProps> = ({ arti
           contextScreenOwnerType={OwnerType.artistSeries}
           contextScreenOwnerId={artistSeries.internalID}
           contextScreenOwnerSlug={artistSeries.slug}
+          stickyHeaderIndices={[0]}
+          HeaderComponent={() => (
+            <Box backgroundColor="white100" py={1}>
+              <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
+                <Text variant="subtitle" color="black60">
+                  Showing {artworksTotal} works
+                </Text>
+                <Touchable haptic onPress={openFilterModal}>
+                  <Flex flexDirection="row">
+                    <FilterIcon fill="black100" width="20px" height="20px" />
+                    <Text variant="subtitle" color="black100">
+                      Sort & Filter
+                    </Text>
+                  </Flex>
+                </Touchable>
+              </Flex>
+              <Spacer mb={1} />
+            </Box>
+          )}
         />
       </Box>
     )

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesArtworks-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesArtworks-tests.tsx
@@ -34,7 +34,12 @@ describe("Artist Series Artworks", () => {
         if (props?.artistSeries) {
           return (
             <ArtworkFiltersStoreProvider>
-              <ArtistSeriesArtworksFragmentContainer artistSeries={props.artistSeries} />
+              <ArtistSeriesArtworksFragmentContainer
+                artistSeries={props.artistSeries}
+                openFilterModal={() => {
+                  console.log("hi")
+                }}
+              />
             </ArtworkFiltersStoreProvider>
           )
         } else if (error) {


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR resolves [FX-2907]

### Description

This PR converts the artist series screen from the floating "pill" filter button to a static button in the header.

I converted the ArtistSeries screen from a Flatlist to a ScrollView to deal with a weird sticky header bug I was having (see gif). Is this a terrible idea? Open to input! My thinking was that this page isn't massive so it wasn't a big deal if we render all of it (though it could get quite long if the user hits "load more artworks" a bunch - does the Flatlist in `InfiniteScrollArtworksGridContainer` handle that?). If converting is a bad idea, I'm sure there's a different way to handle this bug.

### Sticky header w/ flatlist (buggy):
![scroll-bug](https://user-images.githubusercontent.com/5361806/117378724-fa77f580-aea3-11eb-98d1-31eab193bc49.gif)

### Sticky header w/ scrollview:


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2907]: https://artsyproduct.atlassian.net/browse/FX-2907