### PR TITLE
feat: add artwork location filter to filter modal

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -24,6 +24,9 @@ upcoming:
     - Add order history to user profile (behind feature flag) - alexj105
     - Enable lotsByFollowedArtists - ole
     - Add ability to unselected "ways to buy" filter - dzmitry tratsiak
+    - Add artwork location filter to artwork grids - iskounen
+
+
 releases:
   - version: 6.9.1
     date: May 18, 2021

--- a/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 283bb03d46853311881583d46b760a82 */
+/* @relayHash b0e35a574a0826b37fa0ad51068d1d89 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -59,7 +59,7 @@ fragment ArtistArtworks_artist_44NygF on Artist {
   id
   slug
   internalID
-  artworks: filterArtworksConnection(first: 10, input: {dimensionRange: "*-*", sort: "-decayed_merch"}, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS]) {
+  artworks: filterArtworksConnection(first: 10, input: {dimensionRange: "*-*", sort: "-decayed_merch"}, aggregations: [COLOR, DIMENSION_RANGE, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -272,11 +272,12 @@ v13 = [
     "value": [
       "COLOR",
       "DIMENSION_RANGE",
-      "PARTNER",
+      "LOCATION_CITY",
       "MAJOR_PERIOD",
+      "MATERIALS_TERMS",
       "MEDIUM",
-      "PRICE_RANGE",
-      "MATERIALS_TERMS"
+      "PARTNER",
+      "PRICE_RANGE"
     ]
   },
   {
@@ -768,7 +769,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"LOCATION_CITY\",\"MAJOR_PERIOD\",\"MATERIALS_TERMS\",\"MEDIUM\",\"PARTNER\",\"PRICE_RANGE\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "artworks",
@@ -789,7 +790,7 @@ return {
     ]
   },
   "params": {
-    "id": "283bb03d46853311881583d46b760a82",
+    "id": "b0e35a574a0826b37fa0ad51068d1d89",
     "metadata": {},
     "name": "ArtistAboveTheFoldQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistArtworksQuery.graphql.ts
+++ b/src/__generated__/ArtistArtworksQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 1d94db5944fa6941f0ca17cd3fc73558 */
+/* @relayHash 037f11e9a4eeaa5a4c32ea114f2a752d */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -94,7 +94,7 @@ fragment ArtistArtworks_artist_YCAiB on Artist {
   id
   slug
   internalID
-  artworks: filterArtworksConnection(first: $count, after: $cursor, input: $input, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS]) {
+  artworks: filterArtworksConnection(first: $count, after: $cursor, input: $input, aggregations: [COLOR, DIMENSION_RANGE, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -255,11 +255,12 @@ v10 = [
     "value": [
       "COLOR",
       "DIMENSION_RANGE",
-      "PARTNER",
+      "LOCATION_CITY",
       "MAJOR_PERIOD",
+      "MATERIALS_TERMS",
       "MEDIUM",
-      "PRICE_RANGE",
-      "MATERIALS_TERMS"
+      "PARTNER",
+      "PRICE_RANGE"
     ]
   },
   {
@@ -737,7 +738,7 @@ return {
     ]
   },
   "params": {
-    "id": "1d94db5944fa6941f0ca17cd3fc73558",
+    "id": "037f11e9a4eeaa5a4c32ea114f2a752d",
     "metadata": {},
     "name": "ArtistArtworksQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistArtworks_artist.graphql.ts
+++ b/src/__generated__/ArtistArtworks_artist.graphql.ts
@@ -103,11 +103,12 @@ return {
           "value": [
             "COLOR",
             "DIMENSION_RANGE",
-            "PARTNER",
+            "LOCATION_CITY",
             "MAJOR_PERIOD",
+            "MATERIALS_TERMS",
             "MEDIUM",
-            "PRICE_RANGE",
-            "MATERIALS_TERMS"
+            "PARTNER",
+            "PRICE_RANGE"
           ]
         },
         {
@@ -264,5 +265,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '10079f10eb368da287ef441279ebc633';
+(node as any).hash = '772ab02113ce651f7426a24951d3cf6b';
 export default node;

--- a/src/__generated__/ArtistSeriesArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 7748253544f89b76183dad5baa31e486 */
+/* @relayHash d2e93cd7f048f99f8fe6c942abf29be8 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -88,7 +88,7 @@ query ArtistSeriesArtworksInfiniteScrollGridQuery(
 fragment ArtistSeriesArtworks_artistSeries_YCAiB on ArtistSeries {
   slug
   internalID
-  artistSeriesArtworks: filterArtworksConnection(first: 20, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS, ARTIST_NATIONALITY], input: $input) {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, after: $cursor, aggregations: [ARTIST_NATIONALITY, COLOR, DIMENSION_RANGE, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE], input: $input) {
     aggregations {
       slice
       counts {
@@ -233,14 +233,15 @@ v8 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST_NATIONALITY",
       "COLOR",
       "DIMENSION_RANGE",
-      "PARTNER",
+      "LOCATION_CITY",
       "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
       "MATERIALS_TERMS",
-      "ARTIST_NATIONALITY"
+      "MEDIUM",
+      "PARTNER",
+      "PRICE_RANGE"
     ]
   },
   {
@@ -716,7 +717,7 @@ return {
     ]
   },
   "params": {
-    "id": "7748253544f89b76183dad5baa31e486",
+    "id": "d2e93cd7f048f99f8fe6c942abf29be8",
     "metadata": {},
     "name": "ArtistSeriesArtworksInfiniteScrollGridQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistSeriesArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworksTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash a56783a729ad46fa6adaee064c336914 */
+/* @relayHash 70ecf44d4514fbe65641225da85433fc */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -28,7 +28,7 @@ query ArtistSeriesArtworksTestsQuery {
 fragment ArtistSeriesArtworks_artistSeries on ArtistSeries {
   slug
   internalID
-  artistSeriesArtworks: filterArtworksConnection(first: 20, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS, ARTIST_NATIONALITY]) {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, aggregations: [ARTIST_NATIONALITY, COLOR, DIMENSION_RANGE, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -143,14 +143,15 @@ v3 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST_NATIONALITY",
       "COLOR",
       "DIMENSION_RANGE",
-      "PARTNER",
+      "LOCATION_CITY",
       "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
       "MATERIALS_TERMS",
-      "ARTIST_NATIONALITY"
+      "MEDIUM",
+      "PARTNER",
+      "PRICE_RANGE"
     ]
   },
   {
@@ -613,7 +614,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\",\"ARTIST_NATIONALITY\"],first:20)"
+            "storageKey": "filterArtworksConnection(aggregations:[\"ARTIST_NATIONALITY\",\"COLOR\",\"DIMENSION_RANGE\",\"LOCATION_CITY\",\"MAJOR_PERIOD\",\"MATERIALS_TERMS\",\"MEDIUM\",\"PARTNER\",\"PRICE_RANGE\"],first:20)"
           },
           {
             "alias": "artistSeriesArtworks",
@@ -633,7 +634,7 @@ return {
     ]
   },
   "params": {
-    "id": "a56783a729ad46fa6adaee064c336914",
+    "id": "70ecf44d4514fbe65641225da85433fc",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artistSeries": {

--- a/src/__generated__/ArtistSeriesArtworks_artistSeries.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworks_artistSeries.graphql.ts
@@ -91,14 +91,15 @@ const node: ReaderFragment = {
           "kind": "Literal",
           "name": "aggregations",
           "value": [
+            "ARTIST_NATIONALITY",
             "COLOR",
             "DIMENSION_RANGE",
-            "PARTNER",
+            "LOCATION_CITY",
             "MAJOR_PERIOD",
-            "MEDIUM",
-            "PRICE_RANGE",
             "MATERIALS_TERMS",
-            "ARTIST_NATIONALITY"
+            "MEDIUM",
+            "PARTNER",
+            "PRICE_RANGE"
           ]
         },
         {
@@ -260,5 +261,5 @@ const node: ReaderFragment = {
   "type": "ArtistSeries",
   "abstractKey": null
 };
-(node as any).hash = 'f57c01b80642bb29e81c32b1b3e7d321';
+(node as any).hash = 'ac1bc9d10b5ff55c34c9c989f3400370';
 export default node;

--- a/src/__generated__/ArtistSeriesQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 971fdeab836dab4acb315050876cad4c */
+/* @relayHash faeb20bd256f2d0104478eed6e8eb47a */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -32,7 +32,7 @@ query ArtistSeriesQuery(
 fragment ArtistSeriesArtworks_artistSeries_2T6kBV on ArtistSeries {
   slug
   internalID
-  artistSeriesArtworks: filterArtworksConnection(first: 20, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS, ARTIST_NATIONALITY], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, aggregations: [ARTIST_NATIONALITY, COLOR, DIMENSION_RANGE, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -259,14 +259,15 @@ v9 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST_NATIONALITY",
       "COLOR",
       "DIMENSION_RANGE",
-      "PARTNER",
+      "LOCATION_CITY",
       "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
       "MATERIALS_TERMS",
-      "ARTIST_NATIONALITY"
+      "MEDIUM",
+      "PARTNER",
+      "PRICE_RANGE"
     ]
   },
   {
@@ -726,7 +727,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\",\"ARTIST_NATIONALITY\"],first:20,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
+            "storageKey": "filterArtworksConnection(aggregations:[\"ARTIST_NATIONALITY\",\"COLOR\",\"DIMENSION_RANGE\",\"LOCATION_CITY\",\"MAJOR_PERIOD\",\"MATERIALS_TERMS\",\"MEDIUM\",\"PARTNER\",\"PRICE_RANGE\"],first:20,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "artistSeriesArtworks",
@@ -824,7 +825,7 @@ return {
     ]
   },
   "params": {
-    "id": "971fdeab836dab4acb315050876cad4c",
+    "id": "faeb20bd256f2d0104478eed6e8eb47a",
     "metadata": {},
     "name": "ArtistSeriesQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 8c9304e1321b0f76696dd07739bf2eea */
+/* @relayHash 8094f14429b373497247ede0620e0d33 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -28,7 +28,7 @@ query ArtistSeriesTestsQuery {
 fragment ArtistSeriesArtworks_artistSeries_2T6kBV on ArtistSeries {
   slug
   internalID
-  artistSeriesArtworks: filterArtworksConnection(first: 20, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS, ARTIST_NATIONALITY], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, aggregations: [ARTIST_NATIONALITY, COLOR, DIMENSION_RANGE, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -248,14 +248,15 @@ v8 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST_NATIONALITY",
       "COLOR",
       "DIMENSION_RANGE",
-      "PARTNER",
+      "LOCATION_CITY",
       "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
       "MATERIALS_TERMS",
-      "ARTIST_NATIONALITY"
+      "MEDIUM",
+      "PARTNER",
+      "PRICE_RANGE"
     ]
   },
   {
@@ -775,7 +776,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\",\"ARTIST_NATIONALITY\"],first:20,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
+            "storageKey": "filterArtworksConnection(aggregations:[\"ARTIST_NATIONALITY\",\"COLOR\",\"DIMENSION_RANGE\",\"LOCATION_CITY\",\"MAJOR_PERIOD\",\"MATERIALS_TERMS\",\"MEDIUM\",\"PARTNER\",\"PRICE_RANGE\"],first:20,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "artistSeriesArtworks",
@@ -873,7 +874,7 @@ return {
     ]
   },
   "params": {
-    "id": "8c9304e1321b0f76696dd07739bf2eea",
+    "id": "8094f14429b373497247ede0620e0d33",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artistSeries": (v10/*: any*/),

--- a/src/__generated__/CollectionArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/CollectionArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 468eafe890b76cfe4e9e80743d4673b3 */
+/* @relayHash 3bc533513217920912dd364bb65784f9 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -126,7 +126,7 @@ fragment CollectionArtworks_collection_YCAiB on MarketingCollection {
   isDepartment
   slug
   id
-  collectionArtworks: artworksConnection(first: $count, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS, ARTIST_NATIONALITY], input: $input) {
+  collectionArtworks: artworksConnection(first: $count, after: $cursor, aggregations: [ARTIST_NATIONALITY, COLOR, DIMENSION_RANGE, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE], input: $input) {
     aggregations {
       slice
       counts {
@@ -236,14 +236,15 @@ v8 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST_NATIONALITY",
       "COLOR",
       "DIMENSION_RANGE",
-      "PARTNER",
+      "LOCATION_CITY",
       "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
       "MATERIALS_TERMS",
-      "ARTIST_NATIONALITY"
+      "MEDIUM",
+      "PARTNER",
+      "PRICE_RANGE"
     ]
   },
   {
@@ -725,7 +726,7 @@ return {
     ]
   },
   "params": {
-    "id": "468eafe890b76cfe4e9e80743d4673b3",
+    "id": "3bc533513217920912dd364bb65784f9",
     "metadata": {},
     "name": "CollectionArtworksInfiniteScrollGridQuery",
     "operationKind": "query",

--- a/src/__generated__/CollectionArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/CollectionArtworksTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash bc565625413fb056b7733873899662f1 */
+/* @relayHash 710e7fe61a6f672115711c05eeec2fb3 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -65,7 +65,7 @@ fragment CollectionArtworks_collection on MarketingCollection {
   isDepartment
   slug
   id
-  collectionArtworks: artworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS, ARTIST_NATIONALITY]) {
+  collectionArtworks: artworksConnection(first: 10, aggregations: [ARTIST_NATIONALITY, COLOR, DIMENSION_RANGE, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -145,14 +145,15 @@ v3 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST_NATIONALITY",
       "COLOR",
       "DIMENSION_RANGE",
-      "PARTNER",
+      "LOCATION_CITY",
       "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
       "MATERIALS_TERMS",
-      "ARTIST_NATIONALITY"
+      "MEDIUM",
+      "PARTNER",
+      "PRICE_RANGE"
     ]
   },
   {
@@ -627,7 +628,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "artworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\",\"ARTIST_NATIONALITY\"],first:10)"
+            "storageKey": "artworksConnection(aggregations:[\"ARTIST_NATIONALITY\",\"COLOR\",\"DIMENSION_RANGE\",\"LOCATION_CITY\",\"MAJOR_PERIOD\",\"MATERIALS_TERMS\",\"MEDIUM\",\"PARTNER\",\"PRICE_RANGE\"],first:10)"
           },
           {
             "alias": "collectionArtworks",
@@ -647,7 +648,7 @@ return {
     ]
   },
   "params": {
-    "id": "bc565625413fb056b7733873899662f1",
+    "id": "710e7fe61a6f672115711c05eeec2fb3",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "marketingCollection": {

--- a/src/__generated__/CollectionArtworks_collection.graphql.ts
+++ b/src/__generated__/CollectionArtworks_collection.graphql.ts
@@ -101,14 +101,15 @@ return {
           "kind": "Literal",
           "name": "aggregations",
           "value": [
+            "ARTIST_NATIONALITY",
             "COLOR",
             "DIMENSION_RANGE",
-            "PARTNER",
+            "LOCATION_CITY",
             "MAJOR_PERIOD",
-            "MEDIUM",
-            "PRICE_RANGE",
             "MATERIALS_TERMS",
-            "ARTIST_NATIONALITY"
+            "MEDIUM",
+            "PARTNER",
+            "PRICE_RANGE"
           ]
         },
         {
@@ -265,5 +266,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '0f05e5423727808d7ea2fec4e6852f78';
+(node as any).hash = 'fbc59216c6350aa9be647245eba3529e';
 export default node;

--- a/src/__generated__/CollectionQuery.graphql.ts
+++ b/src/__generated__/CollectionQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash f097c67e787c6db2978efe4d8958098d */
+/* @relayHash bce1eeba6db6ec04d8db232126b32ce7 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -113,7 +113,7 @@ fragment CollectionArtworks_collection_2T6kBV on MarketingCollection {
   isDepartment
   slug
   id
-  collectionArtworks: artworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS, ARTIST_NATIONALITY], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
+  collectionArtworks: artworksConnection(first: 10, aggregations: [ARTIST_NATIONALITY, COLOR, DIMENSION_RANGE, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -325,14 +325,15 @@ v8 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST_NATIONALITY",
       "COLOR",
       "DIMENSION_RANGE",
-      "PARTNER",
+      "LOCATION_CITY",
       "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
       "MATERIALS_TERMS",
-      "ARTIST_NATIONALITY"
+      "MEDIUM",
+      "PARTNER",
+      "PRICE_RANGE"
     ]
   },
   {
@@ -877,7 +878,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "artworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\",\"ARTIST_NATIONALITY\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
+            "storageKey": "artworksConnection(aggregations:[\"ARTIST_NATIONALITY\",\"COLOR\",\"DIMENSION_RANGE\",\"LOCATION_CITY\",\"MAJOR_PERIOD\",\"MATERIALS_TERMS\",\"MEDIUM\",\"PARTNER\",\"PRICE_RANGE\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "collectionArtworks",
@@ -1133,7 +1134,7 @@ return {
     ]
   },
   "params": {
-    "id": "f097c67e787c6db2978efe4d8958098d",
+    "id": "bce1eeba6db6ec04d8db232126b32ce7",
     "metadata": {},
     "name": "CollectionQuery",
     "operationKind": "query",

--- a/src/__generated__/CollectionTestsQuery.graphql.ts
+++ b/src/__generated__/CollectionTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 0666f374304bf0ae5b828b644dfd726c */
+/* @relayHash a2ec26020d078a0dec233d01aba90586 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -108,7 +108,7 @@ fragment CollectionArtworks_collection_2T6kBV on MarketingCollection {
   isDepartment
   slug
   id
-  collectionArtworks: artworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS, ARTIST_NATIONALITY], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
+  collectionArtworks: artworksConnection(first: 10, aggregations: [ARTIST_NATIONALITY, COLOR, DIMENSION_RANGE, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -308,14 +308,15 @@ v7 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST_NATIONALITY",
       "COLOR",
       "DIMENSION_RANGE",
-      "PARTNER",
+      "LOCATION_CITY",
       "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
       "MATERIALS_TERMS",
-      "ARTIST_NATIONALITY"
+      "MEDIUM",
+      "PARTNER",
+      "PRICE_RANGE"
     ]
   },
   {
@@ -920,7 +921,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "artworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\",\"ARTIST_NATIONALITY\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
+            "storageKey": "artworksConnection(aggregations:[\"ARTIST_NATIONALITY\",\"COLOR\",\"DIMENSION_RANGE\",\"LOCATION_CITY\",\"MAJOR_PERIOD\",\"MATERIALS_TERMS\",\"MEDIUM\",\"PARTNER\",\"PRICE_RANGE\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "collectionArtworks",
@@ -1176,7 +1177,7 @@ return {
     ]
   },
   "params": {
-    "id": "0666f374304bf0ae5b828b644dfd726c",
+    "id": "a2ec26020d078a0dec233d01aba90586",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "marketingCollection": {

--- a/src/__generated__/FairAllFollowedArtistsQuery.graphql.ts
+++ b/src/__generated__/FairAllFollowedArtistsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash efc6ca1863f58ab07b4d3698ab735f2b */
+/* @relayHash d61eda39780fb79ba25c9b43f500fb51 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -98,7 +98,7 @@ fragment FairAllFollowedArtists_fairForFilters on Fair {
 fragment FairArtworks_fair_6zGp3 on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST, MATERIALS_TERMS, ARTIST_NATIONALITY], input: {includeArtworksByFollowedArtists: true, sort: "-decayed_merch", dimensionRange: "*-*"}) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [ARTIST, ARTIST_NATIONALITY, COLOR, DIMENSION_RANGE, FOLLOWED_ARTISTS, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE], input: {includeArtworksByFollowedArtists: true, sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -186,16 +186,17 @@ v4 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST",
+      "ARTIST_NATIONALITY",
       "COLOR",
       "DIMENSION_RANGE",
-      "PARTNER",
-      "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
       "FOLLOWED_ARTISTS",
-      "ARTIST",
+      "LOCATION_CITY",
+      "MAJOR_PERIOD",
       "MATERIALS_TERMS",
-      "ARTIST_NATIONALITY"
+      "MEDIUM",
+      "PARTNER",
+      "PRICE_RANGE"
     ]
   },
   {
@@ -662,7 +663,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\",\"MATERIALS_TERMS\",\"ARTIST_NATIONALITY\"],first:30,input:{\"dimensionRange\":\"*-*\",\"includeArtworksByFollowedArtists\":true,\"sort\":\"-decayed_merch\"})"
+            "storageKey": "filterArtworksConnection(aggregations:[\"ARTIST\",\"ARTIST_NATIONALITY\",\"COLOR\",\"DIMENSION_RANGE\",\"FOLLOWED_ARTISTS\",\"LOCATION_CITY\",\"MAJOR_PERIOD\",\"MATERIALS_TERMS\",\"MEDIUM\",\"PARTNER\",\"PRICE_RANGE\"],first:30,input:{\"dimensionRange\":\"*-*\",\"includeArtworksByFollowedArtists\":true,\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "fairArtworks",
@@ -740,7 +741,7 @@ return {
     ]
   },
   "params": {
-    "id": "efc6ca1863f58ab07b4d3698ab735f2b",
+    "id": "d61eda39780fb79ba25c9b43f500fb51",
     "metadata": {},
     "name": "FairAllFollowedArtistsQuery",
     "operationKind": "query",

--- a/src/__generated__/FairAllFollowedArtistsTestsQuery.graphql.ts
+++ b/src/__generated__/FairAllFollowedArtistsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash bfeddee2aa01b8f62aa55055228ac5f4 */
+/* @relayHash 3ebc9b39d0811e3c5b0341f1c373d160 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -98,7 +98,7 @@ fragment FairAllFollowedArtists_fairForFilters on Fair {
 fragment FairArtworks_fair_6zGp3 on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST, MATERIALS_TERMS, ARTIST_NATIONALITY], input: {includeArtworksByFollowedArtists: true, sort: "-decayed_merch", dimensionRange: "*-*"}) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [ARTIST, ARTIST_NATIONALITY, COLOR, DIMENSION_RANGE, FOLLOWED_ARTISTS, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE], input: {includeArtworksByFollowedArtists: true, sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -186,16 +186,17 @@ v4 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST",
+      "ARTIST_NATIONALITY",
       "COLOR",
       "DIMENSION_RANGE",
-      "PARTNER",
-      "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
       "FOLLOWED_ARTISTS",
-      "ARTIST",
+      "LOCATION_CITY",
+      "MAJOR_PERIOD",
       "MATERIALS_TERMS",
-      "ARTIST_NATIONALITY"
+      "MEDIUM",
+      "PARTNER",
+      "PRICE_RANGE"
     ]
   },
   {
@@ -753,7 +754,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\",\"MATERIALS_TERMS\",\"ARTIST_NATIONALITY\"],first:30,input:{\"dimensionRange\":\"*-*\",\"includeArtworksByFollowedArtists\":true,\"sort\":\"-decayed_merch\"})"
+            "storageKey": "filterArtworksConnection(aggregations:[\"ARTIST\",\"ARTIST_NATIONALITY\",\"COLOR\",\"DIMENSION_RANGE\",\"FOLLOWED_ARTISTS\",\"LOCATION_CITY\",\"MAJOR_PERIOD\",\"MATERIALS_TERMS\",\"MEDIUM\",\"PARTNER\",\"PRICE_RANGE\"],first:30,input:{\"dimensionRange\":\"*-*\",\"includeArtworksByFollowedArtists\":true,\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "fairArtworks",
@@ -831,7 +832,7 @@ return {
     ]
   },
   "params": {
-    "id": "bfeddee2aa01b8f62aa55055228ac5f4",
+    "id": "3ebc9b39d0811e3c5b0341f1c373d160",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "fair": (v10/*: any*/),

--- a/src/__generated__/FairArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/FairArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 2e14d1aa87065fb4a3301f31175137c7 */
+/* @relayHash 87af1f3ad4ec50f56cb4f609de8b5a5c */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -125,7 +125,7 @@ fragment ArtworkGridItem_artwork on Artwork {
 fragment FairArtworks_fair_YCAiB on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: $count, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST, MATERIALS_TERMS, ARTIST_NATIONALITY], input: $input) {
+  fairArtworks: filterArtworksConnection(first: $count, after: $cursor, aggregations: [ARTIST, ARTIST_NATIONALITY, COLOR, DIMENSION_RANGE, FOLLOWED_ARTISTS, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE], input: $input) {
     aggregations {
       slice
       counts {
@@ -236,16 +236,17 @@ v8 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST",
+      "ARTIST_NATIONALITY",
       "COLOR",
       "DIMENSION_RANGE",
-      "PARTNER",
-      "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
       "FOLLOWED_ARTISTS",
-      "ARTIST",
+      "LOCATION_CITY",
+      "MAJOR_PERIOD",
       "MATERIALS_TERMS",
-      "ARTIST_NATIONALITY"
+      "MEDIUM",
+      "PARTNER",
+      "PRICE_RANGE"
     ]
   },
   {
@@ -729,7 +730,7 @@ return {
     ]
   },
   "params": {
-    "id": "2e14d1aa87065fb4a3301f31175137c7",
+    "id": "87af1f3ad4ec50f56cb4f609de8b5a5c",
     "metadata": {},
     "name": "FairArtworksInfiniteScrollGridQuery",
     "operationKind": "query",

--- a/src/__generated__/FairArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/FairArtworksTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 4b46371fe40b98676dc9f28452c21ebe */
+/* @relayHash d5dc737ccc3385ce39713501cec51669 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -68,7 +68,7 @@ fragment ArtworkGridItem_artwork on Artwork {
 fragment FairArtworks_fair on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST, MATERIALS_TERMS, ARTIST_NATIONALITY]) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [ARTIST, ARTIST_NATIONALITY, COLOR, DIMENSION_RANGE, FOLLOWED_ARTISTS, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -156,16 +156,17 @@ v4 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST",
+      "ARTIST_NATIONALITY",
       "COLOR",
       "DIMENSION_RANGE",
-      "PARTNER",
-      "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
       "FOLLOWED_ARTISTS",
-      "ARTIST",
+      "LOCATION_CITY",
+      "MAJOR_PERIOD",
       "MATERIALS_TERMS",
-      "ARTIST_NATIONALITY"
+      "MEDIUM",
+      "PARTNER",
+      "PRICE_RANGE"
     ]
   },
   {
@@ -635,7 +636,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\",\"MATERIALS_TERMS\",\"ARTIST_NATIONALITY\"],first:30)"
+            "storageKey": "filterArtworksConnection(aggregations:[\"ARTIST\",\"ARTIST_NATIONALITY\",\"COLOR\",\"DIMENSION_RANGE\",\"FOLLOWED_ARTISTS\",\"LOCATION_CITY\",\"MAJOR_PERIOD\",\"MATERIALS_TERMS\",\"MEDIUM\",\"PARTNER\",\"PRICE_RANGE\"],first:30)"
           },
           {
             "alias": "fairArtworks",
@@ -656,7 +657,7 @@ return {
     ]
   },
   "params": {
-    "id": "4b46371fe40b98676dc9f28452c21ebe",
+    "id": "d5dc737ccc3385ce39713501cec51669",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "fair": {

--- a/src/__generated__/FairArtworks_fair.graphql.ts
+++ b/src/__generated__/FairArtworks_fair.graphql.ts
@@ -92,16 +92,17 @@ const node: ReaderFragment = {
           "kind": "Literal",
           "name": "aggregations",
           "value": [
+            "ARTIST",
+            "ARTIST_NATIONALITY",
             "COLOR",
             "DIMENSION_RANGE",
-            "PARTNER",
-            "MAJOR_PERIOD",
-            "MEDIUM",
-            "PRICE_RANGE",
             "FOLLOWED_ARTISTS",
-            "ARTIST",
+            "LOCATION_CITY",
+            "MAJOR_PERIOD",
             "MATERIALS_TERMS",
-            "ARTIST_NATIONALITY"
+            "MEDIUM",
+            "PARTNER",
+            "PRICE_RANGE"
           ]
         },
         {
@@ -270,5 +271,5 @@ const node: ReaderFragment = {
   "type": "Fair",
   "abstractKey": null
 };
-(node as any).hash = '794b6c6130e2af7d3a970db28838888e';
+(node as any).hash = 'd84eca9d44c1b2e254e252efbd19aaee';
 export default node;

--- a/src/__generated__/FairQuery.graphql.ts
+++ b/src/__generated__/FairQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 28435f0adbcc91d5a317669afc2a4969 */
+/* @relayHash b65aad4342ad2178d42f518b2e9e3afb */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -79,7 +79,7 @@ fragment ArtworkTileRailCard_artwork on Artwork {
 fragment FairArtworks_fair_2T6kBV on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST, MATERIALS_TERMS, ARTIST_NATIONALITY], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [ARTIST, ARTIST_NATIONALITY, COLOR, DIMENSION_RANGE, FOLLOWED_ARTISTS, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -507,16 +507,17 @@ v19 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST",
+      "ARTIST_NATIONALITY",
       "COLOR",
       "DIMENSION_RANGE",
-      "PARTNER",
-      "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
       "FOLLOWED_ARTISTS",
-      "ARTIST",
+      "LOCATION_CITY",
+      "MAJOR_PERIOD",
       "MATERIALS_TERMS",
-      "ARTIST_NATIONALITY"
+      "MEDIUM",
+      "PARTNER",
+      "PRICE_RANGE"
     ]
   },
   (v18/*: any*/),
@@ -1382,7 +1383,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\",\"MATERIALS_TERMS\",\"ARTIST_NATIONALITY\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
+            "storageKey": "filterArtworksConnection(aggregations:[\"ARTIST\",\"ARTIST_NATIONALITY\",\"COLOR\",\"DIMENSION_RANGE\",\"FOLLOWED_ARTISTS\",\"LOCATION_CITY\",\"MAJOR_PERIOD\",\"MATERIALS_TERMS\",\"MEDIUM\",\"PARTNER\",\"PRICE_RANGE\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "fairArtworks",
@@ -1609,7 +1610,7 @@ return {
     ]
   },
   "params": {
-    "id": "28435f0adbcc91d5a317669afc2a4969",
+    "id": "b65aad4342ad2178d42f518b2e9e3afb",
     "metadata": {},
     "name": "FairQuery",
     "operationKind": "query",

--- a/src/__generated__/FairTestsQuery.graphql.ts
+++ b/src/__generated__/FairTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 920f3751b87d912193109c1249d74901 */
+/* @relayHash 7f0e66ce05b6fcc822099c410bcdc410 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -79,7 +79,7 @@ fragment ArtworkTileRailCard_artwork on Artwork {
 fragment FairArtworks_fair_2T6kBV on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST, MATERIALS_TERMS, ARTIST_NATIONALITY], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [ARTIST, ARTIST_NATIONALITY, COLOR, DIMENSION_RANGE, FOLLOWED_ARTISTS, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -507,16 +507,17 @@ v19 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST",
+      "ARTIST_NATIONALITY",
       "COLOR",
       "DIMENSION_RANGE",
-      "PARTNER",
-      "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
       "FOLLOWED_ARTISTS",
-      "ARTIST",
+      "LOCATION_CITY",
+      "MAJOR_PERIOD",
       "MATERIALS_TERMS",
-      "ARTIST_NATIONALITY"
+      "MEDIUM",
+      "PARTNER",
+      "PRICE_RANGE"
     ]
   },
   (v18/*: any*/),
@@ -1496,7 +1497,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\",\"MATERIALS_TERMS\",\"ARTIST_NATIONALITY\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
+            "storageKey": "filterArtworksConnection(aggregations:[\"ARTIST\",\"ARTIST_NATIONALITY\",\"COLOR\",\"DIMENSION_RANGE\",\"FOLLOWED_ARTISTS\",\"LOCATION_CITY\",\"MAJOR_PERIOD\",\"MATERIALS_TERMS\",\"MEDIUM\",\"PARTNER\",\"PRICE_RANGE\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "fairArtworks",
@@ -1723,7 +1724,7 @@ return {
     ]
   },
   "params": {
-    "id": "920f3751b87d912193109c1249d74901",
+    "id": "7f0e66ce05b6fcc822099c410bcdc410",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "fair": (v30/*: any*/),

--- a/src/__generated__/FilterModalTestsQuery.graphql.ts
+++ b/src/__generated__/FilterModalTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 2eb57afdd7380224047c4b6aedd80eb4 */
+/* @relayHash f70ec3fe8b1cdb7055b89f4a3f139539 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -136,7 +136,7 @@ fragment CollectionArtworks_collection on MarketingCollection {
   isDepartment
   slug
   id
-  collectionArtworks: artworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS, ARTIST_NATIONALITY]) {
+  collectionArtworks: artworksConnection(first: 10, aggregations: [ARTIST_NATIONALITY, COLOR, DIMENSION_RANGE, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -216,14 +216,15 @@ v3 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST_NATIONALITY",
       "COLOR",
       "DIMENSION_RANGE",
-      "PARTNER",
+      "LOCATION_CITY",
       "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
       "MATERIALS_TERMS",
-      "ARTIST_NATIONALITY"
+      "MEDIUM",
+      "PARTNER",
+      "PRICE_RANGE"
     ]
   },
   {
@@ -698,7 +699,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "artworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\",\"ARTIST_NATIONALITY\"],first:10)"
+            "storageKey": "artworksConnection(aggregations:[\"ARTIST_NATIONALITY\",\"COLOR\",\"DIMENSION_RANGE\",\"LOCATION_CITY\",\"MAJOR_PERIOD\",\"MATERIALS_TERMS\",\"MEDIUM\",\"PARTNER\",\"PRICE_RANGE\"],first:10)"
           },
           {
             "alias": "collectionArtworks",
@@ -718,7 +719,7 @@ return {
     ]
   },
   "params": {
-    "id": "2eb57afdd7380224047c4b6aedd80eb4",
+    "id": "f70ec3fe8b1cdb7055b89f4a3f139539",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "marketingCollection": {

--- a/src/__generated__/ShowArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/ShowArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash ca29380587e897558c542ce4c73bf99d */
+/* @relayHash a970d9da5b01aab3fa6924b9dce664e8 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -148,7 +148,7 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
 fragment ShowArtworks_show_YCAiB on Show {
   slug
   internalID
-  showArtworks: filterArtworksConnection(first: 30, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS, ARTIST_NATIONALITY], input: $input) {
+  showArtworks: filterArtworksConnection(first: 30, after: $cursor, aggregations: [ARTIST_NATIONALITY, COLOR, DIMENSION_RANGE, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PRICE_RANGE], input: $input) {
     aggregations {
       slice
       counts {
@@ -234,13 +234,14 @@ v8 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST_NATIONALITY",
       "COLOR",
       "DIMENSION_RANGE",
+      "LOCATION_CITY",
       "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
       "MATERIALS_TERMS",
-      "ARTIST_NATIONALITY"
+      "MEDIUM",
+      "PRICE_RANGE"
     ]
   },
   {
@@ -717,7 +718,7 @@ return {
     ]
   },
   "params": {
-    "id": "ca29380587e897558c542ce4c73bf99d",
+    "id": "a970d9da5b01aab3fa6924b9dce664e8",
     "metadata": {},
     "name": "ShowArtworksInfiniteScrollGridQuery",
     "operationKind": "query",

--- a/src/__generated__/ShowArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/ShowArtworksTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 91241e4462f3b646b5ae115a64dd1f84 */
+/* @relayHash eb57a1d0fd18ea3652e18d47fa38078a */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -92,7 +92,7 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
 fragment ShowArtworks_show on Show {
   slug
   internalID
-  showArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS, ARTIST_NATIONALITY]) {
+  showArtworks: filterArtworksConnection(first: 30, aggregations: [ARTIST_NATIONALITY, COLOR, DIMENSION_RANGE, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -155,13 +155,14 @@ v4 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST_NATIONALITY",
       "COLOR",
       "DIMENSION_RANGE",
+      "LOCATION_CITY",
       "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
       "MATERIALS_TERMS",
-      "ARTIST_NATIONALITY"
+      "MEDIUM",
+      "PRICE_RANGE"
     ]
   },
   {
@@ -624,7 +625,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\",\"ARTIST_NATIONALITY\"],first:30)"
+            "storageKey": "filterArtworksConnection(aggregations:[\"ARTIST_NATIONALITY\",\"COLOR\",\"DIMENSION_RANGE\",\"LOCATION_CITY\",\"MAJOR_PERIOD\",\"MATERIALS_TERMS\",\"MEDIUM\",\"PRICE_RANGE\"],first:30)"
           },
           {
             "alias": "showArtworks",
@@ -645,7 +646,7 @@ return {
     ]
   },
   "params": {
-    "id": "91241e4462f3b646b5ae115a64dd1f84",
+    "id": "eb57a1d0fd18ea3652e18d47fa38078a",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "show": {

--- a/src/__generated__/ShowArtworks_show.graphql.ts
+++ b/src/__generated__/ShowArtworks_show.graphql.ts
@@ -91,13 +91,14 @@ const node: ReaderFragment = {
           "kind": "Literal",
           "name": "aggregations",
           "value": [
+            "ARTIST_NATIONALITY",
             "COLOR",
             "DIMENSION_RANGE",
+            "LOCATION_CITY",
             "MAJOR_PERIOD",
-            "MEDIUM",
-            "PRICE_RANGE",
             "MATERIALS_TERMS",
-            "ARTIST_NATIONALITY"
+            "MEDIUM",
+            "PRICE_RANGE"
           ]
         },
         {
@@ -259,5 +260,5 @@ const node: ReaderFragment = {
   "type": "Show",
   "abstractKey": null
 };
-(node as any).hash = 'e6a828b8857e6995b7675a93557e9c1e';
+(node as any).hash = 'ebcfd5b5a891747ed9987e7431b2a28c';
 export default node;

--- a/src/__generated__/ShowQuery.graphql.ts
+++ b/src/__generated__/ShowQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 0ea7eaab6322fd7ed2552121b5565b2c */
+/* @relayHash e81e97e2d93cf8b45bab0efc9f78f42f */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -97,7 +97,7 @@ fragment ShowArtworksEmptyState_show on Show {
 fragment ShowArtworks_show_1lt5O6 on Show {
   slug
   internalID
-  showArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS, ARTIST_NATIONALITY], input: {sort: "partner_show_position", dimensionRange: "*-*"}) {
+  showArtworks: filterArtworksConnection(first: 30, aggregations: [ARTIST_NATIONALITY, COLOR, DIMENSION_RANGE, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PRICE_RANGE], input: {sort: "partner_show_position", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -376,13 +376,14 @@ v14 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST_NATIONALITY",
       "COLOR",
       "DIMENSION_RANGE",
+      "LOCATION_CITY",
       "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
       "MATERIALS_TERMS",
-      "ARTIST_NATIONALITY"
+      "MEDIUM",
+      "PRICE_RANGE"
     ]
   },
   {
@@ -1178,7 +1179,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\",\"ARTIST_NATIONALITY\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"partner_show_position\"})"
+            "storageKey": "filterArtworksConnection(aggregations:[\"ARTIST_NATIONALITY\",\"COLOR\",\"DIMENSION_RANGE\",\"LOCATION_CITY\",\"MAJOR_PERIOD\",\"MATERIALS_TERMS\",\"MEDIUM\",\"PRICE_RANGE\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"partner_show_position\"})"
           },
           {
             "alias": "showArtworks",
@@ -1225,7 +1226,7 @@ return {
     ]
   },
   "params": {
-    "id": "0ea7eaab6322fd7ed2552121b5565b2c",
+    "id": "e81e97e2d93cf8b45bab0efc9f78f42f",
     "metadata": {},
     "name": "ShowQuery",
     "operationKind": "query",

--- a/src/__generated__/ShowTestsQuery.graphql.ts
+++ b/src/__generated__/ShowTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 085f6973791bca3fd3f6b5605671e385 */
+/* @relayHash 3b3d909141225b20187753c10fedc429 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -97,7 +97,7 @@ fragment ShowArtworksEmptyState_show on Show {
 fragment ShowArtworks_show_1lt5O6 on Show {
   slug
   internalID
-  showArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS, ARTIST_NATIONALITY], input: {sort: "partner_show_position", dimensionRange: "*-*"}) {
+  showArtworks: filterArtworksConnection(first: 30, aggregations: [ARTIST_NATIONALITY, COLOR, DIMENSION_RANGE, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PRICE_RANGE], input: {sort: "partner_show_position", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -376,13 +376,14 @@ v14 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST_NATIONALITY",
       "COLOR",
       "DIMENSION_RANGE",
+      "LOCATION_CITY",
       "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
       "MATERIALS_TERMS",
-      "ARTIST_NATIONALITY"
+      "MEDIUM",
+      "PRICE_RANGE"
     ]
   },
   {
@@ -1232,7 +1233,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\",\"ARTIST_NATIONALITY\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"partner_show_position\"})"
+            "storageKey": "filterArtworksConnection(aggregations:[\"ARTIST_NATIONALITY\",\"COLOR\",\"DIMENSION_RANGE\",\"LOCATION_CITY\",\"MAJOR_PERIOD\",\"MATERIALS_TERMS\",\"MEDIUM\",\"PRICE_RANGE\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"partner_show_position\"})"
           },
           {
             "alias": "showArtworks",
@@ -1279,7 +1280,7 @@ return {
     ]
   },
   "params": {
-    "id": "085f6973791bca3fd3f6b5605671e385",
+    "id": "3b3d909141225b20187753c10fedc429",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "show": {

--- a/src/__generated__/VanityURLEntityQuery.graphql.ts
+++ b/src/__generated__/VanityURLEntityQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 3e2b561f96afed58cb52550edf269e82 */
+/* @relayHash 15e3966a65b4152669828e6221f47660 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -99,7 +99,7 @@ fragment ArtworkTileRailCard_artwork on Artwork {
 fragment FairArtworks_fair_2T6kBV on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST, MATERIALS_TERMS, ARTIST_NATIONALITY], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [ARTIST, ARTIST_NATIONALITY, COLOR, DIMENSION_RANGE, FOLLOWED_ARTISTS, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -749,16 +749,17 @@ v21 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST",
+      "ARTIST_NATIONALITY",
       "COLOR",
       "DIMENSION_RANGE",
-      "PARTNER",
-      "MAJOR_PERIOD",
-      "MEDIUM",
-      "PRICE_RANGE",
       "FOLLOWED_ARTISTS",
-      "ARTIST",
+      "LOCATION_CITY",
+      "MAJOR_PERIOD",
       "MATERIALS_TERMS",
-      "ARTIST_NATIONALITY"
+      "MEDIUM",
+      "PARTNER",
+      "PRICE_RANGE"
     ]
   },
   (v20/*: any*/),
@@ -1744,7 +1745,7 @@ return {
                   (v5/*: any*/),
                   (v36/*: any*/)
                 ],
-                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\",\"MATERIALS_TERMS\",\"ARTIST_NATIONALITY\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
+                "storageKey": "filterArtworksConnection(aggregations:[\"ARTIST\",\"ARTIST_NATIONALITY\",\"COLOR\",\"DIMENSION_RANGE\",\"FOLLOWED_ARTISTS\",\"LOCATION_CITY\",\"MAJOR_PERIOD\",\"MATERIALS_TERMS\",\"MEDIUM\",\"PARTNER\",\"PRICE_RANGE\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
               },
               {
                 "alias": "fairArtworks",
@@ -2382,7 +2383,7 @@ return {
     ]
   },
   "params": {
-    "id": "3e2b561f96afed58cb52550edf269e82",
+    "id": "15e3966a65b4152669828e6221f47660",
     "metadata": {},
     "name": "VanityURLEntityQuery",
     "operationKind": "query",

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -197,7 +197,7 @@ export default createPaginationContainer(
           first: $count
           after: $cursor
           input: $input
-          aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS]
+          aggregations: [COLOR, DIMENSION_RANGE, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE]
         ) @connection(key: "ArtistArtworksGrid_artworks") {
           aggregations {
             slice

--- a/src/lib/Components/ArtworkFilter/ArtworkFilter.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilter.tsx
@@ -35,6 +35,7 @@ import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
 import { FancyModal } from "../FancyModal/FancyModal"
 import { ArtworkFilterOptionsScreen, FilterModalMode as ArtworkFilterMode } from "./ArtworkFilterOptionsScreen"
+import { LocationCitiesOptionsScreen } from "./Filters/LocationCitiesOptions"
 
 interface ArtworkFilterProps extends ViewProps {
   closeModal?: () => void
@@ -72,6 +73,7 @@ export type ArtworkFilterNavigationStack = {
   FilterOptionsScreen: ArtworkFilterOptionsScreenParams
   GalleriesAndInstitutionsOptionsScreen: undefined
   MaterialsTermsOptionsScreen: undefined
+  LocationCitiesOptionsScreen: undefined
   MediumOptionsScreen: undefined
   PriceRangeOptionsScreen: undefined
   SizeOptionsScreen: undefined
@@ -180,6 +182,7 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
             <Stack.Screen name="CategoriesOptionsScreen" component={CategoriesOptionsScreen} />
             <Stack.Screen name="MaterialsTermsOptionsScreen" component={MaterialsTermsOptionsScreen} />
             <Stack.Screen name="ArtistNationalitiesOptionsScreen" component={ArtistNationalitiesOptionsScreen} />
+            <Stack.Screen name="LocationCitiesOptionsScreen" component={LocationCitiesOptionsScreen} />
           </Stack.Navigator>
 
           <Separator my={0} />

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -13,6 +13,7 @@ export enum FilterDisplayName {
   color = "Color",
   colors = "Color",
   estimateRange = "Price/estimate range",
+  locationCities = "Artwork location",
   materialsTerms = "Material",
   medium = "Medium",
   partnerIDs = "Galleries and institutions",
@@ -42,6 +43,7 @@ export enum FilterParamName {
   estimateRange = "estimateRange",
   height = "height",
   latestCreatedYear = "latestCreatedYear",
+  locationCities = "locationCities",
   materialsTerms = "materialsTerms",
   medium = "medium",
   partnerIDs = "partnerIDs",
@@ -96,6 +98,7 @@ export const ParamDefaultValues = {
   includeArtworksByFollowedArtists: false,
   inquireableOnly: false,
   latestCreatedYear: undefined,
+  locationCities: [],
   majorPeriods: [],
   materialsTerms: [],
   medium: "*",
@@ -127,6 +130,7 @@ export const defaultCommonFilterOptions = {
   includeArtworksByFollowedArtists: ParamDefaultValues.includeArtworksByFollowedArtists,
   inquireableOnly: ParamDefaultValues.inquireableOnly,
   latestCreatedYear: ParamDefaultValues.latestCreatedYear,
+  locationCities: ParamDefaultValues.locationCities,
   majorPeriods: ParamDefaultValues.majorPeriods,
   materialsTerms: ParamDefaultValues.materialsTerms,
   medium: ParamDefaultValues.medium,
@@ -155,6 +159,7 @@ export type AggregationName =
   | "earliestCreatedYear"
   | "FOLLOWED_ARTISTS"
   | "latestCreatedYear"
+  | "LOCATION_CITY"
   | "MAJOR_PERIOD"
   | "MATERIALS_TERMS"
   | "MEDIUM"
@@ -191,6 +196,7 @@ export const filterKeyFromAggregation: Record<AggregationName, FilterParamName |
   earliestCreatedYear: "earliestCreatedYear",
   FOLLOWED_ARTISTS: "artistsIFollow",
   latestCreatedYear: "earliestCreatedYear",
+  LOCATION_CITY: FilterParamName.locationCities,
   MAJOR_PERIOD: FilterParamName.timePeriod,
   MATERIALS_TERMS: FilterParamName.materialsTerms,
   MEDIUM: FilterParamName.additionalGeneIDs,
@@ -432,6 +438,7 @@ export const aggregationNameFromFilter: Record<string, AggregationName | undefin
   dimensionRange: "DIMENSION_RANGE",
   earliestCreatedYear: "earliestCreatedYear",
   latestCreatedYear: "latestCreatedYear",
+  locationCities: "LOCATION_CITY",
   majorPeriods: "MAJOR_PERIOD",
   materialsTerms: "MATERIALS_TERMS",
   medium: "MEDIUM",

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -30,6 +30,7 @@ export type FilterScreen =
   | "colors"
   | "dimensionRange"
   | "estimateRange"
+  | "locationCities"
   | "majorPeriods"
   | "materialsTerms"
   | "medium"
@@ -425,6 +426,11 @@ export const filterOptionToDisplayConfigMap: Record<string, FilterDisplayConfig>
     filterType: "partnerIDs",
     ScreenComponent: "GalleriesAndInstitutionsOptionsScreen",
   },
+  locationCities: {
+    displayText: FilterDisplayName.locationCities,
+    filterType: "locationCities",
+    ScreenComponent: "LocationCitiesOptionsScreen",
+  },
   majorPeriods: {
     displayText: FilterDisplayName.timePeriod,
     filterType: "majorPeriods",
@@ -480,6 +486,7 @@ const CollectionFiltersSorted: FilterScreen[] = [
   "attributionClass",
   "priceRange",
   "waysToBuy",
+  "locationCities",
   "dimensionRange",
   "majorPeriods",
   "colors",
@@ -493,6 +500,7 @@ const ArtistArtworksFiltersSorted: FilterScreen[] = [
   "attributionClass",
   "priceRange",
   "waysToBuy",
+  "locationCities",
   "partnerIDs",
   "dimensionRange",
   "majorPeriods",
@@ -506,6 +514,7 @@ const ArtistSeriesFiltersSorted: FilterScreen[] = [
   "attributionClass",
   "priceRange",
   "waysToBuy",
+  "locationCities",
   "dimensionRange",
   "majorPeriods",
   "colors",
@@ -521,6 +530,7 @@ const FairFiltersSorted: FilterScreen[] = [
   "attributionClass",
   "priceRange",
   "waysToBuy",
+  "locationCities",
   "dimensionRange",
   "majorPeriods",
   "colors",

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterStore.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterStore.tsx
@@ -240,6 +240,7 @@ export const DEFAULT_FILTERS: FilterArray = [
   { paramName: FilterParamName.priceRange, paramValue: "*-*", displayText: "All" },
   { paramName: FilterParamName.size, paramValue: "*-*", displayText: "All" },
   { paramName: FilterParamName.partnerIDs, paramValue: [], displayText: "All" },
+  { paramName: FilterParamName.locationCities, paramValue: [], displayText: "All" },
   { paramName: FilterParamName.colors, displayText: "All" },
   { paramName: FilterParamName.timePeriod, paramValue: [], displayText: "All" },
   { paramName: FilterParamName.waysToBuyBuy, paramValue: false, displayText: "Buy now" },

--- a/src/lib/Components/ArtworkFilter/Filters/LocationCitiesOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/LocationCitiesOptions.tsx
@@ -1,0 +1,36 @@
+import { StackScreenProps } from "@react-navigation/stack"
+import { ArtworkFilterNavigationStack } from "lib/Components/ArtworkFilter"
+import { FilterData, FilterDisplayName, FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
+import React from "react"
+import { useArtworkFiltersAggregation } from "../useArtworkFilters"
+import { MultiSelectOptionScreen } from "./MultiSelectOption"
+import { useMultiSelect } from "./useMultiSelect"
+
+interface LocationCitiesOptionsScreenProps
+  extends StackScreenProps<ArtworkFilterNavigationStack, "LocationCitiesOptionsScreen"> {}
+
+export const LocationCitiesOptionsScreen: React.FC<LocationCitiesOptionsScreenProps> = ({ navigation }) => {
+  const { aggregation } = useArtworkFiltersAggregation({ paramName: FilterParamName.locationCities })
+
+  const options: FilterData[] = (aggregation?.counts ?? []).map(({ value: paramValue, name }) => {
+    return { displayText: name, paramName: FilterParamName.locationCities, paramValue }
+  })
+
+  const { handleSelect, isSelected, handleClear, isActive } = useMultiSelect({
+    options,
+    paramName: FilterParamName.locationCities,
+  })
+
+  const filterOptions = options.map((option) => ({ ...option, paramValue: isSelected(option) }))
+
+  return (
+    <MultiSelectOptionScreen
+      onSelect={handleSelect}
+      filterHeaderText={FilterDisplayName.locationCities}
+      filterOptions={filterOptions}
+      navigation={navigation}
+      searchable
+      {...(isActive ? { rightButtonText: "Clear", onRightButtonPress: handleClear } : {})}
+    />
+  )
+}

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/LocationCitiesOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/LocationCitiesOptions-tests.tsx
@@ -1,0 +1,102 @@
+import { OptionListItem as FilterModalOptionListItem } from "lib/Components/ArtworkFilter"
+import { OptionListItem as MultiSelectOptionListItem } from "../MultiSelectOption"
+
+import { FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { Check } from "palette"
+import React from "react"
+import { MockFilterScreen } from "../../__tests__/FilterTestHelper"
+import { ArtworkFiltersState, ArtworkFiltersStoreProvider } from "../../ArtworkFilterStore"
+import { LocationCitiesOptionsScreen } from "../LocationCitiesOptions"
+import { getEssentialProps } from "./helper"
+
+describe(LocationCitiesOptionsScreen, () => {
+  const initialState: ArtworkFiltersState = {
+    aggregations: [
+      {
+        slice: "LOCATION_CITY",
+        counts: [
+          {
+            count: 44,
+            name: "Paris, France",
+            value: "Paris, France",
+          },
+          {
+            count: 30,
+            name: "London, United Kingdom",
+            value: "London, United Kingdom",
+          },
+          {
+            count: 26,
+            name: "Milan, Italy",
+            value: "Milan, Italy",
+          },
+        ],
+      },
+    ],
+    appliedFilters: [],
+    applyFilters: false,
+    counts: {
+      total: null,
+      followedArtists: null,
+    },
+    filterType: "artwork",
+    previouslyAppliedFilters: [],
+    selectedFilters: [],
+  }
+
+  const MockLocationCitiesOptionsScreen = ({ initialData = initialState }: { initialData?: ArtworkFiltersState }) => {
+    return (
+      <ArtworkFiltersStoreProvider initialData={initialData}>
+        <LocationCitiesOptionsScreen {...getEssentialProps()} />
+      </ArtworkFiltersStoreProvider>
+    )
+  }
+
+  describe("no filters are selected", () => {
+    it("renders all options present in the aggregation", () => {
+      const tree = renderWithWrappers(<MockLocationCitiesOptionsScreen initialData={initialState} />)
+
+      expect(tree.root.findAllByType(MultiSelectOptionListItem)).toHaveLength(3)
+
+      const items = tree.root.findAllByType(MultiSelectOptionListItem)
+      expect(items.map(extractText)).toEqual(["Paris, France", "London, United Kingdom", "Milan, Italy"])
+    })
+  })
+
+  describe("a filter is selected", () => {
+    const state: ArtworkFiltersState = {
+      ...initialState,
+      selectedFilters: [
+        {
+          displayText: "Paris, France, Milan, Italy",
+          paramName: FilterParamName.locationCities,
+          paramValue: ["Paris, France", "Milan, Italy"],
+        },
+      ],
+    }
+
+    it("displays a comma-separated list of the selected filters on the filter modal screen", () => {
+      const tree = renderWithWrappers(<MockFilterScreen initialState={state} />)
+
+      const items = tree.root.findAllByType(FilterModalOptionListItem)
+      const item = items.find((i) => extractText(i).startsWith("Artwork location"))
+
+      expect(item).not.toBeUndefined()
+      if (item) {
+        expect(extractText(item)).toContain("Paris, France, Milan, Italy")
+      }
+    })
+
+    it("toggles selected filters 'ON' and unselected filters 'OFF", async () => {
+      const tree = renderWithWrappers(<MockLocationCitiesOptionsScreen initialData={state} />)
+
+      const options = tree.root.findAllByType(Check)
+
+      expect(options[0].props.selected).toBe(true)
+      expect(options[1].props.selected).toBe(false)
+      expect(options[2].props.selected).toBe(true)
+    })
+  })
+})

--- a/src/lib/Components/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
@@ -1138,6 +1138,11 @@ describe("selectedOptionsUnion", () => {
         },
         {
           displayText: "All",
+          paramName: "locationCities",
+          paramValue: [],
+        },
+        {
+          displayText: "All",
           paramName: "colors",
         },
         {
@@ -1237,6 +1242,11 @@ describe("selectedOptionsUnion", () => {
         {
           displayText: "All",
           paramName: "partnerIDs",
+          paramValue: [],
+        },
+        {
+          displayText: "All",
+          paramName: "locationCities",
           paramValue: [],
         },
         {
@@ -1350,6 +1360,11 @@ describe("selectedOptionsUnion", () => {
         {
           displayText: "All",
           paramName: "partnerIDs",
+          paramValue: [],
+        },
+        {
+          displayText: "All",
+          paramName: "locationCities",
           paramValue: [],
         },
         {
@@ -1478,6 +1493,11 @@ describe("selectedOptionsUnion", () => {
         },
         {
           displayText: "All",
+          paramName: "locationCities",
+          paramValue: [],
+        },
+        {
+          displayText: "All",
           paramName: "colors",
         },
         {
@@ -1592,6 +1612,11 @@ describe("selectedOptionsUnion", () => {
         },
         {
           displayText: "All",
+          paramName: "locationCities",
+          paramValue: [],
+        },
+        {
+          displayText: "All",
           paramName: "colors",
         },
         {
@@ -1678,6 +1703,11 @@ describe("selectedOptionsUnion", () => {
         {
           displayText: "All",
           paramName: "partnerIDs",
+          paramValue: [],
+        },
+        {
+          displayText: "All",
+          paramName: "locationCities",
           paramValue: [],
         },
         {
@@ -1781,6 +1811,11 @@ describe("selectedOptionsUnion", () => {
         {
           displayText: "All",
           paramName: "partnerIDs",
+          paramValue: [],
+        },
+        {
+          displayText: "All",
+          paramName: "locationCities",
           paramValue: [],
         },
         {
@@ -1889,6 +1924,11 @@ describe("selectedOptionsUnion", () => {
         },
         {
           displayText: "All",
+          paramName: "locationCities",
+          paramValue: [],
+        },
+        {
+          displayText: "All",
           paramName: "colors",
         },
         {
@@ -1970,6 +2010,11 @@ describe("selectedOptionsUnion", () => {
         {
           displayText: "All",
           paramName: "partnerIDs",
+          paramValue: [],
+        },
+        {
+          displayText: "All",
+          paramName: "locationCities",
           paramValue: [],
         },
         {

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
@@ -103,14 +103,15 @@ export const ArtistSeriesArtworksFragmentContainer = createPaginationContainer(
           first: 20
           after: $cursor
           aggregations: [
+            ARTIST_NATIONALITY
             COLOR
             DIMENSION_RANGE
-            PARTNER
+            LOCATION_CITY
             MAJOR_PERIOD
-            MEDIUM
-            PRICE_RANGE
             MATERIALS_TERMS
-            ARTIST_NATIONALITY
+            MEDIUM
+            PARTNER
+            PRICE_RANGE
           ]
           input: $input
         ) @connection(key: "ArtistSeries_artistSeriesArtworks") {

--- a/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -114,14 +114,15 @@ export const CollectionArtworksFragmentContainer = createPaginationContainer(
           first: $count
           after: $cursor
           aggregations: [
+            ARTIST_NATIONALITY
             COLOR
             DIMENSION_RANGE
-            PARTNER
+            LOCATION_CITY
             MAJOR_PERIOD
-            MEDIUM
-            PRICE_RANGE
             MATERIALS_TERMS
-            ARTIST_NATIONALITY
+            MEDIUM
+            PARTNER
+            PRICE_RANGE
           ]
           input: $input
         ) @connection(key: "Collection_collectionArtworks") {

--- a/src/lib/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/lib/Scenes/Fair/Components/FairArtworks.tsx
@@ -125,16 +125,17 @@ export const FairArtworksFragmentContainer = createPaginationContainer(
           first: $count
           after: $cursor
           aggregations: [
+            ARTIST
+            ARTIST_NATIONALITY
             COLOR
             DIMENSION_RANGE
-            PARTNER
-            MAJOR_PERIOD
-            MEDIUM
-            PRICE_RANGE
             FOLLOWED_ARTISTS
-            ARTIST
+            LOCATION_CITY
+            MAJOR_PERIOD
             MATERIALS_TERMS
-            ARTIST_NATIONALITY
+            MEDIUM
+            PARTNER
+            PRICE_RANGE
           ]
           input: $input
         ) @connection(key: "Fair_fairArtworks") {

--- a/src/lib/Scenes/Show/Components/ShowArtworks.tsx
+++ b/src/lib/Scenes/Show/Components/ShowArtworks.tsx
@@ -121,7 +121,16 @@ export const ShowArtworksPaginationContainer = createPaginationContainer(
         showArtworks: filterArtworksConnection(
           first: 30
           after: $cursor
-          aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS, ARTIST_NATIONALITY]
+          aggregations: [
+            ARTIST_NATIONALITY
+            COLOR
+            DIMENSION_RANGE
+            LOCATION_CITY
+            MAJOR_PERIOD
+            MATERIALS_TERMS
+            MEDIUM
+            PRICE_RANGE
+          ]
           input: $input
         ) @connection(key: "Show_showArtworks") {
           aggregations {


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-2636]

### Description

Allows users to filter by an artwork's location on the following screens:

- Artist
- Artist series
- Collection
- Fair
- Show

![artwork-location](https://user-images.githubusercontent.com/44589599/119129193-95281680-ba04-11eb-812e-96c60b2394a5.gif)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS**.
- [ ] I have tested my changes on **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[FX-2636]: https://artsyproduct.atlassian.net/browse/FX-2636