### PR TITLE
feat: Adds flag for order history feature

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -7,6 +7,7 @@ upcoming:
     - Update open simulator command in getting started docs - ole
     - Update debugging docs - mounir
     - Send data in the filter params format for saved search - dzmitry tratsiak
+    - Enables external flag for order history - sweir
   user_facing:
     - Pick up should be displayed in Sold by section - Serge0n
     - Country should be written with full name - Serge0n

--- a/src/lib/store/config/features.ts
+++ b/src/lib/store/config/features.ts
@@ -95,7 +95,8 @@ export const features = defineFeatures({
     showInAdminMenu: true,
   },
   AREnableOrderHistoryOption: {
-    readyForRelease: false,
+    readyForRelease: true,
+    echoFlagKey: "AREnableOrderHistoryOption",
     description: "Enable Order History in settings",
     showInAdminMenu: true,
   },


### PR DESCRIPTION
The type of this PR is: **Feature**

### Description

This PR makes the Order History feature configurable via an echo flag. (Corresponding echo PR here: https://github.com/artsy/echo/pull/95)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
