### PR TITLE
fix(search input): fix a bug in search where the clear button doesnt go away

### DIFF
--- a/src/lib/Components/Input/Input.tsx
+++ b/src/lib/Components/Input/Input.tsx
@@ -70,8 +70,8 @@ export const Input = React.forwardRef<TextInput, InputProps>(
     useImperativeHandle(ref, () => ({
       ...input.current!,
       // these next three are a dirty hack in order for typecheck to pass
-      setState: () => {},
-      forceUpdate: () => {},
+      setState: () => {}, // tslint:disable-line:no-empty
+      forceUpdate: () => {}, // tslint:disable-line:no-empty
       render: () => null,
 
       // our actual changes
@@ -164,7 +164,7 @@ export const Input = React.forwardRef<TextInput, InputProps>(
               />
             </Flex>
             {renderShowPasswordIcon()}
-            {value !== undefined && value !== "" && enableClearButton && (
+            {!!(value !== undefined && value !== "" && enableClearButton) && (
               <Flex pr="1" justifyContent="center" flexGrow={0}>
                 <TouchableOpacity
                   onPress={() => {

--- a/src/lib/Components/Input/Input.tsx
+++ b/src/lib/Components/Input/Input.tsx
@@ -68,15 +68,32 @@ export const Input = React.forwardRef<TextInput, InputProps>(
     }
 
     useImperativeHandle(ref, () => ({
-      ...input.current!,
-      // these next three are a dirty hack in order for typecheck to pass
-      setState: () => {}, // tslint:disable-line:no-empty
-      forceUpdate: () => {}, // tslint:disable-line:no-empty
-      render: () => null,
+      // ...input.current!, for some reason destructuring is not working 😡
+      blur: input.current!.blur,
+      focus: input.current!.focus,
+      isFocused: input.current!.isFocused,
+      measure: input.current!.measure,
+      measureLayout: input.current!.measureLayout,
+      measureInWindow: input.current!.measureInWindow,
+      setNativeProps: input.current!.setNativeProps,
+      setTimeout: input.current!.setTimeout,
+      clearTimeout: input.current!.clearTimeout,
+      setImmediate: input.current!.setImmediate,
+      clearImmediate: input.current!.clearImmediate,
+      setInterval: input.current!.setInterval,
+      clearInterval: input.current!.clearInterval,
+      refs: input.current!.refs,
+      requestAnimationFrame: input.current!.requestAnimationFrame,
+      cancelAnimationFrame: input.current!.cancelAnimationFrame,
+      context: input.current!.context,
+      props: input.current!.props,
+      state: input.current!.state,
+      setState: input.current!.setState,
+      forceUpdate: input.current!.forceUpdate,
+      render: input.current!.render,
 
       // our actual changes
       clear: localClear,
-      blur: () => input.current!.blur(),
     }))
 
     useEffect(() => {

--- a/src/lib/Components/SearchInput.tsx
+++ b/src/lib/Components/SearchInput.tsx
@@ -43,8 +43,6 @@ export const SearchInput = React.forwardRef<TextInput, SearchInputProps>(
             {!!inputFocused && (
               <TouchableOpacity
                 onPress={() => {
-                  onChangeText?.("")
-                  onClear?.()
                   ;(ref as RefObject<TextInput>).current?.blur()
                   ;(ref as RefObject<TextInput>).current?.clear()
                 }}


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [CX-434]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-]

### Description


While working on the search input placeholder, I saw this bug and fixed it.

Notice, when hitting `Cancel`, the `X` button doesn't go away, when it should

Before
https://user-images.githubusercontent.com/100233/119155391-0c809900-ba4b-11eb-8aa6-872859e4963a.mov

After
https://user-images.githubusercontent.com/100233/119155524-32a63900-ba4b-11eb-954e-e43641e7a87e.mov



<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434