### PR TITLE
feat: add PR description parser for changelog generation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
     "@images/(.*)": "<rootDir>/images/$1",
     "@relay/(.*)": "<rootDir>/src/lib/relay/$1",
   },
-  testMatch: ["<rootDir>/src/**/__tests__/*tests.(ts|tsx|js)"],
+  testMatch: ["<rootDir>/src/**/__tests__/*tests.(ts|tsx|js)", "<rootDir>/scripts/**/*tests.(ts|tsx|js)"],
   testEnvironment: "jsdom",
   testURL: "http://localhost/",
   setupFilesAfterEnv: ["./src/setupJest.ts"],

--- a/scripts/changelog/changelog-types.d.ts
+++ b/scripts/changelog/changelog-types.d.ts
@@ -1,0 +1,10 @@
+export type ParseResult =
+  | { type: "error" } // for when no changelog-related stuff is found
+  | { type: "no_changes" } // for when we add #nochangelog hashtag
+  | {
+      type: "changes"
+      crossPlatformUserFacingChanges: string[]
+      iOSUserFacingChanges: string[]
+      androidUserFacingChanges: string[]
+      devChanges: string[]
+    }

--- a/scripts/changelog/generateChangelogSectionTemplate.js
+++ b/scripts/changelog/generateChangelogSectionTemplate.js
@@ -1,0 +1,53 @@
+// @ts-check
+
+const changelogTemplateSections = {
+  crossPlatformUserFacingChanges: "Cross-platform user-facing changes",
+  iOSUserFacingChanges: "iOS user-facing changes",
+  androidUserFacingChanges: "Android user-facing changes",
+  devChanges: "Dev changes",
+}
+
+module.exports.changelogTemplateSections = changelogTemplateSections
+
+module.exports.generateChangelogSectionTemplate = () => {
+  return `### Changelog updates
+
+<!-- 📝 Please fill out at least one of these sections. -->
+<!-- ⓘ 'User-facing' changes will be published as release notes. -->
+<!-- ⌫ Feel free to remove sections that don't apply. -->
+<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
+<!-- 🤷‍♂️ Replace this entire block with the hashtag \`#nochangelog\` to avoid updating the changelog. -->
+${Object.entries(changelogTemplateSections)
+  .map(([, title]) => "#### " + title)
+  .join("\n-\n")}
+-
+
+<!-- end_changelog_updates -->
+`
+}
+
+const fs = require("fs")
+const prettier = require("prettier")
+
+/**
+ * @param {string} filePath
+ */
+module.exports.updateChangelogSectionTemplate = (filePath) => {
+  let fileContents = fs.readFileSync(filePath, "utf8").toString()
+
+  const regex = /### Changelog updates[\S\s]+end_changelog_updates.*/g
+  if (!fileContents.match(regex)) {
+    console.error("Can't find 'Changelog updates' section in pull request template", filePath)
+    process.exit(1)
+  }
+
+  fileContents = fileContents.replace(regex, this.generateChangelogSectionTemplate())
+  fileContents = prettier.format(fileContents, { parser: "markdown" })
+
+  fs.writeFileSync(filePath, fileContents, "utf8")
+}
+
+// @ts-ignore
+if (require.main === module) {
+  this.updateChangelogSectionTemplate("./docs/pull_request_template.md")
+}

--- a/scripts/changelog/parsePRDescription-tests.ts
+++ b/scripts/changelog/parsePRDescription-tests.ts
@@ -1,0 +1,190 @@
+import { ParseResult as PRDescriptionParseResult } from "./changelog-types"
+import { parsePRDescription } from "./parsePRDescription"
+
+const ERROR: PRDescriptionParseResult = { type: "error" }
+const NO_CHANGES: PRDescriptionParseResult = { type: "no_changes" }
+
+describe("parsePRDescription", () => {
+  it("returns error for empty PR description", () => {
+    expect(parsePRDescription("")).toEqual(ERROR)
+  })
+
+  it("returns error for PR description that does not contain any changelog info", () => {
+    expect(
+      parsePRDescription(`
+# Description
+
+This pull request adds some stuff to the thing so that it can blah.
+    `)
+    ).toEqual(ERROR)
+  })
+
+  it("returns no_changes when the user includes '#nochangelog' hashtag", () => {
+    expect(
+      parsePRDescription(`
+# Description
+
+This pull request adds some stuff to the thing so that it can blah.
+
+#nochangelog
+    `)
+    ).toEqual(NO_CHANGES)
+  })
+
+  it("returns error when no changes have been declared and #nochangelog has not been included", () => {
+    expect(
+      parsePRDescription(`
+# Description
+
+This pull request adds some stuff to the thing so that it can blah.
+### Changelog updates
+
+<!-- 📝 Please fill out at least one of these sections. -->
+<!-- ⓘ 'User-facing' changes will be published as release notes. -->
+<!-- ⌫ Feel free to remove sections that don't apply. -->
+<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
+<!-- 🤷‍♂️ Replace this entire block with the hashtag \`#nochangelog\` to avoid updating the changelog. -->
+
+#### Cross-platform user-facing changes
+-
+#### iOS user-facing changes
+-
+#### Android user-facing changes
+-
+#### Dev changes
+-
+
+### Other stuff
+      `)
+    ).toEqual(ERROR)
+  })
+
+  it("returns any changes specified by the PR author", () => {
+    expect(
+      parsePRDescription(`
+# Description
+
+This pull request adds some stuff to the thing so that it can blah.
+### Changelog updates
+
+#### Cross-platform user-facing changes
+- Added a new button
+  for the checkout flow
+- Fixed modal close button
+#### iOS user-facing changes
+- Fixed input focus styles
+#### Android user-facing changes
+Updated splash screen color
+#### Dev changes
+- Improved changelog tooling
+- Upgraded lodash
+
+### Other stuff
+
+blah
+      `)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "androidUserFacingChanges": Array [
+          "Updated splash screen color",
+        ],
+        "crossPlatformUserFacingChanges": Array [
+          "Added a new button
+      for the checkout flow",
+          "Fixed modal close button",
+        ],
+        "devChanges": Array [
+          "Improved changelog tooling",
+          "Upgraded lodash",
+        ],
+        "iOSUserFacingChanges": Array [
+          "Fixed input focus styles",
+        ],
+        "type": "changes",
+      }
+    `)
+  })
+
+  it("allows sections of the changelog to be deleted", () => {
+    expect(
+      parsePRDescription(`
+### Description
+blah blah
+
+### Changelog updates
+
+#### iOS user-facing changes
+- Fixed input focus styles
+
+### Other stuff
+
+blah
+      `)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "androidUserFacingChanges": Array [],
+        "crossPlatformUserFacingChanges": Array [],
+        "devChanges": Array [],
+        "iOSUserFacingChanges": Array [
+          "Fixed input focus styles",
+        ],
+        "type": "changes",
+      }
+    `)
+  })
+
+  it("supports single-level markdown lists", () => {
+    expect(
+      parsePRDescription(`
+### Changelog updates
+
+#### iOS user-facing changes
+- Fixed input focus styles
+- Added things
+- Removed things
+- Updated things
+    `)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "androidUserFacingChanges": Array [],
+        "crossPlatformUserFacingChanges": Array [],
+        "devChanges": Array [],
+        "iOSUserFacingChanges": Array [
+          "Fixed input focus styles",
+          "Added things",
+          "Removed things",
+          "Updated things",
+        ],
+        "type": "changes",
+      }
+    `)
+  })
+
+  it("supports paragraphs of text", () => {
+    expect(
+      parsePRDescription(`
+### Changelog updates
+
+#### iOS user-facing changes
+made the modals close a bit faster
+by updating the transition gradient
+
+uses a trampoline to avoid the problem
+where the click didn't work
+    `)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "androidUserFacingChanges": Array [],
+        "crossPlatformUserFacingChanges": Array [],
+        "devChanges": Array [],
+        "iOSUserFacingChanges": Array [
+          "made the modals close a bit faster
+      by updating the transition gradient",
+          "uses a trampoline to avoid the problem
+      where the click didn't work",
+        ],
+        "type": "changes",
+      }
+    `)
+  })
+})

--- a/scripts/changelog/parsePRDescription.js
+++ b/scripts/changelog/parsePRDescription.js
@@ -1,0 +1,98 @@
+// @ts-check
+
+const { changelogTemplateSections } = require("./generateChangelogSectionTemplate")
+
+/**
+ * @param {string} description
+ * @returns {import('./changelog-types').ParseResult}
+ */
+module.exports.parsePRDescription = (description) => {
+  description = stripComments(description)
+  if (description.includes("#nochangelog")) {
+    return { type: "no_changes" }
+  }
+
+  const lines = description.split("\n")
+
+  /**
+   * @type {import('./changelog-types').ParseResult}
+   */
+  const result = {
+    type: "changes",
+    androidUserFacingChanges: [],
+    crossPlatformUserFacingChanges: [],
+    devChanges: [],
+    iOSUserFacingChanges: [],
+  }
+
+  for (const [sectionKey, sectionTitle] of Object.entries(changelogTemplateSections)) {
+    let i = lines.indexOf("#### " + sectionTitle)
+    if (i === -1) {
+      continue
+    }
+    i++
+    // either a single text paragraph or a list
+    const sectionLines = []
+    while (i < lines.length && lines[i].match(/^( *\w|-[\w ]|\*[\w ]|\s*$)/)) {
+      sectionLines.push(lines[i])
+      i++
+    }
+    // @ts-expect-error
+    result[sectionKey] = groupItems(sectionLines)
+  }
+
+  if (
+    result.androidUserFacingChanges.length === 0 &&
+    result.crossPlatformUserFacingChanges.length === 0 &&
+    result.devChanges.length === 0 &&
+    result.iOSUserFacingChanges.length === 0
+  ) {
+    return { type: "error" }
+  }
+
+  return result
+}
+
+/**
+ * @param {string} text
+ */
+function stripComments(text) {
+  return text.replace(/<!--.*?-->/g, "")
+}
+
+/**
+ * @param {string[]} lines
+ */
+function groupItems(lines) {
+  /**
+   * @type {string[]}
+   */
+  const result = []
+
+  /**
+   * @type {string[]}
+   */
+  let group = []
+
+  for (const line of lines) {
+    if (line.startsWith("-") || line.startsWith("*")) {
+      if (group.length) {
+        result.push(group.join("\n"))
+      }
+      group = [line.slice(1).trim()]
+    } else if (line.match(/^\s*$/)) {
+      // paragraph
+      if (group.length) {
+        result.push(group.join("\n"))
+      }
+      group = []
+    } else {
+      group.push(line.trim())
+    }
+  }
+  if (group.length) {
+    result.push(group.join("\n"))
+  }
+
+  return result
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
     "types": ["jest", "react", "react-native"],
     "noEmit": true
   },
-  "include": ["typings/*.d.ts", "src/**/*.ts", "src/**/*.tsx"],
+  "include": ["typings/*.d.ts", "src/**/*.ts", "src/**/*.tsx", "scripts/changelog/**/*.ts"],
   "exclude": [
     "dangerfile.ts",
     "node_modules",


### PR DESCRIPTION
This PR resolves [CX-1211]

### Description

This creates a parser for PR descriptions, to extract the changelog information that folks will be able to add soon. See the RFC #4499 for more info.

This parser will be used in two places:

- In a danger rule to make sure folks are providing changelog information in their PR descriptions
- In a changelog compiler that will automatically generate a CHANGELOG.md file for each platform, based on the PRs merged between releases.

I implemented the parser in plain JS with JSDoc-based type annotations, checked by `tsc`. 

Because the parser depends on the exact wording of the [PR template header descriptions](https://github.com/artsy/eigen/blob/53f8f05cb8db1acd51c447e2cbb2e798fe3865bf/scripts/changelog/generateChangelogSectionTemplate.js#L3-L8), I added a function which can be used to update the PR template file. This could then be used on CI to check that the PR template file is in sync with the parser. I'll show this stuff off in Knowledge Share today.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-1211]: https://artsyproduct.atlassian.net/browse/CX-1211