### PR TITLE
fix: Order History. Sold by: "Ships from" is displayed for "Pickup" fulfillment (PX-4257)

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -7,6 +7,7 @@ upcoming:
     - Update open simulator command in getting started docs - ole
     - Update debugging docs - mounir
   user_facing:
+    - Pick up should be displayed in Sold by section - Serge0n
     - Country should be written with full name - Serge0n
     - Name from shipping address should be displayed instead of account name - Serge0n
     - User can see the way of delivery - Serge0n

--- a/src/__generated__/OrderDetailsQuery.graphql.ts
+++ b/src/__generated__/OrderDetailsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash b9e275bec133e03df208f7ffb668b101 */
+/* @relayHash e5d3e8f25b88d24839893b0cd77ca40e */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -124,6 +124,12 @@ fragment ShipsToSection_address on CommerceOrder {
 
 fragment SoldBySection_soldBy on CommerceOrder {
   __isCommerceOrder: __typename
+  requestedFulfillment {
+    __typename
+    ... on CommercePickup {
+      __typename
+    }
+  }
   lineItems(first: 1) {
     edges {
       node {
@@ -592,7 +598,7 @@ return {
     ]
   },
   "params": {
-    "id": "b9e275bec133e03df208f7ffb668b101",
+    "id": "e5d3e8f25b88d24839893b0cd77ca40e",
     "metadata": {},
     "name": "OrderDetailsQuery",
     "operationKind": "query",

--- a/src/__generated__/OrderDetailsTestsQuery.graphql.ts
+++ b/src/__generated__/OrderDetailsTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash ea59384642e4efcc932f22547de960ed */
+/* @relayHash 2a2112c6ef6818738e048d1629a5b99c */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -120,6 +120,12 @@ fragment ShipsToSection_address on CommerceOrder {
 
 fragment SoldBySection_soldBy on CommerceOrder {
   __isCommerceOrder: __typename
+  requestedFulfillment {
+    __typename
+    ... on CommercePickup {
+      __typename
+    }
+  }
   lineItems(first: 1) {
     edges {
       node {
@@ -599,7 +605,7 @@ return {
     ]
   },
   "params": {
-    "id": "ea59384642e4efcc932f22547de960ed",
+    "id": "2a2112c6ef6818738e048d1629a5b99c",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "commerceOrder": {

--- a/src/__generated__/SoldBySectionTestsQuery.graphql.ts
+++ b/src/__generated__/SoldBySectionTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 6b5bba482249ddd8c0ce7cb3bb4bf61a */
+/* @relayHash 902d13fa17686c944f1b5b68c514d648 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -29,6 +29,12 @@ query SoldBySectionTestsQuery {
 
 fragment SoldBySection_soldBy on CommerceOrder {
   __isCommerceOrder: __typename
+  requestedFulfillment {
+    __typename
+    ... on CommercePickup {
+      __typename
+    }
+  }
   lineItems(first: 1) {
     edges {
       node {
@@ -59,33 +65,40 @@ var v0 = [
     "value": "some-id"
   }
 ],
-v1 = [
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v2 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 1
   }
 ],
-v2 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v3 = {
+v4 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v4 = {
+v5 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v5 = {
+v6 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -132,20 +145,26 @@ return {
         "name": "commerceOrder",
         "plural": false,
         "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "__typename",
-            "storageKey": null
-          },
+          (v1/*: any*/),
           {
             "kind": "TypeDiscriminator",
             "abstractKey": "__isCommerceOrder"
           },
           {
             "alias": null,
-            "args": (v1/*: any*/),
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "requestedFulfillment",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
             "concreteType": "CommerceLineItemConnection",
             "kind": "LinkedField",
             "name": "lineItems",
@@ -182,13 +201,13 @@ return {
                             "name": "shippingOrigin",
                             "storageKey": null
                           },
-                          (v2/*: any*/)
+                          (v3/*: any*/)
                         ],
                         "storageKey": null
                       },
                       {
                         "alias": null,
-                        "args": (v1/*: any*/),
+                        "args": (v2/*: any*/),
                         "concreteType": "CommerceFulfillmentConnection",
                         "kind": "LinkedField",
                         "name": "fulfillments",
@@ -217,7 +236,7 @@ return {
                                     "name": "estimatedDelivery",
                                     "storageKey": null
                                   },
-                                  (v2/*: any*/)
+                                  (v3/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -227,7 +246,7 @@ return {
                         ],
                         "storageKey": "fulfillments(first:1)"
                       },
-                      (v2/*: any*/)
+                      (v3/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -237,14 +256,14 @@ return {
             ],
             "storageKey": "lineItems(first:1)"
           },
-          (v2/*: any*/)
+          (v3/*: any*/)
         ],
         "storageKey": "commerceOrder(id:\"some-id\")"
       }
     ]
   },
   "params": {
-    "id": "6b5bba482249ddd8c0ce7cb3bb4bf61a",
+    "id": "902d13fa17686c944f1b5b68c514d648",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "commerceOrder": {
@@ -253,9 +272,9 @@ return {
           "plural": false,
           "type": "CommerceOrder"
         },
-        "commerceOrder.__isCommerceOrder": (v3/*: any*/),
-        "commerceOrder.__typename": (v3/*: any*/),
-        "commerceOrder.id": (v4/*: any*/),
+        "commerceOrder.__isCommerceOrder": (v4/*: any*/),
+        "commerceOrder.__typename": (v4/*: any*/),
+        "commerceOrder.id": (v5/*: any*/),
         "commerceOrder.lineItems": {
           "enumValues": null,
           "nullable": true,
@@ -280,8 +299,8 @@ return {
           "plural": false,
           "type": "Artwork"
         },
-        "commerceOrder.lineItems.edges.node.artwork.id": (v4/*: any*/),
-        "commerceOrder.lineItems.edges.node.artwork.shippingOrigin": (v5/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.id": (v5/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.shippingOrigin": (v6/*: any*/),
         "commerceOrder.lineItems.edges.node.fulfillments": {
           "enumValues": null,
           "nullable": true,
@@ -300,9 +319,16 @@ return {
           "plural": false,
           "type": "CommerceFulfillment"
         },
-        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.estimatedDelivery": (v5/*: any*/),
-        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.id": (v4/*: any*/),
-        "commerceOrder.lineItems.edges.node.id": (v4/*: any*/)
+        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.estimatedDelivery": (v6/*: any*/),
+        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.id": (v5/*: any*/),
+        "commerceOrder.lineItems.edges.node.id": (v5/*: any*/),
+        "commerceOrder.requestedFulfillment": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CommerceRequestedFulfillmentUnion"
+        },
+        "commerceOrder.requestedFulfillment.__typename": (v4/*: any*/)
       }
     },
     "name": "SoldBySectionTestsQuery",

--- a/src/__generated__/SoldBySection_soldBy.graphql.ts
+++ b/src/__generated__/SoldBySection_soldBy.graphql.ts
@@ -5,6 +5,13 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type SoldBySection_soldBy = {
+    readonly requestedFulfillment: ({
+        readonly __typename: "CommercePickup";
+    } | {
+        /*This will never be '%other', but we need some
+        value in case none of the concrete values match.*/
+        readonly __typename: "%other";
+    }) | null;
     readonly lineItems: {
         readonly edges: ReadonlyArray<{
             readonly node: {
@@ -45,6 +52,31 @@ return {
   "metadata": null,
   "name": "SoldBySection_soldBy",
   "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": null,
+      "kind": "LinkedField",
+      "name": "requestedFulfillment",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "InlineFragment",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "__typename",
+              "storageKey": null
+            }
+          ],
+          "type": "CommercePickup",
+          "abstractKey": null
+        }
+      ],
+      "storageKey": null
+    },
     {
       "alias": null,
       "args": (v0/*: any*/),
@@ -141,5 +173,5 @@ return {
   "abstractKey": "__isCommerceOrder"
 };
 })();
-(node as any).hash = '858d48a0fb09c332db0d60297af07234';
+(node as any).hash = 'b53a929fc3601d35c2e371d3bfb21b52';
 export default node;

--- a/src/lib/Scenes/OrderHistory/OrderDetails/Components/SoldBySection.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/Components/SoldBySection.tsx
@@ -11,29 +11,31 @@ interface Props {
 }
 
 export const SoldBySection: React.FC<Props> = ({ soldBy }) => {
-  if (!soldBy) {
+  if (!soldBy || !soldBy.lineItems || !soldBy.lineItems.edges?.length) {
     return null
   }
   const { fulfillments, artwork } = extractNodes(soldBy.lineItems)[0]
-  const estimatedDelivery = extractNodes(fulfillments)[0]?.estimatedDelivery
+  const estimatedDelivery = extractNodes(fulfillments)?.[0]?.estimatedDelivery
   const orderEstimatedDelivery = estimatedDelivery ? DateTime.fromISO(estimatedDelivery) : null
-  const pickUpCondition = soldBy?.requestedFulfillment?.__typename === "CommercePickup"
+  const isForPickup = soldBy?.requestedFulfillment?.__typename === "CommercePickup"
 
   return (
     <Box>
       <Box flexDirection="row" testID="soldByInfo">
         <Text variant="text" color="black60">
-          {pickUpCondition ? "Pick up " : "Ships from "}
+          {isForPickup ? "Pick up " : "Ships from "}
         </Text>
         <Text testID="shippingOrigin" color="black60" variant="text">
-          {pickUpCondition ? `(${artwork?.shippingOrigin})` : artwork?.shippingOrigin}
+          {isForPickup ? `(${artwork?.shippingOrigin})` : artwork?.shippingOrigin}
         </Text>
       </Box>
       {!!orderEstimatedDelivery && (
         <Box flexDirection="row">
-          <Text variant="text">Estimated Delivery: </Text>
-          <Text testID="delivery" variant="text">
-            {orderEstimatedDelivery.toLocaleString(DateTime.DATE_SHORT as LocaleOptions)}
+          <Text color="black60" variant="text">
+            Estimated Delivery:{" "}
+          </Text>
+          <Text color="black60" testID="delivery" variant="text">
+            {orderEstimatedDelivery.toLocaleString(DateTime.DATE_MED as LocaleOptions)}
           </Text>
         </Box>
       )}

--- a/src/lib/Scenes/OrderHistory/OrderDetails/Components/SoldBySection.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/Components/SoldBySection.tsx
@@ -11,21 +11,22 @@ interface Props {
 }
 
 export const SoldBySection: React.FC<Props> = ({ soldBy }) => {
-  const { fulfillments, artwork } = extractNodes(soldBy.lineItems)[0]
-  const estimatedDelivery = extractNodes(fulfillments)[0]?.estimatedDelivery
-  const orderEstimatedDelivery = estimatedDelivery ? DateTime.fromISO(estimatedDelivery) : null
   if (!soldBy) {
     return null
   }
+  const { fulfillments, artwork } = extractNodes(soldBy.lineItems)[0]
+  const estimatedDelivery = extractNodes(fulfillments)[0]?.estimatedDelivery
+  const orderEstimatedDelivery = estimatedDelivery ? DateTime.fromISO(estimatedDelivery) : null
+  const pickUpCondition = soldBy?.requestedFulfillment?.__typename === "CommercePickup"
 
   return (
     <Box>
-      <Box flexDirection="row">
+      <Box flexDirection="row" testID="soldByInfo">
         <Text variant="text" color="black60">
-          Ships from{" "}
+          {pickUpCondition ? "Pick up " : "Ships from "}
         </Text>
         <Text testID="shippingOrigin" color="black60" variant="text">
-          {artwork?.shippingOrigin}
+          {pickUpCondition ? `(${artwork?.shippingOrigin})` : artwork?.shippingOrigin}
         </Text>
       </Box>
       {!!orderEstimatedDelivery && (
@@ -43,6 +44,11 @@ export const SoldBySection: React.FC<Props> = ({ soldBy }) => {
 export const SoldBySectionFragmentContainer = createFragmentContainer(SoldBySection, {
   soldBy: graphql`
     fragment SoldBySection_soldBy on CommerceOrder {
+      requestedFulfillment {
+        ... on CommercePickup {
+          __typename
+        }
+      }
       lineItems(first: 1) {
         edges {
           node {

--- a/src/lib/Scenes/OrderHistory/OrderDetails/__tests__/SoldBySection-tests.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/__tests__/SoldBySection-tests.tsx
@@ -96,7 +96,7 @@ describe("SoldBySection", () => {
       }),
     })
 
-    expect(tree.findByProps({ testID: "delivery" }).props.children).toBe("8/10/2021")
+    expect(tree.findByProps({ testID: "delivery" }).props.children).toBe("May 8, 2022")
     expect(extractText(tree.findByProps({ testID: "soldByInfo" }))).toBe("Pick up (Minsk, Belarus)")
   })
 })

--- a/src/lib/Scenes/OrderHistory/OrderDetails/__tests__/SoldBySection-tests.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/__tests__/SoldBySection-tests.tsx
@@ -62,7 +62,7 @@ describe("SoldBySection", () => {
       }),
     })
 
-    expect(tree.findByProps({ testID: "delivery" }).props.children).toBe("8/10/2021")
+    expect(tree.findByProps({ testID: "delivery" }).props.children).toBe("Aug 10, 2021")
     expect(extractText(tree.findByProps({ testID: "soldByInfo" }))).toBe("Ships from Minsk, Belarus")
   })
 
@@ -96,7 +96,7 @@ describe("SoldBySection", () => {
       }),
     })
 
-    expect(tree.findByProps({ testID: "delivery" }).props.children).toBe("May 8, 2022")
+    expect(tree.findByProps({ testID: "delivery" }).props.children).toBe("Aug 10, 2021")
     expect(extractText(tree.findByProps({ testID: "soldByInfo" }))).toBe("Pick up (Minsk, Belarus)")
   })
 })


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [PX-4257]

### Description

"Pick up ..." - are displayed when "Pick up" fulfillment chosen
"Ships from..." - are displayed when "Shipping" fulfillment chosen

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

![Запись экрана 2021-06-21 в 10 26 38](https://user-images.githubusercontent.com/55637696/122728841-34992d00-d281-11eb-82a9-584ea5c73edc.gif)



[PX-4257]: https://artsyproduct.atlassian.net/browse/PX-4257