### PR TITLE
feat: Change home screen "lots for you" copy

### DIFF
--- a/src/lib/Scenes/Home/Components/SaleArtworksHomeRail.tsx
+++ b/src/lib/Scenes/Home/Components/SaleArtworksHomeRail.tsx
@@ -46,7 +46,7 @@ export const SaleArtworksHomeRail: React.FC<Props> = ({ me, relay }) => {
   return (
     <Flex>
       <Flex mx={2}>
-        <SectionTitle title="Lots by artists you follow" />
+        <SectionTitle title="Auction lots for you ending soon" />
       </Flex>
       <CardRailFlatList
         data={artworks}

--- a/src/lib/Scenes/Home/Components/__tests__/SaleArtworksHomeRail-tests.tsx
+++ b/src/lib/Scenes/Home/Components/__tests__/SaleArtworksHomeRail-tests.tsx
@@ -42,7 +42,7 @@ describe("SaleArtworksHomeRail", () => {
 
     mockEnvironmentPayload(mockEnvironment, mockProps)
 
-    expect(tree.root.findAllByType(SectionTitle)[0].props.title).toEqual("Lots by artists you follow")
+    expect(tree.root.findAllByType(SectionTitle)[0].props.title).toEqual("Auction lots for you ending soon")
     expect(tree.root.findAllByType(SaleArtworkTileRailCardContainer)).toHaveLength(PAGE_SIZE)
   })
 


### PR DESCRIPTION
The type of this PR is: Feature

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1438]

### Description

Update section copy to: “Auction lots for you ending soon”.

No changelog required - we already have it there.


![image](https://user-images.githubusercontent.com/4691889/117674410-f00f7180-b1ab-11eb-81f4-aba206669aea.png)


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1438]: https://artsyproduct.atlassian.net/browse/CX-1438