### PR TITLE
fix: apply "cancel all" instantly

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -38,7 +38,7 @@ upcoming:
     - Fix registration flow error handling (e.g. invalid phone number) - ole
     - Decode html entities in markdown - ole
     - close keyboard on message send - lily
-    - Clear applyied filters after click on "clear all" button immediately - dzmitry tratsiak
+    - Clear applied filters after click on "clear all" button immediately - dzmitry tratsiak
 
 releases:
   - version: 6.9.2

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -38,6 +38,7 @@ upcoming:
     - Fix registration flow error handling (e.g. invalid phone number) - ole
     - Decode html entities in markdown - ole
     - close keyboard on message send - lily
+    - Clear applyied filters after click on "clear all" button immediately - dzmitry tratsiak
 
 releases:
   - version: 6.9.2

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -62,14 +62,14 @@ export const ArtworkFilterOptionsScreen: React.FC<
   StackScreenProps<ArtworkFilterNavigationStack, "FilterOptionsScreen">
 > = ({ navigation, route }) => {
   const tracking = useTracking()
-  const { closeModal, id, mode, slug, title = "Sort & Filter" } = route.params
+  const { closeModal, exitModal, id, mode, slug, title = "Sort & Filter" } = route.params
 
   const appliedFiltersState = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
   const selectedFiltersState = ArtworksFiltersStore.useStoreState((state) => state.selectedFilters)
   const aggregationsState = ArtworksFiltersStore.useStoreState((state) => state.aggregations)
   const filterTypeState = ArtworksFiltersStore.useStoreState((state) => state.filterType)
 
-  const clearAllAction = ArtworksFiltersStore.useStoreActions((action) => action.clearAllAction)
+  const clearFiltersZeroStateAction = ArtworksFiltersStore.useStoreActions((action) => action.clearFiltersZeroStateAction)
 
   const selectedOptions = useSelectedOptionsDisplay()
 
@@ -95,7 +95,8 @@ export const ArtworkFilterOptionsScreen: React.FC<
     .filter((filterOption) => filterOption.filterType)
 
   const clearAllFilters = () => {
-    clearAllAction()
+    clearFiltersZeroStateAction()
+    exitModal?.()
   }
 
   const trackClear = (screenName: PageNames, ownerEntity: OwnerEntityTypes) => {

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterStore.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterStore.tsx
@@ -22,7 +22,6 @@ export interface ArtworkFiltersModel {
   counts: FilterCounts
   applyFiltersAction: Action<ArtworkFiltersModel>
   selectFiltersAction: Action<ArtworkFiltersModel, FilterData>
-  clearAllAction: Action<ArtworkFiltersModel>
   resetFiltersAction: Action<ArtworkFiltersModel>
   clearFiltersZeroStateAction: Action<ArtworkFiltersModel>
   setAggregationsAction: Action<ArtworkFiltersModel, any>
@@ -177,12 +176,6 @@ export const ArtworkFiltersModel: ArtworkFiltersModel = {
     })
 
     state.selectedFilters = selectedFilters
-    state.applyFilters = false
-  }),
-
-  clearAllAction: action((state) => {
-    state.selectedFilters = []
-    state.previouslyAppliedFilters = []
     state.applyFilters = false
   }),
 

--- a/src/lib/Components/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
@@ -8,69 +8,6 @@ let filterState: ArtworkFiltersState
 const getFilterArtworksStore = (state: ArtworkFiltersState) =>
   createStore<ArtworkFiltersModel>({ ...ArtworkFiltersModel, ...state })
 
-describe("Clear All Filters", () => {
-  it("clears out the previouslyAppliedFilters if nothing has been applied", () => {
-    filterState = {
-      appliedFilters: [],
-      selectedFilters: [],
-      previouslyAppliedFilters: [{ displayText: "Price (low to high)", paramName: FilterParamName.sort }],
-      applyFilters: false,
-      aggregations: [],
-      filterType: "artwork",
-      counts: {
-        total: null,
-        followedArtists: null,
-      },
-    }
-    const filterArtworksStore = getFilterArtworksStore(filterState)
-    filterArtworksStore.getActions().clearAllAction()
-
-    expect(filterArtworksStore.getState()).toEqual({
-      appliedFilters: [],
-      applyFilters: false,
-      selectedFilters: [],
-      previouslyAppliedFilters: [],
-      aggregations: [],
-      filterType: "artwork",
-      counts: {
-        total: null,
-        followedArtists: null,
-      },
-    })
-  })
-
-  it("clears out the previouslyAppliedFilters and selectedFilters", () => {
-    filterState = {
-      appliedFilters: [{ displayText: "Recently updated", paramName: FilterParamName.sort }],
-      selectedFilters: [{ displayText: "Artwork year (descending)", paramName: FilterParamName.sort }],
-      previouslyAppliedFilters: [{ displayText: "Recently updated", paramName: FilterParamName.sort }],
-      applyFilters: true,
-      aggregations: [],
-      filterType: "artwork",
-      counts: {
-        total: null,
-        followedArtists: null,
-      },
-    }
-
-    const filterArtworksStore = getFilterArtworksStore(filterState)
-    filterArtworksStore.getActions().clearAllAction()
-
-    expect(filterArtworksStore.getState()).toEqual({
-      appliedFilters: [{ displayText: "Recently updated", paramName: FilterParamName.sort }],
-      applyFilters: false,
-      selectedFilters: [],
-      previouslyAppliedFilters: [],
-      aggregations: [],
-      filterType: "artwork",
-      counts: {
-        total: null,
-        followedArtists: null,
-      },
-    })
-  })
-})
-
 describe("Reset Filters", () => {
   it("returns empty arrays/default state values ", () => {
     filterState = {
@@ -1061,6 +998,38 @@ describe("clearFiltersZeroState", () => {
       },
     })
   })
+
+  it("clears out the selectedFilters", () => {
+    filterState = {
+      appliedFilters: [],
+      selectedFilters: [{ displayText: "Artwork year (descending)", paramName: FilterParamName.sort }],
+      previouslyAppliedFilters: [],
+      applyFilters: true,
+      aggregations: [],
+      filterType: "artwork",
+      counts: {
+        total: null,
+        followedArtists: null,
+      },
+    }
+
+    const filterArtworksStore = getFilterArtworksStore(filterState)
+    filterArtworksStore.getActions().clearFiltersZeroStateAction()
+
+    expect(filterArtworksStore.getState()).toEqual({
+      appliedFilters: [],
+      applyFilters: true,
+      selectedFilters: [],
+      previouslyAppliedFilters: [],
+      aggregations: [],
+      filterType: "artwork",
+      counts: {
+        total: null,
+        followedArtists: null,
+      },
+    })
+  })
+
 })
 
 describe("SetInitialFilterState", () => {

--- a/src/lib/Components/ArtworkFilter/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/FilterModal-tests.tsx
@@ -367,7 +367,7 @@ describe("Clearing filters", () => {
     expect(extractText(filterScreen.root.findAllByType(CurrentOption)[0])).toEqual("")
   })
 
-  it("exit modal when clear all button was pressed", () => {
+  it("exits the modal when clear all button is pressed", () => {
     const injectedState: ArtworkFiltersState = {
       selectedFilters: [],
       appliedFilters: [{ displayText: "Recently added", paramName: FilterParamName.sort }],

--- a/src/lib/Components/ArtworkFilter/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/FilterModal-tests.tsx
@@ -367,7 +367,7 @@ describe("Clearing filters", () => {
     expect(extractText(filterScreen.root.findAllByType(CurrentOption)[0])).toEqual("")
   })
 
-  it("enables the apply button when clearing all if no other options are selected", () => {
+  it("exit modal when clear all button was pressed", () => {
     const injectedState: ArtworkFiltersState = {
       selectedFilters: [],
       appliedFilters: [{ displayText: "Recently added", paramName: FilterParamName.sort }],
@@ -392,7 +392,7 @@ describe("Clearing filters", () => {
 
     expect(filterModal.find(CurrentOption).at(0).text()).toEqual("")
     expect(filterModal.find(CurrentOption).at(1).text()).toEqual("")
-    expect(filterModal.find(ApplyButton).at(0).props().disabled).toEqual(false)
+    expect(exitModalMock).toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR resolves [FX-2926]

### Description
As a user, when I press “clear all” I expect the following to happen:
1. The active filters should be removed
2. The clear operation should be applied
3. The modal should close

#### Demo
https://user-images.githubusercontent.com/3513494/120184720-f7a9bf80-c219-11eb-8506-f749c815f4e0.mp4

https://user-images.githubusercontent.com/3513494/120184705-f1b3de80-c219-11eb-88f8-2d22066a3810.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2926]: https://artsyproduct.atlassian.net/browse/FX-2926