### PR TITLE
feat(FX-2632): add material filter without search UI

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -10,15 +10,14 @@ upcoming:
     - Update android play store metadata - brian
   user_facing:
     - Fix wrong input font on android - dzmitry
-    - 
- 
+    - Add artwork Material filter - dzmitry tratsiak
 
 releases:
   - version: 6.9.1
     date: May 18, 2021
     dev:
-     - lock screen orientation to portrait on android phones - mounir
-     - Fix artist follow is incorrectly firing action_name - dzmitry
+      - lock screen orientation to portrait on android phones - mounir
+      - Fix artist follow is incorrectly firing action_name - dzmitry
     user_facing:
       - Correct formatted large numbers' display - kizito
       - Fix cancel button next to search bar doesn't clear terms/results - yauheni

--- a/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash e8c589d40442a5d7773f6877a07c42b7 */
+/* @relayHash 283bb03d46853311881583d46b760a82 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -59,7 +59,7 @@ fragment ArtistArtworks_artist_44NygF on Artist {
   id
   slug
   internalID
-  artworks: filterArtworksConnection(first: 10, input: {dimensionRange: "*-*", sort: "-decayed_merch"}, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  artworks: filterArtworksConnection(first: 10, input: {dimensionRange: "*-*", sort: "-decayed_merch"}, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS]) {
     aggregations {
       slice
       counts {
@@ -275,7 +275,8 @@ v13 = [
       "PARTNER",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "MATERIALS_TERMS"
     ]
   },
   {
@@ -767,7 +768,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "artworks",
@@ -788,7 +789,7 @@ return {
     ]
   },
   "params": {
-    "id": "e8c589d40442a5d7773f6877a07c42b7",
+    "id": "283bb03d46853311881583d46b760a82",
     "metadata": {},
     "name": "ArtistAboveTheFoldQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistArtworksQuery.graphql.ts
+++ b/src/__generated__/ArtistArtworksQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 1470d1787550a2640d505d9a52b82f88 */
+/* @relayHash 1d94db5944fa6941f0ca17cd3fc73558 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -94,7 +94,7 @@ fragment ArtistArtworks_artist_YCAiB on Artist {
   id
   slug
   internalID
-  artworks: filterArtworksConnection(first: $count, after: $cursor, input: $input, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  artworks: filterArtworksConnection(first: $count, after: $cursor, input: $input, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS]) {
     aggregations {
       slice
       counts {
@@ -258,7 +258,8 @@ v10 = [
       "PARTNER",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "MATERIALS_TERMS"
     ]
   },
   {
@@ -736,7 +737,7 @@ return {
     ]
   },
   "params": {
-    "id": "1470d1787550a2640d505d9a52b82f88",
+    "id": "1d94db5944fa6941f0ca17cd3fc73558",
     "metadata": {},
     "name": "ArtistArtworksQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistArtworks_artist.graphql.ts
+++ b/src/__generated__/ArtistArtworks_artist.graphql.ts
@@ -106,7 +106,8 @@ return {
             "PARTNER",
             "MAJOR_PERIOD",
             "MEDIUM",
-            "PRICE_RANGE"
+            "PRICE_RANGE",
+            "MATERIALS_TERMS"
           ]
         },
         {
@@ -263,5 +264,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '8052b338d0a74f7d8857e05740092e5d';
+(node as any).hash = '10079f10eb368da287ef441279ebc633';
 export default node;

--- a/src/__generated__/ArtistSeriesArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash d19f3f249830131fc24f85c021c7b402 */
+/* @relayHash 255db346d14e7101b63ef5387a9c4ac1 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -88,7 +88,7 @@ query ArtistSeriesArtworksInfiniteScrollGridQuery(
 fragment ArtistSeriesArtworks_artistSeries_YCAiB on ArtistSeries {
   slug
   internalID
-  artistSeriesArtworks: filterArtworksConnection(first: 20, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: $input) {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS], input: $input) {
     aggregations {
       slice
       counts {
@@ -238,7 +238,8 @@ v8 = [
       "PARTNER",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "MATERIALS_TERMS"
     ]
   },
   {
@@ -714,7 +715,7 @@ return {
     ]
   },
   "params": {
-    "id": "d19f3f249830131fc24f85c021c7b402",
+    "id": "255db346d14e7101b63ef5387a9c4ac1",
     "metadata": {},
     "name": "ArtistSeriesArtworksInfiniteScrollGridQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistSeriesArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworksTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash ab9e0b6e0ea7bd88b2820d1dc7383945 */
+/* @relayHash 64e698192f0dacaaa3157935240981b2 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -28,7 +28,7 @@ query ArtistSeriesArtworksTestsQuery {
 fragment ArtistSeriesArtworks_artistSeries on ArtistSeries {
   slug
   internalID
-  artistSeriesArtworks: filterArtworksConnection(first: 20, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS]) {
     aggregations {
       slice
       counts {
@@ -148,7 +148,8 @@ v3 = [
       "PARTNER",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "MATERIALS_TERMS"
     ]
   },
   {
@@ -611,7 +612,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:20)"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\"],first:20)"
           },
           {
             "alias": "artistSeriesArtworks",
@@ -631,7 +632,7 @@ return {
     ]
   },
   "params": {
-    "id": "ab9e0b6e0ea7bd88b2820d1dc7383945",
+    "id": "64e698192f0dacaaa3157935240981b2",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artistSeries": {

--- a/src/__generated__/ArtistSeriesArtworks_artistSeries.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworks_artistSeries.graphql.ts
@@ -96,7 +96,8 @@ const node: ReaderFragment = {
             "PARTNER",
             "MAJOR_PERIOD",
             "MEDIUM",
-            "PRICE_RANGE"
+            "PRICE_RANGE",
+            "MATERIALS_TERMS"
           ]
         },
         {
@@ -258,5 +259,5 @@ const node: ReaderFragment = {
   "type": "ArtistSeries",
   "abstractKey": null
 };
-(node as any).hash = '6fbfe98a700a1d3b80237a9c2748ac25';
+(node as any).hash = 'a9d795af2c6d5f9781a340b705968938';
 export default node;

--- a/src/__generated__/ArtistSeriesQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash ef99c1209a5bb110d826a8287db5bbbe */
+/* @relayHash 0b1cf86d8e6d441b6175e79855539bbd */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -32,7 +32,7 @@ query ArtistSeriesQuery(
 fragment ArtistSeriesArtworks_artistSeries_2T6kBV on ArtistSeries {
   slug
   internalID
-  artistSeriesArtworks: filterArtworksConnection(first: 20, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -264,7 +264,8 @@ v9 = [
       "PARTNER",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "MATERIALS_TERMS"
     ]
   },
   {
@@ -724,7 +725,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:20,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\"],first:20,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "artistSeriesArtworks",
@@ -822,7 +823,7 @@ return {
     ]
   },
   "params": {
-    "id": "ef99c1209a5bb110d826a8287db5bbbe",
+    "id": "0b1cf86d8e6d441b6175e79855539bbd",
     "metadata": {},
     "name": "ArtistSeriesQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 45f4965387cd30ae28c0c5839d625c41 */
+/* @relayHash fece286b8f3f94fd4726d8aa49bf213f */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -28,7 +28,7 @@ query ArtistSeriesTestsQuery {
 fragment ArtistSeriesArtworks_artistSeries_2T6kBV on ArtistSeries {
   slug
   internalID
-  artistSeriesArtworks: filterArtworksConnection(first: 20, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
+  artistSeriesArtworks: filterArtworksConnection(first: 20, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -253,7 +253,8 @@ v8 = [
       "PARTNER",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "MATERIALS_TERMS"
     ]
   },
   {
@@ -773,7 +774,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:20,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\"],first:20,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "artistSeriesArtworks",
@@ -871,7 +872,7 @@ return {
     ]
   },
   "params": {
-    "id": "45f4965387cd30ae28c0c5839d625c41",
+    "id": "fece286b8f3f94fd4726d8aa49bf213f",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "artistSeries": (v10/*: any*/),

--- a/src/__generated__/CollectionArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/CollectionArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash b41290892bca64ae1c9ce28201820dbc */
+/* @relayHash ae39df864637b4f973132bcc9fb42ad1 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -126,7 +126,7 @@ fragment CollectionArtworks_collection_YCAiB on MarketingCollection {
   isDepartment
   slug
   id
-  collectionArtworks: artworksConnection(first: $count, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: $input) {
+  collectionArtworks: artworksConnection(first: $count, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS], input: $input) {
     aggregations {
       slice
       counts {
@@ -241,7 +241,8 @@ v8 = [
       "PARTNER",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "MATERIALS_TERMS"
     ]
   },
   {
@@ -723,7 +724,7 @@ return {
     ]
   },
   "params": {
-    "id": "b41290892bca64ae1c9ce28201820dbc",
+    "id": "ae39df864637b4f973132bcc9fb42ad1",
     "metadata": {},
     "name": "CollectionArtworksInfiniteScrollGridQuery",
     "operationKind": "query",

--- a/src/__generated__/CollectionArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/CollectionArtworksTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash e222dcd88bcc449e72fd45af08984588 */
+/* @relayHash 3be49cd83469bd362e09a0ec73f462de */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -65,7 +65,7 @@ fragment CollectionArtworks_collection on MarketingCollection {
   isDepartment
   slug
   id
-  collectionArtworks: artworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  collectionArtworks: artworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS]) {
     aggregations {
       slice
       counts {
@@ -150,7 +150,8 @@ v3 = [
       "PARTNER",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "MATERIALS_TERMS"
     ]
   },
   {
@@ -625,7 +626,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "artworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:10)"
+            "storageKey": "artworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\"],first:10)"
           },
           {
             "alias": "collectionArtworks",
@@ -645,7 +646,7 @@ return {
     ]
   },
   "params": {
-    "id": "e222dcd88bcc449e72fd45af08984588",
+    "id": "3be49cd83469bd362e09a0ec73f462de",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "marketingCollection": {

--- a/src/__generated__/CollectionArtworks_collection.graphql.ts
+++ b/src/__generated__/CollectionArtworks_collection.graphql.ts
@@ -106,7 +106,8 @@ return {
             "PARTNER",
             "MAJOR_PERIOD",
             "MEDIUM",
-            "PRICE_RANGE"
+            "PRICE_RANGE",
+            "MATERIALS_TERMS"
           ]
         },
         {
@@ -263,5 +264,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = 'ff711457103eb03e87e46bd7c9d451c8';
+(node as any).hash = '0c657cfc9796b7cbb55f3e36292476ab';
 export default node;

--- a/src/__generated__/CollectionQuery.graphql.ts
+++ b/src/__generated__/CollectionQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 4d04baf853b528f15686a89252b3a323 */
+/* @relayHash 855f8c3cf694559ade21bb2529e1ddbe */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -113,7 +113,7 @@ fragment CollectionArtworks_collection_2T6kBV on MarketingCollection {
   isDepartment
   slug
   id
-  collectionArtworks: artworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
+  collectionArtworks: artworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -330,7 +330,8 @@ v8 = [
       "PARTNER",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "MATERIALS_TERMS"
     ]
   },
   {
@@ -875,7 +876,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "artworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
+            "storageKey": "artworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "collectionArtworks",
@@ -1131,7 +1132,7 @@ return {
     ]
   },
   "params": {
-    "id": "4d04baf853b528f15686a89252b3a323",
+    "id": "855f8c3cf694559ade21bb2529e1ddbe",
     "metadata": {},
     "name": "CollectionQuery",
     "operationKind": "query",

--- a/src/__generated__/CollectionTestsQuery.graphql.ts
+++ b/src/__generated__/CollectionTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash b9f58eb6b37c53fe8087f97659fe55f7 */
+/* @relayHash 37f0425841de21e226659b61165fd40e */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -108,7 +108,7 @@ fragment CollectionArtworks_collection_2T6kBV on MarketingCollection {
   isDepartment
   slug
   id
-  collectionArtworks: artworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
+  collectionArtworks: artworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -313,7 +313,8 @@ v7 = [
       "PARTNER",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "MATERIALS_TERMS"
     ]
   },
   {
@@ -918,7 +919,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "artworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
+            "storageKey": "artworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "collectionArtworks",
@@ -1174,7 +1175,7 @@ return {
     ]
   },
   "params": {
-    "id": "b9f58eb6b37c53fe8087f97659fe55f7",
+    "id": "37f0425841de21e226659b61165fd40e",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "marketingCollection": {

--- a/src/__generated__/FairAllFollowedArtistsQuery.graphql.ts
+++ b/src/__generated__/FairAllFollowedArtistsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 5bfb57722ef735fa8e24d04b45f995a8 */
+/* @relayHash 4ca2dd82d8f5c0d001e3b2913f070da8 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -98,7 +98,7 @@ fragment FairAllFollowedArtists_fairForFilters on Fair {
 fragment FairArtworks_fair_6zGp3 on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], input: {includeArtworksByFollowedArtists: true, sort: "-decayed_merch", dimensionRange: "*-*"}) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST, MATERIALS_TERMS], input: {includeArtworksByFollowedArtists: true, sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -181,22 +181,22 @@ v3 = {
   "name": "slug",
   "storageKey": null
 },
-v4 = {
-  "kind": "Literal",
-  "name": "aggregations",
-  "value": [
-    "COLOR",
-    "DIMENSION_RANGE",
-    "PARTNER",
-    "MAJOR_PERIOD",
-    "MEDIUM",
-    "PRICE_RANGE",
-    "FOLLOWED_ARTISTS",
-    "ARTIST"
-  ]
-},
-v5 = [
-  (v4/*: any*/),
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "aggregations",
+    "value": [
+      "COLOR",
+      "DIMENSION_RANGE",
+      "PARTNER",
+      "MAJOR_PERIOD",
+      "MEDIUM",
+      "PRICE_RANGE",
+      "FOLLOWED_ARTISTS",
+      "ARTIST",
+      "MATERIALS_TERMS"
+    ]
+  },
   {
     "kind": "Literal",
     "name": "first",
@@ -212,14 +212,14 @@ v5 = [
     }
   }
 ],
-v6 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v7 = {
+v6 = {
   "alias": null,
   "args": null,
   "concreteType": "ArtworksAggregationResults",
@@ -249,7 +249,7 @@ v7 = {
           "name": "count",
           "storageKey": null
         },
-        (v6/*: any*/),
+        (v5/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -263,21 +263,21 @@ v7 = {
   ],
   "storageKey": null
 },
-v8 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v9 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v10 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -345,13 +345,13 @@ return {
           (v3/*: any*/),
           {
             "alias": "fairArtworks",
-            "args": (v5/*: any*/),
+            "args": (v4/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
-              (v7/*: any*/),
+              (v6/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -368,8 +368,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v8/*: any*/),
-                      (v9/*: any*/)
+                      (v7/*: any*/),
+                      (v8/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -398,7 +398,7 @@ return {
                     "name": "total",
                     "storageKey": null
                   },
-                  (v10/*: any*/)
+                  (v9/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -427,7 +427,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v8/*: any*/),
+              (v7/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -457,7 +457,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v9/*: any*/),
+                      (v8/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -570,7 +570,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v8/*: any*/)
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -625,7 +625,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v8/*: any*/)
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -637,8 +637,8 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v6/*: any*/),
-                              (v8/*: any*/)
+                              (v5/*: any*/),
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -648,7 +648,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v8/*: any*/)
+                          (v7/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -661,11 +661,11 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:30,input:{\"dimensionRange\":\"*-*\",\"includeArtworksByFollowedArtists\":true,\"sort\":\"-decayed_merch\"})"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\",\"MATERIALS_TERMS\"],first:30,input:{\"dimensionRange\":\"*-*\",\"includeArtworksByFollowedArtists\":true,\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "fairArtworks",
-            "args": (v5/*: any*/),
+            "args": (v4/*: any*/),
             "filters": [
               "aggregations",
               "input"
@@ -675,7 +675,7 @@ return {
             "kind": "LinkedHandle",
             "name": "filterArtworksConnection"
           },
-          (v8/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       },
@@ -690,7 +690,20 @@ return {
           {
             "alias": null,
             "args": [
-              (v4/*: any*/),
+              {
+                "kind": "Literal",
+                "name": "aggregations",
+                "value": [
+                  "COLOR",
+                  "DIMENSION_RANGE",
+                  "PARTNER",
+                  "MAJOR_PERIOD",
+                  "MEDIUM",
+                  "PRICE_RANGE",
+                  "FOLLOWED_ARTISTS",
+                  "ARTIST"
+                ]
+              },
               {
                 "kind": "Literal",
                 "name": "first",
@@ -702,7 +715,7 @@ return {
             "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
-              (v7/*: any*/),
+              (v6/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -711,22 +724,22 @@ return {
                 "name": "counts",
                 "plural": false,
                 "selections": [
-                  (v10/*: any*/)
+                  (v9/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v8/*: any*/)
+              (v7/*: any*/)
             ],
             "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:0)"
           },
-          (v8/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "5bfb57722ef735fa8e24d04b45f995a8",
+    "id": "4ca2dd82d8f5c0d001e3b2913f070da8",
     "metadata": {},
     "name": "FairAllFollowedArtistsQuery",
     "operationKind": "query",

--- a/src/__generated__/FairAllFollowedArtistsTestsQuery.graphql.ts
+++ b/src/__generated__/FairAllFollowedArtistsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 9c402342e1a6adb8001b6203b46ba714 */
+/* @relayHash 50d11ed5f17d92c5ca457f5618520e52 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -98,7 +98,7 @@ fragment FairAllFollowedArtists_fairForFilters on Fair {
 fragment FairArtworks_fair_6zGp3 on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], input: {includeArtworksByFollowedArtists: true, sort: "-decayed_merch", dimensionRange: "*-*"}) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST, MATERIALS_TERMS], input: {includeArtworksByFollowedArtists: true, sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -181,22 +181,22 @@ v3 = {
   "name": "slug",
   "storageKey": null
 },
-v4 = {
-  "kind": "Literal",
-  "name": "aggregations",
-  "value": [
-    "COLOR",
-    "DIMENSION_RANGE",
-    "PARTNER",
-    "MAJOR_PERIOD",
-    "MEDIUM",
-    "PRICE_RANGE",
-    "FOLLOWED_ARTISTS",
-    "ARTIST"
-  ]
-},
-v5 = [
-  (v4/*: any*/),
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "aggregations",
+    "value": [
+      "COLOR",
+      "DIMENSION_RANGE",
+      "PARTNER",
+      "MAJOR_PERIOD",
+      "MEDIUM",
+      "PRICE_RANGE",
+      "FOLLOWED_ARTISTS",
+      "ARTIST",
+      "MATERIALS_TERMS"
+    ]
+  },
   {
     "kind": "Literal",
     "name": "first",
@@ -212,14 +212,14 @@ v5 = [
     }
   }
 ],
-v6 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v7 = {
+v6 = {
   "alias": null,
   "args": null,
   "concreteType": "ArtworksAggregationResults",
@@ -249,7 +249,7 @@ v7 = {
           "name": "count",
           "storageKey": null
         },
-        (v6/*: any*/),
+        (v5/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -263,64 +263,64 @@ v7 = {
   ],
   "storageKey": null
 },
-v8 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v9 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v10 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "followedArtists",
   "storageKey": null
 },
-v11 = {
+v10 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Fair"
 },
-v12 = {
+v11 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FilterArtworksConnection"
 },
-v13 = {
+v12 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v14 = {
+v13 = {
   "enumValues": null,
   "nullable": true,
   "plural": true,
   "type": "ArtworksAggregationResults"
 },
-v15 = {
+v14 = {
   "enumValues": null,
   "nullable": true,
   "plural": true,
   "type": "AggregationCount"
 },
-v16 = {
+v15 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v17 = {
+v16 = {
   "enumValues": [
     "ARTIST",
     "ARTIST_NATIONALITY",
@@ -345,31 +345,31 @@ v17 = {
   "plural": false,
   "type": "ArtworkAggregation"
 },
-v18 = {
+v17 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FilterArtworksCounts"
 },
-v19 = {
+v18 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FormattedNumber"
 },
-v20 = {
+v19 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v21 = {
+v20 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v22 = {
+v21 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -436,13 +436,13 @@ return {
           (v3/*: any*/),
           {
             "alias": "fairArtworks",
-            "args": (v5/*: any*/),
+            "args": (v4/*: any*/),
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
-              (v7/*: any*/),
+              (v6/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -459,8 +459,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v8/*: any*/),
-                      (v9/*: any*/)
+                      (v7/*: any*/),
+                      (v8/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -489,7 +489,7 @@ return {
                     "name": "total",
                     "storageKey": null
                   },
-                  (v10/*: any*/)
+                  (v9/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -518,7 +518,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v8/*: any*/),
+              (v7/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -548,7 +548,7 @@ return {
                     "name": "edges",
                     "plural": true,
                     "selections": [
-                      (v9/*: any*/),
+                      (v8/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -661,7 +661,7 @@ return {
                                 "name": "endAt",
                                 "storageKey": null
                               },
-                              (v8/*: any*/)
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -716,7 +716,7 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v8/*: any*/)
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -728,8 +728,8 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v6/*: any*/),
-                              (v8/*: any*/)
+                              (v5/*: any*/),
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -739,7 +739,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v8/*: any*/)
+                          (v7/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -752,11 +752,11 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:30,input:{\"dimensionRange\":\"*-*\",\"includeArtworksByFollowedArtists\":true,\"sort\":\"-decayed_merch\"})"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\",\"MATERIALS_TERMS\"],first:30,input:{\"dimensionRange\":\"*-*\",\"includeArtworksByFollowedArtists\":true,\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "fairArtworks",
-            "args": (v5/*: any*/),
+            "args": (v4/*: any*/),
             "filters": [
               "aggregations",
               "input"
@@ -766,7 +766,7 @@ return {
             "kind": "LinkedHandle",
             "name": "filterArtworksConnection"
           },
-          (v8/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       },
@@ -781,7 +781,20 @@ return {
           {
             "alias": null,
             "args": [
-              (v4/*: any*/),
+              {
+                "kind": "Literal",
+                "name": "aggregations",
+                "value": [
+                  "COLOR",
+                  "DIMENSION_RANGE",
+                  "PARTNER",
+                  "MAJOR_PERIOD",
+                  "MEDIUM",
+                  "PRICE_RANGE",
+                  "FOLLOWED_ARTISTS",
+                  "ARTIST"
+                ]
+              },
               {
                 "kind": "Literal",
                 "name": "first",
@@ -793,7 +806,7 @@ return {
             "name": "filterArtworksConnection",
             "plural": false,
             "selections": [
-              (v7/*: any*/),
+              (v6/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -802,57 +815,57 @@ return {
                 "name": "counts",
                 "plural": false,
                 "selections": [
-                  (v10/*: any*/)
+                  (v9/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v8/*: any*/)
+              (v7/*: any*/)
             ],
             "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:0)"
           },
-          (v8/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "9c402342e1a6adb8001b6203b46ba714",
+    "id": "50d11ed5f17d92c5ca457f5618520e52",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "fair": (v11/*: any*/),
-        "fair.fairArtworks": (v12/*: any*/),
-        "fair.fairArtworks.__isArtworkConnectionInterface": (v13/*: any*/),
-        "fair.fairArtworks.aggregations": (v14/*: any*/),
-        "fair.fairArtworks.aggregations.counts": (v15/*: any*/),
-        "fair.fairArtworks.aggregations.counts.count": (v16/*: any*/),
-        "fair.fairArtworks.aggregations.counts.name": (v13/*: any*/),
-        "fair.fairArtworks.aggregations.counts.value": (v13/*: any*/),
-        "fair.fairArtworks.aggregations.slice": (v17/*: any*/),
-        "fair.fairArtworks.counts": (v18/*: any*/),
-        "fair.fairArtworks.counts.followedArtists": (v19/*: any*/),
-        "fair.fairArtworks.counts.total": (v19/*: any*/),
+        "fair": (v10/*: any*/),
+        "fair.fairArtworks": (v11/*: any*/),
+        "fair.fairArtworks.__isArtworkConnectionInterface": (v12/*: any*/),
+        "fair.fairArtworks.aggregations": (v13/*: any*/),
+        "fair.fairArtworks.aggregations.counts": (v14/*: any*/),
+        "fair.fairArtworks.aggregations.counts.count": (v15/*: any*/),
+        "fair.fairArtworks.aggregations.counts.name": (v12/*: any*/),
+        "fair.fairArtworks.aggregations.counts.value": (v12/*: any*/),
+        "fair.fairArtworks.aggregations.slice": (v16/*: any*/),
+        "fair.fairArtworks.counts": (v17/*: any*/),
+        "fair.fairArtworks.counts.followedArtists": (v18/*: any*/),
+        "fair.fairArtworks.counts.total": (v18/*: any*/),
         "fair.fairArtworks.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "ArtworkEdgeInterface"
         },
-        "fair.fairArtworks.edges.__isNode": (v13/*: any*/),
-        "fair.fairArtworks.edges.__typename": (v13/*: any*/),
-        "fair.fairArtworks.edges.cursor": (v13/*: any*/),
-        "fair.fairArtworks.edges.id": (v20/*: any*/),
+        "fair.fairArtworks.edges.__isNode": (v12/*: any*/),
+        "fair.fairArtworks.edges.__typename": (v12/*: any*/),
+        "fair.fairArtworks.edges.cursor": (v12/*: any*/),
+        "fair.fairArtworks.edges.id": (v19/*: any*/),
         "fair.fairArtworks.edges.node": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Artwork"
         },
-        "fair.fairArtworks.edges.node.__typename": (v13/*: any*/),
-        "fair.fairArtworks.edges.node.artistNames": (v21/*: any*/),
-        "fair.fairArtworks.edges.node.date": (v21/*: any*/),
-        "fair.fairArtworks.edges.node.href": (v21/*: any*/),
-        "fair.fairArtworks.edges.node.id": (v20/*: any*/),
+        "fair.fairArtworks.edges.node.__typename": (v12/*: any*/),
+        "fair.fairArtworks.edges.node.artistNames": (v20/*: any*/),
+        "fair.fairArtworks.edges.node.date": (v20/*: any*/),
+        "fair.fairArtworks.edges.node.href": (v20/*: any*/),
+        "fair.fairArtworks.edges.node.id": (v19/*: any*/),
         "fair.fairArtworks.edges.node.image": {
           "enumValues": null,
           "nullable": true,
@@ -865,27 +878,27 @@ return {
           "plural": false,
           "type": "Float"
         },
-        "fair.fairArtworks.edges.node.image.url": (v21/*: any*/),
-        "fair.fairArtworks.edges.node.internalID": (v20/*: any*/),
+        "fair.fairArtworks.edges.node.image.url": (v20/*: any*/),
+        "fair.fairArtworks.edges.node.internalID": (v19/*: any*/),
         "fair.fairArtworks.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "fair.fairArtworks.edges.node.partner.id": (v20/*: any*/),
-        "fair.fairArtworks.edges.node.partner.name": (v21/*: any*/),
+        "fair.fairArtworks.edges.node.partner.id": (v19/*: any*/),
+        "fair.fairArtworks.edges.node.partner.name": (v20/*: any*/),
         "fair.fairArtworks.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "fair.fairArtworks.edges.node.sale.displayTimelyAt": (v21/*: any*/),
-        "fair.fairArtworks.edges.node.sale.endAt": (v21/*: any*/),
-        "fair.fairArtworks.edges.node.sale.id": (v20/*: any*/),
-        "fair.fairArtworks.edges.node.sale.isAuction": (v22/*: any*/),
-        "fair.fairArtworks.edges.node.sale.isClosed": (v22/*: any*/),
+        "fair.fairArtworks.edges.node.sale.displayTimelyAt": (v20/*: any*/),
+        "fair.fairArtworks.edges.node.sale.endAt": (v20/*: any*/),
+        "fair.fairArtworks.edges.node.sale.id": (v19/*: any*/),
+        "fair.fairArtworks.edges.node.sale.isAuction": (v21/*: any*/),
+        "fair.fairArtworks.edges.node.sale.isClosed": (v21/*: any*/),
         "fair.fairArtworks.edges.node.saleArtwork": {
           "enumValues": null,
           "nullable": true,
@@ -898,49 +911,49 @@ return {
           "plural": false,
           "type": "SaleArtworkCounts"
         },
-        "fair.fairArtworks.edges.node.saleArtwork.counts.bidderPositions": (v19/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.counts.bidderPositions": (v18/*: any*/),
         "fair.fairArtworks.edges.node.saleArtwork.currentBid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCurrentBid"
         },
-        "fair.fairArtworks.edges.node.saleArtwork.currentBid.display": (v21/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork.id": (v20/*: any*/),
-        "fair.fairArtworks.edges.node.saleArtwork.lotLabel": (v21/*: any*/),
-        "fair.fairArtworks.edges.node.saleMessage": (v21/*: any*/),
-        "fair.fairArtworks.edges.node.slug": (v20/*: any*/),
-        "fair.fairArtworks.edges.node.title": (v21/*: any*/),
-        "fair.fairArtworks.id": (v20/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.currentBid.display": (v20/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.id": (v19/*: any*/),
+        "fair.fairArtworks.edges.node.saleArtwork.lotLabel": (v20/*: any*/),
+        "fair.fairArtworks.edges.node.saleMessage": (v20/*: any*/),
+        "fair.fairArtworks.edges.node.slug": (v19/*: any*/),
+        "fair.fairArtworks.edges.node.title": (v20/*: any*/),
+        "fair.fairArtworks.id": (v19/*: any*/),
         "fair.fairArtworks.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "fair.fairArtworks.pageInfo.endCursor": (v21/*: any*/),
+        "fair.fairArtworks.pageInfo.endCursor": (v20/*: any*/),
         "fair.fairArtworks.pageInfo.hasNextPage": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Boolean"
         },
-        "fair.fairArtworks.pageInfo.startCursor": (v21/*: any*/),
-        "fair.id": (v20/*: any*/),
-        "fair.internalID": (v20/*: any*/),
-        "fair.slug": (v20/*: any*/),
-        "fairForFilters": (v11/*: any*/),
-        "fairForFilters.filterArtworksConnection": (v12/*: any*/),
-        "fairForFilters.filterArtworksConnection.aggregations": (v14/*: any*/),
-        "fairForFilters.filterArtworksConnection.aggregations.counts": (v15/*: any*/),
-        "fairForFilters.filterArtworksConnection.aggregations.counts.count": (v16/*: any*/),
-        "fairForFilters.filterArtworksConnection.aggregations.counts.name": (v13/*: any*/),
-        "fairForFilters.filterArtworksConnection.aggregations.counts.value": (v13/*: any*/),
-        "fairForFilters.filterArtworksConnection.aggregations.slice": (v17/*: any*/),
-        "fairForFilters.filterArtworksConnection.counts": (v18/*: any*/),
-        "fairForFilters.filterArtworksConnection.counts.followedArtists": (v19/*: any*/),
-        "fairForFilters.filterArtworksConnection.id": (v20/*: any*/),
-        "fairForFilters.id": (v20/*: any*/)
+        "fair.fairArtworks.pageInfo.startCursor": (v20/*: any*/),
+        "fair.id": (v19/*: any*/),
+        "fair.internalID": (v19/*: any*/),
+        "fair.slug": (v19/*: any*/),
+        "fairForFilters": (v10/*: any*/),
+        "fairForFilters.filterArtworksConnection": (v11/*: any*/),
+        "fairForFilters.filterArtworksConnection.aggregations": (v13/*: any*/),
+        "fairForFilters.filterArtworksConnection.aggregations.counts": (v14/*: any*/),
+        "fairForFilters.filterArtworksConnection.aggregations.counts.count": (v15/*: any*/),
+        "fairForFilters.filterArtworksConnection.aggregations.counts.name": (v12/*: any*/),
+        "fairForFilters.filterArtworksConnection.aggregations.counts.value": (v12/*: any*/),
+        "fairForFilters.filterArtworksConnection.aggregations.slice": (v16/*: any*/),
+        "fairForFilters.filterArtworksConnection.counts": (v17/*: any*/),
+        "fairForFilters.filterArtworksConnection.counts.followedArtists": (v18/*: any*/),
+        "fairForFilters.filterArtworksConnection.id": (v19/*: any*/),
+        "fairForFilters.id": (v19/*: any*/)
       }
     },
     "name": "FairAllFollowedArtistsTestsQuery",

--- a/src/__generated__/FairArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/FairArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 306569cc4c19f09af119485c751fcf0d */
+/* @relayHash cf59629904eb00a3375f312737f2ab8d */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -125,7 +125,7 @@ fragment ArtworkGridItem_artwork on Artwork {
 fragment FairArtworks_fair_YCAiB on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: $count, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], input: $input) {
+  fairArtworks: filterArtworksConnection(first: $count, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST, MATERIALS_TERMS], input: $input) {
     aggregations {
       slice
       counts {
@@ -243,7 +243,8 @@ v8 = [
       "MEDIUM",
       "PRICE_RANGE",
       "FOLLOWED_ARTISTS",
-      "ARTIST"
+      "ARTIST",
+      "MATERIALS_TERMS"
     ]
   },
   {
@@ -727,7 +728,7 @@ return {
     ]
   },
   "params": {
-    "id": "306569cc4c19f09af119485c751fcf0d",
+    "id": "cf59629904eb00a3375f312737f2ab8d",
     "metadata": {},
     "name": "FairArtworksInfiniteScrollGridQuery",
     "operationKind": "query",

--- a/src/__generated__/FairArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/FairArtworksTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash c6653891f5b08bddaa74edad1c4ed5e4 */
+/* @relayHash ce852b8d3393b11abb2f609fc5eba379 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -68,7 +68,7 @@ fragment ArtworkGridItem_artwork on Artwork {
 fragment FairArtworks_fair on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST]) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST, MATERIALS_TERMS]) {
     aggregations {
       slice
       counts {
@@ -163,7 +163,8 @@ v4 = [
       "MEDIUM",
       "PRICE_RANGE",
       "FOLLOWED_ARTISTS",
-      "ARTIST"
+      "ARTIST",
+      "MATERIALS_TERMS"
     ]
   },
   {
@@ -633,7 +634,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:30)"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\",\"MATERIALS_TERMS\"],first:30)"
           },
           {
             "alias": "fairArtworks",
@@ -654,7 +655,7 @@ return {
     ]
   },
   "params": {
-    "id": "c6653891f5b08bddaa74edad1c4ed5e4",
+    "id": "ce852b8d3393b11abb2f609fc5eba379",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "fair": {

--- a/src/__generated__/FairArtworks_fair.graphql.ts
+++ b/src/__generated__/FairArtworks_fair.graphql.ts
@@ -99,7 +99,8 @@ const node: ReaderFragment = {
             "MEDIUM",
             "PRICE_RANGE",
             "FOLLOWED_ARTISTS",
-            "ARTIST"
+            "ARTIST",
+            "MATERIALS_TERMS"
           ]
         },
         {
@@ -268,5 +269,5 @@ const node: ReaderFragment = {
   "type": "Fair",
   "abstractKey": null
 };
-(node as any).hash = '8d5992f9f759cb71836a07d68e287767';
+(node as any).hash = '10e6eaf912f6b127c22a13c14dd8981f';
 export default node;

--- a/src/__generated__/FairQuery.graphql.ts
+++ b/src/__generated__/FairQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash a0ad4030a25f11867ffa1e7e3f8118cf */
+/* @relayHash 9c69e1d315b7b0f6d1b8f89d5e3b982a */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -79,7 +79,7 @@ fragment ArtworkTileRailCard_artwork on Artwork {
 fragment FairArtworks_fair_2T6kBV on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST, MATERIALS_TERMS], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -514,7 +514,8 @@ v19 = [
       "MEDIUM",
       "PRICE_RANGE",
       "FOLLOWED_ARTISTS",
-      "ARTIST"
+      "ARTIST",
+      "MATERIALS_TERMS"
     ]
   },
   (v18/*: any*/),
@@ -1380,7 +1381,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\",\"MATERIALS_TERMS\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "fairArtworks",
@@ -1607,7 +1608,7 @@ return {
     ]
   },
   "params": {
-    "id": "a0ad4030a25f11867ffa1e7e3f8118cf",
+    "id": "9c69e1d315b7b0f6d1b8f89d5e3b982a",
     "metadata": {},
     "name": "FairQuery",
     "operationKind": "query",

--- a/src/__generated__/FairTestsQuery.graphql.ts
+++ b/src/__generated__/FairTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 386cddffb19195c90e8dc099cb0bebe0 */
+/* @relayHash 2ea37d0352f9cb1e61b899f6fd96f86b */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -79,7 +79,7 @@ fragment ArtworkTileRailCard_artwork on Artwork {
 fragment FairArtworks_fair_2T6kBV on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST, MATERIALS_TERMS], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -514,7 +514,8 @@ v19 = [
       "MEDIUM",
       "PRICE_RANGE",
       "FOLLOWED_ARTISTS",
-      "ARTIST"
+      "ARTIST",
+      "MATERIALS_TERMS"
     ]
   },
   (v18/*: any*/),
@@ -1494,7 +1495,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\",\"MATERIALS_TERMS\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
           },
           {
             "alias": "fairArtworks",
@@ -1721,7 +1722,7 @@ return {
     ]
   },
   "params": {
-    "id": "386cddffb19195c90e8dc099cb0bebe0",
+    "id": "2ea37d0352f9cb1e61b899f6fd96f86b",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "fair": (v30/*: any*/),

--- a/src/__generated__/FilterModalTestsQuery.graphql.ts
+++ b/src/__generated__/FilterModalTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 997dfdbe690cc098092fcbcbb3f51930 */
+/* @relayHash 55782b36fa0fd18edad51944483891db */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -136,7 +136,7 @@ fragment CollectionArtworks_collection on MarketingCollection {
   isDepartment
   slug
   id
-  collectionArtworks: artworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  collectionArtworks: artworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS]) {
     aggregations {
       slice
       counts {
@@ -221,7 +221,8 @@ v3 = [
       "PARTNER",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "MATERIALS_TERMS"
     ]
   },
   {
@@ -696,7 +697,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "artworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:10)"
+            "storageKey": "artworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\"],first:10)"
           },
           {
             "alias": "collectionArtworks",
@@ -716,7 +717,7 @@ return {
     ]
   },
   "params": {
-    "id": "997dfdbe690cc098092fcbcbb3f51930",
+    "id": "55782b36fa0fd18edad51944483891db",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "marketingCollection": {

--- a/src/__generated__/PartnerArtworkInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/PartnerArtworkInfiniteScrollGridQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 7eb024cee2ca25b51987e01beb4845ce */
+/* @relayHash 6cebefdb977a1d105bcefe7304bd0137 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -149,7 +149,7 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
 fragment PartnerArtwork_partner_YCAiB on Partner {
   internalID
   slug
-  artworks: filterArtworksConnection(first: $count, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: $input) {
+  artworks: filterArtworksConnection(first: $count, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS], input: $input) {
     aggregations {
       slice
       counts {
@@ -236,7 +236,8 @@ v8 = [
       "DIMENSION_RANGE",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "MATERIALS_TERMS"
     ]
   },
   {
@@ -695,7 +696,7 @@ return {
     ]
   },
   "params": {
-    "id": "7eb024cee2ca25b51987e01beb4845ce",
+    "id": "6cebefdb977a1d105bcefe7304bd0137",
     "metadata": {},
     "name": "PartnerArtworkInfiniteScrollGridQuery",
     "operationKind": "query",

--- a/src/__generated__/PartnerArtworkTestsQuery.graphql.ts
+++ b/src/__generated__/PartnerArtworkTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 818d5b4652b9746d067102a6c86a2628 */
+/* @relayHash dd64a66fd343237134633c7d95046473 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -156,7 +156,7 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
 fragment PartnerArtwork_partner on Partner {
   internalID
   slug
-  artworks: filterArtworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  artworks: filterArtworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS]) {
     aggregations {
       slice
       counts {
@@ -213,7 +213,8 @@ v3 = [
       "DIMENSION_RANGE",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "MATERIALS_TERMS"
     ]
   },
   {
@@ -628,7 +629,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:10)"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\"],first:10)"
           },
           {
             "alias": "artworks",
@@ -649,7 +650,7 @@ return {
     ]
   },
   "params": {
-    "id": "818d5b4652b9746d067102a6c86a2628",
+    "id": "dd64a66fd343237134633c7d95046473",
     "metadata": {},
     "name": "PartnerArtworkTestsQuery",
     "operationKind": "query",

--- a/src/__generated__/PartnerArtwork_partner.graphql.ts
+++ b/src/__generated__/PartnerArtwork_partner.graphql.ts
@@ -92,7 +92,8 @@ const node: ReaderFragment = {
             "DIMENSION_RANGE",
             "MAJOR_PERIOD",
             "MEDIUM",
-            "PRICE_RANGE"
+            "PRICE_RANGE",
+            "MATERIALS_TERMS"
           ]
         },
         {
@@ -236,5 +237,5 @@ const node: ReaderFragment = {
   "type": "Partner",
   "abstractKey": null
 };
-(node as any).hash = '4dccca55accab018cafb3e1ca3910f26';
+(node as any).hash = 'bb3bc1d92fc1d4b793beef4feb8886e1';
 export default node;

--- a/src/__generated__/PartnerQuery.graphql.ts
+++ b/src/__generated__/PartnerQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash b06f53606ad6b91151b53f78bb7af8db */
+/* @relayHash 7c65aa55e5d2e543648745d604d81805 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -108,7 +108,7 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
 fragment PartnerArtwork_partner_BRGa6 on Partner {
   internalID
   slug
-  artworks: filterArtworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: {sort: "-partner_updated_at", dimensionRange: "*-*"}) {
+  artworks: filterArtworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS], input: {sort: "-partner_updated_at", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -359,7 +359,8 @@ v7 = [
       "DIMENSION_RANGE",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "MATERIALS_TERMS"
     ]
   },
   (v6/*: any*/),
@@ -887,7 +888,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-partner_updated_at\"})"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-partner_updated_at\"})"
           },
           {
             "alias": "artworks",
@@ -1274,7 +1275,7 @@ return {
     ]
   },
   "params": {
-    "id": "b06f53606ad6b91151b53f78bb7af8db",
+    "id": "7c65aa55e5d2e543648745d604d81805",
     "metadata": {},
     "name": "PartnerQuery",
     "operationKind": "query",

--- a/src/__generated__/PartnerRefetchQuery.graphql.ts
+++ b/src/__generated__/PartnerRefetchQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 37d71a95a4f73153c3be8ce52162f9f8 */
+/* @relayHash d3018808da7d23a90db639637cbf3d48 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -109,7 +109,7 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
 fragment PartnerArtwork_partner_BRGa6 on Partner {
   internalID
   slug
-  artworks: filterArtworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: {sort: "-partner_updated_at", dimensionRange: "*-*"}) {
+  artworks: filterArtworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS], input: {sort: "-partner_updated_at", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -367,7 +367,8 @@ v8 = [
       "DIMENSION_RANGE",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "MATERIALS_TERMS"
     ]
   },
   (v7/*: any*/),
@@ -892,7 +893,7 @@ return {
                     "abstractKey": "__isArtworkConnectionInterface"
                   }
                 ],
-                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-partner_updated_at\"})"
+                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-partner_updated_at\"})"
               },
               {
                 "alias": "artworks",
@@ -1283,7 +1284,7 @@ return {
     ]
   },
   "params": {
-    "id": "37d71a95a4f73153c3be8ce52162f9f8",
+    "id": "d3018808da7d23a90db639637cbf3d48",
     "metadata": {},
     "name": "PartnerRefetchQuery",
     "operationKind": "query",

--- a/src/__generated__/ShowArtworksInfiniteScrollGridQuery.graphql.ts
+++ b/src/__generated__/ShowArtworksInfiniteScrollGridQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash ef1984353d3cac25969308bc4f559ee5 */
+/* @relayHash 1940978047538977addac739d41f7f49 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -148,7 +148,7 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
 fragment ShowArtworks_show_YCAiB on Show {
   slug
   internalID
-  showArtworks: filterArtworksConnection(first: 30, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: $input) {
+  showArtworks: filterArtworksConnection(first: 30, after: $cursor, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS], input: $input) {
     aggregations {
       slice
       counts {
@@ -238,7 +238,8 @@ v8 = [
       "DIMENSION_RANGE",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "MATERIALS_TERMS"
     ]
   },
   {
@@ -715,7 +716,7 @@ return {
     ]
   },
   "params": {
-    "id": "ef1984353d3cac25969308bc4f559ee5",
+    "id": "1940978047538977addac739d41f7f49",
     "metadata": {},
     "name": "ShowArtworksInfiniteScrollGridQuery",
     "operationKind": "query",

--- a/src/__generated__/ShowArtworksTestsQuery.graphql.ts
+++ b/src/__generated__/ShowArtworksTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash ca9af872bd452240be255696af557338 */
+/* @relayHash 069a6288c21270180b81dc8973e4877c */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -92,7 +92,7 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
 fragment ShowArtworks_show on Show {
   slug
   internalID
-  showArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]) {
+  showArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS]) {
     aggregations {
       slice
       counts {
@@ -159,7 +159,8 @@ v4 = [
       "DIMENSION_RANGE",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "MATERIALS_TERMS"
     ]
   },
   {
@@ -622,7 +623,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:30)"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\"],first:30)"
           },
           {
             "alias": "showArtworks",
@@ -643,7 +644,7 @@ return {
     ]
   },
   "params": {
-    "id": "ca9af872bd452240be255696af557338",
+    "id": "069a6288c21270180b81dc8973e4877c",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "show": {

--- a/src/__generated__/ShowArtworks_show.graphql.ts
+++ b/src/__generated__/ShowArtworks_show.graphql.ts
@@ -95,7 +95,8 @@ const node: ReaderFragment = {
             "DIMENSION_RANGE",
             "MAJOR_PERIOD",
             "MEDIUM",
-            "PRICE_RANGE"
+            "PRICE_RANGE",
+            "MATERIALS_TERMS"
           ]
         },
         {
@@ -257,5 +258,5 @@ const node: ReaderFragment = {
   "type": "Show",
   "abstractKey": null
 };
-(node as any).hash = '2880f17c827447d2d0c4b9ea06bdbb81';
+(node as any).hash = '98b12dc32959123c752e60764c7f6278';
 export default node;

--- a/src/__generated__/ShowQuery.graphql.ts
+++ b/src/__generated__/ShowQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 9aacffa102c972bbf14d296c779b83ba */
+/* @relayHash 2963c55a1a9307b178642da3c3573df0 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -97,7 +97,7 @@ fragment ShowArtworksEmptyState_show on Show {
 fragment ShowArtworks_show_1lt5O6 on Show {
   slug
   internalID
-  showArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: {sort: "partner_show_position", dimensionRange: "*-*"}) {
+  showArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS], input: {sort: "partner_show_position", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -380,7 +380,8 @@ v14 = [
       "DIMENSION_RANGE",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "MATERIALS_TERMS"
     ]
   },
   {
@@ -1176,7 +1177,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"partner_show_position\"})"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"partner_show_position\"})"
           },
           {
             "alias": "showArtworks",
@@ -1223,7 +1224,7 @@ return {
     ]
   },
   "params": {
-    "id": "9aacffa102c972bbf14d296c779b83ba",
+    "id": "2963c55a1a9307b178642da3c3573df0",
     "metadata": {},
     "name": "ShowQuery",
     "operationKind": "query",

--- a/src/__generated__/ShowTestsQuery.graphql.ts
+++ b/src/__generated__/ShowTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash dfaaeb4310bf893d19130b6235ec55d7 */
+/* @relayHash 8d0ff5dea869c013c221a1bafcf40d80 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -97,7 +97,7 @@ fragment ShowArtworksEmptyState_show on Show {
 fragment ShowArtworks_show_1lt5O6 on Show {
   slug
   internalID
-  showArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: {sort: "partner_show_position", dimensionRange: "*-*"}) {
+  showArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS], input: {sort: "partner_show_position", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -380,7 +380,8 @@ v14 = [
       "DIMENSION_RANGE",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "MATERIALS_TERMS"
     ]
   },
   {
@@ -1230,7 +1231,7 @@ return {
                 "abstractKey": "__isArtworkConnectionInterface"
               }
             ],
-            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"partner_show_position\"})"
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"partner_show_position\"})"
           },
           {
             "alias": "showArtworks",
@@ -1277,7 +1278,7 @@ return {
     ]
   },
   "params": {
-    "id": "dfaaeb4310bf893d19130b6235ec55d7",
+    "id": "8d0ff5dea869c013c221a1bafcf40d80",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "show": {

--- a/src/__generated__/VanityURLEntityQuery.graphql.ts
+++ b/src/__generated__/VanityURLEntityQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 6b288480e2b34467fce95f1915233a9e */
+/* @relayHash cd5bc86002e67d85dd03cb1cacd13810 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -394,7 +394,7 @@ fragment InfiniteScrollArtworksGrid_connection on ArtworkConnectionInterface {
 fragment PartnerArtwork_partner_BRGa6 on Partner {
   internalID
   slug
-  artworks: filterArtworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE], input: {sort: "-partner_updated_at", dimensionRange: "*-*"}) {
+  artworks: filterArtworksConnection(first: 10, aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS], input: {sort: "-partner_updated_at", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -1113,7 +1113,8 @@ v43 = [
       "DIMENSION_RANGE",
       "MAJOR_PERIOD",
       "MEDIUM",
-      "PRICE_RANGE"
+      "PRICE_RANGE",
+      "MATERIALS_TERMS"
     ]
   },
   (v42/*: any*/),
@@ -2006,7 +2007,7 @@ return {
                   (v5/*: any*/),
                   (v36/*: any*/)
                 ],
-                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-partner_updated_at\"})"
+                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"MATERIALS_TERMS\"],first:10,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-partner_updated_at\"})"
               },
               {
                 "alias": "artworks",
@@ -2379,7 +2380,7 @@ return {
     ]
   },
   "params": {
-    "id": "6b288480e2b34467fce95f1915233a9e",
+    "id": "cd5bc86002e67d85dd03cb1cacd13810",
     "metadata": {},
     "name": "VanityURLEntityQuery",
     "operationKind": "query",

--- a/src/__generated__/VanityURLEntityQuery.graphql.ts
+++ b/src/__generated__/VanityURLEntityQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash c60501172b216c0fa313574a5d5fe019 */
+/* @relayHash 6b288480e2b34467fce95f1915233a9e */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -99,7 +99,7 @@ fragment ArtworkTileRailCard_artwork on Artwork {
 fragment FairArtworks_fair_2T6kBV on Fair {
   slug
   internalID
-  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
+  fairArtworks: filterArtworksConnection(first: 30, aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST, MATERIALS_TERMS], input: {sort: "-decayed_merch", dimensionRange: "*-*"}) {
     aggregations {
       slice
       counts {
@@ -756,7 +756,8 @@ v21 = [
       "MEDIUM",
       "PRICE_RANGE",
       "FOLLOWED_ARTISTS",
-      "ARTIST"
+      "ARTIST",
+      "MATERIALS_TERMS"
     ]
   },
   (v20/*: any*/),
@@ -1740,7 +1741,7 @@ return {
                   (v5/*: any*/),
                   (v36/*: any*/)
                 ],
-                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
+                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"PARTNER\",\"MAJOR_PERIOD\",\"MEDIUM\",\"PRICE_RANGE\",\"FOLLOWED_ARTISTS\",\"ARTIST\",\"MATERIALS_TERMS\"],first:30,input:{\"dimensionRange\":\"*-*\",\"sort\":\"-decayed_merch\"})"
               },
               {
                 "alias": "fairArtworks",
@@ -2378,7 +2379,7 @@ return {
     ]
   },
   "params": {
-    "id": "c60501172b216c0fa313574a5d5fe019",
+    "id": "6b288480e2b34467fce95f1915233a9e",
     "metadata": {},
     "name": "VanityURLEntityQuery",
     "operationKind": "query",

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -194,7 +194,7 @@ export default createPaginationContainer(
           first: $count
           after: $cursor
           input: $input
-          aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]
+          aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS]
         ) @connection(key: "ArtistArtworksGrid_artworks") {
           aggregations {
             slice

--- a/src/lib/Components/ArtworkFilter/ArtworkFilter.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilter.tsx
@@ -15,6 +15,7 @@ import { AttributionClassOptionsScreen } from "lib/Components/ArtworkFilter/Filt
 import { CategoriesOptionsScreen } from "lib/Components/ArtworkFilter/Filters/CategoriesOptions"
 import { ColorsOptionsScreen } from "lib/Components/ArtworkFilter/Filters/ColorsOptions"
 import { EstimateRangeOptionsScreen } from "lib/Components/ArtworkFilter/Filters/EstimateRangeOptions"
+import { MaterialsTermsOptionsScreen } from "lib/Components/ArtworkFilter/Filters/MaterialsTermsOptions"
 import { MediumOptionsScreen } from "lib/Components/ArtworkFilter/Filters/MediumOptions"
 import { PriceRangeOptionsScreen } from "lib/Components/ArtworkFilter/Filters/PriceRangeOptions"
 import { SizeOptionsScreen } from "lib/Components/ArtworkFilter/Filters/SizeOptions"
@@ -176,6 +177,7 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
             />
             <Stack.Screen name="WaysToBuyOptionsScreen" component={WaysToBuyOptionsScreen} />
             <Stack.Screen name="CategoriesOptionsScreen" component={CategoriesOptionsScreen} />
+            <Stack.Screen name="MaterialsTermsOptionsScreen" component={MaterialsTermsOptionsScreen} />
           </Stack.Navigator>
 
           <Separator my={0} />

--- a/src/lib/Components/ArtworkFilter/ArtworkFilter.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilter.tsx
@@ -78,6 +78,7 @@ export type ArtworkFilterNavigationStack = {
   ViewAsOptionsScreen: undefined
   WaysToBuyOptionsScreen: undefined
   YearOptionsScreen: undefined
+  MaterialsTermsOptionsScreen: undefined
 }
 
 const Stack = createStackNavigator<ArtworkFilterNavigationStack>()

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -21,6 +21,7 @@ export enum FilterDisplayName {
   viewAs = "View as",
   waysToBuy = "Ways to buy",
   year = "Artwork date",
+  materialsTerms = "Material",
 }
 
 // General filter types and objects

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -49,6 +49,7 @@ export enum FilterParamName {
   waysToBuyBuy = "acquireable",
   waysToBuyInquire = "inquireableOnly",
   waysToBuyMakeOffer = "offerable",
+  materialsTerms = "materialsTerms",
 }
 
 // Types for the parameters passed to Relay
@@ -95,6 +96,7 @@ export const ParamDefaultValues = {
   sortArtworks: "-decayed_merch",
   sortSaleArtworks: "position",
   viewAs: ViewAsValues.Grid,
+  materialsTerms: [],
 }
 
 export const defaultCommonFilterOptions = {
@@ -121,6 +123,7 @@ export const defaultCommonFilterOptions = {
   sizes: ParamDefaultValues.sizes,
   sort: ParamDefaultValues.sortArtworks,
   viewAs: ParamDefaultValues.viewAs,
+  materialsTerms: ParamDefaultValues.materialsTerms,
 }
 
 export type Aggregations = Array<{
@@ -142,6 +145,7 @@ export type AggregationName =
   | "ARTIST"
   | "earliestCreatedYear"
   | "latestCreatedYear"
+  | "MATERIALS_TERMS"
 
 export interface Aggregation {
   count: number
@@ -399,6 +403,7 @@ export const aggregationNameFromFilter: Record<string, AggregationName | undefin
   medium: "MEDIUM",
   partnerIDs: "PARTNER",
   priceRange: "PRICE_RANGE",
+  materialsTerms: "MATERIALS_TERMS",
 }
 
 export const aggregationForFilter = (filterKey: string, aggregations: Aggregations) => {

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -180,6 +180,7 @@ export const filterKeyFromAggregation: Record<AggregationName, FilterParamName |
   ARTIST: "artistIDs",
   earliestCreatedYear: "earliestCreatedYear",
   latestCreatedYear: "earliestCreatedYear",
+  MATERIALS_TERMS: FilterParamName.materialsTerms,
 }
 
 const DEFAULT_ARTWORKS_PARAMS = {

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -37,6 +37,7 @@ export type FilterScreen =
   | "viewAs"
   | "waysToBuy"
   | "year"
+  | "materialsTerms"
 
 export interface FilterDisplayConfig {
   filterType: FilterScreen
@@ -447,6 +448,11 @@ export const filterOptionToDisplayConfigMap: Record<string, FilterDisplayConfig>
     displayText: FilterDisplayName.waysToBuy,
     filterType: "waysToBuy",
     ScreenComponent: "WaysToBuyOptionsScreen",
+  },
+  materialsTerms: {
+    displayText: FilterDisplayName.materialsTerms,
+    filterType: "materialsTerms",
+    ScreenComponent: "MaterialsTermsOptionsScreen",
   },
 }
 

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -221,6 +221,7 @@ export const getStaticFilterOptionsByMode = (mode: FilterModalMode) => {
         filterOptionToDisplayConfigMap.sort,
         filterOptionToDisplayConfigMap.waysToBuy,
         filterOptionToDisplayConfigMap.attributionClass,
+        filterOptionToDisplayConfigMap.materialsTerms,
       ]
   }
 }
@@ -472,6 +473,7 @@ const ArtistArtworksFiltersSorted: FilterScreen[] = [
   "sort",
   "medium",
   "additionalGeneIDs",
+  "materialsTerms",
   "attributionClass",
   "priceRange",
   "waysToBuy",

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -221,7 +221,6 @@ export const getStaticFilterOptionsByMode = (mode: FilterModalMode) => {
         filterOptionToDisplayConfigMap.sort,
         filterOptionToDisplayConfigMap.waysToBuy,
         filterOptionToDisplayConfigMap.attributionClass,
-        filterOptionToDisplayConfigMap.materialsTerms,
       ]
   }
 }
@@ -257,6 +256,7 @@ export const getFilterScreenSortByMode = (mode: FilterModalMode) => (
       sortOrder = [
         "sort",
         "medium",
+        "materialsTerms",
         "attributionClass",
         "priceRange",
         "waysToBuy",
@@ -461,6 +461,7 @@ const CollectionFiltersSorted: FilterScreen[] = [
   "sort",
   "medium",
   "additionalGeneIDs",
+  "materialsTerms",
   "attributionClass",
   "priceRange",
   "waysToBuy",
@@ -486,6 +487,7 @@ const ArtistSeriesFiltersSorted: FilterScreen[] = [
   "sort",
   "medium",
   "additionalGeneIDs",
+  "materialsTerms",
   "attributionClass",
   "priceRange",
   "waysToBuy",
@@ -500,6 +502,7 @@ const FairFiltersSorted: FilterScreen[] = [
   "artistsIFollow",
   "medium",
   "additionalGeneIDs",
+  "materialsTerms",
   "attributionClass",
   "priceRange",
   "waysToBuy",
@@ -515,6 +518,7 @@ const SaleArtworksFiltersSorted: FilterScreen[] = [
   "artistIDs",
   "medium",
   "additionalGeneIDs",
+  "materialsTerms",
 ]
 
 const AuctionResultsFiltersSorted: FilterScreen[] = ["sort", "categories", "sizes", "year"]

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterStore.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterStore.tsx
@@ -242,6 +242,7 @@ export const useSelectedOptionsDisplay = (): FilterArray => {
 export const DEFAULT_FILTERS: FilterArray = [
   { paramName: FilterParamName.estimateRange, paramValue: "", displayText: "All" },
   { paramName: FilterParamName.medium, paramValue: "*", displayText: "All" },
+  { paramName: FilterParamName.materialsTerms, paramValue: [], displayText: "All" },
   { paramName: FilterParamName.priceRange, paramValue: "*-*", displayText: "All" },
   { paramName: FilterParamName.size, paramValue: "*-*", displayText: "All" },
   { paramName: FilterParamName.partnerIDs, paramValue: [], displayText: "All" },
@@ -255,7 +256,6 @@ export const DEFAULT_FILTERS: FilterArray = [
   { paramName: FilterParamName.artistIDs, paramValue: [], displayText: "All" },
   { paramName: FilterParamName.viewAs, paramValue: false, displayText: "Grid" },
   { paramName: FilterParamName.attributionClass, paramValue: "", displayText: "All" },
-  { paramName: FilterParamName.materialsTerms, paramValue: [], displayText: "All" },
 ]
 
 export const selectedOptionsUnion = ({

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterStore.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterStore.tsx
@@ -255,6 +255,7 @@ export const DEFAULT_FILTERS: FilterArray = [
   { paramName: FilterParamName.artistIDs, paramValue: [], displayText: "All" },
   { paramName: FilterParamName.viewAs, paramValue: false, displayText: "Grid" },
   { paramName: FilterParamName.attributionClass, paramValue: "", displayText: "All" },
+  { paramName: FilterParamName.materialsTerms, paramValue: [], displayText: "All" },
 ]
 
 export const selectedOptionsUnion = ({

--- a/src/lib/Components/ArtworkFilter/Filters/MaterialsTermsOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/MaterialsTermsOptions.tsx
@@ -1,0 +1,64 @@
+import { StackScreenProps } from "@react-navigation/stack"
+import { FilterData, FilterDisplayName, FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { ArtworksFiltersStore, useSelectedOptionsDisplay } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
+import React, { useState } from "react"
+import { ArtworkFilterNavigationStack } from "../ArtworkFilter"
+import { MultiSelectOptionScreen } from "./MultiSelectOption"
+
+interface MaterialsTermsOptionsScreenProps
+  extends StackScreenProps<ArtworkFilterNavigationStack, "MaterialsTermsOptionsScreen"> {}
+
+export const MaterialsTermsOptionsScreen: React.FC<MaterialsTermsOptionsScreenProps> = ({ navigation }) => {
+  const selectFiltersAction = ArtworksFiltersStore.useStoreActions((state) => state.selectFiltersAction)
+
+  const selectedOptions = useSelectedOptionsDisplay()
+
+  const filterNames = [
+    FilterParamName.waysToBuyBuy,
+    FilterParamName.waysToBuyMakeOffer,
+    FilterParamName.waysToBuyBid,
+    FilterParamName.waysToBuyInquire,
+  ]
+
+  const options = selectedOptions.filter((value) => filterNames.includes(value.paramName))
+
+  const sortedOptions = options.sort(({ paramName: left }: FilterData, { paramName: right }: FilterData): number => {
+    if (filterNames.indexOf(left) < filterNames.indexOf(right)) {
+      return -1
+    } else {
+      return 1
+    }
+  })
+
+  const [key, setKey] = useState(0)
+
+  const handleSelect = (option: FilterData, updatedValue: boolean) => {
+    selectFiltersAction({
+      displayText: option.displayText,
+      paramValue: updatedValue,
+      paramName: option.paramName,
+    })
+  }
+
+  const handleClear = () => {
+    options.map((option) => {
+      selectFiltersAction({ ...option, paramValue: false })
+    })
+
+    // Force re-render
+    setKey((n) => n + 1)
+  }
+
+  const selected = options.filter((option) => option.paramValue)
+
+  return (
+    <MultiSelectOptionScreen
+      key={key}
+      onSelect={handleSelect}
+      filterHeaderText={FilterDisplayName.materialsTerms}
+      filterOptions={sortedOptions}
+      navigation={navigation}
+      {...(selected.length > 0 ? { rightButtonText: "Clear", onRightButtonPress: handleClear } : {})}
+    />
+  )
+}

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/MaterialsTermsOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/MaterialsTermsOptions-tests.tsx
@@ -1,0 +1,106 @@
+import { OptionListItem as FilterModalOptionListItem } from "lib/Components/ArtworkFilter"
+import { OptionListItem as MultiSelectOptionListItem } from "../MultiSelectOption"
+
+import { FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { Check } from "palette"
+import React from "react"
+import { MockFilterScreen } from "../../__tests__/FilterTestHelper"
+import { ArtworkFiltersState, ArtworkFiltersStoreProvider } from "../../ArtworkFilterStore"
+import { MaterialsTermsOptionsScreen } from "../MaterialsTermsOptions"
+import { getEssentialProps } from "./helper"
+
+describe("Materials Options Screen", () => {
+  const initialState: ArtworkFiltersState = {
+    aggregations: [
+      {
+        slice: "MATERIALS_TERMS",
+        counts: [
+          {
+            count: 44,
+            name: "Acrylic",
+            value: "acrylic"
+          },
+          {
+            count: 30,
+            name: "Canvas",
+            value: "canvas"
+          },
+          {
+            count: 26,
+            name: "Metal",
+            value: "metal"
+          },
+        ]
+      },
+    ],
+    appliedFilters: [],
+    applyFilters: false,
+    counts: {
+      total: null,
+      followedArtists: null,
+    },
+    filterType: "artwork",
+    previouslyAppliedFilters: [],
+    selectedFilters: [],
+  }
+
+  const MockMaterialsTermsOptionsScreen = ({
+    initialData = initialState,
+  }: {
+    initialData?: ArtworkFiltersState
+  }) => {
+    return (
+      <ArtworkFiltersStoreProvider initialData={initialData}>
+        <MaterialsTermsOptionsScreen {...getEssentialProps()} />
+      </ArtworkFiltersStoreProvider>
+    )
+  }
+
+  describe("before any filters are selected", () => {
+    it("renders all options present in the aggregation", () => {
+      const tree = renderWithWrappers(<MockMaterialsTermsOptionsScreen initialData={initialState} />)
+
+      expect(tree.root.findAllByType(MultiSelectOptionListItem)).toHaveLength(3)
+
+      const items = tree.root.findAllByType(MultiSelectOptionListItem)
+      expect(items.map(extractText)).toEqual(["Acrylic", "Canvas", "Metal"])
+    })
+  })
+
+  describe("when filters are selected", () => {
+    const state: ArtworkFiltersState = {
+      ...initialState,
+      selectedFilters: [
+        {
+          displayText: "Acrylic",
+          paramName: FilterParamName.materialsTerms,
+          paramValue: ["acrylic"],
+        },
+      ],
+    }
+
+    it("displays a comma-separated list of the selected filters on the filter modal screen", () => {
+      const tree = renderWithWrappers(<MockFilterScreen initialState={state} />)
+
+      const items = tree.root.findAllByType(FilterModalOptionListItem)
+      const item = items.find((i) => extractText(i).startsWith("Material"))
+
+      expect(item).not.toBeUndefined()
+      if (item) {
+        expect(extractText(item)).toContain("Acrylic")
+      }
+    })
+
+    it("toggles selected filters 'ON' and unselected filters 'OFF", async () => {
+      const tree = renderWithWrappers(<MockMaterialsTermsOptionsScreen initialData={state} />)
+
+      const options = tree.root.findAllByType(Check)
+
+      expect(options[0].props.selected).toBe(true)
+      expect(options[1].props.selected).toBe(false)
+      expect(options[2].props.selected).toBe(false)
+    })
+  })
+})

--- a/src/lib/Components/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
@@ -1093,6 +1093,11 @@ describe("selectedOptionsUnion", () => {
         },
         {
           displayText: "All",
+          paramName: "materialsTerms",
+          paramValue: [],
+        },
+        {
+          displayText: "All",
           paramName: "priceRange",
           paramValue: "*-*",
         },
@@ -1188,6 +1193,11 @@ describe("selectedOptionsUnion", () => {
           displayText: "All",
           paramName: "medium",
           paramValue: "*",
+        },
+        {
+          displayText: "All",
+          paramName: "materialsTerms",
+          paramValue: [],
         },
         {
           displayText: "All",
@@ -1296,6 +1306,11 @@ describe("selectedOptionsUnion", () => {
           displayText: "All",
           paramName: "medium",
           paramValue: "*",
+        },
+        {
+          displayText: "All",
+          paramName: "materialsTerms",
+          paramValue: [],
         },
         {
           displayText: "All",
@@ -1418,6 +1433,11 @@ describe("selectedOptionsUnion", () => {
         },
         {
           displayText: "All",
+          paramName: "materialsTerms",
+          paramValue: [],
+        },
+        {
+          displayText: "All",
           paramName: "priceRange",
           paramValue: "*-*",
         },
@@ -1527,6 +1547,11 @@ describe("selectedOptionsUnion", () => {
         },
         {
           displayText: "All",
+          paramName: "materialsTerms",
+          paramValue: [],
+        },
+        {
+          displayText: "All",
           paramName: "priceRange",
           paramValue: "*-*",
         },
@@ -1609,6 +1634,11 @@ describe("selectedOptionsUnion", () => {
           displayText: "All",
           paramName: "medium",
           paramValue: "*",
+        },
+        {
+          displayText: "All",
+          paramName: "materialsTerms",
+          paramValue: [],
         },
         {
           displayText: "All",
@@ -1707,6 +1737,11 @@ describe("selectedOptionsUnion", () => {
           displayText: "All",
           paramName: "medium",
           paramValue: "*",
+        },
+        {
+          displayText: "All",
+          paramName: "materialsTerms",
+          paramValue: [],
         },
         {
           displayText: "All",
@@ -1809,6 +1844,11 @@ describe("selectedOptionsUnion", () => {
         },
         {
           displayText: "All",
+          paramName: "materialsTerms",
+          paramValue: [],
+        },
+        {
+          displayText: "All",
           paramName: "priceRange",
           paramValue: "*-*",
         },
@@ -1886,6 +1926,11 @@ describe("selectedOptionsUnion", () => {
           displayText: "All",
           paramName: "medium",
           paramValue: "*",
+        },
+        {
+          displayText: "All",
+          paramName: "materialsTerms",
+          paramValue: [],
         },
         {
           displayText: "All",

--- a/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
@@ -622,6 +622,43 @@ describe("selectedOption", () => {
       })
     })
   })
+
+  describe("materialsTerms", () => {
+    it("returns the correct result when nothing is selected", () => {
+      const selectedOptions = [
+        { paramName: FilterParamName.materialsTerms, paramValue: [], displayText: "All" },
+      ]
+
+      expect(selectedOption({ selectedOptions, filterScreen: "materialsTerms", aggregations: [] })).toEqual("All")
+    })
+
+    it("returns the correct result when one item is selected", () => {
+      const selectedOptions = [
+        { paramName: FilterParamName.timePeriod, paramValue: "*-*", displayText: "All" },
+        {
+          paramName: FilterParamName.materialsTerms,
+          paramValue: ["screen print"],
+          displayText: "Screen print",
+        },
+      ]
+
+      expect(selectedOption({ selectedOptions, filterScreen: "materialsTerms", aggregations: [] })).toEqual("Screen print")
+    })
+    it("returns the correct result when multiple items is selected", () => {
+      const selectedOptions = [
+        { paramName: FilterParamName.timePeriod, paramValue: "*-*", displayText: "All" },
+        {
+          paramName: FilterParamName.materialsTerms,
+          paramValue: ["screen print", "paper"],
+          displayText: "Screen print, Paper",
+        },
+      ]
+
+      expect(selectedOption({ selectedOptions, filterScreen: "materialsTerms", aggregations: [] })).toEqual(
+        "Screen print, Paper"
+      )
+    })
+  })
 })
 
 describe("aggregationsWithFollowedArtists", () => {

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
@@ -99,7 +99,7 @@ export const ArtistSeriesArtworksFragmentContainer = createPaginationContainer(
         artistSeriesArtworks: filterArtworksConnection(
           first: 20
           after: $cursor
-          aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]
+          aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS]
           input: $input
         ) @connection(key: "ArtistSeries_artistSeriesArtworks") {
           aggregations {

--- a/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -110,7 +110,7 @@ export const CollectionArtworksFragmentContainer = createPaginationContainer(
         collectionArtworks: artworksConnection(
           first: $count
           after: $cursor
-          aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]
+          aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS]
           input: $input
         ) @connection(key: "Collection_collectionArtworks") {
           aggregations {

--- a/src/lib/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/lib/Scenes/Fair/Components/FairArtworks.tsx
@@ -124,7 +124,7 @@ export const FairArtworksFragmentContainer = createPaginationContainer(
         fairArtworks: filterArtworksConnection(
           first: $count
           after: $cursor
-          aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST],
+          aggregations: [COLOR, DIMENSION_RANGE, PARTNER, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, FOLLOWED_ARTISTS, ARTIST, MATERIALS_TERMS],
           input: $input
         ) @connection(key: "Fair_fairArtworks") {
           aggregations {

--- a/src/lib/Scenes/Partner/Components/PartnerArtwork.tsx
+++ b/src/lib/Scenes/Partner/Components/PartnerArtwork.tsx
@@ -70,7 +70,7 @@ export const PartnerArtworkFragmentContainer = createPaginationContainer(
         artworks: filterArtworksConnection(
           first: $count
           after: $cursor
-          aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]
+          aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS]
           input: $input
         ) @connection(key: "Partner_artworks") {
           aggregations {

--- a/src/lib/Scenes/Show/Components/ShowArtworks.tsx
+++ b/src/lib/Scenes/Show/Components/ShowArtworks.tsx
@@ -116,7 +116,7 @@ export const ShowArtworksPaginationContainer = createPaginationContainer(
         showArtworks: filterArtworksConnection(
           first: 30
           after: $cursor
-          aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE]
+          aggregations: [COLOR, DIMENSION_RANGE, MAJOR_PERIOD, MEDIUM, PRICE_RANGE, MATERIALS_TERMS]
           input: $input
         ) @connection(key: "Show_showArtworks") {
           aggregations {


### PR DESCRIPTION
The type of this PR is: **FEATURE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[CX-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-2632]

### Description
- Add artwork Material filter without search UI
- Use the new checkbox UI for multi-select.
- Order values by most number of items in the result set

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[FX-2632]: https://artsyproduct.atlassian.net/browse/FX-2632