### PR TITLE
fix (CX-1621): locations menu does not redirect correctly

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -8,6 +8,7 @@ upcoming:
   user_facing:
     - Fix unfollowing categories - katsiaryna alshannikava
     - Remove "Enable push notification" guard for disabling saved search - dzmitry tratsiak
+    - Fix locations menu redirection - katsiaryna alshannikava
 
 releases:
   - version: 6.9.5

--- a/src/lib/Components/LocationMap/index.tsx
+++ b/src/lib/Components/LocationMap/index.tsx
@@ -92,7 +92,7 @@ export const tappedOnMap = (
       },
     },
     (buttonIndex: number) => {
-      if (buttonIndex === 1) {
+      if (buttonIndex === 0) {
         const mapLink = mapLinkForService(
           MapServiceURLType.Apple,
           lat,
@@ -103,7 +103,7 @@ export const tappedOnMap = (
           suffix
         )
         Linking.openURL(mapLink)
-      } else if (buttonIndex === 2) {
+      } else if (buttonIndex === 1) {
         const mapLink = mapLinkForService(
           MapServiceURLType.CityMapper,
           lat,
@@ -114,7 +114,7 @@ export const tappedOnMap = (
           suffix
         )
         Linking.openURL(mapLink)
-      } else if (buttonIndex === 3) {
+      } else if (buttonIndex === 2) {
         const appLink = mapLinkForService(
           MapServiceURLType.GoogleApp,
           lat,
@@ -144,7 +144,7 @@ export const tappedOnMap = (
           .catch(() => {
             Linking.openURL(webLink)
           })
-      } else if (buttonIndex === 4) {
+      } else if (buttonIndex === 3) {
         // Copy to pasteboard
         Clipboard.setString(title)
       }


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1621]

### Description

STR:
1. Open app
2. Click on search 
3. Search for Secret Art Ltd
4. Click "Overview"
5. Click "See all location details"
6. On Locations page, click any location to open menu
7. Click any options on the menu

**Actual result:**
Links are not mapped correctly with the menu options.
"Open in Apple Maps", no response (does not open Apple Map)
"Open in City Mapper", opens Apple Map
"Open in Google Map", option opens City Mapper
"Copy Address", opens Google Map

**Expected result:**
When clicking on an option, the app redirects to the relevant page accordingly

**After the fix:**

https://user-images.githubusercontent.com/27921300/123621145-35930700-d80b-11eb-8a29-01da63aa75d8.mov



### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

[CX-1621]: https://artsyproduct.atlassian.net/browse/CX-1621