### PR TITLE
fix: toggle saved search banner label by enable/disable state

### DIFF
--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -196,7 +196,7 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({ me, artist
       alignItems="center"
     >
       <Text variant="small" color="black">
-        New works alert for this search
+        {enabled ? "Remove alert for this artist" : "Set alert for this artist"}
       </Text>
       <Button
         variant={enabled ? "secondaryOutline" : "primaryBlack"}


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3035]

### Description
That copy that is displayed on the banner where users can enable or disable a saved search does not match the design specs.

Currently, this banner shows “New works alert for this search” but the design specs indicate that this copy should be “Set alert for this artist” in the disabled state, and “Remove alert for this artist” in the enabled state.

#### iOS

https://user-images.githubusercontent.com/3513494/123254699-a37fbb80-d4f7-11eb-8d50-9d009bbdb4b6.mp4

#### Android

https://user-images.githubusercontent.com/3513494/123254735-ae3a5080-d4f7-11eb-9a4e-25510d8bbd76.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Update the saved search banner label for enable/disable states - dzmitry tratsiak


<!-- end_changelog_updates -->


[FX-3035]: https://artsyproduct.atlassian.net/browse/FX-3035