### PR TITLE
fix: Prevent multiline input placeholder on Android

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -27,6 +27,7 @@ upcoming:
     - Add order history to user profile (behind feature flag) - alexj105
     - Enable lotsByFollowedArtists - ole
     - Add ability to unselected "ways to buy" filter - dzmitry tratsiak
+    - Prevent multiline input placeholder on Android - ole
 releases:
   - version: 6.9.1
     date: May 18, 2021

--- a/src/lib/Components/Input/Input.tsx
+++ b/src/lib/Components/Input/Input.tsx
@@ -244,7 +244,12 @@ export const Input = React.forwardRef<TextInput, InputProps>(
               {placeholderMeasuringHack}
               <StyledInput
                 onLayout={(event) => {
-                  setInputWidth(event.nativeEvent.layout.width)
+                  const newWidth = event.nativeEvent.layout.width
+                  if (newWidth > inputWidth) {
+                    requestAnimationFrame(() => setInputWidth(newWidth))
+                  } else {
+                    setInputWidth(newWidth)
+                  }
                 }}
                 ref={input}
                 placeholderTextColor={color("black60")}


### PR DESCRIPTION
The type of this PR is: Bugfix

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [CX-434]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1506]

### Description

This PR delays the placeholder text update when the size of the input increases to prevent it from being rendered on multiple lines on Android. 

If the placeholder text gets changed in `onLayout()` it will be rendered before the size of the input increases which can cause the placeholder to be rendered on multiple lines on Android (see screenshot in [CX-1506]).

https://user-images.githubusercontent.com/4691889/119473804-cded2600-bd4b-11eb-8ceb-03b51d4b02e9.mp4

[onLayout Documentation](https://reactnative.dev/docs/view#onlayout)

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434
[CX-1506]: https://artsyproduct.atlassian.net/browse/CX-1506
[CX-1506]: https://artsyproduct.atlassian.net/browse/CX-1506




