### PR TITLE
fix: align InfoCircleIcon inside InfoButton

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -24,6 +24,7 @@ upcoming:
     - Implement infinite scroll on android - kizito
     - Show a toast message for saved search mutations - dzmitry tratsiak
     - Added "Auction lots for you" landing screen - damon
+    - Fix Aligned InfoCircleIcon - gkartalis
 
 releases:
   - version: 6.9.4

--- a/src/lib/Components/Buttons/InfoButton.tsx
+++ b/src/lib/Components/Buttons/InfoButton.tsx
@@ -30,7 +30,7 @@ export const InfoButton: React.FC<InfoButtonProps> = ({
 
   return (
     <>
-      <Flex flexDirection="row">
+      <Flex flexDirection="row" alignItems="center">
         {titleElement ? (
           titleElement
         ) : (
@@ -46,7 +46,7 @@ export const InfoButton: React.FC<InfoButtonProps> = ({
           }}
           hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
         >
-          <InfoCircleIcon style={{ top: 3 }} fill="black60" />
+          <InfoCircleIcon fill="black60" />
         </TouchableOpacity>
       </Flex>
       {!!subTitle && <Text color="black60">{subTitle}</Text>}


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1614]

### Description
The Info icon on the artist insights tab is not aligned with the text next to it. The same goes for the other references of the same Button.

Fixed the alignment issues
<!-- Implementation description -->
|Android|iphone SE (1st gen)| iphone 8 | iphone 12 pro|
|---|---|---|---|
|![Screenshot_1623848731](https://user-images.githubusercontent.com/21178754/122226029-dac9e900-ceb5-11eb-9080-8f2ad330fb51.png)|![Simulator Screen Shot - iPhone SE (1st generation) - 2021-06-16 at 14 55 09](https://user-images.githubusercontent.com/21178754/122226027-dac9e900-ceb5-11eb-8fe5-60d4d34a6a63.png)|![Simulator Screen Shot - iPhone 8 - 2021-06-16 at 14 48 34](https://user-images.githubusercontent.com/21178754/122226017-d8678f00-ceb5-11eb-9c1f-99eccb3082e4.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-06-16 at 14 42 02](https://user-images.githubusercontent.com/21178754/122226022-d998bc00-ceb5-11eb-8c27-add492a418d1.png)|




### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-1614]: https://artsyproduct.atlassian.net/browse/CX-1614