### PR TITLE
Add buyer guarantee message and link to inquiry make offer button

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -24,6 +24,7 @@ upcoming:
     - Update home screen modules (change order, remove recently saved) - ole
     - Route artist auction results to artist insights - ole
     - Add "Lots by artists I follow" rails to the home screen - ole
+    - Add buyer guarantee message and link to inquiry make offer button - lily
 
 releases:
   - version: 6.8.4

--- a/src/lib/Scenes/Inbox/Components/Conversations/OpenInquiryModalButton.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/OpenInquiryModalButton.tsx
@@ -2,7 +2,7 @@ import { tappedMakeOffer } from "@artsy/cohesion"
 import { OpenInquiryModalButtonQuery } from "__generated__/OpenInquiryModalButtonQuery.graphql"
 import { navigate } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
-import { Button, Flex, Separator } from "palette"
+import { Button, CheckCircleIcon, Flex, Separator, Text } from "palette"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -26,6 +26,23 @@ export const OpenInquiryModalButton: React.FC<OpenInquiryModalButtonProps> = ({ 
     <>
       <ShadowSeparator />
       <Flex p={1.5}>
+        <Flex flexDirection="row">
+          <CheckCircleIcon mr={1} mt="3px" />
+          <Text color="black60" variant="small" mb={1}>
+            Only purchases completed with our secure checkout are protected by{" "}
+            <Text
+              style={{ textDecorationLine: "underline" }}
+              color="black100"
+              variant="small"
+              onPress={() => {
+                navigate(`buyer-guarantee`)
+              }}
+            >
+              The Artsy Guarantee
+            </Text>
+            .
+          </Text>
+        </Flex>
         <Button
           onPress={() => {
             trackEvent(tappedMakeOffer(conversationID as string))

--- a/src/lib/Scenes/Inbox/Components/Conversations/ReviewOfferButton.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/ReviewOfferButton.tsx
@@ -105,11 +105,12 @@ export const ReviewOfferButton: React.FC<ReviewOfferButtonProps> = ({ conversati
     >
       <Flex
         px={2}
+        py={1}
         justifyContent="space-between"
         alignItems="center"
         bg={backgroundColor}
         flexDirection="row"
-        height={60}
+        minHeight={60}
       >
         <Flex flexDirection="row">
           <Icon mt="3px" fill="white100" />

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/OpenInquiryModalButton-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/OpenInquiryModalButton-tests.tsx
@@ -1,6 +1,8 @@
 import { OpenInquiryModalButtonTestsQuery } from "__generated__/OpenInquiryModalButtonTestsQuery.graphql"
+import { navigate } from "lib/navigation/navigate"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { Text } from "palette"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { act } from "react-test-renderer"
@@ -77,6 +79,22 @@ describe("OpenInquiryModalButtonQueryRenderer", () => {
 
       expect(tree.root.findAllByType(OpenInquiryModalButton)).toHaveLength(0)
       expect(extractText(tree.root)).not.toContain("Make Offer")
+    })
+  })
+
+  describe("Artsy guarantee message ad link", () => {
+    it("display the correct message", () => {
+      const tree = getWrapper()
+
+      expect(extractText(tree.root)).toContain("Only purchases completed with our secure checkout are protected")
+      expect(tree.root.findAllByType(OpenInquiryModalButton)).toHaveLength(1)
+    })
+
+    it("navigates to the buyer guarantee page when tapped", () => {
+      const tree = getWrapper()
+      tree.root.findAllByType(Text)[1].props.onPress()
+
+      expect(navigate).toHaveBeenCalledWith("buyer-guarantee")
     })
   })
 })


### PR DESCRIPTION
[PURCHASE-2538] 

This ticket adds a message about and link to the buyer guarantee page to the inquiry make offer button area. I also made small style adjustments to the CTA to fix a padding issue.

__Buyer guarantee message:__

<img width="439" alt="Screen Shot 2021-05-07 at 9 33 16 AM" src="https://user-images.githubusercontent.com/5643895/117483936-6bff8480-af34-11eb-9aa7-ee8c7fc32d20.png">

__CTA padding issue__

_Before:_
<img width="442" alt="Screen Shot 2021-05-03 at 1 31 49 PM" src="https://user-images.githubusercontent.com/5643895/117484013-876a8f80-af34-11eb-8242-c411651c2a28.png">

_After:_
<img width="449" alt="Screen Shot 2021-05-07 at 1 57 29 PM" src="https://user-images.githubusercontent.com/5643895/117507908-b9d8b480-af55-11eb-96c8-4b2740ebe7c6.png">





[PURCHASE-2538]: https://artsyproduct.atlassian.net/browse/PURCHASE-2538