### PR TITLE
fix (CX-1532): user can't unfollow category

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -36,6 +36,7 @@ upcoming:
     - Hide spinner when there is no more artworks to load - katsiaryna alshannikava
     - Aligned 'Next' button in the 'Sell work' menu - katsiaryna alshannikava
     - Fix home screen articles rail spacing - ole
+    - Fix unfollowing categories - katsiaryna alshannikava
 
 releases:
   - version: 6.9.4

--- a/src/lib/Components/Gene/Header.tsx
+++ b/src/lib/Components/Gene/Header.tsx
@@ -74,6 +74,7 @@ class Header extends React.Component<Props, State> {
           variables: {
             input: {
               geneID: slug,
+              unfollow: isFollowed,
             },
           },
           optimisticResponse: {


### PR DESCRIPTION
The type of this PR is: Bugfix

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1532]

### Description

User was is to unfollow a category - it remains being followed after refresh.
<!-- Implementation description -->

**The bug**

https://user-images.githubusercontent.com/27921300/123100356-576b4300-d433-11eb-87de-0cbdc1edf4f1.mov



**The fix**

https://user-images.githubusercontent.com/27921300/123099972-f80d3300-d432-11eb-88a0-5657657da7ed.mov



### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.


[CX-1532]: https://artsyproduct.atlassian.net/browse/CX-1532