### PR TITLE
Close keyboard on message send

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -33,6 +33,7 @@ upcoming:
     - Update order of filters - dzmitry tratsiak
     - Fix time mismatch between auction list and individual auction page - matt
     - Fix swiping on filter options selects them - dzmitry tratsiak
+    - close keyboard on message send - lily
 
 releases:
   - version: 6.9.2

--- a/src/lib/Scenes/Inbox/Components/Conversations/Composer.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/Composer.tsx
@@ -4,7 +4,7 @@ import colors from "lib/data/colors"
 import { Schema, Track, track as _track } from "lib/utils/track"
 import { Button, color, Flex, themeProps } from "palette"
 import React from "react"
-import { TextInput, TouchableWithoutFeedback } from "react-native"
+import { Keyboard, TextInput, TouchableWithoutFeedback } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components/native"
 import { ConversationCTAFragmentContainer } from "./ConversationCTA"
@@ -60,6 +60,7 @@ export default class Composer extends React.Component<Props, State> {
     if (this.props.onSubmit && this.state.text) {
       this.props.onSubmit(this.state.text)
       this.setState({ text: null })
+      Keyboard.dismiss()
     }
   }
 


### PR DESCRIPTION
The type of this PR is: Bugfix
This PR resolves [PURCHASE-2724]

### Description

keyboard doesn't close when message is sent - you have to tap outside. We should hide on message send. To do this I called `Keyboard.dismiss()` in the button's `onPress`.

### PR Checklist (tick all before merging)

https://user-images.githubusercontent.com/5643895/119893686-aba10700-bf09-11eb-8928-f6c35b6ac24c.mov
