### PR TITLE
[WIP] feat: convert artist insights filter button to new style

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -693,25 +693,14 @@ DEPENDENCIES:
   - Yoga (from `./node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/artsy/Specs.git:
-    - Aerodramus
-    - "Artsy+UIColors"
-    - "Artsy+UIFonts"
-    - "Artsy+UILabels"
-    - Artsy-UIButtons
-    - Extraction
-  trunk:
+  https://cdn.cocoapods.org/:
     - "@react-native-mapbox-gl-mapbox-static"
     - AFNetworkActivityLogger
-    - AFNetworking
-    - Analytics
     - ARAnalytics
-    - boost-for-react-native
     - CocoaAsyncSocket
     - CocoaLumberjack
     - DHCShakeNotifier
     - EDColor
-    - Expecta
     - "Expecta+Snapshots"
     - FBSDKCoreKit
     - FBSDKLoginKit
@@ -735,7 +724,6 @@ SPEC REPOS:
     - MARKRangeSlider
     - MMMarkdown
     - MultiDelegate
-    - Nimble
     - Nimble-Snapshots
     - NPKeyboardLayoutGuide
     - ObjectiveSugar
@@ -743,12 +731,10 @@ SPEC REPOS:
     - OHHTTPStubs
     - OpenSSL-Universal
     - ORKeyboardReactingApplication
-    - ORStackView
     - Quick
     - SailthruMobile
     - SDWebImage
     - Sentry
-    - Specta
     - Starscream
     - Stripe
     - SwiftyJSON
@@ -758,6 +744,23 @@ SPEC REPOS:
     - "UIView+BooleanAnimations"
     - "XCTest+OHHTTPStubSuiteCleanUp"
     - YogaKit
+  https://github.com/artsy/Specs.git:
+    - Aerodramus
+    - "Artsy+UIColors"
+    - "Artsy+UIFonts"
+    - "Artsy+UILabels"
+    - Artsy-UIButtons
+    - Extraction
+  https://github.com/CocoaPods/Specs.git:
+    - AFNetworking
+    - Analytics
+    - boost-for-react-native
+    - Expecta
+    - FBSnapshotTestCase
+    - Nimble
+    - ORStackView
+    - SDWebImage
+    - Specta
 
 EXTERNAL SOURCES:
   AFOAuth1Client:

--- a/src/lib/Components/Artist/ArtistInsights/__tests__/ArtistInsightsAuctionResults-tests.tsx
+++ b/src/lib/Components/Artist/ArtistInsights/__tests__/ArtistInsightsAuctionResults-tests.tsx
@@ -10,7 +10,7 @@ import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment } from "relay-test-utils"
 import { mockEnvironmentPayload } from "../../../../tests/mockEnvironmentPayload"
 import { AuctionResultFragmentContainer } from "../../../Lists/AuctionResultListItem"
-import { ArtistInsightsAuctionResultsPaginationContainer, SortMode } from "../ArtistInsightsAuctionResults"
+import { ArtistInsightsAuctionResultsPaginationContainer, WorksCount } from "../ArtistInsightsAuctionResults"
 
 jest.unmock("react-relay")
 
@@ -52,6 +52,9 @@ describe("ArtistInsightsAuctionResults", () => {
               <ArtistInsightsAuctionResultsPaginationContainer
                 artist={props.artist}
                 scrollToTop={() => {
+                  console.log("do nothing")
+                }}
+                openFilterModal={() => {
                   console.log("do nothing")
                 }}
               />
@@ -104,7 +107,7 @@ describe("ArtistInsightsAuctionResults", () => {
         }),
       })
 
-      expect(extractText(tree.root.findByType(SortMode))).toBe("1 result • Sorted by most recent sale date")
+      expect(extractText(tree.root.findByType(WorksCount))).toBe("1 result")
     })
 
     it("renders the results string when totalCount is greater than 1", () => {
@@ -117,7 +120,7 @@ describe("ArtistInsightsAuctionResults", () => {
           },
         }),
       })
-      expect(extractText(tree.root.findByType(SortMode))).toBe("10 results • Sorted by most recent sale date")
+      expect(extractText(tree.root.findByType(WorksCount))).toBe("10 results")
     })
   })
 })


### PR DESCRIPTION
The type of this PR is: **FEAT**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-2905]

### Description

Following up on #4703, this PR does the same for the Insights tab

Still to resolve:
- [ ] Stickiness

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [ ] I have documented any follow-up work that this PR will require, or it does not require any.
- [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[FX-2905]: https://artsyproduct.atlassian.net/browse/FX-2905