### PR TITLE
fix: reregister for push notifications on login every time

### DIFF
--- a/Artsy/App/ARAppNotificationsDelegate.m
+++ b/Artsy/App/ARAppNotificationsDelegate.m
@@ -36,8 +36,12 @@
         // lets show you a prompt to go to settings
         [self displayPushNotificationSettingsPrompt];
     } else if (![AROptions boolForOption:ARPushNotificationsAppleDialogueSeen] && [self shouldPresentPushNotificationAgain]) {
-        // As long as you've not seen Apple's dialogue already, we will show you our pre-prompt.
+        // As long as you've not seen Apple's dialogue already we will show you our pre-prompt.
         [self displayPushNotificationLocalRequestPrompt];
+    } else {
+        // Otherwise fallback to requesting directly with apple to make sure we have
+        // up to date push tokens
+        [self registerForDeviceNotificationsWithApple];
     }
 }
 

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -31,6 +31,7 @@ upcoming:
     - Fix spaces between items in SaleList - yauheni
     - Inquiry checkout copy additions from legal - lily
     - Fix artwork unavailable issue on the conversation screen - starsirius
+    - Fix push notification registration - brian
 
 releases:
   - version: 6.9.0


### PR DESCRIPTION
The type of this PR is: **fix**

This PR resolves [CX-1477]

### Description

Fixes a bug with our push token registration. 

When a user logs out we delete the users push token from our servers, previously we had also been clearing out all the users NSUserDefaults which was causing us to prompt for and register for push notifications every time the user logs in: https://artsyproduct.atlassian.net/browse/CX-841. When we fixed this bug it uncovered this new bug 🐛. Falling back to registering every time a user logs in. 

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-1477]: https://artsyproduct.atlassian.net/browse/CX-1477