### PR TITLE
feat: do not render make offer button when fetching artwork fails (PURCHASE-2685)

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -10,6 +10,7 @@ upcoming:
     - Fix push notification pre request prompt showing up everytime - kizito
     - Fix spaces between items in SaleList - yauheni
     - Inquiry checkout copy additions from legal - lily
+    - Fix artwork unavailable issue on the conversation screen - starsirius
 
 releases:
   - version: 6.9.0

--- a/src/lib/Scenes/Inbox/Components/Conversations/OpenInquiryModalButton.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/OpenInquiryModalButton.tsx
@@ -1,4 +1,5 @@
 import { tappedMakeOffer } from "@artsy/cohesion"
+import { captureMessage } from "@sentry/react-native"
 import { OpenInquiryModalButtonQuery } from "__generated__/OpenInquiryModalButtonQuery.graphql"
 import { navigate } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
@@ -79,7 +80,11 @@ export const OpenInquiryModalButtonQueryRenderer: React.FC<{
       cacheConfig={{ force: true }}
       render={({ props, error }): null | JSX.Element => {
         if (error) {
-          throw new Error(error.message)
+          // A typical scenario an error happens would be 404 (artwork deleted, unpublished, etc.). This captures the
+          // error in Sentry and simply doesn't render to button for now. We can be more specific about particular
+          // errors and also improve the UX through some messaging.
+          captureMessage(error.stack!)
+          return null
         }
 
         if (props?.artwork?.isOfferableFromInquiry) {


### PR DESCRIPTION
The type of this PR is: **Bugfix**

Currently when fetching an artwork fails (e.g. artwork being unpublished or deleted) on the conversation screen, we raise an error (on beta it shows a blank screen). We should still allow partner and collector to keep talking in the conversation even when the artwork is unavailable. This updates the error handling to simply not render the Make Offer button in this situation, and both parties can keep chatting in the conversation.

### Before
![artwork-error-2](https://user-images.githubusercontent.com/796573/118504473-889c7900-b6f9-11eb-974e-f00e2e11b7c1.gif)

### After
![artwork-error](https://user-images.githubusercontent.com/796573/118504483-8b976980-b6f9-11eb-8413-34b04335a0cc.gif)

This PR resolves [PURCHASE-2685]

### Description

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[PURCHASE-2685]: https://artsyproduct.atlassian.net/browse/PURCHASE-2685