### PR TITLE
fix(analytics): fix off by one error, the fresh install event was not firing.

### DIFF
--- a/src/lib/AndroidApp.tsx
+++ b/src/lib/AndroidApp.tsx
@@ -55,7 +55,7 @@ const Main: React.FC<{}> = track()(({}) => {
 
   useEffect(() => {
     const launchCount = getCurrentEmissionState().launchCount
-    if (launchCount >= 1) {
+    if (launchCount > 1) {
       return
     }
     SegmentTrackingProvider.postEvent({ name: AnalyticsConstants.FreshInstall })


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-]

### Description

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

This might be the smallest PR I've ever done on eigen :D.

Basically, on first launch after fresh install of the app, the launchCount is 1. That if was returning, skipping the event sending.

So now it appears:
<img width="1289" alt="Screenshot 2021-05-12 at 11 52 10" src="https://user-images.githubusercontent.com/100233/117963792-b7d97180-b318-11eb-8947-424345ec9c8a.png">



- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434