### PR TITLE
feat: size filter for saved search

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -16,6 +16,7 @@ upcoming:
     - Update PR template to not automatically attach an unrelated Jira ticket - erikdstock
     - Add createSavedSearch mutation - dzmitry tratsiak
     - Add deleteSavedSearch mutation - dzmitry tratsiak
+    - Pass size filter parameters to a saved search criteria - dzmitry tratsiak
   user_facing:
     - Fix wrong displaying in Order History when fields are too long - Serge0n
     - Add payment method section (behind feature flag) - irina-sid

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -78,34 +78,6 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({ me, attrib
     })
   }
 
-  const deleteSavedSearch = () => {
-    setSaving(true)
-    commitMutation<SavedSearchBannerDeleteSavedSearchMutation>(relay.environment, {
-      mutation: graphql`
-        mutation SavedSearchBannerDeleteSavedSearchMutation($input: DeleteSavedSearchInput!) {
-          deleteSavedSearch(input: $input) {
-            savedSearchOrErrors {
-              ... on SearchCriteria {
-                internalID
-              }
-            }
-          }
-        }
-      `,
-      variables: {
-        input: {
-          searchCriteriaID: me!.savedSearch!.internalID,
-        },
-      },
-      onCompleted: () => {
-        setSaving(false)
-      },
-      onError: () => {
-        setSaving(false)
-      },
-    })
-  }
-
   const handleSaveSearchFiltersPress = () => {
     if (inProcess) {
       return

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -2,8 +2,8 @@ import { captureMessage } from "@sentry/react-native"
 import { SavedSearchBanner_me } from "__generated__/SavedSearchBanner_me.graphql"
 import { SavedSearchBannerCreateSavedSearchMutation } from "__generated__/SavedSearchBannerCreateSavedSearchMutation.graphql"
 import { SavedSearchBannerDeleteSavedSearchMutation } from "__generated__/SavedSearchBannerDeleteSavedSearchMutation.graphql"
-import { SavedSearchBannerQuery, SearchCriteriaAttributes } from "__generated__/SavedSearchBannerQuery.graphql"
-import { FilterParams, prepareFilterParamsForSaveSearchInput } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { SavedSearchBannerQuery, SearchCriteriaAttributes } from '__generated__/SavedSearchBannerQuery.graphql'
+import { FilterParams, prepareFilterParamsForSaveSearchInput } from 'lib/Components/ArtworkFilter/ArtworkFilterHelpers'
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { Button, Flex, Text } from "palette"
 import React, { useState } from "react"
@@ -75,6 +75,34 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({ me, attrib
       onError: () => {
         setSaving(false)
       },
+    })
+  }
+
+  const deleteSavedSearch = () => {
+    setSaving(true)
+    commitMutation<SavedSearchBannerDeleteSavedSearchMutation>(relay.environment, {
+      mutation: graphql`
+      mutation SavedSearchBannerDeleteSavedSearchMutation($input: DeleteSavedSearchInput!) {
+        deleteSavedSearch(input: $input) {
+          savedSearchOrErrors {
+            ... on SearchCriteria {
+              internalID
+            }
+          }
+        }
+      }
+    `,
+      variables: {
+        input: {
+          searchCriteriaID: me!.savedSearch!.internalID
+        }
+      },
+      onCompleted: () => {
+        setSaving(false)
+      },
+      onError: () => {
+        setSaving(false)
+      }
     })
   }
 

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -2,8 +2,8 @@ import { captureMessage } from "@sentry/react-native"
 import { SavedSearchBanner_me } from "__generated__/SavedSearchBanner_me.graphql"
 import { SavedSearchBannerCreateSavedSearchMutation } from "__generated__/SavedSearchBannerCreateSavedSearchMutation.graphql"
 import { SavedSearchBannerDeleteSavedSearchMutation } from "__generated__/SavedSearchBannerDeleteSavedSearchMutation.graphql"
-import { SavedSearchBannerQuery, SearchCriteriaAttributes } from '__generated__/SavedSearchBannerQuery.graphql'
-import { FilterParams, prepareFilterParamsForSaveSearchInput } from 'lib/Components/ArtworkFilter/ArtworkFilterHelpers'
+import { SavedSearchBannerQuery, SearchCriteriaAttributes } from "__generated__/SavedSearchBannerQuery.graphql"
+import { FilterParams, prepareFilterParamsForSaveSearchInput } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { Button, Flex, Text } from "palette"
 import React, { useState } from "react"
@@ -82,27 +82,27 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({ me, attrib
     setSaving(true)
     commitMutation<SavedSearchBannerDeleteSavedSearchMutation>(relay.environment, {
       mutation: graphql`
-      mutation SavedSearchBannerDeleteSavedSearchMutation($input: DeleteSavedSearchInput!) {
-        deleteSavedSearch(input: $input) {
-          savedSearchOrErrors {
-            ... on SearchCriteria {
-              internalID
+        mutation SavedSearchBannerDeleteSavedSearchMutation($input: DeleteSavedSearchInput!) {
+          deleteSavedSearch(input: $input) {
+            savedSearchOrErrors {
+              ... on SearchCriteria {
+                internalID
+              }
             }
           }
         }
-      }
-    `,
+      `,
       variables: {
         input: {
-          searchCriteriaID: me!.savedSearch!.internalID
-        }
+          searchCriteriaID: me!.savedSearch!.internalID,
+        },
       },
       onCompleted: () => {
         setSaving(false)
       },
       onError: () => {
         setSaving(false)
-      }
+      },
     })
   }
 

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -1,7 +1,7 @@
 import { SearchCriteriaAttributes } from "__generated__/SavedSearchBannerQuery.graphql"
 import { FilterScreen } from "lib/Components/ArtworkFilter"
 import { capitalize, compact, groupBy, isEqual, pick, sortBy } from "lodash"
-import { LOCALIZED_UNIT, parseRange } from "./Filters/helpers"
+import { LOCALIZED_UNIT, parseRangeByKeys } from "./Filters/helpers"
 
 export enum FilterDisplayName {
   // artist = "Artists",
@@ -539,16 +539,47 @@ export const prepareFilterArtworksParamsForInput = (filters: FilterParams) => {
   ])
 }
 
-export const parseFilterParamPrice = (value: string) => {
-  const { min, max } = parseRange(value)
-  const input: SearchCriteriaAttributes = {}
+export const parseFilledRangeByKeys = (range: string, minKey: string, maxKey: string) => {
+  const filledRange: Record<string, number> = {}
+  const parsedRange = parseRangeByKeys(range, { minKey, maxKey })
 
-  if (min !== "*") {
-    input.priceMin = min
-  }
+  Object.entries(parsedRange).forEach((entry) => {
+    const [key, value] = entry
 
-  if (max !== "*") {
-    input.priceMax = max
+    if (value !== "*") {
+      filledRange[key] = value
+    }
+  })
+
+  return filledRange
+}
+
+export const parseFilterParamSize = (filterParams: FilterParams) => {
+  let input: SearchCriteriaAttributes = {}
+  const sizeParamValue = filterParams[FilterParamName.dimensionRange] as string
+  const widthParamValue = filterParams[FilterParamName.width] as string
+  const heightParamValue = filterParams[FilterParamName.height] as string
+
+  // Custom sizes
+  if (sizeParamValue === "0-*") {
+    if (widthParamValue) {
+      input = {
+        ...input,
+        ...parseFilledRangeByKeys(widthParamValue, "widthMin", "widthMax"),
+      }
+    }
+
+    if (heightParamValue) {
+      input = {
+        ...input,
+        ...parseFilledRangeByKeys(heightParamValue, "heightMin", "heightMax"),
+      }
+    }
+  } else {
+    input = {
+      ...input,
+      ...parseFilledRangeByKeys(sizeParamValue, "dimensionScoreMin", "dimensionScoreMax"),
+    }
   }
 
   return input
@@ -556,11 +587,13 @@ export const parseFilterParamPrice = (value: string) => {
 
 export const prepareFilterParamsForSaveSearchInput = (filterParams: FilterParams) => {
   let input: SearchCriteriaAttributes = {}
-  const canSendWithoutChangesKeys = [
+  const canSendIfNotEqualByDefault = [
     FilterParamName.waysToBuyBuy,
     FilterParamName.waysToBuyBid,
     FilterParamName.waysToBuyInquire,
     FilterParamName.waysToBuyMakeOffer,
+  ]
+  const canSendWithoutChangesKeys = [
     FilterParamName.additionalGeneIDs,
     FilterParamName.colors,
     FilterParamName.locationCities,
@@ -573,11 +606,19 @@ export const prepareFilterParamsForSaveSearchInput = (filterParams: FilterParams
     const [key, value] = entry
 
     if (key === FilterParamName.priceRange) {
-      input = { ...input, ...parseFilterParamPrice(value as string) }
+      input = { ...input, ...parseFilledRangeByKeys(value as string, "priceMin", "priceMax") }
     } else if (key === FilterParamName.attributionClass) {
       input.attributionClasses = value as string[]
+    } else if (key === FilterParamName.dimensionRange) {
+      input = { ...input, ...parseFilterParamSize(filterParams) }
     } else if (canSendWithoutChangesKeys.includes(key as FilterParamName)) {
       input[key as keyof SearchCriteriaAttributes] = value as any
+    } else if (canSendIfNotEqualByDefault.includes(key as FilterParamName)) {
+      const defaultValue = defaultCommonFilterOptions[key as FilterParamName]
+
+      if (!isEqual(defaultValue, value)) {
+        input[key as keyof SearchCriteriaAttributes] = value as any
+      }
     }
   })
 

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/helpers-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/helpers-tests.tsx
@@ -1,4 +1,4 @@
-import { localizeDimension, parseRange } from "../helpers"
+import { localizeDimension, parseRange, parseRangeByKeys } from "../helpers"
 
 describe("parseRange", () => {
   it("parses a default range string", () => {
@@ -29,6 +29,20 @@ describe("parseRange", () => {
     expect(parseRange("0-*")).toEqual({ min: 0, max: "*" })
     expect(parseRange("*-0")).toEqual({ min: "*", max: 0 })
     expect(parseRange("0-0")).toEqual({ min: 0, max: 0 })
+  })
+})
+
+describe("parseRangeByKeys", () => {
+  it("parses min value as minValue and max as maxValue", () => {
+    expect(parseRangeByKeys("*-*", { minKey: "minValue", maxKey: "maxValue" })).toEqual({ minValue: "*", maxValue: "*" })
+  })
+
+  it("parses min value as minValue and max", () => {
+    expect(parseRangeByKeys("1.333-99.1234", { minKey: "minValue" })).toEqual({ minValue: 1.333, max: 99.1234 })
+  })
+
+  it("parses max value as maxValue and min", () => {
+    expect(parseRangeByKeys("1-2", { maxKey: "maxValue" })).toEqual({ min: 1, maxValue: 2 })
   })
 })
 

--- a/src/lib/Components/ArtworkFilter/Filters/helpers.ts
+++ b/src/lib/Components/ArtworkFilter/Filters/helpers.ts
@@ -98,3 +98,19 @@ export const parseRange = (range: string): Range => {
 
   return { min: enforceNumeric(min), max: enforceNumeric(max) }
 }
+
+export const parseRangeByKeys = (
+  range: string,
+  keys?: {
+    minKey?: string
+    maxKey?: string
+  }
+): Record<string, Numeric> => {
+  const minKey = keys?.minKey ?? "min"
+  const maxKey = keys?.maxKey ?? "max"
+  const { min, max } = parseRange(range)
+  return {
+    [minKey]: min,
+    [maxKey]: max,
+  }
+}

--- a/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
@@ -1,4 +1,4 @@
-import { Aggregations, FilterArray } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { Aggregations, FilterArray, parseFilterParamSize, parseRangeByKeys } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import {
   aggregationsWithFollowedArtists,
   changedFiltersParams,

--- a/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
@@ -829,7 +829,7 @@ describe("prepareFilterArtworksParamsForInput", () => {
 })
 
 describe("prepareFilterParamsForSaveSearchInput", () => {
-  it("returns fields in the CreateSavedSearchInput format", () => {
+  it("returns fields in the saved search criteria format", () => {
     const filters = filterArtworksParams([
       {
         displayText: "Large (over 100cm)",
@@ -904,6 +904,18 @@ describe("prepareFilterParamsForSaveSearchInput", () => {
     })
   })
 
+  it("return nothing if only the sort filter is selected", () => {
+    const filters = filterArtworksParams([
+      {
+        displayText: "Recently updated",
+        paramName: FilterParamName.sort,
+        paramValue: "-partner_updated_at",
+      },
+    ]);
+
+    expect(prepareFilterParamsForSaveSearchInput(filters)).toEqual({})
+  })
+
   it("returns minPrice and maxPrice fields if only the price filter is selected", () => {
     const filters = filterArtworksParams([
       {
@@ -933,7 +945,7 @@ describe("prepareFilterParamsForSaveSearchInput", () => {
     })
   })
 
-  it("returns only the selected `ways to buy` values", () => {
+  it("returns the selected `ways to buy` values", () => {
     const filters = filterArtworksParams([
       {
         displayText: "Bid",
@@ -941,7 +953,7 @@ describe("prepareFilterParamsForSaveSearchInput", () => {
         paramValue: true,
       },
       {
-        displayText: "Bid",
+        displayText: "Inquire",
         paramName: FilterParamName.waysToBuyInquire,
         paramValue: true,
       },
@@ -997,6 +1009,25 @@ describe("prepareFilterParamsForSaveSearchInput", () => {
     expect(prepareFilterParamsForSaveSearchInput(filters)).toEqual({
       widthMin: 12.5,
       widthMax: 34.6,
+    })
+  })
+
+  it("returns only custom max width size", () => {
+    const filters = filterArtworksParams([
+      {
+        displayText: "*-500",
+        paramName: FilterParamName.width,
+        paramValue: "*-196.8503937007874",
+      },
+      {
+        displayText: "Custom size",
+        paramName: FilterParamName.dimensionRange,
+        paramValue: "0-*",
+      }
+    ]);
+
+    expect(prepareFilterParamsForSaveSearchInput(filters)).toEqual({
+      widthMax: 196.8503937007874,
     })
   })
 

--- a/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
@@ -891,14 +891,12 @@ describe("prepareFilterParamsForSaveSearchInput", () => {
       priceMax: 10000,
       attributionClasses: ["limited edition"],
       additionalGeneIDs: ["prints"],
-      acquireable: false,
       atAuction: true,
-      inquireableOnly: false,
-      offerable: false,
       majorPeriods: ["1990"],
       colors: ["yellow", "red"],
       locationCities: ["London, United Kingdom"],
       materialsTerms: ["paper"],
+      dimensionScoreMin: 40,
       partnerIDs: [
         "cypress-test-partner-for-automated-testing-purposes",
         "tate-ward-auctions"
@@ -918,10 +916,6 @@ describe("prepareFilterParamsForSaveSearchInput", () => {
     expect(prepareFilterParamsForSaveSearchInput(filters)).toEqual({
       priceMin: 1000,
       priceMax: 5000,
-      acquireable: false,
-      atAuction: false,
-      inquireableOnly: false,
-      offerable: false,
     })
   })
 
@@ -936,10 +930,92 @@ describe("prepareFilterParamsForSaveSearchInput", () => {
 
     expect(prepareFilterParamsForSaveSearchInput(filters)).toEqual({
       priceMin: 50000,
-      acquireable: false,
-      atAuction: false,
-      inquireableOnly: false,
-      offerable: false,
+    })
+  })
+
+  it("returns only the selected `ways to buy` values", () => {
+    const filters = filterArtworksParams([
+      {
+        displayText: "Bid",
+        paramName: FilterParamName.waysToBuyBid,
+        paramValue: true,
+      },
+      {
+        displayText: "Bid",
+        paramName: FilterParamName.waysToBuyInquire,
+        paramValue: true,
+      },
+    ]);
+
+    expect(prepareFilterParamsForSaveSearchInput(filters)).toEqual({
+      atAuction: true,
+      inquireableOnly: true,
+    })
+  })
+
+  it("returns custom filter sizes", () => {
+    const filters = filterArtworksParams([
+      {
+        displayText: "200-250",
+        paramName: FilterParamName.height,
+        paramValue: "78.74015748031496-98.4251968503937",
+      },
+      {
+        displayText: "100-150",
+        paramName: FilterParamName.width,
+        paramValue: "39.37007874015748-59.05511811023622",
+      },
+      {
+        displayText: "Custom size",
+        paramName: FilterParamName.dimensionRange,
+        paramValue: "0-*",
+      }
+    ]);
+
+    expect(prepareFilterParamsForSaveSearchInput(filters)).toEqual({
+      widthMin: 39.37007874015748,
+      widthMax: 59.05511811023622,
+      heightMin: 78.74015748031496,
+      heightMax: 98.4251968503937,
+    })
+  })
+
+  it("returns only custom width sizes", () => {
+    const filters = filterArtworksParams([
+      {
+        displayText: "100-150",
+        paramName: FilterParamName.width,
+        paramValue: "12.5-34.6",
+      },
+      {
+        displayText: "Custom size",
+        paramName: FilterParamName.dimensionRange,
+        paramValue: "0-*",
+      }
+    ]);
+
+    expect(prepareFilterParamsForSaveSearchInput(filters)).toEqual({
+      widthMin: 12.5,
+      widthMax: 34.6,
+    })
+  })
+
+  it("returns only custom min height size", () => {
+    const filters = filterArtworksParams([
+      {
+        displayText: "100-150",
+        paramName: FilterParamName.width,
+        paramValue: "10-*",
+      },
+      {
+        displayText: "Custom size",
+        paramName: FilterParamName.dimensionRange,
+        paramValue: "0-*",
+      }
+    ]);
+
+    expect(prepareFilterParamsForSaveSearchInput(filters)).toEqual({
+      widthMin: 10,
     })
   })
 })

--- a/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
@@ -1,4 +1,4 @@
-import { Aggregations, FilterArray, parseFilterParamSize, parseRangeByKeys } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { Aggregations, FilterArray } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import {
   aggregationsWithFollowedArtists,
   changedFiltersParams,


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3001]

### Description
As an admin,
When I switch on the saved search banner
A new searchCriteria and userSearchCriteria are created in Gravity
With the specified size filter values I have selected in the UI

Acceptance criteria:
* Toggling the switch "on" executes the mutation
* For the purposes of this ticket, it's sufficient to check that the searchCriteria and userSearchCriteria were created with specified size filter values
* Not in scope: handling failure
* Not in scope: preserving banner "on" state on reload/reapplication of same filters
* Not in scope: deletion of previously saved searchCritera on toggle off

#### Demo

https://user-images.githubusercontent.com/3513494/121169421-aa060600-c85c-11eb-90d1-d8fe16960ee0.mp4



<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-3001]: https://artsyproduct.atlassian.net/browse/FX-3001