### PR TITLE
feat: add env var to silence beta failures #trivial

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -27,8 +27,7 @@ lane :ship_beta_ios do
   api_key = app_store_connect_api_key(
     key_id: ENV['ARTSY_APP_STORE_CONNECT_API_KEY_ID'],
     issuer_id: ENV['ARTSY_APP_STORE_CONNECT_API_KEY_ISSUER_ID'],
-    key_content: ENV['ARTSY_APP_STORE_CONNECT_API_KEY_CONTENT_BASE64'],
-    is_key_content_base64: true,
+    key_content: ENV['ARTSY_APP_STORE_CONNECT_API_KEY_CONTENT'],
     in_house: false,
   )
 
@@ -175,6 +174,15 @@ lane :ship_beta_android do
 end
 
 lane :promote_beta_ios do
+   api_key = app_store_connect_api_key(
+    key_id: ENV['ARTSY_APP_STORE_CONNECT_API_KEY_ID'],
+    issuer_id: ENV['ARTSY_APP_STORE_CONNECT_API_KEY_ISSUER_ID'],
+    key_content: ENV['ARTSY_APP_STORE_CONNECT_API_KEY_CONTENT_BASE64'],
+    is_key_content_base64: true,
+    in_house: false,
+  )
+
+
   api_key = app_store_connect_api_key(
     key_id: ENV['ARTSY_APP_STORE_CONNECT_API_KEY_ID'],
     issuer_id: ENV['ARTSY_APP_STORE_CONNECT_API_KEY_ISSUER_ID'],
@@ -376,15 +384,17 @@ lane :notify_beta_failed do |options|
               Looks like the latest beta failed to deploy!
               See circle job for more details.
             MSG
-  slack(
-    message: message,
-    success: false,
-    payload: {
-      'Circle Build' => ENV['CIRCLE_BUILD_URL'],
-      'Exception' => exception.message
-    },
-    default_payloads: []
-  )
+
+  puts message
+  # slack(
+  #   message: message,
+  #   success: false,
+  #   payload: {
+  #     'Circle Build' => ENV['CIRCLE_BUILD_URL'],
+  #     'Exception' => exception.message
+  #   },
+  #   default_payloads: []
+  # )
 end
 
 lane :promote_beta_android do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -174,15 +174,6 @@ lane :ship_beta_android do
 end
 
 lane :promote_beta_ios do
-   api_key = app_store_connect_api_key(
-    key_id: ENV['ARTSY_APP_STORE_CONNECT_API_KEY_ID'],
-    issuer_id: ENV['ARTSY_APP_STORE_CONNECT_API_KEY_ISSUER_ID'],
-    key_content: ENV['ARTSY_APP_STORE_CONNECT_API_KEY_CONTENT_BASE64'],
-    is_key_content_base64: true,
-    in_house: false,
-  )
-
-
   api_key = app_store_connect_api_key(
     key_id: ENV['ARTSY_APP_STORE_CONNECT_API_KEY_ID'],
     issuer_id: ENV['ARTSY_APP_STORE_CONNECT_API_KEY_ISSUER_ID'],
@@ -384,17 +375,15 @@ lane :notify_beta_failed do |options|
               Looks like the latest beta failed to deploy!
               See circle job for more details.
             MSG
-
-  puts message
-  # slack(
-  #   message: message,
-  #   success: false,
-  #   payload: {
-  #     'Circle Build' => ENV['CIRCLE_BUILD_URL'],
-  #     'Exception' => exception.message
-  #   },
-  #   default_payloads: []
-  # )
+  slack(
+    message: message,
+    success: false,
+    payload: {
+      'Circle Build' => ENV['CIRCLE_BUILD_URL'],
+      'Exception' => exception.message
+    },
+    default_payloads: []
+  )
 end
 
 lane :promote_beta_android do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -409,7 +409,10 @@ lane :tag_and_push do |options|
 end
 
 error do |lane, exception|
+  silence_beta_failures = ENV['FASTLANE_SILENCE_BETA_FAILURES']
   if lane == :ship_beta or lane == :ship_beta_ios or lane == :ship_beta_android
-    notify_beta_failed(exception: exception)
+    if silence_beta_failures.to_s.downcase != "true"
+      notify_beta_failed(exception: exception)
+    end
   end
 end


### PR DESCRIPTION
The type of this PR is: **feat**

### Description

Adds an environment variable to silence beta build failures in circle while I debug build failures.
