### PR TITLE
fix: send only changed filter params in the analytics event

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -10,6 +10,7 @@ upcoming:
    - Fix iOS app blank screen - ole, mounir
    - Replace "color" filter with "colors" filter - dzmitry tratsiak
    - Add Saved Search feature flag - kizito
+   - Send only changed filter params in the analytics event - dzmitry tratsiak
  user_facing:
    - Add order details skeleton (behind feature flag) - Serge0n
    - Fix wrong input font on android - dzmitry

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -1,5 +1,5 @@
 import { FilterScreen } from "lib/Components/ArtworkFilter"
-import { capitalize, compact, forOwn, groupBy, pick, sortBy } from "lodash"
+import { capitalize, compact, groupBy, isEqual, pick, sortBy } from "lodash"
 import { LOCALIZED_UNIT } from "./Filters/helpers"
 
 export enum FilterDisplayName {
@@ -257,27 +257,18 @@ const getDefaultParamsByType = (filterType: FilterType) => {
   }[filterType]
 }
 
-const getChangedParams = (appliedFilters: FilterArray, filterType: FilterType = "artwork") => {
-  const defaultFilterParams = getDefaultParamsByType(filterType)
-  const filterParams = paramsFromAppliedFilters(appliedFilters, { ...defaultFilterParams }, filterType)
-  // when filters cleared return default params
-  return Object.keys(filterParams).length === 0 ? defaultFilterParams : filterParams
-}
-
 export const changedFiltersParams = (currentFilterParams: FilterParams, selectedFilterOptions: FilterArray) => {
-  const selectedFilterParams = getChangedParams(selectedFilterOptions)
   const changedFilters: { [key: string]: any } = {}
 
-  /***
-   *  If a filter option has been updated e.g. was { medium: "photography" } but
-   *  is now { medium: "sculpture" } add the updated filter to changedFilters. Otherwise,
-   *  add filter option to changedFilters.
-   ***/
-  forOwn(getChangedParams(selectedFilterOptions), (_value, paramName) => {
-    const filterParamName = paramName as FilterParamName
-    if (currentFilterParams[filterParamName] !== selectedFilterParams[filterParamName]) {
-      changedFilters[filterParamName] = selectedFilterParams[filterParamName]
+  selectedFilterOptions.forEach((selectedFilterOption) => {
+    const { paramName, paramValue } = selectedFilterOption
+    const currentFilterParamValue = currentFilterParams[paramName]
+
+    if (currentFilterParamValue && isEqual(paramValue, currentFilterParamValue)) {
+      return
     }
+
+    changedFilters[paramName] = paramValue
   })
 
   return changedFilters

--- a/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
@@ -111,7 +111,7 @@ describe("changedFiltersParams helper", () => {
     ).toEqual({ sort: "year" })
   })
 
-  it("when clearing applied filters", () => {
+  it("when clearing applied sort selection", () => {
     const appliedFilters = filterArtworksParams([
       {
         displayText: "Artwork year (ascending)",
@@ -125,7 +125,13 @@ describe("changedFiltersParams helper", () => {
         paramName: FilterParamName.priceRange,
       },
     ])
-    expect(changedFiltersParams(appliedFilters, [])).toEqual({
+    expect(changedFiltersParams(appliedFilters, [
+      {
+        displayText: "Default",
+        paramValue: "-decayed_merch",
+        paramName: FilterParamName.sort,
+      },
+    ])).toEqual({
       sort: "-decayed_merch",
     })
   })
@@ -143,7 +149,18 @@ describe("changedFiltersParams helper", () => {
         paramName: FilterParamName.medium,
       },
     ])
-    expect(changedFiltersParams(appliedFilters, [])).toEqual({ sort: "-decayed_merch", medium: "*" })
+    expect(changedFiltersParams(appliedFilters, [
+      {
+        displayText: "Default",
+        paramValue: "-decayed_merch",
+        paramName: FilterParamName.sort,
+      },
+      {
+        displayText: "All",
+        paramValue: "*",
+        paramName: FilterParamName.medium,
+      },
+    ])).toEqual({ sort: "-decayed_merch", medium: "*" })
   })
 })
 


### PR DESCRIPTION
The type of this PR is: **FIX**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR resolves [FX-2888]

### Description
When either “Ways to buy”, “size” or “price range” filter is selected, selecting another filter resets their value in the analytics event

#### Demo

https://user-images.githubusercontent.com/3513494/120470555-556e1100-c3ac-11eb-9f57-b62a0e798cb2.mp4


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2888]: https://artsyproduct.atlassian.net/browse/FX-2888