### PR TITLE
feat(PX-4061): Order history feature flag

### DIFF
--- a/src/lib/store/config/features.ts
+++ b/src/lib/store/config/features.ts
@@ -97,6 +97,11 @@ export const features = defineFeatures({
     description: "Use improved artwork filters",
     showInAdminMenu: true,
   },
+  AREnableOrderHistoryOption: {
+    readyForRelease: false,
+    description: "Enable Order History in settings",
+    showInAdminMenu: true,
+  },
 })
 
 export interface DevToggleDescriptor {


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR resolves [PX-4061]

### Description

Added "AREnableOrderHistoryOption" feature flag so that admin can toggle it. Will be used to enable “Order History” option in settings.


[PX-4061]: https://artsyproduct.atlassian.net/browse/PX-4061