### PR TITLE
fix(CX-1322): incorrect action name

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,12 +3,12 @@ upcoming:
   date: TBD
   dev:
     - lock screen orientation to portrait on android phones - mounir
-    - 
+    - Fix artist follow is incorrectly firing action_name - dzmitry
   user_facing:
     - Fix cancel button next to search bar doesn't clear terms/results - yauheni
     - Fix phone input misalignment on android - kizito
     - Fix push notification pre request prompt showing up everytime - kizito
-    - 
+    -
 
 releases:
   - version: 6.9.0

--- a/src/lib/Components/Artist/ArtistHeader.tsx
+++ b/src/lib/Components/Artist/ArtistHeader.tsx
@@ -85,7 +85,7 @@ export const ArtistHeader: React.FC<Props> = ({ artist, relay }) => {
 
   const successfulFollowChange = () => {
     trackEvent({
-      action_name: artist.isFollowed ? Schema.ActionNames.ArtistFollow : Schema.ActionNames.ArtistUnfollow,
+      action_name: artist.isFollowed ? Schema.ActionNames.ArtistUnfollow : Schema.ActionNames.ArtistFollow,
       action_type: Schema.ActionTypes.Success,
       owner_id: artist.internalID,
       owner_slug: artist.slug,

--- a/src/lib/Scenes/Artwork/Components/FollowArtistButton.tsx
+++ b/src/lib/Scenes/Artwork/Components/FollowArtistButton.tsx
@@ -15,7 +15,7 @@ interface Props {
 export class FollowArtistButton extends React.Component<Props> {
   @track((props: Props) => {
     return {
-      action_name: props.artist.is_followed ? Schema.ActionNames.ArtistFollow : Schema.ActionNames.ArtistUnfollow,
+      action_name: props.artist.is_followed ? Schema.ActionNames.ArtistUnfollow : Schema.ActionNames.ArtistFollow,
       action_type: Schema.ActionTypes.Success,
       owner_id: props.artist.internalID,
       owner_slug: props.artist.slug,


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1322]

### Description
This PR fixes incorrectly firing action_name for success event
<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1322]: https://artsyproduct.atlassian.net/browse/CX-1322