### PR TITLE
chore: add saved search analytics tracking

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -10,6 +10,7 @@ upcoming:
     - Enables external flag for order history - sweir
     - Prepare search criteria values to filter params - dzmitry tratsiak
     - Add specs for deleteSavedSearch and createSavedSearch mutations - dzmitry tratsiak
+    - add toggledSavedSearch analytics tracking  - devon blandin
   user_facing:
     - Fixed "Unable to load" error on OrderHistory page when artwork is deleted/unpublished from order
     - Pick up should be displayed in Sold by section - Serge0n

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "cheerio": "0.22.0"
   },
   "dependencies": {
-    "@artsy/cohesion": "2.3.0",
+    "@artsy/cohesion": "2.4.0",
     "@artsy/palette-tokens": "^1.3.1",
     "@expo/react-native-action-sheet": "^3.8.0",
     "@ptomasroos/react-native-multi-slider": "^2.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/auto-config/-/auto-config-1.0.2.tgz#b79f6fd0d0bda0c5e0764ced55e014cf58174d6f"
   integrity sha512-mJyuKNDMYZcgc2oLIkvmpVIr1RexklV71JmU+to5qs3Y9pv5dsj4WHl8+wf9g74EQNOyhWH2SYMGBm1JoPYh/Q==
 
-"@artsy/cohesion@2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-2.3.0.tgz#356846a355a97a5d7ed0ac7a623fe5b081a083fe"
-  integrity sha512-tkBlHquie6HuEWEx62Ct5gyU1RoHKG9u3YbJiP91jRMhKllywCHObWmHkuFOn/clrUHN8uKXGuQ9E+/oXLDMSA==
+"@artsy/cohesion@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-2.4.0.tgz#637361b2bf0dfa4b7941daa662643ba85c64172c"
+  integrity sha512-XLwg6AeROM06pZwjOLDIIeAZrSM/y3IEJc6Q7gIqoRYgx6VFWJRPxYT8iBQSWLPqNIrqM95frjJMIw9G/WILFQ==
   dependencies:
     core-js "3"
 


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3014]

### Description

Use the new `toggledSavedSearch` event in @artsy/cohesion to track when a user enables+disables a saved search.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

### Screenshots

<img src="https://user-images.githubusercontent.com/123595/123080630-6cd57280-d41d-11eb-9eb5-916874940dab.png" width=300 />

<img src="https://user-images.githubusercontent.com/123595/123080685-7ced5200-d41d-11eb-937f-acb29913f96d.png" width=300 />


[FX-3014]: https://artsyproduct.atlassian.net/browse/FX-3014