### PR TITLE
fix: remove separator on home sale artworks rail when no sale artwork…

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -28,6 +28,7 @@ upcoming:
     - Route artist auction results to artist insights - ole
     - Add "Lots by artists I follow" rails to the home screen - ole
     - Add buyer guarantee message and link to inquiry make offer button - lily
+    - Fix extra padding on home module rails - mounir, ole
 
 releases:
   - version: 6.8.4

--- a/src/lib/Scenes/Home/Components/SaleArtworksHomeRail.tsx
+++ b/src/lib/Scenes/Home/Components/SaleArtworksHomeRail.tsx
@@ -7,7 +7,7 @@ import { navigate } from "lib/navigation/navigate"
 import { extractNodes } from "lib/utils/extractNodes"
 import { isCloseToEdge } from "lib/utils/isCloseToEdge"
 import { Flex } from "palette"
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 
 export const PAGE_SIZE = 6
@@ -15,10 +15,16 @@ export const PAGE_SIZE = 6
 interface Props {
   me: SaleArtworksHomeRail_me
   relay: RelayPaginationProp
+  onHide?: () => void
+  onShow?: () => void
 }
 
-export const SaleArtworksHomeRail: React.FC<Props> = ({ me, relay }) => {
+export const SaleArtworksHomeRail: React.FC<Props> = ({ me, relay, onShow, onHide }) => {
   const artworks = extractNodes(me?.lotsByFollowedArtistsConnection)
+
+  useEffect(() => {
+    artworks.length ? onShow?.() : onHide?.()
+  }, [artworks.length])
 
   if (!artworks?.length) {
     return null

--- a/src/lib/Scenes/Home/Components/__tests__/SaleArtworksHomeRail-tests.tsx
+++ b/src/lib/Scenes/Home/Components/__tests__/SaleArtworksHomeRail-tests.tsx
@@ -6,9 +6,13 @@ import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment } from "relay-test-utils"
+import { flushPromiseQueue } from "../../../../tests/flushPromiseQueue"
 import { PAGE_SIZE, SaleArtworksHomeRailContainer } from "..//SaleArtworksHomeRail"
 
 jest.unmock("react-relay")
+
+const onShowMock = jest.fn()
+const onHideMock = jest.fn()
 
 describe("SaleArtworksHomeRail", () => {
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
@@ -26,7 +30,7 @@ describe("SaleArtworksHomeRail", () => {
       variables={{}}
       render={({ props }) => {
         if (props?.me) {
-          return <SaleArtworksHomeRailContainer me={props.me} />
+          return <SaleArtworksHomeRailContainer me={props.me} onShow={onShowMock} onHide={onHideMock} />
         }
         return null
       }}
@@ -37,16 +41,18 @@ describe("SaleArtworksHomeRail", () => {
     mockEnvironment = createMockEnvironment()
   })
 
-  it("Renders list of sale artworks without throwing an error", () => {
+  it("Renders list of sale artworks without throwing an error", async () => {
     const tree = renderWithWrappers(<TestRenderer />)
 
     mockEnvironmentPayload(mockEnvironment, mockProps)
+    await flushPromiseQueue()
+    expect(onShowMock).toHaveBeenCalled()
 
     expect(tree.root.findAllByType(SectionTitle)[0].props.title).toEqual("Lots by artists you follow")
     expect(tree.root.findAllByType(SaleArtworkTileRailCardContainer)).toHaveLength(PAGE_SIZE)
   })
 
-  it("returns null if there are no artworks", () => {
+  it("returns null if there are no artworks", async () => {
     const tree = renderWithWrappers(<TestRenderer />)
 
     const noArtworksProps = {
@@ -57,9 +63,11 @@ describe("SaleArtworksHomeRail", () => {
       }),
     }
     mockEnvironmentPayload(mockEnvironment, noArtworksProps)
+    await flushPromiseQueue()
     // React-test-renderer has no isEmptyComponent or isNullComponent therefore I am testing for the container
     // expect(tree.root.findAllByType(Flex)).toHaveLength(0)
     expect(tree.toJSON()).toBeNull()
+    expect(onHideMock).toHaveBeenCalled()
   })
 })
 

--- a/src/lib/Scenes/Home/Home.tsx
+++ b/src/lib/Scenes/Home/Home.tsx
@@ -123,7 +123,7 @@ const Home = (props: Props) => {
             data={rowData}
             initialNumToRender={5}
             refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />}
-            renderItem={({ item, index }) => {
+            renderItem={({ item, index, separators }) => {
               switch (item.type) {
                 case "artwork":
                   return <ArtworkRailFragmentContainer rail={item.data} scrollRef={scrollRefs.current[index]} />
@@ -143,7 +143,13 @@ const Home = (props: Props) => {
                 case "viewing-rooms":
                   return <ViewingRoomsHomeRail featured={featured} />
                 case "lotsByFollowedArtists":
-                  return <SaleArtworksHomeRailContainer me={me} />
+                  return (
+                    <SaleArtworksHomeRailContainer
+                      me={me}
+                      onShow={() => separators.updateProps("leading", { hideSeparator: false })}
+                      onHide={() => separators.updateProps("leading", { hideSeparator: true })}
+                    />
+                  )
               }
             }}
             ListHeaderComponent={
@@ -156,7 +162,7 @@ const Home = (props: Props) => {
                 <Spacer mb="2" />
               </Box>
             }
-            ItemSeparatorComponent={() => <Spacer mb={3} />}
+            ItemSeparatorComponent={({ hideSeparator }) => (!hideSeparator ? <Spacer mb={3} /> : null)}
             ListFooterComponent={() => <Spacer mb={3} />}
             keyExtractor={(_item, index) => String(index)}
           />


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1439]

### Description
- Remove separator on home sale artworks rail when no sale artworks available
![Group 1 (8)](https://user-images.githubusercontent.com/11945712/117812083-a3866d80-b261-11eb-80b7-c1a00924fb17.png)

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1439]: https://artsyproduct.atlassian.net/browse/CX-1439