### PR TITLE
fix: screen transition not fading when transitioning from sign up to login

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -14,6 +14,7 @@ upcoming:
     - Show loading spinner in all infinite scroll artowrk grids - ole
     - Fix missing bottom space on the Partner Artworks screen - ole
     - Animate welcome screen - mounir
+    - Add fading screen transition when transitioning from sign up to login
 
 releases:
   - version: 6.8.4

--- a/src/lib/Scenes/Onboarding/OnboardingCreateAccount/OnboardingCreateAccount.tsx
+++ b/src/lib/Scenes/Onboarding/OnboardingCreateAccount/OnboardingCreateAccount.tsx
@@ -125,7 +125,7 @@ export const OnboardingCreateAccount: React.FC<OnboardingCreateAccountProps> = (
         </StackNavigator.Navigator>
         <OnboardingCreateAccountButton
           navigateToLogin={() => {
-            navigation.replace("OnboardingLogin", { withFadeAnimation: false, email: formik.values.email })
+            navigation.replace("OnboardingLogin", { withFadeAnimation: true, email: formik.values.email })
           }}
           acceptedTerms={acceptedTerms}
           setAcceptedTerms={setAcceptedTerms}

--- a/src/lib/Scenes/Onboarding/OnboardingLogin.tsx
+++ b/src/lib/Scenes/Onboarding/OnboardingLogin.tsx
@@ -47,12 +47,17 @@ export const OnboardingLoginForm: React.FC<OnboardingLoginProps> = ({ navigation
    * to overwrite withFadeAnimation param once the screen shows up
    */
   useEffect(() => {
-    setTimeout(() => {
+    const timeout = setTimeout(() => {
       navigation.setParams({ withFadeAnimation: false })
     }, 1000)
     if (route.params?.email) {
       handleChange("email")(route.params.email)
     }
+
+    // When the user presses back on the back button immediately
+    // after opening the screen, we need to clear the timeout to avoid
+    // setting params on an unmounted screen
+    return clearTimeout(timeout)
   }, [])
 
   return (


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description
- Fix screen transition not fading when transitioning from Sign up to login
- Clear timeout when the user immediately navigates back to the welcome screen after they navigate to the login screen
<img width="334" alt="Screenshot 2021-05-05 at 13 00 58" src="https://user-images.githubusercontent.com/11945712/117132335-0334d280-ada3-11eb-9947-af6b4acf26a4.png">


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434