### PR TITLE
feat: set web view deceleration rate to normal

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -37,6 +37,7 @@ upcoming:
     - Hide spinner when there is no more artworks to load - katsiaryna alshannikava
     - Aligned 'Next' button in the 'Sell work' menu - katsiaryna alshannikava
     - Fix home screen articles rail spacing - ole
+    - Decrease web view scroll deceleration rate - ole
 
 releases:
   - version: 6.9.4

--- a/src/lib/Components/ArtsyReactWebView.tsx
+++ b/src/lib/Components/ArtsyReactWebView.tsx
@@ -85,6 +85,7 @@ export const ArtsyReactWebView = React.forwardRef<
         // sharedCookiesEnabled is required on iOS for the user to be implicitly logged into force/prediction
         // on android it works without it
         sharedCookiesEnabled
+        decelerationRate="normal"
         source={{ uri }}
         style={{ flex: 1 }}
         userAgent={userAgent}

--- a/src/lib/Components/StyledWebView.tsx
+++ b/src/lib/Components/StyledWebView.tsx
@@ -39,6 +39,7 @@ export const StyledWebView: React.FC<{ body: string }> = ({ body }) => {
         const msg = decodeURIComponent(decodeURIComponent(e.nativeEvent.data))
         setWebViewHeight(parseInt(msg, 10))
       }}
+      decelerationRate="normal"
       onShouldStartLoadWithRequest={(e) => {
         if (e.navigationType === "click") {
           Linking.openURL(e.url)


### PR DESCRIPTION
The type of this PR is: Bugfix

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1613]

### Description

Sets the deceleration rate for web views to normal (default is fast). This aligns scroll behaviour in web views to the rest of the app.

<!-- Implementation description -->

### QA Plan

- [ ] Open a web view (e.g. an article) and scroll down.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-1613]: https://artsyproduct.atlassian.net/browse/CX-1613