### PR TITLE
fix(CX-1375) Artist Icon is not round

### DIFF
--- a/src/palette/elements/Avatar/Avatar.tsx
+++ b/src/palette/elements/Avatar/Avatar.tsx
@@ -109,19 +109,17 @@ export const Avatar: FunctionComponent<AvatarProps> = ({ ...props }) => {
     <BaseAvatar
       size={props.size}
       renderAvatar={() => (
-        <Flex height={diameter} width={diameter} borderRadius={diameter / 2} overflow="hidden">
-          <Image
-            resizeMode="stretch"
-            style={{
-              width: diameter,
-              height: diameter,
-              borderRadius: diameter / 2,
-            }}
-            source={{
-              uri: props.src,
-            }}
-          />
-        </Flex>
+        <Image
+          resizeMode="cover"
+          style={{
+            width: diameter,
+            height: diameter,
+            borderRadius: diameter / 2,
+          }}
+          source={{
+            uri: props.src,
+          }}
+        />
       )}
       {...props}
     />


### PR DESCRIPTION
The type of this PR is: fix

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1375]

### Description

<!-- Implementation description -->
This PR fixes square-like artist icons in the saves and follow section

![Screenshot 2021-05-10 at 14 09 01](https://user-images.githubusercontent.com/73339470/117650392-50e17e80-b199-11eb-9466-db2a37db21ac.png)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1375]: https://artsyproduct.atlassian.net/browse/CX-1375