### PR TITLE
remove horizontal scrolling indicator

### DIFF
--- a/src/lib/Scenes/Home/Components/ArticlesRail.tsx
+++ b/src/lib/Scenes/Home/Components/ArticlesRail.tsx
@@ -38,6 +38,7 @@ export const ArticlesRail: React.FC<ArticlesRailProps> = ({ articlesConnection }
       <Flex>
         <FlatList
           horizontal
+          showsHorizontalScrollIndicator={false}
           ListHeaderComponent={() => <Spacer ml="2" />}
           ListFooterComponent={() => <Spacer ml="2" />}
           data={articles}


### PR DESCRIPTION
The type of this PR is: Bugfix

https://artsyproduct.atlassian.net/browse/CX-1596
This PR resolves [CX-1596]
### Description

Hide scrolling indicator for Market News rail to avoid overlapping.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

https://user-images.githubusercontent.com/27921300/121891809-39f3f600-cd1c-11eb-84f7-1e53c183dfc9.mov




[CX-1596]: https://artsyproduct.atlassian.net/browse/CX-1596