### PR TITLE
fix: ensure make offer butten refetches when conversation is pulled to refetched

### DIFF
--- a/src/__generated__/OpenInquiryModalButtonRefetchQuery.graphql.ts
+++ b/src/__generated__/OpenInquiryModalButtonRefetchQuery.graphql.ts
@@ -1,0 +1,115 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash 97b950c26c067f533fb4e54f61baa9e2 */
+
+import { ConcreteRequest } from "relay-runtime";
+export type OpenInquiryModalButtonRefetchQueryVariables = {
+    artworkID: string;
+};
+export type OpenInquiryModalButtonRefetchQueryResponse = {
+    readonly artwork: {
+        readonly isOfferableFromInquiry: boolean | null;
+    } | null;
+};
+export type OpenInquiryModalButtonRefetchQuery = {
+    readonly response: OpenInquiryModalButtonRefetchQueryResponse;
+    readonly variables: OpenInquiryModalButtonRefetchQueryVariables;
+};
+
+
+
+/*
+query OpenInquiryModalButtonRefetchQuery(
+  $artworkID: String!
+) {
+  artwork(id: $artworkID) {
+    isOfferableFromInquiry
+    id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "artworkID"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "artworkID"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isOfferableFromInquiry",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "OpenInquiryModalButtonRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "OpenInquiryModalButtonRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "97b950c26c067f533fb4e54f61baa9e2",
+    "metadata": {},
+    "name": "OpenInquiryModalButtonRefetchQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = 'c9a88b826d5ae1ff9a7afab2c73bfb8e';
+export default node;

--- a/src/__generated__/OpenInquiryModalButton_artwork.graphql.ts
+++ b/src/__generated__/OpenInquiryModalButton_artwork.graphql.ts
@@ -1,0 +1,37 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type OpenInquiryModalButton_artwork = {
+    readonly isOfferableFromInquiry: boolean | null;
+    readonly " $refType": "OpenInquiryModalButton_artwork";
+};
+export type OpenInquiryModalButton_artwork$data = OpenInquiryModalButton_artwork;
+export type OpenInquiryModalButton_artwork$key = {
+    readonly " $data"?: OpenInquiryModalButton_artwork$data;
+    readonly " $fragmentRefs": FragmentRefs<"OpenInquiryModalButton_artwork">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "OpenInquiryModalButton_artwork",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "isOfferableFromInquiry",
+      "storageKey": null
+    }
+  ],
+  "type": "Artwork",
+  "abstractKey": null
+};
+(node as any).hash = '8172a374d06e5bbe5f3f61516143b611';
+export default node;

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/OpenInquiryModalButton-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/OpenInquiryModalButton-tests.tsx
@@ -7,7 +7,7 @@ import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { act } from "react-test-renderer"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
-import { OpenInquiryModalButton } from "../OpenInquiryModalButton"
+import { OpenInquiryModalButtonContainer } from "../OpenInquiryModalButton"
 
 jest.unmock("react-relay")
 
@@ -31,7 +31,7 @@ const TestRenderer = () => {
         }
 
         if (props?.artwork?.isOfferableFromInquiry) {
-          return <OpenInquiryModalButton artworkID="i-love-nyc" conversationID="test-id" />
+          return <OpenInquiryModalButtonContainer artworkID="i-love-nyc" conversationID="test-id" />
         } else {
           return null
         }
@@ -72,12 +72,12 @@ describe("OpenInquiryModalButtonQueryRenderer", () => {
       const tree = getWrapper()
 
       expect(extractText(tree.root)).toContain("Make Offer")
-      expect(tree.root.findAllByType(OpenInquiryModalButton)).toHaveLength(1)
+      expect(tree.root.findAllByType(OpenInquiryModalButtonContainer)).toHaveLength(1)
     })
     it("does not render make offer button for for works not elibable for inquiry checkout", () => {
       const tree = getWrapper(uneligibleArtworkMockResolver)
 
-      expect(tree.root.findAllByType(OpenInquiryModalButton)).toHaveLength(0)
+      expect(tree.root.findAllByType(OpenInquiryModalButtonContainer)).toHaveLength(0)
       expect(extractText(tree.root)).not.toContain("Make Offer")
     })
   })
@@ -87,7 +87,7 @@ describe("OpenInquiryModalButtonQueryRenderer", () => {
       const tree = getWrapper()
 
       expect(extractText(tree.root)).toContain("Only purchases completed with our secure checkout are protected")
-      expect(tree.root.findAllByType(OpenInquiryModalButton)).toHaveLength(1)
+      expect(tree.root.findAllByType(OpenInquiryModalButtonContainer)).toHaveLength(1)
     })
 
     it("navigates to the buyer guarantee page when tapped", () => {

--- a/src/lib/Scenes/Inbox/Screens/Conversation.tsx
+++ b/src/lib/Scenes/Inbox/Screens/Conversation.tsx
@@ -108,6 +108,8 @@ export class Conversation extends React.Component<Props, State> {
       },
       { force: true }
     )
+    navigationEvents.emit("refetchConversation")
+    console.warn("called refetch 2")
   }
 
   maybeMarkLastMessageAsRead() {
@@ -233,6 +235,7 @@ export class Conversation extends React.Component<Props, State> {
                 },
                 { force: true }
               )
+              navigationEvents.emit("refetchConversation")
             }}
           />
         </Container>


### PR DESCRIPTION
The type of this PR is: **FIX**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [PURCHASE-2616]

### Description

<!-- Implementation description -->

Because the Make Offer button uses a separate QueryRenderer, when the <Conversation> is refetched via pull-to-refresh the button isn't being updated when an artwork is marked sold. This PR wraps the <OpenInquiryModalButton> in a RefetchContainer and triggers a refetch through an event emitter inside the Conversation component.

https://user-images.githubusercontent.com/5201004/118890201-49725180-b8cc-11eb-8293-d653dc986dd4.mp4

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [ ] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [ ] I have documented any follow-up work that this PR will require, or it does not require any.
- [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[PURCHASE-2616]: https://artsyproduct.atlassian.net/browse/PURCHASE-2616