### PR TITLE
fix(CX-1436): User unable to search on iOS

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -7,6 +7,7 @@ upcoming:
     - Add analytics on android - pavlos
     - Add staging support for deep links on android - mounir, ole
     - Refactor filter event payloads to send JSON - roop
+    - Fix issue with ARSpinner being registered more than once - mounir, kizito
   user_facing:
     - Combine gallery and institution artwork filters - mdole
     - Remove old login from android - adam, barry, david, jonathan, mounir, pavlos

--- a/src/lib/Components/Spinner.tsx
+++ b/src/lib/Components/Spinner.tsx
@@ -27,7 +27,6 @@ const Spinner: React.FC<SpinnerProps> = ({
   ...props
 }) => {
   if (Platform.OS === "ios") {
-    const NativeSpinner: React.ComponentClass<any> = requireNativeComponent("ARSpinner")
     return (
       <View style={[props.style, styles.container]} testID={props.testID}>
         <NativeSpinner spinnerColor={processColor(spinnerColor)} style={{ size }} />
@@ -48,5 +47,8 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
 })
+
+const NativeSpinner: React.ComponentClass<any> =
+  Platform.OS === "ios" ? requireNativeComponent("ARSpinner") : ActivityIndicator
 
 export default Spinner


### PR DESCRIPTION
Co-authored-by: Kizito Egeonu <kizito.egeonu@gmail.com>

The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1436]

### Description
- We were registering the same native component every time the spinner props change and this lead to an issue were the native component gets registered more than once and leads to the app crashing. 
- We solved that by making sure that the component is only registered once on iOS and avoiding the native registration on android in favor of ActivityIndicator.


https://user-images.githubusercontent.com/11945712/117629036-0ac8f280-b17a-11eb-8264-8fca8fdf2a78.mov


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1436]: https://artsyproduct.atlassian.net/browse/CX-1436