### PR TITLE
fix[CX-1604] Facebook login is failing after signing up for a new account

### DIFF
--- a/Artsy/View_Controllers/Login_and_Onboarding/AROnboardingViewController.m
+++ b/Artsy/View_Controllers/Login_and_Onboarding/AROnboardingViewController.m
@@ -623,6 +623,7 @@
 {
     __weak typeof(self) wself = self;
     if (email && ![email isEqualToString:@""]) {
+        [wself deleteGravitySecureSessionCookieToken];
         [[ARUserManager sharedManager] createUserViaFacebookWithToken:token
                                                                 email:email
                                                                  name:name
@@ -694,6 +695,15 @@
                                            }];
 }
 
+- (void)deleteGravitySecureSessionCookieToken
+{
+    NSHTTPCookieStorage *cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+    for(NSHTTPCookie *cookie in cookieStorage.cookies) {
+        if ([cookie.name isEqualToString:@"_gravity_secure_session"]) {
+            [cookieStorage deleteCookie:cookie];
+        }
+    }
+}
 
 #pragma mark -
 #pragma mark Apple Dance

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -32,6 +32,7 @@ upcoming:
     - Hide spinner when there is no more artworks to load - katsiaryna alshannikava
     - Aligned 'Next' button in the 'Sell work' menu - katsiaryna alshannikava
     - Fix home screen articles rail spacing - ole
+    - Fix facebook login failing after signing up for a new account - stanislau hanchar
 
 releases:
   - version: 6.9.4


### PR DESCRIPTION
The type of this PR is: Fix

This PR resolves [CX-1604](https://artsyproduct.atlassian.net/browse/CX-1604)

### Steps to Reproduce:

1. Create an account in staging using Facebook auth
2. Log out
3. Log back in using Facebook auth
4. Observe you get error ‘Couldn’t link Facebook account'

### Description

If we login via Facebook for the first time, we don’t have the gravity_session_id cookie (1 screenshot), but before the second login it is (2 screenshots), and because of its presence when sending a request for gravity -> device will authorize us by session ID and sets the value for current_user -> returns an error that the user already exists (3 screenshots).
![success](https://user-images.githubusercontent.com/21379857/123114836-47119300-d448-11eb-80d6-41dfdb5e9d71.png)
![fail](https://user-images.githubusercontent.com/21379857/123114845-48db5680-d448-11eb-93f6-df8034c912a5.png)
![Screenshot 2021-06-22 at 17 02 35](https://user-images.githubusercontent.com/21379857/123114856-4aa51a00-d448-11eb-8085-28950f430dee.png)

Since the failed login is only affected by the session cookies, I decided to delete them before logging in with facebook.

I'm not sure if the solution with deleting cookies before logging in via facebook is the best solution, but it seemed to me the most quickly implemented, in any case I'm open to suggestions :)

### Result

https://user-images.githubusercontent.com/21379857/123115851-18e08300-d449-11eb-9a45-9a8afb9c09b0.mov

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.
