### PR TITLE
fix: correct round cm values during inch convert

### DIFF
--- a/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
@@ -148,10 +148,8 @@ export const SizeOptionsScreen: React.FC<SizeOptionsScreenProps> = ({ navigation
     return {
       ...acc,
       [option.paramName]: {
-        // Values will always be in inches since that's what Gravity accepts.
-        // Round off floating point precision errors.
-        min: round(localizeDimension(min, "in").value),
-        max: round(localizeDimension(max, "in").value),
+        min: localizeDimension(min, "in").value,
+        max: localizeDimension(max, "in").value,
       },
     }
   }, DEFAULT_CUSTOM_SIZE)

--- a/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
@@ -11,7 +11,7 @@ import { ArtworksFiltersStore, useSelectedOptionsDisplay } from "lib/Components/
 import { Input } from "lib/Components/Input/Input"
 import { Flex, Spacer, Text } from "palette"
 import React, { useEffect, useRef, useState } from "react"
-import { IS_USA, LOCALIZED_UNIT, localizeDimension, parseRange, Range, round, toIn } from "./helpers"
+import { IS_USA, LOCALIZED_UNIT, localizeDimension, parseRange, Range, toIn } from "./helpers"
 import { SingleSelectOptionScreen } from "./SingleSelectOption"
 
 const PARAM_NAME = FilterParamName.size // dimensionRange

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/helpers-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/helpers-tests.tsx
@@ -69,5 +69,10 @@ describe("localizeDimension", () => {
     it("accepts inches and returns centimeters", () => {
       expect(localizeDimension(10, "in")).toEqual({ value: 25.4, unit: "cm" })
     })
+
+    it("correct converts inches to centimeters", () => {
+      const inches = localizeDimension(100, "cm")
+      expect(localizeDimension(inches.value, "in")).toEqual(100)
+    })
   })
 })

--- a/src/lib/Components/ArtworkFilter/Filters/helpers.ts
+++ b/src/lib/Components/ArtworkFilter/Filters/helpers.ts
@@ -47,7 +47,9 @@ export const inToCm = (inches: Numeric) => {
     return inches
   }
 
-  return inches * ONE_IN_TO_CM
+  // Values will always be in inches since that's what Gravity accepts.
+  // Round off floating point precision errors.
+  return round(inches * ONE_IN_TO_CM)
 }
 
 export const toIn = (value: Numeric, unit: Unit): Numeric => {

--- a/src/lib/Components/ArtworkFilter/Filters/helpers.ts
+++ b/src/lib/Components/ArtworkFilter/Filters/helpers.ts
@@ -42,14 +42,19 @@ export const cmToIn = (centimeters: Numeric) => {
   return centimeters / ONE_IN_TO_CM
 }
 
-export const inToCm = (inches: Numeric) => {
+export const inToCm = (inches: Numeric, shouldRound: boolean = true) => {
   if (inches === "*") {
     return inches
   }
 
-  // Values will always be in inches since that's what Gravity accepts.
-  // Round off floating point precision errors.
-  return round(inches * ONE_IN_TO_CM)
+  const centimeters = inches * ONE_IN_TO_CM
+
+  if (shouldRound) {
+    // Round off floating point precision errors.
+    return round(centimeters)
+  }
+
+  return centimeters
 }
 
 export const toIn = (value: Numeric, unit: Unit): Numeric => {


### PR DESCRIPTION
The type of this PR is: **FIX**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves []

### Description
Rounding the value when converting from inches to centimeters globally

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
