### PR TITLE
fix android native go back from sale tab to search

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -48,6 +48,7 @@ upcoming:
     - Add saved search banner (behind feature flag) - dzmitry tratsiak
     - Add articles rail to home screen - ole
     - Update articles rail design on artist overview screen - ole
+    - Fix android native go back from sale tab to search - yauheni
 
 releases:
   - version: 6.9.3

--- a/src/lib/Components/Artist/ArtistConsignButton.tsx
+++ b/src/lib/Components/Artist/ArtistConsignButton.tsx
@@ -44,7 +44,7 @@ export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = (props) =
           destination_path: destination,
         })
 
-        navigate(destination, { passProps: { initialGoBackPath: "search" } })
+        isSalesTab ? navigate(destination) : navigate(destination, { passProps: { initialGoBackPath: "search" } })
       }}
     >
       <BorderBox p={0}>

--- a/src/lib/Components/Artist/ArtistConsignButton.tsx
+++ b/src/lib/Components/Artist/ArtistConsignButton.tsx
@@ -44,7 +44,7 @@ export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = (props) =
           destination_path: destination,
         })
 
-        navigate(destination)
+        navigate(destination, { passProps: { initialGoBackPath: "search" } })
       }}
     >
       <BorderBox p={0}>

--- a/src/lib/Components/Artist/ArtistConsignButton.tsx
+++ b/src/lib/Components/Artist/ArtistConsignButton.tsx
@@ -44,7 +44,9 @@ export const ArtistConsignButton: React.FC<ArtistConsignButtonProps> = (props) =
           destination_path: destination,
         })
 
-        isSalesTab ? navigate(destination) : navigate(destination, { passProps: { initialGoBackPath: "search" } })
+        isSalesTab
+          ? navigate(destination)
+          : navigate(destination, { passProps: { overwriteHardwareBackButtonPath: "search" } })
       }}
     >
       <BorderBox p={0}>

--- a/src/lib/Components/Artist/__tests__/ArtistConsignButton-tests.tsx
+++ b/src/lib/Components/Artist/__tests__/ArtistConsignButton-tests.tsx
@@ -220,7 +220,7 @@ describe("ArtistConsignButton", () => {
       })
       tree.root.findByType(TouchableOpacity).props.onPress()
 
-      expect(navigate).toHaveBeenCalledWith("/sales")
+      expect(navigate).toHaveBeenCalledWith("/sales", { passProps: { initialGoBackPath: "search" } })
     })
 
     it("sends user to a new instance of landing page if user is already in sales tab", () => {
@@ -237,7 +237,9 @@ describe("ArtistConsignButton", () => {
       })
       tree.root.findByType(TouchableOpacity).props.onPress()
 
-      expect(navigate).toHaveBeenCalledWith("/collections/my-collection/marketing-landing")
+      expect(navigate).toHaveBeenCalledWith("/collections/my-collection/marketing-landing", {
+        passProps: { initialGoBackPath: "search" },
+      })
     })
   })
 })

--- a/src/lib/Components/Artist/__tests__/ArtistConsignButton-tests.tsx
+++ b/src/lib/Components/Artist/__tests__/ArtistConsignButton-tests.tsx
@@ -237,9 +237,7 @@ describe("ArtistConsignButton", () => {
       })
       tree.root.findByType(TouchableOpacity).props.onPress()
 
-      expect(navigate).toHaveBeenCalledWith("/collections/my-collection/marketing-landing", {
-        passProps: { initialGoBackPath: "search" },
-      })
+      expect(navigate).toHaveBeenCalledWith("/collections/my-collection/marketing-landing")
     })
   })
 })

--- a/src/lib/Components/Artist/__tests__/ArtistConsignButton-tests.tsx
+++ b/src/lib/Components/Artist/__tests__/ArtistConsignButton-tests.tsx
@@ -220,7 +220,7 @@ describe("ArtistConsignButton", () => {
       })
       tree.root.findByType(TouchableOpacity).props.onPress()
 
-      expect(navigate).toHaveBeenCalledWith("/sales", { passProps: { initialGoBackPath: "search" } })
+      expect(navigate).toHaveBeenCalledWith("/sales", { passProps: { overwriteHardwareBackButtonPath: "search" } })
     })
 
     it("sends user to a new instance of landing page if user is already in sales tab", () => {

--- a/src/lib/Scenes/Consignments/index.tsx
+++ b/src/lib/Scenes/Consignments/index.tsx
@@ -1,6 +1,6 @@
 import { goBack, switchTab } from "lib/navigation/navigate"
 import { GlobalStore } from "lib/store/GlobalStore"
-import React, { useEffect, useRef } from "react"
+import React, { useCallback, useEffect, useRef } from "react"
 import { BackHandler } from "react-native"
 import { Image as RNCImage } from "react-native-image-crop-picker"
 import { BottomTabType } from "../../Scenes/BottomTabs/BottomTabType"
@@ -80,15 +80,15 @@ export const Consignments: React.FC = () => {
   }, [initialGoPackPathString])
 
   useEffect(
-    React.useCallback(() => {
+    useCallback(() => {
       BackHandler.addEventListener("hardwareBackPress", handleBackButton)
 
       return () => BackHandler.removeEventListener("hardwareBackPress", handleBackButton)
     }, [])
   )
 
-  const handleBackButton = () => {
-    if (sellTabPropsRef.current !== null) {
+  const handleBackButton = useCallback(() => {
+    if (sellTabPropsRef.current) {
       switchTab(sellTabPropsRef.current)
       GlobalStore.actions.bottomTabs.setTabProps({ tab: "sell", props: {} })
     } else {
@@ -96,7 +96,7 @@ export const Consignments: React.FC = () => {
     }
 
     return true
-  }
+  }, [sellTabPropsRef.current])
 
   return <ConsignmentsHomeQueryRenderer />
 }

--- a/src/lib/Scenes/Consignments/index.tsx
+++ b/src/lib/Scenes/Consignments/index.tsx
@@ -62,21 +62,21 @@ export interface ConsignmentSetup {
   editionScreenViewed?: boolean
 }
 
-export interface GlobalStoreData {
+export interface SellTabProps {
   initialGoBackPath?: BottomTabType
 }
 
 export const Consignments: React.FC = () => {
-  const globalStoreData = GlobalStore.useAppState((state) => {
+  const sellTabProps = GlobalStore.useAppState((state) => {
     return state.bottomTabs.sessionState.tabProps.sell ?? {}
-  }) as GlobalStoreData
+  }) as SellTabProps
 
-  const initialGoPackPathString = globalStoreData?.initialGoBackPath ?? null
+  const initialGoPackPathString = sellTabProps?.initialGoBackPath ?? null
 
-  const globalStoreDataRef = useRef<BottomTabType | null>(null)
+  const sellTabPropsRef = useRef<BottomTabType | null>(null)
 
   useEffect(() => {
-    globalStoreDataRef.current = initialGoPackPathString
+    sellTabPropsRef.current = initialGoPackPathString
   }, [initialGoPackPathString])
 
   useEffect(
@@ -88,8 +88,8 @@ export const Consignments: React.FC = () => {
   )
 
   const handleBackButton = () => {
-    if (globalStoreDataRef.current !== null) {
-      switchTab(globalStoreDataRef.current)
+    if (sellTabPropsRef.current !== null) {
+      switchTab(sellTabPropsRef.current)
       GlobalStore.actions.bottomTabs.setTabProps({ tab: "sell", props: {} })
     } else {
       goBack()

--- a/src/lib/Scenes/Consignments/index.tsx
+++ b/src/lib/Scenes/Consignments/index.tsx
@@ -63,7 +63,7 @@ export interface ConsignmentSetup {
 }
 
 export interface SellTabProps {
-  initialGoBackPath?: BottomTabType
+  overwriteHardwareBackButtonPath?: BottomTabType
 }
 
 export const Consignments: React.FC = () => {
@@ -71,13 +71,13 @@ export const Consignments: React.FC = () => {
     return state.bottomTabs.sessionState.tabProps.sell ?? {}
   }) as SellTabProps
 
-  const initialGoBackPathString = sellTabProps?.initialGoBackPath ?? null
+  const overwriteHardwareBackButtonPath = sellTabProps?.overwriteHardwareBackButtonPath ?? null
 
   const sellTabPropsRef = useRef<BottomTabType | null>(null)
 
   useEffect(() => {
-    sellTabPropsRef.current = initialGoBackPathString
-  }, [initialGoBackPathString])
+    sellTabPropsRef.current = overwriteHardwareBackButtonPath
+  }, [overwriteHardwareBackButtonPath])
 
   useEffect(
     useCallback(() => {

--- a/src/lib/Scenes/Consignments/index.tsx
+++ b/src/lib/Scenes/Consignments/index.tsx
@@ -1,5 +1,9 @@
-import React from "react"
+import { goBack, switchTab } from "lib/navigation/navigate"
+import { GlobalStore } from "lib/store/GlobalStore"
+import React, { useEffect, useRef } from "react"
+import { BackHandler } from "react-native"
 import { Image as RNCImage } from "react-native-image-crop-picker"
+import { BottomTabType } from "../../Scenes/BottomTabs/BottomTabType"
 import { ConsignmentsHomeQueryRenderer } from "./ConsignmentsHome/ConsignmentsHome"
 
 /** The metadata for a consigned work */
@@ -58,6 +62,41 @@ export interface ConsignmentSetup {
   editionScreenViewed?: boolean
 }
 
+export interface GlobalStoreData {
+  initialGoBackPath?: BottomTabType
+}
+
 export const Consignments: React.FC = () => {
+  const globalStoreData = GlobalStore.useAppState((state) => {
+    return state.bottomTabs.sessionState.tabProps.sell ?? {}
+  }) as GlobalStoreData
+
+  const initialGoPackPathString = globalStoreData?.initialGoBackPath ?? null
+
+  const globalStoreDataRef = useRef<BottomTabType | null>(null)
+
+  useEffect(() => {
+    globalStoreDataRef.current = initialGoPackPathString
+  }, [initialGoPackPathString])
+
+  useEffect(
+    React.useCallback(() => {
+      BackHandler.addEventListener("hardwareBackPress", handleBackButton)
+
+      return () => BackHandler.removeEventListener("hardwareBackPress", handleBackButton)
+    }, [])
+  )
+
+  const handleBackButton = () => {
+    if (globalStoreDataRef.current !== null) {
+      switchTab(globalStoreDataRef.current)
+      GlobalStore.actions.bottomTabs.setTabProps({ tab: "sell", props: {} })
+    } else {
+      goBack()
+    }
+
+    return true
+  }
+
   return <ConsignmentsHomeQueryRenderer />
 }

--- a/src/lib/Scenes/Consignments/index.tsx
+++ b/src/lib/Scenes/Consignments/index.tsx
@@ -71,13 +71,13 @@ export const Consignments: React.FC = () => {
     return state.bottomTabs.sessionState.tabProps.sell ?? {}
   }) as SellTabProps
 
-  const initialGoPackPathString = sellTabProps?.initialGoBackPath ?? null
+  const initialGoBackPathString = sellTabProps?.initialGoBackPath ?? null
 
   const sellTabPropsRef = useRef<BottomTabType | null>(null)
 
   useEffect(() => {
-    sellTabPropsRef.current = initialGoPackPathString
-  }, [initialGoPackPathString])
+    sellTabPropsRef.current = initialGoBackPathString
+  }, [initialGoBackPathString])
 
   useEffect(
     useCallback(() => {

--- a/src/lib/navigation/navigate.ts
+++ b/src/lib/navigation/navigate.ts
@@ -59,7 +59,7 @@ export async function navigate(url: string, options: { modal?: boolean; passProp
     // this view is one of our root tab views, e.g. home, search, etc.
     // switch to the tab, pop the stack, and scroll to the top.
     await LegacyNativeModules.ARScreenPresenterModule.popToRootAndScrollToTop(module.options.isRootViewForTabName)
-    switchTab(module.options.isRootViewForTabName, result.params)
+    switchTab(module.options.isRootViewForTabName, screenDescriptor.props)
   } else {
     const selectedTab = unsafe__getSelectedTab()
     if (module.options.onlyShowInTabName) {


### PR DESCRIPTION
The type of this PR is: **fix**

This PR resolves [CX-1289]

### Description

I fixed an issue where pressing the android native button back would return us to the home tab. Now, if we switched to the sales tab from the search tab when we click the android native back button, we return to the search tab:

https://user-images.githubusercontent.com/30176348/120526543-f75c2080-c3e1-11eb-81be-89dc211f38b3.mov

### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-1289]: https://artsyproduct.atlassian.net/browse/CX-1289