### PR TITLE
fix(CX-1536): align the button to center in the 'sell work' menu

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -27,6 +27,7 @@ upcoming:
     - Show a toast message for saved search mutations - dzmitry tratsiak
     - Added "Auction lots for you" landing screen - damon
     - Fix Aligned InfoCircleIcon - gkartalis
+    - Aligned 'Next' button in the 'Sell work' menu
 
 releases:
   - version: 6.9.4

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -27,7 +27,7 @@ upcoming:
     - Show a toast message for saved search mutations - dzmitry tratsiak
     - Added "Auction lots for you" landing screen - damon
     - Fix Aligned InfoCircleIcon - gkartalis
-    - Aligned 'Next' button in the 'Sell work' menu
+    - Aligned 'Next' button in the 'Sell work' menu - katsiaryna alshannikava
 
 releases:
   - version: 6.9.4

--- a/src/lib/Scenes/Consignments/Screens/Overview.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Overview.tsx
@@ -309,8 +309,9 @@ export class Overview extends React.Component<Props, State> {
             />
             <Spacer mb={isPad ? 80 : 2} />
           </View>
-          <Flex px="2" width="100%" maxWidth={540}>
+          <Flex px="2" width="100%" alignItems="center">
             <Button
+              maxWidth={540}
               block
               onPress={this.state.hasLoaded && canSubmit ? this.submitFinalSubmission : undefined}
               disabled={!canSubmit}


### PR DESCRIPTION
The type of this PR is: Bugfix

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1536]

### Description

The 'Next' button should be aligned to center

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

Before:
![image](https://user-images.githubusercontent.com/27921300/122387636-589dfb00-cf6f-11eb-8f62-40713fe41e00.png)

After:
![Screenshot 2021-06-17 at 12 57 17](https://user-images.githubusercontent.com/27921300/122387093-cbf33d00-cf6e-11eb-9e52-d46ae9d04358.png)


[CX-1536]: https://artsyproduct.atlassian.net/browse/CX-1536