### PR TITLE
fix: broken test due to missing redux-flipper

### DIFF
--- a/src/lib/store/GlobalStore.tsx
+++ b/src/lib/store/GlobalStore.tsx
@@ -23,7 +23,7 @@ function createGlobalStore() {
     middleware.push(persistenceMiddleware)
   }
 
-  if (__DEV__) {
+  if (__DEV__ && !__TEST__) {
     const reduxInFlipper = require("redux-flipper").default
     middleware.push(reduxInFlipper())
   }


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves https://artsy.slack.com/archives/CP9P4KR35/p1624443687243500

### Description

As Redux-flipper wasn't mocked it was breaking the globalstore initiation. I was going to mock it but it seemed unnecessary for me as it's only part of the dev process. So I just disabled it while testing.
<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
