### PR TITLE
fix: prevent home screen placeholders from rerendering

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -50,7 +50,7 @@ upcoming:
     - Add saved search banner (behind feature flag) - dzmitry tratsiak
     - Add articles rail to home screen - ole
     - Update articles rail design on artist overview screen - ole
-
+    - Fix home screen placeholder changing with bug 🎉 - ole
 releases:
   - version: 6.9.3
     date: June 1, 2021

--- a/src/lib/Scenes/Home/Home.tsx
+++ b/src/lib/Scenes/Home/Home.tsx
@@ -22,7 +22,7 @@ import { Home_featured } from "__generated__/Home_featured.graphql"
 import { AboveTheFoldFlatList } from "lib/Components/AboveTheFoldFlatList"
 import { GlobalStore, useFeatureFlag } from "lib/store/GlobalStore"
 import { isPad } from "lib/utils/hardware"
-import { PlaceholderBox, PlaceholderText } from "lib/utils/placeholders"
+import { PlaceholderBox, PlaceholderText, RandomWidthPlaceholderText, useMemoizedRandom } from "lib/utils/placeholders"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "lib/utils/track"
 import { ViewingRoomsHomeRail } from "../ViewingRoom/Components/ViewingRoomsHomeRail"
@@ -251,9 +251,6 @@ export const HomeFragmentContainer = createRefetchContainer(
 )
 
 const HomePlaceholder: React.FC<{}> = () => {
-  // We use Math.random() here instead of PlaceholderRaggedText because its random
-  // length is too deterministic, and we don't have any snapshot tests to worry about.
-
   const viewingRoomsEchoFlag = useFeatureFlag("AREnableViewingRooms")
 
   return (
@@ -270,15 +267,15 @@ const HomePlaceholder: React.FC<{}> = () => {
           times(2).map((r) => (
             <Box key={r} ml={2} mr={2}>
               <Spacer mb={3} />
-              <PlaceholderText width={100 + Math.random() * 100} />
+              <RandomWidthPlaceholderText minWidth={100} maxWidth={200} />
               <Flex flexDirection="row" mt={1}>
                 <Join separator={<Spacer width={15} />}>
-                  {times(3 + Math.random() * 10).map((index) => (
+                  {times(3 + useMemoizedRandom() * 10).map((index) => (
                     <Flex key={index}>
                       <PlaceholderBox height={120} width={120} />
                       <Spacer mb={2} />
                       <PlaceholderText width={120} />
-                      <PlaceholderText width={30 + Math.random() * 60} />
+                      <RandomWidthPlaceholderText minWidth={30} maxWidth={90} />
                     </Flex>
                   ))}
                 </Join>
@@ -291,7 +288,7 @@ const HomePlaceholder: React.FC<{}> = () => {
         {/* Larger tiles to mimic the fairs, sales, and collections rails */}
         <Box ml={2} mr={2}>
           <Spacer mb={3} />
-          <PlaceholderText width={100 + Math.random() * 100} />
+          <RandomWidthPlaceholderText minWidth={100} maxWidth={200} />
           <Flex flexDirection="row" mt={1}>
             <Join separator={<Spacer width={15} />}>
               {times(10).map((index) => (
@@ -304,7 +301,7 @@ const HomePlaceholder: React.FC<{}> = () => {
 
         {!!viewingRoomsEchoFlag && (
           <Flex ml="2" mt="3">
-            <PlaceholderText width={100 + Math.random() * 100} marginBottom={20} />
+            <RandomWidthPlaceholderText minWidth={100} maxWidth={200} marginBottom={20} />
             <Flex flexDirection="row">
               {times(4).map((i) => (
                 <PlaceholderBox key={i} width={280} height={370} marginRight={15} />

--- a/src/lib/utils/placeholders.tsx
+++ b/src/lib/utils/placeholders.tsx
@@ -69,6 +69,20 @@ const TEXT_MARGIN = 7
 export const PlaceholderText: React.FC<ViewStyle> = ({ ...props }) => {
   return <PlaceholderBox height={TEXT_HEIGHT} marginBottom={TEXT_MARGIN} {...props} />
 }
+
+export const useMemoizedRandom = () => useMemo(Math.random, [])
+
+/**
+ * Placeholder with memoized random with between `minWidth` and `maxWidth`.
+ */
+export const RandomWidthPlaceholderText: React.FC<ViewStyle & { minWidth: number; maxWidth: number }> = ({
+  minWidth,
+  maxWidth,
+  ...props
+}) => {
+  return <PlaceholderText width={minWidth + useMemoizedRandom() * (maxWidth - minWidth)} {...props} />
+}
+
 const BUTTON_HEIGHT = 42
 export const PlaceholderButton: React.FC<ViewStyle> = ({ ...props }) => {
   return <PlaceholderBox height={BUTTON_HEIGHT} {...props} />


### PR DESCRIPTION
The type of this PR is: Bugfix

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [CX-434]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1027]

### Description

Prevent home screen placeholders from rerendering and changing the size before the real content is visible

https://user-images.githubusercontent.com/4691889/120608205-38d7e480-c451-11eb-9577-86d6a53364b3.mp4


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434

[CX-1027]: https://artsyproduct.atlassian.net/browse/CX-1027