### PR TITLE
fix: add webViewRoute for buyer guarantee page

### DIFF
--- a/src/lib/Scenes/Inbox/Components/Conversations/OpenInquiryModalButton.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/OpenInquiryModalButton.tsx
@@ -30,7 +30,7 @@ export const OpenInquiryModalButton: React.FC<OpenInquiryModalButtonProps> = ({ 
                 color="black100"
                 variant="small"
                 onPress={() => {
-                  navigate(`buyer-guarantee`)
+                  navigate(`/buyer-guarantee`)
                 }}
               >
                 The Artsy Guarantee

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/OpenInquiryModalButton-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/OpenInquiryModalButton-tests.tsx
@@ -94,7 +94,7 @@ describe("OpenInquiryModalButtonQueryRenderer", () => {
       const tree = getWrapper()
       tree.root.findAllByType(Text)[1].props.onPress()
 
-      expect(navigate).toHaveBeenCalledWith("buyer-guarantee")
+      expect(navigate).toHaveBeenCalledWith("/buyer-guarantee")
     })
   })
 })

--- a/src/lib/navigation/routes.tsx
+++ b/src/lib/navigation/routes.tsx
@@ -175,6 +175,7 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
     webViewRoute("/identity-verification-faq"),
     webViewRoute("/terms"),
     webViewRoute("/buy-now-feature-faq"),
+    webViewRoute("/buyer-guarantee"),
 
     new RouteMatcher("/city-bmw-list/:citySlug", "CityBMWList"),
     new RouteMatcher("/make-offer/:artworkID", "MakeOfferModal"),


### PR DESCRIPTION
The type of this PR is: **FIX**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [PURCHASE-2665]

### Description

<!-- Implementation description -->
This adds an add webViewRoute for the buyer guarantee page.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [ ] I have documented any follow-up work that this PR will require, or it does not require any.
- [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[PURCHASE-2665]: https://artsyproduct.atlassian.net/browse/PURCHASE-2665