### PR TITLE
fix: add spinner and padding to infinite scroll artworks grid

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -46,6 +46,7 @@ releases:
       - Fix palette button disabled state on iOS - mounir
       - Fix artwork filter apply button disabled logic - iskounen
       - Fix Filter Artwork title text breaking - mounir
+      - Add loading spinner (iOS) and bottom padding (Android) to artwork grid on partner page - ole
 
   - version: 6.8.3
     date: Apr 14, 2021

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -9,6 +9,8 @@ upcoming:
     - Rename artist about tab to artist overview tab - iskounen
     - Move rails on artist artwork tab to artist overview tab - iskounen
     - Update onboarding screens copy - mounir
+    - Show loading spinner in all infinite scroll artowrk grids - ole
+    - Fix missing bottom space on the Partner Artworks screen - ole
 
 releases:
   - version: 6.8.4
@@ -46,7 +48,6 @@ releases:
       - Fix palette button disabled state on iOS - mounir
       - Fix artwork filter apply button disabled logic - iskounen
       - Fix Filter Artwork title text breaking - mounir
-      - Add loading spinner (iOS) and bottom padding (Android) to artwork grid on partner page - ole
 
   - version: 6.8.3
     date: Apr 14, 2021

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -11,9 +11,8 @@ import {
 import { StickyTabPageScrollView } from "lib/Components/StickyTabPage/StickyTabPageScrollView"
 import { PAGE_SIZE } from "lib/data/constants"
 import { Schema } from "lib/utils/track"
-import { Box, Flex, Spacer } from "palette"
+import { Box, Spacer } from "palette"
 import React, { useEffect, useState } from "react"
-import { ActivityIndicator } from "react-native"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import { useTracking } from "react-tracking"
 
@@ -174,15 +173,6 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ViewableItemRefs> = 
             contextScreenOwnerId={artist.internalID}
             contextScreenOwnerSlug={artist.slug}
           />
-          <Flex
-            alignItems="center"
-            justifyContent="center"
-            p="3"
-            pb="9"
-            style={{ opacity: relay.isLoading() && relay.hasMore() ? 1 : 0 }}
-          >
-            <ActivityIndicator />
-          </Flex>
         </>
       )
     }

--- a/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -7,7 +7,16 @@
 // 4. Update height of grid to encompass all items.
 
 import React from "react"
-import { Dimensions, LayoutChangeEvent, Platform, ScrollView, StyleSheet, View, ViewStyle } from "react-native"
+import {
+  ActivityIndicator,
+  Dimensions,
+  LayoutChangeEvent,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  View,
+  ViewStyle,
+} from "react-native"
 import { createFragmentContainer, RelayPaginationProp } from "react-relay"
 
 import Artwork from "./ArtworkGridItem"
@@ -19,7 +28,7 @@ import { PAGE_SIZE } from "lib/data/constants"
 import { ScreenOwnerType } from "@artsy/cohesion"
 import { InfiniteScrollArtworksGrid_connection } from "__generated__/InfiniteScrollArtworksGrid_connection.graphql"
 import { extractNodes } from "lib/utils/extractNodes"
-import { Box, Button, space, Theme } from "palette"
+import { Box, Button, Flex, space, Theme } from "palette"
 import { graphql } from "relay-runtime"
 
 /**
@@ -272,39 +281,50 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
 
     return (
       <Theme>
-        <ScrollView
-          onScroll={(ev) => {
-            if (autoFetch) {
-              this.handleFetchNextPageOnScroll(ev)
-            }
-          }}
-          scrollEventThrottle={50}
-          onLayout={this.onLayout}
-          scrollsToTop={false}
-          accessibilityLabel="Artworks ScrollView"
-          stickyHeaderIndices={stickyHeaderIndices}
-        >
-          {this.renderHeader()}
-          <Box px={boxPadding}>
-            <View style={styles.container} accessibilityLabel="Artworks Content View">
-              {artworks}
-            </View>
-          </Box>
+        <>
+          <ScrollView
+            onScroll={(ev) => {
+              if (autoFetch) {
+                this.handleFetchNextPageOnScroll(ev)
+              }
+            }}
+            scrollEventThrottle={50}
+            onLayout={this.onLayout}
+            scrollsToTop={false}
+            accessibilityLabel="Artworks ScrollView"
+            stickyHeaderIndices={stickyHeaderIndices}
+          >
+            {this.renderHeader()}
+            <Box px={boxPadding}>
+              <View style={styles.container} accessibilityLabel="Artworks Content View">
+                {artworks}
+              </View>
+            </Box>
 
-          {!autoFetch && !!hasMore() && (
-            <Button
-              mt={5}
-              mb={3}
-              variant="secondaryGray"
-              size="large"
-              block
-              onPress={this.fetchNextPage}
-              loading={this.state.isLoading}
-            >
-              Show more
-            </Button>
-          )}
-        </ScrollView>
+            {!autoFetch && !!hasMore() && (
+              <Button
+                mt={5}
+                mb={3}
+                variant="secondaryGray"
+                size="large"
+                block
+                onPress={this.fetchNextPage}
+                loading={this.state.isLoading}
+              >
+                Show more
+              </Button>
+            )}
+          </ScrollView>
+          <Flex
+            alignItems="center"
+            justifyContent="center"
+            p="3"
+            pb="9"
+            style={{ opacity: this.state.isLoading && hasMore() ? 1 : 0 }}
+          >
+            <ActivityIndicator />
+          </Flex>
+        </>
       </Theme>
     )
   }

--- a/src/lib/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/lib/Scenes/Fair/Components/FairArtworks.tsx
@@ -92,7 +92,7 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
   }
 
   return (
-    <Box mb={3}>
+    <Box>
       <InfiniteScrollArtworksGridContainer
         connection={artworks}
         loadMore={relay.loadMore}

--- a/src/lib/Scenes/Partner/Components/PartnerArtwork.tsx
+++ b/src/lib/Scenes/Partner/Components/PartnerArtwork.tsx
@@ -5,9 +5,8 @@ import { InfiniteScrollArtworksGridContainer as InfiniteScrollArtworksGrid } fro
 import { StickyTabPageScrollView } from "lib/Components/StickyTabPage/StickyTabPageScrollView"
 import { TabEmptyState } from "lib/Components/TabEmptyState"
 import { get } from "lib/utils/get"
-import { Flex, Spacer } from "palette"
+import { Spacer } from "palette"
 import React, { useState } from "react"
-import { ActivityIndicator } from "react-native"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 
 export const PartnerArtwork: React.FC<{
@@ -26,18 +25,7 @@ export const PartnerArtwork: React.FC<{
         <Spacer mb={2} />
 
         {artworks ? (
-          <>
-            <InfiniteScrollArtworksGrid connection={artworks} loadMore={relay.loadMore} hasMore={relay.hasMore} />
-            <Flex
-              alignItems="center"
-              justifyContent="center"
-              p="3"
-              pb="9"
-              style={{ opacity: relay.isLoading() && relay.hasMore() ? 1 : 0 }}
-            >
-              <ActivityIndicator />
-            </Flex>
-          </>
+          <InfiniteScrollArtworksGrid connection={artworks} loadMore={relay.loadMore} hasMore={relay.hasMore} />
         ) : (
           <TabEmptyState text="There is no artwork from this gallery yet" />
         )}

--- a/src/lib/Scenes/Partner/Components/PartnerArtwork.tsx
+++ b/src/lib/Scenes/Partner/Components/PartnerArtwork.tsx
@@ -5,8 +5,9 @@ import { InfiniteScrollArtworksGridContainer as InfiniteScrollArtworksGrid } fro
 import { StickyTabPageScrollView } from "lib/Components/StickyTabPage/StickyTabPageScrollView"
 import { TabEmptyState } from "lib/Components/TabEmptyState"
 import { get } from "lib/utils/get"
-import { Spacer } from "palette"
+import { Flex, Spacer } from "palette"
 import React, { useState } from "react"
+import { ActivityIndicator } from "react-native"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 
 export const PartnerArtwork: React.FC<{
@@ -25,7 +26,18 @@ export const PartnerArtwork: React.FC<{
         <Spacer mb={2} />
 
         {artworks ? (
-          <InfiniteScrollArtworksGrid connection={artworks} loadMore={relay.loadMore} hasMore={relay.hasMore} />
+          <>
+            <InfiniteScrollArtworksGrid connection={artworks} loadMore={relay.loadMore} hasMore={relay.hasMore} />
+            <Flex
+              alignItems="center"
+              justifyContent="center"
+              p="3"
+              pb="9"
+              style={{ opacity: relay.isLoading() && relay.hasMore() ? 1 : 0 }}
+            >
+              <ActivityIndicator />
+            </Flex>
+          </>
         ) : (
           <TabEmptyState text="There is no artwork from this gallery yet" />
         )}

--- a/src/lib/Scenes/Show/Components/ShowArtworks.tsx
+++ b/src/lib/Scenes/Show/Components/ShowArtworks.tsx
@@ -86,7 +86,7 @@ const ShowArtworks: React.FC<Props> = ({ show, relay, initiallyAppliedFilter }) 
   }
 
   return (
-    <Box mb={3}>
+    <Box>
       <InfiniteScrollArtworksGridContainer
         connection={artworks}
         loadMore={relay.loadMore}


### PR DESCRIPTION
The type of this PR is: Bugfix

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1365]

### Description

This PR adds a spinner and padding to the partner artworks page similar to the artist artworks page (https://github.com/artsy/eigen/blob/master/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx#L168).

The change fixes the missing space below the "Show More" button and makes the visual experience consistent with the artist artworks page. 

| Android | iOS |
|---|---|
| | |
| ![image](https://user-images.githubusercontent.com/4691889/117011052-bcd16c00-aced-11eb-9e44-684ced47598f.png) |![image](https://user-images.githubusercontent.com/4691889/117011717-66186200-acee-11eb-955b-bf1094ae3c34.png)|

iOS: https://user-images.githubusercontent.com/4691889/117011263-f1ddbe80-aced-11eb-9209-fc520b75c019.mp4

**Affected screens:**
- [x] ArtistArtworks
- [ ] Gene
- [ ] ArtistSeriesArtworks
- [x] CollectionArtworks
- [ ] FairArtworks
- [ ] PartnerArtwors
- [ ] SaleLotsList
- [ ] LotsByFollowedArtists
- [ ] ShowArtists

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- I have documented any follow-up work that this PR will require, or it does not require any.
- I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1365]: https://artsyproduct.atlassian.net/browse/CX-1365