### PR TITLE
chore: add specs for deleteSavedSearch and createSavedSearch mutations

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -9,6 +9,7 @@ upcoming:
     - Send data in the filter params format for saved search - dzmitry tratsiak
     - Enables external flag for order history - sweir
     - Prepare search criteria values to filter params - dzmitry tratsiak
+    - Add specs for deleteSavedSearch and createSavedSearch mutations - dzmitry tratsiak
   user_facing:
     - Fixed "Unable to load" error on OrderHistory page when artwork is deleted/unpublished from order
     - Pick up should be displayed in Sold by section - Serge0n

--- a/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
@@ -1,6 +1,6 @@
 import { SearchCriteriaAttributes } from "__generated__/SavedSearchBannerQuery.graphql"
 import { SavedSearchBannerTestsQuery } from "__generated__/SavedSearchBannerTestsQuery.graphql"
-import { PopoverMessage } from 'lib/Components/PopoverMessage/PopoverMessage'
+import { PopoverMessage } from "lib/Components/PopoverMessage/PopoverMessage"
 import { LegacyNativeModules } from "lib/NativeModules/LegacyNativeModules"
 import { PushAuthorizationStatus } from "lib/Scenes/MyProfile/MyProfilePushNotifications"
 import { mockEnvironmentPayload } from "lib/tests/mockEnvironmentPayload"
@@ -13,6 +13,15 @@ import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { SavedSearchBannerRefetchContainer } from "../SavedSearchBanner"
 
 jest.unmock("react-relay")
+
+interface Mutation {
+  name: string
+  variables: Record<string, any>
+}
+interface Popover {
+  title: string
+  message: string
+}
 
 const mockFetchNotificationPermissions = LegacyNativeModules.ARTemporaryAPIModule
   .fetchNotificationPermissions as jest.Mock<any>
@@ -52,6 +61,36 @@ describe("SavedSearchBanner", () => {
     )
   }
 
+  const checkLogicForMutations = (mockResolvers = {}, mutation: Mutation, popover: Popover) => {
+    mockFetchNotificationPermissions.mockImplementationOnce((cb) => cb(null, PushAuthorizationStatus.Authorized))
+
+    const tree = renderWithWrappers(<TestRenderer />)
+    const buttonComponent = tree.root.findByType(Button)
+
+    mockEnvironmentPayload(mockEnvironment, mockResolvers)
+
+    act(() => buttonComponent.props.onPress())
+
+    const createOperation = mockEnvironment.mock.getMostRecentOperation()
+
+    expect(buttonComponent.props.loading).toBe(true)
+    expect(createOperation.request.node.operation.name).toEqual(mutation.name)
+    expect(createOperation.request.variables).toEqual(mutation.variables)
+
+    act(() => mockEnvironment.mock.resolve(createOperation, MockPayloadGenerator.generate(createOperation)))
+
+    const refetchOperation = mockEnvironment.mock.getMostRecentOperation()
+    expect(refetchOperation.request.node.operation.name).toEqual("SavedSearchBannerRefetchQuery")
+
+    act(() => mockEnvironment.mock.resolveMostRecentOperation(MockPayloadGenerator.generate(refetchOperation)))
+
+    const popoverMessageInstance = tree.root.findByType(PopoverMessage)
+    const textInstances = popoverMessageInstance.findAllByType(Text)
+
+    expect(textInstances[0].props.children).toEqual(popover.title)
+    expect(textInstances[1].props.children).toEqual(popover.message)
+  }
+
   it("renders correctly disabled state", () => {
     const tree = renderWithWrappers(<TestRenderer />)
     mockEnvironmentPayload(mockEnvironment, {
@@ -86,81 +125,49 @@ describe("SavedSearchBanner", () => {
   })
 
   it("createSavedSearch mutation is handled correctly", async () => {
-    mockFetchNotificationPermissions.mockImplementationOnce((cb) => cb(null, PushAuthorizationStatus.Authorized))
-
-    const tree = renderWithWrappers(<TestRenderer />)
-    const buttonComponent = tree.root.findByType(Button)
-
-    mockEnvironmentPayload(mockEnvironment, {
+    const mockResolvers = {
       Me: () => ({
         savedSearch: null,
       }),
-    })
-
-    act(() => buttonComponent.props.onPress())
-
-    const createOperation = mockEnvironment.mock.getMostRecentOperation()
-
-    expect(buttonComponent.props.loading).toBe(true)
-    expect(createOperation.request.node.operation.name).toEqual("SavedSearchBannerCreateSavedSearchMutation")
-    expect(createOperation.request.variables).toEqual({
-      input: {
-        attributes,
+    }
+    const mutation: Mutation = {
+      name: "SavedSearchBannerCreateSavedSearchMutation",
+      variables: {
+        input: {
+          attributes,
+        },
       },
-    })
+    }
+    const popover: Popover = {
+      title: "Your alert has been set.",
+      message: "We will send you a push notification once new works are added.",
+    }
 
-    act(() => mockEnvironment.mock.resolve(createOperation, MockPayloadGenerator.generate(createOperation)))
-
-    const refetchOperation = mockEnvironment.mock.getMostRecentOperation()
-    expect(refetchOperation.request.node.operation.name).toEqual("SavedSearchBannerRefetchQuery")
-
-    act(() => mockEnvironment.mock.resolveMostRecentOperation(MockPayloadGenerator.generate(refetchOperation)))
-
-    const popoverMessageInstance = tree.root.findByType(PopoverMessage)
-    const textInstances = popoverMessageInstance.findAllByType(Text)
-
-    expect(textInstances[0].props.children).toEqual("Your alert has been set.")
-    expect(textInstances[1].props.children).toEqual("We will send you a push notification once new works are added.")
+    checkLogicForMutations(mockResolvers, mutation, popover)
   })
 
   it("deleteSavedSearch mutation is handled correctly", async () => {
-    mockFetchNotificationPermissions.mockImplementationOnce((cb) => cb(null, PushAuthorizationStatus.Authorized))
-
     const savedSearchCriteriaId = "some-unique-name"
-    const tree = renderWithWrappers(<TestRenderer />)
-    const buttonComponent = tree.root.findByType(Button)
-
-    mockEnvironmentPayload(mockEnvironment, {
+    const mockResolvers = {
       Me: () => ({
         savedSearch: {
           internalID: savedSearchCriteriaId,
         },
       }),
-    })
-
-    act(() => buttonComponent.props.onPress())
-
-    const createOperation = mockEnvironment.mock.getMostRecentOperation()
-
-    expect(buttonComponent.props.loading).toBe(true)
-    expect(createOperation.request.node.operation.name).toEqual("SavedSearchBannerDeleteSavedSearchMutation")
-    expect(createOperation.request.variables).toEqual({
-      input: {
-        searchCriteriaID: savedSearchCriteriaId,
+    }
+    const mutation: Mutation = {
+      name: "SavedSearchBannerDeleteSavedSearchMutation",
+      variables: {
+        input: {
+          searchCriteriaID: savedSearchCriteriaId,
+        },
       },
-    })
+    }
+    const popover: Popover = {
+      title: "Your alert has been removed.",
+      message: "Don't worry, you can always create a new one.",
+    }
 
-    act(() => mockEnvironment.mock.resolve(createOperation, MockPayloadGenerator.generate(createOperation)))
-
-    const refetchOperation = mockEnvironment.mock.getMostRecentOperation()
-    expect(refetchOperation.request.node.operation.name).toEqual("SavedSearchBannerRefetchQuery")
-
-    act(() => mockEnvironment.mock.resolveMostRecentOperation(MockPayloadGenerator.generate(refetchOperation)))
-
-    const popoverMessageInstance = tree.root.findByType(PopoverMessage)
-    const textInstances = popoverMessageInstance.findAllByType(Text)
-
-    expect(textInstances[0].props.children).toEqual("Your alert has been removed.")
-    expect(textInstances[1].props.children).toEqual("Don't worry, you can always create a new one.")
+    checkLogicForMutations(mockResolvers, mutation, popover)
   })
 })

--- a/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
@@ -115,10 +115,7 @@ describe("SavedSearchBanner", () => {
     const refetchOperation = mockEnvironment.mock.getMostRecentOperation()
     expect(refetchOperation.request.node.operation.name).toEqual("SavedSearchBannerRefetchQuery")
 
-    act(() => mockEnvironment.mock.resolveMostRecentOperation({
-      errors: [],
-      data: {}
-    }))
+    act(() => mockEnvironment.mock.resolveMostRecentOperation(MockPayloadGenerator.generate(refetchOperation)))
 
     const popoverMessageInstance = tree.root.findByType(PopoverMessage)
     const textInstances = popoverMessageInstance.findAllByType(Text)

--- a/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
@@ -3,7 +3,6 @@ import { SavedSearchBannerTestsQuery } from "__generated__/SavedSearchBannerTest
 import { PopoverMessage } from 'lib/Components/PopoverMessage/PopoverMessage'
 import { LegacyNativeModules } from "lib/NativeModules/LegacyNativeModules"
 import { PushAuthorizationStatus } from "lib/Scenes/MyProfile/MyProfilePushNotifications"
-import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
 import { mockEnvironmentPayload } from "lib/tests/mockEnvironmentPayload"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { Button, Text } from "palette"
@@ -86,7 +85,7 @@ describe("SavedSearchBanner", () => {
     expect(buttonComponent.props.loading).toBe(true)
   })
 
-  it("returns", async () => {
+  it("createSavedSearch mutation is handled correctly", async () => {
     mockFetchNotificationPermissions.mockImplementationOnce((cb) => cb(null, PushAuthorizationStatus.Authorized))
 
     const tree = renderWithWrappers(<TestRenderer />)

--- a/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
@@ -1,11 +1,12 @@
 import { SearchCriteriaAttributes } from "__generated__/SavedSearchBannerQuery.graphql"
 import { SavedSearchBannerTestsQuery } from "__generated__/SavedSearchBannerTestsQuery.graphql"
+import { PopoverMessage } from 'lib/Components/PopoverMessage/PopoverMessage'
 import { LegacyNativeModules } from "lib/NativeModules/LegacyNativeModules"
 import { PushAuthorizationStatus } from "lib/Scenes/MyProfile/MyProfilePushNotifications"
 import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
 import { mockEnvironmentPayload } from "lib/tests/mockEnvironmentPayload"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
-import { Button } from "palette"
+import { Button, Text } from "palette"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { act } from "react-test-renderer"
@@ -114,9 +115,15 @@ describe("SavedSearchBanner", () => {
     const refetchOperation = mockEnvironment.mock.getMostRecentOperation()
     expect(refetchOperation.request.node.operation.name).toEqual("SavedSearchBannerRefetchQuery")
 
-    act(() => mockEnvironment.mock.resolve(refetchOperation, MockPayloadGenerator.generate(refetchOperation)))
+    act(() => mockEnvironment.mock.resolveMostRecentOperation({
+      errors: [],
+      data: {}
+    }))
 
-    await flushPromiseQueue()
-    expect(buttonComponent.props.loading).toBe(false)
+    const popoverMessageInstance = tree.root.findByType(PopoverMessage)
+    const textInstances = popoverMessageInstance.findAllByType(Text)
+
+    expect(textInstances[0].props.children).toEqual("Your alert has been set.")
+    expect(textInstances[1].props.children).toEqual("We will send you a push notification once new works are added.")
   })
 })


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3007] and [FX-3006]

### Description
**createSavedSearch**
Check the UI update for the saved search banner when the user clicks the "enable" button and performs the create saved search mutation


**deleteSavedSearch** 
Check the UI update for the saved search banner when the user clicks the "disable" button and performs the delete saved search mutation

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[FX-3007]: https://artsyproduct.atlassian.net/browse/FX-3007
[FX-3006]: https://artsyproduct.atlassian.net/browse/FX-3006