### PR TITLE
fix disabled button bug for works with only one edition

### DIFF
--- a/src/lib/Scenes/Inbox/Components/Conversations/MakeOfferModal.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/MakeOfferModal.tsx
@@ -8,7 +8,7 @@ import { CollapsibleArtworkDetailsFragmentContainer as CollapsibleArtworkDetails
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import { ProvideScreenTrackingWithCohesionSchema } from "lib/utils/track"
 import { BorderBox, Button, Flex, Text } from "palette"
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { View } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import { InquiryMakeOfferButtonFragmentContainer as InquiryMakeOfferButton } from "./InquiryMakeOfferButton"
@@ -22,6 +22,7 @@ interface MakeOfferModalProps {
 
 export const MakeOfferModal: React.FC<MakeOfferModalProps> = ({ ...props }) => {
   const { artwork, conversationID } = props
+  const { editionSets } = artwork
   const [selectedEdition, setSelectedEdition] = useState<string>()
 
   const selectEdition = (editionSetID: string, isAvailable?: boolean) => {
@@ -29,6 +30,12 @@ export const MakeOfferModal: React.FC<MakeOfferModalProps> = ({ ...props }) => {
       setSelectedEdition(editionSetID)
     }
   }
+
+  useEffect(() => {
+    if (editionSets?.length === 1) {
+      setSelectedEdition(editionSets[0]?.internalID)
+    }
+  })
 
   return (
     <View>

--- a/src/lib/Scenes/Inbox/Components/Conversations/MakeOfferModal.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/MakeOfferModal.tsx
@@ -8,7 +8,7 @@ import { CollapsibleArtworkDetailsFragmentContainer as CollapsibleArtworkDetails
 import renderWithLoadProgress from "lib/utils/renderWithLoadProgress"
 import { ProvideScreenTrackingWithCohesionSchema } from "lib/utils/track"
 import { BorderBox, Button, Flex, Text } from "palette"
-import React, { useEffect, useState } from "react"
+import React, { useState } from "react"
 import { View } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import { InquiryMakeOfferButtonFragmentContainer as InquiryMakeOfferButton } from "./InquiryMakeOfferButton"
@@ -23,19 +23,17 @@ interface MakeOfferModalProps {
 export const MakeOfferModal: React.FC<MakeOfferModalProps> = ({ ...props }) => {
   const { artwork, conversationID } = props
   const { editionSets } = artwork
-  const [selectedEdition, setSelectedEdition] = useState<string>()
+
+  const knownEditionSets = (editionSets as unknown) as Array<{ internalID: string }>
+  const [selectedEdition, setSelectedEdition] = useState<string | null>(
+    editionSets?.length === 1 ? knownEditionSets[0].internalID : null
+  )
 
   const selectEdition = (editionSetID: string, isAvailable?: boolean) => {
     if (isAvailable) {
       setSelectedEdition(editionSetID)
     }
   }
-
-  useEffect(() => {
-    if (editionSets?.length === 1) {
-      setSelectedEdition(editionSets[0]?.internalID)
-    }
-  })
 
   return (
     <View>

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/MakeOfferModal-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/MakeOfferModal-tests.tsx
@@ -92,6 +92,22 @@ const mockEditionsResolver = {
   }),
 }
 
+const mockSingleEditionResolver = {
+  Artwork: () => ({
+    title: "test-single-edition-artwork",
+    isEdition: true,
+    editionSets: [
+      {
+        internalID: "edition-1",
+        isOfferableFromInquiry: true,
+        listPrice: {
+          display: "€100",
+        },
+      },
+    ],
+  }),
+}
+
 const getWrapper = (mockResolvers = mockResolver, renderer = renderComponent) => {
   const tree = renderWithWrappers(<TestRenderer renderer={renderer} />)
   act(() => {
@@ -138,6 +154,13 @@ describe("<MakeOfferModal />", () => {
       const confirmBtn = wrapper.root.findByType(InquiryMakeOfferButton)
       expect(confirmBtn.props.disabled).toBeTruthy()
     })
+
+    it("doesn't disable the confirm button if an editioned work only has one edition", () => {
+      const wrapper = getWrapper(mockSingleEditionResolver)
+      const confirmBtn = wrapper.root.findByType(InquiryMakeOfferButton)
+      expect(confirmBtn.props.disabled).toBeFalsy()
+    })
+
     it("shows unavailable editions as unavailable and doesn't allow selection", async () => {
       const wrapper = getWrapper(mockEditionsResolver)
       const selection = wrapper.root


### PR DESCRIPTION
The type of this PR is: Bugfix

[PURCHASE-2723]

### Description
As per [this discussion]("https://artsy.slack.com/archives/C9YNS4X32/p1622137949282200"), it is clear this is happening for edition works with only 1 edition. For editioned works, we hide the edition selector when `editionSets` has a length of 1,  but we also disable the button unless an edition has been selected. To fix this, I set `selectedEdition` to be the only edition in `editionSets`.

__Before:__
<img width="472" alt="Screen Shot 2021-05-27 at 1 51 21 PM" src="https://user-images.githubusercontent.com/5643895/119881339-2e6e9580-befb-11eb-976f-c5c447255b23.png">

__After:__
<img width="430" alt="Screen Shot 2021-05-27 at 2 48 54 PM" src="https://user-images.githubusercontent.com/5643895/119881363-34fd0d00-befb-11eb-9c89-02ff0915696a.png">

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[PURCHASE-2723]: https://artsyproduct.atlassian.net/browse/PURCHASE-2723