### PR TITLE
feat(FX-2646): add material filter with search UI

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -13,6 +13,7 @@ upcoming:
     - Fix wrong input font on android - dzmitry
     - Add artwork Material filter - dzmitry tratsiak
     - Fix unusable slider on android - dzmitry
+    - Add search UI for material filter - dzmitry tratsiak
 
 releases:
   - version: 6.9.1

--- a/src/lib/Components/ArtworkFilter/Filters/MaterialsTermsOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/MaterialsTermsOptions.tsx
@@ -32,6 +32,8 @@ export const MaterialsTermsOptionsScreen: React.FC<MaterialsTermsOptionsScreenPr
       filterHeaderText={FilterDisplayName.materialsTerms}
       filterOptions={sortedFilterOptions}
       navigation={navigation}
+      searchable
+      noResultsLabel="No results found"
       {...(isActive ? { rightButtonText: "Clear", onRightButtonPress: handleClear } : {})}
     />
   )

--- a/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
@@ -18,6 +18,7 @@ interface MultiSelectOptionScreenProps extends FancyModalHeaderProps {
   isDisabled?: (item: FilterData) => boolean
   /** Utilize a search input to further filter results */
   searchable?: boolean
+  noResultsLabel?: string
 }
 
 export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = ({
@@ -29,6 +30,7 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
   isDisabled,
   children,
   searchable,
+  noResultsLabel = "No results",
   ...rest
 }) => {
   const handleBackNavigation = () => {
@@ -71,7 +73,7 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
 
           {filteredOptions.length === 0 && (
             <Flex my={1.5} mx={2} alignItems="center">
-              <Text variant="caption">No results</Text>
+              <Text variant="caption">{noResultsLabel}</Text>
             </Flex>
           )}
         </>


### PR DESCRIPTION
The type of this PR is: **FEATURE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [CX-434]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-2646]

### Description
- As a user I can type into the search bar and as I type the long list of values are narrowed according to my query.
- If there are no results that match my query I  see “No results found” in the list w/ no other options
- If I find value(s) from the search box that I want to apply I have to tap the checkbox and tap the “Show # results” button. 
- If I don’t select a value from the list I have to click X to clear the search box.
- To remove an applied values I can unselect the check marks or tap “Clear all”.
- When a collector applies a value(s) **it is pinned to the top of the list**

### How the material filter works
[Material filter search](https://user-images.githubusercontent.com/3513494/119138208-5026d300-ba4a-11eb-8cc4-7a422877562d.mp4)

![1](https://user-images.githubusercontent.com/3513494/119139080-4b165380-ba4b-11eb-86ac-d09f6fbd001d.jpeg)
![2](https://user-images.githubusercontent.com/3513494/119139079-4a7dbd00-ba4b-11eb-808a-7ecbbb6b2a37.jpeg)
![3](https://user-images.githubusercontent.com/3513494/119139074-494c9000-ba4b-11eb-9e07-8691fcff823a.jpeg)

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[FX-2646]: https://artsyproduct.atlassian.net/browse/FX-2646