### PR TITLE
fix(FX-2934): add ability to unselected ways to buy options

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -18,7 +18,7 @@ upcoming:
     - Add search UI for material filter - dzmitry tratsiak
     - Implements custom size filter with localization (behind feature flag) - damon
     - Adds artist nationality & ethnicity filter (behind feature flag) - damon
-    -
+    - Add ability to unselected "ways to buy" filter - dzmitry tratsiak
 
 releases:
   - version: 6.9.1

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterStore.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterStore.tsx
@@ -1,6 +1,6 @@
 import { Action, action, createContextStore, State } from "easy-peasy"
 import { assignDeep } from "lib/store/persistence"
-import { filter, find, isEqual, pullAllBy, union, unionBy } from "lodash"
+import { filter, find, isEqual, unionBy } from "lodash"
 import {
   Aggregations,
   defaultCommonFilterOptions,

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterStore.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterStore.tsx
@@ -58,8 +58,7 @@ export const ArtworkFiltersModel: ArtworkFiltersModel = {
       sort: getSortDefaultValueByFilterType(state.filterType),
     }
 
-    let multiOptionFilters = unionBy(state.previouslyAppliedFilters, state.selectedFilters, "paramName")
-
+    let multiOptionFilters = unionBy(state.selectedFilters, state.previouslyAppliedFilters, "paramName")
     multiOptionFilters = multiOptionFilters.filter((f) => f.paramValue === true)
 
     // get all filter options excluding ways to buy filter types and replace previously applied options with currently selected options

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterStore.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterStore.tsx
@@ -58,12 +58,9 @@ export const ArtworkFiltersModel: ArtworkFiltersModel = {
       sort: getSortDefaultValueByFilterType(state.filterType),
     }
 
-    let multiOptionFilters = unionBy(state.selectedFilters, state.previouslyAppliedFilters, "paramName")
-    multiOptionFilters = multiOptionFilters.filter((f) => f.paramValue === true)
-
-    // get all filter options excluding ways to buy filter types and replace previously applied options with currently selected options
-    const singleOptionFilters = unionBy(
-      pullAllBy([...state.selectedFilters, ...state.previouslyAppliedFilters], multiOptionFilters, "paramValue"),
+    // replace previously applied options with currently selected options
+    const filtersToApply = unionBy(
+      state.selectedFilters, state.previouslyAppliedFilters,
       ({ paramValue, paramName }) => {
         // We don't want to union the artistID params, as each entry corresponds to a
         // different artist that may be selected. Instead we de-dupe based on the paramValue.
@@ -74,8 +71,6 @@ export const ArtworkFiltersModel: ArtworkFiltersModel = {
         }
       }
     )
-
-    const filtersToApply = union([...singleOptionFilters, ...multiOptionFilters])
 
     // Remove default values as those are accounted for when we make the API request.
     const appliedFilters = filter(filtersToApply, ({ paramName, paramValue }) => {

--- a/src/lib/Components/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
@@ -797,6 +797,31 @@ describe("Apply Filters", () => {
     })
   })
 
+  fit("applies false ways to buy filters correctly", () => {
+    filterState = {
+      applyFilters: false,
+      appliedFilters: [{ paramName: FilterParamName.waysToBuyBuy, paramValue: true, displayText: "Buy now" }],
+      previouslyAppliedFilters: [{ paramName: FilterParamName.waysToBuyBuy, paramValue: true, displayText: "Buy now" }],
+      selectedFilters: [{ paramName: FilterParamName.waysToBuyBuy, paramValue: false, displayText: "Buy now" }],
+      aggregations: [],
+      filterType: "artwork",
+      counts: { total: null, followedArtists: null },
+    }
+
+    const filterArtworksStore = getFilterArtworksStore(filterState)
+    filterArtworksStore.getActions().applyFiltersAction()
+
+    expect(filterArtworksStore.getState()).toEqual({
+      applyFilters: false,
+      appliedFilters: [{ paramName: FilterParamName.waysToBuyBuy, paramValue: false, displayText: "Buy now" }],
+      previouslyAppliedFilters: [{ paramName: FilterParamName.waysToBuyBuy, paramValue: true, displayText: "Buy now" }],
+      selectedFilters: [],
+      aggregations: [],
+      filterType: "artwork",
+      counts: { total: null, followedArtists: null },
+    })
+  })
+
   it("replaces previously applied filters with newly selected ones", () => {
     filterState = {
       applyFilters: true,

--- a/src/lib/Components/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
@@ -812,9 +812,9 @@ describe("Apply Filters", () => {
     filterArtworksStore.getActions().applyFiltersAction()
 
     expect(filterArtworksStore.getState()).toEqual({
-      applyFilters: false,
-      appliedFilters: [{ paramName: FilterParamName.waysToBuyBuy, paramValue: false, displayText: "Buy now" }],
-      previouslyAppliedFilters: [{ paramName: FilterParamName.waysToBuyBuy, paramValue: true, displayText: "Buy now" }],
+      applyFilters: true,
+      appliedFilters: [],
+      previouslyAppliedFilters: [],
       selectedFilters: [],
       aggregations: [],
       filterType: "artwork",

--- a/src/lib/Components/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
@@ -797,7 +797,7 @@ describe("Apply Filters", () => {
     })
   })
 
-  fit("applies false ways to buy filters correctly", () => {
+  it("applies false ways to buy filters correctly", () => {
     filterState = {
       applyFilters: false,
       appliedFilters: [{ paramName: FilterParamName.waysToBuyBuy, paramValue: true, displayText: "Buy now" }],


### PR DESCRIPTION
The type of this PR is: **Bugfixes**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [CX-434]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-2934]

### Description
Add ability to unselected "ways to buy" filter options

https://user-images.githubusercontent.com/3513494/119193114-ceef3080-ba89-11eb-95d4-20b7d042a1a1.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

[FX-2934]: https://artsyproduct.atlassian.net/browse/FX-2934

[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434