### PR TITLE
fix: add border radius for auction image item

### DIFF
--- a/src/lib/Components/Lists/AuctionResultListItem.tsx
+++ b/src/lib/Components/Lists/AuctionResultListItem.tsx
@@ -44,6 +44,7 @@ const AuctionResultListItem: React.FC<Props> = ({ auctionResult, onPress }) => {
             backgroundColor="black"
             alignItems="center"
             justifyContent="center"
+            overflow="hidden"
           >
             <OpaqueImageView width={60} height={60} imageURL={auctionResult.images.thumbnail.url} />
           </Flex>


### PR DESCRIPTION
The type of this PR is: **FIX**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1048]

### Description

<!-- Implementation description -->
Add border radius to images in auction result rows 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

#### iOS

_before_
![ios-before](https://user-images.githubusercontent.com/3513494/117698305-442a4e00-b1cc-11eb-9665-ae10072b01d9.png)

_after_
![ios-after](https://user-images.githubusercontent.com/3513494/117698323-49879880-b1cc-11eb-917d-0026625ee2d6.png)

#### Android

_before_
![android-before](https://user-images.githubusercontent.com/3513494/117698344-50161000-b1cc-11eb-89e9-56e4b5bdaf27.png)

_after_
![android-after](https://user-images.githubusercontent.com/3513494/117698365-56a48780-b1cc-11eb-8063-2f45ae154b2c.png)

[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1048]: https://artsyproduct.atlassian.net/browse/CX-1048