### PR TITLE
feat: check savedSearch query field

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -58,6 +58,7 @@ upcoming:
     - Change articles rail design in artist overview page - ole
     - Specified a more specific error for logging in with Apple or Facebook - stas hanchar
     - fix inaccurate validators for artwork submission - yauheni
+    - Check saved search when the user applied the filter - dzmitry tratsiak
 
 releases:
   - version: 6.9.3

--- a/src/__generated__/SavedSearchBannerCreateSavedSearchMutation.graphql.ts
+++ b/src/__generated__/SavedSearchBannerCreateSavedSearchMutation.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 3842c737387a99e03f0d577d6430f91b */
+/* @relayHash 2d4ce3cc3701a50d6da342637f2e179c */
 
 import { ConcreteRequest } from "relay-runtime";
 export type CreateSavedSearchInput = {
@@ -31,25 +31,25 @@ export type SearchCriteriaAttributes = {
     widthMax?: number | null;
     widthMin?: number | null;
 };
-export type ArtistArtworksContainerCreateSavedSearchMutationVariables = {
+export type SavedSearchBannerCreateSavedSearchMutationVariables = {
     input: CreateSavedSearchInput;
 };
-export type ArtistArtworksContainerCreateSavedSearchMutationResponse = {
+export type SavedSearchBannerCreateSavedSearchMutationResponse = {
     readonly createSavedSearch: {
         readonly savedSearchOrErrors: {
             readonly internalID?: string;
         };
     } | null;
 };
-export type ArtistArtworksContainerCreateSavedSearchMutation = {
-    readonly response: ArtistArtworksContainerCreateSavedSearchMutationResponse;
-    readonly variables: ArtistArtworksContainerCreateSavedSearchMutationVariables;
+export type SavedSearchBannerCreateSavedSearchMutation = {
+    readonly response: SavedSearchBannerCreateSavedSearchMutationResponse;
+    readonly variables: SavedSearchBannerCreateSavedSearchMutationVariables;
 };
 
 
 
 /*
-mutation ArtistArtworksContainerCreateSavedSearchMutation(
+mutation SavedSearchBannerCreateSavedSearchMutation(
   $input: CreateSavedSearchInput!
 ) {
   createSavedSearch(input: $input) {
@@ -97,7 +97,7 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "ArtistArtworksContainerCreateSavedSearchMutation",
+    "name": "SavedSearchBannerCreateSavedSearchMutation",
     "selections": [
       {
         "alias": null,
@@ -130,7 +130,7 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "ArtistArtworksContainerCreateSavedSearchMutation",
+    "name": "SavedSearchBannerCreateSavedSearchMutation",
     "selections": [
       {
         "alias": null,
@@ -165,13 +165,13 @@ return {
     ]
   },
   "params": {
-    "id": "3842c737387a99e03f0d577d6430f91b",
+    "id": "2d4ce3cc3701a50d6da342637f2e179c",
     "metadata": {},
-    "name": "ArtistArtworksContainerCreateSavedSearchMutation",
+    "name": "SavedSearchBannerCreateSavedSearchMutation",
     "operationKind": "mutation",
     "text": null
   }
 };
 })();
-(node as any).hash = '7bb63934512b019e56e62d406910e6a6';
+(node as any).hash = 'ec74f515330205f5267cbaee00cf40f3';
 export default node;

--- a/src/__generated__/SavedSearchBannerDeleteSavedSearchMutation.graphql.ts
+++ b/src/__generated__/SavedSearchBannerDeleteSavedSearchMutation.graphql.ts
@@ -1,32 +1,32 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash cfac0c7e54c2601783e10bca99bb8db7 */
+/* @relayHash 956ec3ea65b6fb1a68dabdf45a966f9f */
 
 import { ConcreteRequest } from "relay-runtime";
 export type DeleteSavedSearchInput = {
     clientMutationId?: string | null;
     searchCriteriaID: string;
 };
-export type ArtistArtworksContainerDeleteSavedSearchMutationVariables = {
+export type SavedSearchBannerDeleteSavedSearchMutationVariables = {
     input: DeleteSavedSearchInput;
 };
-export type ArtistArtworksContainerDeleteSavedSearchMutationResponse = {
+export type SavedSearchBannerDeleteSavedSearchMutationResponse = {
     readonly deleteSavedSearch: {
         readonly savedSearchOrErrors: {
             readonly internalID?: string;
         };
     } | null;
 };
-export type ArtistArtworksContainerDeleteSavedSearchMutation = {
-    readonly response: ArtistArtworksContainerDeleteSavedSearchMutationResponse;
-    readonly variables: ArtistArtworksContainerDeleteSavedSearchMutationVariables;
+export type SavedSearchBannerDeleteSavedSearchMutation = {
+    readonly response: SavedSearchBannerDeleteSavedSearchMutationResponse;
+    readonly variables: SavedSearchBannerDeleteSavedSearchMutationVariables;
 };
 
 
 
 /*
-mutation ArtistArtworksContainerDeleteSavedSearchMutation(
+mutation SavedSearchBannerDeleteSavedSearchMutation(
   $input: DeleteSavedSearchInput!
 ) {
   deleteSavedSearch(input: $input) {
@@ -74,7 +74,7 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "ArtistArtworksContainerDeleteSavedSearchMutation",
+    "name": "SavedSearchBannerDeleteSavedSearchMutation",
     "selections": [
       {
         "alias": null,
@@ -107,7 +107,7 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "ArtistArtworksContainerDeleteSavedSearchMutation",
+    "name": "SavedSearchBannerDeleteSavedSearchMutation",
     "selections": [
       {
         "alias": null,
@@ -142,13 +142,13 @@ return {
     ]
   },
   "params": {
-    "id": "cfac0c7e54c2601783e10bca99bb8db7",
+    "id": "956ec3ea65b6fb1a68dabdf45a966f9f",
     "metadata": {},
-    "name": "ArtistArtworksContainerDeleteSavedSearchMutation",
+    "name": "SavedSearchBannerDeleteSavedSearchMutation",
     "operationKind": "mutation",
     "text": null
   }
 };
 })();
-(node as any).hash = '38ab97f0f41ace38f49bfc35cc3d0973';
+(node as any).hash = '4aa47c8faec3244c12d629027d56602d';
 export default node;

--- a/src/__generated__/SavedSearchBannerQuery.graphql.ts
+++ b/src/__generated__/SavedSearchBannerQuery.graphql.ts
@@ -12,6 +12,8 @@ export type SearchCriteriaAttributes = {
     atAuction?: boolean | null;
     attributionClasses?: Array<string> | null;
     colors?: Array<string> | null;
+    dimensionScoreMax?: number | null;
+    dimensionScoreMin?: number | null;
     heightMax?: number | null;
     heightMin?: number | null;
     inquireableOnly?: boolean | null;
@@ -22,7 +24,6 @@ export type SearchCriteriaAttributes = {
     partnerIDs?: Array<string> | null;
     priceMax?: number | null;
     priceMin?: number | null;
-    size?: string | null;
     widthMax?: number | null;
     widthMin?: number | null;
 };

--- a/src/__generated__/SavedSearchBannerQuery.graphql.ts
+++ b/src/__generated__/SavedSearchBannerQuery.graphql.ts
@@ -1,0 +1,157 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash bd10b9bcddc714d41e9dd17e0a623d22 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SearchCriteriaAttributes = {
+    acquireable?: boolean | null;
+    additionalGeneIDs?: Array<string> | null;
+    artistID?: string | null;
+    atAuction?: boolean | null;
+    attributionClasses?: Array<string> | null;
+    colors?: Array<string> | null;
+    heightMax?: number | null;
+    heightMin?: number | null;
+    inquireableOnly?: boolean | null;
+    locationCities?: Array<string> | null;
+    majorPeriods?: Array<string> | null;
+    materialsTerms?: Array<string> | null;
+    offerable?: boolean | null;
+    partnerIDs?: Array<string> | null;
+    priceMax?: number | null;
+    priceMin?: number | null;
+    size?: string | null;
+    widthMax?: number | null;
+    widthMin?: number | null;
+};
+export type SavedSearchBannerQueryVariables = {
+    criteria: SearchCriteriaAttributes;
+};
+export type SavedSearchBannerQueryResponse = {
+    readonly me: {
+        readonly " $fragmentRefs": FragmentRefs<"SavedSearchBanner_me">;
+    } | null;
+};
+export type SavedSearchBannerQuery = {
+    readonly response: SavedSearchBannerQueryResponse;
+    readonly variables: SavedSearchBannerQueryVariables;
+};
+
+
+
+/*
+query SavedSearchBannerQuery(
+  $criteria: SearchCriteriaAttributes!
+) {
+  me {
+    ...SavedSearchBanner_me_1ff8oJ
+    id
+  }
+}
+
+fragment SavedSearchBanner_me_1ff8oJ on Me {
+  savedSearch(criteria: $criteria) {
+    internalID
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "criteria"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "criteria",
+    "variableName": "criteria"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SavedSearchBannerQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": (v1/*: any*/),
+            "kind": "FragmentSpread",
+            "name": "SavedSearchBanner_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SavedSearchBannerQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v1/*: any*/),
+            "concreteType": "SearchCriteria",
+            "kind": "LinkedField",
+            "name": "savedSearch",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "internalID",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "bd10b9bcddc714d41e9dd17e0a623d22",
+    "metadata": {},
+    "name": "SavedSearchBannerQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = 'c28e13298e14360bc0033208d5d6b3a9';
+export default node;

--- a/src/__generated__/SavedSearchBannerTestsQuery.graphql.ts
+++ b/src/__generated__/SavedSearchBannerTestsQuery.graphql.ts
@@ -1,0 +1,180 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash 49a9660077d5ee2cfb30cfde706fb0ee */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SearchCriteriaAttributes = {
+    acquireable?: boolean | null;
+    additionalGeneIDs?: Array<string> | null;
+    artistID?: string | null;
+    atAuction?: boolean | null;
+    attributionClasses?: Array<string> | null;
+    colors?: Array<string> | null;
+    heightMax?: number | null;
+    heightMin?: number | null;
+    inquireableOnly?: boolean | null;
+    locationCities?: Array<string> | null;
+    majorPeriods?: Array<string> | null;
+    materialsTerms?: Array<string> | null;
+    offerable?: boolean | null;
+    partnerIDs?: Array<string> | null;
+    priceMax?: number | null;
+    priceMin?: number | null;
+    size?: string | null;
+    widthMax?: number | null;
+    widthMin?: number | null;
+};
+export type SavedSearchBannerTestsQueryVariables = {
+    criteria: SearchCriteriaAttributes;
+};
+export type SavedSearchBannerTestsQueryResponse = {
+    readonly me: {
+        readonly " $fragmentRefs": FragmentRefs<"SavedSearchBanner_me">;
+    } | null;
+};
+export type SavedSearchBannerTestsQuery = {
+    readonly response: SavedSearchBannerTestsQueryResponse;
+    readonly variables: SavedSearchBannerTestsQueryVariables;
+};
+
+
+
+/*
+query SavedSearchBannerTestsQuery(
+  $criteria: SearchCriteriaAttributes!
+) {
+  me {
+    ...SavedSearchBanner_me_1ff8oJ
+    id
+  }
+}
+
+fragment SavedSearchBanner_me_1ff8oJ on Me {
+  savedSearch(criteria: $criteria) {
+    internalID
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "criteria"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "criteria",
+    "variableName": "criteria"
+  }
+],
+v2 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SavedSearchBannerTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": (v1/*: any*/),
+            "kind": "FragmentSpread",
+            "name": "SavedSearchBanner_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SavedSearchBannerTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v1/*: any*/),
+            "concreteType": "SearchCriteria",
+            "kind": "LinkedField",
+            "name": "savedSearch",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "internalID",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "49a9660077d5ee2cfb30cfde706fb0ee",
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "me": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Me"
+        },
+        "me.id": (v2/*: any*/),
+        "me.savedSearch": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SearchCriteria"
+        },
+        "me.savedSearch.internalID": (v2/*: any*/)
+      }
+    },
+    "name": "SavedSearchBannerTestsQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = 'ccd74d9b109fe4a436fbcdceeb46e417';
+export default node;

--- a/src/__generated__/SavedSearchBannerTestsQuery.graphql.ts
+++ b/src/__generated__/SavedSearchBannerTestsQuery.graphql.ts
@@ -12,6 +12,8 @@ export type SearchCriteriaAttributes = {
     atAuction?: boolean | null;
     attributionClasses?: Array<string> | null;
     colors?: Array<string> | null;
+    dimensionScoreMax?: number | null;
+    dimensionScoreMin?: number | null;
     heightMax?: number | null;
     heightMin?: number | null;
     inquireableOnly?: boolean | null;
@@ -22,7 +24,6 @@ export type SearchCriteriaAttributes = {
     partnerIDs?: Array<string> | null;
     priceMax?: number | null;
     priceMin?: number | null;
-    size?: string | null;
     widthMax?: number | null;
     widthMin?: number | null;
 };

--- a/src/__generated__/SavedSearchBanner_me.graphql.ts
+++ b/src/__generated__/SavedSearchBanner_me.graphql.ts
@@ -1,0 +1,62 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SavedSearchBanner_me = {
+    readonly savedSearch: {
+        readonly internalID: string;
+    } | null;
+    readonly " $refType": "SavedSearchBanner_me";
+};
+export type SavedSearchBanner_me$data = SavedSearchBanner_me;
+export type SavedSearchBanner_me$key = {
+    readonly " $data"?: SavedSearchBanner_me$data;
+    readonly " $fragmentRefs": FragmentRefs<"SavedSearchBanner_me">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "criteria"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "SavedSearchBanner_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "criteria",
+          "variableName": "criteria"
+        }
+      ],
+      "concreteType": "SearchCriteria",
+      "kind": "LinkedField",
+      "name": "savedSearch",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "internalID",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Me",
+  "abstractKey": null
+};
+(node as any).hash = 'ba718ab14d3a5c00afa6b2fb930f9fab';
+export default node;

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -136,7 +136,6 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
 
   useEffect(
     () => {
-      console.log('[SavedSearchBanner] setJSX rerender')
       setJSX(
         <Box backgroundColor="white" mt={2} px={2}>
           <Flex flexDirection="row" justifyContent="space-between" alignItems="center">

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -1,12 +1,9 @@
 import { OwnerType } from "@artsy/cohesion"
 import { ArtistArtworks_artist } from "__generated__/ArtistArtworks_artist.graphql"
-import { ArtistArtworksContainerCreateSavedSearchMutation } from "__generated__/ArtistArtworksContainerCreateSavedSearchMutation.graphql"
-import { ArtistArtworksContainerDeleteSavedSearchMutation } from "__generated__/ArtistArtworksContainerDeleteSavedSearchMutation.graphql"
 import { ArtworkFilterNavigator, FilterModalMode } from "lib/Components/ArtworkFilter"
 import {
   filterArtworksParams,
   prepareFilterArtworksParamsForInput,
-  prepareFilterParamsForSaveSearchInput,
 } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworkFiltersStoreProvider, ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
@@ -21,10 +18,10 @@ import { useFeatureFlag } from "lib/store/GlobalStore"
 import { Schema } from "lib/utils/track"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { Box, FilterIcon, Flex, Separator, Spacer, Text, Touchable } from "palette"
-import React, { useContext, useEffect, useState } from "react"
-import { commitMutation, createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
+import React, { useContext, useEffect, useMemo, useState } from "react"
+import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import { useTracking } from "react-tracking"
-import { SavedSearchBanner } from "./SavedSearchBanner"
+import { SavedSearchBannerQueryRender } from "./SavedSearchBanner"
 
 interface ArtworksGridProps extends InfiniteScrollGridProps {
   artist: ArtistArtworks_artist
@@ -92,18 +89,17 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
 }) => {
   const tracking = useTracking()
   const enableSavedSearch = useFeatureFlag("AREnableSavedSearch")
-  const [isSavedSearch, setIsSavedSearch] = useState(false)
-  const [savingFilterSearch, setSavingFilterSearch] = useState(false)
   const appliedFilters = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
   const applyFilters = ArtworksFiltersStore.useStoreState((state) => state.applyFilters)
   const shouldShowSavedSearchBanner = enableSavedSearch && appliedFilters.length > 0
 
   const setAggregationsAction = ArtworksFiltersStore.useStoreActions((state) => state.setAggregationsAction)
 
-  const filterParams = filterArtworksParams(appliedFilters)
+  const filterParams = useMemo(() => filterArtworksParams(appliedFilters), [appliedFilters])
   const artworks = artist.artworks
   const artworksCount = artworks?.edges?.length
   const artworksTotal = artworks?.counts?.total
+  const artistInternalId = artist.internalID
 
   useEffect(() => {
     if (applyFilters) {
@@ -135,91 +131,12 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
     })
   }
 
-  const deleteSavedSearch = (searchCriteriaID: string) => {
-    setSavingFilterSearch(true)
-    commitMutation<ArtistArtworksContainerDeleteSavedSearchMutation>(relay.environment, {
-      mutation: graphql`
-      mutation ArtistArtworksContainerDeleteSavedSearchMutation($input: DeleteSavedSearchInput!) {
-        deleteSavedSearch(input: $input) {
-          savedSearchOrErrors {
-            ... on SearchCriteria {
-              internalID
-            }
-          }
-        }
-      }
-    `,
-      variables: {
-        input: {
-          searchCriteriaID
-        }
-      },
-      onCompleted: () => {
-        setSavingFilterSearch(false)
-      },
-      onError: () => {
-        setSavingFilterSearch(false)
-      }
-    })
-  }
-
-  const createSavedSearch = () => {
-    const input = prepareFilterParamsForSaveSearchInput(filterParams)
-
-    setSavingFilterSearch(true)
-    commitMutation<ArtistArtworksContainerCreateSavedSearchMutation>(relay.environment, {
-      mutation: graphql`
-      mutation ArtistArtworksContainerCreateSavedSearchMutation($input: CreateSavedSearchInput!) {
-        createSavedSearch(input: $input) {
-          savedSearchOrErrors {
-            ... on SearchCriteria {
-              internalID
-            }
-          }
-        }
-      }
-    `,
-      variables: {
-        input: {
-          attributes: {
-            artistID: artist.internalID,
-            ...input,
-          }
-        }
-      },
-      onCompleted: (response) => {
-        setSavingFilterSearch(false)
-        const savedSearchId = response.createSavedSearch?.savedSearchOrErrors.internalID;
-
-        if (savedSearchId) {
-          deleteSavedSearch(savedSearchId)
-        }
-      },
-      onError: () => {
-        setSavingFilterSearch(false)
-      }
-    })
-  }
-
-  const handleSaveSearchFiltersPress = () => {
-    if (savingFilterSearch) {
-      return
-    }
-
-    const nextIsSavedSearchState = !isSavedSearch
-
-    if (nextIsSavedSearchState) {
-      createSavedSearch()
-    }
-
-    setIsSavedSearch(nextIsSavedSearchState)
-  }
-
   const setJSX = useContext(StickyTabPageFlatListContext).setJSX
   const screenWidth = useScreenDimensions().width
 
   useEffect(
-    () =>
+    () => {
+      console.log('[SavedSearchBanner] setJSX rerender')
       setJSX(
         <Box backgroundColor="white" mt={2} px={2}>
           <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
@@ -238,13 +155,14 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
           <Separator mt={2} ml={-2} width={screenWidth} />
           {!!shouldShowSavedSearchBanner && (
             <>
-              <SavedSearchBanner enabled={isSavedSearch} onPress={handleSaveSearchFiltersPress} loading={savingFilterSearch} />
+              <SavedSearchBannerQueryRender artistId={artistInternalId} filters={filterParams} />
               <Separator ml={-2} width={screenWidth} />
             </>
           )}
         </Box>
-      ),
-    [artworksTotal, shouldShowSavedSearchBanner, isSavedSearch, savingFilterSearch]
+      )
+    },
+    [artworksTotal, shouldShowSavedSearchBanner, artistInternalId, filterParams]
   )
 
   const filteredArtworks = () => {

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -87,7 +87,7 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({ me, attrib
   )
 }
 
-export const SavedSearchBannerContainer = createFragmentContainer(
+export const SavedSearchBannerFragmentContainer = createFragmentContainer(
   SavedSearchBanner,
   {
     me: graphql`
@@ -119,7 +119,7 @@ export const SavedSearchBannerQueryRender: React.FC<{ filters: FilterParams, art
           }
         }
       `}
-      render={({ props }) => <SavedSearchBannerContainer {...props} loading={props === null} attributes={attributes} artistId={artistId} />}
+      render={({ props }) => <SavedSearchBannerFragmentContainer {...props} loading={props === null} attributes={attributes} artistId={artistId} />}
       variables={{
         criteria: attributes
       }}

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -146,10 +146,10 @@ export const SavedSearchBannerQueryRender: React.FC<{ filters: FilterParams; art
           }
         }
       `}
-      render={({ props }) => (
+      render={({ props, error }) => (
         <SavedSearchBannerFragmentContainer
           me={props?.me ?? null}
-          loading={props === null}
+          loading={props === null && error === null}
           attributes={attributes}
           artistId={artistId}
         />

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -1,8 +1,8 @@
-import { SavedSearchBanner_me } from '__generated__/SavedSearchBanner_me.graphql'
+import { SavedSearchBanner_me } from "__generated__/SavedSearchBanner_me.graphql"
 import { SavedSearchBannerCreateSavedSearchMutation } from "__generated__/SavedSearchBannerCreateSavedSearchMutation.graphql"
 import { SavedSearchBannerDeleteSavedSearchMutation } from "__generated__/SavedSearchBannerDeleteSavedSearchMutation.graphql"
-import { SavedSearchBannerQuery, SearchCriteriaAttributes } from '__generated__/SavedSearchBannerQuery.graphql'
-import { FilterParams, prepareFilterParamsForSaveSearchInput } from 'lib/Components/ArtworkFilter/ArtworkFilterHelpers'
+import { SavedSearchBannerQuery, SearchCriteriaAttributes } from "__generated__/SavedSearchBannerQuery.graphql"
+import { FilterParams, prepareFilterParamsForSaveSearchInput } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { Button, Flex, Text } from "palette"
 import React, { useState } from "react"
@@ -25,27 +25,27 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({ me, attrib
     setSaving(true)
     commitMutation<SavedSearchBannerCreateSavedSearchMutation>(relay.environment, {
       mutation: graphql`
-      mutation SavedSearchBannerCreateSavedSearchMutation($input: CreateSavedSearchInput!) {
-        createSavedSearch(input: $input) {
-          savedSearchOrErrors {
-            ... on SearchCriteria {
-              internalID
+        mutation SavedSearchBannerCreateSavedSearchMutation($input: CreateSavedSearchInput!) {
+          createSavedSearch(input: $input) {
+            savedSearchOrErrors {
+              ... on SearchCriteria {
+                internalID
+              }
             }
           }
         }
-      }
-    `,
+      `,
       variables: {
         input: {
           attributes,
-        }
+        },
       },
       onCompleted: () => {
         setSaving(false)
       },
       onError: () => {
         setSaving(false)
-      }
+      },
     })
   }
 
@@ -53,27 +53,27 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({ me, attrib
     setSaving(true)
     commitMutation<SavedSearchBannerDeleteSavedSearchMutation>(relay.environment, {
       mutation: graphql`
-      mutation SavedSearchBannerDeleteSavedSearchMutation($input: DeleteSavedSearchInput!) {
-        deleteSavedSearch(input: $input) {
-          savedSearchOrErrors {
-            ... on SearchCriteria {
-              internalID
+        mutation SavedSearchBannerDeleteSavedSearchMutation($input: DeleteSavedSearchInput!) {
+          deleteSavedSearch(input: $input) {
+            savedSearchOrErrors {
+              ... on SearchCriteria {
+                internalID
+              }
             }
           }
         }
-      }
-    `,
+      `,
       variables: {
         input: {
-          searchCriteriaID: me!.savedSearch!.internalID
-        }
+          searchCriteriaID: me!.savedSearch!.internalID,
+        },
       },
       onCompleted: () => {
         setSaving(false)
       },
       onError: () => {
         setSaving(false)
-      }
+      },
     })
   }
 
@@ -116,22 +116,20 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({ me, attrib
   )
 }
 
-export const SavedSearchBannerFragmentContainer = createFragmentContainer(
-  SavedSearchBanner,
-  {
-    me: graphql`
-      fragment SavedSearchBanner_me on Me @argumentDefinitions(
-        criteria: { type: "SearchCriteriaAttributes" }
-      ){
-        savedSearch(criteria: $criteria) {
-          internalID
-        }
+export const SavedSearchBannerFragmentContainer = createFragmentContainer(SavedSearchBanner, {
+  me: graphql`
+    fragment SavedSearchBanner_me on Me @argumentDefinitions(criteria: { type: "SearchCriteriaAttributes" }) {
+      savedSearch(criteria: $criteria) {
+        internalID
       }
-    `,
-  },
-)
+    }
+  `,
+})
 
-export const SavedSearchBannerQueryRender: React.FC<{ filters: FilterParams, artistId: string }> = ({ filters, artistId }) => {
+export const SavedSearchBannerQueryRender: React.FC<{ filters: FilterParams; artistId: string }> = ({
+  filters,
+  artistId,
+}) => {
   const input = prepareFilterParamsForSaveSearchInput(filters)
   const attributes = {
     artistID: artistId,
@@ -148,9 +146,16 @@ export const SavedSearchBannerQueryRender: React.FC<{ filters: FilterParams, art
           }
         }
       `}
-      render={({ props }) => <SavedSearchBannerFragmentContainer me={props?.me ?? null} loading={props === null} attributes={attributes} artistId={artistId} />}
+      render={({ props }) => (
+        <SavedSearchBannerFragmentContainer
+          me={props?.me ?? null}
+          loading={props === null}
+          attributes={attributes}
+          artistId={artistId}
+        />
+      )}
       variables={{
-        criteria: attributes
+        criteria: attributes,
       }}
     />
   )

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -123,7 +123,6 @@ export const SavedSearchBannerQueryRender: React.FC<{ filters: FilterParams, art
       variables={{
         criteria: attributes
       }}
-      cacheConfig={{ force: true }}
     />
   )
 }

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -1,3 +1,4 @@
+import { captureMessage } from "@sentry/react-native"
 import { SavedSearchBanner_me } from "__generated__/SavedSearchBanner_me.graphql"
 import { SavedSearchBannerCreateSavedSearchMutation } from "__generated__/SavedSearchBannerCreateSavedSearchMutation.graphql"
 import { SavedSearchBannerDeleteSavedSearchMutation } from "__generated__/SavedSearchBannerDeleteSavedSearchMutation.graphql"
@@ -146,14 +147,24 @@ export const SavedSearchBannerQueryRender: React.FC<{ filters: FilterParams; art
           }
         }
       `}
-      render={({ props, error }) => (
-        <SavedSearchBannerFragmentContainer
-          me={props?.me ?? null}
-          loading={props === null && error === null}
-          attributes={attributes}
-          artistId={artistId}
-        />
-      )}
+      render={({ props, error }) => {
+        if (error) {
+          if (__DEV__) {
+            console.error(error)
+          } else {
+            captureMessage(error.stack!)
+          }
+        }
+
+        return (
+          <SavedSearchBannerFragmentContainer
+            me={props?.me ?? null}
+            loading={props === null && error === null}
+            attributes={attributes}
+            artistId={artistId}
+          />
+        )
+      }}
       variables={{
         criteria: attributes,
       }}

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -1,13 +1,65 @@
+import { SavedSearchBanner_me } from '__generated__/SavedSearchBanner_me.graphql'
+import { SavedSearchBannerCreateSavedSearchMutation } from "__generated__/SavedSearchBannerCreateSavedSearchMutation.graphql"
+import { SavedSearchBannerQuery, SearchCriteriaAttributes } from '__generated__/SavedSearchBannerQuery.graphql'
+import { FilterParams, prepareFilterParamsForSaveSearchInput } from 'lib/Components/ArtworkFilter/ArtworkFilterHelpers'
+import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { Button, Flex, Text } from "palette"
-import React from "react"
+import React, { useState } from "react"
+import { commitMutation, createFragmentContainer, graphql, QueryRenderer, RelayProp } from "react-relay"
 
 interface SavedSearchBannerProps {
-  enabled: boolean
+  me?: SavedSearchBanner_me | null
+  artistId: string
+  attributes: SearchCriteriaAttributes
   loading?: boolean
-  onPress: () => void
+  relay: RelayProp
 }
 
-export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({ enabled, loading, onPress }) => {
+export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({ me, attributes, loading, relay }) => {
+  const [saving, setSaving] = useState(false)
+  const enabled = !!me?.savedSearch?.internalID
+  const inProcess = loading || saving
+
+  const createSavedSearch = () => {
+    setSaving(true)
+    commitMutation<SavedSearchBannerCreateSavedSearchMutation>(relay.environment, {
+      mutation: graphql`
+      mutation SavedSearchBannerCreateSavedSearchMutation($input: CreateSavedSearchInput!) {
+        createSavedSearch(input: $input) {
+          savedSearchOrErrors {
+            ... on SearchCriteria {
+              internalID
+            }
+          }
+        }
+      }
+    `,
+      variables: {
+        input: {
+          attributes,
+        }
+      },
+      onCompleted: () => {
+        setSaving(false)
+      },
+      onError: () => {
+        setSaving(false)
+      }
+    })
+  }
+
+  const handleSaveSearchFiltersPress = () => {
+    if (inProcess) {
+      return
+    }
+
+    if (enabled) {
+      // TODO: deleteSavedSearch
+    } else {
+      createSavedSearch()
+    }
+  }
+
   return (
     <Flex
       backgroundColor="white"
@@ -23,14 +75,55 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({ enabled, l
       </Text>
       <Button
         variant={enabled ? "secondaryOutline" : "primaryBlack"}
-        onPress={onPress}
+        onPress={handleSaveSearchFiltersPress}
         size="small"
-        loading={loading}
+        loading={inProcess}
         longestText="Disable"
         haptic
       >
         {enabled ? "Disable" : "Enable"}
       </Button>
     </Flex>
+  )
+}
+
+export const SavedSearchBannerContainer = createFragmentContainer(
+  SavedSearchBanner,
+  {
+    me: graphql`
+      fragment SavedSearchBanner_me on Me @argumentDefinitions(
+        criteria: { type: "SearchCriteriaAttributes" }
+      ){
+        savedSearch(criteria: $criteria) {
+          internalID
+        }
+      }
+    `,
+  },
+)
+
+export const SavedSearchBannerQueryRender: React.FC<{ filters: FilterParams, artistId: string }> = ({ filters, artistId }) => {
+  const input = prepareFilterParamsForSaveSearchInput(filters)
+  const attributes = {
+    artistID: artistId,
+    ...input,
+  }
+
+  return (
+    <QueryRenderer<SavedSearchBannerQuery>
+      environment={defaultEnvironment}
+      query={graphql`
+        query SavedSearchBannerQuery($criteria: SearchCriteriaAttributes!) {
+          me {
+            ...SavedSearchBanner_me @arguments(criteria: $criteria)
+          }
+        }
+      `}
+      render={({ props }) => <SavedSearchBannerContainer {...props} loading={props === null} attributes={attributes} artistId={artistId} />}
+      variables={{
+        criteria: attributes
+      }}
+      cacheConfig={{ force: true }}
+    />
   )
 }

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -1,5 +1,6 @@
 import { SavedSearchBanner_me } from '__generated__/SavedSearchBanner_me.graphql'
 import { SavedSearchBannerCreateSavedSearchMutation } from "__generated__/SavedSearchBannerCreateSavedSearchMutation.graphql"
+import { SavedSearchBannerDeleteSavedSearchMutation } from "__generated__/SavedSearchBannerDeleteSavedSearchMutation.graphql"
 import { SavedSearchBannerQuery, SearchCriteriaAttributes } from '__generated__/SavedSearchBannerQuery.graphql'
 import { FilterParams, prepareFilterParamsForSaveSearchInput } from 'lib/Components/ArtworkFilter/ArtworkFilterHelpers'
 import { defaultEnvironment } from "lib/relay/createEnvironment"
@@ -48,13 +49,41 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({ me, attrib
     })
   }
 
+  const deleteSavedSearch = () => {
+    setSaving(true)
+    commitMutation<SavedSearchBannerDeleteSavedSearchMutation>(relay.environment, {
+      mutation: graphql`
+      mutation SavedSearchBannerDeleteSavedSearchMutation($input: DeleteSavedSearchInput!) {
+        deleteSavedSearch(input: $input) {
+          savedSearchOrErrors {
+            ... on SearchCriteria {
+              internalID
+            }
+          }
+        }
+      }
+    `,
+      variables: {
+        input: {
+          searchCriteriaID: me!.savedSearch!.internalID
+        }
+      },
+      onCompleted: () => {
+        setSaving(false)
+      },
+      onError: () => {
+        setSaving(false)
+      }
+    })
+  }
+
   const handleSaveSearchFiltersPress = () => {
     if (inProcess) {
       return
     }
 
     if (enabled) {
-      // TODO: deleteSavedSearch
+      deleteSavedSearch()
     } else {
       createSavedSearch()
     }
@@ -119,7 +148,7 @@ export const SavedSearchBannerQueryRender: React.FC<{ filters: FilterParams, art
           }
         }
       `}
-      render={({ props }) => <SavedSearchBannerFragmentContainer {...props} loading={props === null} attributes={attributes} artistId={artistId} />}
+      render={({ props }) => <SavedSearchBannerFragmentContainer me={props?.me ?? null} loading={props === null} attributes={attributes} artistId={artistId} />}
       variables={{
         criteria: attributes
       }}

--- a/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
@@ -1,41 +1,73 @@
+import { SavedSearchBannerQuery, SearchCriteriaAttributes } from '__generated__/SavedSearchBannerQuery.graphql'
+import { SavedSearchBannerTestsQuery } from "__generated__/SavedSearchBannerTestsQuery.graphql"
+import { mockEnvironmentPayload } from 'lib/tests/mockEnvironmentPayload'
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { Button } from "palette"
 import React from "react"
-import { SavedSearchBanner } from "../SavedSearchBanner"
+import { graphql, QueryRenderer } from "react-relay"
+import { createMockEnvironment } from "relay-test-utils"
+import { SavedSearchBannerFragmentContainer } from "../SavedSearchBanner"
+
+jest.unmock("react-relay")
 
 describe("SavedSearchBanner", () => {
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+  const attributes: SearchCriteriaAttributes = {
+    priceMin: 300,
+    priceMax: 500,
+  }
+
+  beforeEach(() => (mockEnvironment = createMockEnvironment()))
+
+  const TestRenderer = () => {
+    return (
+      <QueryRenderer<SavedSearchBannerTestsQuery>
+          environment={mockEnvironment}
+          query={graphql`
+            query SavedSearchBannerTestsQuery($criteria: SearchCriteriaAttributes!) @relay_test_operation {
+              me {
+                ...SavedSearchBanner_me @arguments(criteria: $criteria)
+              }
+            }
+          `}
+          render={({ props }) => <SavedSearchBannerFragmentContainer {...props} loading={props === null} attributes={attributes} artistId="banksy" />}
+          variables={{
+            criteria: attributes
+          }}
+        />
+    )
+  }
+
   it("renders correctly disabled state", () => {
-    const onPress = jest.fn()
-    const tree = renderWithWrappers(<SavedSearchBanner enabled={false} onPress={onPress} />)
+    const tree = renderWithWrappers(<TestRenderer />)
+    mockEnvironmentPayload(mockEnvironment, {
+      Me: () => ({
+        savedSearch: null
+      })
+    })
+
     const buttonComponent = tree.root.findByType(Button)
 
     expect(buttonComponent.props.children).toEqual("Enable")
     expect(buttonComponent.props.variant).toBe("primaryBlack")
+    expect(buttonComponent.props.loading).toBe(false)
   })
 
   it("renders correctly enabled state", () => {
-    const onPress = jest.fn()
-    const tree = renderWithWrappers(<SavedSearchBanner enabled={true} loading={true} onPress={onPress} />)
+    const tree = renderWithWrappers(<TestRenderer />)
+    mockEnvironmentPayload(mockEnvironment)
+
     const buttonComponent = tree.root.findByType(Button)
 
     expect(buttonComponent.props.children).toEqual("Disable")
     expect(buttonComponent.props.variant).toBe("secondaryOutline")
+    expect(buttonComponent.props.loading).toBe(false)
   })
 
   it("renders correctly loading state", () => {
-    const onPress = jest.fn()
-    const tree = renderWithWrappers(<SavedSearchBanner enabled={false} loading={true} onPress={onPress} />)
+    const tree = renderWithWrappers(<TestRenderer />)
     const buttonComponent = tree.root.findByType(Button)
 
     expect(buttonComponent.props.loading).toBe(true)
-  })
-
-  it("calls onPress when button is pressed", () => {
-    const onPress = jest.fn()
-    const tree = renderWithWrappers(<SavedSearchBanner enabled={false} loading={false} onPress={onPress} />)
-    const buttonComponent = tree.root.findByType(Button)
-
-    buttonComponent.props.onPress()
-    expect(onPress).toHaveBeenCalled()
   })
 })

--- a/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
@@ -1,4 +1,4 @@
-import { SavedSearchBannerQuery, SearchCriteriaAttributes } from '__generated__/SavedSearchBannerQuery.graphql'
+import { SearchCriteriaAttributes } from '__generated__/SavedSearchBannerQuery.graphql'
 import { SavedSearchBannerTestsQuery } from "__generated__/SavedSearchBannerTestsQuery.graphql"
 import { mockEnvironmentPayload } from 'lib/tests/mockEnvironmentPayload'
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -1,4 +1,4 @@
-import { SearchCriteriaAttributes } from "__generated__/ArtistArtworksContainerCreateSavedSearchMutation.graphql"
+import { SearchCriteriaAttributes } from "__generated__/SavedSearchBannerQuery.graphql"
 import { FilterScreen } from "lib/Components/ArtworkFilter"
 import { capitalize, compact, groupBy, isEqual, pick, sortBy } from "lodash"
 import { LOCALIZED_UNIT, parseRange } from "./Filters/helpers"


### PR DESCRIPTION
The type of this PR is: **FEATURE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-2967]

### Description
As an admin with the saved search feature flag enabled
_When I_ apply filters on the artist artwork screen
_A query_ is executed that checks if I have a saved search with those filters

##### Acceptance criteria:
* Every time a user with the saved search flag applies filters, a query is executed that checks if that user has an existing saved search with those filters
* End result of this ticket could just be logging out the result of that query

#### Demo

https://user-images.githubusercontent.com/3513494/121049697-9e650180-c7c0-11eb-9c11-e93e46673b2e.mp4

https://user-images.githubusercontent.com/3513494/121050503-4c70ab80-c7c1-11eb-8feb-832316e97550.mp4


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2967]: https://artsyproduct.atlassian.net/browse/FX-2967