### PR TITLE
chore: 6.9.4 release prep

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,3 +1,7 @@
-This update includes a number of small improvements and bug fixes.
+This update includes a number of improvements and bug fixes, including:
+
+- New filters and improvements to existing filters
+- Search shortcuts to artist insights and artworks 
+- Home feed improvements, see Artsy articles in your feed
 
 Have feedback? Email us at support@artsy.net

--- a/fastlane/metadata/en-US/name.txt
+++ b/fastlane/metadata/en-US/name.txt
@@ -1,1 +1,1 @@
-Artsy: Buy & Sell Original Art
+Artsy — Buy and Sell Fine Art

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,5 +1,7 @@
 This update includes a number of improvements and bug fixes, including:
 
-- Fixes make offer bug for artworks with a single edition
+- New filters and improvements to existing filters
+- Search shortcuts to artist insights and artworks 
+- Home feed improvements, see Artsy articles in your feed
 
 Have feedback? Email us at support@artsy.net

--- a/fastlane/metadata/en-US/subtitle.txt
+++ b/fastlane/metadata/en-US/subtitle.txt
@@ -1,1 +1,1 @@
-Shop from auctions & galleries
+Collect Art by Leading Artists


### PR DESCRIPTION
The type of this PR is: **chore**

### Description

- Updates release notes for version 6.9.4 on both Android and iOS
- Updates title and subtile of app to new copy from marketing
