### PR TITLE
feat: delete saved search mutation

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -15,6 +15,7 @@ upcoming:
     - Send only changed filter params in the analytics event - dzmitry tratsiak
     - Update PR template to not automatically attach an unrelated Jira ticket - erikdstock
     - Add createSavedSearch mutation - dzmitry tratsiak
+    - Add deleteSavedSearch mutation - dzmitry tratsiak
   user_facing:
     - Fix wrong displaying in Order History when fields are too long - Serge0n
     - Add payment method section (behind feature flag) - irina-sid

--- a/src/__generated__/ArtistArtworksContainerDeleteSavedSearchMutation.graphql.ts
+++ b/src/__generated__/ArtistArtworksContainerDeleteSavedSearchMutation.graphql.ts
@@ -1,0 +1,154 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash cfac0c7e54c2601783e10bca99bb8db7 */
+
+import { ConcreteRequest } from "relay-runtime";
+export type DeleteSavedSearchInput = {
+    clientMutationId?: string | null;
+    searchCriteriaID: string;
+};
+export type ArtistArtworksContainerDeleteSavedSearchMutationVariables = {
+    input: DeleteSavedSearchInput;
+};
+export type ArtistArtworksContainerDeleteSavedSearchMutationResponse = {
+    readonly deleteSavedSearch: {
+        readonly savedSearchOrErrors: {
+            readonly internalID?: string;
+        };
+    } | null;
+};
+export type ArtistArtworksContainerDeleteSavedSearchMutation = {
+    readonly response: ArtistArtworksContainerDeleteSavedSearchMutationResponse;
+    readonly variables: ArtistArtworksContainerDeleteSavedSearchMutationVariables;
+};
+
+
+
+/*
+mutation ArtistArtworksContainerDeleteSavedSearchMutation(
+  $input: DeleteSavedSearchInput!
+) {
+  deleteSavedSearch(input: $input) {
+    savedSearchOrErrors {
+      __typename
+      ... on SearchCriteria {
+        internalID
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    }
+  ],
+  "type": "SearchCriteria",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtistArtworksContainerDeleteSavedSearchMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "DeleteSavedSearchPayload",
+        "kind": "LinkedField",
+        "name": "deleteSavedSearch",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "savedSearchOrErrors",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ArtistArtworksContainerDeleteSavedSearchMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "DeleteSavedSearchPayload",
+        "kind": "LinkedField",
+        "name": "deleteSavedSearch",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "savedSearchOrErrors",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "__typename",
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "cfac0c7e54c2601783e10bca99bb8db7",
+    "metadata": {},
+    "name": "ArtistArtworksContainerDeleteSavedSearchMutation",
+    "operationKind": "mutation",
+    "text": null
+  }
+};
+})();
+(node as any).hash = '38ab97f0f41ace38f49bfc35cc3d0973';
+export default node;


### PR DESCRIPTION
The type of this PR is: **FEATURE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-2973]

### Description
As an admin with the saved search flag enabled,
**When** viewing the artworks grid with an existing saved search
**I can** toggle to "off"
**And** the saved search will be deleted

#### Acceptance criteria:
* Toggling to "off" deletes UserSearchCriteria, leaves SearchCriteria intact
* Out of scope: error handling
* Out of scope: saved search persistence/finding a previously existing saved search. This ticket assumes that a user has just created a saved search by toggling "on", _then immediately toggles_ "off"

#### Demo

https://user-images.githubusercontent.com/3513494/120839344-7d5aa180-c571-11eb-9f86-4b9e85bb65a8.mp4


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2973]: https://artsyproduct.atlassian.net/browse/FX-2973