### PR TITLE
analytics(android): send to segment release when not in __DEV__

### DIFF
--- a/src/lib/utils/track/SegmentTrackingProvider.ts
+++ b/src/lib/utils/track/SegmentTrackingProvider.ts
@@ -9,7 +9,7 @@ export const SegmentTrackingProvider: TrackingProvider = {
     analytics = require("@segment/analytics-react-native").default
 
     analytics
-      .setup(Config.SEGMENT_STAGING_WRITE_KEY_ANDROID, {})
+      .setup(__DEV__ ? Config.SEGMENT_STAGING_WRITE_KEY_ANDROID : Config.SEGMENT_PRODUCTION_WRITE_KEY_ANDROID, {})
       // trackAppLifecycleEvents: true,
       .then(() => console.log("Analytics is ready"))
       .catch((err) => console.error("Something went wrong", err))


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [CX-434]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-]

### Description


Silly me, I was sending all analytics events to staging/dev, when I should be sending to prod/release too!


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434