### PR TITLE
feat: don’t close modal when “clear all” tapped

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -59,6 +59,7 @@ upcoming:
     - Specified a more specific error for logging in with Apple or Facebook - stas hanchar
     - fix inaccurate validators for artwork submission - yauheni
     - Check saved search when the user applied the filter - dzmitry tratsiak
+    - Don't close filter artwork modal when "clear all" tapped - dzmitry tratsiak
 
 releases:
   - version: 6.9.3

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -32,9 +32,8 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) 
   const tracking = useTracking()
   const [isFilterArtworksModalVisible, setFilterArtworkModalVisible] = useState(false)
 
-  const handleFilterArtworksModal = () => {
-    setFilterArtworkModalVisible(!isFilterArtworksModalVisible)
-  }
+  const handleCloseFilterArtworksModal = () => setFilterArtworkModalVisible(false)
+  const handleOpenFilterArtworksModal = () => setFilterArtworkModalVisible(true)
 
   const openFilterArtworksModal = () => {
     tracking.trackEvent({
@@ -45,7 +44,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) 
       context_screen_owner_slug: artist.slug,
       action_type: Schema.ActionTypes.Tap,
     })
-    handleFilterArtworksModal()
+    handleOpenFilterArtworksModal()
   }
 
   const closeFilterArtworksModal = () => {
@@ -57,7 +56,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) 
       context_screen_owner_slug: artist.slug,
       action_type: Schema.ActionTypes.Tap,
     })
-    handleFilterArtworksModal()
+    handleCloseFilterArtworksModal()
   }
 
   return (
@@ -69,7 +68,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) 
           id={artist.internalID}
           slug={artist.slug}
           isFilterArtworksModalVisible={isFilterArtworksModalVisible}
-          exitModal={handleFilterArtworksModal}
+          exitModal={handleCloseFilterArtworksModal}
           closeModal={closeFilterArtworksModal}
           mode={FilterModalMode.ArtistArtworks}
         />

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -62,7 +62,7 @@ export const ArtworkFilterOptionsScreen: React.FC<
   StackScreenProps<ArtworkFilterNavigationStack, "FilterOptionsScreen">
 > = ({ navigation, route }) => {
   const tracking = useTracking()
-  const { closeModal, exitModal, id, mode, slug, title = "Sort & Filter" } = route.params
+  const { closeModal, id, mode, slug, title = "Sort & Filter" } = route.params
 
   const appliedFiltersState = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
   const selectedFiltersState = ArtworksFiltersStore.useStoreState((state) => state.selectedFilters)
@@ -98,7 +98,6 @@ export const ArtworkFilterOptionsScreen: React.FC<
 
   const clearAllFilters = () => {
     clearFiltersZeroStateAction()
-    exitModal?.()
   }
 
   const trackClear = (screenName: PageNames, ownerEntity: OwnerEntityTypes) => {

--- a/src/lib/Components/ArtworkFilter/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/FilterModal-tests.tsx
@@ -392,7 +392,6 @@ describe("Clearing filters", () => {
 
     expect(filterModal.find(CurrentOption).at(0).text()).toEqual("")
     expect(filterModal.find(CurrentOption).at(1).text()).toEqual("")
-    expect(exitModalMock).toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
The type of this PR is: **FEATURE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3000]

### Description
User Story:As a collector, when I click "clear all" when filtering I expect the filter options to clear without closing the modal so I can immediately choose a new set of them. 

#### Demo
https://user-images.githubusercontent.com/3513494/121177984-b1321180-c866-11eb-9b98-cb830b943694.mp4


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-3000]: https://artsyproduct.atlassian.net/browse/FX-3000