### PR TITLE
chore(dev): some quick access info for artwork

### DIFF
--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -16,6 +16,7 @@ import {
   PlaceholderText,
   ProvidePlaceholderContext,
 } from "lib/utils/placeholders"
+import { QAInfoPanel } from "lib/utils/QAInfo"
 import { Schema, screenTrack } from "lib/utils/track"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { Box, Separator, space, Spacer } from "palette"
@@ -289,19 +290,29 @@ export class Artwork extends React.Component<Props, State> {
   }
 
   render() {
-    return (
-      <FlatList<ArtworkPageSection>
-        keyboardShouldPersistTaps="handled"
-        data={this.sections()}
-        ItemSeparatorComponent={() => (
-          <Box mx={2} my={3}>
-            <Separator />
-          </Box>
-        )}
-        refreshControl={<RefreshControl refreshing={this.state.refreshing} onRefresh={this.onRefresh} />}
-        contentContainerStyle={{ paddingBottom: 40 }}
-        renderItem={({ item }) => (item.excludePadding ? item.element : <Box px={2}>{item.element}</Box>)}
+    const QAInfo = () => (
+      <QAInfoPanel
+        style={{ position: "absolute", top: 200, left: 10, backgroundColor: "grey" }}
+        info={[["id", this.props.artworkAboveTheFold.internalID]]}
       />
+    )
+
+    return (
+      <>
+        <FlatList<ArtworkPageSection>
+          keyboardShouldPersistTaps="handled"
+          data={this.sections()}
+          ItemSeparatorComponent={() => (
+            <Box mx={2} my={3}>
+              <Separator />
+            </Box>
+          )}
+          refreshControl={<RefreshControl refreshing={this.state.refreshing} onRefresh={this.onRefresh} />}
+          contentContainerStyle={{ paddingBottom: 40 }}
+          renderItem={({ item }) => (item.excludePadding ? item.element : <Box px={2}>{item.element}</Box>)}
+        />
+        <QAInfo />
+      </>
     )
   }
 }


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-]

### Description

A small PR to add the id of the artwork. This shows up when the `Quick Access` DevToggle is enabled.

<img width="393" alt="Screenshot 2021-05-12 at 16 40 11" src="https://user-images.githubusercontent.com/100233/118003804-cdfb2800-b340-11eb-9ca4-0e709e54f36c.png">



<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434