### PR TITLE
fix: add roundedButtonStyle to floating button

### DIFF
--- a/src/lib/Scenes/ViewingRoom/Components/ViewingRoomViewWorksButton.tsx
+++ b/src/lib/Scenes/ViewingRoom/Components/ViewingRoomViewWorksButton.tsx
@@ -24,9 +24,13 @@ export const ViewingRoomViewWorksButton: React.FC<ViewingRoomViewWorksButtonProp
   }
 
   const pluralizedArtworksCount = artworksCount === 1 ? "work" : "works"
+
+  const roundedButtonStyle = { borderRadius: 20 }
+
   return (
     <View>
       <AnimatedBottomButton
+        buttonStyles={roundedButtonStyle}
         isVisible={props.isVisible}
         onPress={() => {
           tracking.trackEvent(tracks.tappedViewWorksButton(viewingRoom.internalID, viewingRoom.slug))


### PR DESCRIPTION
The type of this PR is: **FIX**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-962]

### Description

The ```<AnimatedBottomButton />``` was missing required styles to be rounded and as a result when pressed it had a square background with white color.

Noticed that it is being used also [here](https://github.com/artsy/eigen/blob/7aba7148840758f94da89730845ad9b5f5aa9dbf/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx) properly rounded so I replicated the usage at the ```<ArtworkFilterOptionScreen />``` where we had the issue.

|Android|iOS|
|---|---|
|![Screenshot_1623744894](https://user-images.githubusercontent.com/21178754/122017930-b2ad8d80-cdc2-11eb-8bf0-36666dac0e48.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-06-15 at 10 13 25](https://user-images.githubusercontent.com/21178754/122017940-b50fe780-cdc2-11eb-91e7-c48f67a4cf1c.png)|

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-962]: https://artsyproduct.atlassian.net/browse/CX-962