### PR TITLE
fix: update popover message markup

### DIFF
--- a/src/lib/Components/PopoverMessage/PopoverMessage.tsx
+++ b/src/lib/Components/PopoverMessage/PopoverMessage.tsx
@@ -121,10 +121,15 @@ export const PopoverMessage: React.FC<PopoverMessageProps> = (props) => {
   const content = (
     <Flex p={1}>
       <Flex flexDirection="row" justifyContent="space-between">
-        <Flex flex={1}>
-          <Text color={titleColor} variant="subtitle">
+        <Flex flex={1} mr={!!showCloseIcon ? 1 : 0}>
+          <Text color={titleColor} variant="subtitle" numberOfLines={1}>
             {title}
           </Text>
+          {!!message && (
+            <Text numberOfLines={2} color="black60" variant="small">
+              {message}
+            </Text>
+          )}
         </Flex>
         {!!showCloseIcon && (
           <Box mt={0.25}>
@@ -134,11 +139,6 @@ export const PopoverMessage: React.FC<PopoverMessageProps> = (props) => {
           </Box>
         )}
       </Flex>
-      {!!message && (
-        <Text numberOfLines={2} mt={0.5} color="black60" variant="small">
-          {message}
-        </Text>
-      )}
     </Flex>
   )
 


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3036]

### Description
The copy in the toast message that is displayed after a user enables an alert does not match how it is laid out in the design spec (see the attached image in Jira ticket). In the design spec, there is a wide margin between the copy and the right edge of the toast box. However, the current implementation has the text folding at the edge, and crowds the X to close the toast.

#### iOS
![Simulator Screen Shot - iPhone 8 - 2021-06-24 at 14 05 52](https://user-images.githubusercontent.com/3513494/123252782-526ec800-d4f5-11eb-9490-bbc8bd0782e8.png)

### Android
![screencap-2021-06-24T105845 378Z](https://user-images.githubusercontent.com/3513494/123252801-5a2e6c80-d4f5-11eb-8b2f-c28c77748f74.png)


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Update the design for Popover Message component – dzmitry tratsiak 

<!-- end_changelog_updates -->


[FX-3036]: https://artsyproduct.atlassian.net/browse/FX-3036