### PR TITLE
chore: handle dismiss modal for andriod

### DIFF
--- a/src/lib/Scenes/Inbox/Screens/Conversation.tsx
+++ b/src/lib/Scenes/Inbox/Screens/Conversation.tsx
@@ -78,11 +78,13 @@ export class Conversation extends React.Component<Props, State> {
     NetInfo.isConnected.addEventListener("connectionChange", this.handleConnectivityChange)
     this.maybeMarkLastMessageAsRead()
     navigationEvents.addListener("modalDismissed", this.handleModalDismissed)
+    navigationEvents.addListener("goBack", this.handleModalDismissed)
   }
 
   componentWillUnmount() {
     NetInfo.isConnected.removeEventListener("connectionChange", this.handleConnectivityChange)
     navigationEvents.removeListener("modalDismissed", this.handleModalDismissed)
+    navigationEvents.removeListener("goBack", this.handleModalDismissed)
   }
 
   // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏

--- a/src/lib/Scenes/Inbox/Screens/__tests__/Conversation-tests.tsx
+++ b/src/lib/Scenes/Inbox/Screens/__tests__/Conversation-tests.tsx
@@ -105,3 +105,13 @@ it("handles a dismissed modal with modalDismiss event", () => {
 
   expect(componentInstance.refetch).toHaveBeenCalled()
 })
+
+it("handles a dismissed modal with goBack event", () => {
+  const conversation = getWrapper()
+  const componentInstance = (conversation.root.findByType(Conversation).children[0] as ReactTestInstance).instance
+
+  jest.spyOn(componentInstance, "refetch")
+  navigationEvents.emit("goBack")
+
+  expect(componentInstance.refetch).toHaveBeenCalled()
+})

--- a/src/lib/navigation/navigate.ts
+++ b/src/lib/navigation/navigate.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "events"
 import { AppModule, modules, ViewOptions } from "lib/AppRegistry"
 import { LegacyNativeModules } from "lib/NativeModules/LegacyNativeModules"
 import { GlobalStore, unsafe__getSelectedTab } from "lib/store/GlobalStore"
-import { Linking } from "react-native"
+import { Linking, Platform } from "react-native"
 import { matchRoute } from "./routes"
 
 export interface ViewDescriptor extends ViewOptions {
@@ -76,10 +76,16 @@ export const navigationEvents = new EventEmitter()
 
 export function dismissModal() {
   LegacyNativeModules.ARScreenPresenterModule.dismissModal()
+  if (Platform.OS === "android") {
+    navigationEvents.emit("modalDismissed")
+  }
 }
 
 export function goBack() {
   LegacyNativeModules.ARScreenPresenterModule.goBack(unsafe__getSelectedTab())
+  if (Platform.OS === "android") {
+    navigationEvents.emit("goBack")
+  }
 }
 
 export function popParentViewController() {


### PR DESCRIPTION
The type of this PR is: **CHORE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [PURCHASE-2574]

### Description

<!-- Implementation description -->
This PR is follow up work to adding a dismiss modal event and addresses https://github.com/artsy/eigen/pull/4712#issuecomment-832507487. This PR specifically emits `dismissModal` and `goBack` events for andriod.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [ ] I have documented any follow-up work that this PR will require, or it does not require any.
- [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[PURCHASE-2574]: https://artsyproduct.atlassian.net/browse/PURCHASE-2574