### PR TITLE
UI tweaks to coversation page for make offer button

### DIFF
--- a/src/lib/Scenes/Inbox/Components/Conversations/OpenInquiryModalButton.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/OpenInquiryModalButton.tsx
@@ -2,22 +2,16 @@ import { tappedMakeOffer } from "@artsy/cohesion"
 import { OpenInquiryModalButtonQuery } from "__generated__/OpenInquiryModalButtonQuery.graphql"
 import { navigate } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
-import { Button, CheckCircleIcon, Flex, Separator, Text } from "palette"
+import { Button, CheckCircleIcon, Flex, Text } from "palette"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { useTracking } from "react-tracking"
-import styled from "styled-components/native"
+import { ShadowSeparator } from "../ShadowSeparator"
 
 export interface OpenInquiryModalButtonProps {
   artworkID: string
   conversationID: string | null | undefined
 }
-
-const ShadowSeparator = styled(Separator)`
-  box-shadow: 0 -1px 1px rgba(50, 50, 50, 0.1);
-  width: 100%;
-  height: 0;
-`
 
 export const OpenInquiryModalButton: React.FC<OpenInquiryModalButtonProps> = ({ artworkID, conversationID }) => {
   const { trackEvent } = useTracking()
@@ -25,23 +19,25 @@ export const OpenInquiryModalButton: React.FC<OpenInquiryModalButtonProps> = ({ 
   return (
     <>
       <ShadowSeparator />
-      <Flex p={1.5}>
+      <Flex p={1}>
         <Flex flexDirection="row">
           <CheckCircleIcon mr={1} mt="3px" />
-          <Text color="black60" variant="small" mb={1}>
-            Only purchases completed with our secure checkout are protected by{" "}
-            <Text
-              style={{ textDecorationLine: "underline" }}
-              color="black100"
-              variant="small"
-              onPress={() => {
-                navigate(`buyer-guarantee`)
-              }}
-            >
-              The Artsy Guarantee
+          <Flex flexShrink={1}>
+            <Text color="black60" variant="small" mb={1}>
+              Only purchases completed with our secure checkout are protected by{" "}
+              <Text
+                style={{ textDecorationLine: "underline" }}
+                color="black100"
+                variant="small"
+                onPress={() => {
+                  navigate(`buyer-guarantee`)
+                }}
+              >
+                The Artsy Guarantee
+              </Text>
+              .
             </Text>
-            .
-          </Text>
+          </Flex>
         </Flex>
         <Button
           onPress={() => {

--- a/src/lib/Scenes/Inbox/Components/ShadowSeparator.tsx
+++ b/src/lib/Scenes/Inbox/Components/ShadowSeparator.tsx
@@ -1,0 +1,8 @@
+import { Separator } from "palette"
+import styled from "styled-components/native"
+
+export const ShadowSeparator = styled(Separator)`
+  box-shadow: 0 -1px 1px rgba(50, 50, 50, 0.1);
+  width: 100%;
+  height: 0;
+`

--- a/src/lib/Scenes/Inbox/Screens/Conversation.tsx
+++ b/src/lib/Scenes/Inbox/Screens/Conversation.tsx
@@ -17,6 +17,7 @@ import React from "react"
 import { View } from "react-native"
 import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
 import styled from "styled-components/native"
+import { ShadowSeparator } from "../Components/ShadowSeparator"
 import { ConversationDetailsQueryRenderer } from "./ConversationDetails"
 
 const Container = styled.View`
@@ -213,6 +214,7 @@ export class Conversation extends React.Component<Props, State> {
               </HeaderTextContainer>
             </Flex>
           </Header>
+          <ShadowSeparator />
           {!this.state.isConnected && <ConnectivityBanner />}
           <Messages
             componentRef={(messages) => (this.messages = messages)}


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [PURCHASE-2669]

### Description

* Adds light grey keyline below header.
* Removes extra space around make offer button
* Fixes make offer info text alignement issue

<details><summary>Screenshots</summary>
Before:

<img width="753" alt="Screenshot_2021-05-12_at_13 58 01" src="https://user-images.githubusercontent.com/687513/118181285-91453480-b405-11eb-9a94-80364cc0db79.png">


After:


iPhone SE:

<img width="376" alt="Screen Shot 2021-05-13 at 3 30 30 PM" src="https://user-images.githubusercontent.com/687513/118181318-9dc98d00-b405-11eb-8e7b-ec70f89f3527.png">

iPhone 12:

<img width="370" alt="Screen Shot 2021-05-13 at 3 46 01 PM" src="https://user-images.githubusercontent.com/687513/118181335-a326d780-b405-11eb-9e0a-d5f25a91934a.png">

Regular conversation:

<img width="371" alt="Screen Shot 2021-05-13 at 4 03 01 PM" src="https://user-images.githubusercontent.com/687513/118181354-a8842200-b405-11eb-9fb5-58e67749c51a.png">

</details>

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.


[PURCHASE-2669]: https://artsyproduct.atlassian.net/browse/PURCHASE-2669