### PR TITLE
fix: make filter modal close and clear all tappable again

### DIFF
--- a/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -113,6 +113,10 @@ export const ArtworkFilterOptionsScreen: React.FC<
   return (
     <Flex style={{ flex: 1 }}>
       <Flex flexGrow={0} flexDirection="row" justifyContent="space-between" alignItems="center" height={space(6)}>
+        <Flex flex={1} alignItems="center">
+          <Text variant="mediumText">{title}</Text>
+        </Flex>
+
         <Flex position="absolute" alignItems="flex-start">
           <CloseIconContainer hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }} onPress={handleTappingCloseIcon}>
             <CloseIcon fill="black100" />
@@ -145,10 +149,6 @@ export const ArtworkFilterOptionsScreen: React.FC<
               Clear all
             </Text>
           </ClearAllButton>
-        </Flex>
-
-        <Flex flex={1} alignItems="center">
-          <Text variant="mediumText">{title}</Text>
         </Flex>
       </Flex>
 


### PR DESCRIPTION
- The type of this PR is: Fix

### Description

I was not able to tap the X to close the filter modal screen or the "Clear all" button to clear selections. This was caused by the "Sort & Filter" title covering both of those elements after their `position` was set to `"absolute"`.

![bug](https://user-images.githubusercontent.com/44589599/117127352-fa73da80-ad69-11eb-9f48-739cb19d1e00.gif)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
