### PR TITLE
fix: select filter item on swipe

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -32,6 +32,7 @@ upcoming:
     - Fix info button in conversation is hard to press - dzmitry
     - Update order of filters - dzmitry tratsiak
     - Fix time mismatch between auction list and individual auction page - matt
+    - Fix swiping on filter options selects them - dzmitry tratsiak
 
 releases:
   - version: 6.9.2
@@ -57,7 +58,6 @@ releases:
       - Add order history to user profile (behind feature flag) - alexj105
       - Enable lotsByFollowedArtists - ole
       - Add ability to unselected "ways to buy" filter - dzmitry tratsiak
-
 
   - version: 6.9.1
     date: May 18, 2021

--- a/src/palette/elements/Touchable/Touchable.tsx
+++ b/src/palette/elements/Touchable/Touchable.tsx
@@ -1,10 +1,12 @@
 import React from "react"
 import {
   GestureResponderEvent,
-  TouchableHighlight,
+  Platform,
+  TouchableHighlight as RNTouchableHighlight,
   TouchableHighlightProps,
-  TouchableWithoutFeedback,
+  TouchableWithoutFeedback as RNTouchableWithoutFeedback,
 } from "react-native"
+import { TouchableHighlight, TouchableWithoutFeedback } from "react-native-gesture-handler";
 import Haptic, { HapticFeedbackTypes } from "react-native-haptic-feedback"
 
 import { color } from "../../Theme"
@@ -39,13 +41,27 @@ export const Touchable: React.FC<TouchableProps> = ({ children, flex, haptic, no
     onPress(evt)
   }
 
-  return noFeedback ? (
-    <TouchableWithoutFeedback {...props} onPress={onPressWrapped}>
+  if (noFeedback) {
+    const NoFeedbackButton = Platform.select({
+      ios: TouchableWithoutFeedback,
+      default: RNTouchableWithoutFeedback,
+    })
+
+    return (
+      <NoFeedbackButton {...props} onPress={onPressWrapped}>
+        {inner}
+      </NoFeedbackButton>
+    )
+  }
+
+  const HighlightButton = Platform.select({
+    ios: TouchableHighlight,
+    default: RNTouchableHighlight,
+  })
+
+  return (
+    <HighlightButton underlayColor={color("white100")} activeOpacity={0.8} {...props} onPress={onPressWrapped}>
       {inner}
-    </TouchableWithoutFeedback>
-  ) : (
-    <TouchableHighlight underlayColor={color("white100")} activeOpacity={0.8} {...props} onPress={onPressWrapped}>
-      {inner}
-    </TouchableHighlight>
+    </HighlightButton>
   )
 }

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -425,6 +425,8 @@ jest.mock("react-native/Libraries/LayoutAnimation/LayoutAnimation", () => ({
 
 jest.mock("react-native-gesture-handler", () => {
   const View = require("react-native/Libraries/Components/View/View")
+  const TouchableWithoutFeedback = require("react-native/Libraries/Components/Touchable/TouchableWithoutFeedback")
+  const TouchableHighlight = require("react-native/Libraries/Components/Touchable/TouchableHighlight")
   return {
     Swipeable: View,
     DrawerLayout: View,
@@ -454,6 +456,8 @@ jest.mock("react-native-gesture-handler", () => {
     FlatList: View,
     gestureHandlerRootHOC: jest.fn(),
     Directions: {},
+    TouchableHighlight,
+    TouchableWithoutFeedback,
   }
 })
 


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR resolves [FX-2885]

### Description
Users can swipe on rows in the filters modal to enter a filter facet or return to the filters overview. When a user does this, it selects the filter facet that was pressed to swipe. The problem is that the filter navigation container is rendered [inside React modal component](https://github.com/artsy/eigen/blob/dimatretyak/fix-select-filter-item-on-swipe/src/lib/Components/ArtworkFilter/ArtworkFilter.tsx#L142) (see attached videos).

https://user-images.githubusercontent.com/3513494/119384422-5aa4cf00-bccd-11eb-91b4-02baffd55bc1.mp4

https://user-images.githubusercontent.com/3513494/119385657-1dd9d780-bccf-11eb-9eeb-bcc0c67770ec.mp4

### There are two possible solutions
1. [Disable the swipe back gesture](https://reactnavigation.org/docs/stack-navigator/#gestureenabled) to go to the previous screen
2. Add extra space on the left and make the swipe back zone equal to the extra space ([This solution](https://github.com/artsy/eigen/blob/master/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx#L89) is already used in the application)
3. Import `TouchableHighlight` and `TouchableWithoutFeedback` from `react-native-gesture-handler` (thanks @MounirDhahri for this hint) – **on iOS this works perfectly, on Android there are problems with tapping**

#### Fixed demos

https://user-images.githubusercontent.com/3513494/119663680-3c5ce180-be3b-11eb-8670-bdb2301569a7.mp4

https://user-images.githubusercontent.com/3513494/119809034-5f47ce00-beed-11eb-8602-31575639ab59.mp4


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2885]: https://artsyproduct.atlassian.net/browse/FX-2885