### PR TITLE
feat: Sticky header on show screen

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -709,7 +709,14 @@ DEPENDENCIES:
   - Yoga (from `./node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://cdn.cocoapods.org/:
+  https://github.com/artsy/Specs.git:
+    - Aerodramus
+    - "Artsy+UIColors"
+    - "Artsy+UIFonts"
+    - "Artsy+UILabels"
+    - Artsy-UIButtons
+    - Extraction
+  trunk:
     - AFNetworkActivityLogger
     - AFNetworking
     - Analytics
@@ -767,13 +774,6 @@ SPEC REPOS:
     - "UIView+BooleanAnimations"
     - "XCTest+OHHTTPStubSuiteCleanUp"
     - YogaKit
-  https://github.com/artsy/Specs.git:
-    - Aerodramus
-    - "Artsy+UIColors"
-    - "Artsy+UIFonts"
-    - "Artsy+UILabels"
-    - Artsy-UIButtons
-    - Extraction
 
 EXTERNAL SOURCES:
   AFOAuth1Client:

--- a/src/lib/Components/HeaderArtworksFilter.tsx
+++ b/src/lib/Components/HeaderArtworksFilter.tsx
@@ -64,8 +64,8 @@ export const HeaderArtworksFilter: React.FC<FilterProps> = ({ total, animationVa
     BACK_BUTTON_SIZE.top -
     PixelRatio.getPixelSizeForLayoutSize(extraOffset)
 
-  return (
-    <Box backgroundColor="white" onLayout={(e) => _onLayout(e)}>
+  const SeparatorWithSmoothOpacity = () => {
+    return (
       <Animated.View
         style={{
           opacity: animationValue.interpolate({
@@ -77,6 +77,16 @@ export const HeaderArtworksFilter: React.FC<FilterProps> = ({ total, animationVa
       >
         <Separator mt={2} width={screenWidth * 2} />
       </Animated.View>
+    )
+  }
+
+  if (!total) {
+    return <SeparatorWithSmoothOpacity />
+  }
+
+  return (
+    <Box backgroundColor="white" onLayout={(e) => _onLayout(e)}>
+      <SeparatorWithSmoothOpacity />
       <Animated.View
         style={{
           transform: [

--- a/src/lib/Components/HeaderArtworksFilter.tsx
+++ b/src/lib/Components/HeaderArtworksFilter.tsx
@@ -1,0 +1,133 @@
+import { isPad } from "lib/utils/hardware"
+import { useScreenDimensions } from "lib/utils/useScreenDimensions"
+import { Box, FilterIcon, Flex, Separator, Text, TouchableHighlightColor } from "palette"
+import React, { useEffect, useState } from "react"
+import { Animated, Dimensions, LayoutChangeEvent, PixelRatio } from "react-native"
+
+interface FilterProps {
+  total: number
+  animationValue: Animated.Value
+  onPress: () => void
+}
+
+const pixelRatio = PixelRatio.get()
+// values based on px used in <BackButton>
+const BACK_BUTTON_SIZE = {
+  top: isPad() ? 10 / pixelRatio : 14 / pixelRatio,
+  left: isPad() ? 20 / pixelRatio : 10 / pixelRatio,
+  right: 0,
+  bottom: 0,
+  image: {
+    height: 40,
+    width: 40,
+  },
+}
+
+export const HeaderArtworksFilter: React.FC<FilterProps> = ({ total, animationValue, onPress }) => {
+  const screenWidth = useScreenDimensions().width
+
+  const [onLayoutCalled, setOnLayoutCalled] = useState(false)
+  const [filterPageY, setPageY] = useState(0)
+
+  useEffect(() => {
+    // orientation changed, allow for recalculation of pageY
+    Dimensions.addEventListener("change", orientationChanged)
+    return () => {
+      Dimensions.removeEventListener("change", orientationChanged)
+    }
+  }, [])
+
+  const orientationChanged = () => {
+    setOnLayoutCalled(false)
+  }
+
+  const _onLayout = (event: LayoutChangeEvent) => {
+    // because onLayout can be called multiple times on android
+    if (onLayoutCalled) {
+      return
+    }
+    // @ts-ignore
+    event.target.measure((x: number, y: number, width: number, height: number, pageX: number, pageY: number) => {
+      setPageY(pageY)
+    })
+    setOnLayoutCalled(true)
+  }
+
+  const extraOffset = 1
+  const topInset = useScreenDimensions().safeAreaInsets.top
+
+  const ANIM_START = BACK_BUTTON_SIZE.image.height * 2
+  const TRANSLATE_X_VALUE = BACK_BUTTON_SIZE.image.width
+  const TRANSLATE_Y_VALUE =
+    topInset -
+    BACK_BUTTON_SIZE.image.height / 2 -
+    BACK_BUTTON_SIZE.top -
+    PixelRatio.getPixelSizeForLayoutSize(extraOffset)
+
+  return (
+    <Box backgroundColor="white" onLayout={(e) => _onLayout(e)}>
+      <Animated.View
+        style={{
+          opacity: animationValue.interpolate({
+            inputRange: filterPageY > 0 ? [0, filterPageY - ANIM_START, filterPageY] : [0, 0, 0],
+            outputRange: filterPageY > 0 ? [1, 0, 0] : [1, 1, 1],
+            extrapolate: "clamp",
+          }),
+        }}
+      >
+        <Separator mt={2} width={screenWidth * 2} />
+      </Animated.View>
+      <Animated.View
+        style={{
+          transform: [
+            {
+              translateY: animationValue.interpolate({
+                inputRange: filterPageY > 0 ? [0, filterPageY - ANIM_START, filterPageY] : [0, 0, 0],
+                outputRange: filterPageY > 0 ? [0, 0, TRANSLATE_Y_VALUE] : [0, 0, 0],
+                extrapolate: "clamp",
+              }),
+            },
+          ],
+        }}
+      >
+        <Box backgroundColor="white" mt={3} px={2} mb={3}>
+          <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
+            <Animated.View
+              style={{
+                transform: [
+                  {
+                    translateX: animationValue.interpolate({
+                      inputRange: filterPageY > 0 ? [0, filterPageY - ANIM_START, filterPageY] : [0, 0, 0],
+                      outputRange: filterPageY > 0 ? [0, 0, TRANSLATE_X_VALUE] : [0, 0, 0],
+                      extrapolate: "clamp",
+                    }),
+                  },
+                ],
+              }}
+            >
+              {!!total && (
+                <Text variant="subtitle" color="black60">
+                  Showing {total} works
+                </Text>
+              )}
+            </Animated.View>
+            {!!total && (
+              <TouchableHighlightColor
+                haptic
+                onPress={onPress}
+                render={({ color }) => (
+                  <Flex flexDirection="row" alignItems="center">
+                    <FilterIcon fill={color} width="20px" height="20px" />
+                    <Text variant="subtitle" color={color}>
+                      Sort & Filter
+                    </Text>
+                  </Flex>
+                )}
+              />
+            )}
+          </Flex>
+        </Box>
+      </Animated.View>
+    </Box>
+  )
+}

--- a/src/lib/Components/HeaderArtworksFilter.tsx
+++ b/src/lib/Components/HeaderArtworksFilter.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from "react"
 import { Animated, Dimensions, LayoutChangeEvent, PixelRatio } from "react-native"
 import styled from "styled-components/native"
 
-interface FilterProps {
+export interface FilterProps {
   total: number
   animationValue: Animated.Value
   onPress: () => void

--- a/src/lib/Components/HeaderArtworksFilter.tsx
+++ b/src/lib/Components/HeaderArtworksFilter.tsx
@@ -3,7 +3,6 @@ import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { Box, FilterIcon, Flex, Separator, Text, TouchableHighlightColor } from "palette"
 import React, { useEffect, useState } from "react"
 import { Animated, Dimensions, LayoutChangeEvent, PixelRatio } from "react-native"
-import styled from "styled-components/native"
 
 export interface FilterProps {
   total: number
@@ -23,10 +22,6 @@ const BACK_BUTTON_SIZE = {
     width: 40,
   },
 }
-
-export const Container = styled(Box)`
-  background-color: white;
-`
 
 export const HeaderArtworksFilter: React.FC<FilterProps> = ({ total, animationValue, onPress }) => {
   const screenWidth = useScreenDimensions().width
@@ -85,60 +80,58 @@ export const HeaderArtworksFilter: React.FC<FilterProps> = ({ total, animationVa
     )
   }
 
-  if (!total) {
-    return <SeparatorWithSmoothOpacity />
-  }
-
   return (
-    <Container onLayout={(e) => _onLayout(e)}>
+    <Box backgroundColor="white" onLayout={(e) => _onLayout(e)}>
       <SeparatorWithSmoothOpacity />
-      <Animated.View
-        style={{
-          transform: [
-            {
-              translateY: animationValue.interpolate({
-                inputRange: filterPageY > 0 ? [0, filterPageY - ANIM_START, filterPageY] : [0, 0, 0],
-                outputRange: filterPageY > 0 ? [0, 0, TRANSLATE_Y_VALUE] : [0, 0, 0],
-                extrapolate: "clamp",
-              }),
-            },
-          ],
-        }}
-      >
-        <Box backgroundColor="white" mt={3} px={2} mb={3}>
-          <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
-            <Animated.View
-              style={{
-                transform: [
-                  {
-                    translateX: animationValue.interpolate({
-                      inputRange: filterPageY > 0 ? [0, filterPageY - ANIM_START, filterPageY] : [0, 0, 0],
-                      outputRange: filterPageY > 0 ? [0, 0, TRANSLATE_X_VALUE] : [0, 0, 0],
-                      extrapolate: "clamp",
-                    }),
-                  },
-                ],
-              }}
-            >
-              <Text variant="subtitle" color="black60">
-                Showing {total} works
-              </Text>
-            </Animated.View>
-            <TouchableHighlightColor
-              haptic
-              onPress={onPress}
-              render={({ color }) => (
-                <Flex flexDirection="row" alignItems="center">
-                  <FilterIcon fill={color} width="20px" height="20px" />
-                  <Text variant="subtitle" color={color}>
-                    Sort & Filter
-                  </Text>
-                </Flex>
-              )}
-            />
-          </Flex>
-        </Box>
-      </Animated.View>
-    </Container>
+      {!!total && (
+        <Animated.View
+          style={{
+            transform: [
+              {
+                translateY: animationValue.interpolate({
+                  inputRange: filterPageY > 0 ? [0, filterPageY - ANIM_START, filterPageY] : [0, 0, 0],
+                  outputRange: filterPageY > 0 ? [0, 0, TRANSLATE_Y_VALUE] : [0, 0, 0],
+                  extrapolate: "clamp",
+                }),
+              },
+            ],
+          }}
+        >
+          <Box backgroundColor="white" mt={3} px={2} mb={3}>
+            <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
+              <Animated.View
+                style={{
+                  transform: [
+                    {
+                      translateX: animationValue.interpolate({
+                        inputRange: filterPageY > 0 ? [0, filterPageY - ANIM_START, filterPageY] : [0, 0, 0],
+                        outputRange: filterPageY > 0 ? [0, 0, TRANSLATE_X_VALUE] : [0, 0, 0],
+                        extrapolate: "clamp",
+                      }),
+                    },
+                  ],
+                }}
+              >
+                <Text variant="subtitle" color="black60">
+                  Showing {total} works
+                </Text>
+              </Animated.View>
+              <TouchableHighlightColor
+                haptic
+                onPress={onPress}
+                render={({ color }) => (
+                  <Flex flexDirection="row" alignItems="center">
+                    <FilterIcon fill={color} width="20px" height="20px" />
+                    <Text variant="subtitle" color={color}>
+                      Sort & Filter
+                    </Text>
+                  </Flex>
+                )}
+              />
+            </Flex>
+          </Box>
+        </Animated.View>
+      )}
+    </Box>
   )
 }

--- a/src/lib/Components/HeaderArtworksFilter.tsx
+++ b/src/lib/Components/HeaderArtworksFilter.tsx
@@ -3,6 +3,7 @@ import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { Box, FilterIcon, Flex, Separator, Text, TouchableHighlightColor } from "palette"
 import React, { useEffect, useState } from "react"
 import { Animated, Dimensions, LayoutChangeEvent, PixelRatio } from "react-native"
+import styled from "styled-components/native"
 
 interface FilterProps {
   total: number
@@ -22,6 +23,10 @@ const BACK_BUTTON_SIZE = {
     width: 40,
   },
 }
+
+export const Container = styled(Box)`
+  background-color: white;
+`
 
 export const HeaderArtworksFilter: React.FC<FilterProps> = ({ total, animationValue, onPress }) => {
   const screenWidth = useScreenDimensions().width
@@ -85,7 +90,7 @@ export const HeaderArtworksFilter: React.FC<FilterProps> = ({ total, animationVa
   }
 
   return (
-    <Box backgroundColor="white" onLayout={(e) => _onLayout(e)}>
+    <Container onLayout={(e) => _onLayout(e)}>
       <SeparatorWithSmoothOpacity />
       <Animated.View
         style={{
@@ -115,29 +120,25 @@ export const HeaderArtworksFilter: React.FC<FilterProps> = ({ total, animationVa
                 ],
               }}
             >
-              {!!total && (
-                <Text variant="subtitle" color="black60">
-                  Showing {total} works
-                </Text>
-              )}
+              <Text variant="subtitle" color="black60">
+                Showing {total} works
+              </Text>
             </Animated.View>
-            {!!total && (
-              <TouchableHighlightColor
-                haptic
-                onPress={onPress}
-                render={({ color }) => (
-                  <Flex flexDirection="row" alignItems="center">
-                    <FilterIcon fill={color} width="20px" height="20px" />
-                    <Text variant="subtitle" color={color}>
-                      Sort & Filter
-                    </Text>
-                  </Flex>
-                )}
-              />
-            )}
+            <TouchableHighlightColor
+              haptic
+              onPress={onPress}
+              render={({ color }) => (
+                <Flex flexDirection="row" alignItems="center">
+                  <FilterIcon fill={color} width="20px" height="20px" />
+                  <Text variant="subtitle" color={color}>
+                    Sort & Filter
+                  </Text>
+                </Flex>
+              )}
+            />
           </Flex>
         </Box>
       </Animated.View>
-    </Box>
+    </Container>
   )
 }

--- a/src/lib/Components/__tests__/HeaderArtworksFilter-tests.tsx
+++ b/src/lib/Components/__tests__/HeaderArtworksFilter-tests.tsx
@@ -1,0 +1,33 @@
+import { useAnimatedValue } from "lib/Scenes/Artwork/Components/ImageCarousel/useAnimatedValue"
+import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { Text, TouchableHighlightColor } from "palette"
+import React from "react"
+import { act } from "react-test-renderer"
+import { FilterProps, HeaderArtworksFilter } from "../HeaderArtworksFilter"
+
+describe("HeaderArtworksFilter", () => {
+  const onPress = jest.fn()
+
+  const MockHeaderArtworksFilter = (props: FilterProps | {}) => {
+    const animationValue = useAnimatedValue(0)
+    return <HeaderArtworksFilter total={120} animationValue={animationValue} onPress={onPress} {...props} />
+  }
+
+  it("renders without throwing an error", () => {
+    renderWithWrappers(<MockHeaderArtworksFilter />)
+  })
+
+  it("should show correct artworks count", () => {
+    const tree = renderWithWrappers(<MockHeaderArtworksFilter />)
+
+    expect(extractText(tree.root.findAllByType(Text)[0])).toEqual("Showing 120 works")
+  })
+
+  it("should call `onPress` when `sort & filter` button is pressed", () => {
+    const tree = renderWithWrappers(<MockHeaderArtworksFilter />)
+    act(() => tree.root.findByType(TouchableHighlightColor).props.onPress())
+
+    expect(onPress).toBeCalled()
+  })
+})

--- a/src/lib/Scenes/Collection/Components/CollectionArtworksFilter.tsx
+++ b/src/lib/Scenes/Collection/Components/CollectionArtworksFilter.tsx
@@ -1,12 +1,10 @@
 import { CollectionArtworks_collection } from "__generated__/CollectionArtworks_collection.graphql"
 import { ArtworkFilterNavigator, FilterModalMode } from "lib/Components/ArtworkFilter"
 import { ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
-import { isPad } from "lib/utils/hardware"
+import { HeaderArtworksFilter } from "lib/Components/HeaderArtworksFilter"
 import { Schema } from "lib/utils/track"
-import { useScreenDimensions } from "lib/utils/useScreenDimensions"
-import { Box, FilterIcon, Flex, Separator, Text, TouchableHighlightColor } from "palette"
-import React, { useEffect, useState } from "react"
-import { Animated, Dimensions, LayoutChangeEvent, PixelRatio } from "react-native"
+import React, { useState } from "react"
+import { Animated } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 
@@ -15,37 +13,12 @@ interface FilterProps {
   animationValue: Animated.Value
 }
 
-const pixelRatio = PixelRatio.get()
-// values based on px used in <BackButton>
-const BACK_BUTTON_SIZE = {
-  top: isPad() ? 10 / pixelRatio : 14 / pixelRatio,
-  left: isPad() ? 20 / pixelRatio : 10 / pixelRatio,
-  right: 0,
-  bottom: 0,
-  image: {
-    height: 40,
-    width: 40,
-  },
-}
-
 export const CollectionArtworksFilter: React.FC<FilterProps> = ({ collection, animationValue }) => {
   const tracking = useTracking()
 
-  const artworksTotal = ArtworksFiltersStore.useStoreState((state) => state.counts.total) || 0
-
-  const screenWidth = useScreenDimensions().width
+  const artworksTotal = ArtworksFiltersStore.useStoreState((state) => state.counts.total) ?? 0
 
   const [isFilterArtworksModalVisible, setFilterArtworkModalVisible] = useState(false)
-  const [onLayoutCalled, setOnLayoutCalled] = useState(false)
-  const [filterPageY, setPageY] = useState(0)
-
-  useEffect(() => {
-    // orientation changed, allow for recalculation of pageY
-    Dimensions.addEventListener("change", orientationChanged)
-    return () => {
-      Dimensions.removeEventListener("change", orientationChanged)
-    }
-  }, [])
 
   const toggleFilterArtworksModal = () => {
     setFilterArtworkModalVisible(!isFilterArtworksModalVisible)
@@ -75,107 +48,18 @@ export const CollectionArtworksFilter: React.FC<FilterProps> = ({ collection, an
     toggleFilterArtworksModal()
   }
 
-  const orientationChanged = () => {
-    setOnLayoutCalled(false)
-  }
-
-  const _onLayout = (event: LayoutChangeEvent) => {
-    // because onLayout can be called multiple times on android
-    if (onLayoutCalled) {
-      return
-    }
-    // @ts-ignore
-    event.target.measure((x: number, y: number, width: number, height: number, pageX: number, pageY: number) => {
-      setPageY(pageY)
-    })
-    setOnLayoutCalled(true)
-  }
-
-  const extraOffset = 1
-  const topInset = useScreenDimensions().safeAreaInsets.top
-
-  const ANIM_START = BACK_BUTTON_SIZE.image.height * 2
-  const TRANSLATE_X_VALUE = BACK_BUTTON_SIZE.image.width
-  const TRANSLATE_Y_VALUE =
-    topInset -
-    BACK_BUTTON_SIZE.image.height / 2 -
-    BACK_BUTTON_SIZE.top -
-    PixelRatio.getPixelSizeForLayoutSize(extraOffset)
-
   return (
-    <Box backgroundColor="white" onLayout={(e) => _onLayout(e)}>
-      <Animated.View
-        style={{
-          opacity: animationValue.interpolate({
-            inputRange: filterPageY > 0 ? [0, filterPageY - ANIM_START, filterPageY] : [0, 0, 0],
-            outputRange: filterPageY > 0 ? [1, 0, 0] : [1, 1, 1],
-            extrapolate: "clamp",
-          }),
-        }}
-      >
-        <Separator mt={2} width={screenWidth * 2} />
-      </Animated.View>
-      <Animated.View
-        style={{
-          transform: [
-            {
-              translateY: animationValue.interpolate({
-                inputRange: filterPageY > 0 ? [0, filterPageY - ANIM_START, filterPageY] : [0, 0, 0],
-                outputRange: filterPageY > 0 ? [0, 0, TRANSLATE_Y_VALUE] : [0, 0, 0],
-                extrapolate: "clamp",
-              }),
-            },
-          ],
-        }}
-      >
-        <Box backgroundColor="white" mt={3} px={2} mb={3}>
-          <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
-            <Animated.View
-              style={{
-                transform: [
-                  {
-                    translateX: animationValue.interpolate({
-                      inputRange: filterPageY > 0 ? [0, filterPageY - ANIM_START, filterPageY] : [0, 0, 0],
-                      outputRange: filterPageY > 0 ? [0, 0, TRANSLATE_X_VALUE] : [0, 0, 0],
-                      extrapolate: "clamp",
-                    }),
-                  },
-                ],
-              }}
-            >
-              {!!artworksTotal && (
-                <Text variant="subtitle" color="black60">
-                  Showing {artworksTotal} works
-                </Text>
-              )}
-            </Animated.View>
-            {!!artworksTotal && (
-              <TouchableHighlightColor
-                haptic
-                onPress={openFilterArtworksModal}
-                render={({ color }) => (
-                  <Flex flexDirection="row" alignItems="center">
-                    <FilterIcon fill={color} width="20px" height="20px" />
-                    <Text variant="subtitle" color={color}>
-                      Sort & Filter
-                    </Text>
-                  </Flex>
-                )}
-              />
-            )}
-          </Flex>
-
-          <ArtworkFilterNavigator
-            id={collection.id}
-            slug={collection.slug}
-            isFilterArtworksModalVisible={isFilterArtworksModalVisible}
-            exitModal={toggleFilterArtworksModal}
-            closeModal={closeFilterArtworksModal}
-            mode={FilterModalMode.Collection}
-          />
-        </Box>
-      </Animated.View>
-    </Box>
+    <>
+      <HeaderArtworksFilter total={artworksTotal} animationValue={animationValue} onPress={openFilterArtworksModal} />
+      <ArtworkFilterNavigator
+        id={collection.id}
+        slug={collection.slug}
+        isFilterArtworksModalVisible={isFilterArtworksModalVisible}
+        exitModal={toggleFilterArtworksModal}
+        closeModal={closeFilterArtworksModal}
+        mode={FilterModalMode.Collection}
+      />
+    </>
   )
 }
 

--- a/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/lib/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -76,7 +76,7 @@ export const CollectionArtworks: React.FC<CollectionArtworksProps> = ({ collecti
 
   if (artworksTotal === 0) {
     return (
-      <Box mt={isDepartment ? "0px" : "-50px"} mb="80px">
+      <Box mb="80px">
         <Spacer mt={3} />
         <FilteredArtworkGridZeroState id={collection.id} slug={collection.slug} trackClear={trackClear} />
       </Box>

--- a/src/lib/Scenes/Show/Components/ShowArtworks.tsx
+++ b/src/lib/Scenes/Show/Components/ShowArtworks.tsx
@@ -47,13 +47,14 @@ export const ShowArtworksWithNavigation = (props: ArtworkProps) => {
 
 const ShowArtworks: React.FC<Props> = ({ show, relay, initiallyAppliedFilter }) => {
   const artworks = show.showArtworks!
+  const artworksTotal = artworks?.counts?.total ?? 0
   const { internalID, slug } = show
 
   const setAggregationsAction = ArtworksFiltersStore.useStoreActions((state) => state.setAggregationsAction)
   const setInitialFilterStateAction = ArtworksFiltersStore.useStoreActions((state) => state.setInitialFilterStateAction)
   const applyFilters = ArtworksFiltersStore.useStoreState((state) => state.applyFilters)
   const setFilterTypeAction = ArtworksFiltersStore.useStoreActions((state) => state.setFilterTypeAction)
-
+  const setFiltersCountAction = ArtworksFiltersStore.useStoreActions((state) => state.setFiltersCountAction)
   const appliedFilters = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
 
   const filterParams = filterArtworksParams(appliedFilters, "showArtwork")
@@ -86,7 +87,14 @@ const ShowArtworks: React.FC<Props> = ({ show, relay, initiallyAppliedFilter }) 
     setAggregationsAction(artworkAggregations)
   }, [])
 
-  if ((artworks?.counts?.total ?? 0) === 0) {
+  useEffect(() => {
+    setFiltersCountAction({
+      total: artworksTotal,
+      followedArtists: null,
+    })
+  }, [artworksTotal])
+
+  if (artworksTotal === 0) {
     return <FilteredArtworkGridZeroState id={internalID} slug={slug} />
   }
 

--- a/src/lib/Scenes/Show/Components/ShowArtworks.tsx
+++ b/src/lib/Scenes/Show/Components/ShowArtworks.tsx
@@ -56,6 +56,7 @@ const ShowArtworks: React.FC<Props> = ({ show, relay, initiallyAppliedFilter }) 
   const setFilterTypeAction = ArtworksFiltersStore.useStoreActions((state) => state.setFilterTypeAction)
   const setFiltersCountAction = ArtworksFiltersStore.useStoreActions((state) => state.setFiltersCountAction)
   const appliedFilters = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
+  const counts = ArtworksFiltersStore.useStoreState((state) => state.counts)
 
   const filterParams = filterArtworksParams(appliedFilters, "showArtwork")
 
@@ -88,10 +89,7 @@ const ShowArtworks: React.FC<Props> = ({ show, relay, initiallyAppliedFilter }) 
   }, [])
 
   useEffect(() => {
-    setFiltersCountAction({
-      total: artworksTotal,
-      followedArtists: null,
-    })
+    setFiltersCountAction({ ...counts, total: artworksTotal })
   }, [artworksTotal])
 
   if (artworksTotal === 0) {

--- a/src/lib/Scenes/Show/Components/ShowArtworksFilter.tsx
+++ b/src/lib/Scenes/Show/Components/ShowArtworksFilter.tsx
@@ -1,8 +1,14 @@
 import { ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { HeaderArtworksFilter } from "lib/Components/HeaderArtworksFilter"
 import React from "react"
+import { Animated } from "react-native"
 
-export const ShowArtworksFilter: React.FC<any> = (props) => {
+interface ShowArtworksFilterProps {
+  animationValue: Animated.Value
+  onPress: () => void
+}
+
+export const ShowArtworksFilter: React.FC<ShowArtworksFilterProps> = (props) => {
   const artworksTotal = ArtworksFiltersStore.useStoreState((state) => state.counts.total) ?? 0
 
   return <HeaderArtworksFilter total={artworksTotal} {...props} />

--- a/src/lib/Scenes/Show/Components/ShowArtworksFilter.tsx
+++ b/src/lib/Scenes/Show/Components/ShowArtworksFilter.tsx
@@ -1,0 +1,9 @@
+import { ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
+import { HeaderArtworksFilter } from "lib/Components/HeaderArtworksFilter"
+import React from "react"
+
+export const ShowArtworksFilter: React.FC<any> = (props) => {
+  const artworksTotal = ArtworksFiltersStore.useStoreState((state) => state.counts.total) ?? 0
+
+  return <HeaderArtworksFilter total={artworksTotal} {...props} />
+}

--- a/src/lib/Scenes/Show/Show.tsx
+++ b/src/lib/Scenes/Show/Show.tsx
@@ -1,6 +1,5 @@
 import { Show_show } from "__generated__/Show_show.graphql"
 import { ShowQuery } from "__generated__/ShowQuery.graphql"
-import { AnimatedArtworkFilterButton } from "lib/Components/ArtworkFilter"
 import { ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { PlaceholderBox, PlaceholderGrid, PlaceholderText } from "lib/utils/placeholders"
@@ -10,10 +9,11 @@ import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { times } from "lodash"
 import { Box, Flex, Separator, Spacer } from "palette"
 import React, { useRef, useState } from "react"
-import { FlatList } from "react-native"
+import { Animated } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import { ShowArtworksWithNavigation as ShowArtworks } from "./Components/ShowArtworks"
 import { ShowArtworksEmptyStateFragmentContainer } from "./Components/ShowArtworksEmptyState"
+import { ShowArtworksFilter } from "./Components/ShowArtworksFilter"
 import { ShowContextCardFragmentContainer as ShowContextCard } from "./Components/ShowContextCard"
 import { ShowHeaderFragmentContainer as ShowHeader } from "./Components/ShowHeader"
 import { ShowInfoFragmentContainer as ShowInfo } from "./Components/ShowInfo"
@@ -47,15 +47,10 @@ interface ViewToken {
 
 export const Show: React.FC<ShowProps> = ({ show }) => {
   const [isFilterArtworksModalVisible, setFilterArtworkModalVisible] = useState(false)
-  const [isFilterButtonVisible, setisFilterButtonVisible] = useState(false)
+
+  const filterComponentAnimationValue = new Animated.Value(0)
 
   const viewConfigRef = useRef({ viewAreaCoveragePercentThreshold: 30 })
-  const viewableItemsChangedRef = useRef(({ viewableItems }: ViewableItems) => {
-    const artworksItem = (viewableItems! ?? []).find((viewableItem: ViewToken) => {
-      return viewableItem?.item?.key === "artworks"
-    })
-    setisFilterButtonVisible(artworksItem?.isViewable ?? false)
-  })
 
   const toggleFilterArtworksModal = () => {
     setFilterArtworkModalVisible(!isFilterArtworksModalVisible)
@@ -70,18 +65,16 @@ export const Show: React.FC<ShowProps> = ({ show }) => {
 
     { key: "info", element: <ShowInfo show={show} mx={2} /> },
 
+    {
+      key: "filter",
+      element: (
+        <ShowArtworksFilter animationValue={filterComponentAnimationValue} onPress={toggleFilterArtworksModal} />
+      ),
+    },
+
     ...(Boolean(show.viewingRoomIDs.length)
       ? [{ key: "viewing-room", element: <ShowViewingRoom show={show} mx={2} /> }]
       : []),
-
-    {
-      key: "separator-top",
-      element: (
-        <Box mx={2}>
-          <Separator />
-        </Box>
-      ),
-    },
 
     {
       key: "artworks",
@@ -114,20 +107,19 @@ export const Show: React.FC<ShowProps> = ({ show }) => {
       }}
     >
       <ArtworkFiltersStoreProvider>
-        <FlatList<Section>
+        <Animated.FlatList<Section>
           data={sections}
           keyExtractor={({ key }) => key}
+          stickyHeaderIndices={[sections.findIndex((section) => section.key === "filter") + 1]}
           viewabilityConfig={viewConfigRef.current}
-          onViewableItemsChanged={viewableItemsChangedRef.current}
           ListHeaderComponent={<Spacer mt={6} pt={2} />}
           ListFooterComponent={<Spacer my={2} />}
           ItemSeparatorComponent={() => <Spacer my={15} />}
           contentContainerStyle={{ paddingTop: useScreenDimensions().safeAreaInsets.top, paddingBottom: 40 }}
           renderItem={({ item: { element } }) => element}
-        />
-        <AnimatedArtworkFilterButton
-          isVisible={isFilterButtonVisible && Boolean(show.counts?.eligibleArtworks)}
-          onPress={toggleFilterArtworksModal}
+          onScroll={Animated.event([{ nativeEvent: { contentOffset: { y: filterComponentAnimationValue } } }], {
+            useNativeDriver: true,
+          })}
         />
       </ArtworkFiltersStoreProvider>
     </ProvideScreenTracking>
@@ -144,10 +136,7 @@ export const ShowFragmentContainer = createFragmentContainer(Show, {
       ...ShowInfo_show
       ...ShowViewingRoom_show
       ...ShowContextCard_show
-      ...ShowArtworks_show @arguments(input: {
-        sort: "partner_show_position",
-        dimensionRange: "*-*"
-      })
+      ...ShowArtworks_show @arguments(input: { sort: "partner_show_position", dimensionRange: "*-*" })
       ...ShowArtworksEmptyState_show
       viewingRoomIDs
       images(default: false) {

--- a/src/lib/Scenes/Show/__tests__/Show-tests.tsx
+++ b/src/lib/Scenes/Show/__tests__/Show-tests.tsx
@@ -1,11 +1,11 @@
 import { ShowTestsQuery } from "__generated__/ShowTestsQuery.graphql"
-import { AnimatedArtworkFilterButton } from "lib/Components/ArtworkFilter"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { act } from "react-test-renderer"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { ShowArtworksFilter } from "../Components/ShowArtworksFilter"
 import { ShowContextCard } from "../Components/ShowContextCard"
 import { Show, ShowFragmentContainer } from "../Show"
 
@@ -91,19 +91,11 @@ describe("Show", () => {
 
   it("renders the context card", () => {
     const wrapper = getWrapper()
-
     expect(wrapper.root.findAllByType(ShowContextCard)).toHaveLength(1)
   })
 
-  it("does not render the sort/filter control if there are no eligible artworks", () => {
-    const wrapper = getWrapper({
-      Show: () => ({
-        counts: {
-          eligibleArtworks: 0,
-        },
-      }),
-    })
-
-    expect(wrapper.root.findByType(AnimatedArtworkFilterButton).props.isVisible).toEqual(false)
+  it("renders show artworks filter header", () => {
+    const wrapper = getWrapper()
+    expect(wrapper.root.findAllByType(ShowArtworksFilter)).toHaveLength(1)
   })
 })

--- a/src/lib/Scenes/Show/__tests__/ShowArtworksFilter-tests.tsx
+++ b/src/lib/Scenes/Show/__tests__/ShowArtworksFilter-tests.tsx
@@ -1,5 +1,4 @@
 import { ArtworkFiltersState, ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
-import { Container } from "lib/Components/HeaderArtworksFilter"
 import { useAnimatedValue } from "lib/Scenes/Artwork/Components/ImageCarousel/useAnimatedValue"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
@@ -46,7 +45,6 @@ describe("Show", () => {
         },
       },
     })
-    expect(wrapper.root.findAllByType(Container)).toHaveLength(1)
 
     const text = extractText(wrapper.root)
     expect(text).toContain("Showing 12 works")
@@ -55,6 +53,10 @@ describe("Show", () => {
 
   it("doesn't render show artworks filter header", () => {
     const wrapper = getWrapper({})
-    expect(wrapper.root.findAllByType(Container)).toHaveLength(0)
+
+    const text = extractText(wrapper.root)
+    expect(text).not.toContain("Showing")
+    expect(text).not.toContain("works")
+    expect(text).not.toContain("Sort & Filter")
   })
 })

--- a/src/lib/Scenes/Show/__tests__/ShowArtworksFilter-tests.tsx
+++ b/src/lib/Scenes/Show/__tests__/ShowArtworksFilter-tests.tsx
@@ -1,12 +1,14 @@
 import { ArtworkFiltersState, ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { Container } from "lib/Components/HeaderArtworksFilter"
-import { useAnimatedValue } from "lib/Components/StickyTabPage/reanimatedHelpers"
+import { useAnimatedValue } from "lib/Scenes/Artwork/Components/ImageCarousel/useAnimatedValue"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { ShowArtworksFilter } from "../Components/ShowArtworksFilter"
 
 describe("Show", () => {
+  const onPress = jest.fn()
+
   const initialState: ArtworkFiltersState = {
     selectedFilters: [],
     appliedFilters: [],
@@ -24,7 +26,7 @@ describe("Show", () => {
     const animationValue = useAnimatedValue(0)
     return (
       <ArtworkFiltersStoreProvider initialData={initialData}>
-        <ShowArtworksFilter animationValue={animationValue} />
+        <ShowArtworksFilter animationValue={animationValue} onPress={onPress} />
       </ArtworkFiltersStoreProvider>
     )
   }

--- a/src/lib/Scenes/Show/__tests__/ShowArtworksFilter-tests.tsx
+++ b/src/lib/Scenes/Show/__tests__/ShowArtworksFilter-tests.tsx
@@ -1,0 +1,58 @@
+import { ArtworkFiltersState, ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
+import { Container } from "lib/Components/HeaderArtworksFilter"
+import { useAnimatedValue } from "lib/Components/StickyTabPage/reanimatedHelpers"
+import { extractText } from "lib/tests/extractText"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import React from "react"
+import { ShowArtworksFilter } from "../Components/ShowArtworksFilter"
+
+describe("Show", () => {
+  const initialState: ArtworkFiltersState = {
+    selectedFilters: [],
+    appliedFilters: [],
+    previouslyAppliedFilters: [],
+    applyFilters: false,
+    aggregations: [],
+    filterType: "artwork",
+    counts: {
+      total: null,
+      followedArtists: null,
+    },
+  }
+
+  const TestShowArtworksFilter = ({ initialData }: { initialData?: ArtworkFiltersState }) => {
+    const animationValue = useAnimatedValue(0)
+    return (
+      <ArtworkFiltersStoreProvider initialData={initialData}>
+        <ShowArtworksFilter animationValue={animationValue} />
+      </ArtworkFiltersStoreProvider>
+    )
+  }
+
+  const getWrapper = ({ initialData = initialState }: { initialData?: ArtworkFiltersState }) => {
+    const tree = renderWithWrappers(<TestShowArtworksFilter initialData={initialData} />)
+    return tree
+  }
+
+  it("renders show artworks filter header with correct text", () => {
+    const wrapper = getWrapper({
+      initialData: {
+        ...initialState,
+        counts: {
+          total: 12,
+          followedArtists: null,
+        },
+      },
+    })
+    expect(wrapper.root.findAllByType(Container)).toHaveLength(1)
+
+    const text = extractText(wrapper.root)
+    expect(text).toContain("Showing 12 works")
+    expect(text).toContain("Sort & Filter")
+  })
+
+  it("doesn't render show artworks filter header", () => {
+    const wrapper = getWrapper({})
+    expect(wrapper.root.findAllByType(Container)).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
The type of this PR is: **Enhancement**

[FX-2908]

This PR resolves []

### Description

I incapsulated logic of sticky header from [here](https://github.com/artsy/eigen/pull/4932) and applied for Show screen

**Before**
![Simulator Screen Shot - iPhone 8 - 2021-06-21 at 13 20 03](https://user-images.githubusercontent.com/44819355/122747233-7e8b0e80-d293-11eb-9444-87419b656349.png)


**After**
![after](https://user-images.githubusercontent.com/44819355/122747253-877be000-d293-11eb-9bed-cbf50eb69e32.gif)



### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2908]: https://artsyproduct.atlassian.net/browse/FX-2908