### PR TITLE
Enhancement(layout): add the scrollbar bar for smaller screens

### DIFF
--- a/src/lib/Scenes/Onboarding/ForgotPassword.tsx
+++ b/src/lib/Scenes/Onboarding/ForgotPassword.tsx
@@ -42,7 +42,6 @@ export const ForgotPasswordForm: React.FC<ForgotPasswordFormProps> = ({
     <View style={{ flex: 1, backgroundColor: "white", flexGrow: 1 }}>
       <ScrollView
         contentContainerStyle={{ paddingTop: useScreenDimensions().safeAreaInsets.top }}
-        showsVerticalScrollIndicator={false}
         keyboardShouldPersistTaps="always"
       >
         <BackButton onPress={() => navigation.goBack()} />

--- a/src/lib/Scenes/Onboarding/OnboardingCreateAccount/OnboardingCreateAccount.tsx
+++ b/src/lib/Scenes/Onboarding/OnboardingCreateAccount/OnboardingCreateAccount.tsx
@@ -169,7 +169,6 @@ export const OnboardingCreateAccountScreenWrapper: React.FC<OnboardingCreateAcco
           paddingTop: useScreenDimensions().safeAreaInsets.top,
           justifyContent: "flex-start",
         }}
-        showsVerticalScrollIndicator={false}
         keyboardDismissMode="on-drag"
         keyboardShouldPersistTaps="always"
       >

--- a/src/lib/Scenes/Onboarding/OnboardingLogin.tsx
+++ b/src/lib/Scenes/Onboarding/OnboardingLogin.tsx
@@ -64,7 +64,6 @@ export const OnboardingLoginForm: React.FC<OnboardingLoginProps> = ({ navigation
     <View style={{ flex: 1, backgroundColor: "white", flexGrow: 1 }}>
       <ScrollView
         contentContainerStyle={{ paddingTop: useScreenDimensions().safeAreaInsets.top, paddingHorizontal: 20 }}
-        showsVerticalScrollIndicator={false}
         keyboardShouldPersistTaps="always"
       >
         <BackButton onPress={() => navigation.goBack()} />

--- a/src/lib/Scenes/Onboarding/OnboardingPersonalization/OnboardingPersonalization.tsx
+++ b/src/lib/Scenes/Onboarding/OnboardingPersonalization/OnboardingPersonalization.tsx
@@ -114,7 +114,6 @@ export const OnboardingPersonalizationList: React.FC<OnboardingPersonalizationLi
           paddingBottom: 80,
           justifyContent: "flex-start",
         }}
-        showsVerticalScrollIndicator={false}
       >
         <OnboardingPersonalizationListHeader
           navigateToModal={() => {


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [CX-434]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-]

### Description


I noticed that for smaller screens it just looks funky, like:
![dc35d525-4763-41ed-a8fd-e6a3e28ff691](https://user-images.githubusercontent.com/100233/119350721-93c24c80-bc97-11eb-87a6-e9bd1275afd0.jpg)

Ignore the button and checkbox being too far to the left. Fixed here: https://github.com/artsy/eigen/pull/4847

Notice that the back button almost not visible, all the way at the top (I have a ticket here https://artsyproduct.atlassian.net/browse/CX-1504). I spend like a minute trying to see what's happening while filling in the input, until I figured out I can actually scroll that screen. It totally seemed like I can't.

No idea why this was there, but now it's way more user friendly.

Before:

https://user-images.githubusercontent.com/100233/119351091-003d4b80-bc98-11eb-88b9-9dad5f74ecf9.mov

After:

https://user-images.githubusercontent.com/100233/119351107-059a9600-bc98-11eb-870d-77545f2356dc.mov





<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434