### PR TITLE
fix(filters): removes max height on modal

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -45,6 +45,7 @@ releases:
       - Fix extra padding on home module rails - mounir, ole
       - Implements custom price filter option (behind feature flag) - damon
       - Remove lots by followed artists rail for now - brian
+      - Removes max-height on artwork filter modal - damon
 
   - version: 6.8.4
     date: Apr 29, 2021

--- a/src/lib/Components/ArtworkFilter/ArtworkFilter.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilter.tsx
@@ -136,7 +136,7 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
 
   return (
     <NavigationContainer independent>
-      <FancyModal visible={props.isFilterArtworksModalVisible} onBackgroundPressed={handleClosingModal} maxHeight={550}>
+      <FancyModal visible={props.isFilterArtworksModalVisible} onBackgroundPressed={handleClosingModal}>
         <View style={{ flex: 1 }}>
           <Stack.Navigator
             // force it to not use react-native-screens, which is broken inside a react-native Modal for some reason


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [FX-2933]

### Description

Just removes the maxHeight. [Discussion here](https://artsy.slack.com/archives/C9SATFLUU/p1620943281438500) — Makes more sense, the filters actually fit on screen now, etc. 

https://user-images.githubusercontent.com/112297/118284925-f862f780-b49e-11eb-8b2b-5d475e75cb96.mov

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2933]: https://artsyproduct.atlassian.net/browse/FX-2933