### PR TITLE
chore: update pr template jira reference

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -12,6 +12,7 @@ upcoming:
     - Replace "color" filter with "colors" filter - dzmitry tratsiak
     - Add Saved Search feature flag - kizito
     - Send only changed filter params in the analytics event - dzmitry tratsiak
+    - Update PR template to not automatically attach an unrelated Jira ticket - erikdstock
   user_facing:
     - Fix wrong displaying in Order History when fields are too long - Serge0n
     - Add payment method section (behind feature flag) - irina-sid

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -2,10 +2,10 @@ The type of this PR is: **TYPE**
 
 <!-- Bugfix/Feature/Enhancement/Documentation -->
 
-<!-- If applicable, write the Jira ticket number in square brackets e.g. [CX-434]
+<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
      The Jira integration will turn it into a clickable link for you. -->
 
-This PR resolves [CX-]
+This PR resolves []
 
 ### Description
 


### PR DESCRIPTION
The type of this PR is: **TYPE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [CX-434]
     The Jira integration will turn it into a clickable link for you. -->

This PR removes the PR template reference to CX-434 in the comment above this line, which causes Peril to attach an unrelated ticket to every PR.

### Description

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

In the PR description below is the link that was automatically attached (along with the `jira synced` label): 

[CX-434]: https://artsyproduct.atlassian.net/browse/CX-434