### PR TITLE
chore: add whitelist paths for android applinks

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,29 +38,20 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data
-                    android:scheme="https"
-                    android:host="staging.artsy.net" />
-            </intent-filter>
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:scheme="https"
-                    android:host="www.artsy.net" />
-            </intent-filter>
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:scheme="https"
-                    android:host="artsy.net" />
+                <data android:scheme="https" />
+                <data android:host="staging.artsy.net" />
+                <data android:host="www.artsy.net" />
+                <data android:host="artsy.net" />
+                <data android:pathPrefix="/artwork" />
+                <data android:pathPrefix="/artworks" />
+                <data android:pathPrefix="/artist" />
+                <data android:pathPrefix="/artists" />
+                <data android:pathPrefix="/auction" />
+                <data android:pathPrefix="/auctions" />
+                <data android:pathPrefix="/gallery" />
+                <data android:pathPrefix="/galleries" />
+                <data android:pathPrefix="/fair" />
+                <data android:pathPrefix="/fairs" />
             </intent-filter>
         </activity>
 


### PR DESCRIPTION
The type of this PR is: Bugfix

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [CX-434]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1454]

### Description

Add a list of `pathPrefix` entries that should work as a whitelist, so that only artist, artwork, auction, fair and gallery URLs are opened in the app.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1454]: https://artsyproduct.atlassian.net/browse/CX-1454