### PR TITLE
fix: ability to uncheck ways to buy filters

### DIFF
--- a/src/lib/Components/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
@@ -797,6 +797,31 @@ describe("Apply Filters", () => {
     })
   })
 
+  fit("applies false ways to buy filters correctly", () => {
+    filterState = {
+      applyFilters: false,
+      appliedFilters: [{ paramName: FilterParamName.waysToBuyBuy, paramValue: true, displayText: "Buy now" }],
+      previouslyAppliedFilters: [{ paramName: FilterParamName.waysToBuyBuy, paramValue: true, displayText: "Buy now" }],
+      selectedFilters: [{ paramName: FilterParamName.waysToBuyBuy, paramValue: false, displayText: "Buy now" }],
+      aggregations: [],
+      filterType: "artwork",
+      counts: { total: null, followedArtists: null },
+    }
+
+    const filterArtworksStore = getFilterArtworksStore(filterState)
+    filterArtworksStore.getActions().applyFiltersAction()
+
+    expect(filterArtworksStore.getState()).toEqual({
+      applyFilters: false,
+      appliedFilters: [{ paramName: FilterParamName.waysToBuyBuy, paramValue: false, displayText: "Buy now" }],
+      previouslyAppliedFilters: [{ paramName: FilterParamName.waysToBuyBuy, paramValue: true, displayText: "Buy now" }],
+      selectedFilters: [],
+      aggregations: [],
+      filterType: "artwork",
+      counts: { total: null, followedArtists: null },
+    })
+  })
+
   it("replaces previously applied filters with newly selected ones", () => {
     filterState = {
       applyFilters: true,


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [FX-2934]

### Description

I'm just opening this to solicit feedback for a fix because I don't understand what's supposed to be happening in the admittedly small piece of code where this bug manifests. This is just a spec that replicates what we're seeing: an inability to apply `false` values to ways to buy filters. I'll leave a comment explaining where this is breaking and how.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [ ] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [ ] I have documented any follow-up work that this PR will require, or it does not require any.
- [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2934]: https://artsyproduct.atlassian.net/browse/FX-2934