### PR TITLE
[WIP] feat[FX-2979]: read artwork filters from notification payload

### DIFF
--- a/Artsy/App/ARAppNotificationsDelegate.m
+++ b/Artsy/App/ARAppNotificationsDelegate.m
@@ -313,7 +313,7 @@
 {
     [ARAnalytics event:ARAnalyticsNotificationTapped withProperties:notificationInfo];
 
-    [[AREmission sharedInstance] navigate:url];
+    [[AREmission sharedInstance] navigate:url payload:notificationInfo];
 }
 
 - (UIWindow *)findVisibleWindow

--- a/emission/Pod/Classes/Core/AREmission.h
+++ b/emission/Pod/Classes/Core/AREmission.h
@@ -34,6 +34,7 @@ extern NSString *const AREnvTest;
 - (NSString *)reactStateStringForKey:(NSString *)stateKey;
 - (BOOL)reactStateBoolForKey:(NSString *)stateKey;
 - (void)navigate:(NSString *)route;
+- (void)navigate:(NSString *)route payload:(NSDictionary *)payload;
 
 - (NSURL *)liveAuctionsURL;
 - (BOOL)isStaging;

--- a/emission/Pod/Classes/Core/AREmission.m
+++ b/emission/Pod/Classes/Core/AREmission.m
@@ -80,6 +80,11 @@ static AREmission *_sharedInstance = nil;
     [[self notificationsManagerModule] requestNavigation:route];
 }
 
+- (void)navigate:(NSString *)route payload:(NSDictionary *)payload
+{
+    [[self notificationsManagerModule] requestNavigation:route payload:payload];
+}
+
 - (void)updateState:(NSDictionary *)state
 {
     [self.notificationsManagerModule updateState:state];

--- a/emission/Pod/Classes/EigenCommunications/ARNotificationsManager.h
+++ b/emission/Pod/Classes/EigenCommunications/ARNotificationsManager.h
@@ -39,6 +39,7 @@
 - (void)updateReactState:(NSDictionary *)reactState;
 
 - (void)requestNavigation:(NSString *)route;
+- (void)requestNavigation:(NSString *)route payload:(NSDictionary *)payload;
 - (void)afterBootstrap:(void (^)(void))completion;
 
 @end

--- a/emission/Pod/Classes/EigenCommunications/ARNotificationsManager.m
+++ b/emission/Pod/Classes/EigenCommunications/ARNotificationsManager.m
@@ -129,6 +129,16 @@ RCT_EXPORT_MODULE();
     }];
 }
 
+- (void)requestNavigation:(NSString *)route  payload:(NSDictionary *)payload
+{
+    __weak typeof(self) wself = self;
+    [self afterBootstrap:^{
+        __strong typeof(self) sself = wself;
+        if (!sself) return;
+        [sself dispatch:requestNavigation data:@{@"route": route, @"payload": payload}];
+    }];
+}
+
 // Will be called when this module's first listener is added.
 - (void)startObserving
 {

--- a/src/__generated__/SavedSearchBannerCriteriaByIdQuery.graphql.ts
+++ b/src/__generated__/SavedSearchBannerCriteriaByIdQuery.graphql.ts
@@ -1,0 +1,275 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash 996b7dc50e8886a03c4d21d002a32a5d */
+
+import { ConcreteRequest } from "relay-runtime";
+export type SavedSearchBannerCriteriaByIdQueryVariables = {
+    criteriaId: string;
+};
+export type SavedSearchBannerCriteriaByIdQueryResponse = {
+    readonly me: {
+        readonly email: string | null;
+        readonly savedSearch: {
+            readonly acquireable: boolean | null;
+            readonly additionalGeneIDs: ReadonlyArray<string>;
+            readonly artistID: string | null;
+            readonly atAuction: boolean | null;
+            readonly attributionClass: ReadonlyArray<string>;
+            readonly colors: ReadonlyArray<string>;
+            readonly dimensionRange: string | null;
+            readonly height: string | null;
+            readonly inquireableOnly: boolean | null;
+            readonly locationCities: ReadonlyArray<string>;
+            readonly majorPeriods: ReadonlyArray<string>;
+            readonly materialsTerms: ReadonlyArray<string>;
+            readonly offerable: boolean | null;
+            readonly partnerIDs: ReadonlyArray<string>;
+            readonly priceRange: string | null;
+            readonly width: string | null;
+        } | null;
+    } | null;
+};
+export type SavedSearchBannerCriteriaByIdQuery = {
+    readonly response: SavedSearchBannerCriteriaByIdQueryResponse;
+    readonly variables: SavedSearchBannerCriteriaByIdQueryVariables;
+};
+
+
+
+/*
+query SavedSearchBannerCriteriaByIdQuery(
+  $criteriaId: ID!
+) {
+  me {
+    email
+    savedSearch(id: $criteriaId) {
+      acquireable
+      additionalGeneIDs
+      artistID
+      atAuction
+      attributionClass
+      colors
+      dimensionRange
+      height
+      inquireableOnly
+      locationCities
+      majorPeriods
+      materialsTerms
+      offerable
+      partnerIDs
+      priceRange
+      width
+    }
+    id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "criteriaId"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "email",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "id",
+      "variableName": "criteriaId"
+    }
+  ],
+  "concreteType": "SearchCriteria",
+  "kind": "LinkedField",
+  "name": "savedSearch",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "acquireable",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "additionalGeneIDs",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "artistID",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "atAuction",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "attributionClass",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "colors",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "dimensionRange",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "height",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "inquireableOnly",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "locationCities",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "majorPeriods",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "materialsTerms",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "offerable",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "partnerIDs",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "priceRange",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "width",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SavedSearchBannerCriteriaByIdQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SavedSearchBannerCriteriaByIdQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "996b7dc50e8886a03c4d21d002a32a5d",
+    "metadata": {},
+    "name": "SavedSearchBannerCriteriaByIdQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = 'dec76cec6ff6efff17accb3f7759ef78';
+export default node;

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -93,6 +93,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
   const tracking = useTracking()
   const enableSavedSearch = useFeatureFlag("AREnableSavedSearch")
   const [isRefreshing, setIsRefreshing] = useState(false)
+  const [shouldFetchCriteria, setShouldFetchCriteria] = useState(!!searchCriteriaId)
   const appliedFilters = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
 
   const setInitialFilterStateAction = ArtworksFiltersStore.useStoreActions((state) => state.setInitialFilterStateAction)
@@ -109,7 +110,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
   const relevantFiltersForSavedSearch = appliedFilters.filter((filter) => !(filter.paramName === FilterParamName.sort))
   const aggregationsFromStore = ArtworksFiltersStore.useStoreState((state) => state.aggregations)
   const shouldShowSavedSearchBanner =
-    enableSavedSearch && (searchCriteriaId || relevantFiltersForSavedSearch.length > 0)
+    enableSavedSearch && (shouldFetchCriteria || relevantFiltersForSavedSearch.length > 0)
 
   const setAggregationsAction = ArtworksFiltersStore.useStoreActions((state) => state.setAggregationsAction)
 
@@ -122,6 +123,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
   useEffect(() => {
     if (applyFilters) {
       setIsRefreshing(true)
+      setShouldFetchCriteria(false)
       relay.refetchConnection(
         PAGE_SIZE,
         (error) => {
@@ -184,6 +186,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
               aggregations={aggregationsFromStore}
               loading={isRefreshing}
               updateFilters={updateFiltersAction}
+              shouldFetchCriteria={shouldFetchCriteria}
             />
             <Separator ml={-2} width={screenWidth} />
           </>
@@ -199,6 +202,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
     updateFiltersAction,
     aggregationsFromStore,
     isRefreshing,
+    shouldFetchCriteria,
   ])
 
   const filteredArtworks = () => {

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -107,7 +107,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
 
   const applyFilters = ArtworksFiltersStore.useStoreState((state) => state.applyFilters)
   const relevantFiltersForSavedSearch = appliedFilters.filter((filter) => !(filter.paramName === FilterParamName.sort))
-  const aggregations = ArtworksFiltersStore.useStoreState((state) => state.aggregations)
+  const aggregationsFromStore = ArtworksFiltersStore.useStoreState((state) => state.aggregations)
   const shouldShowSavedSearchBanner =
     enableSavedSearch && (searchCriteriaId || relevantFiltersForSavedSearch.length > 0)
 
@@ -181,7 +181,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
               artistId={artistInternalId}
               filters={filterParams}
               searchCriteriaId={searchCriteriaId}
-              aggregations={aggregations}
+              aggregations={aggregationsFromStore}
               loading={isRefreshing}
               updateFilters={updateFiltersAction}
             />
@@ -197,7 +197,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
     filterParams,
     searchCriteriaId,
     updateFiltersAction,
-    aggregations,
+    aggregationsFromStore,
     isRefreshing,
   ])
 

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -98,7 +98,7 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = (props) => {
           const searchCriteriaAttributes = response.me?.savedSearch as SearchCriteriaAttributes
 
           if (searchCriteriaAttributes) {
-            const filterParams = convertSavedSearchCriteriaToFilterParams(searchCriteriaAttributes, aggregations)
+            const filterParams = convertSavedSearchCriteriaToFilterParams(searchCriteriaAttributes, aggregations!)
             updateFilters(filterParams)
           }
         } catch (error) {

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -76,7 +76,7 @@ const getSearchCriteriaById = graphql`
 `
 
 export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = (props) => {
-  const { me, attributes, searchCriteriaId, loading, aggregations, updateFilters, relay } = props
+  const { me, artistId, attributes, searchCriteriaId, loading, aggregations, updateFilters, relay } = props
   const [saving, setSaving] = useState(false)
   const popoverMessage = usePopoverMessage()
   const enabled = !!me?.savedSearch?.internalID
@@ -265,9 +265,9 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = (props) => {
     })
   }
 
-  const trackToggledSavedSearchEvent = (modified: boolean, searchCriteriaId: string | undefined) => {
-    if (searchCriteriaId) {
-      tracking.trackEvent(tracks.toggleSavedSearch(modified, artistId, searchCriteriaId))
+  const trackToggledSavedSearchEvent = (modified: boolean, id: string | undefined) => {
+    if (id) {
+      tracking.trackEvent(tracks.toggleSavedSearch(modified, artistId, id))
     }
   }
 

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -3,9 +3,10 @@ import { captureMessage } from "@sentry/react-native"
 import { SavedSearchBanner_me } from "__generated__/SavedSearchBanner_me.graphql"
 import { SavedSearchBannerCreateSavedSearchMutation } from "__generated__/SavedSearchBannerCreateSavedSearchMutation.graphql"
 import { SavedSearchBannerDeleteSavedSearchMutation } from "__generated__/SavedSearchBannerDeleteSavedSearchMutation.graphql"
-import { SavedSearchBannerQuery, SearchCriteriaAttributes } from "__generated__/SavedSearchBannerQuery.graphql"
+import { SavedSearchBannerQuery } from "__generated__/SavedSearchBannerQuery.graphql"
 import { FilterParams, prepareFilterParamsForSaveSearchInput } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
-import { usePopoverMessage } from "lib/Components/PopoverMessage/popoverMessageHooks"
+import { SearchCriteriaAttributes } from 'lib/Components/ArtworkFilter/SavedSearch/types'
+import { usePopoverMessage } from 'lib/Components/PopoverMessage/popoverMessageHooks'
 import { LegacyNativeModules } from "lib/NativeModules/LegacyNativeModules"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { PushAuthorizationStatus } from "lib/Scenes/MyProfile/MyProfilePushNotifications"

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -86,19 +86,29 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = (props) => {
   useEffect(() => {
     if (searchCriteriaId && aggregations) {
       const fetchCriteriaAndUpdateFilters = async () => {
-        const response = await fetchQuery<SavedSearchBannerCriteriaByIdQuery>(
-          relay.environment,
-          getSearchCriteriaById,
-          {
-            criteriaId: searchCriteriaId,
-          },
-          { force: true }
-        )
-        const searchCriteriaAttributes = response.me?.savedSearch as SearchCriteriaAttributes
+        try {
+          const response = await fetchQuery<SavedSearchBannerCriteriaByIdQuery>(
+            relay.environment,
+            getSearchCriteriaById,
+            {
+              criteriaId: searchCriteriaId,
+            },
+            { force: true }
+          )
+          const searchCriteriaAttributes = response.me?.savedSearch as SearchCriteriaAttributes
 
-        if (searchCriteriaAttributes) {
-          const filterParams = convertSavedSearchCriteriaToFilterParams(searchCriteriaAttributes, aggregations)
-          updateFilters(filterParams)
+          if (searchCriteriaAttributes) {
+            const filterParams = convertSavedSearchCriteriaToFilterParams(searchCriteriaAttributes, aggregations)
+            updateFilters(filterParams)
+          }
+        } catch (error) {
+          if (error) {
+            if (__DEV__) {
+              console.error(error)
+            } else {
+              captureMessage(error.stack!)
+            }
+          }
         }
       }
 

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -84,7 +84,7 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = (props) => {
   const tracking = useTracking()
 
   useEffect(() => {
-    if (searchCriteriaId && aggregations) {
+    if (searchCriteriaId && aggregations?.length! > 0) {
       const fetchCriteriaAndUpdateFilters = async () => {
         try {
           const response = await fetchQuery<SavedSearchBannerCriteriaByIdQuery>(

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -36,6 +36,7 @@ interface SavedSearchBaseProps {
   searchCriteriaId?: string
   aggregations?: Aggregations
   loading?: boolean
+  shouldFetchCriteria?: boolean
   updateFilters: (params: FilterArray) => void
 }
 
@@ -76,7 +77,17 @@ const getSearchCriteriaById = graphql`
 `
 
 export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = (props) => {
-  const { me, artistId, attributes, searchCriteriaId, loading, aggregations, updateFilters, relay } = props
+  const {
+    me,
+    artistId,
+    attributes,
+    searchCriteriaId,
+    loading,
+    shouldFetchCriteria,
+    aggregations,
+    updateFilters,
+    relay,
+  } = props
   const [saving, setSaving] = useState(false)
   const popoverMessage = usePopoverMessage()
   const enabled = !!me?.savedSearch?.internalID
@@ -84,7 +95,7 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = (props) => {
   const tracking = useTracking()
 
   useEffect(() => {
-    if (searchCriteriaId && aggregations?.length! > 0) {
+    if (shouldFetchCriteria && searchCriteriaId && aggregations?.length! > 0) {
       const fetchCriteriaAndUpdateFilters = async () => {
         try {
           const response = await fetchQuery<SavedSearchBannerCriteriaByIdQuery>(
@@ -114,7 +125,7 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = (props) => {
 
       fetchCriteriaAndUpdateFilters()
     }
-  }, [aggregations, searchCriteriaId])
+  }, [shouldFetchCriteria, aggregations, searchCriteriaId])
 
   // doing refetch as opposed to updating `enabled` in state with savedSearch internalID
   // because change in applied filters will update the `me` prop in the QueryRenderer
@@ -319,7 +330,7 @@ export const SavedSearchBannerRefetchContainer = createRefetchContainer(
 )
 
 export const SavedSearchBannerQueryRender: React.FC<SavedSearchBannerQueryRenderProps> = (props) => {
-  const { filters, artistId, searchCriteriaId, aggregations, loading, updateFilters } = props
+  const { filters, artistId, searchCriteriaId, aggregations, loading, shouldFetchCriteria, updateFilters } = props
   const input = prepareFilterParamsForSaveSearchInput(filters)
   const attributes: SearchCriteriaAttributes = {
     artistID: artistId,
@@ -353,6 +364,7 @@ export const SavedSearchBannerQueryRender: React.FC<SavedSearchBannerQueryRender
             artistId={artistId}
             searchCriteriaId={searchCriteriaId}
             aggregations={aggregations}
+            shouldFetchCriteria={shouldFetchCriteria}
             updateFilters={updateFilters}
           />
         )

--- a/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
@@ -31,8 +31,7 @@ const mockFetchNotificationPermissions = LegacyNativeModules.ARTemporaryAPIModul
 describe("SavedSearchBanner", () => {
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
   const attributes: SearchCriteriaAttributes = {
-    priceMin: 300,
-    priceMax: 500,
+    priceRange: "300-500",
   }
   const trackEvent = jest.fn()
 

--- a/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
@@ -228,7 +228,9 @@ describe("SavedSearchBanner", () => {
   })
 
   it("should query the saved search criteria by id", () => {
-    renderWithWrappers(<TestRenderer searchCriteriaId="search-criteria-id" aggregations={aggregations} />)
+    renderWithWrappers(
+      <TestRenderer searchCriteriaId="search-criteria-id" shouldFetchCriteria={true} aggregations={aggregations} />
+    )
 
     mockEnvironmentPayload(mockEnvironment, {
       SearchCriteria: () => ({
@@ -247,7 +249,12 @@ describe("SavedSearchBanner", () => {
     const updateFilters = jest.fn()
 
     renderWithWrappers(
-      <TestRenderer searchCriteriaId="search-criteria-id" aggregations={aggregations} updateFilters={updateFilters} />
+      <TestRenderer
+        searchCriteriaId="search-criteria-id"
+        shouldFetchCriteria={true}
+        aggregations={aggregations}
+        updateFilters={updateFilters}
+      />
     )
 
     mockEnvironmentPayload(mockEnvironment)
@@ -286,7 +293,12 @@ describe("SavedSearchBanner", () => {
     const updateFilters = jest.fn()
 
     renderWithWrappers(
-      <TestRenderer searchCriteriaId="search-criteria-id" aggregations={aggregations} updateFilters={updateFilters} />
+      <TestRenderer
+        searchCriteriaId="search-criteria-id"
+        shouldFetchCriteria={true}
+        aggregations={aggregations}
+        updateFilters={updateFilters}
+      />
     )
 
     mockEnvironmentPayload(mockEnvironment)
@@ -299,7 +311,9 @@ describe("SavedSearchBanner", () => {
   it("should not call updateFilters if only aggregations passed", async () => {
     const updateFilters = jest.fn()
 
-    renderWithWrappers(<TestRenderer aggregations={aggregations} updateFilters={updateFilters} />)
+    renderWithWrappers(
+      <TestRenderer aggregations={aggregations} shouldFetchCriteria={true} updateFilters={updateFilters} />
+    )
 
     mockEnvironmentPayload(mockEnvironment)
 
@@ -310,7 +324,9 @@ describe("SavedSearchBanner", () => {
   it("should not call updateFilters if only searchCriteriaId passed", async () => {
     const updateFilters = jest.fn()
 
-    renderWithWrappers(<TestRenderer searchCriteriaId="search-criteria-id" updateFilters={updateFilters} />)
+    renderWithWrappers(
+      <TestRenderer searchCriteriaId="search-criteria-id" shouldFetchCriteria={true} updateFilters={updateFilters} />
+    )
 
     mockEnvironmentPayload(mockEnvironment)
 

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -1,7 +1,7 @@
-import { SearchCriteriaAttributes } from "__generated__/SavedSearchBannerQuery.graphql"
 import { FilterScreen } from "lib/Components/ArtworkFilter"
 import { capitalize, compact, groupBy, isEqual, pick, sortBy } from "lodash"
 import { LOCALIZED_UNIT } from "./Filters/helpers"
+import { SearchCriteriaAttributes } from "./SavedSearch/types"
 
 export enum FilterDisplayName {
   // artist = "Artists",

--- a/src/lib/Components/ArtworkFilter/SavedSearch/__tests__/convertersToFilterParams-tests.ts
+++ b/src/lib/Components/ArtworkFilter/SavedSearch/__tests__/convertersToFilterParams-tests.ts
@@ -1,4 +1,3 @@
-import { SearchCriteriaAttributes } from "__generated__/SavedSearchBannerQuery.graphql"
 import { Aggregation, Aggregations, FilterParamName } from "../../ArtworkFilterHelpers"
 import {
   AggregationByFilterParamName,
@@ -11,6 +10,7 @@ import {
   convertSizeToFilterParams,
   convertWaysToBuyToFilterParams,
 } from "../convertersToFilterParams"
+import { SearchCriteriaAttributes } from "../types"
 
 describe("convertPriceToFilterParam", () => {
   it("returns `$100–200` price range", () => {

--- a/src/lib/Components/ArtworkFilter/SavedSearch/__tests__/convertersToFilterParams-tests.ts
+++ b/src/lib/Components/ArtworkFilter/SavedSearch/__tests__/convertersToFilterParams-tests.ts
@@ -508,8 +508,6 @@ describe("convertSavedSearchCriteriaToFilterParams", () => {
       attributionClass: ["unknown edition", "open edition"],
       colors: ["gold", "red"],
       dimensionRange: "16.0-40.0",
-      heightMax: null,
-      heightMin: null,
       inquireableOnly: null,
       locationCities: ["New York, NY, USA"],
       majorPeriods: ["2000"],
@@ -517,8 +515,6 @@ describe("convertSavedSearchCriteriaToFilterParams", () => {
       offerable: true,
       partnerIDs: ["tate-ward-auctions"],
       priceRange: "10000-50000",
-      widthMax: null,
-      widthMin: null,
     }
     const result = convertSavedSearchCriteriaToFilterParams(criteria, aggregations)
 
@@ -649,8 +645,6 @@ describe("convertSavedSearchCriteriaToFilterParams", () => {
       attributionClass: null,
       colors: null,
       dimensionRange: "16.0-40.0",
-      heightMax: null,
-      heightMin: null,
       inquireableOnly: null,
       locationCities: ["New York, NY, USA"],
       majorPeriods: ["2000"],
@@ -658,8 +652,6 @@ describe("convertSavedSearchCriteriaToFilterParams", () => {
       offerable: true,
       partnerIDs: ["tate-ward-auctions"],
       priceRange: "10000-50000",
-      widthMax: null,
-      widthMin: null,
     }
     const result = convertSavedSearchCriteriaToFilterParams(criteria, aggregations)
 

--- a/src/lib/Components/ArtworkFilter/SavedSearch/convertersToFilterParams.ts
+++ b/src/lib/Components/ArtworkFilter/SavedSearch/convertersToFilterParams.ts
@@ -213,7 +213,7 @@ export const convertSavedSearchCriteriaToFilterParams = (
     const aggregationValue = aggregationValueByFilterParamName[filterParamName]
     const criteriaValue = criteria[filterParamName as SearchCriteriaAttributeKeys] as string[]
 
-    if (aggregationValue) {
+    if (aggregationValue && Array.isArray(criteriaValue)) {
       const filterParamItem = convertAggregationValueNamesToFilterParam(
         filterParamName,
         aggregationValue,

--- a/src/lib/Components/ArtworkFilter/SavedSearch/convertersToFilterParams.ts
+++ b/src/lib/Components/ArtworkFilter/SavedSearch/convertersToFilterParams.ts
@@ -1,4 +1,3 @@
-import { SearchCriteriaAttributes } from "__generated__/SavedSearchBannerQuery.graphql"
 import { Dictionary, isNil, keyBy, mapValues } from "lodash"
 import {
   Aggregation,
@@ -14,8 +13,8 @@ import { COLORS_INDEXED_BY_VALUE } from "../Filters/ColorsOptions"
 import { localizeDimension, parsePriceRangeLabel, parseRange } from "../Filters/helpers"
 import { SIZE_OPTIONS } from "../Filters/SizeOptions"
 import { WAYS_TO_BUY_FILTER_PARAM_NAMES } from "../Filters/WaysToBuyOptions"
+import { SearchCriteriaAttributeKeys, SearchCriteriaAttributes } from "./types"
 
-type SearchCriteriaAttributeKeys = keyof SearchCriteriaAttributes
 export type AggregationByFilterParamName = Dictionary<Aggregation[]>
 
 export const convertPriceToFilterParam = (criteria: SearchCriteriaAttributes): FilterData | null => {

--- a/src/lib/Components/ArtworkFilter/SavedSearch/types.ts
+++ b/src/lib/Components/ArtworkFilter/SavedSearch/types.ts
@@ -1,0 +1,20 @@
+export interface SearchCriteriaAttributes {
+  artistID?: string | null
+  locationCities?: string[] | null
+  colors?: string[] | null
+  partnerIDs?: string[] | null
+  additionalGeneIDs?: string[] | null
+  attributionClass?: string[] | null
+  majorPeriods?: string[] | null
+  acquireable?: boolean | null
+  atAuction?: boolean | null
+  inquireableOnly?: boolean | null
+  offerable?: boolean | null
+  dimensionRange?: string | null
+  height?: string | null
+  width?: string | null
+  materialsTerms?: string[] | null
+  priceRange?: string | null
+}
+
+export type SearchCriteriaAttributeKeys = keyof SearchCriteriaAttributes

--- a/src/lib/Scenes/Artist/Artist.tsx
+++ b/src/lib/Scenes/Artist/Artist.tsx
@@ -25,8 +25,6 @@ import { RelayModernEnvironment } from "relay-runtime/lib/store/RelayModernEnvir
 const INITIAL_TAB = "Artworks"
 export interface NotificationPayload {
   searchCriteriaID: string
-  // TODO: replace with proper searchCriteriaAttributes type when defined
-  searchCriteriaAttributes: {}
 }
 
 interface ArtistProps {

--- a/src/lib/Scenes/Artist/Artist.tsx
+++ b/src/lib/Scenes/Artist/Artist.tsx
@@ -23,12 +23,21 @@ import { graphql } from "react-relay"
 import { RelayModernEnvironment } from "relay-runtime/lib/store/RelayModernEnvironment"
 
 const INITIAL_TAB = "Artworks"
+interface NotificationPayload {
+  searchCriteriaID: string
+  // TODO: replace with proper searchCriteriaAttributes type when defined
+  searchCriteriaAttributes: {}
+}
 
-export const Artist: React.FC<{
+interface ArtistProps {
   artistAboveTheFold: NonNullable<ArtistAboveTheFoldQuery["response"]["artist"]>
   artistBelowTheFold?: ArtistBelowTheFoldQuery["response"]["artist"]
   initialTab?: string
-}> = ({ artistAboveTheFold, artistBelowTheFold, initialTab = INITIAL_TAB }) => {
+  notificationPayload?: NotificationPayload
+}
+
+export const Artist: React.FC<ArtistProps> = (props) => {
+  const { artistAboveTheFold, artistBelowTheFold, initialTab = INITIAL_TAB, notificationPayload } = props
   const tabs: TabProps[] = []
   const displayAboutSection =
     artistAboveTheFold.has_metadata ||
@@ -45,7 +54,12 @@ export const Artist: React.FC<{
   if ((artistAboveTheFold.counts?.artworks ?? 0) > 0) {
     tabs.push({
       title: "Artworks",
-      content: <ArtistArtworks artist={artistAboveTheFold} />,
+      content: (
+        <ArtistArtworks
+          artist={artistAboveTheFold}
+          searchCriteriaAttributes={notificationPayload?.searchCriteriaAttributes}
+        />
+      ),
     })
   }
 
@@ -101,9 +115,11 @@ export const Artist: React.FC<{
 interface ArtistQueryRendererProps extends ArtistAboveTheFoldQueryVariables, ArtistBelowTheFoldQueryVariables {
   environment?: RelayModernEnvironment
   initialTab?: string
+  notificationPayload?: NotificationPayload
 }
 
-export const ArtistQueryRenderer: React.FC<ArtistQueryRendererProps> = ({ artistID, environment, initialTab }) => {
+export const ArtistQueryRenderer: React.FC<ArtistQueryRendererProps> = (props) => {
+  const { artistID, environment, initialTab, notificationPayload } = props
   return (
     <AboveTheFoldQueryRenderer<ArtistAboveTheFoldQuery, ArtistBelowTheFoldQuery>
       environment={environment || defaultEnvironment}
@@ -147,7 +163,14 @@ export const ArtistQueryRenderer: React.FC<ArtistQueryRendererProps> = ({ artist
           if (!above.artist) {
             throw new Error("no artist data")
           }
-          return <Artist artistAboveTheFold={above.artist} artistBelowTheFold={below?.artist} initialTab={initialTab} />
+          return (
+            <Artist
+              artistAboveTheFold={above.artist}
+              artistBelowTheFold={below?.artist}
+              initialTab={initialTab}
+              notificationPayload={notificationPayload}
+            />
+          )
         },
       }}
     />

--- a/src/lib/Scenes/Artist/Artist.tsx
+++ b/src/lib/Scenes/Artist/Artist.tsx
@@ -57,7 +57,7 @@ export const Artist: React.FC<ArtistProps> = (props) => {
       content: (
         <ArtistArtworks
           artist={artistAboveTheFold}
-          searchCriteriaAttributes={notificationPayload?.searchCriteriaAttributes}
+          searchCriteriaId={notificationPayload?.searchCriteriaID}
         />
       ),
     })

--- a/src/lib/Scenes/Artist/Artist.tsx
+++ b/src/lib/Scenes/Artist/Artist.tsx
@@ -23,7 +23,7 @@ import { graphql } from "react-relay"
 import { RelayModernEnvironment } from "relay-runtime/lib/store/RelayModernEnvironment"
 
 const INITIAL_TAB = "Artworks"
-interface NotificationPayload {
+export interface NotificationPayload {
   searchCriteriaID: string
   // TODO: replace with proper searchCriteriaAttributes type when defined
   searchCriteriaAttributes: {}

--- a/src/lib/Scenes/Artist/__tests__/Artist-tests.tsx
+++ b/src/lib/Scenes/Artist/__tests__/Artist-tests.tsx
@@ -1,21 +1,26 @@
 import ArtistArtworks from "lib/Components/Artist/ArtistArtworks/ArtistArtworks"
+import { SavedSearchBanner } from "lib/Components/Artist/ArtistArtworks/SavedSearchBanner"
 import { ArtistHeaderFragmentContainer } from "lib/Components/Artist/ArtistHeader"
 import { ArtistInsights } from "lib/Components/Artist/ArtistInsights/ArtistInsights"
+import { CurrentOption } from "lib/Components/ArtworkFilter"
 import { StickyTab } from "lib/Components/StickyTabPage/StickyTabPageTabBar"
 import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { postEventToProviders } from "lib/utils/track/providers"
 import _ from "lodash"
+import { TouchableHighlightColor } from "palette"
 import React from "react"
 import "react-native"
+import { act } from "react-test-renderer"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { MockResolvers } from "relay-test-utils/lib/RelayMockPayloadGenerator"
 import { ArtistAboutContainer } from "../../../Components/Artist/ArtistAbout/ArtistAbout"
-import { ArtistQueryRenderer } from "../Artist"
+import { ArtistQueryRenderer, NotificationPayload } from "../Artist"
 
 jest.unmock("react-relay")
 jest.unmock("react-tracking")
+jest.unmock("lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx")
 
 type ArtistQueries = "ArtistAboveTheFoldQuery" | "ArtistBelowTheFoldQuery"
 
@@ -41,8 +46,8 @@ describe("availableTabs", () => {
     })
   }
 
-  const TestWrapper = () => {
-    return <ArtistQueryRenderer artistID="ignored" environment={environment} />
+  const TestWrapper = (props: Record<string, any>) => {
+    return <ArtistQueryRenderer artistID="ignored" environment={environment} {...props} />
   }
 
   it("returns an empty state if artist has no metadata, shows, insights, or works", async () => {
@@ -150,6 +155,110 @@ describe("availableTabs", () => {
       context_screen_owner_id: '<mock-value-for-field-"internalID">',
       context_screen_owner_slug: '<mock-value-for-field-"slug">',
       context_screen_owner_type: "Artist",
+    })
+  })
+
+  describe("Saved Search", () => {
+    const getWrapper = (notificationPayload?: NotificationPayload) => {
+      const tree = renderWithWrappers(<TestWrapper notificationPayload={notificationPayload} />)
+
+      mockMostRecentOperation("ArtistAboveTheFoldQuery", {
+        Artist() {
+          return {
+            has_metadata: true,
+            counts: { articles: 0, related_artists: 0, artworks: 1, partner_shows: 0 },
+            auctionResultsConnection: {
+              totalCount: 0,
+            },
+          }
+        },
+      })
+
+      return tree
+    }
+
+    it("should not render banner when criteria attributes passed and AREnableSavedSearch flag set to false", () => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableSavedSearch: false })
+
+      const tree = getWrapper({
+        searchCriteriaID: "search-criteria-id",
+        searchCriteriaAttributes: {
+          attributionClass: ["limited edition", "open edition"],
+        },
+      })
+
+      expect(tree.root.findAllByType(SavedSearchBanner)).toHaveLength(0)
+    })
+
+    it("should not render banner when criteria attributes not passed and AREnableSavedSearch flag set to true", () => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableSavedSearch: true })
+
+      const tree = getWrapper()
+
+      expect(tree.root.findAllByType(SavedSearchBanner)).toHaveLength(0)
+    })
+
+    it("should render banner when criteria attributes passed and AREnableSavedSearch flag set to true", () => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableSavedSearch: true })
+
+      const tree = getWrapper({
+        searchCriteriaID: "search-criteria-id",
+        searchCriteriaAttributes: {
+          attributionClass: ["limited edition", "open edition"],
+        },
+      })
+
+      expect(tree.root.findAllByType(SavedSearchBanner)).toHaveLength(1)
+    })
+
+    it("should convert the criteria attributes to the filter params format", () => {
+      const tree = getWrapper({
+        searchCriteriaID: "search-criteria-id",
+        searchCriteriaAttributes: {
+          attributionClass: ["limited edition", "open edition"],
+          acquireable: true,
+          inquireableOnly: true,
+        },
+      })
+
+      act(() => tree.root.findByType(TouchableHighlightColor).props.onPress())
+
+      const filterTextValues = tree.root.findAllByType(CurrentOption).map(extractText)
+
+      expect(filterTextValues).toContain("Buy now, Inquire")
+      expect(filterTextValues).toContain("Limited Edition, Open Edition")
+    })
+
+    it("should call refetch with the passed criteria attribute variables", () => {
+      getWrapper({
+        searchCriteriaID: "search-criteria-id",
+        searchCriteriaAttributes: {
+          attributionClass: ["limited edition", "open edition"],
+          acquireable: true,
+          inquireableOnly: true,
+        },
+      })
+
+      const operation = environment.mock.getMostRecentOperation()
+
+      expect(operation.request.node.operation.name).toEqual("ArtistArtworksQuery")
+      expect(operation.request.variables).toEqual({
+        count: 10,
+        cursor: null,
+        id: "artist-id",
+        input: {
+          acquireable: true,
+          atAuction: false,
+          attributionClass: ["limited edition", "open edition"],
+          dimensionRange: "*-*",
+          includeArtworksByFollowedArtists: false,
+          inquireableOnly: true,
+          medium: "*",
+          offerable: false,
+          priceRange: "*-*",
+          sort: "-decayed_merch",
+        },
+      })
     })
   })
 })

--- a/src/lib/navigation/__tests__/navigate-tests.tsx
+++ b/src/lib/navigation/__tests__/navigate-tests.tsx
@@ -76,6 +76,29 @@ describe(navigate, () => {
     expect(Linking.openURL).toHaveBeenCalledWith("https://google.com/banana")
   })
 
+  it("passes additional props", async () => {
+    await navigate("/artist/banksy", {
+      passProps: {
+        someAdditionalKey: "value",
+      },
+    })
+    expect(LegacyNativeModules.ARScreenPresenterModule.pushView).toHaveBeenCalled()
+    expect(args(LegacyNativeModules.ARScreenPresenterModule.pushView as any)).toMatchInlineSnapshot(`
+        Array [
+          "home",
+          Object {
+            "moduleName": "Artist",
+            "props": Object {
+              "artistID": "banksy",
+              "someAdditionalKey": "value",
+            },
+            "replace": false,
+            "type": "react",
+          },
+        ]
+      `)
+  })
+
   describe("presents modals", () => {
     it("when the screen requires it", () => {
       navigate("https://live.artsy.net/blah")

--- a/src/lib/store/NativeModel.ts
+++ b/src/lib/store/NativeModel.ts
@@ -16,7 +16,7 @@ export type NativeEvent =
     }
   | {
       type: "REQUEST_NAVIGATION"
-      payload: { route: string }
+      payload: { route: string; payload: {} }
     }
   | {
       type: "MODAL_DISMISSED"
@@ -61,7 +61,7 @@ listenToNativeEvents((event: NativeEvent) => {
       GlobalStore.actions.bottomTabs.fetchCurrentUnreadConversationCount()
       return
     case "REQUEST_NAVIGATION":
-      navigate(event.payload.route)
+      navigate(event.payload.route, { passProps: { notificationPayload: event.payload.payload } })
       return
     case "MODAL_DISMISSED":
       navigationEvents.emit("modalDismissed")

--- a/src/lib/store/__tests__/NativeModel-tests.ts
+++ b/src/lib/store/__tests__/NativeModel-tests.ts
@@ -1,4 +1,5 @@
 import { NotificationsManager } from "lib/NativeModules/NotificationsManager"
+import { navigate } from "lib/navigation/navigate"
 import { __globalStoreTestUtils__ } from "../GlobalStore"
 import { NativeEvent } from "../NativeModel"
 
@@ -13,5 +14,44 @@ describe("NativeModel", () => {
       type: "NOTIFICATION_RECEIVED",
     } as NativeEvent)
     expect(__globalStoreTestUtils__?.getLastAction().type).toContain("fetchCurrentUnreadConversationCount")
+  })
+
+  describe("REQUEST_NAVIGATION", () => {
+    it("calls the navigation method with only the route param", () => {
+      NotificationsManager.emit("event", {
+        type: "REQUEST_NAVIGATION",
+        payload: {
+          route: "some-route-path",
+        },
+      } as NativeEvent)
+
+      expect(navigate).toBeCalledWith("some-route-path", {
+        passProps: {
+          notifcationPayload: undefined,
+        },
+      })
+    })
+
+    it("calls the navigation method with the route and the passed params", () => {
+      NotificationsManager.emit("event", {
+        type: "REQUEST_NAVIGATION",
+        payload: {
+          route: "some-route-path",
+          payload: {
+            canRead: false,
+            someAdditionalKey: "value",
+          },
+        },
+      } as NativeEvent)
+
+      expect(navigate).toBeCalledWith("some-route-path", {
+        passProps: {
+          notifcationPayload: {
+            canRead: false,
+            someAdditionalKey: "value",
+          },
+        },
+      })
+    })
   })
 })

--- a/src/lib/store/__tests__/NativeModel-tests.ts
+++ b/src/lib/store/__tests__/NativeModel-tests.ts
@@ -27,7 +27,7 @@ describe("NativeModel", () => {
 
       expect(navigate).toBeCalledWith("some-route-path", {
         passProps: {
-          notifcationPayload: undefined,
+          notificationPayload: undefined,
         },
       })
     })
@@ -46,7 +46,7 @@ describe("NativeModel", () => {
 
       expect(navigate).toBeCalledWith("some-route-path", {
         passProps: {
-          notifcationPayload: {
+          notificationPayload: {
             canRead: false,
             someAdditionalKey: "value",
           },


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->
This PR resolves [FX-2979]

### Description

[Still WIP] Currently, this PR allows React Native to read the full payload of a notification. Previously, only the URL for navigation was passed from the native Obj-C code.

Next steps: 
- [ ] Successfully apply hardcoded filter on navigation to artist screen
- [ ] Apply a filter in notification payload on navigation
- [ ] Apply all filters contained in notification payload on navigation

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [ ] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [ ] I have documented any follow-up work that this PR will require, or it does not require any.
- [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-2977]: https://artsyproduct.atlassian.net/browse/FX-2977

[FX-2979]: https://artsyproduct.atlassian.net/browse/FX-2979