### PR TITLE
fix: iOS artwork preview misalignment

### DIFF
--- a/src/lib/Scenes/Inbox/Components/Conversations/Preview/ArtworkPreview.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/Preview/ArtworkPreview.tsx
@@ -63,11 +63,7 @@ export class ArtworkPreview extends React.Component<Props> {
     const artworkImage = artwork.image
 
     return (
-      <Touchable
-        style={{ maxWidth: "66.67%", flex: 1 }}
-        underlayColor={Colors.GrayLight}
-        onPress={this.props.onSelected && this.attachmentSelected.bind(this)}
-      >
+      <Touchable underlayColor={Colors.GrayLight} onPress={this.props.onSelected && this.attachmentSelected.bind(this)}>
         <Container>
           {!!artworkImage && (
             <ImageContainer>


### PR DESCRIPTION
The type of this PR is: Bugfix

This PR resolves [PURCHASE-2733]

### Description

Remove line, that causes a problem on iOS. After removing it looks fine on iOS and Android on different devices. 
Narrow android example:
![image](https://user-images.githubusercontent.com/19696618/122766410-29a6c280-d2aa-11eb-9f86-4406d186939b.png)
Wide iOS example:
![image](https://user-images.githubusercontent.com/19696618/122766473-3f1bec80-d2aa-11eb-8031-2bcf392fda77.png)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[PURCHASE-2733]: https://artsyproduct.atlassian.net/browse/PURCHASE-2733