### PR TITLE
fix: wrong displaying in Order History when fields are too long (PX-4065)

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -13,6 +13,7 @@ upcoming:
     - Add Saved Search feature flag - kizito
     - Send only changed filter params in the analytics event - dzmitry tratsiak
   user_facing:
+    - Fix wrong displaying in Order History when fields are too long - Serge0n
     - Add order details skeleton (behind feature flag) - Serge0n
     - Fix wrong input font on android - dzmitry
     - Fix home screen load failure on logout - brian

--- a/src/lib/Scenes/OrderHistory/OrderHistoryRow.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderHistoryRow.tsx
@@ -33,33 +33,31 @@ export const OrderHistoryRow: React.FC<OrderHistoryRowProps> = ({ order }) => {
               <Box width={5} height={5} backgroundColor="black10" data-test-id="image-box" />
             )}
           </Flex>
-          <Box flexGrow={1}>
-            <Text variant="mediumText" data-test-id="artist-names">
+          <Flex width="50%" flexGrow={1} mr={2}>
+            <Text variant="mediumText" data-test-id="artist-names" ellipsizeMode="tail" numberOfLines={1}>
               {artwork?.artistNames}
             </Text>
-            <Text variant="caption" color="black60" data-test-id="partner-name">
+            <Text variant="caption" color="black60" data-test-id="partner-name" ellipsizeMode="tail" numberOfLines={1}>
               {artwork?.partner?.name}
             </Text>
             <Text variant="caption" color="black60" data-test-id="date">
               {moment(order.createdAt).format("l")}
             </Text>
-          </Box>
-          <Box>
-            <Flex justifyContent="flex-end">
-              <Text textAlign="right" variant="text" data-test-id="price">
-                {order.buyerTotal}
-              </Text>
-              <Text
-                textAlign="right"
-                variant="caption"
-                color={order.state === "CANCELED" ? "red100" : "black60"}
-                style={{ textTransform: "capitalize" }}
-                data-test-id="order-status"
-              >
-                {order.state.toLowerCase()}
-              </Text>
-            </Flex>
-          </Box>
+          </Flex>
+          <Flex>
+            <Text textAlign="right" variant="text" data-test-id="price">
+              {order.buyerTotal}
+            </Text>
+            <Text
+              textAlign="right"
+              variant="caption"
+              color={order.state === "CANCELED" ? "red100" : "black60"}
+              style={{ textTransform: "capitalize" }}
+              data-test-id="order-status"
+            >
+              {order.state.toLowerCase()}
+            </Text>
+          </Flex>
         </Flex>
       </Flex>
       {trackingId ? (


### PR DESCRIPTION
The type of this PR is: **Enhancement**

This PR resolves [PX-4065]

### Description

Fixed wrong displaying in Order History when fields are too long.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
![Запись экрана 2021-06-03 в 14 42 05](https://user-images.githubusercontent.com/55637696/120639895-89b00300-c47a-11eb-8dce-8b7ea4721a5c.gif)


[PX-4065]: https://artsyproduct.atlassian.net/browse/PX-4065