### PR TITLE
[WIP] feat(FX-2646): add material filter with search UI

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -13,6 +13,7 @@ upcoming:
     - Fix wrong input font on android - dzmitry
     - Add artwork Material filter - dzmitry tratsiak
     - Fix unusable slider on android - dzmitry
+    - Add search UI for material filter - dzmitry tratsiak
 
 releases:
   - version: 6.9.1

--- a/src/lib/Components/ArtworkFilter/Filters/MaterialsTermsOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/MaterialsTermsOptions.tsx
@@ -32,6 +32,9 @@ export const MaterialsTermsOptionsScreen: React.FC<MaterialsTermsOptionsScreenPr
       filterHeaderText={FilterDisplayName.materialsTerms}
       filterOptions={sortedFilterOptions}
       navigation={navigation}
+      searchable
+      noResultsLabel="No results found"
+      pinSelectedToTheTop
       {...(isActive ? { rightButtonText: "Clear", onRightButtonPress: handleClear } : {})}
     />
   )

--- a/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
@@ -18,6 +18,7 @@ interface MultiSelectOptionScreenProps extends FancyModalHeaderProps {
   isDisabled?: (item: FilterData) => boolean
   /** Utilize a search input to further filter results */
   searchable?: boolean
+  noResultsLabel?: string
 }
 
 export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = ({
@@ -29,6 +30,7 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
   isDisabled,
   children,
   searchable,
+  noResultsLabel = "No results",
   ...rest
 }) => {
   const handleBackNavigation = () => {
@@ -71,7 +73,7 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
 
           {filteredOptions.length === 0 && (
             <Flex my={1.5} mx={2} alignItems="center">
-              <Text variant="caption">No results</Text>
+              <Text variant="caption">{noResultsLabel}</Text>
             </Flex>
           )}
         </>

--- a/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
@@ -19,6 +19,7 @@ interface MultiSelectOptionScreenProps extends FancyModalHeaderProps {
   /** Utilize a search input to further filter results */
   searchable?: boolean
   noResultsLabel?: string
+  pinSelectedToTheTop?: boolean
 }
 
 export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = ({
@@ -31,6 +32,7 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
   children,
   searchable,
   noResultsLabel = "No results",
+  pinSelectedToTheTop,
   ...rest
 }) => {
   const handleBackNavigation = () => {
@@ -54,8 +56,16 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
   }
 
   const [query, setQuery] = useState("")
+  let preparedOptions = filterOptions
 
-  const filteredOptions = filterOptions.filter((option) =>
+  if (pinSelectedToTheTop) {
+    const selectedOptions = filterOptions.filter(option => option.paramValue === true)
+    const unselectedOptions = filterOptions.filter(option => option.paramValue === false)
+
+    preparedOptions = [...selectedOptions, ...unselectedOptions];
+  }
+
+  const filteredOptions = preparedOptions.filter((option) =>
     option.displayText.toLowerCase().includes(query.toLowerCase())
   )
 

--- a/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
@@ -59,8 +59,8 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
   let preparedOptions = filterOptions
 
   if (pinSelectedToTheTop) {
-    const selectedOptions = filterOptions.filter(option => option.paramValue === true)
-    const unselectedOptions = filterOptions.filter(option => option.paramValue === false)
+    const selectedOptions = filterOptions.filter(option => itemIsSelected(option))
+    const unselectedOptions = filterOptions.filter(option => !itemIsSelected(option))
 
     preparedOptions = [...selectedOptions, ...unselectedOptions];
   }

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/MultiSelectOption-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/MultiSelectOption-tests.tsx
@@ -1,6 +1,7 @@
 import { SearchInput } from "lib/Components/SearchInput"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { Check } from "palette"
 import React from "react"
 import { FilterData, FilterParamName } from "../../ArtworkFilterHelpers"
 import { MultiSelectOptionScreen } from "../MultiSelectOption"
@@ -44,6 +45,43 @@ describe("MultiSelectOption", () => {
       tree.root.findByType(SearchInput).props.onChangeText("garbage")
 
       expect(extractText(tree.root)).toEqual("No results")
+    })
+  })
+
+
+  describe("renders selected options to the top", () => {
+    it("one option selected", () => {
+      const initialOptions: FilterData[] = [
+        { displayText: "Paper", paramValue: false, paramName: FilterParamName.materialsTerms },
+        { displayText: "Wove paper", paramValue: false, paramName: FilterParamName.materialsTerms },
+        { displayText: "Vinyl", paramValue: true, paramName: FilterParamName.materialsTerms },
+      ]
+      const tree = renderWithWrappers(
+        <MultiSelectOptionScreen filterOptions={initialOptions} pinSelectedToTheTop {...getEssentialProps()} />
+      )
+
+      const options = tree.root.findAllByType(Check)
+
+      expect(options[0].props.selected).toBe(true)
+      expect(options[1].props.selected).toBe(false)
+      expect(options[2].props.selected).toBe(false)
+    })
+
+    it("two options selected", () => {
+      const initialOptions: FilterData[] = [
+        { displayText: "Paper", paramValue: false, paramName: FilterParamName.materialsTerms },
+        { displayText: "Wove paper", paramValue: true, paramName: FilterParamName.materialsTerms },
+        { displayText: "Vinyl", paramValue: true, paramName: FilterParamName.materialsTerms },
+      ]
+      const tree = renderWithWrappers(
+        <MultiSelectOptionScreen filterOptions={initialOptions} pinSelectedToTheTop {...getEssentialProps()} />
+      )
+
+      const options = tree.root.findAllByType(Check)
+
+      expect(options[0].props.selected).toBe(true)
+      expect(options[1].props.selected).toBe(true)
+      expect(options[2].props.selected).toBe(false)
     })
   })
 })


### PR DESCRIPTION
The type of this PR is: **FEATURE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [CX-434]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-2646]

### Description
- As a user I can type into the search bar and as I type the long list of values are narrowed according to my query.
- If there are no results that match my query I  see “No results found” in the list w/ no other options
- If I find value(s) from the search box that I want to apply I have to tap the checkbox and tap the “Show # results” button. 
- If I don’t select a value from the list I have to click X to clear the search box.
- To remove an applied values I can unselect the check marks or tap “Clear all”.
- When a collector applies a value(s) **it is pinned to the top of the list**

### How the material filter works
[How the material filter works on the web version](https://user-images.githubusercontent.com/3513494/119125318-4d23e680-ba3a-11eb-911d-bec99d77fa50.mp4)

[How the material filter works in the mobile app](https://user-images.githubusercontent.com/3513494/119125378-60cf4d00-ba3a-11eb-9212-89faa6e0b807.mp4)

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.




[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[FX-2646]: https://artsyproduct.atlassian.net/browse/FX-2646