### PR TITLE
fix: Invalid user name + acronym for country name (PX-4241) and OrderSummary fixes (PX-4212)

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -6,6 +6,8 @@ upcoming:
     - Update open simulator command in getting started docs - ole
     - Update debugging docs - mounir
   user_facing:
+    - Country should be written with full name - Serge0n
+    - Name from shipping address should be displayed instead of account name - Serge0n
     - User can see the way of delivery - Serge0n
     - OrderDetails with SoldBy section - alexj105
     - OrderDetails with headInfo - alexj105

--- a/src/__generated__/OrderDetailsQuery.graphql.ts
+++ b/src/__generated__/OrderDetailsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 8d9d0d71338f5ea096b7018a384fb7d6 */
+/* @relayHash b9e275bec133e03df208f7ffb668b101 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -11,9 +11,6 @@ export type OrderDetailsQueryVariables = {
 export type OrderDetailsQueryResponse = {
     readonly order: {
         readonly " $fragmentRefs": FragmentRefs<"OrderDetails_order">;
-    } | null;
-    readonly me: {
-        readonly name: string | null;
     } | null;
 };
 export type OrderDetailsQuery = {
@@ -30,10 +27,6 @@ query OrderDetailsQuery(
   order: commerceOrder(id: $orderID) {
     __typename
     ...OrderDetails_order
-    id
-  }
-  me {
-    name
     id
   }
 }
@@ -79,6 +72,7 @@ fragment OrderDetails_order on CommerceOrder {
     __typename
     ... on CommerceShip {
       __typename
+      name
     }
     ... on CommercePickup {
       __typename
@@ -179,14 +173,14 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "__typename",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "__typename",
+  "name": "name",
   "storageKey": null
 },
 v4 = [
@@ -204,10 +198,6 @@ v5 = {
   "storageKey": null
 },
 v6 = [
-  (v2/*: any*/),
-  (v5/*: any*/)
-],
-v7 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -236,18 +226,6 @@ return {
           }
         ],
         "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "Me",
-        "kind": "LinkedField",
-        "name": "me",
-        "plural": false,
-        "selections": [
-          (v2/*: any*/)
-        ],
-        "storageKey": null
       }
     ],
     "type": "Query",
@@ -267,7 +245,7 @@ return {
         "name": "commerceOrder",
         "plural": false,
         "selections": [
-          (v3/*: any*/),
+          (v2/*: any*/),
           {
             "kind": "TypeDiscriminator",
             "abstractKey": "__isCommerceOrder"
@@ -280,10 +258,11 @@ return {
             "name": "requestedFulfillment",
             "plural": false,
             "selections": [
-              (v3/*: any*/),
+              (v2/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
+                  (v3/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -379,7 +358,10 @@ return {
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": [
+                              (v3/*: any*/),
+                              (v5/*: any*/)
+                            ],
                             "storageKey": null
                           },
                           (v5/*: any*/),
@@ -551,28 +533,28 @@ return {
           },
           {
             "alias": null,
-            "args": (v7/*: any*/),
+            "args": (v6/*: any*/),
             "kind": "ScalarField",
             "name": "buyerTotal",
             "storageKey": "buyerTotal(precision:2)"
           },
           {
             "alias": null,
-            "args": (v7/*: any*/),
+            "args": (v6/*: any*/),
             "kind": "ScalarField",
             "name": "taxTotal",
             "storageKey": "taxTotal(precision:2)"
           },
           {
             "alias": null,
-            "args": (v7/*: any*/),
+            "args": (v6/*: any*/),
             "kind": "ScalarField",
             "name": "shippingTotal",
             "storageKey": "shippingTotal(precision:2)"
           },
           {
             "alias": null,
-            "args": (v7/*: any*/),
+            "args": (v6/*: any*/),
             "kind": "ScalarField",
             "name": "totalListPrice",
             "storageKey": "totalListPrice(precision:2)"
@@ -606,21 +588,11 @@ return {
           (v5/*: any*/)
         ],
         "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "Me",
-        "kind": "LinkedField",
-        "name": "me",
-        "plural": false,
-        "selections": (v6/*: any*/),
-        "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "8d9d0d71338f5ea096b7018a384fb7d6",
+    "id": "b9e275bec133e03df208f7ffb668b101",
     "metadata": {},
     "name": "OrderDetailsQuery",
     "operationKind": "query",
@@ -628,5 +600,5 @@ return {
   }
 };
 })();
-(node as any).hash = '2c64d5c8cae59749f393fe76f293dde6';
+(node as any).hash = '8066640df756aa777d763d82714ee562';
 export default node;

--- a/src/__generated__/OrderDetailsTestsQuery.graphql.ts
+++ b/src/__generated__/OrderDetailsTestsQuery.graphql.ts
@@ -1,17 +1,14 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash cfb062dadb66b0560e969f68f8b04c31 */
+/* @relayHash ea59384642e4efcc932f22547de960ed */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type OrderDetailsTestsQueryVariables = {};
 export type OrderDetailsTestsQueryResponse = {
-    readonly order: {
+    readonly commerceOrder: {
         readonly " $fragmentRefs": FragmentRefs<"OrderDetails_order">;
-    } | null;
-    readonly me: {
-        readonly name: string | null;
     } | null;
 };
 export type OrderDetailsTestsQuery = {
@@ -23,13 +20,9 @@ export type OrderDetailsTestsQuery = {
 
 /*
 query OrderDetailsTestsQuery {
-  order: commerceOrder(id: "order-id") {
+  commerceOrder(id: "order-id") {
     __typename
     ...OrderDetails_order
-    id
-  }
-  me {
-    name
     id
   }
 }
@@ -169,14 +162,14 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "__typename",
   "storageKey": null
 },
 v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "__typename",
+  "name": "name",
   "storageKey": null
 },
 v3 = [
@@ -194,16 +187,30 @@ v4 = {
   "storageKey": null
 },
 v5 = [
-  (v1/*: any*/),
-  (v4/*: any*/)
-],
-v6 = [
   {
     "kind": "Literal",
     "name": "precision",
     "value": 2
   }
-];
+],
+v6 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v7 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v8 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+};
 return {
   "fragment": {
     "argumentDefinitions": [],
@@ -212,7 +219,7 @@ return {
     "name": "OrderDetailsTestsQuery",
     "selections": [
       {
-        "alias": "order",
+        "alias": null,
         "args": (v0/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
@@ -226,18 +233,6 @@ return {
           }
         ],
         "storageKey": "commerceOrder(id:\"order-id\")"
-      },
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "Me",
-        "kind": "LinkedField",
-        "name": "me",
-        "plural": false,
-        "selections": [
-          (v1/*: any*/)
-        ],
-        "storageKey": null
       }
     ],
     "type": "Query",
@@ -250,14 +245,14 @@ return {
     "name": "OrderDetailsTestsQuery",
     "selections": [
       {
-        "alias": "order",
+        "alias": null,
         "args": (v0/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "commerceOrder",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
+          (v1/*: any*/),
           {
             "kind": "TypeDiscriminator",
             "abstractKey": "__isCommerceOrder"
@@ -270,11 +265,11 @@ return {
             "name": "requestedFulfillment",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
+              (v1/*: any*/),
               {
                 "kind": "InlineFragment",
                 "selections": [
-                  (v1/*: any*/),
+                  (v2/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -370,7 +365,10 @@ return {
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
-                            "selections": (v5/*: any*/),
+                            "selections": [
+                              (v2/*: any*/),
+                              (v4/*: any*/)
+                            ],
                             "storageKey": null
                           },
                           (v4/*: any*/),
@@ -542,28 +540,28 @@ return {
           },
           {
             "alias": null,
-            "args": (v6/*: any*/),
+            "args": (v5/*: any*/),
             "kind": "ScalarField",
             "name": "buyerTotal",
             "storageKey": "buyerTotal(precision:2)"
           },
           {
             "alias": null,
-            "args": (v6/*: any*/),
+            "args": (v5/*: any*/),
             "kind": "ScalarField",
             "name": "taxTotal",
             "storageKey": "taxTotal(precision:2)"
           },
           {
             "alias": null,
-            "args": (v6/*: any*/),
+            "args": (v5/*: any*/),
             "kind": "ScalarField",
             "name": "shippingTotal",
             "storageKey": "shippingTotal(precision:2)"
           },
           {
             "alias": null,
-            "args": (v6/*: any*/),
+            "args": (v5/*: any*/),
             "kind": "ScalarField",
             "name": "totalListPrice",
             "storageKey": "totalListPrice(precision:2)"
@@ -597,27 +595,148 @@ return {
           (v4/*: any*/)
         ],
         "storageKey": "commerceOrder(id:\"order-id\")"
-      },
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "Me",
-        "kind": "LinkedField",
-        "name": "me",
-        "plural": false,
-        "selections": (v5/*: any*/),
-        "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "cfb062dadb66b0560e969f68f8b04c31",
-    "metadata": {},
+    "id": "ea59384642e4efcc932f22547de960ed",
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "commerceOrder": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CommerceOrder"
+        },
+        "commerceOrder.__isCommerceOrder": (v6/*: any*/),
+        "commerceOrder.__typename": (v6/*: any*/),
+        "commerceOrder.buyerTotal": (v7/*: any*/),
+        "commerceOrder.code": (v6/*: any*/),
+        "commerceOrder.createdAt": (v6/*: any*/),
+        "commerceOrder.creditCard": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CreditCard"
+        },
+        "commerceOrder.creditCard.brand": (v6/*: any*/),
+        "commerceOrder.creditCard.id": (v8/*: any*/),
+        "commerceOrder.creditCard.lastDigits": (v6/*: any*/),
+        "commerceOrder.id": (v8/*: any*/),
+        "commerceOrder.lineItems": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CommerceLineItemConnection"
+        },
+        "commerceOrder.lineItems.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "CommerceLineItemEdge"
+        },
+        "commerceOrder.lineItems.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CommerceLineItem"
+        },
+        "commerceOrder.lineItems.edges.node.artwork": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "commerceOrder.lineItems.edges.node.artwork.artistNames": (v7/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.date": (v7/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.dimensions": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "dimensions"
+        },
+        "commerceOrder.lineItems.edges.node.artwork.dimensions.cm": (v7/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.dimensions.in": (v7/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.editionOf": (v7/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.id": (v8/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.image": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Image"
+        },
+        "commerceOrder.lineItems.edges.node.artwork.image.url": (v7/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.medium": (v7/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.partner": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Partner"
+        },
+        "commerceOrder.lineItems.edges.node.artwork.partner.id": (v8/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.partner.name": (v7/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.shippingOrigin": (v7/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.title": (v7/*: any*/),
+        "commerceOrder.lineItems.edges.node.fulfillments": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CommerceFulfillmentConnection"
+        },
+        "commerceOrder.lineItems.edges.node.fulfillments.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "CommerceFulfillmentEdge"
+        },
+        "commerceOrder.lineItems.edges.node.fulfillments.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CommerceFulfillment"
+        },
+        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.estimatedDelivery": (v7/*: any*/),
+        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.id": (v8/*: any*/),
+        "commerceOrder.lineItems.edges.node.id": (v8/*: any*/),
+        "commerceOrder.requestedFulfillment": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CommerceRequestedFulfillmentUnion"
+        },
+        "commerceOrder.requestedFulfillment.__typename": (v6/*: any*/),
+        "commerceOrder.requestedFulfillment.addressLine1": (v7/*: any*/),
+        "commerceOrder.requestedFulfillment.addressLine2": (v7/*: any*/),
+        "commerceOrder.requestedFulfillment.city": (v7/*: any*/),
+        "commerceOrder.requestedFulfillment.country": (v7/*: any*/),
+        "commerceOrder.requestedFulfillment.name": (v7/*: any*/),
+        "commerceOrder.requestedFulfillment.phoneNumber": (v7/*: any*/),
+        "commerceOrder.requestedFulfillment.postalCode": (v7/*: any*/),
+        "commerceOrder.requestedFulfillment.region": (v7/*: any*/),
+        "commerceOrder.shippingTotal": (v7/*: any*/),
+        "commerceOrder.state": {
+          "enumValues": [
+            "ABANDONED",
+            "APPROVED",
+            "CANCELED",
+            "FULFILLED",
+            "PENDING",
+            "REFUNDED",
+            "SUBMITTED"
+          ],
+          "nullable": false,
+          "plural": false,
+          "type": "CommerceOrderStateEnum"
+        },
+        "commerceOrder.taxTotal": (v7/*: any*/),
+        "commerceOrder.totalListPrice": (v7/*: any*/)
+      }
+    },
     "name": "OrderDetailsTestsQuery",
     "operationKind": "query",
     "text": null
   }
 };
 })();
-(node as any).hash = '256ff19a85686a62616295c42e63501c';
+(node as any).hash = '76f7f61c266d40b4bf94126da71e5bb3';
 export default node;

--- a/src/__generated__/OrderDetailsTestsQuery.graphql.ts
+++ b/src/__generated__/OrderDetailsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 551f5542aa059832c842dea04667183b */
+/* @relayHash cfb062dadb66b0560e969f68f8b04c31 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -75,6 +75,7 @@ fragment OrderDetails_order on CommerceOrder {
     __typename
     ... on CommerceShip {
       __typename
+      name
     }
     ... on CommercePickup {
       __typename
@@ -273,6 +274,7 @@ return {
               {
                 "kind": "InlineFragment",
                 "selections": [
+                  (v1/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -609,7 +611,7 @@ return {
     ]
   },
   "params": {
-    "id": "551f5542aa059832c842dea04667183b",
+    "id": "cfb062dadb66b0560e969f68f8b04c31",
     "metadata": {},
     "name": "OrderDetailsTestsQuery",
     "operationKind": "query",

--- a/src/__generated__/OrderDetails_order.graphql.ts
+++ b/src/__generated__/OrderDetails_order.graphql.ts
@@ -8,6 +8,7 @@ export type CommerceOrderStateEnum = "ABANDONED" | "APPROVED" | "CANCELED" | "FU
 export type OrderDetails_order = {
     readonly requestedFulfillment: ({
         readonly __typename: "CommerceShip";
+        readonly name: string | null;
     } | {
         readonly __typename: "CommercePickup";
     } | {
@@ -41,15 +42,20 @@ export type OrderDetails_order$key = {
 
 
 const node: ReaderFragment = (function(){
-var v0 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "__typename",
-    "storageKey": null
-  }
-];
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
 return {
   "argumentDefinitions": [],
   "kind": "Fragment",
@@ -66,13 +72,18 @@ return {
       "selections": [
         {
           "kind": "InlineFragment",
-          "selections": (v0/*: any*/),
+          "selections": [
+            (v0/*: any*/),
+            (v1/*: any*/)
+          ],
           "type": "CommerceShip",
           "abstractKey": null
         },
         {
           "kind": "InlineFragment",
-          "selections": (v0/*: any*/),
+          "selections": [
+            (v0/*: any*/)
+          ],
           "type": "CommercePickup",
           "abstractKey": null
         }
@@ -125,13 +136,7 @@ return {
                       "name": "partner",
                       "plural": false,
                       "selections": [
-                        {
-                          "alias": null,
-                          "args": null,
-                          "kind": "ScalarField",
-                          "name": "name",
-                          "storageKey": null
-                        }
+                        (v1/*: any*/)
                       ],
                       "storageKey": null
                     }
@@ -198,5 +203,5 @@ return {
   "abstractKey": "__isCommerceOrder"
 };
 })();
-(node as any).hash = '64be54dcbe4dad3f094f88d2fb3a876d';
+(node as any).hash = '699ce8fe541eef672d38b01ff49fd337';
 export default node;

--- a/src/lib/Scenes/OrderHistory/OrderDetails/Components/OrderDetails.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/Components/OrderDetails.tsx
@@ -27,7 +27,8 @@ interface SectionListItem {
 
 const OrderDetails: React.FC<OrderDetailsProps> = ({ order }) => {
   const partnerName = extractNodes(order.lineItems)[0].artwork?.partner
-  const shippingName = order?.requestedFulfillment?.__typename === "CommerceShip" && order?.requestedFulfillment.name
+  const shippingName =
+    order?.requestedFulfillment?.__typename === "CommerceShip" ? order?.requestedFulfillment.name : null
   const DATA: SectionListItem[] = [
     {
       key: "OrderDetailsHeader",

--- a/src/lib/Scenes/OrderHistory/OrderDetails/Components/OrderDetails.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/Components/OrderDetails.tsx
@@ -18,7 +18,6 @@ import { SummarySectionFragmentContainer } from "./SummarySection"
 
 export interface OrderDetailsProps {
   order: OrderDetails_order
-  me: OrderDetailsQuery["response"]["me"]
 }
 interface SectionListItem {
   key: string
@@ -26,8 +25,9 @@ interface SectionListItem {
   data: readonly JSX.Element[]
 }
 
-const OrderDetails: React.FC<OrderDetailsProps> = ({ order, me }) => {
+const OrderDetails: React.FC<OrderDetailsProps> = ({ order }) => {
   const partnerName = extractNodes(order.lineItems)[0].artwork?.partner
+  const shippingName = order?.requestedFulfillment?.__typename === "CommerceShip" && order?.requestedFulfillment.name
   const DATA: SectionListItem[] = [
     {
       key: "OrderDetailsHeader",
@@ -50,7 +50,7 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({ order, me }) => {
     },
     {
       key: "ShipTo_Section",
-      title: `Ships to ${me?.name}`,
+      title: `Ships to ${shippingName}`,
       data: [<ShipsToSectionFragmentContainer address={order} />],
     },
     {
@@ -163,6 +163,7 @@ export const OrderDetailsContainer = createFragmentContainer(OrderDetails, {
       requestedFulfillment {
         ... on CommerceShip {
           __typename
+          name
         }
         ... on CommercePickup {
           __typename
@@ -197,9 +198,6 @@ export const OrderDetailsQueryRender: React.FC<{ orderID: string }> = ({ orderID
         query OrderDetailsQuery($orderID: ID!) {
           order: commerceOrder(id: $orderID) {
             ...OrderDetails_order
-          }
-          me {
-            name
           }
         }
       `}

--- a/src/lib/Scenes/OrderHistory/OrderDetails/Components/ShipsToSection.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/Components/ShipsToSection.tsx
@@ -1,4 +1,5 @@
 import { ShipsToSection_address } from "__generated__/ShipsToSection_address.graphql"
+import { COUNTRY_SELECT_OPTIONS } from "lib/Components/CountrySelect"
 import { Box, Flex, Text } from "palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -12,35 +13,35 @@ export const ShipsToSection: React.FC<Props> = ({ address }) => {
     return null
   }
   if (address.requestedFulfillment.__typename === "CommerceShip") {
-    const addressInfo = address.requestedFulfillment
-    const addedComma = addressInfo.city ? "," : ""
+    const { city, addressLine1, addressLine2, region, postalCode, country, phoneNumber } = address.requestedFulfillment
+    const addedComma = city ? "," : ""
     return (
       <Flex style={{ flexDirection: "column", justifyContent: "space-between" }}>
         <Text testID="addressLine1" color="black60" variant="text">
-          {addressInfo.addressLine1}
+          {addressLine1}
         </Text>
-        {!!addressInfo.addressLine2 && (
+        {!!addressLine2 && (
           <Text color="black60" variant="text">
-            {addressInfo.addressLine2}
+            {addressLine2}
           </Text>
         )}
 
         <Box display="flex" flexDirection="row">
           <Text testID="city" color="black60" variant="text">
-            {addressInfo.city + addedComma + " "}
+            {city + addedComma + " "}
           </Text>
           <Text testID="region" color="black60" variant="text">
-            {addressInfo.region + " "}
+            {region + " "}
           </Text>
           <Text testID="postalCode" color="black60" variant="text">
-            {addressInfo.postalCode}
+            {postalCode}
           </Text>
         </Box>
         <Text testID="country" color="black60" variant="text">
-          {addressInfo.country}
+          {COUNTRY_SELECT_OPTIONS.find(({ value }) => value === country)!.label}
         </Text>
         <Text testID="phoneNumber" color="black60" variant="text">
-          {addressInfo.phoneNumber}
+          {phoneNumber}
         </Text>
       </Flex>
     )

--- a/src/lib/Scenes/OrderHistory/OrderDetails/Components/ShipsToSection.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/Components/ShipsToSection.tsx
@@ -38,7 +38,7 @@ export const ShipsToSection: React.FC<Props> = ({ address }) => {
           </Text>
         </Box>
         <Text testID="country" color="black60" variant="text">
-          {COUNTRY_SELECT_OPTIONS.find(({ value }) => value === country)!.label}
+          {COUNTRY_SELECT_OPTIONS.find(({ value }) => value === country)?.label || country}
         </Text>
         <Text testID="phoneNumber" color="black60" variant="text">
           {phoneNumber}

--- a/src/lib/Scenes/OrderHistory/OrderDetails/Components/SummarySection.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/Components/SummarySection.tsx
@@ -15,10 +15,10 @@ export const SummarySection: React.FC<Props> = ({ section }) => {
       <Flex>
         <Text variant="text">Price</Text>
         <Text variant="text" mt={0.5}>
-          Premium delivery
+          Shipping
         </Text>
         <Text mt={0.5} variant="text">
-          Sales Tax
+          Tax
         </Text>
         <Text variant="mediumText" mt={0.5}>
           Total
@@ -28,10 +28,10 @@ export const SummarySection: React.FC<Props> = ({ section }) => {
         <Text variant="text" color="black60" testID="totalListPrice">
           {totalListPrice}
         </Text>
-        <Text variant="text" color="black60" mt={1.5} testID="shippingTotal">
+        <Text variant="text" color="black60" testID="shippingTotal" mt={0.5}>
           {shippingTotal}
         </Text>
-        <Text variant="text" color="black60" testID="taxTotal">
+        <Text variant="text" color="black60" testID="taxTotal" mt={0.5}>
           {taxTotal}
         </Text>
         <Text variant="mediumText" mt={0.5} testID="buyerTotal">

--- a/src/lib/Scenes/OrderHistory/OrderDetails/__tests__/OrderDetails-tests.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/__tests__/OrderDetails-tests.tsx
@@ -19,31 +19,26 @@ jest.unmock("react-relay")
 
 describe(OrderDetailsQueryRender, () => {
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
+  beforeEach(() => (mockEnvironment = createMockEnvironment()))
 
   const TestRenderer = () => (
     <QueryRenderer<OrderDetailsTestsQuery>
       environment={mockEnvironment}
       query={graphql`
-        query OrderDetailsTestsQuery {
-          order: commerceOrder(id: "order-id") {
+        query OrderDetailsTestsQuery @relay_test_operation {
+          commerceOrder(id: "order-id") {
             ...OrderDetails_order
-          }
-          me {
-            name
           }
         }
       `}
-      variables={{}}
+      variables={{ id: "order-id" }}
       render={({ props }) => {
-        if (props?.order) {
-          return <OrderDetailsContainer me={props.me} order={props.order} />
+        if (props?.commerceOrder) {
+          return <OrderDetailsContainer order={props.commerceOrder} />
         }
       }}
     />
   )
-  beforeEach(() => {
-    mockEnvironment = createMockEnvironment()
-  })
   const getWrapper = (mockResolvers = {}) => {
     const tree = renderWithWrappers(<TestRenderer />)
     act(() => {
@@ -58,15 +53,13 @@ describe(OrderDetailsQueryRender, () => {
     const tree = renderWithWrappers(<TestRenderer />)
 
     mockEnvironmentPayload(mockEnvironment, {
-      Me: () => ({
-        name: "my name",
-      }),
       CommerceOrder: () => ({
         internalID: "222",
         requestedFulfillment: {
+          name: "my name",
           addressLine1: "myadress",
           city: "mycity",
-          country: "mycountry",
+          country: "BY",
           postalCode: "11238",
           phoneNumber: "7777",
           region: "myregion",
@@ -110,8 +103,12 @@ describe(OrderDetailsQueryRender, () => {
 
   it("renders props for OrderDetails if feature flag is on", () => {
     const tree = getWrapper({
-      Me: () => ({
-        name: "my name",
+      CommerceOrder: () => ({
+        internalID: "222",
+        requestedFulfillment: {
+          __typename: "CommerceShip",
+          name: "my name",
+        },
       }),
     })
     expect(extractText(tree.root)).toContain("my name")

--- a/src/lib/Scenes/OrderHistory/OrderDetails/__tests__/ShipsToSection-tests.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/__tests__/ShipsToSection-tests.tsx
@@ -37,9 +37,11 @@ describe("ShipsToSection", () => {
     mockEnvironmentPayload(mockEnvironment, {
       CommerceOrder: () => ({
         requestedFulfillment: {
+          ____typename: "CommerceShip",
+          name: "my name",
           addressLine1: "myadress",
           city: "mycity",
-          country: "mycountry",
+          country: "BY",
           postalCode: "11238",
           phoneNumber: "7777",
           region: "myregion",
@@ -51,7 +53,7 @@ describe("ShipsToSection", () => {
     expect(tree.findByProps({ testID: "city" }).props.children).toBe("mycity, ")
     expect(tree.findByProps({ testID: "region" }).props.children).toBe("myregion ")
     expect(tree.findByProps({ testID: "phoneNumber" }).props.children).toBe("7777")
-    expect(tree.findByProps({ testID: "country" }).props.children).toBe("mycountry")
+    expect(tree.findByProps({ testID: "country" }).props.children).toBe("Belarus")
     expect(tree.findByProps({ testID: "postalCode" }).props.children).toBe("11238")
   })
 })

--- a/src/lib/Scenes/OrderHistory/OrderDetails/__tests__/ShipsToSection-tests.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/__tests__/ShipsToSection-tests.tsx
@@ -37,7 +37,7 @@ describe("ShipsToSection", () => {
     mockEnvironmentPayload(mockEnvironment, {
       CommerceOrder: () => ({
         requestedFulfillment: {
-          ____typename: "CommerceShip",
+          __typename: "CommerceShip",
           name: "my name",
           addressLine1: "myadress",
           city: "mycity",


### PR DESCRIPTION
The type of this PR is: **Enhancement**

This PR resolves [PX-4212] and [PX-4212] (reopened) with small fixes

### Description

1. Name from shipping address should be displayed instead of the account name
2. Country should be written with the full name 
3. “Shipping” and “Tax” fields names should be returned back
4. Order Summary paddings fix

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

![image](https://user-images.githubusercontent.com/55637696/122366396-318dfc00-cf64-11eb-9439-f0865ef5c3e1.png)

[PX-4212]: https://artsyproduct.atlassian.net/browse/PX-4212
[PX-4212]: https://artsyproduct.atlassian.net/browse/PX-4212