### PR TITLE
feat: don't show saved search for only sort filter

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -66,8 +66,8 @@ upcoming:
     - Continue to show the offer approved banner in an inquiry offer conversation after fulfillment - erikdstock
     - Add link to Conditions of Sale in sign up - dzmitry
     - Show visual feedback when the "Sort & Filter" button is pressed - dzmitry tratsiak
-
     - Don't show saved search banner when only sort filter is selected - dzmitry tratsiak
+
 releases:
   - version: 6.9.3
     date: June 1, 2021

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -67,6 +67,7 @@ upcoming:
     - Add link to Conditions of Sale in sign up - dzmitry
     - Show visual feedback when the "Sort & Filter" button is pressed - dzmitry tratsiak
 
+    - Don't show saved search banner when only sort filter is selected - dzmitry tratsiak
 releases:
   - version: 6.9.3
     date: June 1, 2021

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -3,6 +3,7 @@ import { ArtistArtworks_artist } from "__generated__/ArtistArtworks_artist.graph
 import { ArtworkFilterNavigator, FilterModalMode } from "lib/Components/ArtworkFilter"
 import {
   filterArtworksParams,
+  FilterParamName,
   prepareFilterArtworksParamsForInput,
 } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworkFiltersStoreProvider, ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
@@ -90,7 +91,8 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
   const enableSavedSearch = useFeatureFlag("AREnableSavedSearch")
   const appliedFilters = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
   const applyFilters = ArtworksFiltersStore.useStoreState((state) => state.applyFilters)
-  const shouldShowSavedSearchBanner = enableSavedSearch && appliedFilters.length > 0
+  const onlySortFilterApplied = appliedFilters.length === 1 && appliedFilters[0].paramName === FilterParamName.sort
+  const shouldShowSavedSearchBanner = enableSavedSearch && appliedFilters.length > 0 && !onlySortFilterApplied
 
   const setAggregationsAction = ArtworksFiltersStore.useStoreActions((state) => state.setAggregationsAction)
 

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -91,8 +91,10 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
   const enableSavedSearch = useFeatureFlag("AREnableSavedSearch")
   const appliedFilters = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
   const applyFilters = ArtworksFiltersStore.useStoreState((state) => state.applyFilters)
-  const onlySortFilterApplied = appliedFilters.length === 1 && appliedFilters[0].paramName === FilterParamName.sort
-  const shouldShowSavedSearchBanner = enableSavedSearch && appliedFilters.length > 0 && !onlySortFilterApplied
+  const relevantFiltersForSavedSearch = appliedFilters.filter(
+    (filter) => !(filter.paramName === FilterParamName.sort)
+  )
+  const shouldShowSavedSearchBanner = enableSavedSearch && relevantFiltersForSavedSearch.length > 0
 
   const setAggregationsAction = ArtworksFiltersStore.useStoreActions((state) => state.setAggregationsAction)
 


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3003]

### Description
As an admin with the saved search feature flag enabled
When I visit the artworks tab for an artist
I do not see the saved search banner
And when I apply only sort filter
I don’t see the saved search banner
When I apply other set of filters
I see the saved search banner

#### Demo

https://user-images.githubusercontent.com/3513494/121387487-60e4ad80-c953-11eb-80bf-594d3dd3ab6f.mp4


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-3003]: https://artsyproduct.atlassian.net/browse/FX-3003