### PR TITLE
feat(FX-2899): convert filter queries to input

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,6 +3,9 @@ upcoming:
   date: TBD
   dev:
     -
+    - lock screen orientation to portrait on android phones - mounir
+    - Fix artist follow is incorrectly firing action_name - dzmitry
+    - Convert filter queries to use a single structured input for filterArtworksConnection requests - dzmitry tratsiak
   user_facing:
     - Fix wrong input font on android - dzmitry
     - 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -3,8 +3,6 @@ upcoming:
   date: TBD
   dev:
     -
-    - lock screen orientation to portrait on android phones - mounir
-    - Fix artist follow is incorrectly firing action_name - dzmitry
     - Convert filter queries to use a single structured input for filterArtworksConnection requests - dzmitry tratsiak
   user_facing:
     - Fix wrong input font on android - dzmitry

--- a/src/__generated__/ArtistAboutTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistAboutTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 619ca8565658a9cfd7dd411f10c95038 */
+/* @relayHash b4012d2dfba16e62157f2bd5dbbb4a4c */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -83,7 +83,7 @@ fragment ArtistAbout_artist on Artist {
   ...Biography_artist
   ...ArtistSeriesMoreSeries_artist
   ...ArtistNotableWorksRail_artist
-  notableWorks: filterArtworksConnection(sort: "-weighted_iconicity", first: 3) {
+  notableWorks: filterArtworksConnection(first: 3, input: {sort: "-weighted_iconicity"}) {
     edges {
       node {
         id
@@ -160,7 +160,7 @@ fragment ArtistConsignButton_artist on Artist {
 fragment ArtistNotableWorksRail_artist on Artist {
   internalID
   slug
-  filterArtworksConnection(sort: "-weighted_iconicity", first: 10) {
+  filterArtworksConnection(first: 10, input: {sort: "-weighted_iconicity"}) {
     edges {
       node {
         id
@@ -333,8 +333,10 @@ v7 = {
 },
 v8 = {
   "kind": "Literal",
-  "name": "sort",
-  "value": "-weighted_iconicity"
+  "name": "input",
+  "value": {
+    "sort": "-weighted_iconicity"
+  }
 },
 v9 = {
   "alias": null,
@@ -870,7 +872,7 @@ return {
               },
               (v9/*: any*/)
             ],
-            "storageKey": "filterArtworksConnection(first:10,sort:\"-weighted_iconicity\")"
+            "storageKey": "filterArtworksConnection(first:10,input:{\"sort\":\"-weighted_iconicity\"})"
           },
           {
             "alias": "notableWorks",
@@ -906,7 +908,7 @@ return {
               },
               (v9/*: any*/)
             ],
-            "storageKey": "filterArtworksConnection(first:3,sort:\"-weighted_iconicity\")"
+            "storageKey": "filterArtworksConnection(first:3,input:{\"sort\":\"-weighted_iconicity\"})"
           },
           {
             "alias": "iconicCollections",
@@ -1264,7 +1266,7 @@ return {
     ]
   },
   "params": {
-    "id": "619ca8565658a9cfd7dd411f10c95038",
+    "id": "b4012d2dfba16e62157f2bd5dbbb4a4c",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artist": (v18/*: any*/),

--- a/src/__generated__/ArtistAbout_artist.graphql.ts
+++ b/src/__generated__/ArtistAbout_artist.graphql.ts
@@ -82,8 +82,10 @@ const node: ReaderFragment = {
         },
         {
           "kind": "Literal",
-          "name": "sort",
-          "value": "-weighted_iconicity"
+          "name": "input",
+          "value": {
+            "sort": "-weighted_iconicity"
+          }
         }
       ],
       "concreteType": "FilterArtworksConnection",
@@ -121,7 +123,7 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ],
-      "storageKey": "filterArtworksConnection(first:3,sort:\"-weighted_iconicity\")"
+      "storageKey": "filterArtworksConnection(first:3,input:{\"sort\":\"-weighted_iconicity\"})"
     },
     {
       "alias": "iconicCollections",
@@ -288,5 +290,5 @@ const node: ReaderFragment = {
   "type": "Artist",
   "abstractKey": null
 };
-(node as any).hash = 'b90ade61430985fc3d4e157ac87167c8';
+(node as any).hash = '6d256142c41f599abfa9db68190c75ad';
 export default node;

--- a/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
@@ -1,12 +1,64 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 39f313d86bb521fd3fe142652866ee3a */
+/* @relayHash 279b65abd41298edaf2ab0023549ca60 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
+export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
+export type FilterArtworksInput = {
+    acquireable?: boolean | null;
+    additionalGeneIDs?: Array<string | null> | null;
+    after?: string | null;
+    aggregationPartnerCities?: Array<string | null> | null;
+    aggregations?: Array<ArtworkAggregation | null> | null;
+    artistID?: string | null;
+    artistIDs?: Array<string | null> | null;
+    artistNationalities?: Array<string | null> | null;
+    artistSeriesID?: string | null;
+    atAuction?: boolean | null;
+    attributionClass?: Array<string | null> | null;
+    before?: string | null;
+    color?: string | null;
+    colors?: Array<string | null> | null;
+    dimensionRange?: string | null;
+    excludeArtworkIDs?: Array<string | null> | null;
+    extraAggregationGeneIDs?: Array<string | null> | null;
+    first?: number | null;
+    forSale?: boolean | null;
+    geneID?: string | null;
+    geneIDs?: Array<string | null> | null;
+    height?: string | null;
+    includeArtworksByFollowedArtists?: boolean | null;
+    includeMediumFilterInAggregation?: boolean | null;
+    inquireableOnly?: boolean | null;
+    keyword?: string | null;
+    keywordMatchExact?: boolean | null;
+    last?: number | null;
+    locationCities?: Array<string | null> | null;
+    majorPeriods?: Array<string | null> | null;
+    marketable?: boolean | null;
+    materialsTerms?: Array<string | null> | null;
+    medium?: string | null;
+    offerable?: boolean | null;
+    page?: number | null;
+    partnerCities?: Array<string | null> | null;
+    partnerID?: string | null;
+    partnerIDs?: Array<string | null> | null;
+    period?: string | null;
+    periods?: Array<string | null> | null;
+    priceRange?: string | null;
+    saleID?: string | null;
+    size?: number | null;
+    sizes?: Array<ArtworkSizes | null> | null;
+    sort?: string | null;
+    tagID?: string | null;
+    width?: string | null;
+};
 export type ArtistAboveTheFoldQueryVariables = {
     artistID: string;
+    input?: FilterArtworksInput | null;
 };
 export type ArtistAboveTheFoldQueryResponse = {
     readonly artist: {
@@ -35,6 +87,7 @@ export type ArtistAboveTheFoldQuery = {
 /*
 query ArtistAboveTheFoldQuery(
   $artistID: String!
+  $input: FilterArtworksInput
 ) {
   artist(id: $artistID) {
     internalID
@@ -47,7 +100,7 @@ query ArtistAboveTheFoldQuery(
       articles
     }
     ...ArtistHeader_artist
-    ...ArtistArtworks_artist
+    ...ArtistArtworks_artist_2VV6jB
     auctionResultsConnection {
       totalCount
     }
@@ -55,11 +108,11 @@ query ArtistAboveTheFoldQuery(
   }
 }
 
-fragment ArtistArtworks_artist on Artist {
+fragment ArtistArtworks_artist_2VV6jB on Artist {
   id
   slug
   internalID
-  artworks: filterArtworksConnection(first: 10, sort: "-decayed_merch", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  artworks: filterArtworksConnection(first: 10, input: $input, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -167,6 +220,11 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "artistID"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
   }
 ],
 v1 = [
@@ -244,20 +302,25 @@ v9 = {
   "storageKey": null
 },
 v10 = {
+  "kind": "Variable",
+  "name": "input",
+  "variableName": "input"
+},
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v12 = [
+v13 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -272,21 +335,12 @@ v12 = [
   },
   {
     "kind": "Literal",
-    "name": "dimensionRange",
-    "value": "*-*"
-  },
-  {
-    "kind": "Literal",
     "name": "first",
     "value": 10
   },
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "-decayed_merch"
-  }
+  (v10/*: any*/)
 ],
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -333,7 +387,9 @@ return {
             "name": "ArtistHeader_artist"
           },
           {
-            "args": null,
+            "args": [
+              (v10/*: any*/)
+            ],
             "kind": "FragmentSpread",
             "name": "ArtistArtworks_artist"
           }
@@ -383,7 +439,7 @@ return {
             ],
             "storageKey": null
           },
-          (v10/*: any*/),
+          (v11/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -391,7 +447,7 @@ return {
             "name": "isFollowed",
             "storageKey": null
           },
-          (v11/*: any*/),
+          (v12/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -408,7 +464,7 @@ return {
           },
           {
             "alias": "artworks",
-            "args": (v12/*: any*/),
+            "args": (v13/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -444,7 +500,7 @@ return {
                         "name": "count",
                         "storageKey": null
                       },
-                      (v11/*: any*/),
+                      (v12/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -474,8 +530,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v10/*: any*/),
-                      (v13/*: any*/)
+                      (v11/*: any*/),
+                      (v14/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -532,7 +588,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v10/*: any*/),
+              (v11/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -562,7 +618,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v13/*: any*/),
+                      (v14/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -675,7 +731,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v10/*: any*/)
+                              (v11/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -730,7 +786,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v10/*: any*/)
+                              (v11/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -742,8 +798,8 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
-                              (v10/*: any*/)
+                              (v12/*: any*/),
+                              (v11/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -753,7 +809,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v10/*: any*/)
+                          (v11/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -766,27 +822,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,sort:\"-decayed_merch\")"
+            "storageKey": null
           },
           {
             "alias": "artworks",
-            "args": (v12/*: any*/),
+            "args": (v13/*: any*/),
             "filters": [
-              "sort",
-              "additionalGeneIDs",
-              "priceRange",
-              "color",
-              "colors",
-              "partnerID",
-              "partnerIDs",
-              "dimensionRange",
-              "majorPeriods",
-              "acquireable",
-              "inquireableOnly",
-              "atAuction",
-              "offerable",
-              "aggregations",
-              "attributionClass"
+              "input",
+              "aggregations"
             ],
             "handle": "connection",
             "key": "ArtistArtworksGrid_artworks",
@@ -800,7 +843,7 @@ return {
     ]
   },
   "params": {
-    "id": "39f313d86bb521fd3fe142652866ee3a",
+    "id": "279b65abd41298edaf2ab0023549ca60",
     "metadata": {},
     "name": "ArtistAboveTheFoldQuery",
     "operationKind": "query",
@@ -808,5 +851,5 @@ return {
   }
 };
 })();
-(node as any).hash = '8f27f7c902dbb51a8bc40a1a07cbbe7b';
+(node as any).hash = 'c77a30c411c594acc62fcfa05072964f';
 export default node;

--- a/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
@@ -1,64 +1,12 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 279b65abd41298edaf2ab0023549ca60 */
+/* @relayHash e8c589d40442a5d7773f6877a07c42b7 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
-export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
-export type FilterArtworksInput = {
-    acquireable?: boolean | null;
-    additionalGeneIDs?: Array<string | null> | null;
-    after?: string | null;
-    aggregationPartnerCities?: Array<string | null> | null;
-    aggregations?: Array<ArtworkAggregation | null> | null;
-    artistID?: string | null;
-    artistIDs?: Array<string | null> | null;
-    artistNationalities?: Array<string | null> | null;
-    artistSeriesID?: string | null;
-    atAuction?: boolean | null;
-    attributionClass?: Array<string | null> | null;
-    before?: string | null;
-    color?: string | null;
-    colors?: Array<string | null> | null;
-    dimensionRange?: string | null;
-    excludeArtworkIDs?: Array<string | null> | null;
-    extraAggregationGeneIDs?: Array<string | null> | null;
-    first?: number | null;
-    forSale?: boolean | null;
-    geneID?: string | null;
-    geneIDs?: Array<string | null> | null;
-    height?: string | null;
-    includeArtworksByFollowedArtists?: boolean | null;
-    includeMediumFilterInAggregation?: boolean | null;
-    inquireableOnly?: boolean | null;
-    keyword?: string | null;
-    keywordMatchExact?: boolean | null;
-    last?: number | null;
-    locationCities?: Array<string | null> | null;
-    majorPeriods?: Array<string | null> | null;
-    marketable?: boolean | null;
-    materialsTerms?: Array<string | null> | null;
-    medium?: string | null;
-    offerable?: boolean | null;
-    page?: number | null;
-    partnerCities?: Array<string | null> | null;
-    partnerID?: string | null;
-    partnerIDs?: Array<string | null> | null;
-    period?: string | null;
-    periods?: Array<string | null> | null;
-    priceRange?: string | null;
-    saleID?: string | null;
-    size?: number | null;
-    sizes?: Array<ArtworkSizes | null> | null;
-    sort?: string | null;
-    tagID?: string | null;
-    width?: string | null;
-};
 export type ArtistAboveTheFoldQueryVariables = {
     artistID: string;
-    input?: FilterArtworksInput | null;
 };
 export type ArtistAboveTheFoldQueryResponse = {
     readonly artist: {
@@ -87,7 +35,6 @@ export type ArtistAboveTheFoldQuery = {
 /*
 query ArtistAboveTheFoldQuery(
   $artistID: String!
-  $input: FilterArtworksInput
 ) {
   artist(id: $artistID) {
     internalID
@@ -100,7 +47,7 @@ query ArtistAboveTheFoldQuery(
       articles
     }
     ...ArtistHeader_artist
-    ...ArtistArtworks_artist_2VV6jB
+    ...ArtistArtworks_artist_44NygF
     auctionResultsConnection {
       totalCount
     }
@@ -108,11 +55,11 @@ query ArtistAboveTheFoldQuery(
   }
 }
 
-fragment ArtistArtworks_artist_2VV6jB on Artist {
+fragment ArtistArtworks_artist_44NygF on Artist {
   id
   slug
   internalID
-  artworks: filterArtworksConnection(first: 10, input: $input, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  artworks: filterArtworksConnection(first: 10, input: {dimensionRange: "*-*", sort: "-decayed_merch"}, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -220,11 +167,6 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "artistID"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "input"
   }
 ],
 v1 = [
@@ -302,9 +244,12 @@ v9 = {
   "storageKey": null
 },
 v10 = {
-  "kind": "Variable",
+  "kind": "Literal",
   "name": "input",
-  "variableName": "input"
+  "value": {
+    "dimensionRange": "*-*",
+    "sort": "-decayed_merch"
+  }
 },
 v11 = {
   "alias": null,
@@ -822,7 +767,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": null
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "artworks",
@@ -843,7 +788,7 @@ return {
     ]
   },
   "params": {
-    "id": "279b65abd41298edaf2ab0023549ca60",
+    "id": "e8c589d40442a5d7773f6877a07c42b7",
     "metadata": {},
     "name": "ArtistAboveTheFoldQuery",
     "operationKind": "query",
@@ -851,5 +796,5 @@ return {
   }
 };
 })();
-(node as any).hash = 'c77a30c411c594acc62fcfa05072964f';
+(node as any).hash = '98b710cba3d88ac681900f6f01c51c65';
 export default node;

--- a/src/__generated__/ArtistArtworksQuery.graphql.ts
+++ b/src/__generated__/ArtistArtworksQuery.graphql.ts
@@ -1,28 +1,66 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash a85461f8b26cea472b22e88705774342 */
+/* @relayHash 1470d1787550a2640d505d9a52b82f88 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
+export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
+export type FilterArtworksInput = {
+    acquireable?: boolean | null;
+    additionalGeneIDs?: Array<string | null> | null;
+    after?: string | null;
+    aggregationPartnerCities?: Array<string | null> | null;
+    aggregations?: Array<ArtworkAggregation | null> | null;
+    artistID?: string | null;
+    artistIDs?: Array<string | null> | null;
+    artistNationalities?: Array<string | null> | null;
+    artistSeriesID?: string | null;
+    atAuction?: boolean | null;
+    attributionClass?: Array<string | null> | null;
+    before?: string | null;
+    color?: string | null;
+    colors?: Array<string | null> | null;
+    dimensionRange?: string | null;
+    excludeArtworkIDs?: Array<string | null> | null;
+    extraAggregationGeneIDs?: Array<string | null> | null;
+    first?: number | null;
+    forSale?: boolean | null;
+    geneID?: string | null;
+    geneIDs?: Array<string | null> | null;
+    height?: string | null;
+    includeArtworksByFollowedArtists?: boolean | null;
+    includeMediumFilterInAggregation?: boolean | null;
+    inquireableOnly?: boolean | null;
+    keyword?: string | null;
+    keywordMatchExact?: boolean | null;
+    last?: number | null;
+    locationCities?: Array<string | null> | null;
+    majorPeriods?: Array<string | null> | null;
+    marketable?: boolean | null;
+    materialsTerms?: Array<string | null> | null;
+    medium?: string | null;
+    offerable?: boolean | null;
+    page?: number | null;
+    partnerCities?: Array<string | null> | null;
+    partnerID?: string | null;
+    partnerIDs?: Array<string | null> | null;
+    period?: string | null;
+    periods?: Array<string | null> | null;
+    priceRange?: string | null;
+    saleID?: string | null;
+    size?: number | null;
+    sizes?: Array<ArtworkSizes | null> | null;
+    sort?: string | null;
+    tagID?: string | null;
+    width?: string | null;
+};
 export type ArtistArtworksQueryVariables = {
     id: string;
     count: number;
     cursor?: string | null;
-    sort?: string | null;
-    additionalGeneIDs?: Array<string | null> | null;
-    priceRange?: string | null;
-    color?: string | null;
-    colors?: Array<string | null> | null;
-    partnerID?: string | null;
-    partnerIDs?: Array<string | null> | null;
-    dimensionRange?: string | null;
-    majorPeriods?: Array<string | null> | null;
-    acquireable?: boolean | null;
-    inquireableOnly?: boolean | null;
-    atAuction?: boolean | null;
-    offerable?: boolean | null;
-    attributionClass?: Array<string | null> | null;
+    input?: FilterArtworksInput | null;
 };
 export type ArtistArtworksQueryResponse = {
     readonly node: {
@@ -41,35 +79,22 @@ query ArtistArtworksQuery(
   $id: ID!
   $count: Int!
   $cursor: String
-  $sort: String
-  $additionalGeneIDs: [String]
-  $priceRange: String
-  $color: String
-  $colors: [String]
-  $partnerID: ID
-  $partnerIDs: [String]
-  $dimensionRange: String
-  $majorPeriods: [String]
-  $acquireable: Boolean
-  $inquireableOnly: Boolean
-  $atAuction: Boolean
-  $offerable: Boolean
-  $attributionClass: [String]
+  $input: FilterArtworksInput
 ) {
   node(id: $id) {
     __typename
     ... on Artist {
-      ...ArtistArtworks_artist_1qqVY9
+      ...ArtistArtworks_artist_YCAiB
     }
     id
   }
 }
 
-fragment ArtistArtworks_artist_1qqVY9 on Artist {
+fragment ArtistArtworks_artist_YCAiB on Artist {
   id
   slug
   internalID
-  artworks: filterArtworksConnection(first: $count, after: $cursor, sort: $sort, additionalGeneIDs: $additionalGeneIDs, priceRange: $priceRange, color: $color, colors: $colors, partnerID: $partnerID, partnerIDs: $partnerIDs, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], attributionClass: $attributionClass) {
+  artworks: filterArtworksConnection(first: $count, after: $cursor, input: $input, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -161,196 +186,64 @@ const node: ConcreteRequest = (function(){
 var v0 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "acquireable"
+  "name": "count"
 },
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "additionalGeneIDs"
+  "name": "cursor"
 },
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "atAuction"
+  "name": "id"
 },
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "attributionClass"
+  "name": "input"
 },
-v4 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "color"
-},
-v5 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "colors"
-},
-v6 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "count"
-},
-v7 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "cursor"
-},
-v8 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "dimensionRange"
-},
-v9 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "id"
-},
-v10 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "inquireableOnly"
-},
-v11 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "majorPeriods"
-},
-v12 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "offerable"
-},
-v13 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "partnerID"
-},
-v14 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "partnerIDs"
-},
-v15 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "priceRange"
-},
-v16 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "sort"
-},
-v17 = [
+v4 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v18 = {
+v5 = {
   "kind": "Variable",
-  "name": "acquireable",
-  "variableName": "acquireable"
+  "name": "input",
+  "variableName": "input"
 },
-v19 = {
-  "kind": "Variable",
-  "name": "additionalGeneIDs",
-  "variableName": "additionalGeneIDs"
-},
-v20 = {
-  "kind": "Variable",
-  "name": "atAuction",
-  "variableName": "atAuction"
-},
-v21 = {
-  "kind": "Variable",
-  "name": "attributionClass",
-  "variableName": "attributionClass"
-},
-v22 = {
-  "kind": "Variable",
-  "name": "color",
-  "variableName": "color"
-},
-v23 = {
-  "kind": "Variable",
-  "name": "colors",
-  "variableName": "colors"
-},
-v24 = {
-  "kind": "Variable",
-  "name": "dimensionRange",
-  "variableName": "dimensionRange"
-},
-v25 = {
-  "kind": "Variable",
-  "name": "inquireableOnly",
-  "variableName": "inquireableOnly"
-},
-v26 = {
-  "kind": "Variable",
-  "name": "majorPeriods",
-  "variableName": "majorPeriods"
-},
-v27 = {
-  "kind": "Variable",
-  "name": "offerable",
-  "variableName": "offerable"
-},
-v28 = {
-  "kind": "Variable",
-  "name": "partnerID",
-  "variableName": "partnerID"
-},
-v29 = {
-  "kind": "Variable",
-  "name": "partnerIDs",
-  "variableName": "partnerIDs"
-},
-v30 = {
-  "kind": "Variable",
-  "name": "priceRange",
-  "variableName": "priceRange"
-},
-v31 = {
-  "kind": "Variable",
-  "name": "sort",
-  "variableName": "sort"
-},
-v32 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v33 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v34 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v35 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v36 = [
-  (v18/*: any*/),
-  (v19/*: any*/),
+v10 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -368,25 +261,14 @@ v36 = [
       "PRICE_RANGE"
     ]
   },
-  (v20/*: any*/),
-  (v21/*: any*/),
-  (v22/*: any*/),
-  (v23/*: any*/),
-  (v24/*: any*/),
   {
     "kind": "Variable",
     "name": "first",
     "variableName": "count"
   },
-  (v25/*: any*/),
-  (v26/*: any*/),
-  (v27/*: any*/),
-  (v28/*: any*/),
-  (v29/*: any*/),
-  (v30/*: any*/),
-  (v31/*: any*/)
+  (v5/*: any*/)
 ],
-v37 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -399,20 +281,7 @@ return {
       (v0/*: any*/),
       (v1/*: any*/),
       (v2/*: any*/),
-      (v3/*: any*/),
-      (v4/*: any*/),
-      (v5/*: any*/),
-      (v6/*: any*/),
-      (v7/*: any*/),
-      (v8/*: any*/),
-      (v9/*: any*/),
-      (v10/*: any*/),
-      (v11/*: any*/),
-      (v12/*: any*/),
-      (v13/*: any*/),
-      (v14/*: any*/),
-      (v15/*: any*/),
-      (v16/*: any*/)
+      (v3/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -420,7 +289,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v17/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
@@ -431,12 +300,6 @@ return {
             "selections": [
               {
                 "args": [
-                  (v18/*: any*/),
-                  (v19/*: any*/),
-                  (v20/*: any*/),
-                  (v21/*: any*/),
-                  (v22/*: any*/),
-                  (v23/*: any*/),
                   {
                     "kind": "Variable",
                     "name": "count",
@@ -447,14 +310,7 @@ return {
                     "name": "cursor",
                     "variableName": "cursor"
                   },
-                  (v24/*: any*/),
-                  (v25/*: any*/),
-                  (v26/*: any*/),
-                  (v27/*: any*/),
-                  (v28/*: any*/),
-                  (v29/*: any*/),
-                  (v30/*: any*/),
-                  (v31/*: any*/)
+                  (v5/*: any*/)
                 ],
                 "kind": "FragmentSpread",
                 "name": "ArtistArtworks_artist"
@@ -473,22 +329,9 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v9/*: any*/),
-      (v6/*: any*/),
-      (v7/*: any*/),
-      (v16/*: any*/),
-      (v1/*: any*/),
-      (v15/*: any*/),
-      (v4/*: any*/),
-      (v5/*: any*/),
-      (v13/*: any*/),
-      (v14/*: any*/),
-      (v8/*: any*/),
-      (v11/*: any*/),
-      (v0/*: any*/),
-      (v10/*: any*/),
       (v2/*: any*/),
-      (v12/*: any*/),
+      (v0/*: any*/),
+      (v1/*: any*/),
       (v3/*: any*/)
     ],
     "kind": "Operation",
@@ -496,22 +339,22 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v17/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v32/*: any*/),
-          (v33/*: any*/),
+          (v6/*: any*/),
+          (v7/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
-              (v34/*: any*/),
-              (v35/*: any*/),
+              (v8/*: any*/),
+              (v9/*: any*/),
               {
                 "alias": "artworks",
-                "args": (v36/*: any*/),
+                "args": (v10/*: any*/),
                 "concreteType": "FilterArtworksConnection",
                 "kind": "LinkedField",
                 "name": "filterArtworksConnection",
@@ -547,7 +390,7 @@ return {
                             "name": "count",
                             "storageKey": null
                           },
-                          (v37/*: any*/),
+                          (v11/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -577,8 +420,8 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v33/*: any*/),
-                          (v32/*: any*/)
+                          (v7/*: any*/),
+                          (v6/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -635,7 +478,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v33/*: any*/),
+                  (v7/*: any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
@@ -665,7 +508,7 @@ return {
                         "name": "edges",
                         "plural": true,
                         "selections": [
-                          (v32/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -674,7 +517,7 @@ return {
                             "name": "node",
                             "plural": false,
                             "selections": [
-                              (v34/*: any*/),
+                              (v8/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -727,7 +570,7 @@ return {
                                 "name": "saleMessage",
                                 "storageKey": null
                               },
-                              (v35/*: any*/),
+                              (v9/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -778,7 +621,7 @@ return {
                                     "name": "endAt",
                                     "storageKey": null
                                   },
-                                  (v33/*: any*/)
+                                  (v7/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -833,7 +676,7 @@ return {
                                     "name": "lotLabel",
                                     "storageKey": null
                                   },
-                                  (v33/*: any*/)
+                                  (v7/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -845,8 +688,8 @@ return {
                                 "name": "partner",
                                 "plural": false,
                                 "selections": [
-                                  (v37/*: any*/),
-                                  (v33/*: any*/)
+                                  (v11/*: any*/),
+                                  (v7/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -856,7 +699,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v33/*: any*/)
+                              (v7/*: any*/)
                             ],
                             "type": "Node",
                             "abstractKey": "__isNode"
@@ -873,23 +716,10 @@ return {
               },
               {
                 "alias": "artworks",
-                "args": (v36/*: any*/),
+                "args": (v10/*: any*/),
                 "filters": [
-                  "sort",
-                  "additionalGeneIDs",
-                  "priceRange",
-                  "color",
-                  "colors",
-                  "partnerID",
-                  "partnerIDs",
-                  "dimensionRange",
-                  "majorPeriods",
-                  "acquireable",
-                  "inquireableOnly",
-                  "atAuction",
-                  "offerable",
-                  "aggregations",
-                  "attributionClass"
+                  "input",
+                  "aggregations"
                 ],
                 "handle": "connection",
                 "key": "ArtistArtworksGrid_artworks",
@@ -906,7 +736,7 @@ return {
     ]
   },
   "params": {
-    "id": "a85461f8b26cea472b22e88705774342",
+    "id": "1470d1787550a2640d505d9a52b82f88",
     "metadata": {},
     "name": "ArtistArtworksQuery",
     "operationKind": "query",
@@ -914,5 +744,5 @@ return {
   }
 };
 })();
-(node as any).hash = 'fdce66f7aa4d33bb47f098f4629b14fb';
+(node as any).hash = '901824f94f9fe7d0330ac1bf131e59c4';
 export default node;

--- a/src/__generated__/ArtistArtworks_artist.graphql.ts
+++ b/src/__generated__/ArtistArtworks_artist.graphql.ts
@@ -49,36 +49,6 @@ var v0 = {
 return {
   "argumentDefinitions": [
     {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "acquireable"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "additionalGeneIDs"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "atAuction"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "attributionClass"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "color"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "colors"
-    },
-    {
       "defaultValue": 10,
       "kind": "LocalArgument",
       "name": "count"
@@ -89,44 +59,9 @@ return {
       "name": "cursor"
     },
     {
-      "defaultValue": "*-*",
-      "kind": "LocalArgument",
-      "name": "dimensionRange"
-    },
-    {
       "defaultValue": null,
       "kind": "LocalArgument",
-      "name": "inquireableOnly"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "majorPeriods"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "offerable"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "partnerID"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "partnerIDs"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "priceRange"
-    },
-    {
-      "defaultValue": "-decayed_merch",
-      "kind": "LocalArgument",
-      "name": "sort"
+      "name": "input"
     }
   ],
   "kind": "Fragment",
@@ -163,16 +98,6 @@ return {
       "alias": "artworks",
       "args": [
         {
-          "kind": "Variable",
-          "name": "acquireable",
-          "variableName": "acquireable"
-        },
-        {
-          "kind": "Variable",
-          "name": "additionalGeneIDs",
-          "variableName": "additionalGeneIDs"
-        },
-        {
           "kind": "Literal",
           "name": "aggregations",
           "value": [
@@ -186,63 +111,8 @@ return {
         },
         {
           "kind": "Variable",
-          "name": "atAuction",
-          "variableName": "atAuction"
-        },
-        {
-          "kind": "Variable",
-          "name": "attributionClass",
-          "variableName": "attributionClass"
-        },
-        {
-          "kind": "Variable",
-          "name": "color",
-          "variableName": "color"
-        },
-        {
-          "kind": "Variable",
-          "name": "colors",
-          "variableName": "colors"
-        },
-        {
-          "kind": "Variable",
-          "name": "dimensionRange",
-          "variableName": "dimensionRange"
-        },
-        {
-          "kind": "Variable",
-          "name": "inquireableOnly",
-          "variableName": "inquireableOnly"
-        },
-        {
-          "kind": "Variable",
-          "name": "majorPeriods",
-          "variableName": "majorPeriods"
-        },
-        {
-          "kind": "Variable",
-          "name": "offerable",
-          "variableName": "offerable"
-        },
-        {
-          "kind": "Variable",
-          "name": "partnerID",
-          "variableName": "partnerID"
-        },
-        {
-          "kind": "Variable",
-          "name": "partnerIDs",
-          "variableName": "partnerIDs"
-        },
-        {
-          "kind": "Variable",
-          "name": "priceRange",
-          "variableName": "priceRange"
-        },
-        {
-          "kind": "Variable",
-          "name": "sort",
-          "variableName": "sort"
+          "name": "input",
+          "variableName": "input"
         }
       ],
       "concreteType": "FilterArtworksConnection",
@@ -393,5 +263,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '3d80f342e7522ee5ff08a1b8ae2f9431';
+(node as any).hash = '8052b338d0a74f7d8857e05740092e5d';
 export default node;

--- a/src/__generated__/ArtistBelowTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtistBelowTheFoldQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 5e8d852a3526af22fc87bce04145e7aa */
+/* @relayHash 38dd015b757ce010e6dd0c2fe8554c9d */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -87,7 +87,7 @@ fragment ArtistAbout_artist on Artist {
   ...Biography_artist
   ...ArtistSeriesMoreSeries_artist
   ...ArtistNotableWorksRail_artist
-  notableWorks: filterArtworksConnection(sort: "-weighted_iconicity", first: 3) {
+  notableWorks: filterArtworksConnection(first: 3, input: {sort: "-weighted_iconicity"}) {
     edges {
       node {
         id
@@ -199,7 +199,7 @@ fragment ArtistInsights_artist on Artist {
 fragment ArtistNotableWorksRail_artist on Artist {
   internalID
   slug
-  filterArtworksConnection(sort: "-weighted_iconicity", first: 10) {
+  filterArtworksConnection(first: 10, input: {sort: "-weighted_iconicity"}) {
     edges {
       node {
         id
@@ -459,8 +459,10 @@ v8 = {
 },
 v9 = {
   "kind": "Literal",
-  "name": "sort",
-  "value": "-weighted_iconicity"
+  "name": "input",
+  "value": {
+    "sort": "-weighted_iconicity"
+  }
 },
 v10 = {
   "alias": null,
@@ -949,7 +951,7 @@ return {
               },
               (v10/*: any*/)
             ],
-            "storageKey": "filterArtworksConnection(first:10,sort:\"-weighted_iconicity\")"
+            "storageKey": "filterArtworksConnection(first:10,input:{\"sort\":\"-weighted_iconicity\"})"
           },
           {
             "alias": "notableWorks",
@@ -985,7 +987,7 @@ return {
               },
               (v10/*: any*/)
             ],
-            "storageKey": "filterArtworksConnection(first:3,sort:\"-weighted_iconicity\")"
+            "storageKey": "filterArtworksConnection(first:3,input:{\"sort\":\"-weighted_iconicity\"})"
           },
           {
             "alias": "iconicCollections",
@@ -1638,7 +1640,7 @@ return {
     ]
   },
   "params": {
-    "id": "5e8d852a3526af22fc87bce04145e7aa",
+    "id": "38dd015b757ce010e6dd0c2fe8554c9d",
     "metadata": {},
     "name": "ArtistBelowTheFoldQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistNotableWorksRailTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistNotableWorksRailTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash bf9c414a0c3ae0f851b68d43dced792f */
+/* @relayHash 4f6f495bb997db55c17a11184c2eee55 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -67,7 +67,7 @@ query ArtistNotableWorksRailTestsQuery {
 fragment ArtistNotableWorksRail_artist on Artist {
   internalID
   slug
-  filterArtworksConnection(sort: "-weighted_iconicity", first: 10) {
+  filterArtworksConnection(first: 10, input: {sort: "-weighted_iconicity"}) {
     edges {
       node {
         id
@@ -191,8 +191,10 @@ return {
               },
               {
                 "kind": "Literal",
-                "name": "sort",
-                "value": "-weighted_iconicity"
+                "name": "input",
+                "value": {
+                  "sort": "-weighted_iconicity"
+                }
               }
             ],
             "concreteType": "FilterArtworksConnection",
@@ -324,7 +326,7 @@ return {
               },
               (v3/*: any*/)
             ],
-            "storageKey": "filterArtworksConnection(first:10,sort:\"-weighted_iconicity\")"
+            "storageKey": "filterArtworksConnection(first:10,input:{\"sort\":\"-weighted_iconicity\"})"
           },
           (v3/*: any*/)
         ],
@@ -333,7 +335,7 @@ return {
     ]
   },
   "params": {
-    "id": "bf9c414a0c3ae0f851b68d43dced792f",
+    "id": "4f6f495bb997db55c17a11184c2eee55",
     "metadata": {},
     "name": "ArtistNotableWorksRailTestsQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistNotableWorksRail_artist.graphql.ts
+++ b/src/__generated__/ArtistNotableWorksRail_artist.graphql.ts
@@ -86,8 +86,10 @@ return {
         },
         {
           "kind": "Literal",
-          "name": "sort",
-          "value": "-weighted_iconicity"
+          "name": "input",
+          "value": {
+            "sort": "-weighted_iconicity"
+          }
         }
       ],
       "concreteType": "FilterArtworksConnection",
@@ -222,12 +224,12 @@ return {
           "storageKey": null
         }
       ],
-      "storageKey": "filterArtworksConnection(first:10,sort:\"-weighted_iconicity\")"
+      "storageKey": "filterArtworksConnection(first:10,input:{\"sort\":\"-weighted_iconicity\"})"
     }
   ],
   "type": "Artist",
   "abstractKey": null
 };
 })();
-(node as any).hash = 'f020d87d7a75e5be053dfeae8f0c8328';
+(node as any).hash = '094672f09cb518d6450aabab85ec4296';
 export default node;

--- a/src/__generated__/ArtistSeriesArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,28 +1,66 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 7a209bd97e7bd7e4f53cd4625a77ce3c */
+/* @relayHash d19f3f249830131fc24f85c021c7b402 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
+export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
+export type FilterArtworksInput = {
+    acquireable?: boolean | null;
+    additionalGeneIDs?: Array<string | null> | null;
+    after?: string | null;
+    aggregationPartnerCities?: Array<string | null> | null;
+    aggregations?: Array<ArtworkAggregation | null> | null;
+    artistID?: string | null;
+    artistIDs?: Array<string | null> | null;
+    artistNationalities?: Array<string | null> | null;
+    artistSeriesID?: string | null;
+    atAuction?: boolean | null;
+    attributionClass?: Array<string | null> | null;
+    before?: string | null;
+    color?: string | null;
+    colors?: Array<string | null> | null;
+    dimensionRange?: string | null;
+    excludeArtworkIDs?: Array<string | null> | null;
+    extraAggregationGeneIDs?: Array<string | null> | null;
+    first?: number | null;
+    forSale?: boolean | null;
+    geneID?: string | null;
+    geneIDs?: Array<string | null> | null;
+    height?: string | null;
+    includeArtworksByFollowedArtists?: boolean | null;
+    includeMediumFilterInAggregation?: boolean | null;
+    inquireableOnly?: boolean | null;
+    keyword?: string | null;
+    keywordMatchExact?: boolean | null;
+    last?: number | null;
+    locationCities?: Array<string | null> | null;
+    majorPeriods?: Array<string | null> | null;
+    marketable?: boolean | null;
+    materialsTerms?: Array<string | null> | null;
+    medium?: string | null;
+    offerable?: boolean | null;
+    page?: number | null;
+    partnerCities?: Array<string | null> | null;
+    partnerID?: string | null;
+    partnerIDs?: Array<string | null> | null;
+    period?: string | null;
+    periods?: Array<string | null> | null;
+    priceRange?: string | null;
+    saleID?: string | null;
+    size?: number | null;
+    sizes?: Array<ArtworkSizes | null> | null;
+    sort?: string | null;
+    tagID?: string | null;
+    width?: string | null;
+};
 export type ArtistSeriesArtworksInfiniteScrollGridQueryVariables = {
     id: string;
     count: number;
     cursor?: string | null;
-    sort?: string | null;
-    additionalGeneIDs?: Array<string | null> | null;
-    priceRange?: string | null;
-    color?: string | null;
-    colors?: Array<string | null> | null;
-    partnerID?: string | null;
-    partnerIDs?: Array<string | null> | null;
-    dimensionRange?: string | null;
-    majorPeriods?: Array<string | null> | null;
-    acquireable?: boolean | null;
-    inquireableOnly?: boolean | null;
-    atAuction?: boolean | null;
-    offerable?: boolean | null;
-    attributionClass?: Array<string | null> | null;
+    input?: FilterArtworksInput | null;
 };
 export type ArtistSeriesArtworksInfiniteScrollGridQueryResponse = {
     readonly artistSeries: {
@@ -40,30 +78,17 @@ export type ArtistSeriesArtworksInfiniteScrollGridQuery = {
 query ArtistSeriesArtworksInfiniteScrollGridQuery(
   $id: ID!
   $cursor: String
-  $sort: String
-  $additionalGeneIDs: [String]
-  $priceRange: String
-  $color: String
-  $colors: [String]
-  $partnerID: ID
-  $partnerIDs: [String]
-  $dimensionRange: String
-  $majorPeriods: [String]
-  $acquireable: Boolean
-  $inquireableOnly: Boolean
-  $atAuction: Boolean
-  $offerable: Boolean
-  $attributionClass: [String]
+  $input: FilterArtworksInput
 ) {
   artistSeries(id: $id) {
-    ...ArtistSeriesArtworks_artistSeries_1qqVY9
+    ...ArtistSeriesArtworks_artistSeries_YCAiB
   }
 }
 
-fragment ArtistSeriesArtworks_artistSeries_1qqVY9 on ArtistSeries {
+fragment ArtistSeriesArtworks_artistSeries_YCAiB on ArtistSeries {
   slug
   internalID
-  artistSeriesArtworks: filterArtworksConnection(first: 20, after: $cursor, sort: $sort, additionalGeneIDs: $additionalGeneIDs, priceRange: $priceRange, color: $color, colors: $colors, partnerID: $partnerID, partnerIDs: $partnerIDs, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], attributionClass: $attributionClass) {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: $input) {
     aggregations {
       slice
       counts {
@@ -155,182 +180,50 @@ const node: ConcreteRequest = (function(){
 var v0 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "acquireable"
+  "name": "count"
 },
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "additionalGeneIDs"
+  "name": "cursor"
 },
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "atAuction"
+  "name": "id"
 },
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "attributionClass"
+  "name": "input"
 },
-v4 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "color"
-},
-v5 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "colors"
-},
-v6 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "count"
-},
-v7 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "cursor"
-},
-v8 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "dimensionRange"
-},
-v9 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "id"
-},
-v10 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "inquireableOnly"
-},
-v11 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "majorPeriods"
-},
-v12 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "offerable"
-},
-v13 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "partnerID"
-},
-v14 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "partnerIDs"
-},
-v15 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "priceRange"
-},
-v16 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "sort"
-},
-v17 = [
+v4 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v18 = {
+v5 = {
   "kind": "Variable",
-  "name": "acquireable",
-  "variableName": "acquireable"
+  "name": "input",
+  "variableName": "input"
 },
-v19 = {
-  "kind": "Variable",
-  "name": "additionalGeneIDs",
-  "variableName": "additionalGeneIDs"
-},
-v20 = {
-  "kind": "Variable",
-  "name": "atAuction",
-  "variableName": "atAuction"
-},
-v21 = {
-  "kind": "Variable",
-  "name": "attributionClass",
-  "variableName": "attributionClass"
-},
-v22 = {
-  "kind": "Variable",
-  "name": "color",
-  "variableName": "color"
-},
-v23 = {
-  "kind": "Variable",
-  "name": "colors",
-  "variableName": "colors"
-},
-v24 = {
-  "kind": "Variable",
-  "name": "dimensionRange",
-  "variableName": "dimensionRange"
-},
-v25 = {
-  "kind": "Variable",
-  "name": "inquireableOnly",
-  "variableName": "inquireableOnly"
-},
-v26 = {
-  "kind": "Variable",
-  "name": "majorPeriods",
-  "variableName": "majorPeriods"
-},
-v27 = {
-  "kind": "Variable",
-  "name": "offerable",
-  "variableName": "offerable"
-},
-v28 = {
-  "kind": "Variable",
-  "name": "partnerID",
-  "variableName": "partnerID"
-},
-v29 = {
-  "kind": "Variable",
-  "name": "partnerIDs",
-  "variableName": "partnerIDs"
-},
-v30 = {
-  "kind": "Variable",
-  "name": "priceRange",
-  "variableName": "priceRange"
-},
-v31 = {
-  "kind": "Variable",
-  "name": "sort",
-  "variableName": "sort"
-},
-v32 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v33 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v34 = [
-  (v18/*: any*/),
-  (v19/*: any*/),
+v8 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -348,39 +241,28 @@ v34 = [
       "PRICE_RANGE"
     ]
   },
-  (v20/*: any*/),
-  (v21/*: any*/),
-  (v22/*: any*/),
-  (v23/*: any*/),
-  (v24/*: any*/),
   {
     "kind": "Literal",
     "name": "first",
     "value": 20
   },
-  (v25/*: any*/),
-  (v26/*: any*/),
-  (v27/*: any*/),
-  (v28/*: any*/),
-  (v29/*: any*/),
-  (v30/*: any*/),
-  (v31/*: any*/)
+  (v5/*: any*/)
 ],
-v35 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v36 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v37 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -393,20 +275,7 @@ return {
       (v0/*: any*/),
       (v1/*: any*/),
       (v2/*: any*/),
-      (v3/*: any*/),
-      (v4/*: any*/),
-      (v5/*: any*/),
-      (v6/*: any*/),
-      (v7/*: any*/),
-      (v8/*: any*/),
-      (v9/*: any*/),
-      (v10/*: any*/),
-      (v11/*: any*/),
-      (v12/*: any*/),
-      (v13/*: any*/),
-      (v14/*: any*/),
-      (v15/*: any*/),
-      (v16/*: any*/)
+      (v3/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -414,7 +283,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v17/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": "ArtistSeries",
         "kind": "LinkedField",
         "name": "artistSeries",
@@ -422,12 +291,6 @@ return {
         "selections": [
           {
             "args": [
-              (v18/*: any*/),
-              (v19/*: any*/),
-              (v20/*: any*/),
-              (v21/*: any*/),
-              (v22/*: any*/),
-              (v23/*: any*/),
               {
                 "kind": "Variable",
                 "name": "count",
@@ -438,14 +301,7 @@ return {
                 "name": "cursor",
                 "variableName": "cursor"
               },
-              (v24/*: any*/),
-              (v25/*: any*/),
-              (v26/*: any*/),
-              (v27/*: any*/),
-              (v28/*: any*/),
-              (v29/*: any*/),
-              (v30/*: any*/),
-              (v31/*: any*/)
+              (v5/*: any*/)
             ],
             "kind": "FragmentSpread",
             "name": "ArtistSeriesArtworks_artistSeries"
@@ -460,22 +316,9 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v9/*: any*/),
-      (v6/*: any*/),
-      (v7/*: any*/),
-      (v16/*: any*/),
-      (v1/*: any*/),
-      (v15/*: any*/),
-      (v4/*: any*/),
-      (v5/*: any*/),
-      (v13/*: any*/),
-      (v14/*: any*/),
-      (v8/*: any*/),
-      (v11/*: any*/),
-      (v0/*: any*/),
-      (v10/*: any*/),
       (v2/*: any*/),
-      (v12/*: any*/),
+      (v0/*: any*/),
+      (v1/*: any*/),
       (v3/*: any*/)
     ],
     "kind": "Operation",
@@ -483,17 +326,17 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v17/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": "ArtistSeries",
         "kind": "LinkedField",
         "name": "artistSeries",
         "plural": false,
         "selections": [
-          (v32/*: any*/),
-          (v33/*: any*/),
+          (v6/*: any*/),
+          (v7/*: any*/),
           {
             "alias": "artistSeriesArtworks",
-            "args": (v34/*: any*/),
+            "args": (v8/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -529,7 +372,7 @@ return {
                         "name": "count",
                         "storageKey": null
                       },
-                      (v35/*: any*/),
+                      (v9/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -559,8 +402,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v36/*: any*/),
-                      (v37/*: any*/)
+                      (v10/*: any*/),
+                      (v11/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -617,7 +460,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v36/*: any*/),
+              (v10/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -647,7 +490,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v37/*: any*/),
+                      (v11/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -656,7 +499,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v32/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -709,7 +552,7 @@ return {
                             "name": "saleMessage",
                             "storageKey": null
                           },
-                          (v33/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -760,7 +603,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v36/*: any*/)
+                              (v10/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -815,7 +658,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v36/*: any*/)
+                              (v10/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -827,8 +670,8 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v35/*: any*/),
-                              (v36/*: any*/)
+                              (v9/*: any*/),
+                              (v10/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -838,7 +681,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v36/*: any*/)
+                          (v10/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -855,23 +698,10 @@ return {
           },
           {
             "alias": "artistSeriesArtworks",
-            "args": (v34/*: any*/),
+            "args": (v8/*: any*/),
             "filters": [
-              "sort",
-              "additionalGeneIDs",
-              "priceRange",
-              "color",
-              "colors",
-              "partnerID",
-              "partnerIDs",
-              "dimensionRange",
-              "majorPeriods",
-              "acquireable",
-              "inquireableOnly",
-              "atAuction",
-              "offerable",
               "aggregations",
-              "attributionClass"
+              "input"
             ],
             "handle": "connection",
             "key": "ArtistSeries_artistSeriesArtworks",
@@ -884,7 +714,7 @@ return {
     ]
   },
   "params": {
-    "id": "7a209bd97e7bd7e4f53cd4625a77ce3c",
+    "id": "d19f3f249830131fc24f85c021c7b402",
     "metadata": {},
     "name": "ArtistSeriesArtworksInfiniteScrollGridQuery",
     "operationKind": "query",
@@ -892,5 +722,5 @@ return {
   }
 };
 })();
-(node as any).hash = '1587a1f722fc146c3bf4416dee0e1cd4';
+(node as any).hash = 'd06e93fe159e10948cf05e1a278a56fc';
 export default node;

--- a/src/__generated__/ArtistSeriesArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworksTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 4d9c20edd52e7ba0acb0d0e6d97ffc90 */
+/* @relayHash ab9e0b6e0ea7bd88b2820d1dc7383945 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -28,7 +28,7 @@ query ArtistSeriesArtworksTestsQuery {
 fragment ArtistSeriesArtworks_artistSeries on ArtistSeries {
   slug
   internalID
-  artistSeriesArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -153,18 +153,8 @@ v3 = [
   },
   {
     "kind": "Literal",
-    "name": "dimensionRange",
-    "value": "*-*"
-  },
-  {
-    "kind": "Literal",
     "name": "first",
     "value": 20
-  },
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "-decayed_merch"
   }
 ],
 v4 = {
@@ -621,27 +611,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:20,sort:\"-decayed_merch\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:20)"
           },
           {
             "alias": "artistSeriesArtworks",
             "args": (v3/*: any*/),
             "filters": [
-              "sort",
-              "additionalGeneIDs",
-              "priceRange",
-              "color",
-              "colors",
-              "partnerID",
-              "partnerIDs",
-              "dimensionRange",
-              "majorPeriods",
-              "acquireable",
-              "inquireableOnly",
-              "atAuction",
-              "offerable",
               "aggregations",
-              "attributionClass"
+              "input"
             ],
             "handle": "connection",
             "key": "ArtistSeries_artistSeriesArtworks",
@@ -654,7 +631,7 @@ return {
     ]
   },
   "params": {
-    "id": "4d9c20edd52e7ba0acb0d0e6d97ffc90",
+    "id": "ab9e0b6e0ea7bd88b2820d1dc7383945",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artistSeries": {

--- a/src/__generated__/ArtistSeriesArtworks_artistSeries.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworks_artistSeries.graphql.ts
@@ -40,36 +40,6 @@ export type ArtistSeriesArtworks_artistSeries$key = {
 const node: ReaderFragment = {
   "argumentDefinitions": [
     {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "acquireable"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "additionalGeneIDs"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "atAuction"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "attributionClass"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "color"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "colors"
-    },
-    {
       "defaultValue": 20,
       "kind": "LocalArgument",
       "name": "count"
@@ -80,44 +50,9 @@ const node: ReaderFragment = {
       "name": "cursor"
     },
     {
-      "defaultValue": "*-*",
-      "kind": "LocalArgument",
-      "name": "dimensionRange"
-    },
-    {
       "defaultValue": null,
       "kind": "LocalArgument",
-      "name": "inquireableOnly"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "majorPeriods"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "offerable"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "partnerID"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "partnerIDs"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "priceRange"
-    },
-    {
-      "defaultValue": "-decayed_merch",
-      "kind": "LocalArgument",
-      "name": "sort"
+      "name": "input"
     }
   ],
   "kind": "Fragment",
@@ -153,16 +88,6 @@ const node: ReaderFragment = {
       "alias": "artistSeriesArtworks",
       "args": [
         {
-          "kind": "Variable",
-          "name": "acquireable",
-          "variableName": "acquireable"
-        },
-        {
-          "kind": "Variable",
-          "name": "additionalGeneIDs",
-          "variableName": "additionalGeneIDs"
-        },
-        {
           "kind": "Literal",
           "name": "aggregations",
           "value": [
@@ -176,63 +101,8 @@ const node: ReaderFragment = {
         },
         {
           "kind": "Variable",
-          "name": "atAuction",
-          "variableName": "atAuction"
-        },
-        {
-          "kind": "Variable",
-          "name": "attributionClass",
-          "variableName": "attributionClass"
-        },
-        {
-          "kind": "Variable",
-          "name": "color",
-          "variableName": "color"
-        },
-        {
-          "kind": "Variable",
-          "name": "colors",
-          "variableName": "colors"
-        },
-        {
-          "kind": "Variable",
-          "name": "dimensionRange",
-          "variableName": "dimensionRange"
-        },
-        {
-          "kind": "Variable",
-          "name": "inquireableOnly",
-          "variableName": "inquireableOnly"
-        },
-        {
-          "kind": "Variable",
-          "name": "majorPeriods",
-          "variableName": "majorPeriods"
-        },
-        {
-          "kind": "Variable",
-          "name": "offerable",
-          "variableName": "offerable"
-        },
-        {
-          "kind": "Variable",
-          "name": "partnerID",
-          "variableName": "partnerID"
-        },
-        {
-          "kind": "Variable",
-          "name": "partnerIDs",
-          "variableName": "partnerIDs"
-        },
-        {
-          "kind": "Variable",
-          "name": "priceRange",
-          "variableName": "priceRange"
-        },
-        {
-          "kind": "Variable",
-          "name": "sort",
-          "variableName": "sort"
+          "name": "input",
+          "variableName": "input"
         }
       ],
       "concreteType": "FilterArtworksConnection",
@@ -388,5 +258,5 @@ const node: ReaderFragment = {
   "type": "ArtistSeries",
   "abstractKey": null
 };
-(node as any).hash = 'bce047cfceaef8bc35678fe80efd854b';
+(node as any).hash = '6fbfe98a700a1d3b80237a9c2748ac25';
 export default node;

--- a/src/__generated__/ArtistSeriesQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash bae75131fa7622e409c91e3cfa7d466c */
+/* @relayHash ef99c1209a5bb110d826a8287db5bbbe */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -29,10 +29,10 @@ query ArtistSeriesQuery(
   }
 }
 
-fragment ArtistSeriesArtworks_artistSeries on ArtistSeries {
+fragment ArtistSeriesArtworks_artistSeries_2T6kBV on ArtistSeries {
   slug
   internalID
-  artistSeriesArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -109,7 +109,7 @@ fragment ArtistSeries_artistSeries on ArtistSeries {
   artistIDs
   ...ArtistSeriesHeader_artistSeries
   ...ArtistSeriesMeta_artistSeries
-  ...ArtistSeriesArtworks_artistSeries
+  ...ArtistSeriesArtworks_artistSeries_2T6kBV
   artist: artists(size: 1) {
     ...ArtistSeriesMoreSeries_artist
     artistSeriesConnection(first: 4) {
@@ -269,18 +269,16 @@ v9 = [
   },
   {
     "kind": "Literal",
-    "name": "dimensionRange",
-    "value": "*-*"
-  },
-  {
-    "kind": "Literal",
     "name": "first",
     "value": 20
   },
   {
     "kind": "Literal",
-    "name": "sort",
-    "value": "-decayed_merch"
+    "name": "input",
+    "value": {
+      "dimensionRange": "*-*",
+      "sort": "-decayed_merch"
+    }
   }
 ],
 v10 = {
@@ -726,27 +724,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:20,sort:\"-decayed_merch\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:20,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "artistSeriesArtworks",
             "args": (v9/*: any*/),
             "filters": [
-              "sort",
-              "additionalGeneIDs",
-              "priceRange",
-              "color",
-              "colors",
-              "partnerID",
-              "partnerIDs",
-              "dimensionRange",
-              "majorPeriods",
-              "acquireable",
-              "inquireableOnly",
-              "atAuction",
-              "offerable",
               "aggregations",
-              "attributionClass"
+              "input"
             ],
             "handle": "connection",
             "key": "ArtistSeries_artistSeriesArtworks",
@@ -837,7 +822,7 @@ return {
     ]
   },
   "params": {
-    "id": "bae75131fa7622e409c91e3cfa7d466c",
+    "id": "ef99c1209a5bb110d826a8287db5bbbe",
     "metadata": {},
     "name": "ArtistSeriesQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash b5f53fead7d6ec8dd64b09aab64084e6 */
+/* @relayHash 45f4965387cd30ae28c0c5839d625c41 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -25,10 +25,10 @@ query ArtistSeriesTestsQuery {
   }
 }
 
-fragment ArtistSeriesArtworks_artistSeries on ArtistSeries {
+fragment ArtistSeriesArtworks_artistSeries_2T6kBV on ArtistSeries {
   slug
   internalID
-  artistSeriesArtworks: filterArtworksConnection(first: 20, sort: "-decayed_merch", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -105,7 +105,7 @@ fragment ArtistSeries_artistSeries on ArtistSeries {
   artistIDs
   ...ArtistSeriesHeader_artistSeries
   ...ArtistSeriesMeta_artistSeries
-  ...ArtistSeriesArtworks_artistSeries
+  ...ArtistSeriesArtworks_artistSeries_2T6kBV
   artist: artists(size: 1) {
     ...ArtistSeriesMoreSeries_artist
     artistSeriesConnection(first: 4) {
@@ -258,18 +258,16 @@ v8 = [
   },
   {
     "kind": "Literal",
-    "name": "dimensionRange",
-    "value": "*-*"
-  },
-  {
-    "kind": "Literal",
     "name": "first",
     "value": 20
   },
   {
     "kind": "Literal",
-    "name": "sort",
-    "value": "-decayed_merch"
+    "name": "input",
+    "value": {
+      "dimensionRange": "*-*",
+      "sort": "-decayed_merch"
+    }
   }
 ],
 v9 = {
@@ -775,27 +773,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:20,sort:\"-decayed_merch\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:20,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "artistSeriesArtworks",
             "args": (v8/*: any*/),
             "filters": [
-              "sort",
-              "additionalGeneIDs",
-              "priceRange",
-              "color",
-              "colors",
-              "partnerID",
-              "partnerIDs",
-              "dimensionRange",
-              "majorPeriods",
-              "acquireable",
-              "inquireableOnly",
-              "atAuction",
-              "offerable",
               "aggregations",
-              "attributionClass"
+              "input"
             ],
             "handle": "connection",
             "key": "ArtistSeries_artistSeriesArtworks",
@@ -886,7 +871,7 @@ return {
     ]
   },
   "params": {
-    "id": "b5f53fead7d6ec8dd64b09aab64084e6",
+    "id": "45f4965387cd30ae28c0c5839d625c41",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artistSeries": (v10/*: any*/),

--- a/src/__generated__/ArtistSeries_artistSeries.graphql.ts
+++ b/src/__generated__/ArtistSeries_artistSeries.graphql.ts
@@ -109,7 +109,16 @@ const node: ReaderFragment = {
       "name": "ArtistSeriesMeta_artistSeries"
     },
     {
-      "args": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "input",
+          "value": {
+            "dimensionRange": "*-*",
+            "sort": "-decayed_merch"
+          }
+        }
+      ],
       "kind": "FragmentSpread",
       "name": "ArtistSeriesArtworks_artistSeries"
     }
@@ -117,5 +126,5 @@ const node: ReaderFragment = {
   "type": "ArtistSeries",
   "abstractKey": null
 };
-(node as any).hash = 'a4b3a5706086f1d6fd73bbe788d2e0e9';
+(node as any).hash = 'd7cdaecd1174f42cc89c096d346c2311';
 export default node;

--- a/src/__generated__/ArtworkBelowTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtworkBelowTheFoldQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 5af9d9e83732a04e8e966a909155a16d */
+/* @relayHash 90e5b68f4950577d20b244cc0a0793b0 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -219,7 +219,7 @@ fragment Artwork_artworkBelowTheFold on Artwork {
   artistSeriesConnection(first: 1) {
     edges {
       node {
-        filterArtworksConnection(sort: "-decayed_merch", first: 20) {
+        filterArtworksConnection(first: 20, input: {sort: "-decayed_merch"}) {
           edges {
             node {
               id
@@ -248,7 +248,7 @@ fragment ArtworksInSeriesRail_artwork on Artwork {
       node {
         slug
         internalID
-        filterArtworksConnection(sort: "-decayed_merch", first: 20) {
+        filterArtworksConnection(first: 20, input: {sort: "-decayed_merch"}) {
           edges {
             node {
               slug
@@ -1246,8 +1246,10 @@ return {
                           },
                           {
                             "kind": "Literal",
-                            "name": "sort",
-                            "value": "-decayed_merch"
+                            "name": "input",
+                            "value": {
+                              "sort": "-decayed_merch"
+                            }
                           }
                         ],
                         "concreteType": "FilterArtworksConnection",
@@ -1336,7 +1338,7 @@ return {
                           },
                           (v2/*: any*/)
                         ],
-                        "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")"
+                        "storageKey": "filterArtworksConnection(first:20,input:{\"sort\":\"-decayed_merch\"})"
                       },
                       (v4/*: any*/),
                       (v7/*: any*/)
@@ -1418,7 +1420,7 @@ return {
     ]
   },
   "params": {
-    "id": "5af9d9e83732a04e8e966a909155a16d",
+    "id": "90e5b68f4950577d20b244cc0a0793b0",
     "metadata": {},
     "name": "ArtworkBelowTheFoldQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtworkRefetchQuery.graphql.ts
+++ b/src/__generated__/ArtworkRefetchQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 65cb8d56901bce81322fbd0c21618f26 */
+/* @relayHash 72face3d23df644d8eeaec6db816efeb */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -337,7 +337,7 @@ fragment Artwork_artworkBelowTheFold on Artwork {
   artistSeriesConnection(first: 1) {
     edges {
       node {
-        filterArtworksConnection(sort: "-decayed_merch", first: 20) {
+        filterArtworksConnection(first: 20, input: {sort: "-decayed_merch"}) {
           edges {
             node {
               id
@@ -366,7 +366,7 @@ fragment ArtworksInSeriesRail_artwork on Artwork {
       node {
         slug
         internalID
-        filterArtworksConnection(sort: "-decayed_merch", first: 20) {
+        filterArtworksConnection(first: 20, input: {sort: "-decayed_merch"}) {
           edges {
             node {
               slug
@@ -2242,8 +2242,10 @@ return {
                           },
                           {
                             "kind": "Literal",
-                            "name": "sort",
-                            "value": "-decayed_merch"
+                            "name": "input",
+                            "value": {
+                              "sort": "-decayed_merch"
+                            }
                           }
                         ],
                         "concreteType": "FilterArtworksConnection",
@@ -2332,7 +2334,7 @@ return {
                           },
                           (v2/*: any*/)
                         ],
-                        "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")"
+                        "storageKey": "filterArtworksConnection(first:20,input:{\"sort\":\"-decayed_merch\"})"
                       },
                       (v4/*: any*/),
                       (v3/*: any*/)
@@ -2363,7 +2365,7 @@ return {
     ]
   },
   "params": {
-    "id": "65cb8d56901bce81322fbd0c21618f26",
+    "id": "72face3d23df644d8eeaec6db816efeb",
     "metadata": {},
     "name": "ArtworkRefetchQuery",
     "operationKind": "query",

--- a/src/__generated__/Artwork_artworkBelowTheFold.graphql.ts
+++ b/src/__generated__/Artwork_artworkBelowTheFold.graphql.ts
@@ -462,8 +462,10 @@ return {
                     },
                     {
                       "kind": "Literal",
-                      "name": "sort",
-                      "value": "-decayed_merch"
+                      "name": "input",
+                      "value": {
+                        "sort": "-decayed_merch"
+                      }
                     }
                   ],
                   "concreteType": "FilterArtworksConnection",
@@ -482,7 +484,7 @@ return {
                       "storageKey": null
                     }
                   ],
-                  "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")"
+                  "storageKey": "filterArtworksConnection(first:20,input:{\"sort\":\"-decayed_merch\"})"
                 }
               ],
               "storageKey": null
@@ -538,5 +540,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = 'dfff91a7572af9d6442cf9cec8030151';
+(node as any).hash = '30f25615a303c3c2dde099834bad0a23';
 export default node;

--- a/src/__generated__/ArtworksInSeriesRailTestsQuery.graphql.ts
+++ b/src/__generated__/ArtworksInSeriesRailTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 37cacf6f5f1bdcabbf9da2ed7a75e9ad */
+/* @relayHash 27d9d3ec937f864f4de098b386bef847 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -88,7 +88,7 @@ fragment ArtworksInSeriesRail_artwork on Artwork {
       node {
         slug
         internalID
-        filterArtworksConnection(sort: "-decayed_merch", first: 20) {
+        filterArtworksConnection(first: 20, input: {sort: "-decayed_merch"}) {
           edges {
             node {
               slug
@@ -246,8 +246,10 @@ return {
                           },
                           {
                             "kind": "Literal",
-                            "name": "sort",
-                            "value": "-decayed_merch"
+                            "name": "input",
+                            "value": {
+                              "sort": "-decayed_merch"
+                            }
                           }
                         ],
                         "concreteType": "FilterArtworksConnection",
@@ -442,7 +444,7 @@ return {
                           },
                           (v3/*: any*/)
                         ],
-                        "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")"
+                        "storageKey": "filterArtworksConnection(first:20,input:{\"sort\":\"-decayed_merch\"})"
                       }
                     ],
                     "storageKey": null
@@ -460,7 +462,7 @@ return {
     ]
   },
   "params": {
-    "id": "37cacf6f5f1bdcabbf9da2ed7a75e9ad",
+    "id": "27d9d3ec937f864f4de098b386bef847",
     "metadata": {},
     "name": "ArtworksInSeriesRailTestsQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtworksInSeriesRail_artwork.graphql.ts
+++ b/src/__generated__/ArtworksInSeriesRail_artwork.graphql.ts
@@ -123,8 +123,10 @@ return {
                     },
                     {
                       "kind": "Literal",
-                      "name": "sort",
-                      "value": "-decayed_merch"
+                      "name": "input",
+                      "value": {
+                        "sort": "-decayed_merch"
+                      }
                     }
                   ],
                   "concreteType": "FilterArtworksConnection",
@@ -314,7 +316,7 @@ return {
                       "storageKey": null
                     }
                   ],
-                  "storageKey": "filterArtworksConnection(first:20,sort:\"-decayed_merch\")"
+                  "storageKey": "filterArtworksConnection(first:20,input:{\"sort\":\"-decayed_merch\"})"
                 }
               ],
               "storageKey": null
@@ -330,5 +332,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '6d4cacadfca1cb2eb6348f82350b7ead';
+(node as any).hash = 'ba9b9f03d00717559fa6b179455ca585';
 export default node;

--- a/src/__generated__/FairAllFollowedArtistsQuery.graphql.ts
+++ b/src/__generated__/FairAllFollowedArtistsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash e5e963766c229e7795d8f49f1f3bd3ef */
+/* @relayHash f4555f1a61e0cc5363ae2db11ae4baa4 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -75,7 +75,7 @@ fragment ArtworkGridItem_artwork on Artwork {
 fragment FairAllFollowedArtists_fair on Fair {
   internalID
   slug
-  ...FairArtworks_fair_485l1x
+  ...FairArtworks_fair_1yydc8
 }
 
 fragment FairAllFollowedArtists_fairForFilters on Fair {
@@ -95,10 +95,10 @@ fragment FairAllFollowedArtists_fairForFilters on Fair {
   }
 }
 
-fragment FairArtworks_fair_485l1x on Fair {
+fragment FairArtworks_fair_1yydc8 on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", dimensionRange: "*-*", includeArtworksByFollowedArtists: true, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], input: {includeArtworksByFollowedArtists: true}) {
     aggregations {
       slice
       counts {
@@ -199,23 +199,15 @@ v5 = [
   (v4/*: any*/),
   {
     "kind": "Literal",
-    "name": "dimensionRange",
-    "value": "*-*"
-  },
-  {
-    "kind": "Literal",
     "name": "first",
     "value": 30
   },
   {
     "kind": "Literal",
-    "name": "includeArtworksByFollowedArtists",
-    "value": true
-  },
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "-decayed_merch"
+    "name": "input",
+    "value": {
+      "includeArtworksByFollowedArtists": true
+    }
   }
 ],
 v6 = {
@@ -667,29 +659,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,includeArtworksByFollowedArtists:true,sort:\"-decayed_merch\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:30,input:{\"includeArtworksByFollowedArtists\":true})"
           },
           {
             "alias": "fairArtworks",
             "args": (v5/*: any*/),
             "filters": [
-              "sort",
-              "additionalGeneIDs",
-              "priceRange",
-              "color",
-              "colors",
-              "partnerID",
-              "partnerIDs",
-              "dimensionRange",
-              "majorPeriods",
-              "acquireable",
-              "inquireableOnly",
-              "atAuction",
-              "offerable",
-              "includeArtworksByFollowedArtists",
-              "artistIDs",
               "aggregations",
-              "attributionClass"
+              "input"
             ],
             "handle": "connection",
             "key": "Fair_fairArtworks",
@@ -747,7 +724,7 @@ return {
     ]
   },
   "params": {
-    "id": "e5e963766c229e7795d8f49f1f3bd3ef",
+    "id": "f4555f1a61e0cc5363ae2db11ae4baa4",
     "metadata": {},
     "name": "FairAllFollowedArtistsQuery",
     "operationKind": "query",

--- a/src/__generated__/FairAllFollowedArtistsQuery.graphql.ts
+++ b/src/__generated__/FairAllFollowedArtistsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash f4555f1a61e0cc5363ae2db11ae4baa4 */
+/* @relayHash 5bfb57722ef735fa8e24d04b45f995a8 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -75,7 +75,7 @@ fragment ArtworkGridItem_artwork on Artwork {
 fragment FairAllFollowedArtists_fair on Fair {
   internalID
   slug
-  ...FairArtworks_fair_1yydc8
+  ...FairArtworks_fair_6zGp3
 }
 
 fragment FairAllFollowedArtists_fairForFilters on Fair {
@@ -95,10 +95,10 @@ fragment FairAllFollowedArtists_fairForFilters on Fair {
   }
 }
 
-fragment FairArtworks_fair_1yydc8 on Fair {
+fragment FairArtworks_fair_6zGp3 on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], input: {includeArtworksByFollowedArtists: true}) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], input: {includeArtworksByFollowedArtists: true, sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -206,7 +206,9 @@ v5 = [
     "kind": "Literal",
     "name": "input",
     "value": {
-      "includeArtworksByFollowedArtists": true
+      "dimensionRange": "*-*",
+      "includeArtworksByFollowedArtists": true,
+      "sort": "-decayed_merch"
     }
   }
 ],
@@ -659,7 +661,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:30,input:{\"includeArtworksByFollowedArtists\":true})"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:30,input:{\"dimensionRange\":\"*-*\",\"includeArtworksByFollowedArtists\":true,\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "fairArtworks",
@@ -724,7 +726,7 @@ return {
     ]
   },
   "params": {
-    "id": "f4555f1a61e0cc5363ae2db11ae4baa4",
+    "id": "5bfb57722ef735fa8e24d04b45f995a8",
     "metadata": {},
     "name": "FairAllFollowedArtistsQuery",
     "operationKind": "query",

--- a/src/__generated__/FairAllFollowedArtistsTestsQuery.graphql.ts
+++ b/src/__generated__/FairAllFollowedArtistsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash f62381dc1c01833a3d507999160a0a5a */
+/* @relayHash d352919207ec8f255936276ea29759c7 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -75,7 +75,7 @@ fragment ArtworkGridItem_artwork on Artwork {
 fragment FairAllFollowedArtists_fair on Fair {
   internalID
   slug
-  ...FairArtworks_fair_485l1x
+  ...FairArtworks_fair_1yydc8
 }
 
 fragment FairAllFollowedArtists_fairForFilters on Fair {
@@ -95,10 +95,10 @@ fragment FairAllFollowedArtists_fairForFilters on Fair {
   }
 }
 
-fragment FairArtworks_fair_485l1x on Fair {
+fragment FairArtworks_fair_1yydc8 on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", dimensionRange: "*-*", includeArtworksByFollowedArtists: true, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], input: {includeArtworksByFollowedArtists: true}) {
     aggregations {
       slice
       counts {
@@ -199,23 +199,15 @@ v5 = [
   (v4/*: any*/),
   {
     "kind": "Literal",
-    "name": "dimensionRange",
-    "value": "*-*"
-  },
-  {
-    "kind": "Literal",
     "name": "first",
     "value": 30
   },
   {
     "kind": "Literal",
-    "name": "includeArtworksByFollowedArtists",
-    "value": true
-  },
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "-decayed_merch"
+    "name": "input",
+    "value": {
+      "includeArtworksByFollowedArtists": true
+    }
   }
 ],
 v6 = {
@@ -758,29 +750,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,includeArtworksByFollowedArtists:true,sort:\"-decayed_merch\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:30,input:{\"includeArtworksByFollowedArtists\":true})"
           },
           {
             "alias": "fairArtworks",
             "args": (v5/*: any*/),
             "filters": [
-              "sort",
-              "additionalGeneIDs",
-              "priceRange",
-              "color",
-              "colors",
-              "partnerID",
-              "partnerIDs",
-              "dimensionRange",
-              "majorPeriods",
-              "acquireable",
-              "inquireableOnly",
-              "atAuction",
-              "offerable",
-              "includeArtworksByFollowedArtists",
-              "artistIDs",
               "aggregations",
-              "attributionClass"
+              "input"
             ],
             "handle": "connection",
             "key": "Fair_fairArtworks",
@@ -838,7 +815,7 @@ return {
     ]
   },
   "params": {
-    "id": "f62381dc1c01833a3d507999160a0a5a",
+    "id": "d352919207ec8f255936276ea29759c7",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "fair": (v11/*: any*/),

--- a/src/__generated__/FairAllFollowedArtistsTestsQuery.graphql.ts
+++ b/src/__generated__/FairAllFollowedArtistsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash d352919207ec8f255936276ea29759c7 */
+/* @relayHash 9c402342e1a6adb8001b6203b46ba714 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -75,7 +75,7 @@ fragment ArtworkGridItem_artwork on Artwork {
 fragment FairAllFollowedArtists_fair on Fair {
   internalID
   slug
-  ...FairArtworks_fair_1yydc8
+  ...FairArtworks_fair_6zGp3
 }
 
 fragment FairAllFollowedArtists_fairForFilters on Fair {
@@ -95,10 +95,10 @@ fragment FairAllFollowedArtists_fairForFilters on Fair {
   }
 }
 
-fragment FairArtworks_fair_1yydc8 on Fair {
+fragment FairArtworks_fair_6zGp3 on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], input: {includeArtworksByFollowedArtists: true}) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], input: {includeArtworksByFollowedArtists: true, sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -206,7 +206,9 @@ v5 = [
     "kind": "Literal",
     "name": "input",
     "value": {
-      "includeArtworksByFollowedArtists": true
+      "dimensionRange": "*-*",
+      "includeArtworksByFollowedArtists": true,
+      "sort": "-decayed_merch"
     }
   }
 ],
@@ -750,7 +752,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:30,input:{\"includeArtworksByFollowedArtists\":true})"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:30,input:{\"dimensionRange\":\"*-*\",\"includeArtworksByFollowedArtists\":true,\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "fairArtworks",
@@ -815,7 +817,7 @@ return {
     ]
   },
   "params": {
-    "id": "d352919207ec8f255936276ea29759c7",
+    "id": "9c402342e1a6adb8001b6203b46ba714",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "fair": (v11/*: any*/),

--- a/src/__generated__/FairAllFollowedArtists_fair.graphql.ts
+++ b/src/__generated__/FairAllFollowedArtists_fair.graphql.ts
@@ -44,7 +44,9 @@ const node: ReaderFragment = {
           "kind": "Literal",
           "name": "input",
           "value": {
-            "includeArtworksByFollowedArtists": true
+            "dimensionRange": "*-*",
+            "includeArtworksByFollowedArtists": true,
+            "sort": "-decayed_merch"
           }
         }
       ],
@@ -55,5 +57,5 @@ const node: ReaderFragment = {
   "type": "Fair",
   "abstractKey": null
 };
-(node as any).hash = '686f5afb388e6a071e4326e10bf3d4c9';
+(node as any).hash = '3252c171b7486ee49bc96af845f77107';
 export default node;

--- a/src/__generated__/FairAllFollowedArtists_fair.graphql.ts
+++ b/src/__generated__/FairAllFollowedArtists_fair.graphql.ts
@@ -42,8 +42,10 @@ const node: ReaderFragment = {
       "args": [
         {
           "kind": "Literal",
-          "name": "includeArtworksByFollowedArtists",
-          "value": true
+          "name": "input",
+          "value": {
+            "includeArtworksByFollowedArtists": true
+          }
         }
       ],
       "kind": "FragmentSpread",
@@ -53,5 +55,5 @@ const node: ReaderFragment = {
   "type": "Fair",
   "abstractKey": null
 };
-(node as any).hash = '6f43d2010c52c6fcb960769e30119d4e';
+(node as any).hash = '686f5afb388e6a071e4326e10bf3d4c9';
 export default node;

--- a/src/__generated__/FairArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/FairArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,30 +1,66 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 730c5add9a5f76ba5f65b8aad91b4073 */
+/* @relayHash 306569cc4c19f09af119485c751fcf0d */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
+export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
+export type FilterArtworksInput = {
+    acquireable?: boolean | null;
+    additionalGeneIDs?: Array<string | null> | null;
+    after?: string | null;
+    aggregationPartnerCities?: Array<string | null> | null;
+    aggregations?: Array<ArtworkAggregation | null> | null;
+    artistID?: string | null;
+    artistIDs?: Array<string | null> | null;
+    artistNationalities?: Array<string | null> | null;
+    artistSeriesID?: string | null;
+    atAuction?: boolean | null;
+    attributionClass?: Array<string | null> | null;
+    before?: string | null;
+    color?: string | null;
+    colors?: Array<string | null> | null;
+    dimensionRange?: string | null;
+    excludeArtworkIDs?: Array<string | null> | null;
+    extraAggregationGeneIDs?: Array<string | null> | null;
+    first?: number | null;
+    forSale?: boolean | null;
+    geneID?: string | null;
+    geneIDs?: Array<string | null> | null;
+    height?: string | null;
+    includeArtworksByFollowedArtists?: boolean | null;
+    includeMediumFilterInAggregation?: boolean | null;
+    inquireableOnly?: boolean | null;
+    keyword?: string | null;
+    keywordMatchExact?: boolean | null;
+    last?: number | null;
+    locationCities?: Array<string | null> | null;
+    majorPeriods?: Array<string | null> | null;
+    marketable?: boolean | null;
+    materialsTerms?: Array<string | null> | null;
+    medium?: string | null;
+    offerable?: boolean | null;
+    page?: number | null;
+    partnerCities?: Array<string | null> | null;
+    partnerID?: string | null;
+    partnerIDs?: Array<string | null> | null;
+    period?: string | null;
+    periods?: Array<string | null> | null;
+    priceRange?: string | null;
+    saleID?: string | null;
+    size?: number | null;
+    sizes?: Array<ArtworkSizes | null> | null;
+    sort?: string | null;
+    tagID?: string | null;
+    width?: string | null;
+};
 export type FairArtworksInfiniteScrollGridQueryVariables = {
     id: string;
     count: number;
     cursor?: string | null;
-    sort?: string | null;
-    additionalGeneIDs?: Array<string | null> | null;
-    priceRange?: string | null;
-    color?: string | null;
-    colors?: Array<string | null> | null;
-    partnerID?: string | null;
-    partnerIDs?: Array<string | null> | null;
-    dimensionRange?: string | null;
-    majorPeriods?: Array<string | null> | null;
-    acquireable?: boolean | null;
-    inquireableOnly?: boolean | null;
-    atAuction?: boolean | null;
-    offerable?: boolean | null;
-    includeArtworksByFollowedArtists?: boolean | null;
-    artistIDs?: Array<string | null> | null;
-    attributionClass?: Array<string | null> | null;
+    input?: FilterArtworksInput | null;
 };
 export type FairArtworksInfiniteScrollGridQueryResponse = {
     readonly fair: {
@@ -41,26 +77,12 @@ export type FairArtworksInfiniteScrollGridQuery = {
 /*
 query FairArtworksInfiniteScrollGridQuery(
   $id: String!
+  $count: Int!
   $cursor: String
-  $sort: String
-  $additionalGeneIDs: [String]
-  $priceRange: String
-  $color: String
-  $colors: [String]
-  $partnerID: ID
-  $partnerIDs: [String]
-  $dimensionRange: String
-  $majorPeriods: [String]
-  $acquireable: Boolean
-  $inquireableOnly: Boolean
-  $atAuction: Boolean
-  $offerable: Boolean
-  $includeArtworksByFollowedArtists: Boolean
-  $artistIDs: [String]
-  $attributionClass: [String]
+  $input: FilterArtworksInput
 ) {
   fair(id: $id) {
-    ...FairArtworks_fair_3KZLoS
+    ...FairArtworks_fair_YCAiB
     id
   }
 }
@@ -100,10 +122,10 @@ fragment ArtworkGridItem_artwork on Artwork {
   }
 }
 
-fragment FairArtworks_fair_3KZLoS on Fair {
+fragment FairArtworks_fair_YCAiB on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, after: $cursor, sort: $sort, additionalGeneIDs: $additionalGeneIDs, priceRange: $priceRange, color: $color, colors: $colors, partnerID: $partnerID, partnerIDs: $partnerIDs, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, includeArtworksByFollowedArtists: $includeArtworksByFollowedArtists, artistIDs: $artistIDs, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], attributionClass: $attributionClass) {
+  fairArtworks: filterArtworksConnection(first: $count, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], input: $input) {
     aggregations {
       slice
       counts {
@@ -161,202 +183,50 @@ const node: ConcreteRequest = (function(){
 var v0 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "acquireable"
+  "name": "count"
 },
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "additionalGeneIDs"
+  "name": "cursor"
 },
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "artistIDs"
+  "name": "id"
 },
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "atAuction"
+  "name": "input"
 },
-v4 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "attributionClass"
-},
-v5 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "color"
-},
-v6 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "colors"
-},
-v7 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "count"
-},
-v8 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "cursor"
-},
-v9 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "dimensionRange"
-},
-v10 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "id"
-},
-v11 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "includeArtworksByFollowedArtists"
-},
-v12 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "inquireableOnly"
-},
-v13 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "majorPeriods"
-},
-v14 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "offerable"
-},
-v15 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "partnerID"
-},
-v16 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "partnerIDs"
-},
-v17 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "priceRange"
-},
-v18 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "sort"
-},
-v19 = [
+v4 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v20 = {
+v5 = {
   "kind": "Variable",
-  "name": "acquireable",
-  "variableName": "acquireable"
+  "name": "input",
+  "variableName": "input"
 },
-v21 = {
-  "kind": "Variable",
-  "name": "additionalGeneIDs",
-  "variableName": "additionalGeneIDs"
-},
-v22 = {
-  "kind": "Variable",
-  "name": "artistIDs",
-  "variableName": "artistIDs"
-},
-v23 = {
-  "kind": "Variable",
-  "name": "atAuction",
-  "variableName": "atAuction"
-},
-v24 = {
-  "kind": "Variable",
-  "name": "attributionClass",
-  "variableName": "attributionClass"
-},
-v25 = {
-  "kind": "Variable",
-  "name": "color",
-  "variableName": "color"
-},
-v26 = {
-  "kind": "Variable",
-  "name": "colors",
-  "variableName": "colors"
-},
-v27 = {
-  "kind": "Variable",
-  "name": "dimensionRange",
-  "variableName": "dimensionRange"
-},
-v28 = {
-  "kind": "Variable",
-  "name": "includeArtworksByFollowedArtists",
-  "variableName": "includeArtworksByFollowedArtists"
-},
-v29 = {
-  "kind": "Variable",
-  "name": "inquireableOnly",
-  "variableName": "inquireableOnly"
-},
-v30 = {
-  "kind": "Variable",
-  "name": "majorPeriods",
-  "variableName": "majorPeriods"
-},
-v31 = {
-  "kind": "Variable",
-  "name": "offerable",
-  "variableName": "offerable"
-},
-v32 = {
-  "kind": "Variable",
-  "name": "partnerID",
-  "variableName": "partnerID"
-},
-v33 = {
-  "kind": "Variable",
-  "name": "partnerIDs",
-  "variableName": "partnerIDs"
-},
-v34 = {
-  "kind": "Variable",
-  "name": "priceRange",
-  "variableName": "priceRange"
-},
-v35 = {
-  "kind": "Variable",
-  "name": "sort",
-  "variableName": "sort"
-},
-v36 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v37 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v38 = [
-  (v20/*: any*/),
-  (v21/*: any*/),
+v8 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -376,41 +246,28 @@ v38 = [
       "ARTIST"
     ]
   },
-  (v22/*: any*/),
-  (v23/*: any*/),
-  (v24/*: any*/),
-  (v25/*: any*/),
-  (v26/*: any*/),
-  (v27/*: any*/),
   {
-    "kind": "Literal",
+    "kind": "Variable",
     "name": "first",
-    "value": 30
+    "variableName": "count"
   },
-  (v28/*: any*/),
-  (v29/*: any*/),
-  (v30/*: any*/),
-  (v31/*: any*/),
-  (v32/*: any*/),
-  (v33/*: any*/),
-  (v34/*: any*/),
-  (v35/*: any*/)
+  (v5/*: any*/)
 ],
-v39 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v40 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v41 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -423,22 +280,7 @@ return {
       (v0/*: any*/),
       (v1/*: any*/),
       (v2/*: any*/),
-      (v3/*: any*/),
-      (v4/*: any*/),
-      (v5/*: any*/),
-      (v6/*: any*/),
-      (v7/*: any*/),
-      (v8/*: any*/),
-      (v9/*: any*/),
-      (v10/*: any*/),
-      (v11/*: any*/),
-      (v12/*: any*/),
-      (v13/*: any*/),
-      (v14/*: any*/),
-      (v15/*: any*/),
-      (v16/*: any*/),
-      (v17/*: any*/),
-      (v18/*: any*/)
+      (v3/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -446,7 +288,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v19/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": "Fair",
         "kind": "LinkedField",
         "name": "fair",
@@ -454,13 +296,6 @@ return {
         "selections": [
           {
             "args": [
-              (v20/*: any*/),
-              (v21/*: any*/),
-              (v22/*: any*/),
-              (v23/*: any*/),
-              (v24/*: any*/),
-              (v25/*: any*/),
-              (v26/*: any*/),
               {
                 "kind": "Variable",
                 "name": "count",
@@ -471,15 +306,7 @@ return {
                 "name": "cursor",
                 "variableName": "cursor"
               },
-              (v27/*: any*/),
-              (v28/*: any*/),
-              (v29/*: any*/),
-              (v30/*: any*/),
-              (v31/*: any*/),
-              (v32/*: any*/),
-              (v33/*: any*/),
-              (v34/*: any*/),
-              (v35/*: any*/)
+              (v5/*: any*/)
             ],
             "kind": "FragmentSpread",
             "name": "FairArtworks_fair"
@@ -494,42 +321,27 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v10/*: any*/),
-      (v7/*: any*/),
-      (v8/*: any*/),
-      (v18/*: any*/),
-      (v1/*: any*/),
-      (v17/*: any*/),
-      (v5/*: any*/),
-      (v6/*: any*/),
-      (v15/*: any*/),
-      (v16/*: any*/),
-      (v9/*: any*/),
-      (v13/*: any*/),
-      (v0/*: any*/),
-      (v12/*: any*/),
-      (v3/*: any*/),
-      (v14/*: any*/),
-      (v11/*: any*/),
       (v2/*: any*/),
-      (v4/*: any*/)
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v3/*: any*/)
     ],
     "kind": "Operation",
     "name": "FairArtworksInfiniteScrollGridQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v19/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": "Fair",
         "kind": "LinkedField",
         "name": "fair",
         "plural": false,
         "selections": [
-          (v36/*: any*/),
-          (v37/*: any*/),
+          (v6/*: any*/),
+          (v7/*: any*/),
           {
             "alias": "fairArtworks",
-            "args": (v38/*: any*/),
+            "args": (v8/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -565,7 +377,7 @@ return {
                         "name": "count",
                         "storageKey": null
                       },
-                      (v39/*: any*/),
+                      (v9/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -595,8 +407,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v40/*: any*/),
-                      (v41/*: any*/)
+                      (v10/*: any*/),
+                      (v11/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -660,7 +472,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v40/*: any*/),
+              (v10/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -690,7 +502,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v41/*: any*/),
+                      (v11/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -699,7 +511,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v36/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -752,7 +564,7 @@ return {
                             "name": "saleMessage",
                             "storageKey": null
                           },
-                          (v37/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -803,7 +615,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v40/*: any*/)
+                              (v10/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -858,7 +670,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v40/*: any*/)
+                              (v10/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -870,8 +682,8 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v39/*: any*/),
-                              (v40/*: any*/)
+                              (v9/*: any*/),
+                              (v10/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -881,7 +693,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v40/*: any*/)
+                          (v10/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -898,39 +710,24 @@ return {
           },
           {
             "alias": "fairArtworks",
-            "args": (v38/*: any*/),
+            "args": (v8/*: any*/),
             "filters": [
-              "sort",
-              "additionalGeneIDs",
-              "priceRange",
-              "color",
-              "colors",
-              "partnerID",
-              "partnerIDs",
-              "dimensionRange",
-              "majorPeriods",
-              "acquireable",
-              "inquireableOnly",
-              "atAuction",
-              "offerable",
-              "includeArtworksByFollowedArtists",
-              "artistIDs",
               "aggregations",
-              "attributionClass"
+              "input"
             ],
             "handle": "connection",
             "key": "Fair_fairArtworks",
             "kind": "LinkedHandle",
             "name": "filterArtworksConnection"
           },
-          (v40/*: any*/)
+          (v10/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "730c5add9a5f76ba5f65b8aad91b4073",
+    "id": "306569cc4c19f09af119485c751fcf0d",
     "metadata": {},
     "name": "FairArtworksInfiniteScrollGridQuery",
     "operationKind": "query",
@@ -938,5 +735,5 @@ return {
   }
 };
 })();
-(node as any).hash = '4d4f3c6649899741dd125518c1d27550';
+(node as any).hash = 'd9c1bf64953786bbe91d4390d093f8a9';
 export default node;

--- a/src/__generated__/FairArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/FairArtworksTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 53d8bb5789d751e294f666a8c4d7ee05 */
+/* @relayHash c6653891f5b08bddaa74edad1c4ed5e4 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -68,7 +68,7 @@ fragment ArtworkGridItem_artwork on Artwork {
 fragment FairArtworks_fair on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
     aggregations {
       slice
       counts {
@@ -168,18 +168,8 @@ v4 = [
   },
   {
     "kind": "Literal",
-    "name": "dimensionRange",
-    "value": "*-*"
-  },
-  {
-    "kind": "Literal",
     "name": "first",
     "value": 30
-  },
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "-decayed_merch"
   }
 ],
 v5 = {
@@ -643,29 +633,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,sort:\"-decayed_merch\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:30)"
           },
           {
             "alias": "fairArtworks",
             "args": (v4/*: any*/),
             "filters": [
-              "sort",
-              "additionalGeneIDs",
-              "priceRange",
-              "color",
-              "colors",
-              "partnerID",
-              "partnerIDs",
-              "dimensionRange",
-              "majorPeriods",
-              "acquireable",
-              "inquireableOnly",
-              "atAuction",
-              "offerable",
-              "includeArtworksByFollowedArtists",
-              "artistIDs",
               "aggregations",
-              "attributionClass"
+              "input"
             ],
             "handle": "connection",
             "key": "Fair_fairArtworks",
@@ -679,7 +654,7 @@ return {
     ]
   },
   "params": {
-    "id": "53d8bb5789d751e294f666a8c4d7ee05",
+    "id": "c6653891f5b08bddaa74edad1c4ed5e4",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "fair": {

--- a/src/__generated__/FairArtworks_fair.graphql.ts
+++ b/src/__generated__/FairArtworks_fair.graphql.ts
@@ -41,41 +41,6 @@ export type FairArtworks_fair$key = {
 const node: ReaderFragment = {
   "argumentDefinitions": [
     {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "acquireable"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "additionalGeneIDs"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "artistIDs"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "atAuction"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "attributionClass"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "color"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "colors"
-    },
-    {
       "defaultValue": 30,
       "kind": "LocalArgument",
       "name": "count"
@@ -86,56 +51,16 @@ const node: ReaderFragment = {
       "name": "cursor"
     },
     {
-      "defaultValue": "*-*",
-      "kind": "LocalArgument",
-      "name": "dimensionRange"
-    },
-    {
       "defaultValue": null,
       "kind": "LocalArgument",
-      "name": "includeArtworksByFollowedArtists"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "inquireableOnly"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "majorPeriods"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "offerable"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "partnerID"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "partnerIDs"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "priceRange"
-    },
-    {
-      "defaultValue": "-decayed_merch",
-      "kind": "LocalArgument",
-      "name": "sort"
+      "name": "input"
     }
   ],
   "kind": "Fragment",
   "metadata": {
     "connection": [
       {
-        "count": null,
+        "count": "count",
         "cursor": "cursor",
         "direction": "forward",
         "path": [
@@ -164,16 +89,6 @@ const node: ReaderFragment = {
       "alias": "fairArtworks",
       "args": [
         {
-          "kind": "Variable",
-          "name": "acquireable",
-          "variableName": "acquireable"
-        },
-        {
-          "kind": "Variable",
-          "name": "additionalGeneIDs",
-          "variableName": "additionalGeneIDs"
-        },
-        {
           "kind": "Literal",
           "name": "aggregations",
           "value": [
@@ -189,73 +104,8 @@ const node: ReaderFragment = {
         },
         {
           "kind": "Variable",
-          "name": "artistIDs",
-          "variableName": "artistIDs"
-        },
-        {
-          "kind": "Variable",
-          "name": "atAuction",
-          "variableName": "atAuction"
-        },
-        {
-          "kind": "Variable",
-          "name": "attributionClass",
-          "variableName": "attributionClass"
-        },
-        {
-          "kind": "Variable",
-          "name": "color",
-          "variableName": "color"
-        },
-        {
-          "kind": "Variable",
-          "name": "colors",
-          "variableName": "colors"
-        },
-        {
-          "kind": "Variable",
-          "name": "dimensionRange",
-          "variableName": "dimensionRange"
-        },
-        {
-          "kind": "Variable",
-          "name": "includeArtworksByFollowedArtists",
-          "variableName": "includeArtworksByFollowedArtists"
-        },
-        {
-          "kind": "Variable",
-          "name": "inquireableOnly",
-          "variableName": "inquireableOnly"
-        },
-        {
-          "kind": "Variable",
-          "name": "majorPeriods",
-          "variableName": "majorPeriods"
-        },
-        {
-          "kind": "Variable",
-          "name": "offerable",
-          "variableName": "offerable"
-        },
-        {
-          "kind": "Variable",
-          "name": "partnerID",
-          "variableName": "partnerID"
-        },
-        {
-          "kind": "Variable",
-          "name": "partnerIDs",
-          "variableName": "partnerIDs"
-        },
-        {
-          "kind": "Variable",
-          "name": "priceRange",
-          "variableName": "priceRange"
-        },
-        {
-          "kind": "Variable",
-          "name": "sort",
-          "variableName": "sort"
+          "name": "input",
+          "variableName": "input"
         }
       ],
       "concreteType": "FilterArtworksConnection",
@@ -418,5 +268,5 @@ const node: ReaderFragment = {
   "type": "Fair",
   "abstractKey": null
 };
-(node as any).hash = 'bd5afc5f907a3fbe230a2968b9d20dfa';
+(node as any).hash = '8d5992f9f759cb71836a07d68e287767';
 export default node;

--- a/src/__generated__/FairFollowedArtistsRailTestsQuery.graphql.ts
+++ b/src/__generated__/FairFollowedArtistsRailTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 934b5f67d66eb75b848f2cd2813ad60a */
+/* @relayHash e7639181bed16646fb2556e926c3665f */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -68,7 +68,7 @@ fragment ArtworkTileRailCard_artwork on Artwork {
 fragment FairFollowedArtistsRail_fair on Fair {
   internalID
   slug
-  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {
+  followedArtistArtworks: filterArtworksConnection(first: 20, input: {includeArtworksByFollowedArtists: true}) {
     edges {
       artwork: node {
         id
@@ -183,8 +183,10 @@ return {
               },
               {
                 "kind": "Literal",
-                "name": "includeArtworksByFollowedArtists",
-                "value": true
+                "name": "input",
+                "value": {
+                  "includeArtworksByFollowedArtists": true
+                }
               }
             ],
             "concreteType": "FilterArtworksConnection",
@@ -258,7 +260,7 @@ return {
               },
               (v4/*: any*/)
             ],
-            "storageKey": "filterArtworksConnection(first:20,includeArtworksByFollowedArtists:true)"
+            "storageKey": "filterArtworksConnection(first:20,input:{\"includeArtworksByFollowedArtists\":true})"
           },
           (v4/*: any*/)
         ],
@@ -267,7 +269,7 @@ return {
     ]
   },
   "params": {
-    "id": "934b5f67d66eb75b848f2cd2813ad60a",
+    "id": "e7639181bed16646fb2556e926c3665f",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "fair": {

--- a/src/__generated__/FairFollowedArtistsRail_fair.graphql.ts
+++ b/src/__generated__/FairFollowedArtistsRail_fair.graphql.ts
@@ -60,8 +60,10 @@ return {
         },
         {
           "kind": "Literal",
-          "name": "includeArtworksByFollowedArtists",
-          "value": true
+          "name": "input",
+          "value": {
+            "includeArtworksByFollowedArtists": true
+          }
         }
       ],
       "concreteType": "FilterArtworksConnection",
@@ -106,12 +108,12 @@ return {
           "storageKey": null
         }
       ],
-      "storageKey": "filterArtworksConnection(first:20,includeArtworksByFollowedArtists:true)"
+      "storageKey": "filterArtworksConnection(first:20,input:{\"includeArtworksByFollowedArtists\":true})"
     }
   ],
   "type": "Fair",
   "abstractKey": null
 };
 })();
-(node as any).hash = 'ff6dc15d670ca15d8e9c1b450ac5f2da';
+(node as any).hash = 'b81993cbfa008efcc7000a2784054251';
 export default node;

--- a/src/__generated__/FairQuery.graphql.ts
+++ b/src/__generated__/FairQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 1391fb0125762b45db3240b04cbe9ef9 */
+/* @relayHash ca9811522b84bb7e617322d9c6eba0bc */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -313,7 +313,7 @@ fragment FairExhibitors_fair on Fair {
 fragment FairFollowedArtistsRail_fair on Fair {
   internalID
   slug
-  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {
+  followedArtistArtworks: filterArtworksConnection(first: 20, input: {includeArtworksByFollowedArtists: true}) {
     edges {
       artwork: node {
         id
@@ -385,7 +385,7 @@ fragment Fair_fair_2VV6jB on Fair {
     artworks
     partnerShows
   }
-  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {
+  followedArtistArtworks: filterArtworksConnection(first: 20, input: {includeArtworksByFollowedArtists: true}) {
     edges {
       __typename
     }
@@ -944,8 +944,10 @@ return {
               (v10/*: any*/),
               {
                 "kind": "Literal",
-                "name": "includeArtworksByFollowedArtists",
-                "value": true
+                "name": "input",
+                "value": {
+                  "includeArtworksByFollowedArtists": true
+                }
               }
             ],
             "concreteType": "FilterArtworksConnection",
@@ -996,7 +998,7 @@ return {
               },
               (v6/*: any*/)
             ],
-            "storageKey": "filterArtworksConnection(first:20,includeArtworksByFollowedArtists:true)"
+            "storageKey": "filterArtworksConnection(first:20,input:{\"includeArtworksByFollowedArtists\":true})"
           },
           {
             "alias": null,
@@ -1663,7 +1665,7 @@ return {
     ]
   },
   "params": {
-    "id": "1391fb0125762b45db3240b04cbe9ef9",
+    "id": "ca9811522b84bb7e617322d9c6eba0bc",
     "metadata": {},
     "name": "FairQuery",
     "operationKind": "query",

--- a/src/__generated__/FairQuery.graphql.ts
+++ b/src/__generated__/FairQuery.graphql.ts
@@ -1,64 +1,12 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash ca9811522b84bb7e617322d9c6eba0bc */
+/* @relayHash a0ad4030a25f11867ffa1e7e3f8118cf */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
-export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
-export type FilterArtworksInput = {
-    acquireable?: boolean | null;
-    additionalGeneIDs?: Array<string | null> | null;
-    after?: string | null;
-    aggregationPartnerCities?: Array<string | null> | null;
-    aggregations?: Array<ArtworkAggregation | null> | null;
-    artistID?: string | null;
-    artistIDs?: Array<string | null> | null;
-    artistNationalities?: Array<string | null> | null;
-    artistSeriesID?: string | null;
-    atAuction?: boolean | null;
-    attributionClass?: Array<string | null> | null;
-    before?: string | null;
-    color?: string | null;
-    colors?: Array<string | null> | null;
-    dimensionRange?: string | null;
-    excludeArtworkIDs?: Array<string | null> | null;
-    extraAggregationGeneIDs?: Array<string | null> | null;
-    first?: number | null;
-    forSale?: boolean | null;
-    geneID?: string | null;
-    geneIDs?: Array<string | null> | null;
-    height?: string | null;
-    includeArtworksByFollowedArtists?: boolean | null;
-    includeMediumFilterInAggregation?: boolean | null;
-    inquireableOnly?: boolean | null;
-    keyword?: string | null;
-    keywordMatchExact?: boolean | null;
-    last?: number | null;
-    locationCities?: Array<string | null> | null;
-    majorPeriods?: Array<string | null> | null;
-    marketable?: boolean | null;
-    materialsTerms?: Array<string | null> | null;
-    medium?: string | null;
-    offerable?: boolean | null;
-    page?: number | null;
-    partnerCities?: Array<string | null> | null;
-    partnerID?: string | null;
-    partnerIDs?: Array<string | null> | null;
-    period?: string | null;
-    periods?: Array<string | null> | null;
-    priceRange?: string | null;
-    saleID?: string | null;
-    size?: number | null;
-    sizes?: Array<ArtworkSizes | null> | null;
-    sort?: string | null;
-    tagID?: string | null;
-    width?: string | null;
-};
 export type FairQueryVariables = {
     fairID: string;
-    input?: FilterArtworksInput | null;
 };
 export type FairQueryResponse = {
     readonly fair: {
@@ -75,10 +23,9 @@ export type FairQuery = {
 /*
 query FairQuery(
   $fairID: String!
-  $input: FilterArtworksInput
 ) {
   fair(id: $fairID) @principalField {
-    ...Fair_fair_2VV6jB
+    ...Fair_fair
     id
   }
 }
@@ -129,10 +76,10 @@ fragment ArtworkTileRailCard_artwork on Artwork {
   saleMessage
 }
 
-fragment FairArtworks_fair_2VV6jB on Fair {
+fragment FairArtworks_fair_2T6kBV on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], input: $input) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -368,7 +315,7 @@ fragment FairTiming_fair on Fair {
   endAt
 }
 
-fragment Fair_fair_2VV6jB on Fair {
+fragment Fair_fair on Fair {
   internalID
   slug
   isActive
@@ -395,7 +342,7 @@ fragment Fair_fair_2VV6jB on Fair {
   ...FairEmptyState_fair
   ...FairEditorial_fair
   ...FairCollections_fair
-  ...FairArtworks_fair_2VV6jB
+  ...FairArtworks_fair_2T6kBV
   ...FairExhibitors_fair
   ...FairFollowedArtistsRail_fair
 }
@@ -431,11 +378,6 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "fairID"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "input"
   }
 ],
 v1 = [
@@ -446,126 +388,121 @@ v1 = [
   }
 ],
 v2 = {
-  "kind": "Variable",
-  "name": "input",
-  "variableName": "input"
-},
-v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v6 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "title",
   "storageKey": null
 },
-v8 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v9 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "artworks",
   "storageKey": null
 },
-v10 = {
+v9 = {
   "kind": "Literal",
   "name": "first",
   "value": 20
 },
-v11 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "artistNames",
   "storageKey": null
 },
-v12 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "imageURL",
   "storageKey": null
 },
-v13 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "saleMessage",
   "storageKey": null
 },
-v14 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "summary",
   "storageKey": null
 },
-v15 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v16 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "aspectRatio",
   "storageKey": null
 },
-v17 = [
+v16 = [
   {
     "kind": "Literal",
     "name": "format",
     "value": "MARKDOWN"
   }
 ],
-v18 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v19 = {
+v18 = {
   "kind": "Literal",
   "name": "first",
   "value": 30
 },
-v20 = [
+v19 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -580,17 +517,24 @@ v20 = [
       "ARTIST"
     ]
   },
-  (v19/*: any*/),
-  (v2/*: any*/)
+  (v18/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "input",
+    "value": {
+      "dimensionRange": "*-*",
+      "sort": "-decayed_merch"
+    }
+  }
 ],
-v21 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v22 = {
+v21 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -615,21 +559,21 @@ v22 = {
   ],
   "storageKey": null
 },
-v23 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isAuction",
   "storageKey": null
 },
-v24 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v25 = {
+v24 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCounts",
@@ -647,7 +591,7 @@ v25 = {
   ],
   "storageKey": null
 },
-v26 = [
+v25 = [
   {
     "alias": null,
     "args": null,
@@ -656,35 +600,35 @@ v26 = [
     "storageKey": null
   }
 ],
-v27 = {
+v26 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCurrentBid",
   "kind": "LinkedField",
   "name": "currentBid",
   "plural": false,
-  "selections": (v26/*: any*/),
+  "selections": (v25/*: any*/),
   "storageKey": null
 },
-v28 = {
+v27 = {
   "kind": "InlineFragment",
   "selections": [
-    (v6/*: any*/)
+    (v5/*: any*/)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v29 = [
-  (v19/*: any*/),
+v28 = [
+  (v18/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "FEATURED_ASC"
   }
 ],
-v30 = [
-  (v6/*: any*/),
-  (v15/*: any*/)
+v29 = [
+  (v5/*: any*/),
+  (v14/*: any*/)
 ];
 return {
   "fragment": {
@@ -702,9 +646,7 @@ return {
         "plural": false,
         "selections": [
           {
-            "args": [
-              (v2/*: any*/)
-            ],
+            "args": null,
             "kind": "FragmentSpread",
             "name": "Fair_fair"
           }
@@ -729,8 +671,8 @@ return {
         "name": "fair",
         "plural": false,
         "selections": [
+          (v2/*: any*/),
           (v3/*: any*/),
-          (v4/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -765,7 +707,7 @@ return {
                 "name": "edges",
                 "plural": true,
                 "selections": [
-                  (v5/*: any*/),
+                  (v4/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -774,11 +716,11 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
+                      (v5/*: any*/),
+                      (v2/*: any*/),
                       (v3/*: any*/),
-                      (v4/*: any*/),
+                      (v6/*: any*/),
                       (v7/*: any*/),
-                      (v8/*: any*/),
                       {
                         "alias": null,
                         "args": [
@@ -840,10 +782,10 @@ return {
             "name": "marketingCollections",
             "plural": true,
             "selections": [
-              (v5/*: any*/),
-              (v6/*: any*/),
               (v4/*: any*/),
-              (v7/*: any*/),
+              (v5/*: any*/),
+              (v3/*: any*/),
+              (v6/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -905,14 +847,14 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v6/*: any*/)
+                          (v5/*: any*/)
                         ],
                         "storageKey": null
                       }
                     ],
                     "storageKey": null
                   },
-                  (v6/*: any*/)
+                  (v5/*: any*/)
                 ],
                 "storageKey": "artworksConnection(first:3)"
               }
@@ -927,7 +869,7 @@ return {
             "name": "counts",
             "plural": false,
             "selections": [
-              (v9/*: any*/),
+              (v8/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -941,7 +883,7 @@ return {
           {
             "alias": "followedArtistArtworks",
             "args": [
-              (v10/*: any*/),
+              (v9/*: any*/),
               {
                 "kind": "Literal",
                 "name": "input",
@@ -963,7 +905,7 @@ return {
                 "name": "edges",
                 "plural": true,
                 "selections": [
-                  (v5/*: any*/),
+                  (v4/*: any*/),
                   {
                     "alias": "artwork",
                     "args": null,
@@ -972,11 +914,11 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
+                      (v5/*: any*/),
+                      (v2/*: any*/),
                       (v3/*: any*/),
-                      (v4/*: any*/),
-                      (v8/*: any*/),
-                      (v11/*: any*/),
+                      (v7/*: any*/),
+                      (v10/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -985,18 +927,18 @@ return {
                         "name": "image",
                         "plural": false,
                         "selections": [
-                          (v12/*: any*/)
+                          (v11/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v13/*: any*/)
+                      (v12/*: any*/)
                     ],
                     "storageKey": null
                   }
                 ],
                 "storageKey": null
               },
-              (v6/*: any*/)
+              (v5/*: any*/)
             ],
             "storageKey": "filterArtworksConnection(first:20,input:{\"includeArtworksByFollowedArtists\":true})"
           },
@@ -1007,8 +949,8 @@ return {
             "name": "about",
             "storageKey": null
           },
+          (v13/*: any*/),
           (v14/*: any*/),
-          (v15/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -1041,7 +983,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v6/*: any*/)
+              (v5/*: any*/)
             ],
             "storageKey": null
           },
@@ -1066,7 +1008,7 @@ return {
                 "name": "url",
                 "storageKey": "url(version:\"large_rectangle\")"
               },
-              (v16/*: any*/)
+              (v15/*: any*/)
             ],
             "storageKey": null
           },
@@ -1085,7 +1027,7 @@ return {
             "name": "location",
             "plural": false,
             "selections": [
-              (v14/*: any*/),
+              (v13/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1111,7 +1053,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v6/*: any*/)
+              (v5/*: any*/)
             ],
             "storageKey": null
           },
@@ -1149,28 +1091,28 @@ return {
           },
           {
             "alias": "fairHours",
-            "args": (v17/*: any*/),
+            "args": (v16/*: any*/),
             "kind": "ScalarField",
             "name": "hours",
             "storageKey": "hours(format:\"MARKDOWN\")"
           },
           {
             "alias": "fairLinks",
-            "args": (v17/*: any*/),
+            "args": (v16/*: any*/),
             "kind": "ScalarField",
             "name": "links",
             "storageKey": "links(format:\"MARKDOWN\")"
           },
           {
             "alias": "fairTickets",
-            "args": (v17/*: any*/),
+            "args": (v16/*: any*/),
             "kind": "ScalarField",
             "name": "tickets",
             "storageKey": "tickets(format:\"MARKDOWN\")"
           },
           {
             "alias": "fairContact",
-            "args": (v17/*: any*/),
+            "args": (v16/*: any*/),
             "kind": "ScalarField",
             "name": "contact",
             "storageKey": "contact(format:\"MARKDOWN\")"
@@ -1189,10 +1131,10 @@ return {
             "name": "startAt",
             "storageKey": null
           },
-          (v18/*: any*/),
+          (v17/*: any*/),
           {
             "alias": "fairArtworks",
-            "args": (v20/*: any*/),
+            "args": (v19/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -1228,7 +1170,7 @@ return {
                         "name": "count",
                         "storageKey": null
                       },
-                      (v15/*: any*/),
+                      (v14/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1258,12 +1200,12 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
-                      (v5/*: any*/)
+                      (v5/*: any*/),
+                      (v4/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v21/*: any*/)
+                  (v20/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -1292,8 +1234,8 @@ return {
                 ],
                 "storageKey": null
               },
-              (v22/*: any*/),
-              (v6/*: any*/),
+              (v21/*: any*/),
+              (v5/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -1323,7 +1265,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v5/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1332,7 +1274,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
+                          (v3/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1341,7 +1283,7 @@ return {
                             "name": "image",
                             "plural": false,
                             "selections": [
-                              (v16/*: any*/),
+                              (v15/*: any*/),
                               {
                                 "alias": null,
                                 "args": [
@@ -1358,7 +1300,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v7/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1366,10 +1308,10 @@ return {
                             "name": "date",
                             "storageKey": null
                           },
-                          (v13/*: any*/),
-                          (v3/*: any*/),
-                          (v11/*: any*/),
-                          (v8/*: any*/),
+                          (v12/*: any*/),
+                          (v2/*: any*/),
+                          (v10/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1378,8 +1320,8 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
+                              (v22/*: any*/),
                               (v23/*: any*/),
-                              (v24/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1387,8 +1329,8 @@ return {
                                 "name": "displayTimelyAt",
                                 "storageKey": null
                               },
-                              (v18/*: any*/),
-                              (v6/*: any*/)
+                              (v17/*: any*/),
+                              (v5/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1400,8 +1342,8 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v25/*: any*/),
-                              (v27/*: any*/),
+                              (v24/*: any*/),
+                              (v26/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1409,7 +1351,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v6/*: any*/)
+                              (v5/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1421,15 +1363,15 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v15/*: any*/),
-                              (v6/*: any*/)
+                              (v14/*: any*/),
+                              (v5/*: any*/)
                             ],
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
-                      (v28/*: any*/)
+                      (v27/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1438,11 +1380,11 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": null
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "fairArtworks",
-            "args": (v20/*: any*/),
+            "args": (v19/*: any*/),
             "filters": [
               "aggregations",
               "input"
@@ -1454,7 +1396,7 @@ return {
           },
           {
             "alias": "exhibitors",
-            "args": (v29/*: any*/),
+            "args": (v28/*: any*/),
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
@@ -1476,7 +1418,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1485,7 +1427,7 @@ return {
                         "name": "counts",
                         "plural": false,
                         "selections": [
-                          (v9/*: any*/)
+                          (v8/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -1497,26 +1439,26 @@ return {
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "kind": "InlineFragment",
-                            "selections": (v30/*: any*/),
+                            "selections": (v29/*: any*/),
                             "type": "Partner",
                             "abstractKey": null
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v30/*: any*/),
+                            "selections": (v29/*: any*/),
                             "type": "ExternalPartner",
                             "abstractKey": null
                           },
-                          (v28/*: any*/)
+                          (v27/*: any*/)
                         ],
                         "storageKey": null
                       },
+                      (v2/*: any*/),
                       (v3/*: any*/),
-                      (v4/*: any*/),
-                      (v8/*: any*/),
+                      (v7/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1525,16 +1467,16 @@ return {
                         "name": "fair",
                         "plural": false,
                         "selections": [
+                          (v2/*: any*/),
                           (v3/*: any*/),
-                          (v4/*: any*/),
-                          (v6/*: any*/)
+                          (v5/*: any*/)
                         ],
                         "storageKey": null
                       },
                       {
                         "alias": "artworks",
                         "args": [
-                          (v10/*: any*/)
+                          (v9/*: any*/)
                         ],
                         "concreteType": "ArtworkConnection",
                         "kind": "LinkedField",
@@ -1557,9 +1499,9 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v8/*: any*/),
-                                  (v11/*: any*/),
-                                  (v6/*: any*/),
+                                  (v7/*: any*/),
+                                  (v10/*: any*/),
+                                  (v5/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -1568,12 +1510,12 @@ return {
                                     "name": "image",
                                     "plural": false,
                                     "selections": [
-                                      (v12/*: any*/),
-                                      (v16/*: any*/)
+                                      (v11/*: any*/),
+                                      (v15/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
-                                  (v13/*: any*/),
+                                  (v12/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -1589,7 +1531,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "openingBid",
                                         "plural": false,
-                                        "selections": (v26/*: any*/),
+                                        "selections": (v25/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -1599,12 +1541,12 @@ return {
                                         "kind": "LinkedField",
                                         "name": "highestBid",
                                         "plural": false,
-                                        "selections": (v26/*: any*/),
+                                        "selections": (v25/*: any*/),
                                         "storageKey": null
                                       },
-                                      (v27/*: any*/),
-                                      (v25/*: any*/),
-                                      (v6/*: any*/)
+                                      (v26/*: any*/),
+                                      (v24/*: any*/),
+                                      (v5/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -1616,16 +1558,16 @@ return {
                                     "name": "sale",
                                     "plural": false,
                                     "selections": [
-                                      (v24/*: any*/),
                                       (v23/*: any*/),
-                                      (v18/*: any*/),
-                                      (v6/*: any*/)
+                                      (v22/*: any*/),
+                                      (v17/*: any*/),
+                                      (v5/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
-                                  (v7/*: any*/),
-                                  (v3/*: any*/),
-                                  (v4/*: any*/)
+                                  (v6/*: any*/),
+                                  (v2/*: any*/),
+                                  (v3/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -1635,21 +1577,21 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:20)"
                       },
-                      (v5/*: any*/)
+                      (v4/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v21/*: any*/)
+                  (v20/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v22/*: any*/)
+              (v21/*: any*/)
             ],
             "storageKey": "showsConnection(first:30,sort:\"FEATURED_ASC\")"
           },
           {
             "alias": "exhibitors",
-            "args": (v29/*: any*/),
+            "args": (v28/*: any*/),
             "filters": [
               "sort"
             ],
@@ -1658,14 +1600,14 @@ return {
             "kind": "LinkedHandle",
             "name": "showsConnection"
           },
-          (v6/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "ca9811522b84bb7e617322d9c6eba0bc",
+    "id": "a0ad4030a25f11867ffa1e7e3f8118cf",
     "metadata": {},
     "name": "FairQuery",
     "operationKind": "query",
@@ -1673,5 +1615,5 @@ return {
   }
 };
 })();
-(node as any).hash = '1373ffdd07220d9e291a889baa49f3f0';
+(node as any).hash = 'ad8991522eeb91c4b76453a3f83ae913';
 export default node;

--- a/src/__generated__/FairQuery.graphql.ts
+++ b/src/__generated__/FairQuery.graphql.ts
@@ -1,12 +1,64 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 6b98247e7e4fdaf9e0f6789bc1ee2f91 */
+/* @relayHash 1391fb0125762b45db3240b04cbe9ef9 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
+export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
+export type FilterArtworksInput = {
+    acquireable?: boolean | null;
+    additionalGeneIDs?: Array<string | null> | null;
+    after?: string | null;
+    aggregationPartnerCities?: Array<string | null> | null;
+    aggregations?: Array<ArtworkAggregation | null> | null;
+    artistID?: string | null;
+    artistIDs?: Array<string | null> | null;
+    artistNationalities?: Array<string | null> | null;
+    artistSeriesID?: string | null;
+    atAuction?: boolean | null;
+    attributionClass?: Array<string | null> | null;
+    before?: string | null;
+    color?: string | null;
+    colors?: Array<string | null> | null;
+    dimensionRange?: string | null;
+    excludeArtworkIDs?: Array<string | null> | null;
+    extraAggregationGeneIDs?: Array<string | null> | null;
+    first?: number | null;
+    forSale?: boolean | null;
+    geneID?: string | null;
+    geneIDs?: Array<string | null> | null;
+    height?: string | null;
+    includeArtworksByFollowedArtists?: boolean | null;
+    includeMediumFilterInAggregation?: boolean | null;
+    inquireableOnly?: boolean | null;
+    keyword?: string | null;
+    keywordMatchExact?: boolean | null;
+    last?: number | null;
+    locationCities?: Array<string | null> | null;
+    majorPeriods?: Array<string | null> | null;
+    marketable?: boolean | null;
+    materialsTerms?: Array<string | null> | null;
+    medium?: string | null;
+    offerable?: boolean | null;
+    page?: number | null;
+    partnerCities?: Array<string | null> | null;
+    partnerID?: string | null;
+    partnerIDs?: Array<string | null> | null;
+    period?: string | null;
+    periods?: Array<string | null> | null;
+    priceRange?: string | null;
+    saleID?: string | null;
+    size?: number | null;
+    sizes?: Array<ArtworkSizes | null> | null;
+    sort?: string | null;
+    tagID?: string | null;
+    width?: string | null;
+};
 export type FairQueryVariables = {
     fairID: string;
+    input?: FilterArtworksInput | null;
 };
 export type FairQueryResponse = {
     readonly fair: {
@@ -23,9 +75,10 @@ export type FairQuery = {
 /*
 query FairQuery(
   $fairID: String!
+  $input: FilterArtworksInput
 ) {
   fair(id: $fairID) @principalField {
-    ...Fair_fair
+    ...Fair_fair_2VV6jB
     id
   }
 }
@@ -76,10 +129,10 @@ fragment ArtworkTileRailCard_artwork on Artwork {
   saleMessage
 }
 
-fragment FairArtworks_fair on Fair {
+fragment FairArtworks_fair_2VV6jB on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], input: $input) {
     aggregations {
       slice
       counts {
@@ -315,7 +368,7 @@ fragment FairTiming_fair on Fair {
   endAt
 }
 
-fragment Fair_fair on Fair {
+fragment Fair_fair_2VV6jB on Fair {
   internalID
   slug
   isActive
@@ -342,7 +395,7 @@ fragment Fair_fair on Fair {
   ...FairEmptyState_fair
   ...FairEditorial_fair
   ...FairCollections_fair
-  ...FairArtworks_fair
+  ...FairArtworks_fair_2VV6jB
   ...FairExhibitors_fair
   ...FairFollowedArtistsRail_fair
 }
@@ -378,6 +431,11 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "fairID"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
   }
 ],
 v1 = [
@@ -388,121 +446,126 @@ v1 = [
   }
 ],
 v2 = {
+  "kind": "Variable",
+  "name": "input",
+  "variableName": "input"
+},
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v3 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v4 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "title",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "artworks",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "kind": "Literal",
   "name": "first",
   "value": 20
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "artistNames",
   "storageKey": null
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "imageURL",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "saleMessage",
   "storageKey": null
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "summary",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "aspectRatio",
   "storageKey": null
 },
-v16 = [
+v17 = [
   {
     "kind": "Literal",
     "name": "format",
     "value": "MARKDOWN"
   }
 ],
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v18 = {
+v19 = {
   "kind": "Literal",
   "name": "first",
   "value": 30
 },
-v19 = [
+v20 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -517,26 +580,17 @@ v19 = [
       "ARTIST"
     ]
   },
-  {
-    "kind": "Literal",
-    "name": "dimensionRange",
-    "value": "*-*"
-  },
-  (v18/*: any*/),
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "-decayed_merch"
-  }
+  (v19/*: any*/),
+  (v2/*: any*/)
 ],
-v20 = {
+v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -561,21 +615,21 @@ v21 = {
   ],
   "storageKey": null
 },
-v22 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isAuction",
   "storageKey": null
 },
-v23 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v24 = {
+v25 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCounts",
@@ -593,7 +647,7 @@ v24 = {
   ],
   "storageKey": null
 },
-v25 = [
+v26 = [
   {
     "alias": null,
     "args": null,
@@ -602,35 +656,35 @@ v25 = [
     "storageKey": null
   }
 ],
-v26 = {
+v27 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCurrentBid",
   "kind": "LinkedField",
   "name": "currentBid",
   "plural": false,
-  "selections": (v25/*: any*/),
+  "selections": (v26/*: any*/),
   "storageKey": null
 },
-v27 = {
+v28 = {
   "kind": "InlineFragment",
   "selections": [
-    (v5/*: any*/)
+    (v6/*: any*/)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v28 = [
-  (v18/*: any*/),
+v29 = [
+  (v19/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "FEATURED_ASC"
   }
 ],
-v29 = [
-  (v5/*: any*/),
-  (v14/*: any*/)
+v30 = [
+  (v6/*: any*/),
+  (v15/*: any*/)
 ];
 return {
   "fragment": {
@@ -648,7 +702,9 @@ return {
         "plural": false,
         "selections": [
           {
-            "args": null,
+            "args": [
+              (v2/*: any*/)
+            ],
             "kind": "FragmentSpread",
             "name": "Fair_fair"
           }
@@ -673,8 +729,8 @@ return {
         "name": "fair",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
           (v3/*: any*/),
+          (v4/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -709,7 +765,7 @@ return {
                 "name": "edges",
                 "plural": true,
                 "selections": [
-                  (v4/*: any*/),
+                  (v5/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -718,11 +774,11 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/),
-                      (v2/*: any*/),
-                      (v3/*: any*/),
                       (v6/*: any*/),
+                      (v3/*: any*/),
+                      (v4/*: any*/),
                       (v7/*: any*/),
+                      (v8/*: any*/),
                       {
                         "alias": null,
                         "args": [
@@ -784,10 +840,10 @@ return {
             "name": "marketingCollections",
             "plural": true,
             "selections": [
-              (v4/*: any*/),
               (v5/*: any*/),
-              (v3/*: any*/),
               (v6/*: any*/),
+              (v4/*: any*/),
+              (v7/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -849,14 +905,14 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v5/*: any*/)
+                          (v6/*: any*/)
                         ],
                         "storageKey": null
                       }
                     ],
                     "storageKey": null
                   },
-                  (v5/*: any*/)
+                  (v6/*: any*/)
                 ],
                 "storageKey": "artworksConnection(first:3)"
               }
@@ -871,7 +927,7 @@ return {
             "name": "counts",
             "plural": false,
             "selections": [
-              (v8/*: any*/),
+              (v9/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -885,7 +941,7 @@ return {
           {
             "alias": "followedArtistArtworks",
             "args": [
-              (v9/*: any*/),
+              (v10/*: any*/),
               {
                 "kind": "Literal",
                 "name": "includeArtworksByFollowedArtists",
@@ -905,7 +961,7 @@ return {
                 "name": "edges",
                 "plural": true,
                 "selections": [
-                  (v4/*: any*/),
+                  (v5/*: any*/),
                   {
                     "alias": "artwork",
                     "args": null,
@@ -914,11 +970,11 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/),
-                      (v2/*: any*/),
+                      (v6/*: any*/),
                       (v3/*: any*/),
-                      (v7/*: any*/),
-                      (v10/*: any*/),
+                      (v4/*: any*/),
+                      (v8/*: any*/),
+                      (v11/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -927,18 +983,18 @@ return {
                         "name": "image",
                         "plural": false,
                         "selections": [
-                          (v11/*: any*/)
+                          (v12/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v12/*: any*/)
+                      (v13/*: any*/)
                     ],
                     "storageKey": null
                   }
                 ],
                 "storageKey": null
               },
-              (v5/*: any*/)
+              (v6/*: any*/)
             ],
             "storageKey": "filterArtworksConnection(first:20,includeArtworksByFollowedArtists:true)"
           },
@@ -949,8 +1005,8 @@ return {
             "name": "about",
             "storageKey": null
           },
-          (v13/*: any*/),
           (v14/*: any*/),
+          (v15/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -983,7 +1039,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v5/*: any*/)
+              (v6/*: any*/)
             ],
             "storageKey": null
           },
@@ -1008,7 +1064,7 @@ return {
                 "name": "url",
                 "storageKey": "url(version:\"large_rectangle\")"
               },
-              (v15/*: any*/)
+              (v16/*: any*/)
             ],
             "storageKey": null
           },
@@ -1027,7 +1083,7 @@ return {
             "name": "location",
             "plural": false,
             "selections": [
-              (v13/*: any*/),
+              (v14/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1053,7 +1109,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v5/*: any*/)
+              (v6/*: any*/)
             ],
             "storageKey": null
           },
@@ -1091,28 +1147,28 @@ return {
           },
           {
             "alias": "fairHours",
-            "args": (v16/*: any*/),
+            "args": (v17/*: any*/),
             "kind": "ScalarField",
             "name": "hours",
             "storageKey": "hours(format:\"MARKDOWN\")"
           },
           {
             "alias": "fairLinks",
-            "args": (v16/*: any*/),
+            "args": (v17/*: any*/),
             "kind": "ScalarField",
             "name": "links",
             "storageKey": "links(format:\"MARKDOWN\")"
           },
           {
             "alias": "fairTickets",
-            "args": (v16/*: any*/),
+            "args": (v17/*: any*/),
             "kind": "ScalarField",
             "name": "tickets",
             "storageKey": "tickets(format:\"MARKDOWN\")"
           },
           {
             "alias": "fairContact",
-            "args": (v16/*: any*/),
+            "args": (v17/*: any*/),
             "kind": "ScalarField",
             "name": "contact",
             "storageKey": "contact(format:\"MARKDOWN\")"
@@ -1131,10 +1187,10 @@ return {
             "name": "startAt",
             "storageKey": null
           },
-          (v17/*: any*/),
+          (v18/*: any*/),
           {
             "alias": "fairArtworks",
-            "args": (v19/*: any*/),
+            "args": (v20/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -1170,7 +1226,7 @@ return {
                         "name": "count",
                         "storageKey": null
                       },
-                      (v14/*: any*/),
+                      (v15/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1200,12 +1256,12 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/),
-                      (v4/*: any*/)
+                      (v6/*: any*/),
+                      (v5/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v20/*: any*/)
+                  (v21/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -1234,8 +1290,8 @@ return {
                 ],
                 "storageKey": null
               },
-              (v21/*: any*/),
-              (v5/*: any*/),
+              (v22/*: any*/),
+              (v6/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -1265,7 +1321,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v4/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1274,7 +1330,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v3/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1283,7 +1339,7 @@ return {
                             "name": "image",
                             "plural": false,
                             "selections": [
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               {
                                 "alias": null,
                                 "args": [
@@ -1300,7 +1356,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v6/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1308,10 +1364,10 @@ return {
                             "name": "date",
                             "storageKey": null
                           },
-                          (v12/*: any*/),
-                          (v2/*: any*/),
-                          (v10/*: any*/),
-                          (v7/*: any*/),
+                          (v13/*: any*/),
+                          (v3/*: any*/),
+                          (v11/*: any*/),
+                          (v8/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1320,8 +1376,8 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v22/*: any*/),
                               (v23/*: any*/),
+                              (v24/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1329,8 +1385,8 @@ return {
                                 "name": "displayTimelyAt",
                                 "storageKey": null
                               },
-                              (v17/*: any*/),
-                              (v5/*: any*/)
+                              (v18/*: any*/),
+                              (v6/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1342,8 +1398,8 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v24/*: any*/),
-                              (v26/*: any*/),
+                              (v25/*: any*/),
+                              (v27/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1351,7 +1407,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v5/*: any*/)
+                              (v6/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1363,15 +1419,15 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
-                              (v5/*: any*/)
+                              (v15/*: any*/),
+                              (v6/*: any*/)
                             ],
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
-                      (v27/*: any*/)
+                      (v28/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1380,29 +1436,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,sort:\"-decayed_merch\")"
+            "storageKey": null
           },
           {
             "alias": "fairArtworks",
-            "args": (v19/*: any*/),
+            "args": (v20/*: any*/),
             "filters": [
-              "sort",
-              "additionalGeneIDs",
-              "priceRange",
-              "color",
-              "colors",
-              "partnerID",
-              "partnerIDs",
-              "dimensionRange",
-              "majorPeriods",
-              "acquireable",
-              "inquireableOnly",
-              "atAuction",
-              "offerable",
-              "includeArtworksByFollowedArtists",
-              "artistIDs",
               "aggregations",
-              "attributionClass"
+              "input"
             ],
             "handle": "connection",
             "key": "Fair_fairArtworks",
@@ -1411,7 +1452,7 @@ return {
           },
           {
             "alias": "exhibitors",
-            "args": (v28/*: any*/),
+            "args": (v29/*: any*/),
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
@@ -1433,7 +1474,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/),
+                      (v6/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1442,7 +1483,7 @@ return {
                         "name": "counts",
                         "plural": false,
                         "selections": [
-                          (v8/*: any*/)
+                          (v9/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -1454,26 +1495,26 @@ return {
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
+                          (v5/*: any*/),
                           {
                             "kind": "InlineFragment",
-                            "selections": (v29/*: any*/),
+                            "selections": (v30/*: any*/),
                             "type": "Partner",
                             "abstractKey": null
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v29/*: any*/),
+                            "selections": (v30/*: any*/),
                             "type": "ExternalPartner",
                             "abstractKey": null
                           },
-                          (v27/*: any*/)
+                          (v28/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v2/*: any*/),
                       (v3/*: any*/),
-                      (v7/*: any*/),
+                      (v4/*: any*/),
+                      (v8/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1482,16 +1523,16 @@ return {
                         "name": "fair",
                         "plural": false,
                         "selections": [
-                          (v2/*: any*/),
                           (v3/*: any*/),
-                          (v5/*: any*/)
+                          (v4/*: any*/),
+                          (v6/*: any*/)
                         ],
                         "storageKey": null
                       },
                       {
                         "alias": "artworks",
                         "args": [
-                          (v9/*: any*/)
+                          (v10/*: any*/)
                         ],
                         "concreteType": "ArtworkConnection",
                         "kind": "LinkedField",
@@ -1514,9 +1555,9 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v7/*: any*/),
-                                  (v10/*: any*/),
-                                  (v5/*: any*/),
+                                  (v8/*: any*/),
+                                  (v11/*: any*/),
+                                  (v6/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -1525,12 +1566,12 @@ return {
                                     "name": "image",
                                     "plural": false,
                                     "selections": [
-                                      (v11/*: any*/),
-                                      (v15/*: any*/)
+                                      (v12/*: any*/),
+                                      (v16/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
-                                  (v12/*: any*/),
+                                  (v13/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -1546,7 +1587,7 @@ return {
                                         "kind": "LinkedField",
                                         "name": "openingBid",
                                         "plural": false,
-                                        "selections": (v25/*: any*/),
+                                        "selections": (v26/*: any*/),
                                         "storageKey": null
                                       },
                                       {
@@ -1556,12 +1597,12 @@ return {
                                         "kind": "LinkedField",
                                         "name": "highestBid",
                                         "plural": false,
-                                        "selections": (v25/*: any*/),
+                                        "selections": (v26/*: any*/),
                                         "storageKey": null
                                       },
-                                      (v26/*: any*/),
-                                      (v24/*: any*/),
-                                      (v5/*: any*/)
+                                      (v27/*: any*/),
+                                      (v25/*: any*/),
+                                      (v6/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -1573,16 +1614,16 @@ return {
                                     "name": "sale",
                                     "plural": false,
                                     "selections": [
+                                      (v24/*: any*/),
                                       (v23/*: any*/),
-                                      (v22/*: any*/),
-                                      (v17/*: any*/),
-                                      (v5/*: any*/)
+                                      (v18/*: any*/),
+                                      (v6/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
-                                  (v6/*: any*/),
-                                  (v2/*: any*/),
-                                  (v3/*: any*/)
+                                  (v7/*: any*/),
+                                  (v3/*: any*/),
+                                  (v4/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -1592,21 +1633,21 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:20)"
                       },
-                      (v4/*: any*/)
+                      (v5/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v20/*: any*/)
+                  (v21/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v21/*: any*/)
+              (v22/*: any*/)
             ],
             "storageKey": "showsConnection(first:30,sort:\"FEATURED_ASC\")"
           },
           {
             "alias": "exhibitors",
-            "args": (v28/*: any*/),
+            "args": (v29/*: any*/),
             "filters": [
               "sort"
             ],
@@ -1615,14 +1656,14 @@ return {
             "kind": "LinkedHandle",
             "name": "showsConnection"
           },
-          (v5/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "6b98247e7e4fdaf9e0f6789bc1ee2f91",
+    "id": "1391fb0125762b45db3240b04cbe9ef9",
     "metadata": {},
     "name": "FairQuery",
     "operationKind": "query",
@@ -1630,5 +1671,5 @@ return {
   }
 };
 })();
-(node as any).hash = 'ad8991522eeb91c4b76453a3f83ae913';
+(node as any).hash = '1373ffdd07220d9e291a889baa49f3f0';
 export default node;

--- a/src/__generated__/FairTestsQuery.graphql.ts
+++ b/src/__generated__/FairTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 2c77136ed04791bdaadd224c23a45971 */
+/* @relayHash 9ad60638dcecf34f3b95ed14604a60ad */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -76,10 +76,10 @@ fragment ArtworkTileRailCard_artwork on Artwork {
   saleMessage
 }
 
-fragment FairArtworks_fair on Fair {
+fragment FairArtworks_fair_4g78v5 on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
     aggregations {
       slice
       counts {
@@ -342,7 +342,7 @@ fragment Fair_fair on Fair {
   ...FairEmptyState_fair
   ...FairEditorial_fair
   ...FairCollections_fair
-  ...FairArtworks_fair
+  ...FairArtworks_fair_4g78v5
   ...FairExhibitors_fair
   ...FairFollowedArtistsRail_fair
 }
@@ -517,17 +517,7 @@ v19 = [
       "ARTIST"
     ]
   },
-  {
-    "kind": "Literal",
-    "name": "dimensionRange",
-    "value": "*-*"
-  },
-  (v18/*: any*/),
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "-decayed_merch"
-  }
+  (v18/*: any*/)
 ],
 v20 = {
   "alias": null,
@@ -1494,29 +1484,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,sort:\"-decayed_merch\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:30)"
           },
           {
             "alias": "fairArtworks",
             "args": (v19/*: any*/),
             "filters": [
-              "sort",
-              "additionalGeneIDs",
-              "priceRange",
-              "color",
-              "colors",
-              "partnerID",
-              "partnerIDs",
-              "dimensionRange",
-              "majorPeriods",
-              "acquireable",
-              "inquireableOnly",
-              "atAuction",
-              "offerable",
-              "includeArtworksByFollowedArtists",
-              "artistIDs",
               "aggregations",
-              "attributionClass"
+              "input"
             ],
             "handle": "connection",
             "key": "Fair_fairArtworks",
@@ -1736,7 +1711,7 @@ return {
     ]
   },
   "params": {
-    "id": "2c77136ed04791bdaadd224c23a45971",
+    "id": "9ad60638dcecf34f3b95ed14604a60ad",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "fair": (v30/*: any*/),

--- a/src/__generated__/FairTestsQuery.graphql.ts
+++ b/src/__generated__/FairTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 0a0f7792f979123c5690a8f701023131 */
+/* @relayHash 386cddffb19195c90e8dc099cb0bebe0 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -76,10 +76,10 @@ fragment ArtworkTileRailCard_artwork on Artwork {
   saleMessage
 }
 
-fragment FairArtworks_fair_4g78v5 on Fair {
+fragment FairArtworks_fair_2T6kBV on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -342,7 +342,7 @@ fragment Fair_fair on Fair {
   ...FairEmptyState_fair
   ...FairEditorial_fair
   ...FairCollections_fair
-  ...FairArtworks_fair_4g78v5
+  ...FairArtworks_fair_2T6kBV
   ...FairExhibitors_fair
   ...FairFollowedArtistsRail_fair
 }
@@ -517,7 +517,15 @@ v19 = [
       "ARTIST"
     ]
   },
-  (v18/*: any*/)
+  (v18/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "input",
+    "value": {
+      "dimensionRange": "*-*",
+      "sort": "-decayed_merch"
+    }
+  }
 ],
 v20 = {
   "alias": null,
@@ -1486,7 +1494,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:30)"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "fairArtworks",
@@ -1713,7 +1721,7 @@ return {
     ]
   },
   "params": {
-    "id": "0a0f7792f979123c5690a8f701023131",
+    "id": "386cddffb19195c90e8dc099cb0bebe0",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "fair": (v30/*: any*/),

--- a/src/__generated__/FairTestsQuery.graphql.ts
+++ b/src/__generated__/FairTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 9ad60638dcecf34f3b95ed14604a60ad */
+/* @relayHash 0a0f7792f979123c5690a8f701023131 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -260,7 +260,7 @@ fragment FairExhibitors_fair on Fair {
 fragment FairFollowedArtistsRail_fair on Fair {
   internalID
   slug
-  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {
+  followedArtistArtworks: filterArtworksConnection(first: 20, input: {includeArtworksByFollowedArtists: true}) {
     edges {
       artwork: node {
         id
@@ -332,7 +332,7 @@ fragment Fair_fair on Fair {
     artworks
     partnerShows
   }
-  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {
+  followedArtistArtworks: filterArtworksConnection(first: 20, input: {includeArtworksByFollowedArtists: true}) {
     edges {
       __typename
     }
@@ -992,8 +992,10 @@ return {
               (v9/*: any*/),
               {
                 "kind": "Literal",
-                "name": "includeArtworksByFollowedArtists",
-                "value": true
+                "name": "input",
+                "value": {
+                  "includeArtworksByFollowedArtists": true
+                }
               }
             ],
             "concreteType": "FilterArtworksConnection",
@@ -1044,7 +1046,7 @@ return {
               },
               (v5/*: any*/)
             ],
-            "storageKey": "filterArtworksConnection(first:20,includeArtworksByFollowedArtists:true)"
+            "storageKey": "filterArtworksConnection(first:20,input:{\"includeArtworksByFollowedArtists\":true})"
           },
           {
             "alias": null,
@@ -1711,7 +1713,7 @@ return {
     ]
   },
   "params": {
-    "id": "9ad60638dcecf34f3b95ed14604a60ad",
+    "id": "0a0f7792f979123c5690a8f701023131",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "fair": (v30/*: any*/),

--- a/src/__generated__/Fair_fair.graphql.ts
+++ b/src/__generated__/Fair_fair.graphql.ts
@@ -162,8 +162,10 @@ return {
         },
         {
           "kind": "Literal",
-          "name": "includeArtworksByFollowedArtists",
-          "value": true
+          "name": "input",
+          "value": {
+            "includeArtworksByFollowedArtists": true
+          }
         }
       ],
       "concreteType": "FilterArtworksConnection",
@@ -182,7 +184,7 @@ return {
           "storageKey": null
         }
       ],
-      "storageKey": "filterArtworksConnection(first:20,includeArtworksByFollowedArtists:true)"
+      "storageKey": "filterArtworksConnection(first:20,input:{\"includeArtworksByFollowedArtists\":true})"
     },
     {
       "args": null,
@@ -230,5 +232,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '7fd0fae7b549a5ae23f97b180420c5f4';
+(node as any).hash = '55853697d6f3ae8331c03b3b82a6a1a3';
 export default node;

--- a/src/__generated__/Fair_fair.graphql.ts
+++ b/src/__generated__/Fair_fair.graphql.ts
@@ -47,13 +47,7 @@ var v0 = [
   }
 ];
 return {
-  "argumentDefinitions": [
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "input"
-    }
-  ],
+  "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
   "name": "Fair_fair",
@@ -209,9 +203,12 @@ return {
     {
       "args": [
         {
-          "kind": "Variable",
+          "kind": "Literal",
           "name": "input",
-          "variableName": "input"
+          "value": {
+            "dimensionRange": "*-*",
+            "sort": "-decayed_merch"
+          }
         }
       ],
       "kind": "FragmentSpread",
@@ -232,5 +229,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '55853697d6f3ae8331c03b3b82a6a1a3';
+(node as any).hash = '6c991142cc4d3ed85f992de42519c078';
 export default node;

--- a/src/__generated__/Fair_fair.graphql.ts
+++ b/src/__generated__/Fair_fair.graphql.ts
@@ -47,7 +47,13 @@ var v0 = [
   }
 ];
 return {
-  "argumentDefinitions": [],
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "input"
+    }
+  ],
   "kind": "Fragment",
   "metadata": null,
   "name": "Fair_fair",
@@ -199,7 +205,13 @@ return {
       "name": "FairCollections_fair"
     },
     {
-      "args": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "input",
+          "variableName": "input"
+        }
+      ],
       "kind": "FragmentSpread",
       "name": "FairArtworks_fair"
     },
@@ -218,5 +230,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '4d0ff22e98f681e8dd4f517a7d2d77be';
+(node as any).hash = '7fd0fae7b549a5ae23f97b180420c5f4';
 export default node;

--- a/src/__generated__/FairsRail_fairsModule.graphql.ts
+++ b/src/__generated__/FairsRail_fairsModule.graphql.ts
@@ -199,8 +199,10 @@ return {
             (v2/*: any*/),
             {
               "kind": "Literal",
-              "name": "includeArtworksByFollowedArtists",
-              "value": true
+              "name": "input",
+              "value": {
+                "includeArtworksByFollowedArtists": true
+              }
             }
           ],
           "concreteType": "FilterArtworksConnection",
@@ -208,7 +210,7 @@ return {
           "name": "filterArtworksConnection",
           "plural": false,
           "selections": (v3/*: any*/),
-          "storageKey": "filterArtworksConnection(first:2,includeArtworksByFollowedArtists:true)"
+          "storageKey": "filterArtworksConnection(first:2,input:{\"includeArtworksByFollowedArtists\":true})"
         },
         {
           "alias": "otherArtworks",
@@ -230,5 +232,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = 'ae3dc57aad680b8b20e7e8bb91b72e39';
+(node as any).hash = '12b4dc456e16dfdced9d770ada80ca05';
 export default node;

--- a/src/__generated__/GenePaginationQuery.graphql.ts
+++ b/src/__generated__/GenePaginationQuery.graphql.ts
@@ -1,17 +1,66 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 2e97f036be66d46ace3c7be8d33e96f3 */
+/* @relayHash f5fe883bc2069f838dfc3e36f0211a7e */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
+export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
+export type FilterArtworksInput = {
+    acquireable?: boolean | null;
+    additionalGeneIDs?: Array<string | null> | null;
+    after?: string | null;
+    aggregationPartnerCities?: Array<string | null> | null;
+    aggregations?: Array<ArtworkAggregation | null> | null;
+    artistID?: string | null;
+    artistIDs?: Array<string | null> | null;
+    artistNationalities?: Array<string | null> | null;
+    artistSeriesID?: string | null;
+    atAuction?: boolean | null;
+    attributionClass?: Array<string | null> | null;
+    before?: string | null;
+    color?: string | null;
+    colors?: Array<string | null> | null;
+    dimensionRange?: string | null;
+    excludeArtworkIDs?: Array<string | null> | null;
+    extraAggregationGeneIDs?: Array<string | null> | null;
+    first?: number | null;
+    forSale?: boolean | null;
+    geneID?: string | null;
+    geneIDs?: Array<string | null> | null;
+    height?: string | null;
+    includeArtworksByFollowedArtists?: boolean | null;
+    includeMediumFilterInAggregation?: boolean | null;
+    inquireableOnly?: boolean | null;
+    keyword?: string | null;
+    keywordMatchExact?: boolean | null;
+    last?: number | null;
+    locationCities?: Array<string | null> | null;
+    majorPeriods?: Array<string | null> | null;
+    marketable?: boolean | null;
+    materialsTerms?: Array<string | null> | null;
+    medium?: string | null;
+    offerable?: boolean | null;
+    page?: number | null;
+    partnerCities?: Array<string | null> | null;
+    partnerID?: string | null;
+    partnerIDs?: Array<string | null> | null;
+    period?: string | null;
+    periods?: Array<string | null> | null;
+    priceRange?: string | null;
+    saleID?: string | null;
+    size?: number | null;
+    sizes?: Array<ArtworkSizes | null> | null;
+    sort?: string | null;
+    tagID?: string | null;
+    width?: string | null;
+};
 export type GenePaginationQueryVariables = {
     id: string;
     count: number;
     cursor?: string | null;
-    sort?: string | null;
-    medium?: string | null;
-    price_range?: string | null;
+    input?: FilterArtworksInput | null;
 };
 export type GenePaginationQueryResponse = {
     readonly node: {
@@ -30,14 +79,12 @@ query GenePaginationQuery(
   $id: ID!
   $count: Int!
   $cursor: String
-  $sort: String
-  $medium: String
-  $price_range: String
+  $input: FilterArtworksInput
 ) {
   node(id: $id) {
     __typename
     ... on Gene {
-      ...Gene_gene_2jVhZq
+      ...Gene_gene_YCAiB
     }
     id
   }
@@ -90,12 +137,12 @@ fragment Biography_gene on Gene {
   description
 }
 
-fragment Gene_gene_2jVhZq on Gene {
+fragment Gene_gene_YCAiB on Gene {
   id
   internalID
   ...Header_gene
   ...About_gene
-  artworks: filterArtworksConnection(first: $count, after: $cursor, medium: $medium, priceRange: $price_range, sort: $sort, aggregations: [MEDIUM, PRICE_RANGE, TOTAL], forSale: true) {
+  artworks: filterArtworksConnection(first: $count, after: $cursor, aggregations: [MEDIUM, PRICE_RANGE, TOTAL], forSale: true, input: $input) {
     counts {
       total
     }
@@ -192,83 +239,63 @@ v2 = {
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "medium"
+  "name": "input"
 },
-v4 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "price_range"
-},
-v5 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "sort"
-},
-v6 = [
+v4 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v7 = {
+v5 = {
   "kind": "Variable",
-  "name": "medium",
-  "variableName": "medium"
+  "name": "input",
+  "variableName": "input"
 },
-v8 = {
-  "kind": "Variable",
-  "name": "priceRange",
-  "variableName": "price_range"
-},
-v9 = {
-  "kind": "Variable",
-  "name": "sort",
-  "variableName": "sort"
-},
-v10 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v11 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v12 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v13 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v14 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v15 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v16 = {
+v12 = {
   "alias": null,
   "args": [
     {
@@ -281,7 +308,7 @@ v16 = {
   "name": "url",
   "storageKey": "url(version:\"large\")"
 },
-v17 = [
+v13 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -306,9 +333,7 @@ v17 = [
     "name": "forSale",
     "value": true
   },
-  (v7/*: any*/),
-  (v8/*: any*/),
-  (v9/*: any*/)
+  (v5/*: any*/)
 ];
 return {
   "fragment": {
@@ -316,9 +341,7 @@ return {
       (v0/*: any*/),
       (v1/*: any*/),
       (v2/*: any*/),
-      (v3/*: any*/),
-      (v4/*: any*/),
-      (v5/*: any*/)
+      (v3/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -326,7 +349,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v6/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
@@ -347,9 +370,7 @@ return {
                     "name": "cursor",
                     "variableName": "cursor"
                   },
-                  (v7/*: any*/),
-                  (v8/*: any*/),
-                  (v9/*: any*/)
+                  (v5/*: any*/)
                 ],
                 "kind": "FragmentSpread",
                 "name": "Gene_gene"
@@ -371,28 +392,26 @@ return {
       (v2/*: any*/),
       (v0/*: any*/),
       (v1/*: any*/),
-      (v5/*: any*/),
-      (v3/*: any*/),
-      (v4/*: any*/)
+      (v3/*: any*/)
     ],
     "kind": "Operation",
     "name": "GenePaginationQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v6/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v10/*: any*/),
-          (v11/*: any*/),
+          (v6/*: any*/),
+          (v7/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
-              (v12/*: any*/),
-              (v13/*: any*/),
+              (v8/*: any*/),
+              (v9/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -400,7 +419,7 @@ return {
                 "name": "isFollowed",
                 "storageKey": null
               },
-              (v14/*: any*/),
+              (v10/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -416,9 +435,9 @@ return {
                 "name": "trendingArtists",
                 "plural": true,
                 "selections": [
+                  (v7/*: any*/),
                   (v11/*: any*/),
-                  (v15/*: any*/),
-                  (v14/*: any*/),
+                  (v10/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -452,7 +471,7 @@ return {
                     "name": "image",
                     "plural": false,
                     "selections": [
-                      (v16/*: any*/)
+                      (v12/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -461,7 +480,7 @@ return {
               },
               {
                 "alias": "artworks",
-                "args": (v17/*: any*/),
+                "args": (v13/*: any*/),
                 "concreteType": "FilterArtworksConnection",
                 "kind": "LinkedField",
                 "name": "filterArtworksConnection",
@@ -515,7 +534,7 @@ return {
                             "name": "value",
                             "storageKey": null
                           },
-                          (v14/*: any*/),
+                          (v10/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -545,8 +564,8 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v11/*: any*/),
-                          (v10/*: any*/)
+                          (v7/*: any*/),
+                          (v6/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -585,7 +604,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v11/*: any*/),
+                  (v7/*: any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
@@ -615,7 +634,7 @@ return {
                         "name": "edges",
                         "plural": true,
                         "selections": [
-                          (v10/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -624,7 +643,7 @@ return {
                             "name": "node",
                             "plural": false,
                             "selections": [
-                              (v13/*: any*/),
+                              (v9/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -640,7 +659,7 @@ return {
                                     "name": "aspectRatio",
                                     "storageKey": null
                                   },
-                                  (v16/*: any*/)
+                                  (v12/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -665,7 +684,7 @@ return {
                                 "name": "saleMessage",
                                 "storageKey": null
                               },
-                              (v12/*: any*/),
+                              (v8/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -673,7 +692,7 @@ return {
                                 "name": "artistNames",
                                 "storageKey": null
                               },
-                              (v15/*: any*/),
+                              (v11/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -710,7 +729,7 @@ return {
                                     "name": "endAt",
                                     "storageKey": null
                                   },
-                                  (v11/*: any*/)
+                                  (v7/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -765,7 +784,7 @@ return {
                                     "name": "lotLabel",
                                     "storageKey": null
                                   },
-                                  (v11/*: any*/)
+                                  (v7/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -777,8 +796,8 @@ return {
                                 "name": "partner",
                                 "plural": false,
                                 "selections": [
-                                  (v14/*: any*/),
-                                  (v11/*: any*/)
+                                  (v10/*: any*/),
+                                  (v7/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -788,7 +807,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v11/*: any*/)
+                              (v7/*: any*/)
                             ],
                             "type": "Node",
                             "abstractKey": "__isNode"
@@ -805,13 +824,11 @@ return {
               },
               {
                 "alias": "artworks",
-                "args": (v17/*: any*/),
+                "args": (v13/*: any*/),
                 "filters": [
-                  "medium",
-                  "priceRange",
-                  "sort",
                   "aggregations",
-                  "forSale"
+                  "forSale",
+                  "input"
                 ],
                 "handle": "connection",
                 "key": "Gene_artworks",
@@ -828,7 +845,7 @@ return {
     ]
   },
   "params": {
-    "id": "2e97f036be66d46ace3c7be8d33e96f3",
+    "id": "f5fe883bc2069f838dfc3e36f0211a7e",
     "metadata": {},
     "name": "GenePaginationQuery",
     "operationKind": "query",
@@ -836,5 +853,5 @@ return {
   }
 };
 })();
-(node as any).hash = '80de8fafefa1e147c123fb57b436cc51';
+(node as any).hash = 'fb098d8685c42e66c13514f12f04ac74';
 export default node;

--- a/src/__generated__/GeneQuery.graphql.ts
+++ b/src/__generated__/GeneQuery.graphql.ts
@@ -1,14 +1,64 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 96489716b5fd3a17df933132d8669d32 */
+/* @relayHash 50272ee0bfab983d47df334ceacb7725 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
+export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
+export type FilterArtworksInput = {
+    acquireable?: boolean | null;
+    additionalGeneIDs?: Array<string | null> | null;
+    after?: string | null;
+    aggregationPartnerCities?: Array<string | null> | null;
+    aggregations?: Array<ArtworkAggregation | null> | null;
+    artistID?: string | null;
+    artistIDs?: Array<string | null> | null;
+    artistNationalities?: Array<string | null> | null;
+    artistSeriesID?: string | null;
+    atAuction?: boolean | null;
+    attributionClass?: Array<string | null> | null;
+    before?: string | null;
+    color?: string | null;
+    colors?: Array<string | null> | null;
+    dimensionRange?: string | null;
+    excludeArtworkIDs?: Array<string | null> | null;
+    extraAggregationGeneIDs?: Array<string | null> | null;
+    first?: number | null;
+    forSale?: boolean | null;
+    geneID?: string | null;
+    geneIDs?: Array<string | null> | null;
+    height?: string | null;
+    includeArtworksByFollowedArtists?: boolean | null;
+    includeMediumFilterInAggregation?: boolean | null;
+    inquireableOnly?: boolean | null;
+    keyword?: string | null;
+    keywordMatchExact?: boolean | null;
+    last?: number | null;
+    locationCities?: Array<string | null> | null;
+    majorPeriods?: Array<string | null> | null;
+    marketable?: boolean | null;
+    materialsTerms?: Array<string | null> | null;
+    medium?: string | null;
+    offerable?: boolean | null;
+    page?: number | null;
+    partnerCities?: Array<string | null> | null;
+    partnerID?: string | null;
+    partnerIDs?: Array<string | null> | null;
+    period?: string | null;
+    periods?: Array<string | null> | null;
+    priceRange?: string | null;
+    saleID?: string | null;
+    size?: number | null;
+    sizes?: Array<ArtworkSizes | null> | null;
+    sort?: string | null;
+    tagID?: string | null;
+    width?: string | null;
+};
 export type GeneQueryVariables = {
     geneID: string;
-    medium?: string | null;
-    price_range?: string | null;
+    input?: FilterArtworksInput | null;
 };
 export type GeneQueryResponse = {
     readonly gene: {
@@ -25,11 +75,10 @@ export type GeneQuery = {
 /*
 query GeneQuery(
   $geneID: String!
-  $medium: String
-  $price_range: String
+  $input: FilterArtworksInput
 ) {
   gene(id: $geneID) {
-    ...Gene_gene_3zv0k0
+    ...Gene_gene_2VV6jB
     id
   }
 }
@@ -81,12 +130,12 @@ fragment Biography_gene on Gene {
   description
 }
 
-fragment Gene_gene_3zv0k0 on Gene {
+fragment Gene_gene_2VV6jB on Gene {
   id
   internalID
   ...Header_gene
   ...About_gene
-  artworks: filterArtworksConnection(first: 10, after: "", medium: $medium, priceRange: $price_range, sort: "-partner_updated_at", aggregations: [MEDIUM, PRICE_RANGE, TOTAL], forSale: true) {
+  artworks: filterArtworksConnection(first: 10, after: "", aggregations: [MEDIUM, PRICE_RANGE, TOTAL], forSale: true, input: $input) {
     counts {
       total
     }
@@ -174,12 +223,7 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
-    "name": "medium"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "price_range"
+    "name": "input"
   }
 ],
 v1 = [
@@ -191,50 +235,45 @@ v1 = [
 ],
 v2 = {
   "kind": "Variable",
-  "name": "medium",
-  "variableName": "medium"
+  "name": "input",
+  "variableName": "input"
 },
 v3 = {
-  "kind": "Variable",
-  "name": "priceRange",
-  "variableName": "price_range"
-},
-v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v6 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v7 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v8 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v9 = {
+v8 = {
   "alias": null,
   "args": [
     {
@@ -247,7 +286,7 @@ v9 = {
   "name": "url",
   "storageKey": "url(version:\"large\")"
 },
-v10 = [
+v9 = [
   {
     "kind": "Literal",
     "name": "after",
@@ -272,15 +311,9 @@ v10 = [
     "name": "forSale",
     "value": true
   },
-  (v2/*: any*/),
-  (v3/*: any*/),
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "-partner_updated_at"
-  }
+  (v2/*: any*/)
 ],
-v11 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -304,8 +337,7 @@ return {
         "selections": [
           {
             "args": [
-              (v2/*: any*/),
-              (v3/*: any*/)
+              (v2/*: any*/)
             ],
             "kind": "FragmentSpread",
             "name": "Gene_gene"
@@ -331,9 +363,9 @@ return {
         "name": "gene",
         "plural": false,
         "selections": [
+          (v3/*: any*/),
           (v4/*: any*/),
           (v5/*: any*/),
-          (v6/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -341,7 +373,7 @@ return {
             "name": "isFollowed",
             "storageKey": null
           },
-          (v7/*: any*/),
+          (v6/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -357,9 +389,9 @@ return {
             "name": "trendingArtists",
             "plural": true,
             "selections": [
-              (v4/*: any*/),
-              (v8/*: any*/),
+              (v3/*: any*/),
               (v7/*: any*/),
+              (v6/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -393,7 +425,7 @@ return {
                 "name": "image",
                 "plural": false,
                 "selections": [
-                  (v9/*: any*/)
+                  (v8/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -402,7 +434,7 @@ return {
           },
           {
             "alias": "artworks",
-            "args": (v10/*: any*/),
+            "args": (v9/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -456,7 +488,7 @@ return {
                         "name": "value",
                         "storageKey": null
                       },
-                      (v7/*: any*/),
+                      (v6/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -486,8 +518,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
-                      (v11/*: any*/)
+                      (v3/*: any*/),
+                      (v10/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -526,7 +558,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v4/*: any*/),
+              (v3/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -556,7 +588,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v11/*: any*/),
+                      (v10/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -565,7 +597,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v6/*: any*/),
+                          (v5/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -581,7 +613,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v9/*: any*/)
+                              (v8/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -606,7 +638,7 @@ return {
                             "name": "saleMessage",
                             "storageKey": null
                           },
-                          (v5/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -614,7 +646,7 @@ return {
                             "name": "artistNames",
                             "storageKey": null
                           },
-                          (v8/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -651,7 +683,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v4/*: any*/)
+                              (v3/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -706,7 +738,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v4/*: any*/)
+                              (v3/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -718,8 +750,8 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v7/*: any*/),
-                              (v4/*: any*/)
+                              (v6/*: any*/),
+                              (v3/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -729,7 +761,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v4/*: any*/)
+                          (v3/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -746,13 +778,11 @@ return {
           },
           {
             "alias": "artworks",
-            "args": (v10/*: any*/),
+            "args": (v9/*: any*/),
             "filters": [
-              "medium",
-              "priceRange",
-              "sort",
               "aggregations",
-              "forSale"
+              "forSale",
+              "input"
             ],
             "handle": "connection",
             "key": "Gene_artworks",
@@ -765,7 +795,7 @@ return {
     ]
   },
   "params": {
-    "id": "96489716b5fd3a17df933132d8669d32",
+    "id": "50272ee0bfab983d47df334ceacb7725",
     "metadata": {},
     "name": "GeneQuery",
     "operationKind": "query",
@@ -773,5 +803,5 @@ return {
   }
 };
 })();
-(node as any).hash = '9e525c0b4500289ba11a410d72265960';
+(node as any).hash = 'c992522ba0da67924426b3a72d993285';
 export default node;

--- a/src/__generated__/Gene_gene.graphql.ts
+++ b/src/__generated__/Gene_gene.graphql.ts
@@ -59,23 +59,9 @@ return {
       "name": "cursor"
     },
     {
-      "defaultValue": "*",
+      "defaultValue": null,
       "kind": "LocalArgument",
-      "name": "medium"
-    },
-    {
-      "defaultValue": "*-*",
-      "kind": "LocalArgument",
-      "name": "priceRange"
-    },
-    {
-      "kind": "RootArgument",
-      "name": "price_range"
-    },
-    {
-      "defaultValue": "-partner_updated_at",
-      "kind": "LocalArgument",
-      "name": "sort"
+      "name": "input"
     }
   ],
   "kind": "Fragment",
@@ -120,18 +106,8 @@ return {
         },
         {
           "kind": "Variable",
-          "name": "medium",
-          "variableName": "medium"
-        },
-        {
-          "kind": "Variable",
-          "name": "priceRange",
-          "variableName": "price_range"
-        },
-        {
-          "kind": "Variable",
-          "name": "sort",
-          "variableName": "sort"
+          "name": "input",
+          "variableName": "input"
         }
       ],
       "concreteType": "FilterArtworksConnection",
@@ -292,5 +268,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = 'b65180f716521310a86843895b5fceeb';
+(node as any).hash = '5d21f435787c427fb70edb84b2903d4b';
 export default node;

--- a/src/__generated__/HomeQuery.graphql.ts
+++ b/src/__generated__/HomeQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 4df2d22c6a99e034ccc09d4f69e27e60 */
+/* @relayHash 18cec0e017c37c801346e52c4f931a9e */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -199,7 +199,7 @@ fragment FairsRail_fairsModule on HomePageFairsModule {
       country
       id
     }
-    followedArtistArtworks: filterArtworksConnection(first: 2, includeArtworksByFollowedArtists: true) {
+    followedArtistArtworks: filterArtworksConnection(first: 2, input: {includeArtworksByFollowedArtists: true}) {
       edges {
         node {
           image {
@@ -658,11 +658,6 @@ v30 = {
   "value": 2
 },
 v31 = {
-  "kind": "Literal",
-  "name": "includeArtworksByFollowedArtists",
-  "value": true
-},
-v32 = {
   "alias": null,
   "args": null,
   "concreteType": "FilterArtworksEdge",
@@ -672,17 +667,21 @@ v32 = {
   "selections": (v29/*: any*/),
   "storageKey": null
 },
-v33 = [
-  (v32/*: any*/),
+v32 = [
+  (v31/*: any*/),
   (v2/*: any*/)
 ],
-v34 = [
+v33 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 6
   },
-  (v31/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "includeArtworksByFollowedArtists",
+    "value": true
+  },
   {
     "kind": "Literal",
     "name": "isAuction",
@@ -694,7 +693,7 @@ v34 = [
     "value": true
   }
 ],
-v35 = [
+v34 = [
   {
     "kind": "Literal",
     "name": "short",
@@ -1147,14 +1146,20 @@ return {
                     "alias": "followedArtistArtworks",
                     "args": [
                       (v30/*: any*/),
-                      (v31/*: any*/)
+                      {
+                        "kind": "Literal",
+                        "name": "input",
+                        "value": {
+                          "includeArtworksByFollowedArtists": true
+                        }
+                      }
                     ],
                     "concreteType": "FilterArtworksConnection",
                     "kind": "LinkedField",
                     "name": "filterArtworksConnection",
                     "plural": false,
-                    "selections": (v33/*: any*/),
-                    "storageKey": "filterArtworksConnection(first:2,includeArtworksByFollowedArtists:true)"
+                    "selections": (v32/*: any*/),
+                    "storageKey": "filterArtworksConnection(first:2,input:{\"includeArtworksByFollowedArtists\":true})"
                   },
                   {
                     "alias": "otherArtworks",
@@ -1165,7 +1170,7 @@ return {
                     "kind": "LinkedField",
                     "name": "filterArtworksConnection",
                     "plural": false,
-                    "selections": (v33/*: any*/),
+                    "selections": (v32/*: any*/),
                     "storageKey": "filterArtworksConnection(first:2)"
                   }
                 ],
@@ -1304,7 +1309,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v32/*: any*/),
+                      (v31/*: any*/),
                       (v2/*: any*/)
                     ],
                     "storageKey": "artworksConnection(first:3)"
@@ -1390,7 +1395,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v34/*: any*/),
+            "args": (v33/*: any*/),
             "concreteType": "SaleArtworksConnection",
             "kind": "LinkedField",
             "name": "lotsByFollowedArtistsConnection",
@@ -1534,7 +1539,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v34/*: any*/),
+            "args": (v33/*: any*/),
             "filters": [
               "includeArtworksByFollowedArtists",
               "isAuction",
@@ -1614,14 +1619,14 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v35/*: any*/),
+                    "args": (v34/*: any*/),
                     "kind": "ScalarField",
                     "name": "distanceToOpen",
                     "storageKey": "distanceToOpen(short:true)"
                   },
                   {
                     "alias": null,
-                    "args": (v35/*: any*/),
+                    "args": (v34/*: any*/),
                     "kind": "ScalarField",
                     "name": "distanceToClose",
                     "storageKey": "distanceToClose(short:true)"
@@ -1639,7 +1644,7 @@ return {
     ]
   },
   "params": {
-    "id": "4df2d22c6a99e034ccc09d4f69e27e60",
+    "id": "18cec0e017c37c801346e52c4f931a9e",
     "metadata": {},
     "name": "HomeQuery",
     "operationKind": "query",

--- a/src/__generated__/HomeRefetchQuery.graphql.ts
+++ b/src/__generated__/HomeRefetchQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash e0d275464a663d65cb803ba254e25a10 */
+/* @relayHash ce7175915f110c3ae5dee0a7b56eed9a */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -199,7 +199,7 @@ fragment FairsRail_fairsModule on HomePageFairsModule {
       country
       id
     }
-    followedArtistArtworks: filterArtworksConnection(first: 2, includeArtworksByFollowedArtists: true) {
+    followedArtistArtworks: filterArtworksConnection(first: 2, input: {includeArtworksByFollowedArtists: true}) {
       edges {
         node {
           image {
@@ -658,11 +658,6 @@ v30 = {
   "value": 2
 },
 v31 = {
-  "kind": "Literal",
-  "name": "includeArtworksByFollowedArtists",
-  "value": true
-},
-v32 = {
   "alias": null,
   "args": null,
   "concreteType": "FilterArtworksEdge",
@@ -672,17 +667,21 @@ v32 = {
   "selections": (v29/*: any*/),
   "storageKey": null
 },
-v33 = [
-  (v32/*: any*/),
+v32 = [
+  (v31/*: any*/),
   (v2/*: any*/)
 ],
-v34 = [
+v33 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 6
   },
-  (v31/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "includeArtworksByFollowedArtists",
+    "value": true
+  },
   {
     "kind": "Literal",
     "name": "isAuction",
@@ -694,7 +693,7 @@ v34 = [
     "value": true
   }
 ],
-v35 = [
+v34 = [
   {
     "kind": "Literal",
     "name": "short",
@@ -1147,14 +1146,20 @@ return {
                     "alias": "followedArtistArtworks",
                     "args": [
                       (v30/*: any*/),
-                      (v31/*: any*/)
+                      {
+                        "kind": "Literal",
+                        "name": "input",
+                        "value": {
+                          "includeArtworksByFollowedArtists": true
+                        }
+                      }
                     ],
                     "concreteType": "FilterArtworksConnection",
                     "kind": "LinkedField",
                     "name": "filterArtworksConnection",
                     "plural": false,
-                    "selections": (v33/*: any*/),
-                    "storageKey": "filterArtworksConnection(first:2,includeArtworksByFollowedArtists:true)"
+                    "selections": (v32/*: any*/),
+                    "storageKey": "filterArtworksConnection(first:2,input:{\"includeArtworksByFollowedArtists\":true})"
                   },
                   {
                     "alias": "otherArtworks",
@@ -1165,7 +1170,7 @@ return {
                     "kind": "LinkedField",
                     "name": "filterArtworksConnection",
                     "plural": false,
-                    "selections": (v33/*: any*/),
+                    "selections": (v32/*: any*/),
                     "storageKey": "filterArtworksConnection(first:2)"
                   }
                 ],
@@ -1304,7 +1309,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v32/*: any*/),
+                      (v31/*: any*/),
                       (v2/*: any*/)
                     ],
                     "storageKey": "artworksConnection(first:3)"
@@ -1390,7 +1395,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v34/*: any*/),
+            "args": (v33/*: any*/),
             "concreteType": "SaleArtworksConnection",
             "kind": "LinkedField",
             "name": "lotsByFollowedArtistsConnection",
@@ -1534,7 +1539,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v34/*: any*/),
+            "args": (v33/*: any*/),
             "filters": [
               "includeArtworksByFollowedArtists",
               "isAuction",
@@ -1614,14 +1619,14 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v35/*: any*/),
+                    "args": (v34/*: any*/),
                     "kind": "ScalarField",
                     "name": "distanceToOpen",
                     "storageKey": "distanceToOpen(short:true)"
                   },
                   {
                     "alias": null,
-                    "args": (v35/*: any*/),
+                    "args": (v34/*: any*/),
                     "kind": "ScalarField",
                     "name": "distanceToClose",
                     "storageKey": "distanceToClose(short:true)"
@@ -1639,7 +1644,7 @@ return {
     ]
   },
   "params": {
-    "id": "e0d275464a663d65cb803ba254e25a10",
+    "id": "ce7175915f110c3ae5dee0a7b56eed9a",
     "metadata": {},
     "name": "HomeRefetchQuery",
     "operationKind": "query",

--- a/src/__generated__/PartnerArtworkInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/PartnerArtworkInfiniteScrollGridQuery.graphql.ts
@@ -1,25 +1,66 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash d38c00931be0fca769d272f548f1a5af */
+/* @relayHash 7eb024cee2ca25b51987e01beb4845ce */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type PartnerArtworkInfiniteScrollGridQueryVariables = {
+export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
+export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
+export type FilterArtworksInput = {
     acquireable?: boolean | null;
+    additionalGeneIDs?: Array<string | null> | null;
+    after?: string | null;
+    aggregationPartnerCities?: Array<string | null> | null;
+    aggregations?: Array<ArtworkAggregation | null> | null;
+    artistID?: string | null;
+    artistIDs?: Array<string | null> | null;
+    artistNationalities?: Array<string | null> | null;
+    artistSeriesID?: string | null;
+    atAuction?: boolean | null;
     attributionClass?: Array<string | null> | null;
+    before?: string | null;
     color?: string | null;
     colors?: Array<string | null> | null;
+    dimensionRange?: string | null;
+    excludeArtworkIDs?: Array<string | null> | null;
+    extraAggregationGeneIDs?: Array<string | null> | null;
+    first?: number | null;
+    forSale?: boolean | null;
+    geneID?: string | null;
+    geneIDs?: Array<string | null> | null;
+    height?: string | null;
+    includeArtworksByFollowedArtists?: boolean | null;
+    includeMediumFilterInAggregation?: boolean | null;
+    inquireableOnly?: boolean | null;
+    keyword?: string | null;
+    keywordMatchExact?: boolean | null;
+    last?: number | null;
+    locationCities?: Array<string | null> | null;
+    majorPeriods?: Array<string | null> | null;
+    marketable?: boolean | null;
+    materialsTerms?: Array<string | null> | null;
+    medium?: string | null;
+    offerable?: boolean | null;
+    page?: number | null;
+    partnerCities?: Array<string | null> | null;
+    partnerID?: string | null;
+    partnerIDs?: Array<string | null> | null;
+    period?: string | null;
+    periods?: Array<string | null> | null;
+    priceRange?: string | null;
+    saleID?: string | null;
+    size?: number | null;
+    sizes?: Array<ArtworkSizes | null> | null;
+    sort?: string | null;
+    tagID?: string | null;
+    width?: string | null;
+};
+export type PartnerArtworkInfiniteScrollGridQueryVariables = {
+    id: string;
     count: number;
     cursor?: string | null;
-    dimensionRange?: string | null;
-    additionalGeneIDs?: Array<string | null> | null;
-    id: string;
-    inquireableOnly?: boolean | null;
-    majorPeriods?: Array<string | null> | null;
-    offerable?: boolean | null;
-    priceRange?: string | null;
-    sort?: string | null;
+    input?: FilterArtworksInput | null;
 };
 export type PartnerArtworkInfiniteScrollGridQueryResponse = {
     readonly partner: {
@@ -35,23 +76,13 @@ export type PartnerArtworkInfiniteScrollGridQuery = {
 
 /*
 query PartnerArtworkInfiniteScrollGridQuery(
-  $acquireable: Boolean
-  $attributionClass: [String]
-  $color: String
-  $colors: [String]
+  $id: String!
   $count: Int!
   $cursor: String
-  $dimensionRange: String
-  $additionalGeneIDs: [String]
-  $id: String!
-  $inquireableOnly: Boolean
-  $majorPeriods: [String]
-  $offerable: Boolean
-  $priceRange: String
-  $sort: String
+  $input: FilterArtworksInput
 ) {
   partner(id: $id) {
-    ...PartnerArtwork_partner_2wu630
+    ...PartnerArtwork_partner_YCAiB
     id
   }
 }
@@ -115,10 +146,10 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
   }
 }
 
-fragment PartnerArtwork_partner_2wu630 on Partner {
+fragment PartnerArtwork_partner_YCAiB on Partner {
   internalID
   slug
-  artworks: filterArtworksConnection(acquireable: $acquireable, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], attributionClass: $attributionClass, color: $color, colors: $colors, dimensionRange: $dimensionRange, additionalGeneIDs: $additionalGeneIDs, first: $count, inquireableOnly: $inquireableOnly, majorPeriods: $majorPeriods, offerable: $offerable, priceRange: $priceRange, sort: $sort) {
+  artworks: filterArtworksConnection(first: $count, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: $input) {
     aggregations {
       slice
       counts {
@@ -148,152 +179,50 @@ const node: ConcreteRequest = (function(){
 var v0 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "acquireable"
+  "name": "count"
 },
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "additionalGeneIDs"
+  "name": "cursor"
 },
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "attributionClass"
+  "name": "id"
 },
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "color"
+  "name": "input"
 },
-v4 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "colors"
-},
-v5 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "count"
-},
-v6 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "cursor"
-},
-v7 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "dimensionRange"
-},
-v8 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "id"
-},
-v9 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "inquireableOnly"
-},
-v10 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "majorPeriods"
-},
-v11 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "offerable"
-},
-v12 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "priceRange"
-},
-v13 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "sort"
-},
-v14 = [
+v4 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v15 = {
+v5 = {
   "kind": "Variable",
-  "name": "acquireable",
-  "variableName": "acquireable"
+  "name": "input",
+  "variableName": "input"
 },
-v16 = {
-  "kind": "Variable",
-  "name": "additionalGeneIDs",
-  "variableName": "additionalGeneIDs"
-},
-v17 = {
-  "kind": "Variable",
-  "name": "attributionClass",
-  "variableName": "attributionClass"
-},
-v18 = {
-  "kind": "Variable",
-  "name": "color",
-  "variableName": "color"
-},
-v19 = {
-  "kind": "Variable",
-  "name": "colors",
-  "variableName": "colors"
-},
-v20 = {
-  "kind": "Variable",
-  "name": "dimensionRange",
-  "variableName": "dimensionRange"
-},
-v21 = {
-  "kind": "Variable",
-  "name": "inquireableOnly",
-  "variableName": "inquireableOnly"
-},
-v22 = {
-  "kind": "Variable",
-  "name": "majorPeriods",
-  "variableName": "majorPeriods"
-},
-v23 = {
-  "kind": "Variable",
-  "name": "offerable",
-  "variableName": "offerable"
-},
-v24 = {
-  "kind": "Variable",
-  "name": "priceRange",
-  "variableName": "priceRange"
-},
-v25 = {
-  "kind": "Variable",
-  "name": "sort",
-  "variableName": "sort"
-},
-v26 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v27 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v28 = [
-  (v15/*: any*/),
-  (v16/*: any*/),
+v8 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -310,36 +239,28 @@ v28 = [
       "PRICE_RANGE"
     ]
   },
-  (v17/*: any*/),
-  (v18/*: any*/),
-  (v19/*: any*/),
-  (v20/*: any*/),
   {
     "kind": "Variable",
     "name": "first",
     "variableName": "count"
   },
-  (v21/*: any*/),
-  (v22/*: any*/),
-  (v23/*: any*/),
-  (v24/*: any*/),
-  (v25/*: any*/)
+  (v5/*: any*/)
 ],
-v29 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v30 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v31 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -352,17 +273,7 @@ return {
       (v0/*: any*/),
       (v1/*: any*/),
       (v2/*: any*/),
-      (v3/*: any*/),
-      (v4/*: any*/),
-      (v5/*: any*/),
-      (v6/*: any*/),
-      (v7/*: any*/),
-      (v8/*: any*/),
-      (v9/*: any*/),
-      (v10/*: any*/),
-      (v11/*: any*/),
-      (v12/*: any*/),
-      (v13/*: any*/)
+      (v3/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -370,7 +281,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v14/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": "Partner",
         "kind": "LinkedField",
         "name": "partner",
@@ -378,11 +289,6 @@ return {
         "selections": [
           {
             "args": [
-              (v15/*: any*/),
-              (v16/*: any*/),
-              (v17/*: any*/),
-              (v18/*: any*/),
-              (v19/*: any*/),
               {
                 "kind": "Variable",
                 "name": "count",
@@ -393,12 +299,7 @@ return {
                 "name": "cursor",
                 "variableName": "cursor"
               },
-              (v20/*: any*/),
-              (v21/*: any*/),
-              (v22/*: any*/),
-              (v23/*: any*/),
-              (v24/*: any*/),
-              (v25/*: any*/)
+              (v5/*: any*/)
             ],
             "kind": "FragmentSpread",
             "name": "PartnerArtwork_partner"
@@ -413,37 +314,27 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v0/*: any*/),
       (v2/*: any*/),
-      (v3/*: any*/),
-      (v4/*: any*/),
-      (v5/*: any*/),
-      (v6/*: any*/),
-      (v7/*: any*/),
+      (v0/*: any*/),
       (v1/*: any*/),
-      (v8/*: any*/),
-      (v9/*: any*/),
-      (v10/*: any*/),
-      (v11/*: any*/),
-      (v12/*: any*/),
-      (v13/*: any*/)
+      (v3/*: any*/)
     ],
     "kind": "Operation",
     "name": "PartnerArtworkInfiniteScrollGridQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v14/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": "Partner",
         "kind": "LinkedField",
         "name": "partner",
         "plural": false,
         "selections": [
-          (v26/*: any*/),
-          (v27/*: any*/),
+          (v6/*: any*/),
+          (v7/*: any*/),
           {
             "alias": "artworks",
-            "args": (v28/*: any*/),
+            "args": (v8/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -479,7 +370,7 @@ return {
                         "name": "count",
                         "storageKey": null
                       },
-                      (v29/*: any*/),
+                      (v9/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -509,8 +400,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v30/*: any*/),
-                      (v31/*: any*/)
+                      (v10/*: any*/),
+                      (v11/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -549,7 +440,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v30/*: any*/),
+              (v10/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -579,7 +470,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v31/*: any*/),
+                      (v11/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -588,7 +479,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v27/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -641,7 +532,7 @@ return {
                             "name": "saleMessage",
                             "storageKey": null
                           },
-                          (v26/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -692,7 +583,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v30/*: any*/)
+                              (v10/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -747,7 +638,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v30/*: any*/)
+                              (v10/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -759,8 +650,8 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v29/*: any*/),
-                              (v30/*: any*/)
+                              (v9/*: any*/),
+                              (v10/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -770,7 +661,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v30/*: any*/)
+                          (v10/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -787,34 +678,24 @@ return {
           },
           {
             "alias": "artworks",
-            "args": (v28/*: any*/),
+            "args": (v8/*: any*/),
             "filters": [
-              "acquireable",
               "aggregations",
-              "attributionClass",
-              "color",
-              "colors",
-              "dimensionRange",
-              "additionalGeneIDs",
-              "inquireableOnly",
-              "majorPeriods",
-              "offerable",
-              "priceRange",
-              "sort"
+              "input"
             ],
             "handle": "connection",
             "key": "Partner_artworks",
             "kind": "LinkedHandle",
             "name": "filterArtworksConnection"
           },
-          (v30/*: any*/)
+          (v10/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "d38c00931be0fca769d272f548f1a5af",
+    "id": "7eb024cee2ca25b51987e01beb4845ce",
     "metadata": {},
     "name": "PartnerArtworkInfiniteScrollGridQuery",
     "operationKind": "query",
@@ -822,5 +703,5 @@ return {
   }
 };
 })();
-(node as any).hash = '2c748a6f7659147bcc96dafccc811b3b';
+(node as any).hash = '009a2d15967b38dbe3825f8db2527e3b';
 export default node;

--- a/src/__generated__/PartnerArtworkTestsQuery.graphql.ts
+++ b/src/__generated__/PartnerArtworkTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 06f66dea309ba0701eb846eb8c41e413 */
+/* @relayHash 818d5b4652b9746d067102a6c86a2628 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -156,7 +156,7 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
 fragment PartnerArtwork_partner on Partner {
   internalID
   slug
-  artworks: filterArtworksConnection(aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], dimensionRange: "*-*", first: 10, sort: "-partner_updated_at") {
+  artworks: filterArtworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -218,18 +218,8 @@ v3 = [
   },
   {
     "kind": "Literal",
-    "name": "dimensionRange",
-    "value": "*-*"
-  },
-  {
-    "kind": "Literal",
     "name": "first",
     "value": 10
-  },
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "-partner_updated_at"
   }
 ],
 v4 = {
@@ -638,24 +628,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,sort:\"-partner_updated_at\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:10)"
           },
           {
             "alias": "artworks",
             "args": (v3/*: any*/),
             "filters": [
-              "acquireable",
               "aggregations",
-              "attributionClass",
-              "color",
-              "colors",
-              "dimensionRange",
-              "additionalGeneIDs",
-              "inquireableOnly",
-              "majorPeriods",
-              "offerable",
-              "priceRange",
-              "sort"
+              "input"
             ],
             "handle": "connection",
             "key": "Partner_artworks",
@@ -669,7 +649,7 @@ return {
     ]
   },
   "params": {
-    "id": "06f66dea309ba0701eb846eb8c41e413",
+    "id": "818d5b4652b9746d067102a6c86a2628",
     "metadata": {},
     "name": "PartnerArtworkTestsQuery",
     "operationKind": "query",

--- a/src/__generated__/PartnerArtwork_partner.graphql.ts
+++ b/src/__generated__/PartnerArtwork_partner.graphql.ts
@@ -37,31 +37,6 @@ export type PartnerArtwork_partner$key = {
 const node: ReaderFragment = {
   "argumentDefinitions": [
     {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "acquireable"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "additionalGeneIDs"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "attributionClass"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "color"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "colors"
-    },
-    {
       "defaultValue": 10,
       "kind": "LocalArgument",
       "name": "count"
@@ -72,34 +47,9 @@ const node: ReaderFragment = {
       "name": "cursor"
     },
     {
-      "defaultValue": "*-*",
-      "kind": "LocalArgument",
-      "name": "dimensionRange"
-    },
-    {
       "defaultValue": null,
       "kind": "LocalArgument",
-      "name": "inquireableOnly"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "majorPeriods"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "offerable"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "priceRange"
-    },
-    {
-      "defaultValue": "-partner_updated_at",
-      "kind": "LocalArgument",
-      "name": "sort"
+      "name": "input"
     }
   ],
   "kind": "Fragment",
@@ -135,16 +85,6 @@ const node: ReaderFragment = {
       "alias": "artworks",
       "args": [
         {
-          "kind": "Variable",
-          "name": "acquireable",
-          "variableName": "acquireable"
-        },
-        {
-          "kind": "Variable",
-          "name": "additionalGeneIDs",
-          "variableName": "additionalGeneIDs"
-        },
-        {
           "kind": "Literal",
           "name": "aggregations",
           "value": [
@@ -157,48 +97,8 @@ const node: ReaderFragment = {
         },
         {
           "kind": "Variable",
-          "name": "attributionClass",
-          "variableName": "attributionClass"
-        },
-        {
-          "kind": "Variable",
-          "name": "color",
-          "variableName": "color"
-        },
-        {
-          "kind": "Variable",
-          "name": "colors",
-          "variableName": "colors"
-        },
-        {
-          "kind": "Variable",
-          "name": "dimensionRange",
-          "variableName": "dimensionRange"
-        },
-        {
-          "kind": "Variable",
-          "name": "inquireableOnly",
-          "variableName": "inquireableOnly"
-        },
-        {
-          "kind": "Variable",
-          "name": "majorPeriods",
-          "variableName": "majorPeriods"
-        },
-        {
-          "kind": "Variable",
-          "name": "offerable",
-          "variableName": "offerable"
-        },
-        {
-          "kind": "Variable",
-          "name": "priceRange",
-          "variableName": "priceRange"
-        },
-        {
-          "kind": "Variable",
-          "name": "sort",
-          "variableName": "sort"
+          "name": "input",
+          "variableName": "input"
         }
       ],
       "concreteType": "FilterArtworksConnection",
@@ -336,5 +236,5 @@ const node: ReaderFragment = {
   "type": "Partner",
   "abstractKey": null
 };
-(node as any).hash = 'ee2ad96c89d4808cb042861ec0ea4e02';
+(node as any).hash = '4dccca55accab018cafb3e1ca3910f26';
 export default node;

--- a/src/__generated__/PartnerQuery.graphql.ts
+++ b/src/__generated__/PartnerQuery.graphql.ts
@@ -1,12 +1,64 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 40f205d039ce3c8e64369a5bb25cc0e5 */
+/* @relayHash 24e06419048510dff957eab54051d91a */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
+export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
+export type FilterArtworksInput = {
+    acquireable?: boolean | null;
+    additionalGeneIDs?: Array<string | null> | null;
+    after?: string | null;
+    aggregationPartnerCities?: Array<string | null> | null;
+    aggregations?: Array<ArtworkAggregation | null> | null;
+    artistID?: string | null;
+    artistIDs?: Array<string | null> | null;
+    artistNationalities?: Array<string | null> | null;
+    artistSeriesID?: string | null;
+    atAuction?: boolean | null;
+    attributionClass?: Array<string | null> | null;
+    before?: string | null;
+    color?: string | null;
+    colors?: Array<string | null> | null;
+    dimensionRange?: string | null;
+    excludeArtworkIDs?: Array<string | null> | null;
+    extraAggregationGeneIDs?: Array<string | null> | null;
+    first?: number | null;
+    forSale?: boolean | null;
+    geneID?: string | null;
+    geneIDs?: Array<string | null> | null;
+    height?: string | null;
+    includeArtworksByFollowedArtists?: boolean | null;
+    includeMediumFilterInAggregation?: boolean | null;
+    inquireableOnly?: boolean | null;
+    keyword?: string | null;
+    keywordMatchExact?: boolean | null;
+    last?: number | null;
+    locationCities?: Array<string | null> | null;
+    majorPeriods?: Array<string | null> | null;
+    marketable?: boolean | null;
+    materialsTerms?: Array<string | null> | null;
+    medium?: string | null;
+    offerable?: boolean | null;
+    page?: number | null;
+    partnerCities?: Array<string | null> | null;
+    partnerID?: string | null;
+    partnerIDs?: Array<string | null> | null;
+    period?: string | null;
+    periods?: Array<string | null> | null;
+    priceRange?: string | null;
+    saleID?: string | null;
+    size?: number | null;
+    sizes?: Array<ArtworkSizes | null> | null;
+    sort?: string | null;
+    tagID?: string | null;
+    width?: string | null;
+};
 export type PartnerQueryVariables = {
     partnerID: string;
+    input?: FilterArtworksInput | null;
 };
 export type PartnerQueryResponse = {
     readonly partner: {
@@ -23,9 +75,10 @@ export type PartnerQuery = {
 /*
 query PartnerQuery(
   $partnerID: String!
+  $input: FilterArtworksInput
 ) {
   partner(id: $partnerID) {
-    ...Partner_partner
+    ...Partner_partner_2VV6jB
     id
   }
 }
@@ -105,10 +158,10 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
   }
 }
 
-fragment PartnerArtwork_partner on Partner {
+fragment PartnerArtwork_partner_2VV6jB on Partner {
   internalID
   slug
-  artworks: filterArtworksConnection(aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], dimensionRange: "*-*", first: 10, sort: "-partner_updated_at") {
+  artworks: filterArtworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: $input) {
     aggregations {
       slice
       counts {
@@ -286,7 +339,7 @@ fragment PartnerShows_partner on Partner {
   ...PartnerShowsRail_partner
 }
 
-fragment Partner_partner on Partner {
+fragment Partner_partner_2VV6jB on Partner {
   id
   internalID
   slug
@@ -295,7 +348,7 @@ fragment Partner_partner on Partner {
     isFollowed
     internalID
   }
-  ...PartnerArtwork_partner
+  ...PartnerArtwork_partner_2VV6jB
   ...PartnerOverview_partner
   ...PartnerShows_partner
   ...PartnerHeader_partner
@@ -303,54 +356,62 @@ fragment Partner_partner on Partner {
 */
 
 const node: ConcreteRequest = (function(){
-var v0 = [
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "partnerID"
-  }
-],
-v1 = [
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "partnerID"
+},
+v2 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "partnerID"
   }
 ],
-v2 = {
+v3 = {
+  "kind": "Variable",
+  "name": "input",
+  "variableName": "input"
+},
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v3 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v4 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v5 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v6 = {
+v8 = {
   "kind": "Literal",
   "name": "first",
   "value": 10
 },
-v7 = [
+v9 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -362,92 +423,83 @@ v7 = [
       "PRICE_RANGE"
     ]
   },
-  {
-    "kind": "Literal",
-    "name": "dimensionRange",
-    "value": "*-*"
-  },
-  (v6/*: any*/),
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "-partner_updated_at"
-  }
+  (v8/*: any*/),
+  (v3/*: any*/)
 ],
-v8 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v9 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v10 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endCursor",
   "storageKey": null
 },
-v11 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "hasNextPage",
   "storageKey": null
 },
-v12 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startCursor",
   "storageKey": null
 },
-v13 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "aspectRatio",
   "storageKey": null
 },
-v14 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v15 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v16 = [
-  (v2/*: any*/)
+v18 = [
+  (v4/*: any*/)
 ],
-v17 = {
+v19 = {
   "kind": "InlineFragment",
-  "selections": (v16/*: any*/),
+  "selections": (v18/*: any*/),
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v18 = [
-  (v6/*: any*/),
+v20 = [
+  (v8/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "SORTABLE_ID_ASC"
   }
 ],
-v19 = {
+v21 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -455,35 +507,35 @@ v19 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v11/*: any*/),
-    (v12/*: any*/),
-    (v10/*: any*/)
+    (v13/*: any*/),
+    (v14/*: any*/),
+    (v12/*: any*/)
   ],
   "storageKey": null
 },
-v20 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v21 = [
-  (v20/*: any*/)
+v23 = [
+  (v22/*: any*/)
 ],
-v22 = {
+v24 = {
   "kind": "Literal",
   "name": "status",
   "value": "CURRENT"
 },
-v23 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isDisplayable",
   "storageKey": null
 },
-v24 = [
+v26 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -500,18 +552,18 @@ v24 = [
     "value": "CLOSED"
   }
 ],
-v25 = {
+v27 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "exhibitionPeriod",
   "storageKey": null
 },
-v26 = [
+v28 = [
   "status",
   "sort"
 ],
-v27 = [
+v29 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -522,25 +574,30 @@ v27 = [
     "name": "sort",
     "value": "END_AT_ASC"
   },
-  (v22/*: any*/)
+  (v24/*: any*/)
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
     "kind": "Fragment",
     "metadata": null,
     "name": "PartnerQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v2/*: any*/),
         "concreteType": "Partner",
         "kind": "LinkedField",
         "name": "partner",
         "plural": false,
         "selections": [
           {
-            "args": null,
+            "args": [
+              (v3/*: any*/)
+            ],
             "kind": "FragmentSpread",
             "name": "Partner_partner"
           }
@@ -553,21 +610,24 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
     "kind": "Operation",
     "name": "PartnerQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v2/*: any*/),
         "concreteType": "Partner",
         "kind": "LinkedField",
         "name": "partner",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
-          (v3/*: any*/),
           (v4/*: any*/),
+          (v5/*: any*/),
+          (v6/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -576,7 +636,7 @@ return {
             "name": "profile",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
+              (v4/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -584,7 +644,7 @@ return {
                 "name": "isFollowed",
                 "storageKey": null
               },
-              (v3/*: any*/),
+              (v5/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -592,13 +652,13 @@ return {
                 "name": "bio",
                 "storageKey": null
               },
-              (v5/*: any*/)
+              (v7/*: any*/)
             ],
             "storageKey": null
           },
           {
             "alias": "artworks",
-            "args": (v7/*: any*/),
+            "args": (v9/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -634,7 +694,7 @@ return {
                         "name": "count",
                         "storageKey": null
                       },
-                      (v5/*: any*/),
+                      (v7/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -664,12 +724,12 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v2/*: any*/),
-                      (v8/*: any*/)
+                      (v4/*: any*/),
+                      (v10/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v9/*: any*/)
+                  (v11/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -681,12 +741,12 @@ return {
                 "name": "pageInfo",
                 "plural": false,
                 "selections": [
-                  (v10/*: any*/),
-                  (v11/*: any*/)
+                  (v12/*: any*/),
+                  (v13/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v2/*: any*/),
+              (v4/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -698,7 +758,7 @@ return {
                     "name": "pageInfo",
                     "plural": false,
                     "selections": [
-                      (v12/*: any*/)
+                      (v14/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -710,7 +770,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v8/*: any*/),
+                      (v10/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -719,7 +779,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -728,7 +788,7 @@ return {
                             "name": "image",
                             "plural": false,
                             "selections": [
-                              (v13/*: any*/),
+                              (v15/*: any*/),
                               {
                                 "alias": null,
                                 "args": [
@@ -766,7 +826,7 @@ return {
                             "name": "saleMessage",
                             "storageKey": null
                           },
-                          (v3/*: any*/),
+                          (v5/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -774,7 +834,7 @@ return {
                             "name": "artistNames",
                             "storageKey": null
                           },
-                          (v14/*: any*/),
+                          (v16/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -804,8 +864,8 @@ return {
                                 "name": "displayTimelyAt",
                                 "storageKey": null
                               },
-                              (v15/*: any*/),
-                              (v2/*: any*/)
+                              (v17/*: any*/),
+                              (v4/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -860,7 +920,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v2/*: any*/)
+                              (v4/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -872,15 +932,15 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v5/*: any*/),
-                              (v2/*: any*/)
+                              (v7/*: any*/),
+                              (v4/*: any*/)
                             ],
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
-                      (v17/*: any*/)
+                      (v19/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -889,31 +949,21 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,sort:\"-partner_updated_at\")"
+            "storageKey": null
           },
           {
             "alias": "artworks",
-            "args": (v7/*: any*/),
+            "args": (v9/*: any*/),
             "filters": [
-              "acquireable",
               "aggregations",
-              "attributionClass",
-              "color",
-              "colors",
-              "dimensionRange",
-              "additionalGeneIDs",
-              "inquireableOnly",
-              "majorPeriods",
-              "offerable",
-              "priceRange",
-              "sort"
+              "input"
             ],
             "handle": "connection",
             "key": "Partner_artworks",
             "kind": "LinkedHandle",
             "name": "filterArtworksConnection"
           },
-          (v5/*: any*/),
+          (v7/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -923,13 +973,13 @@ return {
           },
           {
             "alias": "artists",
-            "args": (v18/*: any*/),
+            "args": (v20/*: any*/),
             "concreteType": "ArtistPartnerConnection",
             "kind": "LinkedField",
             "name": "artistsConnection",
             "plural": false,
             "selections": [
-              (v19/*: any*/),
+              (v21/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -946,10 +996,10 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v2/*: any*/),
-                      (v3/*: any*/),
                       (v4/*: any*/),
                       (v5/*: any*/),
+                      (v6/*: any*/),
+                      (v7/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -957,7 +1007,7 @@ return {
                         "name": "initials",
                         "storageKey": null
                       },
-                      (v14/*: any*/),
+                      (v16/*: any*/),
                       {
                         "alias": "is_followed",
                         "args": null,
@@ -993,7 +1043,7 @@ return {
                         "kind": "LinkedField",
                         "name": "image",
                         "plural": false,
-                        "selections": (v21/*: any*/),
+                        "selections": (v23/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -1014,12 +1064,12 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v8/*: any*/)
+                      (v10/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v9/*: any*/),
-                  (v2/*: any*/)
+                  (v11/*: any*/),
+                  (v4/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -1028,7 +1078,7 @@ return {
           },
           {
             "alias": "artists",
-            "args": (v18/*: any*/),
+            "args": (v20/*: any*/),
             "filters": [
               "sort"
             ],
@@ -1064,8 +1114,8 @@ return {
           {
             "alias": "recentShows",
             "args": [
-              (v6/*: any*/),
-              (v22/*: any*/)
+              (v8/*: any*/),
+              (v24/*: any*/)
             ],
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
@@ -1088,8 +1138,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v2/*: any*/),
-                      (v23/*: any*/)
+                      (v4/*: any*/),
+                      (v25/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1101,13 +1151,13 @@ return {
           },
           {
             "alias": "pastShows",
-            "args": (v24/*: any*/),
+            "args": (v26/*: any*/),
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
             "selections": [
-              (v19/*: any*/),
+              (v21/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1124,11 +1174,11 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v23/*: any*/),
-                      (v2/*: any*/),
-                      (v5/*: any*/),
-                      (v4/*: any*/),
                       (v25/*: any*/),
+                      (v4/*: any*/),
+                      (v7/*: any*/),
+                      (v6/*: any*/),
+                      (v27/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1137,17 +1187,17 @@ return {
                         "name": "coverImage",
                         "plural": false,
                         "selections": [
-                          (v20/*: any*/),
-                          (v13/*: any*/)
+                          (v22/*: any*/),
+                          (v15/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v14/*: any*/),
-                      (v8/*: any*/)
+                      (v16/*: any*/),
+                      (v10/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v9/*: any*/)
+                  (v11/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -1156,8 +1206,8 @@ return {
           },
           {
             "alias": "pastShows",
-            "args": (v24/*: any*/),
-            "filters": (v26/*: any*/),
+            "args": (v26/*: any*/),
+            "filters": (v28/*: any*/),
             "handle": "connection",
             "key": "Partner_pastShows",
             "kind": "LinkedHandle",
@@ -1165,13 +1215,13 @@ return {
           },
           {
             "alias": "currentAndUpcomingShows",
-            "args": (v27/*: any*/),
+            "args": (v29/*: any*/),
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
             "selections": [
-              (v19/*: any*/),
+              (v21/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1188,13 +1238,13 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v23/*: any*/),
-                      (v2/*: any*/),
-                      (v3/*: any*/),
+                      (v25/*: any*/),
                       (v4/*: any*/),
                       (v5/*: any*/),
-                      (v25/*: any*/),
-                      (v15/*: any*/),
+                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      (v27/*: any*/),
+                      (v17/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1202,7 +1252,7 @@ return {
                         "kind": "LinkedField",
                         "name": "images",
                         "plural": true,
-                        "selections": (v21/*: any*/),
+                        "selections": (v23/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -1213,19 +1263,19 @@ return {
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v8/*: any*/),
+                          (v10/*: any*/),
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v5/*: any*/)
+                              (v7/*: any*/)
                             ],
                             "type": "Partner",
                             "abstractKey": null
                           },
-                          (v17/*: any*/),
+                          (v19/*: any*/),
                           {
                             "kind": "InlineFragment",
-                            "selections": (v16/*: any*/),
+                            "selections": (v18/*: any*/),
                             "type": "ExternalPartner",
                             "abstractKey": null
                           }
@@ -1239,14 +1289,14 @@ return {
                         "kind": "LinkedField",
                         "name": "coverImage",
                         "plural": false,
-                        "selections": (v21/*: any*/),
+                        "selections": (v23/*: any*/),
                         "storageKey": null
                       },
-                      (v8/*: any*/)
+                      (v10/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v9/*: any*/)
+                  (v11/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -1255,8 +1305,8 @@ return {
           },
           {
             "alias": "currentAndUpcomingShows",
-            "args": (v27/*: any*/),
-            "filters": (v26/*: any*/),
+            "args": (v29/*: any*/),
+            "filters": (v28/*: any*/),
             "handle": "connection",
             "key": "Partner_currentAndUpcomingShows",
             "kind": "LinkedHandle",
@@ -1286,7 +1336,7 @@ return {
     ]
   },
   "params": {
-    "id": "40f205d039ce3c8e64369a5bb25cc0e5",
+    "id": "24e06419048510dff957eab54051d91a",
     "metadata": {},
     "name": "PartnerQuery",
     "operationKind": "query",
@@ -1294,5 +1344,5 @@ return {
   }
 };
 })();
-(node as any).hash = '0b0eed91e660004592661f2cc3617d05';
+(node as any).hash = '8ffb86f6d5a77666686bb82771e0c882';
 export default node;

--- a/src/__generated__/PartnerQuery.graphql.ts
+++ b/src/__generated__/PartnerQuery.graphql.ts
@@ -1,64 +1,12 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 24e06419048510dff957eab54051d91a */
+/* @relayHash b06f53606ad6b91151b53f78bb7af8db */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
-export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
-export type FilterArtworksInput = {
-    acquireable?: boolean | null;
-    additionalGeneIDs?: Array<string | null> | null;
-    after?: string | null;
-    aggregationPartnerCities?: Array<string | null> | null;
-    aggregations?: Array<ArtworkAggregation | null> | null;
-    artistID?: string | null;
-    artistIDs?: Array<string | null> | null;
-    artistNationalities?: Array<string | null> | null;
-    artistSeriesID?: string | null;
-    atAuction?: boolean | null;
-    attributionClass?: Array<string | null> | null;
-    before?: string | null;
-    color?: string | null;
-    colors?: Array<string | null> | null;
-    dimensionRange?: string | null;
-    excludeArtworkIDs?: Array<string | null> | null;
-    extraAggregationGeneIDs?: Array<string | null> | null;
-    first?: number | null;
-    forSale?: boolean | null;
-    geneID?: string | null;
-    geneIDs?: Array<string | null> | null;
-    height?: string | null;
-    includeArtworksByFollowedArtists?: boolean | null;
-    includeMediumFilterInAggregation?: boolean | null;
-    inquireableOnly?: boolean | null;
-    keyword?: string | null;
-    keywordMatchExact?: boolean | null;
-    last?: number | null;
-    locationCities?: Array<string | null> | null;
-    majorPeriods?: Array<string | null> | null;
-    marketable?: boolean | null;
-    materialsTerms?: Array<string | null> | null;
-    medium?: string | null;
-    offerable?: boolean | null;
-    page?: number | null;
-    partnerCities?: Array<string | null> | null;
-    partnerID?: string | null;
-    partnerIDs?: Array<string | null> | null;
-    period?: string | null;
-    periods?: Array<string | null> | null;
-    priceRange?: string | null;
-    saleID?: string | null;
-    size?: number | null;
-    sizes?: Array<ArtworkSizes | null> | null;
-    sort?: string | null;
-    tagID?: string | null;
-    width?: string | null;
-};
 export type PartnerQueryVariables = {
     partnerID: string;
-    input?: FilterArtworksInput | null;
 };
 export type PartnerQueryResponse = {
     readonly partner: {
@@ -75,10 +23,9 @@ export type PartnerQuery = {
 /*
 query PartnerQuery(
   $partnerID: String!
-  $input: FilterArtworksInput
 ) {
   partner(id: $partnerID) {
-    ...Partner_partner_2VV6jB
+    ...Partner_partner
     id
   }
 }
@@ -158,10 +105,10 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
   }
 }
 
-fragment PartnerArtwork_partner_2VV6jB on Partner {
+fragment PartnerArtwork_partner_BRGa6 on Partner {
   internalID
   slug
-  artworks: filterArtworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: $input) {
+  artworks: filterArtworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: {sort: "-partner_updated_at", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -339,7 +286,7 @@ fragment PartnerShows_partner on Partner {
   ...PartnerShowsRail_partner
 }
 
-fragment Partner_partner_2VV6jB on Partner {
+fragment Partner_partner on Partner {
   id
   internalID
   slug
@@ -348,7 +295,7 @@ fragment Partner_partner_2VV6jB on Partner {
     isFollowed
     internalID
   }
-  ...PartnerArtwork_partner_2VV6jB
+  ...PartnerArtwork_partner_BRGa6
   ...PartnerOverview_partner
   ...PartnerShows_partner
   ...PartnerHeader_partner
@@ -356,62 +303,54 @@ fragment Partner_partner_2VV6jB on Partner {
 */
 
 const node: ConcreteRequest = (function(){
-var v0 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "input"
-},
-v1 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "partnerID"
-},
-v2 = [
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "partnerID"
+  }
+],
+v1 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "partnerID"
   }
 ],
-v3 = {
-  "kind": "Variable",
-  "name": "input",
-  "variableName": "input"
-},
-v4 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v5 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v6 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v7 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v8 = {
+v6 = {
   "kind": "Literal",
   "name": "first",
   "value": 10
 },
-v9 = [
+v7 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -423,83 +362,90 @@ v9 = [
       "PRICE_RANGE"
     ]
   },
-  (v8/*: any*/),
-  (v3/*: any*/)
+  (v6/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "input",
+    "value": {
+      "dimensionRange": "*-*",
+      "sort": "-partner_updated_at"
+    }
+  }
 ],
-v10 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v11 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v12 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endCursor",
   "storageKey": null
 },
-v13 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "hasNextPage",
   "storageKey": null
 },
-v14 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startCursor",
   "storageKey": null
 },
-v15 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "aspectRatio",
   "storageKey": null
 },
-v16 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v17 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v18 = [
-  (v4/*: any*/)
+v16 = [
+  (v2/*: any*/)
 ],
-v19 = {
+v17 = {
   "kind": "InlineFragment",
-  "selections": (v18/*: any*/),
+  "selections": (v16/*: any*/),
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v20 = [
-  (v8/*: any*/),
+v18 = [
+  (v6/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "SORTABLE_ID_ASC"
   }
 ],
-v21 = {
+v19 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -507,35 +453,35 @@ v21 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v13/*: any*/),
-    (v14/*: any*/),
-    (v12/*: any*/)
+    (v11/*: any*/),
+    (v12/*: any*/),
+    (v10/*: any*/)
   ],
   "storageKey": null
 },
-v22 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v23 = [
-  (v22/*: any*/)
+v21 = [
+  (v20/*: any*/)
 ],
-v24 = {
+v22 = {
   "kind": "Literal",
   "name": "status",
   "value": "CURRENT"
 },
-v25 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isDisplayable",
   "storageKey": null
 },
-v26 = [
+v24 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -552,18 +498,18 @@ v26 = [
     "value": "CLOSED"
   }
 ],
-v27 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "exhibitionPeriod",
   "storageKey": null
 },
-v28 = [
+v26 = [
   "status",
   "sort"
 ],
-v29 = [
+v27 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -574,30 +520,25 @@ v29 = [
     "name": "sort",
     "value": "END_AT_ASC"
   },
-  (v24/*: any*/)
+  (v22/*: any*/)
 ];
 return {
   "fragment": {
-    "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "PartnerQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v2/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": "Partner",
         "kind": "LinkedField",
         "name": "partner",
         "plural": false,
         "selections": [
           {
-            "args": [
-              (v3/*: any*/)
-            ],
+            "args": null,
             "kind": "FragmentSpread",
             "name": "Partner_partner"
           }
@@ -610,24 +551,21 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": [
-      (v1/*: any*/),
-      (v0/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "PartnerQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v2/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": "Partner",
         "kind": "LinkedField",
         "name": "partner",
         "plural": false,
         "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
           (v4/*: any*/),
-          (v5/*: any*/),
-          (v6/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -636,7 +574,7 @@ return {
             "name": "profile",
             "plural": false,
             "selections": [
-              (v4/*: any*/),
+              (v2/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -644,7 +582,7 @@ return {
                 "name": "isFollowed",
                 "storageKey": null
               },
-              (v5/*: any*/),
+              (v3/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -652,13 +590,13 @@ return {
                 "name": "bio",
                 "storageKey": null
               },
-              (v7/*: any*/)
+              (v5/*: any*/)
             ],
             "storageKey": null
           },
           {
             "alias": "artworks",
-            "args": (v9/*: any*/),
+            "args": (v7/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -694,7 +632,7 @@ return {
                         "name": "count",
                         "storageKey": null
                       },
-                      (v7/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -724,12 +662,12 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
-                      (v10/*: any*/)
+                      (v2/*: any*/),
+                      (v8/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v11/*: any*/)
+                  (v9/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -741,12 +679,12 @@ return {
                 "name": "pageInfo",
                 "plural": false,
                 "selections": [
-                  (v12/*: any*/),
-                  (v13/*: any*/)
+                  (v10/*: any*/),
+                  (v11/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v4/*: any*/),
+              (v2/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -758,7 +696,7 @@ return {
                     "name": "pageInfo",
                     "plural": false,
                     "selections": [
-                      (v14/*: any*/)
+                      (v12/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -770,7 +708,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v10/*: any*/),
+                      (v8/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -779,7 +717,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v6/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -788,7 +726,7 @@ return {
                             "name": "image",
                             "plural": false,
                             "selections": [
-                              (v15/*: any*/),
+                              (v13/*: any*/),
                               {
                                 "alias": null,
                                 "args": [
@@ -826,7 +764,7 @@ return {
                             "name": "saleMessage",
                             "storageKey": null
                           },
-                          (v5/*: any*/),
+                          (v3/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -834,7 +772,7 @@ return {
                             "name": "artistNames",
                             "storageKey": null
                           },
-                          (v16/*: any*/),
+                          (v14/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -864,8 +802,8 @@ return {
                                 "name": "displayTimelyAt",
                                 "storageKey": null
                               },
-                              (v17/*: any*/),
-                              (v4/*: any*/)
+                              (v15/*: any*/),
+                              (v2/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -920,7 +858,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v4/*: any*/)
+                              (v2/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -932,15 +870,15 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v7/*: any*/),
-                              (v4/*: any*/)
+                              (v5/*: any*/),
+                              (v2/*: any*/)
                             ],
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
-                      (v19/*: any*/)
+                      (v17/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -949,11 +887,11 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": null
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-partner_updated_at\"})"
           },
           {
             "alias": "artworks",
-            "args": (v9/*: any*/),
+            "args": (v7/*: any*/),
             "filters": [
               "aggregations",
               "input"
@@ -963,7 +901,7 @@ return {
             "kind": "LinkedHandle",
             "name": "filterArtworksConnection"
           },
-          (v7/*: any*/),
+          (v5/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -973,13 +911,13 @@ return {
           },
           {
             "alias": "artists",
-            "args": (v20/*: any*/),
+            "args": (v18/*: any*/),
             "concreteType": "ArtistPartnerConnection",
             "kind": "LinkedField",
             "name": "artistsConnection",
             "plural": false,
             "selections": [
-              (v21/*: any*/),
+              (v19/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -996,10 +934,10 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
+                      (v2/*: any*/),
+                      (v3/*: any*/),
                       (v4/*: any*/),
                       (v5/*: any*/),
-                      (v6/*: any*/),
-                      (v7/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1007,7 +945,7 @@ return {
                         "name": "initials",
                         "storageKey": null
                       },
-                      (v16/*: any*/),
+                      (v14/*: any*/),
                       {
                         "alias": "is_followed",
                         "args": null,
@@ -1043,7 +981,7 @@ return {
                         "kind": "LinkedField",
                         "name": "image",
                         "plural": false,
-                        "selections": (v23/*: any*/),
+                        "selections": (v21/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -1064,12 +1002,12 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v10/*: any*/)
+                      (v8/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v11/*: any*/),
-                  (v4/*: any*/)
+                  (v9/*: any*/),
+                  (v2/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -1078,7 +1016,7 @@ return {
           },
           {
             "alias": "artists",
-            "args": (v20/*: any*/),
+            "args": (v18/*: any*/),
             "filters": [
               "sort"
             ],
@@ -1114,8 +1052,8 @@ return {
           {
             "alias": "recentShows",
             "args": [
-              (v8/*: any*/),
-              (v24/*: any*/)
+              (v6/*: any*/),
+              (v22/*: any*/)
             ],
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
@@ -1138,8 +1076,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
-                      (v25/*: any*/)
+                      (v2/*: any*/),
+                      (v23/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1151,13 +1089,13 @@ return {
           },
           {
             "alias": "pastShows",
-            "args": (v26/*: any*/),
+            "args": (v24/*: any*/),
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
             "selections": [
-              (v21/*: any*/),
+              (v19/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1174,11 +1112,11 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v25/*: any*/),
+                      (v23/*: any*/),
+                      (v2/*: any*/),
+                      (v5/*: any*/),
                       (v4/*: any*/),
-                      (v7/*: any*/),
-                      (v6/*: any*/),
-                      (v27/*: any*/),
+                      (v25/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1187,17 +1125,17 @@ return {
                         "name": "coverImage",
                         "plural": false,
                         "selections": [
-                          (v22/*: any*/),
-                          (v15/*: any*/)
+                          (v20/*: any*/),
+                          (v13/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v16/*: any*/),
-                      (v10/*: any*/)
+                      (v14/*: any*/),
+                      (v8/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v11/*: any*/)
+                  (v9/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -1206,8 +1144,8 @@ return {
           },
           {
             "alias": "pastShows",
-            "args": (v26/*: any*/),
-            "filters": (v28/*: any*/),
+            "args": (v24/*: any*/),
+            "filters": (v26/*: any*/),
             "handle": "connection",
             "key": "Partner_pastShows",
             "kind": "LinkedHandle",
@@ -1215,13 +1153,13 @@ return {
           },
           {
             "alias": "currentAndUpcomingShows",
-            "args": (v29/*: any*/),
+            "args": (v27/*: any*/),
             "concreteType": "ShowConnection",
             "kind": "LinkedField",
             "name": "showsConnection",
             "plural": false,
             "selections": [
-              (v21/*: any*/),
+              (v19/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1238,13 +1176,13 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v25/*: any*/),
+                      (v23/*: any*/),
+                      (v2/*: any*/),
+                      (v3/*: any*/),
                       (v4/*: any*/),
                       (v5/*: any*/),
-                      (v6/*: any*/),
-                      (v7/*: any*/),
-                      (v27/*: any*/),
-                      (v17/*: any*/),
+                      (v25/*: any*/),
+                      (v15/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1252,7 +1190,7 @@ return {
                         "kind": "LinkedField",
                         "name": "images",
                         "plural": true,
-                        "selections": (v23/*: any*/),
+                        "selections": (v21/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -1263,19 +1201,19 @@ return {
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v10/*: any*/),
+                          (v8/*: any*/),
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v7/*: any*/)
+                              (v5/*: any*/)
                             ],
                             "type": "Partner",
                             "abstractKey": null
                           },
-                          (v19/*: any*/),
+                          (v17/*: any*/),
                           {
                             "kind": "InlineFragment",
-                            "selections": (v18/*: any*/),
+                            "selections": (v16/*: any*/),
                             "type": "ExternalPartner",
                             "abstractKey": null
                           }
@@ -1289,14 +1227,14 @@ return {
                         "kind": "LinkedField",
                         "name": "coverImage",
                         "plural": false,
-                        "selections": (v23/*: any*/),
+                        "selections": (v21/*: any*/),
                         "storageKey": null
                       },
-                      (v10/*: any*/)
+                      (v8/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v11/*: any*/)
+                  (v9/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -1305,8 +1243,8 @@ return {
           },
           {
             "alias": "currentAndUpcomingShows",
-            "args": (v29/*: any*/),
-            "filters": (v28/*: any*/),
+            "args": (v27/*: any*/),
+            "filters": (v26/*: any*/),
             "handle": "connection",
             "key": "Partner_currentAndUpcomingShows",
             "kind": "LinkedHandle",
@@ -1336,7 +1274,7 @@ return {
     ]
   },
   "params": {
-    "id": "24e06419048510dff957eab54051d91a",
+    "id": "b06f53606ad6b91151b53f78bb7af8db",
     "metadata": {},
     "name": "PartnerQuery",
     "operationKind": "query",
@@ -1344,5 +1282,5 @@ return {
   }
 };
 })();
-(node as any).hash = '8ffb86f6d5a77666686bb82771e0c882';
+(node as any).hash = '0b0eed91e660004592661f2cc3617d05';
 export default node;

--- a/src/__generated__/PartnerRefetchQuery.graphql.ts
+++ b/src/__generated__/PartnerRefetchQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash f57afe897641d2d39005561eddf25baa */
+/* @relayHash 37d71a95a4f73153c3be8ce52162f9f8 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -106,10 +106,10 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
   }
 }
 
-fragment PartnerArtwork_partner_4g78v5 on Partner {
+fragment PartnerArtwork_partner_BRGa6 on Partner {
   internalID
   slug
-  artworks: filterArtworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  artworks: filterArtworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: {sort: "-partner_updated_at", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -296,7 +296,7 @@ fragment Partner_partner on Partner {
     isFollowed
     internalID
   }
-  ...PartnerArtwork_partner_4g78v5
+  ...PartnerArtwork_partner_BRGa6
   ...PartnerOverview_partner
   ...PartnerShows_partner
   ...PartnerHeader_partner
@@ -370,7 +370,15 @@ v8 = [
       "PRICE_RANGE"
     ]
   },
-  (v7/*: any*/)
+  (v7/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "input",
+    "value": {
+      "dimensionRange": "*-*",
+      "sort": "-partner_updated_at"
+    }
+  }
 ],
 v9 = {
   "alias": null,
@@ -884,7 +892,7 @@ return {
                     "abstractKey": "__isArtworkConnectionInterface"
                   }
                 ],
-                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:10)"
+                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-partner_updated_at\"})"
               },
               {
                 "alias": "artworks",
@@ -1275,7 +1283,7 @@ return {
     ]
   },
   "params": {
-    "id": "f57afe897641d2d39005561eddf25baa",
+    "id": "37d71a95a4f73153c3be8ce52162f9f8",
     "metadata": {},
     "name": "PartnerRefetchQuery",
     "operationKind": "query",

--- a/src/__generated__/PartnerRefetchQuery.graphql.ts
+++ b/src/__generated__/PartnerRefetchQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash ee5938bb907da6c82d5118f9a537ad6e */
+/* @relayHash f57afe897641d2d39005561eddf25baa */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -106,10 +106,10 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
   }
 }
 
-fragment PartnerArtwork_partner on Partner {
+fragment PartnerArtwork_partner_4g78v5 on Partner {
   internalID
   slug
-  artworks: filterArtworksConnection(aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], dimensionRange: "*-*", first: 10, sort: "-partner_updated_at") {
+  artworks: filterArtworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -296,7 +296,7 @@ fragment Partner_partner on Partner {
     isFollowed
     internalID
   }
-  ...PartnerArtwork_partner
+  ...PartnerArtwork_partner_4g78v5
   ...PartnerOverview_partner
   ...PartnerShows_partner
   ...PartnerHeader_partner
@@ -370,17 +370,7 @@ v8 = [
       "PRICE_RANGE"
     ]
   },
-  {
-    "kind": "Literal",
-    "name": "dimensionRange",
-    "value": "*-*"
-  },
-  (v7/*: any*/),
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "-partner_updated_at"
-  }
+  (v7/*: any*/)
 ],
 v9 = {
   "alias": null,
@@ -894,24 +884,14 @@ return {
                     "abstractKey": "__isArtworkConnectionInterface"
                   }
                 ],
-                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,sort:\"-partner_updated_at\")"
+                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:10)"
               },
               {
                 "alias": "artworks",
                 "args": (v8/*: any*/),
                 "filters": [
-                  "acquireable",
                   "aggregations",
-                  "attributionClass",
-                  "color",
-                  "colors",
-                  "dimensionRange",
-                  "additionalGeneIDs",
-                  "inquireableOnly",
-                  "majorPeriods",
-                  "offerable",
-                  "priceRange",
-                  "sort"
+                  "input"
                 ],
                 "handle": "connection",
                 "key": "Partner_artworks",
@@ -1295,7 +1275,7 @@ return {
     ]
   },
   "params": {
-    "id": "ee5938bb907da6c82d5118f9a537ad6e",
+    "id": "f57afe897641d2d39005561eddf25baa",
     "metadata": {},
     "name": "PartnerRefetchQuery",
     "operationKind": "query",

--- a/src/__generated__/Partner_partner.graphql.ts
+++ b/src/__generated__/Partner_partner.graphql.ts
@@ -40,7 +40,13 @@ v1 = {
   "storageKey": null
 };
 return {
-  "argumentDefinitions": [],
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "input"
+    }
+  ],
   "kind": "Fragment",
   "metadata": null,
   "name": "Partner_partner",
@@ -75,7 +81,13 @@ return {
       "storageKey": null
     },
     {
-      "args": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "input",
+          "variableName": "input"
+        }
+      ],
       "kind": "FragmentSpread",
       "name": "PartnerArtwork_partner"
     },
@@ -99,5 +111,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '1c1790711f9aa1867fea2a077435e852';
+(node as any).hash = '3c7378c0461ee1ed1043f07776fb0d69';
 export default node;

--- a/src/__generated__/Partner_partner.graphql.ts
+++ b/src/__generated__/Partner_partner.graphql.ts
@@ -40,13 +40,7 @@ v1 = {
   "storageKey": null
 };
 return {
-  "argumentDefinitions": [
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "input"
-    }
-  ],
+  "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
   "name": "Partner_partner",
@@ -83,9 +77,12 @@ return {
     {
       "args": [
         {
-          "kind": "Variable",
+          "kind": "Literal",
           "name": "input",
-          "variableName": "input"
+          "value": {
+            "dimensionRange": "*-*",
+            "sort": "-partner_updated_at"
+          }
         }
       ],
       "kind": "FragmentSpread",
@@ -111,5 +108,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '3c7378c0461ee1ed1043f07776fb0d69';
+(node as any).hash = '7fa0395369fdf04450d4be9d31ceb520';
 export default node;

--- a/src/__generated__/ShowArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/ShowArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,26 +1,66 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 9eaf996e626c3f493f53ff15bbe68f9e */
+/* @relayHash ef1984353d3cac25969308bc4f559ee5 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
+export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
+export type FilterArtworksInput = {
+    acquireable?: boolean | null;
+    additionalGeneIDs?: Array<string | null> | null;
+    after?: string | null;
+    aggregationPartnerCities?: Array<string | null> | null;
+    aggregations?: Array<ArtworkAggregation | null> | null;
+    artistID?: string | null;
+    artistIDs?: Array<string | null> | null;
+    artistNationalities?: Array<string | null> | null;
+    artistSeriesID?: string | null;
+    atAuction?: boolean | null;
+    attributionClass?: Array<string | null> | null;
+    before?: string | null;
+    color?: string | null;
+    colors?: Array<string | null> | null;
+    dimensionRange?: string | null;
+    excludeArtworkIDs?: Array<string | null> | null;
+    extraAggregationGeneIDs?: Array<string | null> | null;
+    first?: number | null;
+    forSale?: boolean | null;
+    geneID?: string | null;
+    geneIDs?: Array<string | null> | null;
+    height?: string | null;
+    includeArtworksByFollowedArtists?: boolean | null;
+    includeMediumFilterInAggregation?: boolean | null;
+    inquireableOnly?: boolean | null;
+    keyword?: string | null;
+    keywordMatchExact?: boolean | null;
+    last?: number | null;
+    locationCities?: Array<string | null> | null;
+    majorPeriods?: Array<string | null> | null;
+    marketable?: boolean | null;
+    materialsTerms?: Array<string | null> | null;
+    medium?: string | null;
+    offerable?: boolean | null;
+    page?: number | null;
+    partnerCities?: Array<string | null> | null;
+    partnerID?: string | null;
+    partnerIDs?: Array<string | null> | null;
+    period?: string | null;
+    periods?: Array<string | null> | null;
+    priceRange?: string | null;
+    saleID?: string | null;
+    size?: number | null;
+    sizes?: Array<ArtworkSizes | null> | null;
+    sort?: string | null;
+    tagID?: string | null;
+    width?: string | null;
+};
 export type ShowArtworksInfiniteScrollGridQueryVariables = {
     id: string;
     count: number;
     cursor?: string | null;
-    sort?: string | null;
-    additionalGeneIDs?: Array<string | null> | null;
-    priceRange?: string | null;
-    color?: string | null;
-    colors?: Array<string | null> | null;
-    dimensionRange?: string | null;
-    majorPeriods?: Array<string | null> | null;
-    acquireable?: boolean | null;
-    inquireableOnly?: boolean | null;
-    atAuction?: boolean | null;
-    offerable?: boolean | null;
-    attributionClass?: Array<string | null> | null;
+    input?: FilterArtworksInput | null;
 };
 export type ShowArtworksInfiniteScrollGridQueryResponse = {
     readonly show: {
@@ -38,21 +78,10 @@ export type ShowArtworksInfiniteScrollGridQuery = {
 query ShowArtworksInfiniteScrollGridQuery(
   $id: String!
   $cursor: String
-  $sort: String
-  $additionalGeneIDs: [String]
-  $priceRange: String
-  $color: String
-  $colors: [String]
-  $dimensionRange: String
-  $majorPeriods: [String]
-  $acquireable: Boolean
-  $inquireableOnly: Boolean
-  $atAuction: Boolean
-  $offerable: Boolean
-  $attributionClass: [String]
+  $input: FilterArtworksInput
 ) {
   show(id: $id) {
-    ...ShowArtworks_show_46RbmC
+    ...ShowArtworks_show_YCAiB
     id
   }
 }
@@ -116,10 +145,10 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
   }
 }
 
-fragment ShowArtworks_show_46RbmC on Show {
+fragment ShowArtworks_show_YCAiB on Show {
   slug
   internalID
-  showArtworks: filterArtworksConnection(first: 30, after: $cursor, sort: $sort, additionalGeneIDs: $additionalGeneIDs, priceRange: $priceRange, color: $color, colors: $colors, dimensionRange: $dimensionRange, majorPeriods: $majorPeriods, acquireable: $acquireable, inquireableOnly: $inquireableOnly, atAuction: $atAuction, offerable: $offerable, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], attributionClass: $attributionClass) {
+  showArtworks: filterArtworksConnection(first: 30, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: $input) {
     aggregations {
       slice
       counts {
@@ -152,162 +181,50 @@ const node: ConcreteRequest = (function(){
 var v0 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "acquireable"
+  "name": "count"
 },
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "additionalGeneIDs"
+  "name": "cursor"
 },
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "atAuction"
+  "name": "id"
 },
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "attributionClass"
+  "name": "input"
 },
-v4 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "color"
-},
-v5 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "colors"
-},
-v6 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "count"
-},
-v7 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "cursor"
-},
-v8 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "dimensionRange"
-},
-v9 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "id"
-},
-v10 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "inquireableOnly"
-},
-v11 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "majorPeriods"
-},
-v12 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "offerable"
-},
-v13 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "priceRange"
-},
-v14 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "sort"
-},
-v15 = [
+v4 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v16 = {
+v5 = {
   "kind": "Variable",
-  "name": "acquireable",
-  "variableName": "acquireable"
+  "name": "input",
+  "variableName": "input"
 },
-v17 = {
-  "kind": "Variable",
-  "name": "additionalGeneIDs",
-  "variableName": "additionalGeneIDs"
-},
-v18 = {
-  "kind": "Variable",
-  "name": "atAuction",
-  "variableName": "atAuction"
-},
-v19 = {
-  "kind": "Variable",
-  "name": "attributionClass",
-  "variableName": "attributionClass"
-},
-v20 = {
-  "kind": "Variable",
-  "name": "color",
-  "variableName": "color"
-},
-v21 = {
-  "kind": "Variable",
-  "name": "colors",
-  "variableName": "colors"
-},
-v22 = {
-  "kind": "Variable",
-  "name": "dimensionRange",
-  "variableName": "dimensionRange"
-},
-v23 = {
-  "kind": "Variable",
-  "name": "inquireableOnly",
-  "variableName": "inquireableOnly"
-},
-v24 = {
-  "kind": "Variable",
-  "name": "majorPeriods",
-  "variableName": "majorPeriods"
-},
-v25 = {
-  "kind": "Variable",
-  "name": "offerable",
-  "variableName": "offerable"
-},
-v26 = {
-  "kind": "Variable",
-  "name": "priceRange",
-  "variableName": "priceRange"
-},
-v27 = {
-  "kind": "Variable",
-  "name": "sort",
-  "variableName": "sort"
-},
-v28 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v29 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v30 = [
-  (v16/*: any*/),
-  (v17/*: any*/),
+v8 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -324,37 +241,28 @@ v30 = [
       "PRICE_RANGE"
     ]
   },
-  (v18/*: any*/),
-  (v19/*: any*/),
-  (v20/*: any*/),
-  (v21/*: any*/),
-  (v22/*: any*/),
   {
     "kind": "Literal",
     "name": "first",
     "value": 30
   },
-  (v23/*: any*/),
-  (v24/*: any*/),
-  (v25/*: any*/),
-  (v26/*: any*/),
-  (v27/*: any*/)
+  (v5/*: any*/)
 ],
-v31 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v32 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v33 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -367,18 +275,7 @@ return {
       (v0/*: any*/),
       (v1/*: any*/),
       (v2/*: any*/),
-      (v3/*: any*/),
-      (v4/*: any*/),
-      (v5/*: any*/),
-      (v6/*: any*/),
-      (v7/*: any*/),
-      (v8/*: any*/),
-      (v9/*: any*/),
-      (v10/*: any*/),
-      (v11/*: any*/),
-      (v12/*: any*/),
-      (v13/*: any*/),
-      (v14/*: any*/)
+      (v3/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -386,7 +283,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v15/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": "Show",
         "kind": "LinkedField",
         "name": "show",
@@ -394,12 +291,6 @@ return {
         "selections": [
           {
             "args": [
-              (v16/*: any*/),
-              (v17/*: any*/),
-              (v18/*: any*/),
-              (v19/*: any*/),
-              (v20/*: any*/),
-              (v21/*: any*/),
               {
                 "kind": "Variable",
                 "name": "count",
@@ -410,12 +301,7 @@ return {
                 "name": "cursor",
                 "variableName": "cursor"
               },
-              (v22/*: any*/),
-              (v23/*: any*/),
-              (v24/*: any*/),
-              (v25/*: any*/),
-              (v26/*: any*/),
-              (v27/*: any*/)
+              (v5/*: any*/)
             ],
             "kind": "FragmentSpread",
             "name": "ShowArtworks_show"
@@ -430,20 +316,9 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v9/*: any*/),
-      (v6/*: any*/),
-      (v7/*: any*/),
-      (v14/*: any*/),
-      (v1/*: any*/),
-      (v13/*: any*/),
-      (v4/*: any*/),
-      (v5/*: any*/),
-      (v8/*: any*/),
-      (v11/*: any*/),
-      (v0/*: any*/),
-      (v10/*: any*/),
       (v2/*: any*/),
-      (v12/*: any*/),
+      (v0/*: any*/),
+      (v1/*: any*/),
       (v3/*: any*/)
     ],
     "kind": "Operation",
@@ -451,17 +326,17 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v15/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": "Show",
         "kind": "LinkedField",
         "name": "show",
         "plural": false,
         "selections": [
-          (v28/*: any*/),
-          (v29/*: any*/),
+          (v6/*: any*/),
+          (v7/*: any*/),
           {
             "alias": "showArtworks",
-            "args": (v30/*: any*/),
+            "args": (v8/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -497,7 +372,7 @@ return {
                         "name": "count",
                         "storageKey": null
                       },
-                      (v31/*: any*/),
+                      (v9/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -527,8 +402,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v32/*: any*/),
-                      (v33/*: any*/)
+                      (v10/*: any*/),
+                      (v11/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -585,7 +460,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v32/*: any*/),
+              (v10/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -615,7 +490,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v33/*: any*/),
+                      (v11/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -624,7 +499,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v28/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -677,7 +552,7 @@ return {
                             "name": "saleMessage",
                             "storageKey": null
                           },
-                          (v29/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -728,7 +603,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v32/*: any*/)
+                              (v10/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -783,7 +658,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v32/*: any*/)
+                              (v10/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -795,8 +670,8 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v31/*: any*/),
-                              (v32/*: any*/)
+                              (v9/*: any*/),
+                              (v10/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -806,7 +681,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v32/*: any*/)
+                          (v10/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -823,35 +698,24 @@ return {
           },
           {
             "alias": "showArtworks",
-            "args": (v30/*: any*/),
+            "args": (v8/*: any*/),
             "filters": [
-              "sort",
-              "additionalGeneIDs",
-              "priceRange",
-              "color",
-              "colors",
-              "dimensionRange",
-              "majorPeriods",
-              "acquireable",
-              "inquireableOnly",
-              "atAuction",
-              "offerable",
               "aggregations",
-              "attributionClass"
+              "input"
             ],
             "handle": "connection",
             "key": "Show_showArtworks",
             "kind": "LinkedHandle",
             "name": "filterArtworksConnection"
           },
-          (v32/*: any*/)
+          (v10/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "9eaf996e626c3f493f53ff15bbe68f9e",
+    "id": "ef1984353d3cac25969308bc4f559ee5",
     "metadata": {},
     "name": "ShowArtworksInfiniteScrollGridQuery",
     "operationKind": "query",
@@ -859,5 +723,5 @@ return {
   }
 };
 })();
-(node as any).hash = 'ef67db40cfefdf53c286e4286c7f5293';
+(node as any).hash = '32c8ec98900b452cf421ee3f6399311b';
 export default node;

--- a/src/__generated__/ShowArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/ShowArtworksTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 3d32e5c1e9160ef29b2474f9d23b6051 */
+/* @relayHash ca9af872bd452240be255696af557338 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -92,7 +92,7 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
 fragment ShowArtworks_show on Show {
   slug
   internalID
-  showArtworks: filterArtworksConnection(first: 30, sort: "partner_show_position", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  showArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -164,18 +164,8 @@ v4 = [
   },
   {
     "kind": "Literal",
-    "name": "dimensionRange",
-    "value": "*-*"
-  },
-  {
-    "kind": "Literal",
     "name": "first",
     "value": 30
-  },
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "partner_show_position"
   }
 ],
 v5 = {
@@ -632,25 +622,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:30,sort:\"partner_show_position\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:30)"
           },
           {
             "alias": "showArtworks",
             "args": (v4/*: any*/),
             "filters": [
-              "sort",
-              "additionalGeneIDs",
-              "priceRange",
-              "color",
-              "colors",
-              "dimensionRange",
-              "majorPeriods",
-              "acquireable",
-              "inquireableOnly",
-              "atAuction",
-              "offerable",
               "aggregations",
-              "attributionClass"
+              "input"
             ],
             "handle": "connection",
             "key": "Show_showArtworks",
@@ -664,7 +643,7 @@ return {
     ]
   },
   "params": {
-    "id": "3d32e5c1e9160ef29b2474f9d23b6051",
+    "id": "ca9af872bd452240be255696af557338",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "show": {

--- a/src/__generated__/ShowArtworks_show.graphql.ts
+++ b/src/__generated__/ShowArtworks_show.graphql.ts
@@ -40,36 +40,6 @@ export type ShowArtworks_show$key = {
 const node: ReaderFragment = {
   "argumentDefinitions": [
     {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "acquireable"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "additionalGeneIDs"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "atAuction"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "attributionClass"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "color"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "colors"
-    },
-    {
       "defaultValue": 30,
       "kind": "LocalArgument",
       "name": "count"
@@ -80,34 +50,9 @@ const node: ReaderFragment = {
       "name": "cursor"
     },
     {
-      "defaultValue": "*-*",
-      "kind": "LocalArgument",
-      "name": "dimensionRange"
-    },
-    {
       "defaultValue": null,
       "kind": "LocalArgument",
-      "name": "inquireableOnly"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "majorPeriods"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "offerable"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "priceRange"
-    },
-    {
-      "defaultValue": "partner_show_position",
-      "kind": "LocalArgument",
-      "name": "sort"
+      "name": "input"
     }
   ],
   "kind": "Fragment",
@@ -143,16 +88,6 @@ const node: ReaderFragment = {
       "alias": "showArtworks",
       "args": [
         {
-          "kind": "Variable",
-          "name": "acquireable",
-          "variableName": "acquireable"
-        },
-        {
-          "kind": "Variable",
-          "name": "additionalGeneIDs",
-          "variableName": "additionalGeneIDs"
-        },
-        {
           "kind": "Literal",
           "name": "aggregations",
           "value": [
@@ -165,53 +100,8 @@ const node: ReaderFragment = {
         },
         {
           "kind": "Variable",
-          "name": "atAuction",
-          "variableName": "atAuction"
-        },
-        {
-          "kind": "Variable",
-          "name": "attributionClass",
-          "variableName": "attributionClass"
-        },
-        {
-          "kind": "Variable",
-          "name": "color",
-          "variableName": "color"
-        },
-        {
-          "kind": "Variable",
-          "name": "colors",
-          "variableName": "colors"
-        },
-        {
-          "kind": "Variable",
-          "name": "dimensionRange",
-          "variableName": "dimensionRange"
-        },
-        {
-          "kind": "Variable",
-          "name": "inquireableOnly",
-          "variableName": "inquireableOnly"
-        },
-        {
-          "kind": "Variable",
-          "name": "majorPeriods",
-          "variableName": "majorPeriods"
-        },
-        {
-          "kind": "Variable",
-          "name": "offerable",
-          "variableName": "offerable"
-        },
-        {
-          "kind": "Variable",
-          "name": "priceRange",
-          "variableName": "priceRange"
-        },
-        {
-          "kind": "Variable",
-          "name": "sort",
-          "variableName": "sort"
+          "name": "input",
+          "variableName": "input"
         }
       ],
       "concreteType": "FilterArtworksConnection",
@@ -367,5 +257,5 @@ const node: ReaderFragment = {
   "type": "Show",
   "abstractKey": null
 };
-(node as any).hash = 'a0da59964bcf6b0e086f24d0afca7043';
+(node as any).hash = '2880f17c827447d2d0c4b9ea06bdbb81';
 export default node;

--- a/src/__generated__/ShowQuery.graphql.ts
+++ b/src/__generated__/ShowQuery.graphql.ts
@@ -1,64 +1,12 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash e94a57a05ddb51ffc20ddafb6425b062 */
+/* @relayHash 9aacffa102c972bbf14d296c779b83ba */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
-export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
-export type FilterArtworksInput = {
-    acquireable?: boolean | null;
-    additionalGeneIDs?: Array<string | null> | null;
-    after?: string | null;
-    aggregationPartnerCities?: Array<string | null> | null;
-    aggregations?: Array<ArtworkAggregation | null> | null;
-    artistID?: string | null;
-    artistIDs?: Array<string | null> | null;
-    artistNationalities?: Array<string | null> | null;
-    artistSeriesID?: string | null;
-    atAuction?: boolean | null;
-    attributionClass?: Array<string | null> | null;
-    before?: string | null;
-    color?: string | null;
-    colors?: Array<string | null> | null;
-    dimensionRange?: string | null;
-    excludeArtworkIDs?: Array<string | null> | null;
-    extraAggregationGeneIDs?: Array<string | null> | null;
-    first?: number | null;
-    forSale?: boolean | null;
-    geneID?: string | null;
-    geneIDs?: Array<string | null> | null;
-    height?: string | null;
-    includeArtworksByFollowedArtists?: boolean | null;
-    includeMediumFilterInAggregation?: boolean | null;
-    inquireableOnly?: boolean | null;
-    keyword?: string | null;
-    keywordMatchExact?: boolean | null;
-    last?: number | null;
-    locationCities?: Array<string | null> | null;
-    majorPeriods?: Array<string | null> | null;
-    marketable?: boolean | null;
-    materialsTerms?: Array<string | null> | null;
-    medium?: string | null;
-    offerable?: boolean | null;
-    page?: number | null;
-    partnerCities?: Array<string | null> | null;
-    partnerID?: string | null;
-    partnerIDs?: Array<string | null> | null;
-    period?: string | null;
-    periods?: Array<string | null> | null;
-    priceRange?: string | null;
-    saleID?: string | null;
-    size?: number | null;
-    sizes?: Array<ArtworkSizes | null> | null;
-    sort?: string | null;
-    tagID?: string | null;
-    width?: string | null;
-};
 export type ShowQueryVariables = {
     showID: string;
-    input?: FilterArtworksInput | null;
 };
 export type ShowQueryResponse = {
     readonly show: {
@@ -75,10 +23,9 @@ export type ShowQuery = {
 /*
 query ShowQuery(
   $showID: String!
-  $input: FilterArtworksInput
 ) {
   show(id: $showID) @principalField {
-    ...Show_show_2VV6jB
+    ...Show_show
     id
   }
 }
@@ -147,10 +94,10 @@ fragment ShowArtworksEmptyState_show on Show {
   status
 }
 
-fragment ShowArtworks_show_2VV6jB on Show {
+fragment ShowArtworks_show_1lt5O6 on Show {
   slug
   internalID
-  showArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: $input) {
+  showArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: {sort: "partner_show_position", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -307,7 +254,7 @@ fragment ShowViewingRoom_show on Show {
   }
 }
 
-fragment Show_show_2VV6jB on Show {
+fragment Show_show on Show {
   internalID
   slug
   ...ShowHeader_show
@@ -315,7 +262,7 @@ fragment Show_show_2VV6jB on Show {
   ...ShowInfo_show
   ...ShowViewingRoom_show
   ...ShowContextCard_show
-  ...ShowArtworks_show_2VV6jB
+  ...ShowArtworks_show_1lt5O6
   ...ShowArtworksEmptyState_show
   viewingRoomIDs
   images(default: false) {
@@ -328,111 +275,103 @@ fragment Show_show_2VV6jB on Show {
 */
 
 const node: ConcreteRequest = (function(){
-var v0 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "input"
-},
-v1 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "showID"
-},
-v2 = [
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "showID"
+  }
+],
+v1 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "showID"
   }
 ],
-v3 = {
-  "kind": "Variable",
-  "name": "input",
-  "variableName": "input"
-},
-v4 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v5 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v6 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v7 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v8 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v9 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v10 = [
-  (v6/*: any*/),
-  (v9/*: any*/)
+v8 = [
+  (v4/*: any*/),
+  (v7/*: any*/)
 ],
-v11 = {
+v9 = {
   "kind": "InlineFragment",
   "selections": [
-    (v9/*: any*/)
+    (v7/*: any*/)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v12 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v13 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "title",
   "storageKey": null
 },
-v14 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "status",
   "storageKey": null
 },
-v15 = [
+v13 = [
   {
     "kind": "Literal",
     "name": "short",
     "value": true
   }
 ],
-v16 = [
+v14 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -449,30 +388,32 @@ v16 = [
     "name": "first",
     "value": 30
   },
-  (v3/*: any*/)
+  {
+    "kind": "Literal",
+    "name": "input",
+    "value": {
+      "dimensionRange": "*-*",
+      "sort": "partner_show_position"
+    }
+  }
 ];
 return {
   "fragment": {
-    "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "ShowQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v2/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": "Show",
         "kind": "LinkedField",
         "name": "show",
         "plural": false,
         "selections": [
           {
-            "args": [
-              (v3/*: any*/)
-            ],
+            "args": null,
             "kind": "FragmentSpread",
             "name": "Show_show"
           }
@@ -485,24 +426,21 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": [
-      (v1/*: any*/),
-      (v0/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "ShowQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v2/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": "Show",
         "kind": "LinkedField",
         "name": "show",
         "plural": false,
         "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
           (v4/*: any*/),
-          (v5/*: any*/),
-          (v6/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -510,7 +448,7 @@ return {
             "name": "startAt",
             "storageKey": null
           },
-          (v7/*: any*/),
+          (v5/*: any*/),
           {
             "alias": "formattedStartAt",
             "args": [
@@ -545,13 +483,13 @@ return {
             "name": "partner",
             "plural": false,
             "selections": [
-              (v8/*: any*/),
+              (v6/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v6/*: any*/),
                   (v4/*: any*/),
-                  (v5/*: any*/),
+                  (v2/*: any*/),
+                  (v3/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -560,8 +498,8 @@ return {
                     "name": "profile",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/),
-                      (v9/*: any*/)
+                      (v3/*: any*/),
+                      (v7/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -631,7 +569,7 @@ return {
                                 ],
                                 "storageKey": null
                               },
-                              (v9/*: any*/)
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -647,11 +585,11 @@ return {
               },
               {
                 "kind": "InlineFragment",
-                "selections": (v10/*: any*/),
+                "selections": (v8/*: any*/),
                 "type": "ExternalPartner",
                 "abstractKey": null
               },
-              (v11/*: any*/)
+              (v9/*: any*/)
             ],
             "storageKey": null
           },
@@ -669,7 +607,7 @@ return {
             "name": "images",
             "plural": true,
             "selections": [
-              (v4/*: any*/),
+              (v2/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -724,11 +662,11 @@ return {
                 ],
                 "storageKey": "resized(height:300)"
               },
-              (v8/*: any*/)
+              (v6/*: any*/)
             ],
             "storageKey": "images(default:false)"
           },
-          (v12/*: any*/),
+          (v10/*: any*/),
           {
             "alias": "about",
             "args": null,
@@ -760,25 +698,25 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
-                      (v5/*: any*/),
-                      (v13/*: any*/),
-                      (v14/*: any*/),
+                      (v2/*: any*/),
+                      (v3/*: any*/),
+                      (v11/*: any*/),
+                      (v12/*: any*/),
                       {
                         "alias": null,
-                        "args": (v15/*: any*/),
+                        "args": (v13/*: any*/),
                         "kind": "ScalarField",
                         "name": "distanceToOpen",
                         "storageKey": "distanceToOpen(short:true)"
                       },
                       {
                         "alias": null,
-                        "args": (v15/*: any*/),
+                        "args": (v13/*: any*/),
                         "kind": "ScalarField",
                         "name": "distanceToClose",
                         "storageKey": "distanceToClose(short:true)"
                       },
-                      (v12/*: any*/),
+                      (v10/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -832,9 +770,9 @@ return {
             "name": "fair",
             "plural": false,
             "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
               (v4/*: any*/),
-              (v5/*: any*/),
-              (v6/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -874,7 +812,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v9/*: any*/)
+                  (v7/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -902,13 +840,13 @@ return {
                 ],
                 "storageKey": null
               },
-              (v9/*: any*/)
+              (v7/*: any*/)
             ],
             "storageKey": null
           },
           {
             "alias": "showArtworks",
-            "args": (v16/*: any*/),
+            "args": (v14/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -944,7 +882,7 @@ return {
                         "name": "count",
                         "storageKey": null
                       },
-                      (v6/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -974,8 +912,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v9/*: any*/),
-                      (v8/*: any*/)
+                      (v7/*: any*/),
+                      (v6/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -1032,7 +970,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v9/*: any*/),
+              (v7/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -1062,7 +1000,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v8/*: any*/),
+                      (v6/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1071,7 +1009,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v3/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1103,7 +1041,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v13/*: any*/),
+                          (v11/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1118,7 +1056,7 @@ return {
                             "name": "saleMessage",
                             "storageKey": null
                           },
-                          (v4/*: any*/),
+                          (v2/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1126,7 +1064,7 @@ return {
                             "name": "artistNames",
                             "storageKey": null
                           },
-                          (v12/*: any*/),
+                          (v10/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1156,8 +1094,8 @@ return {
                                 "name": "displayTimelyAt",
                                 "storageKey": null
                               },
-                              (v7/*: any*/),
-                              (v9/*: any*/)
+                              (v5/*: any*/),
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1212,7 +1150,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v9/*: any*/)
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1223,13 +1161,13 @@ return {
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
-                            "selections": (v10/*: any*/),
+                            "selections": (v8/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
-                      (v11/*: any*/)
+                      (v9/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1238,11 +1176,11 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": null
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"partner_show_position\"})"
           },
           {
             "alias": "showArtworks",
-            "args": (v16/*: any*/),
+            "args": (v14/*: any*/),
             "filters": [
               "aggregations",
               "input"
@@ -1252,7 +1190,7 @@ return {
             "kind": "LinkedHandle",
             "name": "filterArtworksConnection"
           },
-          (v14/*: any*/),
+          (v12/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -1278,14 +1216,14 @@ return {
             ],
             "storageKey": null
           },
-          (v9/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "e94a57a05ddb51ffc20ddafb6425b062",
+    "id": "9aacffa102c972bbf14d296c779b83ba",
     "metadata": {},
     "name": "ShowQuery",
     "operationKind": "query",
@@ -1293,5 +1231,5 @@ return {
   }
 };
 })();
-(node as any).hash = '07511cb0f3c0c706d38f3bdd0b90da3b';
+(node as any).hash = 'd8007c357e4cab7f008a47fb2405291c';
 export default node;

--- a/src/__generated__/ShowQuery.graphql.ts
+++ b/src/__generated__/ShowQuery.graphql.ts
@@ -1,12 +1,64 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash a766e14baa264bd8580e53a1cd499043 */
+/* @relayHash e94a57a05ddb51ffc20ddafb6425b062 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
+export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
+export type FilterArtworksInput = {
+    acquireable?: boolean | null;
+    additionalGeneIDs?: Array<string | null> | null;
+    after?: string | null;
+    aggregationPartnerCities?: Array<string | null> | null;
+    aggregations?: Array<ArtworkAggregation | null> | null;
+    artistID?: string | null;
+    artistIDs?: Array<string | null> | null;
+    artistNationalities?: Array<string | null> | null;
+    artistSeriesID?: string | null;
+    atAuction?: boolean | null;
+    attributionClass?: Array<string | null> | null;
+    before?: string | null;
+    color?: string | null;
+    colors?: Array<string | null> | null;
+    dimensionRange?: string | null;
+    excludeArtworkIDs?: Array<string | null> | null;
+    extraAggregationGeneIDs?: Array<string | null> | null;
+    first?: number | null;
+    forSale?: boolean | null;
+    geneID?: string | null;
+    geneIDs?: Array<string | null> | null;
+    height?: string | null;
+    includeArtworksByFollowedArtists?: boolean | null;
+    includeMediumFilterInAggregation?: boolean | null;
+    inquireableOnly?: boolean | null;
+    keyword?: string | null;
+    keywordMatchExact?: boolean | null;
+    last?: number | null;
+    locationCities?: Array<string | null> | null;
+    majorPeriods?: Array<string | null> | null;
+    marketable?: boolean | null;
+    materialsTerms?: Array<string | null> | null;
+    medium?: string | null;
+    offerable?: boolean | null;
+    page?: number | null;
+    partnerCities?: Array<string | null> | null;
+    partnerID?: string | null;
+    partnerIDs?: Array<string | null> | null;
+    period?: string | null;
+    periods?: Array<string | null> | null;
+    priceRange?: string | null;
+    saleID?: string | null;
+    size?: number | null;
+    sizes?: Array<ArtworkSizes | null> | null;
+    sort?: string | null;
+    tagID?: string | null;
+    width?: string | null;
+};
 export type ShowQueryVariables = {
     showID: string;
+    input?: FilterArtworksInput | null;
 };
 export type ShowQueryResponse = {
     readonly show: {
@@ -23,9 +75,10 @@ export type ShowQuery = {
 /*
 query ShowQuery(
   $showID: String!
+  $input: FilterArtworksInput
 ) {
   show(id: $showID) @principalField {
-    ...Show_show
+    ...Show_show_2VV6jB
     id
   }
 }
@@ -94,10 +147,10 @@ fragment ShowArtworksEmptyState_show on Show {
   status
 }
 
-fragment ShowArtworks_show on Show {
+fragment ShowArtworks_show_2VV6jB on Show {
   slug
   internalID
-  showArtworks: filterArtworksConnection(first: 30, sort: "partner_show_position", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  showArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: $input) {
     aggregations {
       slice
       counts {
@@ -254,7 +307,7 @@ fragment ShowViewingRoom_show on Show {
   }
 }
 
-fragment Show_show on Show {
+fragment Show_show_2VV6jB on Show {
   internalID
   slug
   ...ShowHeader_show
@@ -262,7 +315,7 @@ fragment Show_show on Show {
   ...ShowInfo_show
   ...ShowViewingRoom_show
   ...ShowContextCard_show
-  ...ShowArtworks_show
+  ...ShowArtworks_show_2VV6jB
   ...ShowArtworksEmptyState_show
   viewingRoomIDs
   images(default: false) {
@@ -275,103 +328,111 @@ fragment Show_show on Show {
 */
 
 const node: ConcreteRequest = (function(){
-var v0 = [
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "showID"
-  }
-],
-v1 = [
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "showID"
+},
+v2 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "showID"
   }
 ],
-v2 = {
+v3 = {
+  "kind": "Variable",
+  "name": "input",
+  "variableName": "input"
+},
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v3 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v4 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v5 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v6 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v7 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v8 = [
-  (v4/*: any*/),
-  (v7/*: any*/)
+v10 = [
+  (v6/*: any*/),
+  (v9/*: any*/)
 ],
-v9 = {
+v11 = {
   "kind": "InlineFragment",
   "selections": [
-    (v7/*: any*/)
+    (v9/*: any*/)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v10 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v11 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "title",
   "storageKey": null
 },
-v12 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "status",
   "storageKey": null
 },
-v13 = [
+v15 = [
   {
     "kind": "Literal",
     "name": "short",
     "value": true
   }
 ],
-v14 = [
+v16 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -385,37 +446,33 @@ v14 = [
   },
   {
     "kind": "Literal",
-    "name": "dimensionRange",
-    "value": "*-*"
-  },
-  {
-    "kind": "Literal",
     "name": "first",
     "value": 30
   },
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "partner_show_position"
-  }
+  (v3/*: any*/)
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
     "kind": "Fragment",
     "metadata": null,
     "name": "ShowQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v2/*: any*/),
         "concreteType": "Show",
         "kind": "LinkedField",
         "name": "show",
         "plural": false,
         "selections": [
           {
-            "args": null,
+            "args": [
+              (v3/*: any*/)
+            ],
             "kind": "FragmentSpread",
             "name": "Show_show"
           }
@@ -428,21 +485,24 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
     "kind": "Operation",
     "name": "ShowQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v2/*: any*/),
         "concreteType": "Show",
         "kind": "LinkedField",
         "name": "show",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
-          (v3/*: any*/),
           (v4/*: any*/),
+          (v5/*: any*/),
+          (v6/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -450,7 +510,7 @@ return {
             "name": "startAt",
             "storageKey": null
           },
-          (v5/*: any*/),
+          (v7/*: any*/),
           {
             "alias": "formattedStartAt",
             "args": [
@@ -485,13 +545,13 @@ return {
             "name": "partner",
             "plural": false,
             "selections": [
-              (v6/*: any*/),
+              (v8/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
+                  (v6/*: any*/),
                   (v4/*: any*/),
-                  (v2/*: any*/),
-                  (v3/*: any*/),
+                  (v5/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -500,8 +560,8 @@ return {
                     "name": "profile",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
-                      (v7/*: any*/)
+                      (v5/*: any*/),
+                      (v9/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -571,7 +631,7 @@ return {
                                 ],
                                 "storageKey": null
                               },
-                              (v7/*: any*/)
+                              (v9/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -587,11 +647,11 @@ return {
               },
               {
                 "kind": "InlineFragment",
-                "selections": (v8/*: any*/),
+                "selections": (v10/*: any*/),
                 "type": "ExternalPartner",
                 "abstractKey": null
               },
-              (v9/*: any*/)
+              (v11/*: any*/)
             ],
             "storageKey": null
           },
@@ -609,7 +669,7 @@ return {
             "name": "images",
             "plural": true,
             "selections": [
-              (v2/*: any*/),
+              (v4/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -664,11 +724,11 @@ return {
                 ],
                 "storageKey": "resized(height:300)"
               },
-              (v6/*: any*/)
+              (v8/*: any*/)
             ],
             "storageKey": "images(default:false)"
           },
-          (v10/*: any*/),
+          (v12/*: any*/),
           {
             "alias": "about",
             "args": null,
@@ -700,25 +760,25 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v2/*: any*/),
-                      (v3/*: any*/),
-                      (v11/*: any*/),
-                      (v12/*: any*/),
+                      (v4/*: any*/),
+                      (v5/*: any*/),
+                      (v13/*: any*/),
+                      (v14/*: any*/),
                       {
                         "alias": null,
-                        "args": (v13/*: any*/),
+                        "args": (v15/*: any*/),
                         "kind": "ScalarField",
                         "name": "distanceToOpen",
                         "storageKey": "distanceToOpen(short:true)"
                       },
                       {
                         "alias": null,
-                        "args": (v13/*: any*/),
+                        "args": (v15/*: any*/),
                         "kind": "ScalarField",
                         "name": "distanceToClose",
                         "storageKey": "distanceToClose(short:true)"
                       },
-                      (v10/*: any*/),
+                      (v12/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -772,9 +832,9 @@ return {
             "name": "fair",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
-              (v3/*: any*/),
               (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -814,7 +874,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v7/*: any*/)
+                  (v9/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -842,13 +902,13 @@ return {
                 ],
                 "storageKey": null
               },
-              (v7/*: any*/)
+              (v9/*: any*/)
             ],
             "storageKey": null
           },
           {
             "alias": "showArtworks",
-            "args": (v14/*: any*/),
+            "args": (v16/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -884,7 +944,7 @@ return {
                         "name": "count",
                         "storageKey": null
                       },
-                      (v4/*: any*/),
+                      (v6/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -914,8 +974,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v7/*: any*/),
-                      (v6/*: any*/)
+                      (v9/*: any*/),
+                      (v8/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -972,7 +1032,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v7/*: any*/),
+              (v9/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -1002,7 +1062,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v6/*: any*/),
+                      (v8/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1011,7 +1071,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v3/*: any*/),
+                          (v5/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1043,7 +1103,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v11/*: any*/),
+                          (v13/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1058,7 +1118,7 @@ return {
                             "name": "saleMessage",
                             "storageKey": null
                           },
-                          (v2/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1066,7 +1126,7 @@ return {
                             "name": "artistNames",
                             "storageKey": null
                           },
-                          (v10/*: any*/),
+                          (v12/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1096,8 +1156,8 @@ return {
                                 "name": "displayTimelyAt",
                                 "storageKey": null
                               },
-                              (v5/*: any*/),
-                              (v7/*: any*/)
+                              (v7/*: any*/),
+                              (v9/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1152,7 +1212,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v7/*: any*/)
+                              (v9/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1163,13 +1223,13 @@ return {
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
-                            "selections": (v8/*: any*/),
+                            "selections": (v10/*: any*/),
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
-                      (v9/*: any*/)
+                      (v11/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1178,32 +1238,21 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:30,sort:\"partner_show_position\")"
+            "storageKey": null
           },
           {
             "alias": "showArtworks",
-            "args": (v14/*: any*/),
+            "args": (v16/*: any*/),
             "filters": [
-              "sort",
-              "additionalGeneIDs",
-              "priceRange",
-              "color",
-              "colors",
-              "dimensionRange",
-              "majorPeriods",
-              "acquireable",
-              "inquireableOnly",
-              "atAuction",
-              "offerable",
               "aggregations",
-              "attributionClass"
+              "input"
             ],
             "handle": "connection",
             "key": "Show_showArtworks",
             "kind": "LinkedHandle",
             "name": "filterArtworksConnection"
           },
-          (v12/*: any*/),
+          (v14/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -1229,14 +1278,14 @@ return {
             ],
             "storageKey": null
           },
-          (v7/*: any*/)
+          (v9/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "a766e14baa264bd8580e53a1cd499043",
+    "id": "e94a57a05ddb51ffc20ddafb6425b062",
     "metadata": {},
     "name": "ShowQuery",
     "operationKind": "query",
@@ -1244,5 +1293,5 @@ return {
   }
 };
 })();
-(node as any).hash = 'd8007c357e4cab7f008a47fb2405291c';
+(node as any).hash = '07511cb0f3c0c706d38f3bdd0b90da3b';
 export default node;

--- a/src/__generated__/ShowTestsQuery.graphql.ts
+++ b/src/__generated__/ShowTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash bba942b2dc2cf6860a4df3c00dc10573 */
+/* @relayHash 45f57778dfdd547f4a8158fab8a90491 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -94,10 +94,10 @@ fragment ShowArtworksEmptyState_show on Show {
   status
 }
 
-fragment ShowArtworks_show on Show {
+fragment ShowArtworks_show_4g78v5 on Show {
   slug
   internalID
-  showArtworks: filterArtworksConnection(first: 30, sort: "partner_show_position", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  showArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -262,7 +262,7 @@ fragment Show_show on Show {
   ...ShowInfo_show
   ...ShowViewingRoom_show
   ...ShowContextCard_show
-  ...ShowArtworks_show
+  ...ShowArtworks_show_4g78v5
   ...ShowArtworksEmptyState_show
   viewingRoomIDs
   images(default: false) {
@@ -385,18 +385,8 @@ v14 = [
   },
   {
     "kind": "Literal",
-    "name": "dimensionRange",
-    "value": "*-*"
-  },
-  {
-    "kind": "Literal",
     "name": "first",
     "value": 30
-  },
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "partner_show_position"
   }
 ],
 v15 = {
@@ -1232,25 +1222,14 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:30,sort:\"partner_show_position\")"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:30)"
           },
           {
             "alias": "showArtworks",
             "args": (v14/*: any*/),
             "filters": [
-              "sort",
-              "additionalGeneIDs",
-              "priceRange",
-              "color",
-              "colors",
-              "dimensionRange",
-              "majorPeriods",
-              "acquireable",
-              "inquireableOnly",
-              "atAuction",
-              "offerable",
               "aggregations",
-              "attributionClass"
+              "input"
             ],
             "handle": "connection",
             "key": "Show_showArtworks",
@@ -1290,7 +1269,7 @@ return {
     ]
   },
   "params": {
-    "id": "bba942b2dc2cf6860a4df3c00dc10573",
+    "id": "45f57778dfdd547f4a8158fab8a90491",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "show": {

--- a/src/__generated__/ShowTestsQuery.graphql.ts
+++ b/src/__generated__/ShowTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 45f57778dfdd547f4a8158fab8a90491 */
+/* @relayHash dfaaeb4310bf893d19130b6235ec55d7 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -94,10 +94,10 @@ fragment ShowArtworksEmptyState_show on Show {
   status
 }
 
-fragment ShowArtworks_show_4g78v5 on Show {
+fragment ShowArtworks_show_1lt5O6 on Show {
   slug
   internalID
-  showArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  showArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: {sort: "partner_show_position", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -262,7 +262,7 @@ fragment Show_show on Show {
   ...ShowInfo_show
   ...ShowViewingRoom_show
   ...ShowContextCard_show
-  ...ShowArtworks_show_4g78v5
+  ...ShowArtworks_show_1lt5O6
   ...ShowArtworksEmptyState_show
   viewingRoomIDs
   images(default: false) {
@@ -387,6 +387,14 @@ v14 = [
     "kind": "Literal",
     "name": "first",
     "value": 30
+  },
+  {
+    "kind": "Literal",
+    "name": "input",
+    "value": {
+      "dimensionRange": "*-*",
+      "sort": "partner_show_position"
+    }
   }
 ],
 v15 = {
@@ -1222,7 +1230,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:30)"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"partner_show_position\"})"
           },
           {
             "alias": "showArtworks",
@@ -1269,7 +1277,7 @@ return {
     ]
   },
   "params": {
-    "id": "45f57778dfdd547f4a8158fab8a90491",
+    "id": "dfaaeb4310bf893d19130b6235ec55d7",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "show": {

--- a/src/__generated__/Show_show.graphql.ts
+++ b/src/__generated__/Show_show.graphql.ts
@@ -26,13 +26,7 @@ export type Show_show$key = {
 
 
 const node: ReaderFragment = {
-  "argumentDefinitions": [
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "input"
-    }
-  ],
+  "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
   "name": "Show_show",
@@ -128,9 +122,12 @@ const node: ReaderFragment = {
     {
       "args": [
         {
-          "kind": "Variable",
+          "kind": "Literal",
           "name": "input",
-          "variableName": "input"
+          "value": {
+            "dimensionRange": "*-*",
+            "sort": "partner_show_position"
+          }
         }
       ],
       "kind": "FragmentSpread",
@@ -145,5 +142,5 @@ const node: ReaderFragment = {
   "type": "Show",
   "abstractKey": null
 };
-(node as any).hash = '93c46afb77d259263205cc3c864936f7';
+(node as any).hash = '447380f516cb2f55083c2ad2c9153b61';
 export default node;

--- a/src/__generated__/Show_show.graphql.ts
+++ b/src/__generated__/Show_show.graphql.ts
@@ -26,7 +26,13 @@ export type Show_show$key = {
 
 
 const node: ReaderFragment = {
-  "argumentDefinitions": [],
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "input"
+    }
+  ],
   "kind": "Fragment",
   "metadata": null,
   "name": "Show_show",
@@ -120,7 +126,13 @@ const node: ReaderFragment = {
       "name": "ShowContextCard_show"
     },
     {
-      "args": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "input",
+          "variableName": "input"
+        }
+      ],
       "kind": "FragmentSpread",
       "name": "ShowArtworks_show"
     },
@@ -133,5 +145,5 @@ const node: ReaderFragment = {
   "type": "Show",
   "abstractKey": null
 };
-(node as any).hash = 'f181f393f2512c84f307c68b11f5a547';
+(node as any).hash = '93c46afb77d259263205cc3c864936f7';
 export default node;

--- a/src/__generated__/VanityURLEntityQuery.graphql.ts
+++ b/src/__generated__/VanityURLEntityQuery.graphql.ts
@@ -1,64 +1,12 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 33665c132f7f567d8d0525cad442a71c */
+/* @relayHash c60501172b216c0fa313574a5d5fe019 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
-export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
-export type FilterArtworksInput = {
-    acquireable?: boolean | null;
-    additionalGeneIDs?: Array<string | null> | null;
-    after?: string | null;
-    aggregationPartnerCities?: Array<string | null> | null;
-    aggregations?: Array<ArtworkAggregation | null> | null;
-    artistID?: string | null;
-    artistIDs?: Array<string | null> | null;
-    artistNationalities?: Array<string | null> | null;
-    artistSeriesID?: string | null;
-    atAuction?: boolean | null;
-    attributionClass?: Array<string | null> | null;
-    before?: string | null;
-    color?: string | null;
-    colors?: Array<string | null> | null;
-    dimensionRange?: string | null;
-    excludeArtworkIDs?: Array<string | null> | null;
-    extraAggregationGeneIDs?: Array<string | null> | null;
-    first?: number | null;
-    forSale?: boolean | null;
-    geneID?: string | null;
-    geneIDs?: Array<string | null> | null;
-    height?: string | null;
-    includeArtworksByFollowedArtists?: boolean | null;
-    includeMediumFilterInAggregation?: boolean | null;
-    inquireableOnly?: boolean | null;
-    keyword?: string | null;
-    keywordMatchExact?: boolean | null;
-    last?: number | null;
-    locationCities?: Array<string | null> | null;
-    majorPeriods?: Array<string | null> | null;
-    marketable?: boolean | null;
-    materialsTerms?: Array<string | null> | null;
-    medium?: string | null;
-    offerable?: boolean | null;
-    page?: number | null;
-    partnerCities?: Array<string | null> | null;
-    partnerID?: string | null;
-    partnerIDs?: Array<string | null> | null;
-    period?: string | null;
-    periods?: Array<string | null> | null;
-    priceRange?: string | null;
-    saleID?: string | null;
-    size?: number | null;
-    sizes?: Array<ArtworkSizes | null> | null;
-    sort?: string | null;
-    tagID?: string | null;
-    width?: string | null;
-};
 export type VanityURLEntityQueryVariables = {
     id: string;
-    input?: FilterArtworksInput | null;
 };
 export type VanityURLEntityQueryResponse = {
     readonly vanityURLEntity: {
@@ -75,11 +23,10 @@ export type VanityURLEntityQuery = {
 /*
 query VanityURLEntityQuery(
   $id: String!
-  $input: FilterArtworksInput
 ) {
   vanityURLEntity(id: $id) {
     __typename
-    ...VanityURLEntity_fairOrPartner_2VV6jB
+    ...VanityURLEntity_fairOrPartner
     ... on Node {
       __isNode: __typename
       id
@@ -149,10 +96,10 @@ fragment ArtworkTileRailCard_artwork on Artwork {
   saleMessage
 }
 
-fragment FairArtworks_fair_4g78v5 on Fair {
+fragment FairArtworks_fair_2T6kBV on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -415,7 +362,7 @@ fragment Fair_fair on Fair {
   ...FairEmptyState_fair
   ...FairEditorial_fair
   ...FairCollections_fair
-  ...FairArtworks_fair_4g78v5
+  ...FairArtworks_fair_2T6kBV
   ...FairExhibitors_fair
   ...FairFollowedArtistsRail_fair
 }
@@ -444,10 +391,10 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
   }
 }
 
-fragment PartnerArtwork_partner_2VV6jB on Partner {
+fragment PartnerArtwork_partner_BRGa6 on Partner {
   internalID
   slug
-  artworks: filterArtworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: $input) {
+  artworks: filterArtworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: {sort: "-partner_updated_at", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -625,7 +572,7 @@ fragment PartnerShows_partner on Partner {
   ...PartnerShowsRail_partner
 }
 
-fragment Partner_partner_2VV6jB on Partner {
+fragment Partner_partner on Partner {
   id
   internalID
   slug
@@ -634,13 +581,13 @@ fragment Partner_partner_2VV6jB on Partner {
     isFollowed
     internalID
   }
-  ...PartnerArtwork_partner_2VV6jB
+  ...PartnerArtwork_partner_BRGa6
   ...PartnerOverview_partner
   ...PartnerShows_partner
   ...PartnerHeader_partner
 }
 
-fragment VanityURLEntity_fairOrPartner_2VV6jB on VanityURLEntityType {
+fragment VanityURLEntity_fairOrPartner on VanityURLEntityType {
   __isVanityURLEntityType: __typename
   __typename
   ... on Fair {
@@ -648,7 +595,7 @@ fragment VanityURLEntity_fairOrPartner_2VV6jB on VanityURLEntityType {
     ...Fair_fair
   }
   ... on Partner {
-    ...Partner_partner_2VV6jB
+    ...Partner_partner
   }
 }
 */
@@ -659,11 +606,6 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "id"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "input"
   }
 ],
 v1 = [
@@ -674,140 +616,135 @@ v1 = [
   }
 ],
 v2 = {
-  "kind": "Variable",
-  "name": "input",
-  "variableName": "input"
-},
-v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v5 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v6 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "title",
   "storageKey": null
 },
-v8 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v9 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "totalCount",
   "storageKey": null
 },
-v10 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "artworks",
   "storageKey": null
 },
-v11 = {
+v10 = {
   "kind": "Literal",
   "name": "first",
   "value": 20
 },
-v12 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "artistNames",
   "storageKey": null
 },
-v13 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "imageURL",
   "storageKey": null
 },
-v14 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "saleMessage",
   "storageKey": null
 },
-v15 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "summary",
   "storageKey": null
 },
-v16 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v17 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "aspectRatio",
   "storageKey": null
 },
-v18 = [
+v17 = [
   {
     "kind": "Literal",
     "name": "format",
     "value": "MARKDOWN"
   }
 ],
-v19 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "exhibitionPeriod",
   "storageKey": null
 },
-v20 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v21 = {
+v20 = {
   "kind": "Literal",
   "name": "first",
   "value": 30
 },
-v22 = [
+v21 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -822,9 +759,17 @@ v22 = [
       "ARTIST"
     ]
   },
-  (v21/*: any*/)
+  (v20/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "input",
+    "value": {
+      "dimensionRange": "*-*",
+      "sort": "-decayed_merch"
+    }
+  }
 ],
-v23 = {
+v22 = {
   "alias": null,
   "args": null,
   "concreteType": "ArtworksAggregationResults",
@@ -854,7 +799,7 @@ v23 = {
           "name": "count",
           "storageKey": null
         },
-        (v16/*: any*/),
+        (v15/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -868,14 +813,14 @@ v23 = {
   ],
   "storageKey": null
 },
-v24 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v25 = {
+v24 = {
   "alias": null,
   "args": null,
   "concreteType": "FilterArtworksEdge",
@@ -891,30 +836,30 @@ v25 = {
       "name": "node",
       "plural": false,
       "selections": [
-        (v6/*: any*/),
-        (v3/*: any*/)
+        (v5/*: any*/),
+        (v2/*: any*/)
       ],
       "storageKey": null
     },
-    (v24/*: any*/)
+    (v23/*: any*/)
   ],
   "storageKey": null
 },
-v26 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endCursor",
   "storageKey": null
 },
-v27 = {
+v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "hasNextPage",
   "storageKey": null
 },
-v28 = {
+v27 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -922,33 +867,33 @@ v28 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v26/*: any*/),
-    (v27/*: any*/)
+    (v25/*: any*/),
+    (v26/*: any*/)
   ],
   "storageKey": null
 },
-v29 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startCursor",
   "storageKey": null
 },
-v30 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isAuction",
   "storageKey": null
 },
-v31 = {
+v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v32 = {
+v31 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCounts",
@@ -966,7 +911,7 @@ v32 = {
   ],
   "storageKey": null
 },
-v33 = [
+v32 = [
   {
     "alias": null,
     "args": null,
@@ -975,26 +920,26 @@ v33 = [
     "storageKey": null
   }
 ],
-v34 = {
+v33 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCurrentBid",
   "kind": "LinkedField",
   "name": "currentBid",
   "plural": false,
-  "selections": (v33/*: any*/),
+  "selections": (v32/*: any*/),
   "storageKey": null
 },
-v35 = [
-  (v6/*: any*/)
+v34 = [
+  (v5/*: any*/)
 ],
-v36 = {
+v35 = {
   "kind": "InlineFragment",
-  "selections": (v35/*: any*/),
+  "selections": (v34/*: any*/),
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v37 = {
+v36 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -1005,7 +950,7 @@ v37 = {
       "name": "pageInfo",
       "plural": false,
       "selections": [
-        (v29/*: any*/)
+        (v28/*: any*/)
       ],
       "storageKey": null
     },
@@ -1017,7 +962,7 @@ v37 = {
       "name": "edges",
       "plural": true,
       "selections": [
-        (v3/*: any*/),
+        (v2/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -1026,7 +971,7 @@ v37 = {
           "name": "node",
           "plural": false,
           "selections": [
-            (v4/*: any*/),
+            (v3/*: any*/),
             {
               "alias": null,
               "args": null,
@@ -1035,7 +980,7 @@ v37 = {
               "name": "image",
               "plural": false,
               "selections": [
-                (v17/*: any*/),
+                (v16/*: any*/),
                 {
                   "alias": null,
                   "args": [
@@ -1052,7 +997,7 @@ v37 = {
               ],
               "storageKey": null
             },
-            (v7/*: any*/),
+            (v6/*: any*/),
             {
               "alias": null,
               "args": null,
@@ -1060,10 +1005,10 @@ v37 = {
               "name": "date",
               "storageKey": null
             },
-            (v14/*: any*/),
-            (v5/*: any*/),
-            (v12/*: any*/),
-            (v8/*: any*/),
+            (v13/*: any*/),
+            (v4/*: any*/),
+            (v11/*: any*/),
+            (v7/*: any*/),
             {
               "alias": null,
               "args": null,
@@ -1072,8 +1017,8 @@ v37 = {
               "name": "sale",
               "plural": false,
               "selections": [
+                (v29/*: any*/),
                 (v30/*: any*/),
-                (v31/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -1081,8 +1026,8 @@ v37 = {
                   "name": "displayTimelyAt",
                   "storageKey": null
                 },
-                (v20/*: any*/),
-                (v6/*: any*/)
+                (v19/*: any*/),
+                (v5/*: any*/)
               ],
               "storageKey": null
             },
@@ -1094,8 +1039,8 @@ v37 = {
               "name": "saleArtwork",
               "plural": false,
               "selections": [
-                (v32/*: any*/),
-                (v34/*: any*/),
+                (v31/*: any*/),
+                (v33/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -1103,7 +1048,7 @@ v37 = {
                   "name": "lotLabel",
                   "storageKey": null
                 },
-                (v6/*: any*/)
+                (v5/*: any*/)
               ],
               "storageKey": null
             },
@@ -1115,15 +1060,15 @@ v37 = {
               "name": "partner",
               "plural": false,
               "selections": [
-                (v16/*: any*/),
-                (v6/*: any*/)
+                (v15/*: any*/),
+                (v5/*: any*/)
               ],
               "storageKey": null
             }
           ],
           "storageKey": null
         },
-        (v36/*: any*/)
+        (v35/*: any*/)
       ],
       "storageKey": null
     }
@@ -1131,34 +1076,34 @@ v37 = {
   "type": "ArtworkConnectionInterface",
   "abstractKey": "__isArtworkConnectionInterface"
 },
-v38 = [
+v37 = [
   "aggregations",
   "input"
 ],
-v39 = [
-  (v21/*: any*/),
+v38 = [
+  (v20/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "FEATURED_ASC"
   }
 ],
+v39 = [
+  (v9/*: any*/)
+],
 v40 = [
-  (v10/*: any*/)
+  (v5/*: any*/),
+  (v15/*: any*/)
 ],
 v41 = [
-  (v6/*: any*/),
-  (v16/*: any*/)
-],
-v42 = [
   "sort"
 ],
-v43 = {
+v42 = {
   "kind": "Literal",
   "name": "first",
   "value": 10
 },
-v44 = [
+v43 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -1170,18 +1115,25 @@ v44 = [
       "PRICE_RANGE"
     ]
   },
-  (v43/*: any*/),
-  (v2/*: any*/)
+  (v42/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "input",
+    "value": {
+      "dimensionRange": "*-*",
+      "sort": "-partner_updated_at"
+    }
+  }
 ],
-v45 = [
-  (v43/*: any*/),
+v44 = [
+  (v42/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "SORTABLE_ID_ASC"
   }
 ],
-v46 = {
+v45 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -1189,35 +1141,35 @@ v46 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v27/*: any*/),
-    (v29/*: any*/),
-    (v26/*: any*/)
+    (v26/*: any*/),
+    (v28/*: any*/),
+    (v25/*: any*/)
   ],
   "storageKey": null
 },
-v47 = {
+v46 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v48 = [
-  (v47/*: any*/)
+v47 = [
+  (v46/*: any*/)
 ],
-v49 = {
+v48 = {
   "kind": "Literal",
   "name": "status",
   "value": "CURRENT"
 },
-v50 = {
+v49 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isDisplayable",
   "storageKey": null
 },
-v51 = [
+v50 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -1234,11 +1186,11 @@ v51 = [
     "value": "CLOSED"
   }
 ],
-v52 = [
+v51 = [
   "status",
   "sort"
 ],
-v53 = [
+v52 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -1249,7 +1201,7 @@ v53 = [
     "name": "sort",
     "value": "END_AT_ASC"
   },
-  (v49/*: any*/)
+  (v48/*: any*/)
 ];
 return {
   "fragment": {
@@ -1267,9 +1219,7 @@ return {
         "plural": false,
         "selections": [
           {
-            "args": [
-              (v2/*: any*/)
-            ],
+            "args": null,
             "kind": "FragmentSpread",
             "name": "VanityURLEntity_fairOrPartner"
           }
@@ -1294,7 +1244,7 @@ return {
         "name": "vanityURLEntity",
         "plural": false,
         "selections": [
-          (v3/*: any*/),
+          (v2/*: any*/),
           {
             "kind": "TypeDiscriminator",
             "abstractKey": "__isVanityURLEntityType"
@@ -1302,8 +1252,8 @@ return {
           {
             "kind": "InlineFragment",
             "selections": [
+              (v3/*: any*/),
               (v4/*: any*/),
-              (v5/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1338,7 +1288,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v3/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1347,11 +1297,11 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v6/*: any*/),
                           (v5/*: any*/),
                           (v4/*: any*/),
+                          (v3/*: any*/),
+                          (v6/*: any*/),
                           (v7/*: any*/),
-                          (v8/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -1389,7 +1339,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v9/*: any*/)
+                  (v8/*: any*/)
                 ],
                 "storageKey": "articlesConnection(first:5,sort:\"PUBLISHED_AT_DESC\")"
               },
@@ -1407,10 +1357,10 @@ return {
                 "name": "marketingCollections",
                 "plural": true,
                 "selections": [
+                  (v2/*: any*/),
+                  (v5/*: any*/),
                   (v3/*: any*/),
                   (v6/*: any*/),
-                  (v4/*: any*/),
-                  (v7/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1472,14 +1422,14 @@ return {
                                 ],
                                 "storageKey": null
                               },
-                              (v6/*: any*/)
+                              (v5/*: any*/)
                             ],
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
-                      (v6/*: any*/)
+                      (v5/*: any*/)
                     ],
                     "storageKey": "artworksConnection(first:3)"
                   }
@@ -1494,7 +1444,7 @@ return {
                 "name": "counts",
                 "plural": false,
                 "selections": [
-                  (v10/*: any*/),
+                  (v9/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1508,7 +1458,7 @@ return {
               {
                 "alias": "followedArtistArtworks",
                 "args": [
-                  (v11/*: any*/),
+                  (v10/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "input",
@@ -1530,7 +1480,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v3/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": "artwork",
                         "args": null,
@@ -1539,11 +1489,11 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v6/*: any*/),
                           (v5/*: any*/),
                           (v4/*: any*/),
-                          (v8/*: any*/),
-                          (v12/*: any*/),
+                          (v3/*: any*/),
+                          (v7/*: any*/),
+                          (v11/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1552,18 +1502,18 @@ return {
                             "name": "image",
                             "plural": false,
                             "selections": [
-                              (v13/*: any*/)
+                              (v12/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v14/*: any*/)
+                          (v13/*: any*/)
                         ],
                         "storageKey": null
                       }
                     ],
                     "storageKey": null
                   },
-                  (v6/*: any*/)
+                  (v5/*: any*/)
                 ],
                 "storageKey": "filterArtworksConnection(first:20,input:{\"includeArtworksByFollowedArtists\":true})"
               },
@@ -1574,8 +1524,8 @@ return {
                 "name": "about",
                 "storageKey": null
               },
+              (v14/*: any*/),
               (v15/*: any*/),
-              (v16/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1608,7 +1558,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v6/*: any*/)
+                  (v5/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -1633,7 +1583,7 @@ return {
                     "name": "url",
                     "storageKey": "url(version:\"large_rectangle\")"
                   },
-                  (v17/*: any*/)
+                  (v16/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -1652,7 +1602,7 @@ return {
                 "name": "location",
                 "plural": false,
                 "selections": [
-                  (v15/*: any*/),
+                  (v14/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1678,7 +1628,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v6/*: any*/)
+                  (v5/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -1716,33 +1666,33 @@ return {
               },
               {
                 "alias": "fairHours",
-                "args": (v18/*: any*/),
+                "args": (v17/*: any*/),
                 "kind": "ScalarField",
                 "name": "hours",
                 "storageKey": "hours(format:\"MARKDOWN\")"
               },
               {
                 "alias": "fairLinks",
-                "args": (v18/*: any*/),
+                "args": (v17/*: any*/),
                 "kind": "ScalarField",
                 "name": "links",
                 "storageKey": "links(format:\"MARKDOWN\")"
               },
               {
                 "alias": "fairTickets",
-                "args": (v18/*: any*/),
+                "args": (v17/*: any*/),
                 "kind": "ScalarField",
                 "name": "tickets",
                 "storageKey": "tickets(format:\"MARKDOWN\")"
               },
               {
                 "alias": "fairContact",
-                "args": (v18/*: any*/),
+                "args": (v17/*: any*/),
                 "kind": "ScalarField",
                 "name": "contact",
                 "storageKey": "contact(format:\"MARKDOWN\")"
               },
-              (v19/*: any*/),
+              (v18/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1750,17 +1700,17 @@ return {
                 "name": "startAt",
                 "storageKey": null
               },
-              (v20/*: any*/),
+              (v19/*: any*/),
               {
                 "alias": "fairArtworks",
-                "args": (v22/*: any*/),
+                "args": (v21/*: any*/),
                 "concreteType": "FilterArtworksConnection",
                 "kind": "LinkedField",
                 "name": "filterArtworksConnection",
                 "plural": false,
                 "selections": [
-                  (v23/*: any*/),
-                  (v25/*: any*/),
+                  (v22/*: any*/),
+                  (v24/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1786,16 +1736,16 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v28/*: any*/),
-                  (v6/*: any*/),
-                  (v37/*: any*/)
+                  (v27/*: any*/),
+                  (v5/*: any*/),
+                  (v36/*: any*/)
                 ],
-                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:30)"
+                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
               },
               {
                 "alias": "fairArtworks",
-                "args": (v22/*: any*/),
-                "filters": (v38/*: any*/),
+                "args": (v21/*: any*/),
+                "filters": (v37/*: any*/),
                 "handle": "connection",
                 "key": "Fair_fairArtworks",
                 "kind": "LinkedHandle",
@@ -1803,7 +1753,7 @@ return {
               },
               {
                 "alias": "exhibitors",
-                "args": (v39/*: any*/),
+                "args": (v38/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
@@ -1825,7 +1775,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v6/*: any*/),
+                          (v5/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1833,7 +1783,7 @@ return {
                             "kind": "LinkedField",
                             "name": "counts",
                             "plural": false,
-                            "selections": (v40/*: any*/),
+                            "selections": (v39/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1844,26 +1794,26 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v3/*: any*/),
+                              (v2/*: any*/),
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v41/*: any*/),
+                                "selections": (v40/*: any*/),
                                 "type": "Partner",
                                 "abstractKey": null
                               },
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v41/*: any*/),
+                                "selections": (v40/*: any*/),
                                 "type": "ExternalPartner",
                                 "abstractKey": null
                               },
-                              (v36/*: any*/)
+                              (v35/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v5/*: any*/),
                           (v4/*: any*/),
-                          (v8/*: any*/),
+                          (v3/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1872,16 +1822,16 @@ return {
                             "name": "fair",
                             "plural": false,
                             "selections": [
-                              (v5/*: any*/),
                               (v4/*: any*/),
-                              (v6/*: any*/)
+                              (v3/*: any*/),
+                              (v5/*: any*/)
                             ],
                             "storageKey": null
                           },
                           {
                             "alias": "artworks",
                             "args": [
-                              (v11/*: any*/)
+                              (v10/*: any*/)
                             ],
                             "concreteType": "ArtworkConnection",
                             "kind": "LinkedField",
@@ -1904,9 +1854,9 @@ return {
                                     "name": "node",
                                     "plural": false,
                                     "selections": [
-                                      (v8/*: any*/),
-                                      (v12/*: any*/),
-                                      (v6/*: any*/),
+                                      (v7/*: any*/),
+                                      (v11/*: any*/),
+                                      (v5/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -1915,12 +1865,12 @@ return {
                                         "name": "image",
                                         "plural": false,
                                         "selections": [
-                                          (v13/*: any*/),
-                                          (v17/*: any*/)
+                                          (v12/*: any*/),
+                                          (v16/*: any*/)
                                         ],
                                         "storageKey": null
                                       },
-                                      (v14/*: any*/),
+                                      (v13/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -1936,7 +1886,7 @@ return {
                                             "kind": "LinkedField",
                                             "name": "openingBid",
                                             "plural": false,
-                                            "selections": (v33/*: any*/),
+                                            "selections": (v32/*: any*/),
                                             "storageKey": null
                                           },
                                           {
@@ -1946,12 +1896,12 @@ return {
                                             "kind": "LinkedField",
                                             "name": "highestBid",
                                             "plural": false,
-                                            "selections": (v33/*: any*/),
+                                            "selections": (v32/*: any*/),
                                             "storageKey": null
                                           },
-                                          (v34/*: any*/),
-                                          (v32/*: any*/),
-                                          (v6/*: any*/)
+                                          (v33/*: any*/),
+                                          (v31/*: any*/),
+                                          (v5/*: any*/)
                                         ],
                                         "storageKey": null
                                       },
@@ -1963,16 +1913,16 @@ return {
                                         "name": "sale",
                                         "plural": false,
                                         "selections": [
-                                          (v31/*: any*/),
                                           (v30/*: any*/),
-                                          (v20/*: any*/),
-                                          (v6/*: any*/)
+                                          (v29/*: any*/),
+                                          (v19/*: any*/),
+                                          (v5/*: any*/)
                                         ],
                                         "storageKey": null
                                       },
-                                      (v7/*: any*/),
-                                      (v5/*: any*/),
-                                      (v4/*: any*/)
+                                      (v6/*: any*/),
+                                      (v4/*: any*/),
+                                      (v3/*: any*/)
                                     ],
                                     "storageKey": null
                                   }
@@ -1982,22 +1932,22 @@ return {
                             ],
                             "storageKey": "artworksConnection(first:20)"
                           },
-                          (v3/*: any*/)
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v24/*: any*/)
+                      (v23/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v28/*: any*/)
+                  (v27/*: any*/)
                 ],
                 "storageKey": "showsConnection(first:30,sort:\"FEATURED_ASC\")"
               },
               {
                 "alias": "exhibitors",
-                "args": (v39/*: any*/),
-                "filters": (v42/*: any*/),
+                "args": (v38/*: any*/),
+                "filters": (v41/*: any*/),
                 "handle": "connection",
                 "key": "FairExhibitorsQuery_exhibitors",
                 "kind": "LinkedHandle",
@@ -2010,9 +1960,9 @@ return {
           {
             "kind": "InlineFragment",
             "selections": [
-              (v6/*: any*/),
               (v5/*: any*/),
               (v4/*: any*/),
+              (v3/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -2021,7 +1971,7 @@ return {
                 "name": "profile",
                 "plural": false,
                 "selections": [
-                  (v6/*: any*/),
+                  (v5/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2029,7 +1979,7 @@ return {
                     "name": "isFollowed",
                     "storageKey": null
                   },
-                  (v5/*: any*/),
+                  (v4/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2037,36 +1987,36 @@ return {
                     "name": "bio",
                     "storageKey": null
                   },
-                  (v16/*: any*/)
+                  (v15/*: any*/)
                 ],
                 "storageKey": null
               },
               {
                 "alias": "artworks",
-                "args": (v44/*: any*/),
+                "args": (v43/*: any*/),
                 "concreteType": "FilterArtworksConnection",
                 "kind": "LinkedField",
                 "name": "filterArtworksConnection",
                 "plural": false,
                 "selections": [
-                  (v23/*: any*/),
-                  (v25/*: any*/),
-                  (v28/*: any*/),
-                  (v6/*: any*/),
-                  (v37/*: any*/)
+                  (v22/*: any*/),
+                  (v24/*: any*/),
+                  (v27/*: any*/),
+                  (v5/*: any*/),
+                  (v36/*: any*/)
                 ],
-                "storageKey": null
+                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-partner_updated_at\"})"
               },
               {
                 "alias": "artworks",
-                "args": (v44/*: any*/),
-                "filters": (v38/*: any*/),
+                "args": (v43/*: any*/),
+                "filters": (v37/*: any*/),
                 "handle": "connection",
                 "key": "Partner_artworks",
                 "kind": "LinkedHandle",
                 "name": "filterArtworksConnection"
               },
-              (v16/*: any*/),
+              (v15/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -2076,13 +2026,13 @@ return {
               },
               {
                 "alias": "artists",
-                "args": (v45/*: any*/),
+                "args": (v44/*: any*/),
                 "concreteType": "ArtistPartnerConnection",
                 "kind": "LinkedField",
                 "name": "artistsConnection",
                 "plural": false,
                 "selections": [
-                  (v46/*: any*/),
+                  (v45/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2099,10 +2049,10 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v6/*: any*/),
                           (v5/*: any*/),
                           (v4/*: any*/),
-                          (v16/*: any*/),
+                          (v3/*: any*/),
+                          (v15/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -2110,7 +2060,7 @@ return {
                             "name": "initials",
                             "storageKey": null
                           },
-                          (v8/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": "is_followed",
                             "args": null,
@@ -2146,7 +2096,7 @@ return {
                             "kind": "LinkedField",
                             "name": "image",
                             "plural": false,
-                            "selections": (v48/*: any*/),
+                            "selections": (v47/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -2156,15 +2106,15 @@ return {
                             "kind": "LinkedField",
                             "name": "counts",
                             "plural": false,
-                            "selections": (v40/*: any*/),
+                            "selections": (v39/*: any*/),
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v24/*: any*/),
-                      (v6/*: any*/)
+                      (v23/*: any*/),
+                      (v5/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -2173,8 +2123,8 @@ return {
               },
               {
                 "alias": "artists",
-                "args": (v45/*: any*/),
-                "filters": (v42/*: any*/),
+                "args": (v44/*: any*/),
+                "filters": (v41/*: any*/),
                 "handle": "connection",
                 "key": "Partner_artists",
                 "kind": "LinkedHandle",
@@ -2194,15 +2144,15 @@ return {
                 "name": "locationsConnection",
                 "plural": false,
                 "selections": [
-                  (v9/*: any*/)
+                  (v8/*: any*/)
                 ],
                 "storageKey": "locationsConnection(first:0)"
               },
               {
                 "alias": "recentShows",
                 "args": [
-                  (v43/*: any*/),
-                  (v49/*: any*/)
+                  (v42/*: any*/),
+                  (v48/*: any*/)
                 ],
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
@@ -2225,8 +2175,8 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v6/*: any*/),
-                          (v50/*: any*/)
+                          (v5/*: any*/),
+                          (v49/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -2238,13 +2188,13 @@ return {
               },
               {
                 "alias": "pastShows",
-                "args": (v51/*: any*/),
+                "args": (v50/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": [
-                  (v46/*: any*/),
+                  (v45/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2261,11 +2211,11 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v50/*: any*/),
-                          (v6/*: any*/),
-                          (v16/*: any*/),
-                          (v4/*: any*/),
-                          (v19/*: any*/),
+                          (v49/*: any*/),
+                          (v5/*: any*/),
+                          (v15/*: any*/),
+                          (v3/*: any*/),
+                          (v18/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -2274,17 +2224,17 @@ return {
                             "name": "coverImage",
                             "plural": false,
                             "selections": [
-                              (v47/*: any*/),
-                              (v17/*: any*/)
+                              (v46/*: any*/),
+                              (v16/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v8/*: any*/),
-                          (v3/*: any*/)
+                          (v7/*: any*/),
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v24/*: any*/)
+                      (v23/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -2293,8 +2243,8 @@ return {
               },
               {
                 "alias": "pastShows",
-                "args": (v51/*: any*/),
-                "filters": (v52/*: any*/),
+                "args": (v50/*: any*/),
+                "filters": (v51/*: any*/),
                 "handle": "connection",
                 "key": "Partner_pastShows",
                 "kind": "LinkedHandle",
@@ -2302,13 +2252,13 @@ return {
               },
               {
                 "alias": "currentAndUpcomingShows",
-                "args": (v53/*: any*/),
+                "args": (v52/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": [
-                  (v46/*: any*/),
+                  (v45/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2325,13 +2275,13 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v50/*: any*/),
-                          (v6/*: any*/),
+                          (v49/*: any*/),
                           (v5/*: any*/),
                           (v4/*: any*/),
-                          (v16/*: any*/),
+                          (v3/*: any*/),
+                          (v15/*: any*/),
+                          (v18/*: any*/),
                           (v19/*: any*/),
-                          (v20/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -2339,7 +2289,7 @@ return {
                             "kind": "LinkedField",
                             "name": "images",
                             "plural": true,
-                            "selections": (v48/*: any*/),
+                            "selections": (v47/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -2350,19 +2300,19 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v3/*: any*/),
+                              (v2/*: any*/),
                               {
                                 "kind": "InlineFragment",
                                 "selections": [
-                                  (v16/*: any*/)
+                                  (v15/*: any*/)
                                 ],
                                 "type": "Partner",
                                 "abstractKey": null
                               },
-                              (v36/*: any*/),
+                              (v35/*: any*/),
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v35/*: any*/),
+                                "selections": (v34/*: any*/),
                                 "type": "ExternalPartner",
                                 "abstractKey": null
                               }
@@ -2376,14 +2326,14 @@ return {
                             "kind": "LinkedField",
                             "name": "coverImage",
                             "plural": false,
-                            "selections": (v48/*: any*/),
+                            "selections": (v47/*: any*/),
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v24/*: any*/)
+                      (v23/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -2392,8 +2342,8 @@ return {
               },
               {
                 "alias": "currentAndUpcomingShows",
-                "args": (v53/*: any*/),
-                "filters": (v52/*: any*/),
+                "args": (v52/*: any*/),
+                "filters": (v51/*: any*/),
                 "handle": "connection",
                 "key": "Partner_currentAndUpcomingShows",
                 "kind": "LinkedHandle",
@@ -2421,14 +2371,14 @@ return {
             "type": "Partner",
             "abstractKey": null
           },
-          (v36/*: any*/)
+          (v35/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "33665c132f7f567d8d0525cad442a71c",
+    "id": "c60501172b216c0fa313574a5d5fe019",
     "metadata": {},
     "name": "VanityURLEntityQuery",
     "operationKind": "query",
@@ -2436,5 +2386,5 @@ return {
   }
 };
 })();
-(node as any).hash = '721d938d828b16c87002389e06afc8f1';
+(node as any).hash = '345c641dc3f2ba52a22786a800cb6439';
 export default node;

--- a/src/__generated__/VanityURLEntityQuery.graphql.ts
+++ b/src/__generated__/VanityURLEntityQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 68153618dde7fdfa0ad8fcc055cbb124 */
+/* @relayHash 8192342c0acee9201a8c2cdd7dc23600 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -96,10 +96,10 @@ fragment ArtworkTileRailCard_artwork on Artwork {
   saleMessage
 }
 
-fragment FairArtworks_fair on Fair {
+fragment FairArtworks_fair_4g78v5 on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, sort: "-decayed_merch", dimensionRange: "*-*", aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
     aggregations {
       slice
       counts {
@@ -362,7 +362,7 @@ fragment Fair_fair on Fair {
   ...FairEmptyState_fair
   ...FairEditorial_fair
   ...FairCollections_fair
-  ...FairArtworks_fair
+  ...FairArtworks_fair_4g78v5
   ...FairExhibitors_fair
   ...FairFollowedArtistsRail_fair
 }
@@ -741,15 +741,10 @@ v19 = {
 },
 v20 = {
   "kind": "Literal",
-  "name": "dimensionRange",
-  "value": "*-*"
-},
-v21 = {
-  "kind": "Literal",
   "name": "first",
   "value": 30
 },
-v22 = [
+v21 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -764,15 +759,9 @@ v22 = [
       "ARTIST"
     ]
   },
-  (v20/*: any*/),
-  (v21/*: any*/),
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "-decayed_merch"
-  }
+  (v20/*: any*/)
 ],
-v23 = {
+v22 = {
   "alias": null,
   "args": null,
   "concreteType": "ArtworksAggregationResults",
@@ -816,14 +805,14 @@ v23 = {
   ],
   "storageKey": null
 },
-v24 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v25 = {
+v24 = {
   "alias": null,
   "args": null,
   "concreteType": "FilterArtworksEdge",
@@ -844,25 +833,25 @@ v25 = {
       ],
       "storageKey": null
     },
-    (v24/*: any*/)
+    (v23/*: any*/)
   ],
   "storageKey": null
 },
-v26 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endCursor",
   "storageKey": null
 },
-v27 = {
+v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "hasNextPage",
   "storageKey": null
 },
-v28 = {
+v27 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -870,33 +859,33 @@ v28 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v26/*: any*/),
-    (v27/*: any*/)
+    (v25/*: any*/),
+    (v26/*: any*/)
   ],
   "storageKey": null
 },
-v29 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startCursor",
   "storageKey": null
 },
-v30 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isAuction",
   "storageKey": null
 },
-v31 = {
+v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isClosed",
   "storageKey": null
 },
-v32 = {
+v31 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCounts",
@@ -914,7 +903,7 @@ v32 = {
   ],
   "storageKey": null
 },
-v33 = [
+v32 = [
   {
     "alias": null,
     "args": null,
@@ -923,26 +912,26 @@ v33 = [
     "storageKey": null
   }
 ],
-v34 = {
+v33 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCurrentBid",
   "kind": "LinkedField",
   "name": "currentBid",
   "plural": false,
-  "selections": (v33/*: any*/),
+  "selections": (v32/*: any*/),
   "storageKey": null
 },
-v35 = [
+v34 = [
   (v5/*: any*/)
 ],
-v36 = {
+v35 = {
   "kind": "InlineFragment",
-  "selections": (v35/*: any*/),
+  "selections": (v34/*: any*/),
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v37 = {
+v36 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -953,7 +942,7 @@ v37 = {
       "name": "pageInfo",
       "plural": false,
       "selections": [
-        (v29/*: any*/)
+        (v28/*: any*/)
       ],
       "storageKey": null
     },
@@ -1020,8 +1009,8 @@ v37 = {
               "name": "sale",
               "plural": false,
               "selections": [
+                (v29/*: any*/),
                 (v30/*: any*/),
-                (v31/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -1042,8 +1031,8 @@ v37 = {
               "name": "saleArtwork",
               "plural": false,
               "selections": [
-                (v32/*: any*/),
-                (v34/*: any*/),
+                (v31/*: any*/),
+                (v33/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -1071,7 +1060,7 @@ v37 = {
           ],
           "storageKey": null
         },
-        (v36/*: any*/)
+        (v35/*: any*/)
       ],
       "storageKey": null
     }
@@ -1079,30 +1068,30 @@ v37 = {
   "type": "ArtworkConnectionInterface",
   "abstractKey": "__isArtworkConnectionInterface"
 },
-v38 = [
-  (v21/*: any*/),
+v37 = [
+  (v20/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "FEATURED_ASC"
   }
 ],
-v39 = [
+v38 = [
   (v9/*: any*/)
 ],
-v40 = [
+v39 = [
   (v5/*: any*/),
   (v15/*: any*/)
 ],
-v41 = [
+v40 = [
   "sort"
 ],
-v42 = {
+v41 = {
   "kind": "Literal",
   "name": "first",
   "value": 10
 },
-v43 = [
+v42 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -1114,23 +1103,27 @@ v43 = [
       "PRICE_RANGE"
     ]
   },
-  (v20/*: any*/),
-  (v42/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "dimensionRange",
+    "value": "*-*"
+  },
+  (v41/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "-partner_updated_at"
   }
 ],
-v44 = [
-  (v42/*: any*/),
+v43 = [
+  (v41/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "SORTABLE_ID_ASC"
   }
 ],
-v45 = {
+v44 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -1138,35 +1131,35 @@ v45 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v27/*: any*/),
-    (v29/*: any*/),
-    (v26/*: any*/)
+    (v26/*: any*/),
+    (v28/*: any*/),
+    (v25/*: any*/)
   ],
   "storageKey": null
 },
-v46 = {
+v45 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v47 = [
-  (v46/*: any*/)
+v46 = [
+  (v45/*: any*/)
 ],
-v48 = {
+v47 = {
   "kind": "Literal",
   "name": "status",
   "value": "CURRENT"
 },
-v49 = {
+v48 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isDisplayable",
   "storageKey": null
 },
-v50 = [
+v49 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -1183,11 +1176,11 @@ v50 = [
     "value": "CLOSED"
   }
 ],
-v51 = [
+v50 = [
   "status",
   "sort"
 ],
-v52 = [
+v51 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -1198,7 +1191,7 @@ v52 = [
     "name": "sort",
     "value": "END_AT_ASC"
   },
-  (v48/*: any*/)
+  (v47/*: any*/)
 ];
 return {
   "fragment": {
@@ -1698,14 +1691,14 @@ return {
               (v19/*: any*/),
               {
                 "alias": "fairArtworks",
-                "args": (v22/*: any*/),
+                "args": (v21/*: any*/),
                 "concreteType": "FilterArtworksConnection",
                 "kind": "LinkedField",
                 "name": "filterArtworksConnection",
                 "plural": false,
                 "selections": [
-                  (v23/*: any*/),
-                  (v25/*: any*/),
+                  (v22/*: any*/),
+                  (v24/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1731,33 +1724,18 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v28/*: any*/),
+                  (v27/*: any*/),
                   (v5/*: any*/),
-                  (v37/*: any*/)
+                  (v36/*: any*/)
                 ],
-                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],dimensionRange:\"*-*\",first:30,sort:\"-decayed_merch\")"
+                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:30)"
               },
               {
                 "alias": "fairArtworks",
-                "args": (v22/*: any*/),
+                "args": (v21/*: any*/),
                 "filters": [
-                  "sort",
-                  "additionalGeneIDs",
-                  "priceRange",
-                  "color",
-                  "colors",
-                  "partnerID",
-                  "partnerIDs",
-                  "dimensionRange",
-                  "majorPeriods",
-                  "acquireable",
-                  "inquireableOnly",
-                  "atAuction",
-                  "offerable",
-                  "includeArtworksByFollowedArtists",
-                  "artistIDs",
                   "aggregations",
-                  "attributionClass"
+                  "input"
                 ],
                 "handle": "connection",
                 "key": "Fair_fairArtworks",
@@ -1766,7 +1744,7 @@ return {
               },
               {
                 "alias": "exhibitors",
-                "args": (v38/*: any*/),
+                "args": (v37/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
@@ -1796,7 +1774,7 @@ return {
                             "kind": "LinkedField",
                             "name": "counts",
                             "plural": false,
-                            "selections": (v39/*: any*/),
+                            "selections": (v38/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1810,17 +1788,17 @@ return {
                               (v2/*: any*/),
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v40/*: any*/),
+                                "selections": (v39/*: any*/),
                                 "type": "Partner",
                                 "abstractKey": null
                               },
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v40/*: any*/),
+                                "selections": (v39/*: any*/),
                                 "type": "ExternalPartner",
                                 "abstractKey": null
                               },
-                              (v36/*: any*/)
+                              (v35/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1899,7 +1877,7 @@ return {
                                             "kind": "LinkedField",
                                             "name": "openingBid",
                                             "plural": false,
-                                            "selections": (v33/*: any*/),
+                                            "selections": (v32/*: any*/),
                                             "storageKey": null
                                           },
                                           {
@@ -1909,11 +1887,11 @@ return {
                                             "kind": "LinkedField",
                                             "name": "highestBid",
                                             "plural": false,
-                                            "selections": (v33/*: any*/),
+                                            "selections": (v32/*: any*/),
                                             "storageKey": null
                                           },
-                                          (v34/*: any*/),
-                                          (v32/*: any*/),
+                                          (v33/*: any*/),
+                                          (v31/*: any*/),
                                           (v5/*: any*/)
                                         ],
                                         "storageKey": null
@@ -1926,8 +1904,8 @@ return {
                                         "name": "sale",
                                         "plural": false,
                                         "selections": [
-                                          (v31/*: any*/),
                                           (v30/*: any*/),
+                                          (v29/*: any*/),
                                           (v19/*: any*/),
                                           (v5/*: any*/)
                                         ],
@@ -1949,18 +1927,18 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v24/*: any*/)
+                      (v23/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v28/*: any*/)
+                  (v27/*: any*/)
                 ],
                 "storageKey": "showsConnection(first:30,sort:\"FEATURED_ASC\")"
               },
               {
                 "alias": "exhibitors",
-                "args": (v38/*: any*/),
-                "filters": (v41/*: any*/),
+                "args": (v37/*: any*/),
+                "filters": (v40/*: any*/),
                 "handle": "connection",
                 "key": "FairExhibitorsQuery_exhibitors",
                 "kind": "LinkedHandle",
@@ -2006,23 +1984,23 @@ return {
               },
               {
                 "alias": "artworks",
-                "args": (v43/*: any*/),
+                "args": (v42/*: any*/),
                 "concreteType": "FilterArtworksConnection",
                 "kind": "LinkedField",
                 "name": "filterArtworksConnection",
                 "plural": false,
                 "selections": [
-                  (v23/*: any*/),
-                  (v25/*: any*/),
-                  (v28/*: any*/),
+                  (v22/*: any*/),
+                  (v24/*: any*/),
+                  (v27/*: any*/),
                   (v5/*: any*/),
-                  (v37/*: any*/)
+                  (v36/*: any*/)
                 ],
                 "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,sort:\"-partner_updated_at\")"
               },
               {
                 "alias": "artworks",
-                "args": (v43/*: any*/),
+                "args": (v42/*: any*/),
                 "filters": [
                   "acquireable",
                   "aggregations",
@@ -2052,13 +2030,13 @@ return {
               },
               {
                 "alias": "artists",
-                "args": (v44/*: any*/),
+                "args": (v43/*: any*/),
                 "concreteType": "ArtistPartnerConnection",
                 "kind": "LinkedField",
                 "name": "artistsConnection",
                 "plural": false,
                 "selections": [
-                  (v45/*: any*/),
+                  (v44/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2122,7 +2100,7 @@ return {
                             "kind": "LinkedField",
                             "name": "image",
                             "plural": false,
-                            "selections": (v47/*: any*/),
+                            "selections": (v46/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -2132,14 +2110,14 @@ return {
                             "kind": "LinkedField",
                             "name": "counts",
                             "plural": false,
-                            "selections": (v39/*: any*/),
+                            "selections": (v38/*: any*/),
                             "storageKey": null
                           },
                           (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v24/*: any*/),
+                      (v23/*: any*/),
                       (v5/*: any*/)
                     ],
                     "storageKey": null
@@ -2149,8 +2127,8 @@ return {
               },
               {
                 "alias": "artists",
-                "args": (v44/*: any*/),
-                "filters": (v41/*: any*/),
+                "args": (v43/*: any*/),
+                "filters": (v40/*: any*/),
                 "handle": "connection",
                 "key": "Partner_artists",
                 "kind": "LinkedHandle",
@@ -2177,8 +2155,8 @@ return {
               {
                 "alias": "recentShows",
                 "args": [
-                  (v42/*: any*/),
-                  (v48/*: any*/)
+                  (v41/*: any*/),
+                  (v47/*: any*/)
                 ],
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
@@ -2202,7 +2180,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v5/*: any*/),
-                          (v49/*: any*/)
+                          (v48/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -2214,13 +2192,13 @@ return {
               },
               {
                 "alias": "pastShows",
-                "args": (v50/*: any*/),
+                "args": (v49/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": [
-                  (v45/*: any*/),
+                  (v44/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2237,7 +2215,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v49/*: any*/),
+                          (v48/*: any*/),
                           (v5/*: any*/),
                           (v15/*: any*/),
                           (v3/*: any*/),
@@ -2250,7 +2228,7 @@ return {
                             "name": "coverImage",
                             "plural": false,
                             "selections": [
-                              (v46/*: any*/),
+                              (v45/*: any*/),
                               (v16/*: any*/)
                             ],
                             "storageKey": null
@@ -2260,7 +2238,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v24/*: any*/)
+                      (v23/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -2269,8 +2247,8 @@ return {
               },
               {
                 "alias": "pastShows",
-                "args": (v50/*: any*/),
-                "filters": (v51/*: any*/),
+                "args": (v49/*: any*/),
+                "filters": (v50/*: any*/),
                 "handle": "connection",
                 "key": "Partner_pastShows",
                 "kind": "LinkedHandle",
@@ -2278,13 +2256,13 @@ return {
               },
               {
                 "alias": "currentAndUpcomingShows",
-                "args": (v52/*: any*/),
+                "args": (v51/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": [
-                  (v45/*: any*/),
+                  (v44/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2301,7 +2279,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v49/*: any*/),
+                          (v48/*: any*/),
                           (v5/*: any*/),
                           (v4/*: any*/),
                           (v3/*: any*/),
@@ -2315,7 +2293,7 @@ return {
                             "kind": "LinkedField",
                             "name": "images",
                             "plural": true,
-                            "selections": (v47/*: any*/),
+                            "selections": (v46/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -2335,10 +2313,10 @@ return {
                                 "type": "Partner",
                                 "abstractKey": null
                               },
-                              (v36/*: any*/),
+                              (v35/*: any*/),
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v35/*: any*/),
+                                "selections": (v34/*: any*/),
                                 "type": "ExternalPartner",
                                 "abstractKey": null
                               }
@@ -2352,14 +2330,14 @@ return {
                             "kind": "LinkedField",
                             "name": "coverImage",
                             "plural": false,
-                            "selections": (v47/*: any*/),
+                            "selections": (v46/*: any*/),
                             "storageKey": null
                           },
                           (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v24/*: any*/)
+                      (v23/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -2368,8 +2346,8 @@ return {
               },
               {
                 "alias": "currentAndUpcomingShows",
-                "args": (v52/*: any*/),
-                "filters": (v51/*: any*/),
+                "args": (v51/*: any*/),
+                "filters": (v50/*: any*/),
                 "handle": "connection",
                 "key": "Partner_currentAndUpcomingShows",
                 "kind": "LinkedHandle",
@@ -2397,14 +2375,14 @@ return {
             "type": "Partner",
             "abstractKey": null
           },
-          (v36/*: any*/)
+          (v35/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "68153618dde7fdfa0ad8fcc055cbb124",
+    "id": "8192342c0acee9201a8c2cdd7dc23600",
     "metadata": {},
     "name": "VanityURLEntityQuery",
     "operationKind": "query",

--- a/src/__generated__/VanityURLEntityQuery.graphql.ts
+++ b/src/__generated__/VanityURLEntityQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 8192342c0acee9201a8c2cdd7dc23600 */
+/* @relayHash de9f38f2aaf9a49e07a363be80d6aeaa */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -280,7 +280,7 @@ fragment FairExhibitors_fair on Fair {
 fragment FairFollowedArtistsRail_fair on Fair {
   internalID
   slug
-  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {
+  followedArtistArtworks: filterArtworksConnection(first: 20, input: {includeArtworksByFollowedArtists: true}) {
     edges {
       artwork: node {
         id
@@ -352,7 +352,7 @@ fragment Fair_fair on Fair {
     artworks
     partnerShows
   }
-  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {
+  followedArtistArtworks: filterArtworksConnection(first: 20, input: {includeArtworksByFollowedArtists: true}) {
     edges {
       __typename
     }
@@ -1451,8 +1451,10 @@ return {
                   (v10/*: any*/),
                   {
                     "kind": "Literal",
-                    "name": "includeArtworksByFollowedArtists",
-                    "value": true
+                    "name": "input",
+                    "value": {
+                      "includeArtworksByFollowedArtists": true
+                    }
                   }
                 ],
                 "concreteType": "FilterArtworksConnection",
@@ -1503,7 +1505,7 @@ return {
                   },
                   (v5/*: any*/)
                 ],
-                "storageKey": "filterArtworksConnection(first:20,includeArtworksByFollowedArtists:true)"
+                "storageKey": "filterArtworksConnection(first:20,input:{\"includeArtworksByFollowedArtists\":true})"
               },
               {
                 "alias": null,
@@ -2382,7 +2384,7 @@ return {
     ]
   },
   "params": {
-    "id": "8192342c0acee9201a8c2cdd7dc23600",
+    "id": "de9f38f2aaf9a49e07a363be80d6aeaa",
     "metadata": {},
     "name": "VanityURLEntityQuery",
     "operationKind": "query",

--- a/src/__generated__/VanityURLEntityQuery.graphql.ts
+++ b/src/__generated__/VanityURLEntityQuery.graphql.ts
@@ -1,12 +1,64 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash de9f38f2aaf9a49e07a363be80d6aeaa */
+/* @relayHash 33665c132f7f567d8d0525cad442a71c */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "TOTAL" | "%future added value";
+export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
+export type FilterArtworksInput = {
+    acquireable?: boolean | null;
+    additionalGeneIDs?: Array<string | null> | null;
+    after?: string | null;
+    aggregationPartnerCities?: Array<string | null> | null;
+    aggregations?: Array<ArtworkAggregation | null> | null;
+    artistID?: string | null;
+    artistIDs?: Array<string | null> | null;
+    artistNationalities?: Array<string | null> | null;
+    artistSeriesID?: string | null;
+    atAuction?: boolean | null;
+    attributionClass?: Array<string | null> | null;
+    before?: string | null;
+    color?: string | null;
+    colors?: Array<string | null> | null;
+    dimensionRange?: string | null;
+    excludeArtworkIDs?: Array<string | null> | null;
+    extraAggregationGeneIDs?: Array<string | null> | null;
+    first?: number | null;
+    forSale?: boolean | null;
+    geneID?: string | null;
+    geneIDs?: Array<string | null> | null;
+    height?: string | null;
+    includeArtworksByFollowedArtists?: boolean | null;
+    includeMediumFilterInAggregation?: boolean | null;
+    inquireableOnly?: boolean | null;
+    keyword?: string | null;
+    keywordMatchExact?: boolean | null;
+    last?: number | null;
+    locationCities?: Array<string | null> | null;
+    majorPeriods?: Array<string | null> | null;
+    marketable?: boolean | null;
+    materialsTerms?: Array<string | null> | null;
+    medium?: string | null;
+    offerable?: boolean | null;
+    page?: number | null;
+    partnerCities?: Array<string | null> | null;
+    partnerID?: string | null;
+    partnerIDs?: Array<string | null> | null;
+    period?: string | null;
+    periods?: Array<string | null> | null;
+    priceRange?: string | null;
+    saleID?: string | null;
+    size?: number | null;
+    sizes?: Array<ArtworkSizes | null> | null;
+    sort?: string | null;
+    tagID?: string | null;
+    width?: string | null;
+};
 export type VanityURLEntityQueryVariables = {
     id: string;
+    input?: FilterArtworksInput | null;
 };
 export type VanityURLEntityQueryResponse = {
     readonly vanityURLEntity: {
@@ -23,10 +75,11 @@ export type VanityURLEntityQuery = {
 /*
 query VanityURLEntityQuery(
   $id: String!
+  $input: FilterArtworksInput
 ) {
   vanityURLEntity(id: $id) {
     __typename
-    ...VanityURLEntity_fairOrPartner
+    ...VanityURLEntity_fairOrPartner_2VV6jB
     ... on Node {
       __isNode: __typename
       id
@@ -391,10 +444,10 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
   }
 }
 
-fragment PartnerArtwork_partner on Partner {
+fragment PartnerArtwork_partner_2VV6jB on Partner {
   internalID
   slug
-  artworks: filterArtworksConnection(aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], dimensionRange: "*-*", first: 10, sort: "-partner_updated_at") {
+  artworks: filterArtworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: $input) {
     aggregations {
       slice
       counts {
@@ -572,7 +625,7 @@ fragment PartnerShows_partner on Partner {
   ...PartnerShowsRail_partner
 }
 
-fragment Partner_partner on Partner {
+fragment Partner_partner_2VV6jB on Partner {
   id
   internalID
   slug
@@ -581,13 +634,13 @@ fragment Partner_partner on Partner {
     isFollowed
     internalID
   }
-  ...PartnerArtwork_partner
+  ...PartnerArtwork_partner_2VV6jB
   ...PartnerOverview_partner
   ...PartnerShows_partner
   ...PartnerHeader_partner
 }
 
-fragment VanityURLEntity_fairOrPartner on VanityURLEntityType {
+fragment VanityURLEntity_fairOrPartner_2VV6jB on VanityURLEntityType {
   __isVanityURLEntityType: __typename
   __typename
   ... on Fair {
@@ -595,7 +648,7 @@ fragment VanityURLEntity_fairOrPartner on VanityURLEntityType {
     ...Fair_fair
   }
   ... on Partner {
-    ...Partner_partner
+    ...Partner_partner_2VV6jB
   }
 }
 */
@@ -606,6 +659,11 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "id"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
   }
 ],
 v1 = [
@@ -616,135 +674,140 @@ v1 = [
   }
 ],
 v2 = {
+  "kind": "Variable",
+  "name": "input",
+  "variableName": "input"
+},
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v3 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v4 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "title",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "totalCount",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "artworks",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "kind": "Literal",
   "name": "first",
   "value": 20
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "artistNames",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "imageURL",
   "storageKey": null
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "saleMessage",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "summary",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "aspectRatio",
   "storageKey": null
 },
-v17 = [
+v18 = [
   {
     "kind": "Literal",
     "name": "format",
     "value": "MARKDOWN"
   }
 ],
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "exhibitionPeriod",
   "storageKey": null
 },
-v19 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v20 = {
+v21 = {
   "kind": "Literal",
   "name": "first",
   "value": 30
 },
-v21 = [
+v22 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -759,9 +822,9 @@ v21 = [
       "ARTIST"
     ]
   },
-  (v20/*: any*/)
+  (v21/*: any*/)
 ],
-v22 = {
+v23 = {
   "alias": null,
   "args": null,
   "concreteType": "ArtworksAggregationResults",
@@ -791,7 +854,7 @@ v22 = {
           "name": "count",
           "storageKey": null
         },
-        (v15/*: any*/),
+        (v16/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -805,14 +868,14 @@ v22 = {
   ],
   "storageKey": null
 },
-v23 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v24 = {
+v25 = {
   "alias": null,
   "args": null,
   "concreteType": "FilterArtworksEdge",
@@ -828,30 +891,30 @@ v24 = {
       "name": "node",
       "plural": false,
       "selections": [
-        (v5/*: any*/),
-        (v2/*: any*/)
+        (v6/*: any*/),
+        (v3/*: any*/)
       ],
       "storageKey": null
     },
-    (v23/*: any*/)
+    (v24/*: any*/)
   ],
-  "storageKey": null
-},
-v25 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "endCursor",
   "storageKey": null
 },
 v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "hasNextPage",
+  "name": "endCursor",
   "storageKey": null
 },
 v27 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "hasNextPage",
+  "storageKey": null
+},
+v28 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -859,33 +922,33 @@ v27 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v25/*: any*/),
-    (v26/*: any*/)
+    (v26/*: any*/),
+    (v27/*: any*/)
   ],
-  "storageKey": null
-},
-v28 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "startCursor",
   "storageKey": null
 },
 v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "isAuction",
+  "name": "startCursor",
   "storageKey": null
 },
 v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "isClosed",
+  "name": "isAuction",
   "storageKey": null
 },
 v31 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isClosed",
+  "storageKey": null
+},
+v32 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCounts",
@@ -903,7 +966,7 @@ v31 = {
   ],
   "storageKey": null
 },
-v32 = [
+v33 = [
   {
     "alias": null,
     "args": null,
@@ -912,26 +975,26 @@ v32 = [
     "storageKey": null
   }
 ],
-v33 = {
+v34 = {
   "alias": null,
   "args": null,
   "concreteType": "SaleArtworkCurrentBid",
   "kind": "LinkedField",
   "name": "currentBid",
   "plural": false,
-  "selections": (v32/*: any*/),
+  "selections": (v33/*: any*/),
   "storageKey": null
 },
-v34 = [
-  (v5/*: any*/)
+v35 = [
+  (v6/*: any*/)
 ],
-v35 = {
+v36 = {
   "kind": "InlineFragment",
-  "selections": (v34/*: any*/),
+  "selections": (v35/*: any*/),
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v36 = {
+v37 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -942,7 +1005,7 @@ v36 = {
       "name": "pageInfo",
       "plural": false,
       "selections": [
-        (v28/*: any*/)
+        (v29/*: any*/)
       ],
       "storageKey": null
     },
@@ -954,7 +1017,7 @@ v36 = {
       "name": "edges",
       "plural": true,
       "selections": [
-        (v2/*: any*/),
+        (v3/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -963,7 +1026,7 @@ v36 = {
           "name": "node",
           "plural": false,
           "selections": [
-            (v3/*: any*/),
+            (v4/*: any*/),
             {
               "alias": null,
               "args": null,
@@ -972,7 +1035,7 @@ v36 = {
               "name": "image",
               "plural": false,
               "selections": [
-                (v16/*: any*/),
+                (v17/*: any*/),
                 {
                   "alias": null,
                   "args": [
@@ -989,7 +1052,7 @@ v36 = {
               ],
               "storageKey": null
             },
-            (v6/*: any*/),
+            (v7/*: any*/),
             {
               "alias": null,
               "args": null,
@@ -997,10 +1060,10 @@ v36 = {
               "name": "date",
               "storageKey": null
             },
-            (v13/*: any*/),
-            (v4/*: any*/),
-            (v11/*: any*/),
-            (v7/*: any*/),
+            (v14/*: any*/),
+            (v5/*: any*/),
+            (v12/*: any*/),
+            (v8/*: any*/),
             {
               "alias": null,
               "args": null,
@@ -1009,8 +1072,8 @@ v36 = {
               "name": "sale",
               "plural": false,
               "selections": [
-                (v29/*: any*/),
                 (v30/*: any*/),
+                (v31/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -1018,8 +1081,8 @@ v36 = {
                   "name": "displayTimelyAt",
                   "storageKey": null
                 },
-                (v19/*: any*/),
-                (v5/*: any*/)
+                (v20/*: any*/),
+                (v6/*: any*/)
               ],
               "storageKey": null
             },
@@ -1031,8 +1094,8 @@ v36 = {
               "name": "saleArtwork",
               "plural": false,
               "selections": [
-                (v31/*: any*/),
-                (v33/*: any*/),
+                (v32/*: any*/),
+                (v34/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -1040,7 +1103,7 @@ v36 = {
                   "name": "lotLabel",
                   "storageKey": null
                 },
-                (v5/*: any*/)
+                (v6/*: any*/)
               ],
               "storageKey": null
             },
@@ -1052,15 +1115,15 @@ v36 = {
               "name": "partner",
               "plural": false,
               "selections": [
-                (v15/*: any*/),
-                (v5/*: any*/)
+                (v16/*: any*/),
+                (v6/*: any*/)
               ],
               "storageKey": null
             }
           ],
           "storageKey": null
         },
-        (v35/*: any*/)
+        (v36/*: any*/)
       ],
       "storageKey": null
     }
@@ -1068,30 +1131,34 @@ v36 = {
   "type": "ArtworkConnectionInterface",
   "abstractKey": "__isArtworkConnectionInterface"
 },
-v37 = [
-  (v20/*: any*/),
+v38 = [
+  "aggregations",
+  "input"
+],
+v39 = [
+  (v21/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "FEATURED_ASC"
   }
 ],
-v38 = [
-  (v9/*: any*/)
-],
-v39 = [
-  (v5/*: any*/),
-  (v15/*: any*/)
-],
 v40 = [
+  (v10/*: any*/)
+],
+v41 = [
+  (v6/*: any*/),
+  (v16/*: any*/)
+],
+v42 = [
   "sort"
 ],
-v41 = {
+v43 = {
   "kind": "Literal",
   "name": "first",
   "value": 10
 },
-v42 = [
+v44 = [
   {
     "kind": "Literal",
     "name": "aggregations",
@@ -1103,27 +1170,18 @@ v42 = [
       "PRICE_RANGE"
     ]
   },
-  {
-    "kind": "Literal",
-    "name": "dimensionRange",
-    "value": "*-*"
-  },
-  (v41/*: any*/),
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "-partner_updated_at"
-  }
+  (v43/*: any*/),
+  (v2/*: any*/)
 ],
-v43 = [
-  (v41/*: any*/),
+v45 = [
+  (v43/*: any*/),
   {
     "kind": "Literal",
     "name": "sort",
     "value": "SORTABLE_ID_ASC"
   }
 ],
-v44 = {
+v46 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -1131,35 +1189,35 @@ v44 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v26/*: any*/),
-    (v28/*: any*/),
-    (v25/*: any*/)
+    (v27/*: any*/),
+    (v29/*: any*/),
+    (v26/*: any*/)
   ],
   "storageKey": null
 },
-v45 = {
+v47 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v46 = [
-  (v45/*: any*/)
+v48 = [
+  (v47/*: any*/)
 ],
-v47 = {
+v49 = {
   "kind": "Literal",
   "name": "status",
   "value": "CURRENT"
 },
-v48 = {
+v50 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isDisplayable",
   "storageKey": null
 },
-v49 = [
+v51 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -1176,11 +1234,11 @@ v49 = [
     "value": "CLOSED"
   }
 ],
-v50 = [
+v52 = [
   "status",
   "sort"
 ],
-v51 = [
+v53 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -1191,7 +1249,7 @@ v51 = [
     "name": "sort",
     "value": "END_AT_ASC"
   },
-  (v47/*: any*/)
+  (v49/*: any*/)
 ];
 return {
   "fragment": {
@@ -1209,7 +1267,9 @@ return {
         "plural": false,
         "selections": [
           {
-            "args": null,
+            "args": [
+              (v2/*: any*/)
+            ],
             "kind": "FragmentSpread",
             "name": "VanityURLEntity_fairOrPartner"
           }
@@ -1234,7 +1294,7 @@ return {
         "name": "vanityURLEntity",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
+          (v3/*: any*/),
           {
             "kind": "TypeDiscriminator",
             "abstractKey": "__isVanityURLEntityType"
@@ -1242,8 +1302,8 @@ return {
           {
             "kind": "InlineFragment",
             "selections": [
-              (v3/*: any*/),
               (v4/*: any*/),
+              (v5/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1278,7 +1338,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v2/*: any*/),
+                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1287,11 +1347,11 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
+                          (v6/*: any*/),
                           (v5/*: any*/),
                           (v4/*: any*/),
-                          (v3/*: any*/),
-                          (v6/*: any*/),
                           (v7/*: any*/),
+                          (v8/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -1329,7 +1389,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v8/*: any*/)
+                  (v9/*: any*/)
                 ],
                 "storageKey": "articlesConnection(first:5,sort:\"PUBLISHED_AT_DESC\")"
               },
@@ -1347,10 +1407,10 @@ return {
                 "name": "marketingCollections",
                 "plural": true,
                 "selections": [
-                  (v2/*: any*/),
-                  (v5/*: any*/),
                   (v3/*: any*/),
                   (v6/*: any*/),
+                  (v4/*: any*/),
+                  (v7/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1412,14 +1472,14 @@ return {
                                 ],
                                 "storageKey": null
                               },
-                              (v5/*: any*/)
+                              (v6/*: any*/)
                             ],
                             "storageKey": null
                           }
                         ],
                         "storageKey": null
                       },
-                      (v5/*: any*/)
+                      (v6/*: any*/)
                     ],
                     "storageKey": "artworksConnection(first:3)"
                   }
@@ -1434,7 +1494,7 @@ return {
                 "name": "counts",
                 "plural": false,
                 "selections": [
-                  (v9/*: any*/),
+                  (v10/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1448,7 +1508,7 @@ return {
               {
                 "alias": "followedArtistArtworks",
                 "args": [
-                  (v10/*: any*/),
+                  (v11/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "input",
@@ -1470,7 +1530,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v2/*: any*/),
+                      (v3/*: any*/),
                       {
                         "alias": "artwork",
                         "args": null,
@@ -1479,11 +1539,11 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
+                          (v6/*: any*/),
                           (v5/*: any*/),
                           (v4/*: any*/),
-                          (v3/*: any*/),
-                          (v7/*: any*/),
-                          (v11/*: any*/),
+                          (v8/*: any*/),
+                          (v12/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1492,18 +1552,18 @@ return {
                             "name": "image",
                             "plural": false,
                             "selections": [
-                              (v12/*: any*/)
+                              (v13/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v13/*: any*/)
+                          (v14/*: any*/)
                         ],
                         "storageKey": null
                       }
                     ],
                     "storageKey": null
                   },
-                  (v5/*: any*/)
+                  (v6/*: any*/)
                 ],
                 "storageKey": "filterArtworksConnection(first:20,input:{\"includeArtworksByFollowedArtists\":true})"
               },
@@ -1514,8 +1574,8 @@ return {
                 "name": "about",
                 "storageKey": null
               },
-              (v14/*: any*/),
               (v15/*: any*/),
+              (v16/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1548,7 +1608,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v5/*: any*/)
+                  (v6/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -1573,7 +1633,7 @@ return {
                     "name": "url",
                     "storageKey": "url(version:\"large_rectangle\")"
                   },
-                  (v16/*: any*/)
+                  (v17/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -1592,7 +1652,7 @@ return {
                 "name": "location",
                 "plural": false,
                 "selections": [
-                  (v14/*: any*/),
+                  (v15/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1618,7 +1678,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v5/*: any*/)
+                  (v6/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -1656,33 +1716,33 @@ return {
               },
               {
                 "alias": "fairHours",
-                "args": (v17/*: any*/),
+                "args": (v18/*: any*/),
                 "kind": "ScalarField",
                 "name": "hours",
                 "storageKey": "hours(format:\"MARKDOWN\")"
               },
               {
                 "alias": "fairLinks",
-                "args": (v17/*: any*/),
+                "args": (v18/*: any*/),
                 "kind": "ScalarField",
                 "name": "links",
                 "storageKey": "links(format:\"MARKDOWN\")"
               },
               {
                 "alias": "fairTickets",
-                "args": (v17/*: any*/),
+                "args": (v18/*: any*/),
                 "kind": "ScalarField",
                 "name": "tickets",
                 "storageKey": "tickets(format:\"MARKDOWN\")"
               },
               {
                 "alias": "fairContact",
-                "args": (v17/*: any*/),
+                "args": (v18/*: any*/),
                 "kind": "ScalarField",
                 "name": "contact",
                 "storageKey": "contact(format:\"MARKDOWN\")"
               },
-              (v18/*: any*/),
+              (v19/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1690,17 +1750,17 @@ return {
                 "name": "startAt",
                 "storageKey": null
               },
-              (v19/*: any*/),
+              (v20/*: any*/),
               {
                 "alias": "fairArtworks",
-                "args": (v21/*: any*/),
+                "args": (v22/*: any*/),
                 "concreteType": "FilterArtworksConnection",
                 "kind": "LinkedField",
                 "name": "filterArtworksConnection",
                 "plural": false,
                 "selections": [
-                  (v22/*: any*/),
-                  (v24/*: any*/),
+                  (v23/*: any*/),
+                  (v25/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1726,19 +1786,16 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v27/*: any*/),
-                  (v5/*: any*/),
-                  (v36/*: any*/)
+                  (v28/*: any*/),
+                  (v6/*: any*/),
+                  (v37/*: any*/)
                 ],
                 "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:30)"
               },
               {
                 "alias": "fairArtworks",
-                "args": (v21/*: any*/),
-                "filters": [
-                  "aggregations",
-                  "input"
-                ],
+                "args": (v22/*: any*/),
+                "filters": (v38/*: any*/),
                 "handle": "connection",
                 "key": "Fair_fairArtworks",
                 "kind": "LinkedHandle",
@@ -1746,7 +1803,7 @@ return {
               },
               {
                 "alias": "exhibitors",
-                "args": (v37/*: any*/),
+                "args": (v39/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
@@ -1768,7 +1825,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1776,7 +1833,7 @@ return {
                             "kind": "LinkedField",
                             "name": "counts",
                             "plural": false,
-                            "selections": (v38/*: any*/),
+                            "selections": (v40/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1787,26 +1844,26 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v2/*: any*/),
+                              (v3/*: any*/),
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v39/*: any*/),
+                                "selections": (v41/*: any*/),
                                 "type": "Partner",
                                 "abstractKey": null
                               },
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v39/*: any*/),
+                                "selections": (v41/*: any*/),
                                 "type": "ExternalPartner",
                                 "abstractKey": null
                               },
-                              (v35/*: any*/)
+                              (v36/*: any*/)
                             ],
                             "storageKey": null
                           },
+                          (v5/*: any*/),
                           (v4/*: any*/),
-                          (v3/*: any*/),
-                          (v7/*: any*/),
+                          (v8/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1815,16 +1872,16 @@ return {
                             "name": "fair",
                             "plural": false,
                             "selections": [
+                              (v5/*: any*/),
                               (v4/*: any*/),
-                              (v3/*: any*/),
-                              (v5/*: any*/)
+                              (v6/*: any*/)
                             ],
                             "storageKey": null
                           },
                           {
                             "alias": "artworks",
                             "args": [
-                              (v10/*: any*/)
+                              (v11/*: any*/)
                             ],
                             "concreteType": "ArtworkConnection",
                             "kind": "LinkedField",
@@ -1847,9 +1904,9 @@ return {
                                     "name": "node",
                                     "plural": false,
                                     "selections": [
-                                      (v7/*: any*/),
-                                      (v11/*: any*/),
-                                      (v5/*: any*/),
+                                      (v8/*: any*/),
+                                      (v12/*: any*/),
+                                      (v6/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -1858,12 +1915,12 @@ return {
                                         "name": "image",
                                         "plural": false,
                                         "selections": [
-                                          (v12/*: any*/),
-                                          (v16/*: any*/)
+                                          (v13/*: any*/),
+                                          (v17/*: any*/)
                                         ],
                                         "storageKey": null
                                       },
-                                      (v13/*: any*/),
+                                      (v14/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -1879,7 +1936,7 @@ return {
                                             "kind": "LinkedField",
                                             "name": "openingBid",
                                             "plural": false,
-                                            "selections": (v32/*: any*/),
+                                            "selections": (v33/*: any*/),
                                             "storageKey": null
                                           },
                                           {
@@ -1889,12 +1946,12 @@ return {
                                             "kind": "LinkedField",
                                             "name": "highestBid",
                                             "plural": false,
-                                            "selections": (v32/*: any*/),
+                                            "selections": (v33/*: any*/),
                                             "storageKey": null
                                           },
-                                          (v33/*: any*/),
-                                          (v31/*: any*/),
-                                          (v5/*: any*/)
+                                          (v34/*: any*/),
+                                          (v32/*: any*/),
+                                          (v6/*: any*/)
                                         ],
                                         "storageKey": null
                                       },
@@ -1906,16 +1963,16 @@ return {
                                         "name": "sale",
                                         "plural": false,
                                         "selections": [
+                                          (v31/*: any*/),
                                           (v30/*: any*/),
-                                          (v29/*: any*/),
-                                          (v19/*: any*/),
-                                          (v5/*: any*/)
+                                          (v20/*: any*/),
+                                          (v6/*: any*/)
                                         ],
                                         "storageKey": null
                                       },
-                                      (v6/*: any*/),
-                                      (v4/*: any*/),
-                                      (v3/*: any*/)
+                                      (v7/*: any*/),
+                                      (v5/*: any*/),
+                                      (v4/*: any*/)
                                     ],
                                     "storageKey": null
                                   }
@@ -1925,22 +1982,22 @@ return {
                             ],
                             "storageKey": "artworksConnection(first:20)"
                           },
-                          (v2/*: any*/)
+                          (v3/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v23/*: any*/)
+                      (v24/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v27/*: any*/)
+                  (v28/*: any*/)
                 ],
                 "storageKey": "showsConnection(first:30,sort:\"FEATURED_ASC\")"
               },
               {
                 "alias": "exhibitors",
-                "args": (v37/*: any*/),
-                "filters": (v40/*: any*/),
+                "args": (v39/*: any*/),
+                "filters": (v42/*: any*/),
                 "handle": "connection",
                 "key": "FairExhibitorsQuery_exhibitors",
                 "kind": "LinkedHandle",
@@ -1953,9 +2010,9 @@ return {
           {
             "kind": "InlineFragment",
             "selections": [
+              (v6/*: any*/),
               (v5/*: any*/),
               (v4/*: any*/),
-              (v3/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1964,7 +2021,7 @@ return {
                 "name": "profile",
                 "plural": false,
                 "selections": [
-                  (v5/*: any*/),
+                  (v6/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1972,7 +2029,7 @@ return {
                     "name": "isFollowed",
                     "storageKey": null
                   },
-                  (v4/*: any*/),
+                  (v5/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1980,49 +2037,36 @@ return {
                     "name": "bio",
                     "storageKey": null
                   },
-                  (v15/*: any*/)
+                  (v16/*: any*/)
                 ],
                 "storageKey": null
               },
               {
                 "alias": "artworks",
-                "args": (v42/*: any*/),
+                "args": (v44/*: any*/),
                 "concreteType": "FilterArtworksConnection",
                 "kind": "LinkedField",
                 "name": "filterArtworksConnection",
                 "plural": false,
                 "selections": [
-                  (v22/*: any*/),
-                  (v24/*: any*/),
-                  (v27/*: any*/),
-                  (v5/*: any*/),
-                  (v36/*: any*/)
+                  (v23/*: any*/),
+                  (v25/*: any*/),
+                  (v28/*: any*/),
+                  (v6/*: any*/),
+                  (v37/*: any*/)
                 ],
-                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],dimensionRange:\"*-*\",first:10,sort:\"-partner_updated_at\")"
+                "storageKey": null
               },
               {
                 "alias": "artworks",
-                "args": (v42/*: any*/),
-                "filters": [
-                  "acquireable",
-                  "aggregations",
-                  "attributionClass",
-                  "color",
-                  "colors",
-                  "dimensionRange",
-                  "additionalGeneIDs",
-                  "inquireableOnly",
-                  "majorPeriods",
-                  "offerable",
-                  "priceRange",
-                  "sort"
-                ],
+                "args": (v44/*: any*/),
+                "filters": (v38/*: any*/),
                 "handle": "connection",
                 "key": "Partner_artworks",
                 "kind": "LinkedHandle",
                 "name": "filterArtworksConnection"
               },
-              (v15/*: any*/),
+              (v16/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -2032,13 +2076,13 @@ return {
               },
               {
                 "alias": "artists",
-                "args": (v43/*: any*/),
+                "args": (v45/*: any*/),
                 "concreteType": "ArtistPartnerConnection",
                 "kind": "LinkedField",
                 "name": "artistsConnection",
                 "plural": false,
                 "selections": [
-                  (v44/*: any*/),
+                  (v46/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2055,10 +2099,10 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
+                          (v6/*: any*/),
                           (v5/*: any*/),
                           (v4/*: any*/),
-                          (v3/*: any*/),
-                          (v15/*: any*/),
+                          (v16/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -2066,7 +2110,7 @@ return {
                             "name": "initials",
                             "storageKey": null
                           },
-                          (v7/*: any*/),
+                          (v8/*: any*/),
                           {
                             "alias": "is_followed",
                             "args": null,
@@ -2102,7 +2146,7 @@ return {
                             "kind": "LinkedField",
                             "name": "image",
                             "plural": false,
-                            "selections": (v46/*: any*/),
+                            "selections": (v48/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -2112,15 +2156,15 @@ return {
                             "kind": "LinkedField",
                             "name": "counts",
                             "plural": false,
-                            "selections": (v38/*: any*/),
+                            "selections": (v40/*: any*/),
                             "storageKey": null
                           },
-                          (v2/*: any*/)
+                          (v3/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v23/*: any*/),
-                      (v5/*: any*/)
+                      (v24/*: any*/),
+                      (v6/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -2129,8 +2173,8 @@ return {
               },
               {
                 "alias": "artists",
-                "args": (v43/*: any*/),
-                "filters": (v40/*: any*/),
+                "args": (v45/*: any*/),
+                "filters": (v42/*: any*/),
                 "handle": "connection",
                 "key": "Partner_artists",
                 "kind": "LinkedHandle",
@@ -2150,15 +2194,15 @@ return {
                 "name": "locationsConnection",
                 "plural": false,
                 "selections": [
-                  (v8/*: any*/)
+                  (v9/*: any*/)
                 ],
                 "storageKey": "locationsConnection(first:0)"
               },
               {
                 "alias": "recentShows",
                 "args": [
-                  (v41/*: any*/),
-                  (v47/*: any*/)
+                  (v43/*: any*/),
+                  (v49/*: any*/)
                 ],
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
@@ -2181,8 +2225,8 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
-                          (v48/*: any*/)
+                          (v6/*: any*/),
+                          (v50/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -2194,13 +2238,13 @@ return {
               },
               {
                 "alias": "pastShows",
-                "args": (v49/*: any*/),
+                "args": (v51/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": [
-                  (v44/*: any*/),
+                  (v46/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2217,11 +2261,11 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v48/*: any*/),
-                          (v5/*: any*/),
-                          (v15/*: any*/),
-                          (v3/*: any*/),
-                          (v18/*: any*/),
+                          (v50/*: any*/),
+                          (v6/*: any*/),
+                          (v16/*: any*/),
+                          (v4/*: any*/),
+                          (v19/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -2230,17 +2274,17 @@ return {
                             "name": "coverImage",
                             "plural": false,
                             "selections": [
-                              (v45/*: any*/),
-                              (v16/*: any*/)
+                              (v47/*: any*/),
+                              (v17/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v7/*: any*/),
-                          (v2/*: any*/)
+                          (v8/*: any*/),
+                          (v3/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v23/*: any*/)
+                      (v24/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -2249,8 +2293,8 @@ return {
               },
               {
                 "alias": "pastShows",
-                "args": (v49/*: any*/),
-                "filters": (v50/*: any*/),
+                "args": (v51/*: any*/),
+                "filters": (v52/*: any*/),
                 "handle": "connection",
                 "key": "Partner_pastShows",
                 "kind": "LinkedHandle",
@@ -2258,13 +2302,13 @@ return {
               },
               {
                 "alias": "currentAndUpcomingShows",
-                "args": (v51/*: any*/),
+                "args": (v53/*: any*/),
                 "concreteType": "ShowConnection",
                 "kind": "LinkedField",
                 "name": "showsConnection",
                 "plural": false,
                 "selections": [
-                  (v44/*: any*/),
+                  (v46/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -2281,13 +2325,13 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v48/*: any*/),
+                          (v50/*: any*/),
+                          (v6/*: any*/),
                           (v5/*: any*/),
                           (v4/*: any*/),
-                          (v3/*: any*/),
-                          (v15/*: any*/),
-                          (v18/*: any*/),
+                          (v16/*: any*/),
                           (v19/*: any*/),
+                          (v20/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -2295,7 +2339,7 @@ return {
                             "kind": "LinkedField",
                             "name": "images",
                             "plural": true,
-                            "selections": (v46/*: any*/),
+                            "selections": (v48/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -2306,19 +2350,19 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v2/*: any*/),
+                              (v3/*: any*/),
                               {
                                 "kind": "InlineFragment",
                                 "selections": [
-                                  (v15/*: any*/)
+                                  (v16/*: any*/)
                                 ],
                                 "type": "Partner",
                                 "abstractKey": null
                               },
-                              (v35/*: any*/),
+                              (v36/*: any*/),
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v34/*: any*/),
+                                "selections": (v35/*: any*/),
                                 "type": "ExternalPartner",
                                 "abstractKey": null
                               }
@@ -2332,14 +2376,14 @@ return {
                             "kind": "LinkedField",
                             "name": "coverImage",
                             "plural": false,
-                            "selections": (v46/*: any*/),
+                            "selections": (v48/*: any*/),
                             "storageKey": null
                           },
-                          (v2/*: any*/)
+                          (v3/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v23/*: any*/)
+                      (v24/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -2348,8 +2392,8 @@ return {
               },
               {
                 "alias": "currentAndUpcomingShows",
-                "args": (v51/*: any*/),
-                "filters": (v50/*: any*/),
+                "args": (v53/*: any*/),
+                "filters": (v52/*: any*/),
                 "handle": "connection",
                 "key": "Partner_currentAndUpcomingShows",
                 "kind": "LinkedHandle",
@@ -2377,14 +2421,14 @@ return {
             "type": "Partner",
             "abstractKey": null
           },
-          (v35/*: any*/)
+          (v36/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "de9f38f2aaf9a49e07a363be80d6aeaa",
+    "id": "33665c132f7f567d8d0525cad442a71c",
     "metadata": {},
     "name": "VanityURLEntityQuery",
     "operationKind": "query",
@@ -2392,5 +2436,5 @@ return {
   }
 };
 })();
-(node as any).hash = '345c641dc3f2ba52a22786a800cb6439';
+(node as any).hash = '721d938d828b16c87002389e06afc8f1';
 export default node;

--- a/src/__generated__/VanityURLEntity_fairOrPartner.graphql.ts
+++ b/src/__generated__/VanityURLEntity_fairOrPartner.graphql.ts
@@ -28,7 +28,13 @@ export type VanityURLEntity_fairOrPartner$key = {
 
 
 const node: ReaderFragment = {
-  "argumentDefinitions": [],
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "input"
+    }
+  ],
   "kind": "Fragment",
   "metadata": null,
   "name": "VanityURLEntity_fairOrPartner",
@@ -63,7 +69,13 @@ const node: ReaderFragment = {
       "kind": "InlineFragment",
       "selections": [
         {
-          "args": null,
+          "args": [
+            {
+              "kind": "Variable",
+              "name": "input",
+              "variableName": "input"
+            }
+          ],
           "kind": "FragmentSpread",
           "name": "Partner_partner"
         }
@@ -75,5 +87,5 @@ const node: ReaderFragment = {
   "type": "VanityURLEntityType",
   "abstractKey": "__isVanityURLEntityType"
 };
-(node as any).hash = '390ae282c3c418c11c6295a43866b292';
+(node as any).hash = '766e22899053d15c876c2546a8aba00c';
 export default node;

--- a/src/__generated__/VanityURLEntity_fairOrPartner.graphql.ts
+++ b/src/__generated__/VanityURLEntity_fairOrPartner.graphql.ts
@@ -28,13 +28,7 @@ export type VanityURLEntity_fairOrPartner$key = {
 
 
 const node: ReaderFragment = {
-  "argumentDefinitions": [
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "input"
-    }
-  ],
+  "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
   "name": "VanityURLEntity_fairOrPartner",
@@ -69,13 +63,7 @@ const node: ReaderFragment = {
       "kind": "InlineFragment",
       "selections": [
         {
-          "args": [
-            {
-              "kind": "Variable",
-              "name": "input",
-              "variableName": "input"
-            }
-          ],
+          "args": null,
           "kind": "FragmentSpread",
           "name": "Partner_partner"
         }
@@ -87,5 +75,5 @@ const node: ReaderFragment = {
   "type": "VanityURLEntityType",
   "abstractKey": "__isVanityURLEntityType"
 };
-(node as any).hash = '766e22899053d15c876c2546a8aba00c';
+(node as any).hash = '390ae282c3c418c11c6295a43866b292';
 export default node;

--- a/src/lib/Components/Artist/ArtistAbout/ArtistAbout.tsx
+++ b/src/lib/Components/Artist/ArtistAbout/ArtistAbout.tsx
@@ -61,7 +61,7 @@ export const ArtistAboutContainer = createFragmentContainer(ArtistAbout, {
       ...ArtistSeriesMoreSeries_artist
       ...ArtistNotableWorksRail_artist
       # this should match the query in ArtistNotableWorksRail
-      notableWorks: filterArtworksConnection(sort: "-weighted_iconicity", first: 3) {
+      notableWorks: filterArtworksConnection(first: 3, input: { sort: "-weighted_iconicity" }) {
         edges {
           node {
             id

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -87,7 +87,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
   const setAggregationsAction = ArtworksFiltersStore.useStoreActions((state) => state.setAggregationsAction)
 
   const filterParams = filterArtworksParams(appliedFilters)
-  const preparedFilterParams = prepareFilterArtworksParamsForInput(filterParams);
+  const preparedFilterParams = prepareFilterArtworksParamsForInput(filterParams)
   const artworks = artist.artworks
   const artworksCount = artworks?.edges?.length
   const artworksTotal = artworks?.counts?.total

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -87,7 +87,6 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
   const setAggregationsAction = ArtworksFiltersStore.useStoreActions((state) => state.setAggregationsAction)
 
   const filterParams = filterArtworksParams(appliedFilters)
-  const preparedFilterParams = prepareFilterArtworksParamsForInput(filterParams)
   const artworks = artist.artworks
   const artworksCount = artworks?.edges?.length
   const artworksTotal = artworks?.counts?.total
@@ -101,7 +100,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
             throw new Error("ArtistArtworks/ArtistArtworks filter error: " + error.message)
           }
         },
-        { input: preparedFilterParams },
+        { input: prepareFilterArtworksParamsForInput(filterParams) },
       )
     }
   }, [appliedFilters])

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -1,7 +1,7 @@
 import { OwnerType } from "@artsy/cohesion"
 import { ArtistArtworks_artist } from "__generated__/ArtistArtworks_artist.graphql"
 import { ArtworkFilterNavigator, FilterModalMode } from "lib/Components/ArtworkFilter"
-import { filterArtworksParams } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { filterArtworksParams, prepareFilterArtworksParamsForInput } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworkFiltersStoreProvider, ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
 import {
@@ -87,6 +87,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
   const setAggregationsAction = ArtworksFiltersStore.useStoreActions((state) => state.setAggregationsAction)
 
   const filterParams = filterArtworksParams(appliedFilters)
+  const preparedFilterParams = prepareFilterArtworksParamsForInput(filterParams);
   const artworks = artist.artworks
   const artworksCount = artworks?.edges?.length
   const artworksTotal = artworks?.counts?.total
@@ -100,7 +101,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
             throw new Error("ArtistArtworks/ArtistArtworks filter error: " + error.message)
           }
         },
-        filterParams
+        { input: preparedFilterParams },
       )
     }
   }, [appliedFilters])
@@ -176,20 +177,7 @@ export default createPaginationContainer(
       @argumentDefinitions(
         count: { type: "Int", defaultValue: 10 }
         cursor: { type: "String" }
-        sort: { type: "String", defaultValue: "-decayed_merch" }
-        additionalGeneIDs: { type: "[String]" }
-        priceRange: { type: "String" }
-        color: { type: "String" }
-        colors: { type: "[String]" }
-        partnerID: { type: "ID" }
-        partnerIDs: { type: "[String]" }
-        dimensionRange: { type: "String", defaultValue: "*-*" }
-        majorPeriods: { type: "[String]" }
-        acquireable: { type: "Boolean" }
-        inquireableOnly: { type: "Boolean" }
-        atAuction: { type: "Boolean" }
-        offerable: { type: "Boolean" }
-        attributionClass: { type: "[String]" }
+        input: { type: "FilterArtworksInput" }
       ) {
         id
         slug
@@ -197,21 +185,8 @@ export default createPaginationContainer(
         artworks: filterArtworksConnection(
           first: $count
           after: $cursor
-          sort: $sort
-          additionalGeneIDs: $additionalGeneIDs
-          priceRange: $priceRange
-          color: $color
-          colors: $colors
-          partnerID: $partnerID
-          partnerIDs: $partnerIDs
-          dimensionRange: $dimensionRange
-          majorPeriods: $majorPeriods
-          acquireable: $acquireable
-          inquireableOnly: $inquireableOnly
-          atAuction: $atAuction
-          offerable: $offerable
+          input: $input
           aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]
-          attributionClass: $attributionClass
         ) @connection(key: "ArtistArtworksGrid_artworks") {
           aggregations {
             slice
@@ -240,8 +215,8 @@ export default createPaginationContainer(
     },
     getVariables(props, { count, cursor }, fragmentVariables) {
       return {
-        ...fragmentVariables,
         id: props.artist.id,
+        input: fragmentVariables.input,
         count,
         cursor,
       }
@@ -251,20 +226,7 @@ export default createPaginationContainer(
         $id: ID!
         $count: Int!
         $cursor: String
-        $sort: String
-        $additionalGeneIDs: [String]
-        $priceRange: String
-        $color: String
-        $colors: [String]
-        $partnerID: ID
-        $partnerIDs: [String]
-        $dimensionRange: String
-        $majorPeriods: [String]
-        $acquireable: Boolean
-        $inquireableOnly: Boolean
-        $atAuction: Boolean
-        $offerable: Boolean
-        $attributionClass: [String]
+        $input: FilterArtworksInput
       ) {
         node(id: $id) {
           ... on Artist {
@@ -272,20 +234,7 @@ export default createPaginationContainer(
               @arguments(
                 count: $count
                 cursor: $cursor
-                sort: $sort
-                additionalGeneIDs: $additionalGeneIDs
-                color: $color
-                colors: $colors
-                partnerID: $partnerID
-                partnerIDs: $partnerIDs
-                priceRange: $priceRange
-                dimensionRange: $dimensionRange
-                majorPeriods: $majorPeriods
-                acquireable: $acquireable
-                inquireableOnly: $inquireableOnly
-                atAuction: $atAuction
-                offerable: $offerable
-                attributionClass: $attributionClass
+                input: $input
               )
           }
         }

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistNotableWorksRail.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistNotableWorksRail.tsx
@@ -100,7 +100,7 @@ export const ArtistNotableWorksRailFragmentContainer = createFragmentContainer(A
       internalID
       slug
       # this should match the notableWorks query in ArtistAbout
-      filterArtworksConnection(sort: "-weighted_iconicity", first: 10) {
+      filterArtworksConnection(first: 10, input: { sort: "-weighted_iconicity" }) {
         edges {
           node {
             id

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -261,7 +261,6 @@ export const changedFiltersParams = (currentFilterParams: FilterParams, selected
 }
 
 export const filterArtworksParams = (appliedFilters: FilterArray, filterType: FilterType = "artwork") => {
-  // console.log("[variables] filterArtworksParams", appliedFilters, filterType)
   const defaultFilterParams = getDefaultParamsByType(filterType)
   return paramsFromAppliedFilters(appliedFilters, { ...defaultFilterParams }, filterType)
 }

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -1,5 +1,5 @@
 import { FilterScreen } from "lib/Components/ArtworkFilter"
-import { capitalize, compact, forOwn, groupBy, sortBy } from "lodash"
+import { capitalize, compact, forOwn, groupBy, pick, sortBy } from "lodash"
 
 export enum FilterDisplayName {
   // artist = "Artists",
@@ -452,4 +452,56 @@ export const getDisplayNameForTimePeriod = (aggregationName: string) => {
   }
 
   return DISPLAY_TEXT[aggregationName] ?? aggregationName
+}
+
+export const prepareFilterArtworksParamsForInput = (filters: FilterParams) => {
+  return pick(filters, [
+    "acquireable",
+    "additionalGeneIDs",
+    "after",
+    "aggregationPartnerCities",
+    "aggregations",
+    "artistID",
+    "artistIDs",
+    "artistNationalities",
+    "artistSeriesID",
+    "atAuction",
+    "attributionClass",
+    "before",
+    "color",
+    "colors",
+    "dimensionRange",
+    "excludeArtworkIDs",
+    "extraAggregationGeneIDs",
+    "first",
+    "forSale",
+    "geneID",
+    "geneIDs",
+    "height",
+    "includeArtworksByFollowedArtists",
+    "includeMediumFilterInAggregation",
+    "inquireableOnly",
+    "keyword",
+    "keywordMatchExact",
+    "last",
+    "locationCities",
+    "majorPeriods",
+    "marketable",
+    "materialsTerms",
+    "medium",
+    "offerable",
+    "page",
+    "partnerCities",
+    "partnerID",
+    "partnerIDs",
+    "period",
+    "periods",
+    "priceRange",
+    "saleID",
+    "size",
+    "sizes",
+    "sort",
+    "tagID",
+    "width",
+  ])
 }

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -261,6 +261,7 @@ export const changedFiltersParams = (currentFilterParams: FilterParams, selected
 }
 
 export const filterArtworksParams = (appliedFilters: FilterArray, filterType: FilterType = "artwork") => {
+  // console.log("[variables] filterArtworksParams", appliedFilters, filterType)
   const defaultFilterParams = getDefaultParamsByType(filterType)
   return paramsFromAppliedFilters(appliedFilters, { ...defaultFilterParams }, filterType)
 }

--- a/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
@@ -4,6 +4,8 @@ import {
   changedFiltersParams,
   filterArtworksParams,
   FilterParamName,
+  FilterParams,
+  prepareFilterArtworksParamsForInput,
   selectedOption,
 } from "../ArtworkFilterHelpers"
 
@@ -706,5 +708,67 @@ describe("aggregationsWithFollowedArtists", () => {
         ],
       },
     ])
+  })
+})
+
+describe("prepareFilterArtworksParamsForInput", () => {
+  it("returns only allowed params when default params are passed", () => {
+    const filters = {
+      acquireable: false,
+      atAuction: false,
+      dimensionRange: "*-*",
+      includeArtworksByFollowedArtists: false,
+      inquireableOnly: false,
+      medium: "*",
+      offerable: false,
+      priceRange: "*-*",
+      sort: "-decayed_merch",
+    } as FilterParams;
+
+    expect(prepareFilterArtworksParamsForInput(filters)).toEqual({
+      acquireable: false,
+      atAuction: false,
+      dimensionRange: "*-*",
+      includeArtworksByFollowedArtists: false,
+      inquireableOnly: false,
+      medium: "*",
+      offerable: false,
+      priceRange: "*-*",
+      sort: "-decayed_merch",
+    })
+  })
+
+  it("returns only allowed params when no params are passed", () => {
+    const filters = {} as FilterParams;
+
+    expect(prepareFilterArtworksParamsForInput(filters)).toEqual({})
+  })
+
+  it("returns only allowed params when extra params are passed", () => {
+    const filters = {
+      acquireable: false,
+      atAuction: false,
+      categories: undefined, // TO check
+      dimensionRange: "*-*",
+      estimateRange: "",
+      inquireableOnly: false,
+      medium: "*",
+      offerable: false,
+      priceRange: "*-*",
+      sort: "-decayed_merch",
+      includeArtworksByFollowedArtists: false,
+    } as FilterParams;
+
+    expect(prepareFilterArtworksParamsForInput(filters)).toEqual({
+      acquireable: false,
+      atAuction: false,
+      dimensionRange: "*-*",
+      includeArtworksByFollowedArtists: false,
+      inquireableOnly: false,
+      medium: "*",
+      offerable: false,
+      priceRange: "*-*",
+      sort: "-decayed_merch",
+    })
   })
 })

--- a/src/lib/Components/ArtworkFilter/useArtworkFilters.ts
+++ b/src/lib/Components/ArtworkFilter/useArtworkFilters.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react"
 import { RelayPaginationProp } from "react-relay"
-import { aggregationForFilter, filterArtworksParams, FilterParamName } from "./ArtworkFilterHelpers"
+import { aggregationForFilter, filterArtworksParams, FilterParamName, prepareFilterArtworksParamsForInput } from "./ArtworkFilterHelpers"
 import { ArtworksFiltersStore, selectedOptionsUnion } from "./ArtworkFilterStore"
 
 export const useArtworkFilters = ({
@@ -31,7 +31,7 @@ export const useArtworkFilters = ({
             throw error
           }
         },
-        filterParams
+        { input: prepareFilterArtworksParamsForInput(filterParams) }
       )
     }
   }, [relay, appliedFilters, filterParams])

--- a/src/lib/Components/ArtworkFilter/useArtworkFilters.ts
+++ b/src/lib/Components/ArtworkFilter/useArtworkFilters.ts
@@ -1,6 +1,11 @@
 import { useEffect } from "react"
 import { RelayPaginationProp } from "react-relay"
-import { aggregationForFilter, filterArtworksParams, FilterParamName, prepareFilterArtworksParamsForInput } from "./ArtworkFilterHelpers"
+import {
+  aggregationForFilter,
+  filterArtworksParams,
+  FilterParamName,
+  prepareFilterArtworksParamsForInput,
+} from "./ArtworkFilterHelpers"
 import { ArtworksFiltersStore, selectedOptionsUnion } from "./ArtworkFilterStore"
 
 export const useArtworkFilters = ({

--- a/src/lib/Containers/__tests__/Gene-tests.tsx
+++ b/src/lib/Containers/__tests__/Gene-tests.tsx
@@ -9,9 +9,11 @@ jest.mock("../../Components/Gene/Header", () => "Header")
 import { Gene } from "../Gene"
 
 const exampleProps = {
-  medium: "propupines",
-  price_range: "1000-80000",
-  sort: "-desc",
+  input: {
+    medium: "propupines",
+    priceRange: "1000-80000",
+    sort: "-desc",
+  },
   gene: { filtered_artworks: { aggregations: [] } },
 }
 
@@ -76,9 +78,11 @@ describe("state", () => {
 
       // As well as trigger new state for Relay ( triggering a new call to metaphysics )
       expect(gene.props.relay.refetchConnection).lastCalledWith(10, undefined, {
-        medium: "porcupines",
-        price_range: "1000-80000",
-        sort: "-desc",
+        input: {
+          medium: "porcupines",
+          priceRange: "1000-80000",
+          sort: "-desc",
+        }
       })
     })
   })

--- a/src/lib/Scenes/Artist/Artist.tsx
+++ b/src/lib/Scenes/Artist/Artist.tsx
@@ -121,7 +121,7 @@ export const ArtistQueryRenderer: React.FC<ArtistQueryRendererProps> = ({ artist
       environment={environment || defaultEnvironment}
       above={{
         query: graphql`
-          query ArtistAboveTheFoldQuery($artistID: String!, $input: FilterArtworksInput) {
+          query ArtistAboveTheFoldQuery($artistID: String!) {
             artist(id: $artistID) {
               internalID
               slug
@@ -133,20 +133,20 @@ export const ArtistQueryRenderer: React.FC<ArtistQueryRendererProps> = ({ artist
                 articles
               }
               ...ArtistHeader_artist
-              ...ArtistArtworks_artist @arguments(input: $input)
+              ...ArtistArtworks_artist
+              @arguments(
+                input: {
+                  dimensionRange: "*-*",
+                  sort: "-decayed_merch",
+                }
+              )
               auctionResultsConnection {
                 totalCount
               }
             }
           }
         `,
-        variables: {
-          artistID,
-          input: {
-            dimensionRange: "*-*",
-            sort: "-decayed_merch",
-          }
-        },
+        variables: { artistID },
       }}
       below={{
         query: graphql`

--- a/src/lib/Scenes/Artist/Artist.tsx
+++ b/src/lib/Scenes/Artist/Artist.tsx
@@ -121,7 +121,7 @@ export const ArtistQueryRenderer: React.FC<ArtistQueryRendererProps> = ({ artist
       environment={environment || defaultEnvironment}
       above={{
         query: graphql`
-          query ArtistAboveTheFoldQuery($artistID: String!) {
+          query ArtistAboveTheFoldQuery($artistID: String!, $input: FilterArtworksInput) {
             artist(id: $artistID) {
               internalID
               slug
@@ -133,14 +133,20 @@ export const ArtistQueryRenderer: React.FC<ArtistQueryRendererProps> = ({ artist
                 articles
               }
               ...ArtistHeader_artist
-              ...ArtistArtworks_artist
+              ...ArtistArtworks_artist @arguments(input: $input)
               auctionResultsConnection {
                 totalCount
               }
             }
           }
         `,
-        variables: { artistID },
+        variables: {
+          artistID,
+          input: {
+            dimensionRange: "*-*",
+            sort: "-decayed_merch",
+          }
+        },
       }}
       below={{
         query: graphql`

--- a/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeries.tsx
@@ -160,7 +160,10 @@ export const ArtistSeriesFragmentContainer = createFragmentContainer(ArtistSerie
 
       ...ArtistSeriesHeader_artistSeries
       ...ArtistSeriesMeta_artistSeries
-      ...ArtistSeriesArtworks_artistSeries
+      ...ArtistSeriesArtworks_artistSeries @arguments(input: {
+        sort: "-decayed_merch",
+        dimensionRange: "*-*"
+      })
 
       artist: artists(size: 1) {
         ...ArtistSeriesMoreSeries_artist

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
@@ -25,7 +25,6 @@ export const ArtistSeriesArtworks: React.FC<ArtistSeriesArtworksProps> = ({ arti
 
   const tracking = useTracking()
   const filterParams = filterArtworksParams(appliedFilters)
-  const preparedFilterParams = prepareFilterArtworksParamsForInput(filterParams)
 
   const artworks = artistSeries?.artistSeriesArtworks!
 
@@ -49,7 +48,7 @@ export const ArtistSeriesArtworks: React.FC<ArtistSeriesArtworksProps> = ({ arti
             throw new Error("ArtistSeries/ArtistSeriesArtworks filter error: " + error.message)
           }
         },
-        { input: preparedFilterParams }
+        { input: prepareFilterArtworksParamsForInput(filterParams) }
       )
     }
   }, [appliedFilters])

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
@@ -1,6 +1,6 @@
 import { OwnerType } from "@artsy/cohesion"
 import { ArtistSeriesArtworks_artistSeries } from "__generated__/ArtistSeriesArtworks_artistSeries.graphql"
-import { filterArtworksParams } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { filterArtworksParams, prepareFilterArtworksParamsForInput } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
 import { InfiniteScrollArtworksGridContainer } from "lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
@@ -25,6 +25,7 @@ export const ArtistSeriesArtworks: React.FC<ArtistSeriesArtworksProps> = ({ arti
 
   const tracking = useTracking()
   const filterParams = filterArtworksParams(appliedFilters)
+  const preparedFilterParams = prepareFilterArtworksParamsForInput(filterParams)
 
   const artworks = artistSeries?.artistSeriesArtworks!
 
@@ -48,7 +49,7 @@ export const ArtistSeriesArtworks: React.FC<ArtistSeriesArtworksProps> = ({ arti
             throw new Error("ArtistSeries/ArtistSeriesArtworks filter error: " + error.message)
           }
         },
-        filterParams
+        { input: preparedFilterParams }
       )
     }
   }, [appliedFilters])
@@ -92,41 +93,15 @@ export const ArtistSeriesArtworksFragmentContainer = createPaginationContainer(
       @argumentDefinitions(
         count: { type: "Int", defaultValue: 20 }
         cursor: { type: "String" }
-        sort: { type: "String", defaultValue: "-decayed_merch" }
-        additionalGeneIDs: { type: "[String]" }
-        priceRange: { type: "String" }
-        color: { type: "String" }
-        colors: { type: "[String]" }
-        partnerID: { type: "ID" }
-        partnerIDs: { type: "[String]" }
-        dimensionRange: { type: "String", defaultValue: "*-*" }
-        majorPeriods: { type: "[String]" }
-        acquireable: { type: "Boolean" }
-        inquireableOnly: { type: "Boolean" }
-        atAuction: { type: "Boolean" }
-        offerable: { type: "Boolean" }
-        attributionClass: { type: "[String]" }
+        input: { type: "FilterArtworksInput" }
       ) {
         slug
         internalID
         artistSeriesArtworks: filterArtworksConnection(
           first: 20
           after: $cursor
-          sort: $sort
-          additionalGeneIDs: $additionalGeneIDs
-          priceRange: $priceRange
-          color: $color
-          colors: $colors
-          partnerID: $partnerID
-          partnerIDs: $partnerIDs
-          dimensionRange: $dimensionRange
-          majorPeriods: $majorPeriods
-          acquireable: $acquireable
-          inquireableOnly: $inquireableOnly
-          atAuction: $atAuction
-          offerable: $offerable
           aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]
-          attributionClass: $attributionClass
+          input: $input
         ) @connection(key: "ArtistSeries_artistSeriesArtworks") {
           aggregations {
             slice
@@ -162,11 +137,11 @@ export const ArtistSeriesArtworksFragmentContainer = createPaginationContainer(
     },
     getVariables(props, { count, cursor }, fragmentVariables) {
       return {
-        ...fragmentVariables,
         props,
         count,
         cursor,
         id: props.artistSeries.slug,
+        input: fragmentVariables.input,
       }
     },
     query: graphql`
@@ -174,40 +149,14 @@ export const ArtistSeriesArtworksFragmentContainer = createPaginationContainer(
         $id: ID!
         $count: Int!
         $cursor: String
-        $sort: String
-        $additionalGeneIDs: [String]
-        $priceRange: String
-        $color: String
-        $colors: [String]
-        $partnerID: ID
-        $partnerIDs: [String]
-        $dimensionRange: String
-        $majorPeriods: [String]
-        $acquireable: Boolean
-        $inquireableOnly: Boolean
-        $atAuction: Boolean
-        $offerable: Boolean
-        $attributionClass: [String]
+        $input: FilterArtworksInput
       ) {
         artistSeries(id: $id) {
           ...ArtistSeriesArtworks_artistSeries
             @arguments(
               count: $count
               cursor: $cursor
-              sort: $sort
-              additionalGeneIDs: $additionalGeneIDs
-              color: $color
-              colors: $colors
-              partnerID: $partnerID
-              partnerIDs: $partnerIDs
-              priceRange: $priceRange
-              dimensionRange: $dimensionRange
-              majorPeriods: $majorPeriods
-              acquireable: $acquireable
-              inquireableOnly: $inquireableOnly
-              atAuction: $atAuction
-              offerable: $offerable
-              attributionClass: $attributionClass
+              input: $input
             )
         }
       }

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -402,7 +402,7 @@ export const ArtworkContainer = createRefetchContainer(
         artistSeriesConnection(first: 1) {
           edges {
             node {
-              filterArtworksConnection(sort: "-decayed_merch", first: 20) {
+              filterArtworksConnection(first: 20, input: { sort: "-decayed_merch" }) {
                 edges {
                   node {
                     id

--- a/src/lib/Scenes/Artwork/Components/ArtworksInSeriesRail.tsx
+++ b/src/lib/Scenes/Artwork/Components/ArtworksInSeriesRail.tsx
@@ -125,7 +125,7 @@ export const ArtworksInSeriesRailFragmentContainer = createFragmentContainer(Art
           node {
             slug
             internalID
-            filterArtworksConnection(sort: "-decayed_merch", first: 20) {
+            filterArtworksConnection(first: 20, input: { sort: "-decayed_merch" }) {
               edges {
                 node {
                   slug

--- a/src/lib/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/lib/Scenes/Fair/Components/FairArtworks.tsx
@@ -42,7 +42,6 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
   const applyFilters = ArtworksFiltersStore.useStoreState((state) => state.applyFilters)
 
   const filterParams = filterArtworksParams(appliedFilters)
-  const preparedFilterParams = prepareFilterArtworksParamsForInput(filterParams)
 
   const trackClear = (id: string, slug: string) => {
     tracking.trackEvent({
@@ -70,7 +69,7 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
             throw new Error("Fair/FairArtworks filter error: " + error.message)
           }
         },
-        { input: preparedFilterParams }
+        { input: prepareFilterArtworksParamsForInput(filterParams) }
       )
     }
   }, [appliedFilters])

--- a/src/lib/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/lib/Scenes/Fair/Components/FairArtworks.tsx
@@ -5,6 +5,7 @@ import {
   aggregationsWithFollowedArtists,
   FilterArray,
   filterArtworksParams,
+  prepareFilterArtworksParamsForInput,
 } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
@@ -41,6 +42,7 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
   const applyFilters = ArtworksFiltersStore.useStoreState((state) => state.applyFilters)
 
   const filterParams = filterArtworksParams(appliedFilters)
+  const preparedFilterParams = prepareFilterArtworksParamsForInput(filterParams)
 
   const trackClear = (id: string, slug: string) => {
     tracking.trackEvent({
@@ -68,7 +70,7 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
             throw new Error("Fair/FairArtworks filter error: " + error.message)
           }
         },
-        filterParams
+        { input: preparedFilterParams }
       )
     }
   }, [appliedFilters])
@@ -116,45 +118,15 @@ export const FairArtworksFragmentContainer = createPaginationContainer(
       @argumentDefinitions(
         count: { type: "Int", defaultValue: 30 }
         cursor: { type: "String" }
-        sort: { type: "String", defaultValue: "-decayed_merch" }
-        additionalGeneIDs: { type: "[String]" }
-        priceRange: { type: "String" }
-        color: { type: "String" }
-        colors: { type: "[String]" }
-        partnerID: { type: "ID" }
-        partnerIDs: { type: "[String]" }
-        dimensionRange: { type: "String", defaultValue: "*-*" }
-        majorPeriods: { type: "[String]" }
-        acquireable: { type: "Boolean" }
-        inquireableOnly: { type: "Boolean" }
-        atAuction: { type: "Boolean" }
-        offerable: { type: "Boolean" }
-        includeArtworksByFollowedArtists: { type: "Boolean" }
-        artistIDs: { type: "[String]" }
-        attributionClass: { type: "[String]" }
+        input: { type: "FilterArtworksInput" }
       ) {
         slug
         internalID
         fairArtworks: filterArtworksConnection(
-          first: 30
+          first: $count
           after: $cursor
-          sort: $sort
-          additionalGeneIDs: $additionalGeneIDs
-          priceRange: $priceRange
-          color: $color
-          colors: $colors
-          partnerID: $partnerID
-          partnerIDs: $partnerIDs
-          dimensionRange: $dimensionRange
-          majorPeriods: $majorPeriods
-          acquireable: $acquireable
-          inquireableOnly: $inquireableOnly
-          atAuction: $atAuction
-          offerable: $offerable
-          includeArtworksByFollowedArtists: $includeArtworksByFollowedArtists
-          artistIDs: $artistIDs
-          aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]
-          attributionClass: $attributionClass
+          aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST],
+          input: $input
         ) @connection(key: "Fair_fairArtworks") {
           aggregations {
             slice
@@ -191,7 +163,7 @@ export const FairArtworksFragmentContainer = createPaginationContainer(
     },
     getVariables(props, { count, cursor }, fragmentVariables) {
       return {
-        ...fragmentVariables,
+        input: fragmentVariables.input,
         props,
         count,
         cursor,
@@ -203,44 +175,14 @@ export const FairArtworksFragmentContainer = createPaginationContainer(
         $id: String!
         $count: Int!
         $cursor: String
-        $sort: String
-        $additionalGeneIDs: [String]
-        $priceRange: String
-        $color: String
-        $colors: [String]
-        $partnerID: ID
-        $partnerIDs: [String]
-        $dimensionRange: String
-        $majorPeriods: [String]
-        $acquireable: Boolean
-        $inquireableOnly: Boolean
-        $atAuction: Boolean
-        $offerable: Boolean
-        $includeArtworksByFollowedArtists: Boolean
-        $artistIDs: [String]
-        $attributionClass: [String]
+        $input: FilterArtworksInput
       ) {
         fair(id: $id) {
           ...FairArtworks_fair
             @arguments(
               count: $count
               cursor: $cursor
-              sort: $sort
-              additionalGeneIDs: $additionalGeneIDs
-              color: $color
-              colors: $colors
-              partnerID: $partnerID
-              partnerIDs: $partnerIDs
-              priceRange: $priceRange
-              dimensionRange: $dimensionRange
-              majorPeriods: $majorPeriods
-              acquireable: $acquireable
-              inquireableOnly: $inquireableOnly
-              atAuction: $atAuction
-              offerable: $offerable
-              includeArtworksByFollowedArtists: $includeArtworksByFollowedArtists
-              artistIDs: $artistIDs
-              attributionClass: $attributionClass
+              input: $input
             )
         }
       }

--- a/src/lib/Scenes/Fair/Components/FairFollowedArtistsRail.tsx
+++ b/src/lib/Scenes/Fair/Components/FairFollowedArtistsRail.tsx
@@ -97,7 +97,7 @@ export const FairFollowedArtistsRailFragmentContainer = createFragmentContainer(
     fragment FairFollowedArtistsRail_fair on Fair {
       internalID
       slug
-      followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {
+      followedArtistArtworks: filterArtworksConnection(first: 20, input: { includeArtworksByFollowedArtists: true }) {
         edges {
           artwork: node {
             id

--- a/src/lib/Scenes/Fair/Fair.tsx
+++ b/src/lib/Scenes/Fair/Fair.tsx
@@ -279,8 +279,7 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
 
 export const FairFragmentContainer = createFragmentContainer(Fair, {
   fair: graphql`
-    fragment Fair_fair on Fair
-    @argumentDefinitions(input: { type: "FilterArtworksInput" }) {
+    fragment Fair_fair on Fair {
       internalID
       slug
       isActive
@@ -305,7 +304,10 @@ export const FairFragmentContainer = createFragmentContainer(Fair, {
       ...FairEmptyState_fair
       ...FairEditorial_fair
       ...FairCollections_fair
-      ...FairArtworks_fair @arguments(input: $input)
+      ...FairArtworks_fair @arguments(input: {
+        sort: "-decayed_merch",
+        dimensionRange: "*-*",
+      })
       ...FairExhibitors_fair
       ...FairFollowedArtistsRail_fair
     }
@@ -317,19 +319,13 @@ export const FairQueryRenderer: React.FC<FairQueryRendererProps> = ({ fairID }) 
     <QueryRenderer<FairQuery>
       environment={defaultEnvironment}
       query={graphql`
-        query FairQuery($fairID: String!, $input: FilterArtworksInput) {
+        query FairQuery($fairID: String!) {
           fair(id: $fairID) @principalField {
-            ...Fair_fair @arguments(input: $input)
+            ...Fair_fair
           }
         }
       `}
-      variables={{
-        fairID,
-        input: {
-          sort: "-decayed_merch",
-          dimensionRange: "*-*",
-        }
-      }}
+      variables={{ fairID }}
       render={renderWithPlaceholder({
         Container: FairFragmentContainer,
         renderPlaceholder: () => <FairPlaceholder />,

--- a/src/lib/Scenes/Fair/Fair.tsx
+++ b/src/lib/Scenes/Fair/Fair.tsx
@@ -296,7 +296,7 @@ export const FairFragmentContainer = createFragmentContainer(Fair, {
         artworks
         partnerShows
       }
-      followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {
+      followedArtistArtworks: filterArtworksConnection(first: 20, input: { includeArtworksByFollowedArtists: true }) {
         edges {
           __typename
         }

--- a/src/lib/Scenes/Fair/Fair.tsx
+++ b/src/lib/Scenes/Fair/Fair.tsx
@@ -279,7 +279,8 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
 
 export const FairFragmentContainer = createFragmentContainer(Fair, {
   fair: graphql`
-    fragment Fair_fair on Fair {
+    fragment Fair_fair on Fair
+    @argumentDefinitions(input: { type: "FilterArtworksInput" }) {
       internalID
       slug
       isActive
@@ -304,7 +305,7 @@ export const FairFragmentContainer = createFragmentContainer(Fair, {
       ...FairEmptyState_fair
       ...FairEditorial_fair
       ...FairCollections_fair
-      ...FairArtworks_fair
+      ...FairArtworks_fair @arguments(input: $input)
       ...FairExhibitors_fair
       ...FairFollowedArtistsRail_fair
     }
@@ -316,13 +317,19 @@ export const FairQueryRenderer: React.FC<FairQueryRendererProps> = ({ fairID }) 
     <QueryRenderer<FairQuery>
       environment={defaultEnvironment}
       query={graphql`
-        query FairQuery($fairID: String!) {
+        query FairQuery($fairID: String!, $input: FilterArtworksInput) {
           fair(id: $fairID) @principalField {
-            ...Fair_fair
+            ...Fair_fair @arguments(input: $input)
           }
         }
       `}
-      variables={{ fairID }}
+      variables={{
+        fairID,
+        input: {
+          sort: "-decayed_merch",
+          dimensionRange: "*-*",
+        }
+      }}
       render={renderWithPlaceholder({
         Container: FairFragmentContainer,
         renderPlaceholder: () => <FairPlaceholder />,

--- a/src/lib/Scenes/Fair/FairAllFollowedArtists.tsx
+++ b/src/lib/Scenes/Fair/FairAllFollowedArtists.tsx
@@ -72,7 +72,9 @@ export const FairAllFollowedArtistsFragmentContainer = createFragmentContainer(F
       internalID
       slug
       ...FairArtworks_fair @arguments(input: {
-        includeArtworksByFollowedArtists: true
+        includeArtworksByFollowedArtists: true,
+        sort: "-decayed_merch",
+        dimensionRange: "*-*",
       })
     }
   `,

--- a/src/lib/Scenes/Fair/FairAllFollowedArtists.tsx
+++ b/src/lib/Scenes/Fair/FairAllFollowedArtists.tsx
@@ -71,7 +71,9 @@ export const FairAllFollowedArtistsFragmentContainer = createFragmentContainer(F
     fragment FairAllFollowedArtists_fair on Fair {
       internalID
       slug
-      ...FairArtworks_fair @arguments(includeArtworksByFollowedArtists: true)
+      ...FairArtworks_fair @arguments(input: {
+        includeArtworksByFollowedArtists: true
+      })
     }
   `,
   /**

--- a/src/lib/Scenes/Home/Components/FairsRail.tsx
+++ b/src/lib/Scenes/Home/Components/FairsRail.tsx
@@ -126,7 +126,7 @@ export const FairsRailFragmentContainer = createFragmentContainer(FairsRail, {
           city
           country
         }
-        followedArtistArtworks: filterArtworksConnection(first: 2, includeArtworksByFollowedArtists: true) {
+        followedArtistArtworks: filterArtworksConnection(first: 2, input: { includeArtworksByFollowedArtists: true }) {
           edges {
             node {
               image {

--- a/src/lib/Scenes/Partner/Components/PartnerArtwork.tsx
+++ b/src/lib/Scenes/Partner/Components/PartnerArtwork.tsx
@@ -60,38 +60,18 @@ export const PartnerArtworkFragmentContainer = createPaginationContainer(
     partner: graphql`
       fragment PartnerArtwork_partner on Partner
       @argumentDefinitions(
-        acquireable: { type: "Boolean" }
-        attributionClass: { type: "[String]" }
-        color: { type: "String" }
-        colors: { type: "[String]" }
         # 10 matches the PAGE_SIZE constant. This is required. See MX-316 for follow-up.
         count: { type: "Int", defaultValue: 10 }
         cursor: { type: "String" }
-        dimensionRange: { type: "String", defaultValue: "*-*" }
-        additionalGeneIDs: { type: "[String]" }
-        inquireableOnly: { type: "Boolean" }
-        majorPeriods: { type: "[String]" }
-        offerable: { type: "Boolean" }
-        priceRange: { type: "String" }
-        sort: { type: "String", defaultValue: "-partner_updated_at" }
+        input: { type: "FilterArtworksInput" }
       ) {
         internalID
         slug
         artworks: filterArtworksConnection(
-          acquireable: $acquireable
+          first: $count
           after: $cursor
           aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]
-          attributionClass: $attributionClass
-          color: $color
-          colors: $colors
-          dimensionRange: $dimensionRange
-          additionalGeneIDs: $additionalGeneIDs
-          first: $count
-          inquireableOnly: $inquireableOnly
-          majorPeriods: $majorPeriods
-          offerable: $offerable
-          priceRange: $priceRange
-          sort: $sort
+          input: $input
         ) @connection(key: "Partner_artworks") {
           aggregations {
             slice
@@ -117,7 +97,7 @@ export const PartnerArtworkFragmentContainer = createPaginationContainer(
     },
     getVariables(props, { count, cursor }, fragmentVariables) {
       return {
-        ...fragmentVariables,
+        input: fragmentVariables.input,
         id: props.partner.internalID,
         count,
         cursor,
@@ -125,37 +105,17 @@ export const PartnerArtworkFragmentContainer = createPaginationContainer(
     },
     query: graphql`
       query PartnerArtworkInfiniteScrollGridQuery(
-        $acquireable: Boolean
-        $attributionClass: [String]
-        $color: String
-        $colors: [String]
+        $id: String!
         $count: Int!
         $cursor: String
-        $dimensionRange: String
-        $additionalGeneIDs: [String]
-        $id: String!
-        $inquireableOnly: Boolean
-        $majorPeriods: [String]
-        $offerable: Boolean
-        $priceRange: String
-        $sort: String
+        $input: FilterArtworksInput
       ) {
         partner(id: $id) {
           ...PartnerArtwork_partner
             @arguments(
-              acquireable: $acquireable
-              attributionClass: $attributionClass
-              color: $color
-              colors: $colors
               count: $count
               cursor: $cursor
-              dimensionRange: $dimensionRange
-              additionalGeneIDs: $additionalGeneIDs
-              inquireableOnly: $inquireableOnly
-              majorPeriods: $majorPeriods
-              offerable: $offerable
-              priceRange: $priceRange
-              sort: $sort
+              input: $input
             )
         }
       }

--- a/src/lib/Scenes/Partner/Partner.tsx
+++ b/src/lib/Scenes/Partner/Partner.tsx
@@ -59,8 +59,7 @@ export const PartnerContainer = createRefetchContainer(
   Partner,
   {
     partner: graphql`
-      fragment Partner_partner on Partner
-      @argumentDefinitions(input: { type: "FilterArtworksInput" }){
+      fragment Partner_partner on Partner {
         id
         internalID
         slug
@@ -70,7 +69,10 @@ export const PartnerContainer = createRefetchContainer(
           internalID
         }
 
-        ...PartnerArtwork_partner @arguments(input: $input)
+        ...PartnerArtwork_partner @arguments(input: {
+          sort: "-partner_updated_at",
+          dimensionRange: "*-*"
+        })
         ...PartnerOverview_partner
         ...PartnerShows_partner
         ...PartnerHeader_partner
@@ -97,19 +99,13 @@ export const PartnerQueryRenderer: React.FC<{
           <QueryRenderer<PartnerQuery>
             environment={defaultEnvironment}
             query={graphql`
-              query PartnerQuery($partnerID: String!, $input: FilterArtworksInput) {
+              query PartnerQuery($partnerID: String!) {
                 partner(id: $partnerID) {
-                  ...Partner_partner @arguments(input: $input)
+                  ...Partner_partner
                 }
               }
             `}
-            variables={{
-              partnerID,
-              input: {
-                sort: "-partner_updated_at",
-                dimensionRange: "*-*"
-              }
-            }}
+            variables={{ partnerID }}
             cacheConfig={{
               // Bypass Relay cache on retries.
               ...(isRetry && { force: true }),

--- a/src/lib/Scenes/Partner/Partner.tsx
+++ b/src/lib/Scenes/Partner/Partner.tsx
@@ -59,7 +59,8 @@ export const PartnerContainer = createRefetchContainer(
   Partner,
   {
     partner: graphql`
-      fragment Partner_partner on Partner {
+      fragment Partner_partner on Partner
+      @argumentDefinitions(input: { type: "FilterArtworksInput" }){
         id
         internalID
         slug
@@ -69,7 +70,7 @@ export const PartnerContainer = createRefetchContainer(
           internalID
         }
 
-        ...PartnerArtwork_partner
+        ...PartnerArtwork_partner @arguments(input: $input)
         ...PartnerOverview_partner
         ...PartnerShows_partner
         ...PartnerHeader_partner
@@ -96,14 +97,18 @@ export const PartnerQueryRenderer: React.FC<{
           <QueryRenderer<PartnerQuery>
             environment={defaultEnvironment}
             query={graphql`
-              query PartnerQuery($partnerID: String!) {
+              query PartnerQuery($partnerID: String!, $input: FilterArtworksInput) {
                 partner(id: $partnerID) {
-                  ...Partner_partner
+                  ...Partner_partner @arguments(input: $input)
                 }
               }
             `}
             variables={{
               partnerID,
+              input: {
+                sort: "-partner_updated_at",
+                dimensionRange: "*-*"
+              }
             }}
             cacheConfig={{
               // Bypass Relay cache on retries.

--- a/src/lib/Scenes/Show/Components/ShowArtworks.tsx
+++ b/src/lib/Scenes/Show/Components/ShowArtworks.tsx
@@ -2,7 +2,7 @@ import { OwnerType } from "@artsy/cohesion"
 import { Show_show } from "__generated__/Show_show.graphql"
 import { ShowArtworks_show } from "__generated__/ShowArtworks_show.graphql"
 import { ArtworkFilterNavigator, FilterModalMode } from "lib/Components/ArtworkFilter"
-import { aggregationsType, FilterArray, filterArtworksParams } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { aggregationsType, FilterArray, filterArtworksParams, prepareFilterArtworksParamsForInput } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
 import { InfiniteScrollArtworksGridContainer } from "lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
@@ -70,7 +70,7 @@ const ShowArtworks: React.FC<Props> = ({ show, relay, initiallyAppliedFilter }) 
             throw new Error("Show/ShowArtworks filter error: " + error.message)
           }
         },
-        filterParams
+        { input: prepareFilterArtworksParamsForInput(filterParams) }
       )
     }
   }, [appliedFilters])
@@ -109,37 +109,15 @@ export const ShowArtworksPaginationContainer = createPaginationContainer(
       @argumentDefinitions(
         count: { type: "Int", defaultValue: 30 }
         cursor: { type: "String" }
-        sort: { type: "String", defaultValue: "partner_show_position" }
-        additionalGeneIDs: { type: "[String]" }
-        priceRange: { type: "String" }
-        color: { type: "String" }
-        colors: { type: "[String]" }
-        dimensionRange: { type: "String", defaultValue: "*-*" }
-        majorPeriods: { type: "[String]" }
-        acquireable: { type: "Boolean" }
-        inquireableOnly: { type: "Boolean" }
-        atAuction: { type: "Boolean" }
-        offerable: { type: "Boolean" }
-        attributionClass: { type: "[String]" }
+        input: { type: "FilterArtworksInput" }
       ) {
         slug
         internalID
         showArtworks: filterArtworksConnection(
           first: 30
           after: $cursor
-          sort: $sort
-          additionalGeneIDs: $additionalGeneIDs
-          priceRange: $priceRange
-          color: $color
-          colors: $colors
-          dimensionRange: $dimensionRange
-          majorPeriods: $majorPeriods
-          acquireable: $acquireable
-          inquireableOnly: $inquireableOnly
-          atAuction: $atAuction
-          offerable: $offerable
           aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]
-          attributionClass: $attributionClass
+          input: $input
         ) @connection(key: "Show_showArtworks") {
           aggregations {
             slice
@@ -171,7 +149,7 @@ export const ShowArtworksPaginationContainer = createPaginationContainer(
     },
     getVariables(props, { count, cursor }, fragmentVariables) {
       return {
-        ...fragmentVariables,
+        input: fragmentVariables.input,
         props,
         count,
         cursor,
@@ -183,36 +161,14 @@ export const ShowArtworksPaginationContainer = createPaginationContainer(
         $id: String!
         $count: Int!
         $cursor: String
-        $sort: String
-        $additionalGeneIDs: [String]
-        $priceRange: String
-        $color: String
-        $colors: [String]
-        $dimensionRange: String
-        $majorPeriods: [String]
-        $acquireable: Boolean
-        $inquireableOnly: Boolean
-        $atAuction: Boolean
-        $offerable: Boolean
-        $attributionClass: [String]
+        $input: FilterArtworksInput
       ) {
         show(id: $id) {
           ...ShowArtworks_show
             @arguments(
               count: $count
               cursor: $cursor
-              sort: $sort
-              additionalGeneIDs: $additionalGeneIDs
-              color: $color
-              colors: $colors
-              priceRange: $priceRange
-              dimensionRange: $dimensionRange
-              majorPeriods: $majorPeriods
-              acquireable: $acquireable
-              inquireableOnly: $inquireableOnly
-              atAuction: $atAuction
-              offerable: $offerable
-              attributionClass: $attributionClass
+              input: $input
             )
         }
       }

--- a/src/lib/Scenes/Show/Show.tsx
+++ b/src/lib/Scenes/Show/Show.tsx
@@ -136,9 +136,7 @@ export const Show: React.FC<ShowProps> = ({ show }) => {
 
 export const ShowFragmentContainer = createFragmentContainer(Show, {
   show: graphql`
-    fragment Show_show on Show @argumentDefinitions(
-      input: { type: "FilterArtworksInput" }
-    ) {
+    fragment Show_show on Show {
       internalID
       slug
       ...ShowHeader_show
@@ -146,7 +144,10 @@ export const ShowFragmentContainer = createFragmentContainer(Show, {
       ...ShowInfo_show
       ...ShowViewingRoom_show
       ...ShowContextCard_show
-      ...ShowArtworks_show @arguments(input: $input)
+      ...ShowArtworks_show @arguments(input: {
+        sort: "partner_show_position",
+        dimensionRange: "*-*"
+      })
       ...ShowArtworksEmptyState_show
       viewingRoomIDs
       images(default: false) {
@@ -164,19 +165,13 @@ export const ShowQueryRenderer: React.FC<ShowQueryRendererProps> = ({ showID }) 
     <QueryRenderer<ShowQuery>
       environment={defaultEnvironment}
       query={graphql`
-        query ShowQuery($showID: String!, $input: FilterArtworksInput) {
+        query ShowQuery($showID: String!) {
           show(id: $showID) @principalField {
-            ...Show_show @arguments(input: $input)
+            ...Show_show
           }
         }
       `}
-      variables={{
-        showID,
-        input: {
-          sort: "partner_show_position",
-          dimensionRange: "*-*"
-        }
-      }}
+      variables={{ showID }}
       render={renderWithPlaceholder({
         Container: ShowFragmentContainer,
         renderPlaceholder: () => <ShowPlaceholder />,

--- a/src/lib/Scenes/Show/Show.tsx
+++ b/src/lib/Scenes/Show/Show.tsx
@@ -136,7 +136,9 @@ export const Show: React.FC<ShowProps> = ({ show }) => {
 
 export const ShowFragmentContainer = createFragmentContainer(Show, {
   show: graphql`
-    fragment Show_show on Show {
+    fragment Show_show on Show @argumentDefinitions(
+      input: { type: "FilterArtworksInput" }
+    ) {
       internalID
       slug
       ...ShowHeader_show
@@ -144,7 +146,7 @@ export const ShowFragmentContainer = createFragmentContainer(Show, {
       ...ShowInfo_show
       ...ShowViewingRoom_show
       ...ShowContextCard_show
-      ...ShowArtworks_show
+      ...ShowArtworks_show @arguments(input: $input)
       ...ShowArtworksEmptyState_show
       viewingRoomIDs
       images(default: false) {
@@ -162,13 +164,19 @@ export const ShowQueryRenderer: React.FC<ShowQueryRendererProps> = ({ showID }) 
     <QueryRenderer<ShowQuery>
       environment={defaultEnvironment}
       query={graphql`
-        query ShowQuery($showID: String!) {
+        query ShowQuery($showID: String!, $input: FilterArtworksInput) {
           show(id: $showID) @principalField {
-            ...Show_show
+            ...Show_show @arguments(input: $input)
           }
         }
       `}
-      variables={{ showID }}
+      variables={{
+        showID,
+        input: {
+          sort: "partner_show_position",
+          dimensionRange: "*-*"
+        }
+      }}
       render={renderWithPlaceholder({
         Container: ShowFragmentContainer,
         renderPlaceholder: () => <ShowPlaceholder />,

--- a/src/lib/Scenes/VanityURL/VanityURLEntity.tsx
+++ b/src/lib/Scenes/VanityURL/VanityURLEntity.tsx
@@ -34,14 +34,15 @@ const VanityURLEntity: React.FC<EntityProps> = ({ fairOrPartner, originalSlug })
 
 const VanityURLEntityFragmentContainer = createFragmentContainer(VanityURLEntity, {
   fairOrPartner: graphql`
-    fragment VanityURLEntity_fairOrPartner on VanityURLEntityType {
+    fragment VanityURLEntity_fairOrPartner on VanityURLEntityType
+    @argumentDefinitions(input: { type: "FilterArtworksInput" }) {
       __typename
       ... on Fair {
         slug
         ...Fair_fair
       }
       ... on Partner {
-        ...Partner_partner
+        ...Partner_partner @arguments(input: $input)
       }
     }
   `,
@@ -62,13 +63,19 @@ export const VanityURLEntityRenderer: React.FC<RendererProps> = ({ entity, slugT
       <QueryRenderer<VanityURLEntityQuery>
         environment={defaultEnvironment}
         query={graphql`
-          query VanityURLEntityQuery($id: String!) {
+          query VanityURLEntityQuery($id: String!, $input: FilterArtworksInput) {
             vanityURLEntity(id: $id) {
-              ...VanityURLEntity_fairOrPartner
+              ...VanityURLEntity_fairOrPartner @arguments(input: $input)
             }
           }
         `}
-        variables={{ id: slug }}
+        variables={{
+          id: slug,
+          input: {
+            sort: "-partner_updated_at",
+            dimensionRange: "*-*"
+          }
+        }}
         render={renderWithPlaceholder({
           renderFallback: () => <VanityURLPossibleRedirect slug={slug} />,
           renderPlaceholder: () => {

--- a/src/lib/Scenes/VanityURL/VanityURLEntity.tsx
+++ b/src/lib/Scenes/VanityURL/VanityURLEntity.tsx
@@ -34,15 +34,14 @@ const VanityURLEntity: React.FC<EntityProps> = ({ fairOrPartner, originalSlug })
 
 const VanityURLEntityFragmentContainer = createFragmentContainer(VanityURLEntity, {
   fairOrPartner: graphql`
-    fragment VanityURLEntity_fairOrPartner on VanityURLEntityType
-    @argumentDefinitions(input: { type: "FilterArtworksInput" }) {
+    fragment VanityURLEntity_fairOrPartner on VanityURLEntityType {
       __typename
       ... on Fair {
         slug
         ...Fair_fair
       }
       ... on Partner {
-        ...Partner_partner @arguments(input: $input)
+        ...Partner_partner
       }
     }
   `,
@@ -63,19 +62,13 @@ export const VanityURLEntityRenderer: React.FC<RendererProps> = ({ entity, slugT
       <QueryRenderer<VanityURLEntityQuery>
         environment={defaultEnvironment}
         query={graphql`
-          query VanityURLEntityQuery($id: String!, $input: FilterArtworksInput) {
+          query VanityURLEntityQuery($id: String!) {
             vanityURLEntity(id: $id) {
-              ...VanityURLEntity_fairOrPartner @arguments(input: $input)
+              ...VanityURLEntity_fairOrPartner
             }
           }
         `}
-        variables={{
-          id: slug,
-          input: {
-            sort: "-partner_updated_at",
-            dimensionRange: "*-*"
-          }
-        }}
+        variables={{ id: slug }}
         render={renderWithPlaceholder({
           renderFallback: () => <VanityURLPossibleRedirect slug={slug} />,
           renderPlaceholder: () => {


### PR DESCRIPTION
The type of this PR is: **FEATURE**

This PR resolves [FX-2899]

### Description
Convert filter queries to use a single structured input for all `filterArtworksConnection` requests. This should be **carefully QA'ed**.

Web version of this change [artsy/force#7151](https://github.com/artsy/force/pull/7151)

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2899]: https://artsyproduct.atlassian.net/browse/FX-2899