### PR TITLE
fix: stop crashing when rendering artworks tabs

### DIFF
--- a/src/lib/Components/StickyTabPage/StickyTabPageFlatList.tsx
+++ b/src/lib/Components/StickyTabPage/StickyTabPageFlatList.tsx
@@ -45,10 +45,7 @@ export const StickyTabPageFlatList: React.FC<StickyTabFlatListProps> = (props) =
   }
   const { tabIsActive, tabSpecificContentHeight } = useContext(StickyTabPageFlatListContext)
 
-  const totalStickyHeaderHeight = Animated.add(
-    stickyHeaderHeight,
-    Animated.cond(Animated.defined(tabSpecificContentHeight), tabSpecificContentHeight!, 0)
-  )
+  const totalStickyHeaderHeight = Animated.add(stickyHeaderHeight, tabSpecificContentHeight ?? 0)
 
   const contentHeight = useAnimatedValue(0)
   const layoutHeight = useAnimatedValue(0)


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

After merging #4753, pages with tabs started crashing. It seems that when @MounirDhahri and I were working on tweaking the conditional, we made a mistake that allowed a `null` value to creep in. Switching back to the original version.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434