### PR TITLE
[PURCHASE-2574]: Swipe down dismiss modal

### DIFF
--- a/Artsy/App/ARModalViewController.m
+++ b/Artsy/App/ARModalViewController.m
@@ -1,6 +1,7 @@
 #import "ARModalViewController.h"
 #import <FLKAutoLayout/UIViewController+FLKAutoLayout.h>
 #import <FLKAutoLayout/UIView+FLKAutoLayout.h>
+#import <Emission/AREmission.h>
 
 @implementation ARModalViewController
 
@@ -16,6 +17,14 @@
     [super viewDidLoad];
     [self addChildViewController:self.stack];
     [self.view addSubview:self.stack.view];
+}
+
+- (void)viewWillDisappear:(BOOL)animated
+{
+    [super viewWillDisappear:animated];
+    if(self.isBeingDismissed){
+        [AREmission.sharedInstance.notificationsManagerModule modalDismissed];
+    }
 }
 
 @end

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -2,7 +2,7 @@ upcoming:
   version: 6.9.0
   date: TBD
   dev:
-    -
+    - Add native modalDismissed event - lily & christina
   user_facing:
     - Combine gallery and institution artwork filters - mdole
     - Allows multi-select filters to be searchable - damon

--- a/emission/Pod/Classes/EigenCommunications/ARNotificationsManager.h
+++ b/emission/Pod/Classes/EigenCommunications/ARNotificationsManager.h
@@ -33,6 +33,8 @@
 
 - (void)notificationReceived;
 
+- (void)modalDismissed;
+
 // this is exported only for tests
 - (void)updateReactState:(NSDictionary *)reactState;
 

--- a/emission/Pod/Classes/EigenCommunications/ARNotificationsManager.m
+++ b/emission/Pod/Classes/EigenCommunications/ARNotificationsManager.m
@@ -45,6 +45,7 @@
 // event keys
 // These should match the values in src/lib/store/NativeModel.ts
 static const NSString *notificationReceived = @"NOTIFICATION_RECEIVED";
+static const NSString *modalDismissed = @"MODAL_DISMISSED";
 static const NSString *stateChanged = @"STATE_CHANGED";
 static const NSString *reactStateChanged = @"STATE_CHANGED";
 static const NSString *requestNavigation = @"REQUEST_NAVIGATION";
@@ -111,6 +112,11 @@ RCT_EXPORT_MODULE();
 - (void)notificationReceived
 {
     [self dispatch:notificationReceived data:@{}];
+}
+
+- (void)modalDismissed
+{
+    [self dispatch:modalDismissed data:@{}];
 }
 
 - (void)requestNavigation:(NSString *)route

--- a/src/lib/Scenes/Inbox/Screens/Conversation.tsx
+++ b/src/lib/Scenes/Inbox/Screens/Conversation.tsx
@@ -78,13 +78,11 @@ export class Conversation extends React.Component<Props, State> {
     NetInfo.isConnected.addEventListener("connectionChange", this.handleConnectivityChange)
     this.maybeMarkLastMessageAsRead()
     navigationEvents.addListener("modalDismissed", this.handleModalDismissed)
-    navigationEvents.addListener("goBack", this.handleModalDismissed)
   }
 
   componentWillUnmount() {
     NetInfo.isConnected.removeEventListener("connectionChange", this.handleConnectivityChange)
     navigationEvents.removeListener("modalDismissed", this.handleModalDismissed)
-    navigationEvents.removeListener("goBack", this.handleModalDismissed)
   }
 
   // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
@@ -97,7 +95,16 @@ export class Conversation extends React.Component<Props, State> {
   }
 
   refetch = () => {
-    this.props.relay.refetch({})
+    this.props.relay.refetch(
+      { conversationID: this.props.me.conversation?.internalID },
+      null,
+      (error) => {
+        if (error) {
+          console.error("Conversation.tsx", error.message)
+        }
+      },
+      { force: true }
+    )
   }
 
   maybeMarkLastMessageAsRead() {

--- a/src/lib/Scenes/Inbox/Screens/__tests__/Conversation-tests.tsx
+++ b/src/lib/Scenes/Inbox/Screens/__tests__/Conversation-tests.tsx
@@ -105,13 +105,3 @@ it("handles a dismissed modal with modalDismiss event", () => {
 
   expect(componentInstance.refetch).toHaveBeenCalled()
 })
-
-it("handles a dismissed modal with goBack event", () => {
-  const conversation = getWrapper()
-  const componentInstance = (conversation.root.findByType(Conversation).children[0] as ReactTestInstance).instance
-
-  jest.spyOn(componentInstance, "refetch")
-  navigationEvents.emit("goBack")
-
-  expect(componentInstance.refetch).toHaveBeenCalled()
-})

--- a/src/lib/navigation/navigate.ts
+++ b/src/lib/navigation/navigate.ts
@@ -76,12 +76,10 @@ export const navigationEvents = new EventEmitter()
 
 export function dismissModal() {
   LegacyNativeModules.ARScreenPresenterModule.dismissModal()
-  navigationEvents.emit("modalDismissed")
 }
 
 export function goBack() {
   LegacyNativeModules.ARScreenPresenterModule.goBack(unsafe__getSelectedTab())
-  navigationEvents.emit("goBack")
 }
 
 export function popParentViewController() {

--- a/src/lib/store/NativeModel.ts
+++ b/src/lib/store/NativeModel.ts
@@ -1,7 +1,7 @@
 import { Action, action, Thunk, thunk } from "easy-peasy"
 import { LegacyNativeModules } from "lib/NativeModules/LegacyNativeModules"
 import { NotificationsManager } from "lib/NativeModules/NotificationsManager"
-import { navigate } from "lib/navigation/navigate"
+import { navigate, navigationEvents } from "lib/navigation/navigate"
 import { GlobalStore } from "./GlobalStore"
 
 // These should match the values in emission/Pod/Classes/EigenCommunications/ARNotificationsManager.m
@@ -17,6 +17,9 @@ export type NativeEvent =
   | {
       type: "REQUEST_NAVIGATION"
       payload: { route: string }
+    }
+  | {
+      type: "MODAL_DISMISSED"
     }
 
 export interface NativeState {
@@ -59,6 +62,9 @@ listenToNativeEvents((event: NativeEvent) => {
       return
     case "REQUEST_NAVIGATION":
       navigate(event.payload.route)
+      return
+    case "MODAL_DISMISSED":
+      navigationEvents.emit("modalDismissed")
       return
     default:
       assertNever(event)


### PR DESCRIPTION
paired with: @lilyfromseattle @ds300
The type of this PR is: **FEAT**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [PURCHASE-2574]

### Description
This is follow up to https://github.com/artsy/eigen/pull/4648 and adds a new native modal dismissed event and uses that in the conversation to determine when we need to refetch conversation data. Previously we were hooking into the local modalDismissed and goBack events in eigen. With this implementation those are no longer needed.

https://user-images.githubusercontent.com/5201004/117042864-7f171800-acda-11eb-8cc6-a5170de842ec.mp4

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[PURCHASE-2574]: https://artsyproduct.atlassian.net/browse/PURCHASE-2574