### PR TITLE
fix: move artsy web view padding to correct place

### DIFF
--- a/src/lib/Components/ArtsyReactWebView.tsx
+++ b/src/lib/Components/ArtsyReactWebView.tsx
@@ -32,11 +32,13 @@ export const ArtsyReactWebViewPage: React.FC<
     isPresentedModally?: boolean
   } & ArtsyWebViewConfig
 > = ({ url, title, isPresentedModally, allowWebViewInnerNavigation = true, mimicBrowserBackButton = true }) => {
+  const paddingTop = useScreenDimensions().safeAreaInsets.top
+
   const [canGoBack, setCanGoBack] = useState(false)
   const ref = useRef<WebView>(null)
 
   return (
-    <View style={{ flex: 1 }}>
+    <View style={{ flex: 1, paddingTop }}>
       <ArtsyKeyboardAvoidingView>
         <FancyModalHeader
           useXButton={isPresentedModally && !canGoBack}
@@ -76,10 +78,8 @@ export const ArtsyReactWebView = React.forwardRef<
   const webURL = useEnvironment().webURL
   const uri = url.startsWith("/") ? webURL + url : url
 
-  const paddingTop = useScreenDimensions().safeAreaInsets.top
-
   return (
-    <View style={{ flex: 1, paddingTop }}>
+    <View style={{ flex: 1 }}>
       <WebView
         ref={ref}
         // sharedCookiesEnabled is required on iOS for the user to be implicitly logged into force/prediction


### PR DESCRIPTION
The type of this PR is: Bugfix

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1567]

### Description

I accidentally removed the top padding in `ArtsyReactWebViewPage` instead of `ArtsyReactWebView` in a previous [fix](https://github.com/artsy/eigen/pull/4938). This PR moves the top padding back.

|Before|Article|Auction FAQs|
|---|---|---|
|![Simulator Screen Shot - iPhone 8 - 2021-06-09 at 13 51 01](https://user-images.githubusercontent.com/4691889/121349403-c15ef500-c929-11eb-8433-cce5d2627133.png)|![Simulator Screen Shot - iPhone 8 - 2021-06-09 at 12 38 47](https://user-images.githubusercontent.com/4691889/121340230-a7b8b000-c91f-11eb-9f8d-bb916823fe33.png) |![Simulator Screen Shot - iPhone 8 - 2021-06-09 at 12 39 32](https://user-images.githubusercontent.com/4691889/121340302-c159f780-c91f-11eb-859f-e85493c124d0.png) |






The PR https://github.com/artsy/eigen/pull/4938 fixed the padding issue at the wrong place. This PR moves the top padding to the correct place.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-1567]: https://artsyproduct.atlassian.net/browse/CX-1567