### PR TITLE
feat: create save search mutation

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -13,6 +13,7 @@ upcoming:
     - Add Saved Search feature flag - kizito
     - Send only changed filter params in the analytics event - dzmitry tratsiak
     - Update PR template to not automatically attach an unrelated Jira ticket - erikdstock
+    - Add createSavedSearch mutation - dzmitry tratsiak
   user_facing:
     - Fix wrong displaying in Order History when fields are too long - Serge0n
     - Add payment method section (behind feature flag) - irina-sid

--- a/src/__generated__/ArtistArtworksContainerCreateSavedSearchMutation.graphql.ts
+++ b/src/__generated__/ArtistArtworksContainerCreateSavedSearchMutation.graphql.ts
@@ -6,12 +6,34 @@
 import { ConcreteRequest } from "relay-runtime";
 export type CreateSavedSearchInput = {
     artistID?: string | null;
+    attributes?: SearchCriteriaAttributes | null;
     attribution?: string | null;
     category?: string | null;
     clientMutationId?: string | null;
     priceMax?: number | null;
     priceMin?: number | null;
     size?: string | null;
+};
+export type SearchCriteriaAttributes = {
+    acquireable?: boolean | null;
+    additionalGeneIDs?: Array<string> | null;
+    artistID?: string | null;
+    atAuction?: boolean | null;
+    attributionClasses?: Array<string> | null;
+    colors?: Array<string> | null;
+    heightMax?: number | null;
+    heightMin?: number | null;
+    inquireableOnly?: boolean | null;
+    locationCities?: Array<string> | null;
+    majorPeriods?: Array<string> | null;
+    materialsTerms?: Array<string> | null;
+    offerable?: boolean | null;
+    partnerIDs?: Array<string> | null;
+    priceMax?: number | null;
+    priceMin?: number | null;
+    size?: string | null;
+    widthMax?: number | null;
+    widthMin?: number | null;
 };
 export type ArtistArtworksContainerCreateSavedSearchMutationVariables = {
     input: CreateSavedSearchInput;

--- a/src/__generated__/ArtistArtworksContainerCreateSavedSearchMutation.graphql.ts
+++ b/src/__generated__/ArtistArtworksContainerCreateSavedSearchMutation.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 0a9e6fd7f91224c79b579d7c3bd40c82 */
+/* @relayHash 3842c737387a99e03f0d577d6430f91b */
 
 import { ConcreteRequest } from "relay-runtime";
 export type CreateSavedSearchInput = {
@@ -18,7 +18,9 @@ export type ArtistArtworksContainerCreateSavedSearchMutationVariables = {
 };
 export type ArtistArtworksContainerCreateSavedSearchMutationResponse = {
     readonly createSavedSearch: {
-        readonly clientMutationId: string | null;
+        readonly savedSearchOrErrors: {
+            readonly internalID?: string;
+        };
     } | null;
 };
 export type ArtistArtworksContainerCreateSavedSearchMutation = {
@@ -33,7 +35,12 @@ mutation ArtistArtworksContainerCreateSavedSearchMutation(
   $input: CreateSavedSearchInput!
 ) {
   createSavedSearch(input: $input) {
-    clientMutationId
+    savedSearchOrErrors {
+      __typename
+      ... on SearchCriteria {
+        internalID
+      }
+    }
   }
 }
 */
@@ -48,37 +55,56 @@ var v0 = [
 ],
 v1 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "input",
-        "variableName": "input"
-      }
-    ],
-    "concreteType": "CreateSavedSearchPayload",
-    "kind": "LinkedField",
-    "name": "createSavedSearch",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "clientMutationId",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
   }
-];
+],
+v2 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    }
+  ],
+  "type": "SearchCriteria",
+  "abstractKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "ArtistArtworksContainerCreateSavedSearchMutation",
-    "selections": (v1/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "CreateSavedSearchPayload",
+        "kind": "LinkedField",
+        "name": "createSavedSearch",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "savedSearchOrErrors",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Mutation",
     "abstractKey": null
   },
@@ -87,10 +113,41 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "ArtistArtworksContainerCreateSavedSearchMutation",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "CreateSavedSearchPayload",
+        "kind": "LinkedField",
+        "name": "createSavedSearch",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "savedSearchOrErrors",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "__typename",
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "id": "0a9e6fd7f91224c79b579d7c3bd40c82",
+    "id": "3842c737387a99e03f0d577d6430f91b",
     "metadata": {},
     "name": "ArtistArtworksContainerCreateSavedSearchMutation",
     "operationKind": "mutation",
@@ -98,5 +155,5 @@ return {
   }
 };
 })();
-(node as any).hash = '7024ad4eb3954afdbea20b02568bf2a9';
+(node as any).hash = '7bb63934512b019e56e62d406910e6a6';
 export default node;

--- a/src/__generated__/ArtistArtworksContainerCreateSavedSearchMutation.graphql.ts
+++ b/src/__generated__/ArtistArtworksContainerCreateSavedSearchMutation.graphql.ts
@@ -1,0 +1,102 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash 0a9e6fd7f91224c79b579d7c3bd40c82 */
+
+import { ConcreteRequest } from "relay-runtime";
+export type CreateSavedSearchInput = {
+    artistID?: string | null;
+    attribution?: string | null;
+    category?: string | null;
+    clientMutationId?: string | null;
+    priceMax?: number | null;
+    priceMin?: number | null;
+    size?: string | null;
+};
+export type ArtistArtworksContainerCreateSavedSearchMutationVariables = {
+    input: CreateSavedSearchInput;
+};
+export type ArtistArtworksContainerCreateSavedSearchMutationResponse = {
+    readonly createSavedSearch: {
+        readonly clientMutationId: string | null;
+    } | null;
+};
+export type ArtistArtworksContainerCreateSavedSearchMutation = {
+    readonly response: ArtistArtworksContainerCreateSavedSearchMutationResponse;
+    readonly variables: ArtistArtworksContainerCreateSavedSearchMutationVariables;
+};
+
+
+
+/*
+mutation ArtistArtworksContainerCreateSavedSearchMutation(
+  $input: CreateSavedSearchInput!
+) {
+  createSavedSearch(input: $input) {
+    clientMutationId
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "CreateSavedSearchPayload",
+    "kind": "LinkedField",
+    "name": "createSavedSearch",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "clientMutationId",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtistArtworksContainerCreateSavedSearchMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ArtistArtworksContainerCreateSavedSearchMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "id": "0a9e6fd7f91224c79b579d7c3bd40c82",
+    "metadata": {},
+    "name": "ArtistArtworksContainerCreateSavedSearchMutation",
+    "operationKind": "mutation",
+    "text": null
+  }
+};
+})();
+(node as any).hash = '7024ad4eb3954afdbea20b02568bf2a9';
+export default node;

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -142,7 +142,11 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
       mutation: graphql`
       mutation ArtistArtworksContainerCreateSavedSearchMutation($input: CreateSavedSearchInput!) {
         createSavedSearch(input: $input) {
-          clientMutationId
+          savedSearchOrErrors {
+            ... on SearchCriteria {
+              internalID
+            }
+          }
         }
       }
     `,

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -152,7 +152,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
     `,
       variables: {
         input: {
-          artistID: artist.slug,
+          artistID: artist.internalID,
           ...input,
         }
       },

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -1,9 +1,11 @@
 import { OwnerType } from "@artsy/cohesion"
 import { ArtistArtworks_artist } from "__generated__/ArtistArtworks_artist.graphql"
+import { ArtistArtworksContainerCreateSavedSearchMutation } from "__generated__/ArtistArtworksContainerCreateSavedSearchMutation.graphql"
 import { ArtworkFilterNavigator, FilterModalMode } from "lib/Components/ArtworkFilter"
 import {
   filterArtworksParams,
   prepareFilterArtworksParamsForInput,
+  prepareFilterParamsForSaveSearchInput,
 } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworkFiltersStoreProvider, ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
@@ -19,7 +21,7 @@ import { Schema } from "lib/utils/track"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { Box, FilterIcon, Flex, Separator, Spacer, Text, Touchable } from "palette"
 import React, { useContext, useEffect, useState } from "react"
-import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
+import { commitMutation, createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import { useTracking } from "react-tracking"
 import { SavedSearchBanner } from "./SavedSearchBanner"
 
@@ -90,6 +92,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
   const tracking = useTracking()
   const enableSavedSearch = useFeatureFlag("AREnableSavedSearch")
   const [isSavedSearch, setIsSavedSearch] = useState(false)
+  const [savingFilterSearch, setSavingFilterSearch] = useState(false)
   const appliedFilters = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
   const applyFilters = ArtworksFiltersStore.useStoreState((state) => state.applyFilters)
   const shouldShowSavedSearchBanner = enableSavedSearch && appliedFilters.length > 0
@@ -131,8 +134,45 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
     })
   }
 
+  const createSavedSearch = () => {
+    const input = prepareFilterParamsForSaveSearchInput(filterParams)
+
+    setSavingFilterSearch(true)
+    commitMutation<ArtistArtworksContainerCreateSavedSearchMutation>(relay.environment, {
+      mutation: graphql`
+      mutation ArtistArtworksContainerCreateSavedSearchMutation($input: CreateSavedSearchInput!) {
+        createSavedSearch(input: $input) {
+          clientMutationId
+        }
+      }
+    `,
+      variables: {
+        input: {
+          artistID: artist.slug,
+          ...input,
+        }
+      },
+      onCompleted: () => {
+        setSavingFilterSearch(false)
+      },
+      onError: () => {
+        setSavingFilterSearch(false)
+      }
+    })
+  }
+
   const handleSaveSearchFiltersPress = () => {
-    setIsSavedSearch(!isSavedSearch)
+    if (savingFilterSearch) {
+      return
+    }
+
+    const nextIsSavedSearchState = !isSavedSearch
+
+    if (nextIsSavedSearchState) {
+      createSavedSearch()
+    }
+
+    setIsSavedSearch(nextIsSavedSearchState)
   }
 
   const setJSX = useContext(StickyTabPageFlatListContext).setJSX
@@ -158,13 +198,13 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
           <Separator mt={2} ml={-2} width={screenWidth} />
           {!!shouldShowSavedSearchBanner && (
             <>
-              <SavedSearchBanner enabled={isSavedSearch} onPress={handleSaveSearchFiltersPress} />
+              <SavedSearchBanner enabled={isSavedSearch} onPress={handleSaveSearchFiltersPress} loading={savingFilterSearch} />
               <Separator ml={-2} width={screenWidth} />
             </>
           )}
         </Box>
       ),
-    [artworksTotal, shouldShowSavedSearchBanner, isSavedSearch]
+    [artworksTotal, shouldShowSavedSearchBanner, isSavedSearch, savingFilterSearch]
   )
 
   const filteredArtworks = () => {

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -152,8 +152,10 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
     `,
       variables: {
         input: {
-          artistID: artist.internalID,
-          ...input,
+          attributes: {
+            artistID: artist.internalID,
+            ...input,
+          }
         }
       },
       onCompleted: () => {

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -1,3 +1,4 @@
+import { CreateSavedSearchInput } from "__generated__/ArtistArtworksContainerCreateSavedSearchMutation.graphql"
 import { FilterScreen } from "lib/Components/ArtworkFilter"
 import { capitalize, compact, groupBy, isEqual, pick, sortBy } from "lodash"
 import { getFilterArtworkSizeName, LOCALIZED_UNIT, parseRange } from "./Filters/helpers"
@@ -67,17 +68,6 @@ export type FilterParams = {
 export enum ViewAsValues {
   Grid = "grid",
   List = "list",
-}
-
-export interface SaveSearchInput {
-  artistID?: string
-  attribution?: string
-  category?: string
-  clientMutationId?: string
-  priceMax?: number
-  priceMin?: number
-  size?: string
-  [key: string]: any
 }
 
 export const getSortDefaultValueByFilterType = (filterType: FilterType) => {
@@ -551,7 +541,7 @@ export const prepareFilterArtworksParamsForInput = (filters: FilterParams) => {
 
 export const parseFilterParamSize = (value: string) => {
   const size = getFilterArtworkSizeName(value)
-  const input: SaveSearchInput = {}
+  const input: CreateSavedSearchInput = {}
 
   if (size === "custom") {
     // TODO: Pass minWidth, maxWidth, minHeight, maxHeight
@@ -564,7 +554,7 @@ export const parseFilterParamSize = (value: string) => {
 
 export const parseFilterParamPrice = (value: string) => {
   const { min, max } = parseRange(value)
-  const input: SaveSearchInput = {}
+  const input: CreateSavedSearchInput = {}
 
   if (min !== "*") {
     input.priceMin = min
@@ -578,7 +568,7 @@ export const parseFilterParamPrice = (value: string) => {
 }
 
 export const prepareFilterParamsForSaveSearchInput = (filterParams: FilterParams) => {
-  let input: SaveSearchInput = {}
+  let input: CreateSavedSearchInput = {}
 
   Object.entries(filterParams).forEach((entry) => {
     const [key, value] = entry

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -1,6 +1,6 @@
 import { FilterScreen } from "lib/Components/ArtworkFilter"
 import { capitalize, compact, groupBy, isEqual, pick, sortBy } from "lodash"
-import { LOCALIZED_UNIT } from "./Filters/helpers"
+import { getFilterArtworkSizeName, LOCALIZED_UNIT, parseRange } from "./Filters/helpers"
 
 export enum FilterDisplayName {
   // artist = "Artists",
@@ -67,6 +67,17 @@ export type FilterParams = {
 export enum ViewAsValues {
   Grid = "grid",
   List = "list",
+}
+
+export interface SaveSearchInput {
+  artistID?: string
+  attribution?: string
+  category?: string
+  clientMutationId?: string
+  priceMax?: number
+  priceMin?: number
+  size?: string
+  [key: string]: any
 }
 
 export const getSortDefaultValueByFilterType = (filterType: FilterType) => {
@@ -536,4 +547,52 @@ export const prepareFilterArtworksParamsForInput = (filters: FilterParams) => {
     "tagID",
     "width",
   ])
+}
+
+export const parseFilterParamSize = (value: string) => {
+  const size = getFilterArtworkSizeName(value)
+  const input: SaveSearchInput = {}
+
+  if (size === "custom") {
+    // TODO: Pass minWidth, maxWidth, minHeight, maxHeight
+  } else if (size !== "all") {
+    input.size = size!
+  }
+
+  return input
+}
+
+export const parseFilterParamPrice = (value: string) => {
+  const { min, max } = parseRange(value)
+  const input: SaveSearchInput = {}
+
+  if (min !== "*") {
+    input.priceMin = min
+  }
+
+  if (max !== "*") {
+    input.priceMax = max
+  }
+
+  return input
+}
+
+export const prepareFilterParamsForSaveSearchInput = (filterParams: FilterParams) => {
+  let input: SaveSearchInput = {}
+
+  Object.entries(filterParams).forEach((entry) => {
+    const [key, value] = entry
+
+    if (key === FilterParamName.priceRange) {
+      input = { ...input, ...parseFilterParamPrice(value as string) }
+    } else if (key === FilterParamName.dimensionRange) {
+      input = { ...input, ...parseFilterParamSize(value as string) }
+    } else if (key === FilterParamName.attributionClass) {
+      input.attribution = (value as string[])[0]
+    } else if (key === FilterParamName.additionalGeneIDs) {
+      input.category = (value as string[])[0]
+    }
+  })
+
+  return input
 }

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -1,4 +1,4 @@
-import { CreateSavedSearchInput } from "__generated__/ArtistArtworksContainerCreateSavedSearchMutation.graphql"
+import { SearchCriteriaAttributes } from "__generated__/ArtistArtworksContainerCreateSavedSearchMutation.graphql"
 import { FilterScreen } from "lib/Components/ArtworkFilter"
 import { capitalize, compact, groupBy, isEqual, pick, sortBy } from "lodash"
 import { getFilterArtworkSizeName, LOCALIZED_UNIT, parseRange } from "./Filters/helpers"
@@ -541,7 +541,7 @@ export const prepareFilterArtworksParamsForInput = (filters: FilterParams) => {
 
 export const parseFilterParamSize = (value: string) => {
   const size = getFilterArtworkSizeName(value)
-  const input: CreateSavedSearchInput = {}
+  const input: SearchCriteriaAttributes = {}
 
   if (size === "custom") {
     // TODO: Pass minWidth, maxWidth, minHeight, maxHeight
@@ -554,7 +554,7 @@ export const parseFilterParamSize = (value: string) => {
 
 export const parseFilterParamPrice = (value: string) => {
   const { min, max } = parseRange(value)
-  const input: CreateSavedSearchInput = {}
+  const input: SearchCriteriaAttributes = {}
 
   if (min !== "*") {
     input.priceMin = min
@@ -568,7 +568,19 @@ export const parseFilterParamPrice = (value: string) => {
 }
 
 export const prepareFilterParamsForSaveSearchInput = (filterParams: FilterParams) => {
-  let input: CreateSavedSearchInput = {}
+  let input: SearchCriteriaAttributes = {}
+  const canSendWithoutChangesKeys = [
+    FilterParamName.waysToBuyBuy,
+    FilterParamName.waysToBuyBid,
+    FilterParamName.waysToBuyInquire,
+    FilterParamName.waysToBuyMakeOffer,
+    FilterParamName.additionalGeneIDs,
+    FilterParamName.colors,
+    FilterParamName.locationCities,
+    FilterParamName.timePeriod,
+    FilterParamName.materialsTerms,
+    FilterParamName.partnerIDs,
+  ]
 
   Object.entries(filterParams).forEach((entry) => {
     const [key, value] = entry
@@ -578,9 +590,9 @@ export const prepareFilterParamsForSaveSearchInput = (filterParams: FilterParams
     } else if (key === FilterParamName.dimensionRange) {
       input = { ...input, ...parseFilterParamSize(value as string) }
     } else if (key === FilterParamName.attributionClass) {
-      input.attribution = (value as string[])[0]
-    } else if (key === FilterParamName.additionalGeneIDs) {
-      input.category = (value as string[])[0]
+      input.attributionClasses = value as string[]
+    } else if (canSendWithoutChangesKeys.includes(key as FilterParamName)) {
+      input[key as keyof SearchCriteriaAttributes] = value as any
     }
   })
 

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -1,7 +1,7 @@
 import { SearchCriteriaAttributes } from "__generated__/ArtistArtworksContainerCreateSavedSearchMutation.graphql"
 import { FilterScreen } from "lib/Components/ArtworkFilter"
 import { capitalize, compact, groupBy, isEqual, pick, sortBy } from "lodash"
-import { getFilterArtworkSizeName, LOCALIZED_UNIT, parseRange } from "./Filters/helpers"
+import { LOCALIZED_UNIT, parseRange } from "./Filters/helpers"
 
 export enum FilterDisplayName {
   // artist = "Artists",
@@ -539,19 +539,6 @@ export const prepareFilterArtworksParamsForInput = (filters: FilterParams) => {
   ])
 }
 
-export const parseFilterParamSize = (value: string) => {
-  const size = getFilterArtworkSizeName(value)
-  const input: SearchCriteriaAttributes = {}
-
-  if (size === "custom") {
-    // TODO: Pass minWidth, maxWidth, minHeight, maxHeight
-  } else if (size !== "all") {
-    input.size = size!
-  }
-
-  return input
-}
-
 export const parseFilterParamPrice = (value: string) => {
   const { min, max } = parseRange(value)
   const input: SearchCriteriaAttributes = {}
@@ -587,8 +574,6 @@ export const prepareFilterParamsForSaveSearchInput = (filterParams: FilterParams
 
     if (key === FilterParamName.priceRange) {
       input = { ...input, ...parseFilterParamPrice(value as string) }
-    } else if (key === FilterParamName.dimensionRange) {
-      input = { ...input, ...parseFilterParamSize(value as string) }
     } else if (key === FilterParamName.attributionClass) {
       input.attributionClasses = value as string[]
     } else if (canSendWithoutChangesKeys.includes(key as FilterParamName)) {

--- a/src/lib/Components/ArtworkFilter/Filters/helpers.ts
+++ b/src/lib/Components/ArtworkFilter/Filters/helpers.ts
@@ -3,13 +3,6 @@ import { isNull, isUndefined, round as __round__ } from "lodash"
 
 type Numeric = "*" | number
 type Unit = "in" | "cm"
-export enum FilterArtworkSize {
-  All = "*-*",
-  Small = "*-16.0",
-  Medium = "16.0-40.0",
-  Large = "40.0-*",
-  Custom = "0-*",
-}
 
 export interface Range {
   min: Numeric

--- a/src/lib/Components/ArtworkFilter/Filters/helpers.ts
+++ b/src/lib/Components/ArtworkFilter/Filters/helpers.ts
@@ -3,6 +3,13 @@ import { isNull, isUndefined, round as __round__ } from "lodash"
 
 type Numeric = "*" | number
 type Unit = "in" | "cm"
+export enum FilterArtworkSize {
+  All = "*-*",
+  Small = "*-16.0",
+  Medium = "16.0-40.0",
+  Large = "40.0-*",
+  Custom = "0-*",
+}
 
 export interface Range {
   min: Numeric
@@ -97,4 +104,16 @@ export const parseRange = (range: string): Range => {
   })
 
   return { min: enforceNumeric(min), max: enforceNumeric(max) }
+}
+
+export const getFilterArtworkSizeName = (filterArtworkSize: string): string | null => {
+  const sizes: Record<FilterArtworkSize, string> = {
+    [FilterArtworkSize.All]: "all",
+    [FilterArtworkSize.Small]: "small",
+    [FilterArtworkSize.Medium]: "medium",
+    [FilterArtworkSize.Large]: "large",
+    [FilterArtworkSize.Custom]: "custom",
+  }
+
+  return sizes[filterArtworkSize as FilterArtworkSize] ?? null
 }

--- a/src/lib/Components/ArtworkFilter/Filters/helpers.ts
+++ b/src/lib/Components/ArtworkFilter/Filters/helpers.ts
@@ -105,15 +105,3 @@ export const parseRange = (range: string): Range => {
 
   return { min: enforceNumeric(min), max: enforceNumeric(max) }
 }
-
-export const getFilterArtworkSizeName = (filterArtworkSize: string): string | null => {
-  const sizes: Record<FilterArtworkSize, string> = {
-    [FilterArtworkSize.All]: "all",
-    [FilterArtworkSize.Small]: "small",
-    [FilterArtworkSize.Medium]: "medium",
-    [FilterArtworkSize.Large]: "large",
-    [FilterArtworkSize.Custom]: "custom",
-  }
-
-  return sizes[filterArtworkSize as FilterArtworkSize] ?? null
-}

--- a/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
@@ -9,7 +9,6 @@ import {
   prepareFilterParamsForSaveSearchInput,
   selectedOption,
 } from "../ArtworkFilterHelpers"
-import { FilterArtworkSize } from '../Filters/helpers'
 
 describe("changedFiltersParams helper", () => {
   it("when a medium selection changed and sort selection unchanged", () => {
@@ -835,7 +834,7 @@ describe("prepareFilterParamsForSaveSearchInput", () => {
       {
         displayText: "Large (over 100cm)",
         paramName: FilterParamName.dimensionRange,
-        paramValue: FilterArtworkSize.Large,
+        paramValue: "40.0-*",
       },
       {
         displayText: "Limited Edition",

--- a/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
@@ -9,7 +9,7 @@ import {
   prepareFilterParamsForSaveSearchInput,
   selectedOption,
 } from "../ArtworkFilterHelpers"
-import { FilterArtworkSize, getFilterArtworkSizeName } from '../Filters/helpers'
+import { FilterArtworkSize } from '../Filters/helpers'
 
 describe("changedFiltersParams helper", () => {
   it("when a medium selection changed and sort selection unchanged", () => {
@@ -826,32 +826,6 @@ describe("prepareFilterArtworksParamsForInput", () => {
       priceRange: "*-*",
       sort: "-decayed_merch",
     })
-  })
-})
-
-describe("getFilterArtworkSizeName", () => {
-  it(`returns "small" for the value "*-16.0"`, () => {
-    expect(getFilterArtworkSizeName(FilterArtworkSize.Small)).toEqual("small")
-  })
-
-  it(`returns "medium" for the value "16.0-40.0"`, () => {
-    expect(getFilterArtworkSizeName(FilterArtworkSize.Medium)).toEqual("medium")
-  })
-
-  it(`returns "large" for the value "40.0-*"`, () => {
-    expect(getFilterArtworkSizeName(FilterArtworkSize.Large)).toEqual("large")
-  })
-
-  it(`returns "custom" for the value "0-*"`, () => {
-    expect(getFilterArtworkSizeName(FilterArtworkSize.Custom)).toEqual("custom")
-  })
-
-  it(`returns "all" for the value "*-*"`, () => {
-    expect(getFilterArtworkSizeName(FilterArtworkSize.All)).toEqual("all")
-  })
-
-  it(`returns "null" for the unknown value`, () => {
-    expect(getFilterArtworkSizeName("some-custom-value")).toBeNull()
   })
 })
 

--- a/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
@@ -856,15 +856,54 @@ describe("prepareFilterParamsForSaveSearchInput", () => {
         displayText: "Paper",
         paramName: FilterParamName.materialsTerms,
         paramValue: ["paper"],
-      }
+      },
+      {
+        displayText: "Bid",
+        paramName: FilterParamName.waysToBuyBid,
+        paramValue: true,
+      },
+      {
+        displayText: "London, United Kingdom",
+        paramName: FilterParamName.locationCities,
+        paramValue: ["London, United Kingdom"]
+      },
+      {
+        displayText: "1990-1999",
+        paramName: FilterParamName.timePeriod,
+        paramValue: ["1990"]
+      },
+      {
+        displayText: "Yellow, Red",
+        paramName: FilterParamName.colors,
+        paramValue: ["yellow", "red"]
+      },
+      {
+        displayText: "Cypress Test Partner [For Automated Testing Purposes], Tate Ward Auctions",
+        paramName: FilterParamName.partnerIDs,
+        paramValue: [
+          "cypress-test-partner-for-automated-testing-purposes",
+          "tate-ward-auctions"
+        ]
+      },
     ]);
 
     expect(prepareFilterParamsForSaveSearchInput(filters)).toEqual({
       priceMin: 5000,
       priceMax: 10000,
-      size: "large",
-      attribution: "limited edition",
-      category: "prints",
+      attributionClasses: ["limited edition"],
+      additionalGeneIDs: ["prints"],
+      acquireable: false,
+      atAuction: true,
+      inquireableOnly: false,
+      offerable: false,
+      majorPeriods: ["1990"],
+      colors: ["yellow", "red"],
+      locationCities: ["London, United Kingdom"],
+      materialsTerms: ["paper"],
+      partnerIDs: [
+        "cypress-test-partner-for-automated-testing-purposes",
+        "tate-ward-auctions"
+      ],
     })
   })
 
@@ -880,6 +919,10 @@ describe("prepareFilterParamsForSaveSearchInput", () => {
     expect(prepareFilterParamsForSaveSearchInput(filters)).toEqual({
       priceMin: 1000,
       priceMax: 5000,
+      acquireable: false,
+      atAuction: false,
+      inquireableOnly: false,
+      offerable: false,
     })
   })
 
@@ -894,20 +937,10 @@ describe("prepareFilterParamsForSaveSearchInput", () => {
 
     expect(prepareFilterParamsForSaveSearchInput(filters)).toEqual({
       priceMin: 50000,
-    })
-  })
-
-  it("returns size field if only the size filter is specified", () => {
-    const filters = filterArtworksParams([
-      {
-        displayText: "Large (over 100cm)",
-        paramName: FilterParamName.dimensionRange,
-        paramValue: FilterArtworkSize.Large,
-      },
-    ]);
-
-    expect(prepareFilterParamsForSaveSearchInput(filters)).toEqual({
-      size: "large",
+      acquireable: false,
+      atAuction: false,
+      inquireableOnly: false,
+      offerable: false,
     })
   })
 })

--- a/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
@@ -8,6 +8,7 @@ import {
   prepareFilterArtworksParamsForInput,
   selectedOption,
 } from "../ArtworkFilterHelpers"
+import { FilterArtworkSize, getFilterArtworkSizeName } from '../Filters/helpers'
 
 describe("changedFiltersParams helper", () => {
   it("when a medium selection changed and sort selection unchanged", () => {
@@ -824,5 +825,31 @@ describe("prepareFilterArtworksParamsForInput", () => {
       priceRange: "*-*",
       sort: "-decayed_merch",
     })
+  })
+})
+
+describe("getFilterArtworkSizeName", () => {
+  it(`returns "small" for the value "*-16.0"`, () => {
+    expect(getFilterArtworkSizeName(FilterArtworkSize.Small)).toEqual("small")
+  })
+
+  it(`returns "medium" for the value "16.0-40.0"`, () => {
+    expect(getFilterArtworkSizeName(FilterArtworkSize.Medium)).toEqual("medium")
+  })
+
+  it(`returns "large" for the value "40.0-*"`, () => {
+    expect(getFilterArtworkSizeName(FilterArtworkSize.Large)).toEqual("large")
+  })
+
+  it(`returns "custom" for the value "0-*"`, () => {
+    expect(getFilterArtworkSizeName(FilterArtworkSize.Custom)).toEqual("custom")
+  })
+
+  it(`returns "all" for the value "*-*"`, () => {
+    expect(getFilterArtworkSizeName(FilterArtworkSize.All)).toEqual("all")
+  })
+
+  it(`returns "null" for the unknown value`, () => {
+    expect(getFilterArtworkSizeName("some-custom-value")).toBeNull()
   })
 })

--- a/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
@@ -6,6 +6,7 @@ import {
   FilterParamName,
   FilterParams,
   prepareFilterArtworksParamsForInput,
+  prepareFilterParamsForSaveSearchInput,
   selectedOption,
 } from "../ArtworkFilterHelpers"
 import { FilterArtworkSize, getFilterArtworkSizeName } from '../Filters/helpers'
@@ -851,5 +852,88 @@ describe("getFilterArtworkSizeName", () => {
 
   it(`returns "null" for the unknown value`, () => {
     expect(getFilterArtworkSizeName("some-custom-value")).toBeNull()
+  })
+})
+
+describe("prepareFilterParamsForSaveSearchInput", () => {
+  it("returns fields in the CreateSavedSearchInput format", () => {
+    const filters = filterArtworksParams([
+      {
+        displayText: "Large (over 100cm)",
+        paramName: FilterParamName.dimensionRange,
+        paramValue: FilterArtworkSize.Large,
+      },
+      {
+        displayText: "Limited Edition",
+        paramName: FilterParamName.attributionClass,
+        paramValue: ["limited edition"],
+      },
+      {
+        displayText: "$5,000-10,000",
+        paramName: FilterParamName.priceRange,
+        paramValue: "5000-10000",
+      },
+      {
+        displayText: "Prints",
+        paramName: FilterParamName.additionalGeneIDs,
+        paramValue: ["prints"],
+      },
+      {
+        displayText: "Paper",
+        paramName: FilterParamName.materialsTerms,
+        paramValue: ["paper"],
+      }
+    ]);
+
+    expect(prepareFilterParamsForSaveSearchInput(filters)).toEqual({
+      priceMin: 5000,
+      priceMax: 10000,
+      size: "large",
+      attribution: "limited edition",
+      category: "prints",
+    })
+  })
+
+  it("returns minPrice and maxPrice fields if only the price filter is selected", () => {
+    const filters = filterArtworksParams([
+      {
+        displayText: "$1,000-5,000",
+        paramName: FilterParamName.priceRange,
+        paramValue: "1000-5000",
+      },
+    ]);
+
+    expect(prepareFilterParamsForSaveSearchInput(filters)).toEqual({
+      priceMin: 1000,
+      priceMax: 5000,
+    })
+  })
+
+  it("returns minPrice field if only the minimum price filter is specified", () => {
+    const filters = filterArtworksParams([
+      {
+        displayText: "$50,000+",
+        paramName: FilterParamName.priceRange,
+        paramValue: "50000-*",
+      },
+    ]);
+
+    expect(prepareFilterParamsForSaveSearchInput(filters)).toEqual({
+      priceMin: 50000,
+    })
+  })
+
+  it("returns size field if only the size filter is specified", () => {
+    const filters = filterArtworksParams([
+      {
+        displayText: "Large (over 100cm)",
+        paramName: FilterParamName.dimensionRange,
+        paramValue: FilterArtworkSize.Large,
+      },
+    ]);
+
+    expect(prepareFilterParamsForSaveSearchInput(filters)).toEqual({
+      size: "large",
+    })
   })
 })


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR resolves [FX-2971]

### Description
As an admin,
When I toggle the on/off switch on the saved search banner
A new searchCriteria and userSearchCriteria are created in Gravity
With the exact combination of filters I have selected in the UI

#### Acceptance criteria:
* Toggling the switch "on" _executes the mutation_
* For the purposes of this ticket, it's sufficient to check that the `searchCriteria` and `userSearchCriteria` were created using a console
* _Not in scope_: handling failure
* _Not in scope_: preserving banner "on" state on reload/reapplication of same filters
* _Not in scope_: deletion of previously saved searchCritera on toggle off

#### Demo

https://user-images.githubusercontent.com/3513494/120678920-4917b000-c4a1-11eb-8042-5fb55b7ee6b3.mp4

https://user-images.githubusercontent.com/3513494/120678945-50d75480-c4a1-11eb-9afb-42cd2a8044d5.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2971]: https://artsyproduct.atlassian.net/browse/FX-2971