### PR TITLE
fix: show approved cta when fulfilled

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -60,7 +60,6 @@ upcoming:
     - Specified a more specific error for logging in with Apple or Facebook - stas hanchar
     - fix inaccurate validators for artwork submission - yauheni
     - Check saved search when the user applied the filter - dzmitry tratsiak
-    - Specified a more specific error for logging in with Apple or Facebook - stas hanchar
     - Continue to show the offer approved banner in an inquiry offer conversation after fulfillment - erikdstock
 
 releases:

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -60,6 +60,8 @@ upcoming:
     - Specified a more specific error for logging in with Apple or Facebook - stas hanchar
     - fix inaccurate validators for artwork submission - yauheni
     - Check saved search when the user applied the filter - dzmitry tratsiak
+    - Specified a more specific error for logging in with Apple or Facebook - stas hanchar
+    - Continue to show the offer approved banner in an inquiry offer conversation after fulfillment - erikdstock
 
 releases:
   - version: 6.9.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -689,14 +689,7 @@ DEPENDENCIES:
   - Yoga (from `./node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/artsy/Specs.git:
-    - Aerodramus
-    - "Artsy+UIColors"
-    - "Artsy+UIFonts"
-    - "Artsy+UILabels"
-    - Artsy-UIButtons
-    - Extraction
-  trunk:
+  https://cdn.cocoapods.org/:
     - AFNetworkActivityLogger
     - AFNetworking
     - Analytics
@@ -753,6 +746,13 @@ SPEC REPOS:
     - "UIView+BooleanAnimations"
     - "XCTest+OHHTTPStubSuiteCleanUp"
     - YogaKit
+  https://github.com/artsy/Specs.git:
+    - Aerodramus
+    - "Artsy+UIColors"
+    - "Artsy+UIFonts"
+    - "Artsy+UILabels"
+    - Artsy-UIButtons
+    - Extraction
 
 EXTERNAL SOURCES:
   AFOAuth1Client:

--- a/src/lib/Scenes/Inbox/Components/Conversations/ConversationCTA.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/ConversationCTA.tsx
@@ -54,13 +54,10 @@ export const ConversationCTA: React.FC<Props> = ({ conversation, show }) => {
         }
       } else if (state === "FULFILLED") {
         kind = "OFFER_ACCEPTED"
-      } else if (state === "APPROVED" && lastOffer?.fromParticipant === "BUYER") {
-        kind = "OFFER_ACCEPTED"
-      } else if (state === "APPROVED" && lastOffer?.fromParticipant === "SELLER" && lastOffer?.definesTotal) {
-        // green CTA. Offer accepted. This appears when collector confirms totals on an accepted provisional offer
-        kind = "PROVISIONAL_OFFER_ACCEPTED"
+      } else if (state === "APPROVED") {
+        const isProvisionalOffer = lastOffer?.fromParticipant === "SELLER" && lastOffer?.definesTotal
+        kind = isProvisionalOffer ? "PROVISIONAL_OFFER_ACCEPTED" : "OFFER_ACCEPTED"
       }
-
       CTA = kind && <ReviewOfferButton kind={kind} activeOrder={activeOrder} conversationID={conversationID} />
     }
   }

--- a/src/lib/Scenes/Inbox/Components/Conversations/ConversationCTA.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/ConversationCTA.tsx
@@ -52,6 +52,8 @@ export const ConversationCTA: React.FC<Props> = ({ conversation, show }) => {
             kind = "OFFER_RECEIVED"
           }
         }
+      } else if (state === "FULFILLED") {
+        kind = "OFFER_ACCEPTED"
       } else if (state === "APPROVED" && lastOffer?.fromParticipant === "BUYER") {
         kind = "OFFER_ACCEPTED"
       } else if (state === "APPROVED" && lastOffer?.fromParticipant === "SELLER" && lastOffer?.definesTotal) {

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/ConversationCTA-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/ConversationCTA-tests.tsx
@@ -150,6 +150,15 @@ describe("ConversationCTA", () => {
       expectReviewOfferButton(wrapper, { bg: "green100", strings: ["Offer Accepted"], Icon: MoneyFillIcon })
     })
 
+    it("shows the 'approved' banner for fulfilled offers", () => {
+      const wrapper = getWrapperWithOrders({
+        state: "FULFILLED",
+        lastOffer: { fromParticipant: "BUYER" },
+      })
+
+      expectReviewOfferButton(wrapper, { bg: "green100", strings: ["Offer Accepted"], Icon: MoneyFillIcon })
+    })
+
     it("shows counter received - confirm total when offer defines total and amount changes", () => {
       const wrapper = getWrapperWithOrders({
         state: "SUBMITTED",

--- a/src/lib/Scenes/Inbox/Components/Conversations/__tests__/ConversationCTA-tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/__tests__/ConversationCTA-tests.tsx
@@ -141,7 +141,7 @@ describe("ConversationCTA", () => {
       expectReviewOfferButton(wrapper, { bg: "copper100", strings: ["Offer Received"], Icon: AlertCircleFillIcon })
     })
 
-    it("shows correct message for accepted offers", () => {
+    it("shows correct message for an offer accepted by the buyer", () => {
       const wrapper = getWrapperWithOrders({
         state: "APPROVED",
         lastOffer: { fromParticipant: "BUYER" },
@@ -150,10 +150,10 @@ describe("ConversationCTA", () => {
       expectReviewOfferButton(wrapper, { bg: "green100", strings: ["Offer Accepted"], Icon: MoneyFillIcon })
     })
 
-    it("shows the 'approved' banner for fulfilled offers", () => {
+    it("shows correct message for an offer accepted by the seller that does not define total (change amount)", () => {
       const wrapper = getWrapperWithOrders({
-        state: "FULFILLED",
-        lastOffer: { fromParticipant: "BUYER" },
+        state: "APPROVED",
+        lastOffer: { fromParticipant: "SELLER", definesTotal: false },
       })
 
       expectReviewOfferButton(wrapper, { bg: "green100", strings: ["Offer Accepted"], Icon: MoneyFillIcon })
@@ -170,6 +170,15 @@ describe("ConversationCTA", () => {
         strings: ["Counteroffer Received", "Confirm Total"],
         Icon: AlertCircleFillIcon,
       })
+    })
+
+    it("shows the 'approved' banner for fulfilled offers", () => {
+      const wrapper = getWrapperWithOrders({
+        state: "FULFILLED",
+        lastOffer: { fromParticipant: "BUYER" },
+      })
+
+      expectReviewOfferButton(wrapper, { bg: "green100", strings: ["Offer Accepted"], Icon: MoneyFillIcon })
     })
 
     it("shows accepted  - confirm total when offer defines total and amount stays the same", () => {


### PR DESCRIPTION
The type of this PR is: **fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

This PR resolves [PURCHASE-2681] by continuing to show the offer approved CTA when an order has been fulfilled. It also corrects a likely bug where we will not show any CTA for an offer approved by the seller that does not define the order total (ie, the total was already available).

### Description

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[PURCHASE-2681]: https://artsyproduct.atlassian.net/browse/PURCHASE-2681