### PR TITLE
Fix(cx-1485): ensure android dark mode can overridden inapp

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -12,6 +12,7 @@ upcoming:
   user_facing:
     - Fix wrong input font on android - dzmitry
     - Add artwork Material filter - dzmitry tratsiak
+    - Prevent android dark mode forced on users - kizito
 
 releases:
   - version: 6.9.1

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -6,6 +6,7 @@
         <item name="colorPrimaryDark">#000000</item>
         <item name="android:statusBarColor">@color/white_background</item>
         <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:forceDarkAllowed">false</item>
     </style>
 
     <style name="Theme.FullScreenDialog" parent="Theme.AppCompat.Light.NoActionBar">
@@ -14,6 +15,7 @@
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:forceDarkAllowed">false</item>
     </style>
 
     <style name="BootTheme" parent="Theme.AppCompat.Light.NoActionBar">
@@ -21,6 +23,7 @@
         <item name="android:navigationBarColor">@color/bootsplash_background</item>
         <item name="android:statusBarColor">@color/transparent_background</item>
         <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:forceDarkAllowed">false</item>
     </style>
 
 </resources>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [CX-434]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1485]

### Description
Stops forcing of dark mode on users. This allows us to override the user's dark mode choice.

#### BEFORE

https://user-images.githubusercontent.com/18648835/119120134-35ddfc80-ba2c-11eb-8110-ceb0ef482766.mp4


#### AFTER

https://user-images.githubusercontent.com/18648835/119120385-8190a600-ba2c-11eb-9588-ef01d3ee58dd.mp4



<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1485]: https://artsyproduct.atlassian.net/browse/CX-1485