### PR TITLE
fix: Use string for user agent when debugging

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -8,6 +8,7 @@ upcoming:
     - Fix artist follow is incorrectly firing action_name - dzmitry
     - Allow sticky tabs to add additional sticky content - mdole
     - Update android play store metadata - brian
+    - Use string for user agent when debugging on Android - ole
   user_facing:
     - Fix wrong input font on android - dzmitry
     - Add artwork Material filter - dzmitry tratsiak

--- a/src/lib/store/GlobalStore.tsx
+++ b/src/lib/store/GlobalStore.tsx
@@ -163,7 +163,10 @@ export function getCurrentEmissionState() {
     return state?.native.sessionState ?? LegacyNativeModules.ARNotificationsManager.nativeState
   }
 
-  const userAgent = `${getUserAgentSync()} Artsy-Mobile/${version} Eigen/${getBuildNumber()}/${version}`
+  // `getUserAgentSync` breaks the Chrome Debugger, so we use a string instead.
+  const userAgent = `${
+    __DEV__ ? "Artsy-Mobile android" : getUserAgentSync()
+  } Artsy-Mobile/${version} Eigen/${getBuildNumber()}/${version}`
 
   const androidData: GlobalStoreModel["native"]["sessionState"] = {
     authenticationToken: state?.auth.userAccessToken!,


### PR DESCRIPTION
The type of this PR is: Bugfix

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [CX-434]
     The Jira integration will turn it into a clickable link for you. -->


### Description

Using `getUserAgentSync()` breaks the Chrome Debugger, so we use a string instead when running the app in a simulator.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434