### PR TITLE
feat: admin sees saved search banner

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -42,6 +42,7 @@ upcoming:
    - Clear applied filters after click on "clear all" button immediately - dzmitry tratsiak
    - Release new price range filter to artwork grids - iskounen
    - Fix padding between section titles and the artwork grids below them - stas hanchar
+   - Add saved search banner (behind feature flag) - dzmitry tratsiak
 
 releases:
   - version: 6.9.3

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -92,6 +92,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
   const [isSavedSearch, setIsSavedSearch] = useState(false)
   const appliedFilters = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
   const applyFilters = ArtworksFiltersStore.useStoreState((state) => state.applyFilters)
+  const shouldShowSavedSearchBanner = enableSavedSearch && appliedFilters.length > 0
 
   const setAggregationsAction = ArtworksFiltersStore.useStoreActions((state) => state.setAggregationsAction)
 
@@ -155,7 +156,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
             </Touchable>
           </Flex>
           <Separator mt={2} ml={-2} width={screenWidth} />
-          {!!enableSavedSearch && (
+          {!!shouldShowSavedSearchBanner && (
             <>
               <SavedSearchBanner enabled={isSavedSearch} onPress={handleSaveSearchFiltersPress} />
               <Separator ml={-2} width={screenWidth} />
@@ -163,7 +164,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
           )}
         </Box>
       ),
-    [artworksTotal, enableSavedSearch, isSavedSearch]
+    [artworksTotal, shouldShowSavedSearchBanner, isSavedSearch]
   )
 
   const filteredArtworks = () => {

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -89,6 +89,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
 }) => {
   const tracking = useTracking()
   const enableSavedSearch = useFeatureFlag("AREnableSavedSearch")
+  const [isSavedSearch, setIsSavedSearch] = useState(false)
   const appliedFilters = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
   const applyFilters = ArtworksFiltersStore.useStoreState((state) => state.applyFilters)
 
@@ -129,8 +130,9 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
     })
   }
 
-  // tslint:disable-next-line:no-empty
-  const handleSaveSearchFiltersPress = () => {}
+  const handleSaveSearchFiltersPress = () => {
+    setIsSavedSearch(!isSavedSearch)
+  }
 
   const setJSX = useContext(StickyTabPageFlatListContext).setJSX
   const screenWidth = useScreenDimensions().width
@@ -155,13 +157,13 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
           <Separator mt={2} ml={-2} width={screenWidth} />
           {!!enableSavedSearch && (
             <>
-              <SavedSearchBanner enabled={false} onPress={handleSaveSearchFiltersPress} />
+              <SavedSearchBanner enabled={isSavedSearch} onPress={handleSaveSearchFiltersPress} />
               <Separator ml={-2} width={screenWidth} />
             </>
           )}
         </Box>
       ),
-    [artworksTotal, enableSavedSearch]
+    [artworksTotal, enableSavedSearch, isSavedSearch]
   )
 
   const filteredArtworks = () => {

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -14,12 +14,14 @@ import {
 import { StickyTabPageFlatListContext } from "lib/Components/StickyTabPage/StickyTabPageFlatList"
 import { StickyTabPageScrollView } from "lib/Components/StickyTabPage/StickyTabPageScrollView"
 import { PAGE_SIZE } from "lib/data/constants"
+import { useFeatureFlag } from 'lib/store/GlobalStore'
 import { Schema } from "lib/utils/track"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { Box, FilterIcon, Flex, Separator, Spacer, Text, Touchable } from "palette"
 import React, { useContext, useEffect, useState } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import { useTracking } from "react-tracking"
+import { SavedSearchBanner } from "./SavedSearchBanner"
 
 interface ArtworksGridProps extends InfiniteScrollGridProps {
   artist: ArtistArtworks_artist
@@ -86,6 +88,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
   ...props
 }) => {
   const tracking = useTracking()
+  const enableSavedSearch = useFeatureFlag("AREnableSavedSearch")
   const appliedFilters = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
   const applyFilters = ArtworksFiltersStore.useStoreState((state) => state.applyFilters)
 
@@ -126,6 +129,9 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
     })
   }
 
+  // tslint:disable-next-line:no-empty
+  const handleSaveSearchFiltersPress = () => {}
+
   const setJSX = useContext(StickyTabPageFlatListContext).setJSX
   const screenWidth = useScreenDimensions().width
 
@@ -147,9 +153,15 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
             </Touchable>
           </Flex>
           <Separator mt={2} ml={-2} width={screenWidth} />
+          {!!enableSavedSearch && (
+            <>
+              <SavedSearchBanner enabled={false} onPress={handleSaveSearchFiltersPress} />
+              <Separator ml={-2} width={screenWidth} />
+            </>
+          )}
         </Box>
       ),
-    [artworksTotal]
+    [artworksTotal, enableSavedSearch]
   )
 
   const filteredArtworks = () => {

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -1,0 +1,28 @@
+import { Button, Flex, Text } from "palette"
+import React from "react"
+
+interface SavedSearchBannerProps {
+  enabled: boolean
+  loading?: boolean
+  onPress: () => void
+}
+
+export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({ enabled, loading, onPress }) => {
+  return (
+    <Flex backgroundColor="white" flexDirection="row" mx={-2} px={2} py={11} justifyContent="space-between" alignItems="center">
+      <Text variant="small" color="black">
+        New works alert for this search
+      </Text>
+      <Button
+        variant={enabled ? "secondaryOutline" : "primaryBlack"}
+        onPress={onPress}
+        size="small"
+        loading={loading}
+        longestText="Disable"
+        haptic
+      >
+        {enabled ? "Disable" : "Enable"}
+      </Button>
+    </Flex>
+  )
+}

--- a/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
@@ -1,0 +1,41 @@
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { Button } from "palette"
+import React from "react"
+import { SavedSearchBanner } from "../SavedSearchBanner"
+
+describe("SavedSearchBanner", () => {
+  it("renders correctly disabled state", () => {
+    const onPress = jest.fn()
+    const tree = renderWithWrappers(<SavedSearchBanner enabled={false} onPress={onPress} />)
+    const buttonComponent = tree.root.findByType(Button)
+
+    expect(buttonComponent.props.children).toEqual("Enable")
+    expect(buttonComponent.props.variant).toBe("primaryBlack")
+  })
+
+  it("renders correctly enabled state", () => {
+    const onPress = jest.fn()
+    const tree = renderWithWrappers(<SavedSearchBanner enabled={true} loading={true} onPress={onPress} />)
+    const buttonComponent = tree.root.findByType(Button)
+
+    expect(buttonComponent.props.children).toEqual("Disable")
+    expect(buttonComponent.props.variant).toBe("secondaryOutline")
+  })
+
+  it("renders correctly loading state", () => {
+    const onPress = jest.fn()
+    const tree = renderWithWrappers(<SavedSearchBanner enabled={false} loading={true} onPress={onPress} />)
+    const buttonComponent = tree.root.findByType(Button)
+
+    expect(buttonComponent.props.loading).toBe(true)
+  })
+
+  it("calls onPress when button is pressed", () => {
+    const onPress = jest.fn()
+    const tree = renderWithWrappers(<SavedSearchBanner enabled={false} loading={false} onPress={onPress} />)
+    const buttonComponent = tree.root.findByType(Button)
+
+    buttonComponent.props.onPress()
+    expect(onPress).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
The type of this PR is: **FEATURE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR resolves [FX-2964] and [FX-2965]

### Description
#### For FX-2964
As an admin,
**When** I visit the artist artworks tab with _the "saved search" feature flag enabled_
**I see** a banner with a toggle

Acceptance criteria/approach
* Toggle on/off changes banner background and text color
* Is sticky with the filter bar, staying at the top of the screen as the user scrolls down and up the screen
* Not in scope: conditional display. For this ticket, banner is always shown (when feature flag is on). 
* Not in scope: any querying or mutations. This ticket is UI-only

#### For FX-2965
As an admin with _the saved search feature flag enabled_
**When** I visit the artworks tab for an artist
**I do not see** the saved search banner
**And when** I apply a set of filters
**I see** the saved search banner

Acceptance criteria
* Any set of filters triggers the banner
* Not in scope: checking whether the user already has this search saved
* Not in scope: any toggle behavior

#### Demo

https://user-images.githubusercontent.com/3513494/120364028-70417680-c315-11eb-9e2a-1c15d65e5b08.mp4


https://user-images.githubusercontent.com/3513494/120365307-f14d3d80-c316-11eb-9e82-0ee4403ebb85.mp4


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2964]: https://artsyproduct.atlassian.net/browse/FX-2964
[FX-2965]: https://artsyproduct.atlassian.net/browse/FX-2965