### PR TITLE
fix: sentry error tagging, update app.json before bundling apk

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -62,8 +62,6 @@ lane :ship_beta_ios do
     profile_name: 'match AppStore net.artsy.artsy.Artsy-Stickers'
   )
 
-  build_ios_app(configuration: 'Store', silent: true)
-
   root = File.expand_path('..', __dir__)
   bundle_version = `/usr/libexec/PlistBuddy -c "print CFBundleVersion" #{File.join(root, 'Artsy/App_Resources/Artsy-Info.plist')}`.strip
   tag_and_push(tag: "ios-#{latest_version}-#{bundle_version}")
@@ -71,6 +69,9 @@ lane :ship_beta_ios do
   # important! this much match the release version specified
   # in Eigen in order for sourcemaps to work correctly
   sentry_release_name = "ios-#{latest_version}+#{bundle_version}"
+  update_sentry_release_name(sentry_release_name: sentry_release_name)
+
+  build_ios_app(configuration: 'Store', silent: true)
 
   upload_sentry_artifacts(sentry_release_name: sentry_release_name, dist_version: bundle_version, platform: "ios")
 
@@ -159,13 +160,16 @@ lane :ship_beta_android do
   vname, vcode = set_build_version_android
   tag_and_push(tag: "android-#{vname}-#{vcode}")
 
+
+  sentry_release_name = "android-#{vname}-#{vcode}"
+  update_sentry_release_name(sentry_release_name: sentry_release_name)
+
   gradle(
     task: "bundle",
     build_type: "Release",
     project_dir: "android/",
   )
 
-  sentry_release_name = "android-#{vname}-#{vcode}"
   upload_sentry_artifacts(sentry_release_name: sentry_release_name, dist_version: "#{vcode}", platform: "android")
 
   upload_to_play_store(
@@ -247,6 +251,14 @@ lane :promote_beta_ios do
   puts 'All done.'
 end
 
+# update releaseName in app.json to tag errors in sentry correctly
+lane :update_sentry_release_name do |options|
+  app_json['sentryReleaseName'] = sentry_release_name
+  File.open(app_json_path, 'w') do |file|
+    file.puts JSON.pretty_generate(app_json)
+  end
+end
+
 lane :upload_sentry_artifacts do |options|
   sentry_release_name = options[:sentry_release_name]
   platform = options[:platform]
@@ -274,12 +286,6 @@ lane :upload_sentry_artifacts do |options|
     source_map_path = 'android/app/build/generated/sourcemaps/react/release/index.android.bundle.map'
     bundle_path = 'android/app/build/generated/assets/react/release/index.android.bundle'
     outfile = '~/index.android.bundle'
-  end
-
-  # update releaseName in app.json to tag errors in sentry correctly
-  app_json['sentryReleaseName'] = sentry_release_name
-  File.open(app_json_path, 'w') do |file|
-    file.puts JSON.pretty_generate(app_json)
   end
 
   sentry_create_release(auth_token: ENV['SentryUploadAuthKey'],


### PR DESCRIPTION
The type of this PR is: **fix**

This PR resolves [CX-1109]

### Description

Android versions were not matching our sourcemaps in sentry because I was updating the app.json after bundling the apk, 🤦 this adds a helper function and update the app.json before bundling the apk.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-1109]: https://artsyproduct.atlassian.net/browse/CX-1109