### PR TITLE
fix: use palette touchable /w underlayColor & consistency style changes in ArtistSeriesListItem

### DIFF
--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesListItem.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesListItem.tsx
@@ -52,12 +52,13 @@ export const ArtistSeriesListItem: React.FC<ArtistSeriesListItemProps> = ({
   return (
     <Touchable
       underlayColor={color("black5")}
+      style={{ marginHorizontal: -20 }}
       onPress={() => {
         trackArtworkClick()
         navigate(`/artist-series/${listItem?.node?.slug}`)
       }}
     >
-      <Flex flexDirection="row" mb={1} justifyContent="space-between">
+      <Flex px={2} my={1} flexDirection="row" justifyContent="space-between">
         <Flex flexDirection="row" justifyContent="space-between" width="100%">
           <Flex flexDirection="row">
             <OpaqueImageView

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesListItem.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesListItem.tsx
@@ -52,6 +52,8 @@ export const ArtistSeriesListItem: React.FC<ArtistSeriesListItemProps> = ({
   return (
     <Touchable
       underlayColor={color("black5")}
+      // the negative margin here is for resetting padding of 20 that all the parent components of this instance
+      // have and to avoid changing the component tree in multiple spots.
       style={{ marginHorizontal: -20 }}
       onPress={() => {
         trackArtworkClick()

--- a/src/lib/Scenes/ArtistSeries/ArtistSeriesListItem.tsx
+++ b/src/lib/Scenes/ArtistSeries/ArtistSeriesListItem.tsx
@@ -2,9 +2,8 @@ import { ActionType, ContextModule, OwnerType, ScreenOwnerType, TappedArtistSeri
 import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { navigate } from "lib/navigation/navigate"
 import { ArtistSeriesConnectionEdge } from "lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
-import { ArrowRightIcon, Flex, Sans } from "palette"
+import { ArrowRightIcon, color, Flex, Sans, Touchable } from "palette"
 import React from "react"
-import { TouchableOpacity } from "react-native"
 import { useTracking } from "react-tracking"
 
 interface ArtistSeriesListItemProps {
@@ -51,7 +50,8 @@ export const ArtistSeriesListItem: React.FC<ArtistSeriesListItemProps> = ({
   }
 
   return (
-    <TouchableOpacity
+    <Touchable
+      underlayColor={color("black5")}
       onPress={() => {
         trackArtworkClick()
         navigate(`/artist-series/${listItem?.node?.slug}`)
@@ -82,6 +82,6 @@ export const ArtistSeriesListItem: React.FC<ArtistSeriesListItemProps> = ({
           </Flex>
         </Flex>
       </Flex>
-    </TouchableOpacity>
+    </Touchable>
   )
 }

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeries-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeries-tests.tsx
@@ -5,8 +5,8 @@ import { ArtistSeriesHeader } from "lib/Scenes/ArtistSeries/ArtistSeriesHeader"
 import { ArtistSeriesMeta } from "lib/Scenes/ArtistSeries/ArtistSeriesMeta"
 import { ArtistSeriesMoreSeries } from "lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { Touchable } from "palette"
 import React from "react"
-import { TouchableOpacity } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
 import { act } from "react-test-renderer"
 import { useTracking } from "react-tracking"
@@ -73,7 +73,7 @@ describe("Artist Series Rail", () => {
         slug: "yayoi-kusama-other-fruits",
       }),
     })
-    const artistSeriesButton = wrapper.root.findByType(ArtistSeriesListItem).findByType(TouchableOpacity)
+    const artistSeriesButton = wrapper.root.findByType(ArtistSeriesListItem).findByType(Touchable)
     act(() => artistSeriesButton.props.onPress())
 
     expect(trackEvent).toHaveBeenCalledWith({

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesFullArtistSeriesList-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesFullArtistSeriesList-tests.tsx
@@ -6,8 +6,8 @@ import { ArtistSeriesFullArtistSeriesListFragmentContainer } from "lib/Scenes/Ar
 import { ArtistSeriesListItem } from "lib/Scenes/ArtistSeries/ArtistSeriesListItem"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { Touchable } from "palette"
 import React from "react"
-import { TouchableOpacity } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
 import { act } from "react-test-renderer"
 import { useTracking } from "react-tracking"
@@ -76,7 +76,7 @@ describe("Full Artist Series List", () => {
 
   it("tracks clicks on an artist series", () => {
     const wrapper = getWrapper()
-    const seriesButton = wrapper.root.findAllByType(ArtistSeriesListItem)[0].findByType(TouchableOpacity)
+    const seriesButton = wrapper.root.findAllByType(ArtistSeriesListItem)[0].findByType(Touchable)
     seriesButton.props.onPress()
     expect(trackEvent).toHaveBeenCalledWith({
       action: "tappedArtistSeriesGroup",

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesListItem-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesListItem-tests.tsx
@@ -4,8 +4,8 @@ import { navigate } from "lib/navigation/navigate"
 import { ArtistSeriesListItem } from "lib/Scenes/ArtistSeries/ArtistSeriesListItem"
 import { ArtistSeriesConnectionEdge } from "lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { Touchable } from "palette"
 import React from "react"
-import { TouchableOpacity } from "react-native"
 import { act } from "react-test-renderer"
 
 jest.unmock("react-relay")
@@ -20,7 +20,7 @@ describe("ArtistSeriesListItem", () => {
       />
     )
 
-    const instance = artistSeriesListItem.root.findAllByType(TouchableOpacity)[0]
+    const instance = artistSeriesListItem.root.findAllByType(Touchable)[0]
 
     act(() => instance.props.onPress())
 
@@ -36,7 +36,7 @@ describe("ArtistSeriesListItem", () => {
       />
     )
 
-    const instance = artistSeriesListItem.root.findAllByType(TouchableOpacity)[0]
+    const instance = artistSeriesListItem.root.findAllByType(Touchable)[0]
 
     expect(instance.findByType(OpaqueImageView).props.imageURL).toBe(
       "https://d32dm0rphc51dk.cloudfront.net/dL3hz4h6f_tMHQjVHsdO4w/medium.jpg"

--- a/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesMoreSeries-tests.tsx
+++ b/src/lib/Scenes/ArtistSeries/__tests__/ArtistSeriesMoreSeries-tests.tsx
@@ -9,8 +9,8 @@ import {
   ArtistSeriesMoreSeriesFragmentContainer,
 } from "lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { Touchable } from "palette"
 import React from "react"
-import { TouchableOpacity } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
 import { act } from "react-test-renderer"
 import { useTracking } from "react-tracking"
@@ -92,7 +92,7 @@ describe("ArtistSeriesMoreSeries", () => {
 
     it("tracks an event on click", () => {
       const wrapper = getWrapper(ArtistSeriesMoreSeriesFixture)
-      const artistSeriesButton = wrapper.root.findAllByType(ArtistSeriesListItem)[0].findByType(TouchableOpacity)
+      const artistSeriesButton = wrapper.root.findAllByType(ArtistSeriesListItem)[0].findByType(Touchable)
 
       act(() => artistSeriesButton.props.onPress())
 

--- a/src/lib/Scenes/Artwork/__tests__/Artwork-tests.tsx
+++ b/src/lib/Scenes/Artwork/__tests__/Artwork-tests.tsx
@@ -14,8 +14,9 @@ import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { merge } from "lodash"
 import _ from "lodash"
+import { Touchable } from "palette"
 import React, { Suspense } from "react"
-import { ActivityIndicator, TouchableOpacity } from "react-native"
+import { ActivityIndicator } from "react-native"
 import { act } from "react-test-renderer"
 import { useTracking } from "react-tracking"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
@@ -239,7 +240,7 @@ describe("Artwork", () => {
       })
       await flushPromiseQueue()
 
-      const artistSeriesButton = tree.root.findByType(ArtistSeriesListItem).findByType(TouchableOpacity)
+      const artistSeriesButton = tree.root.findByType(ArtistSeriesListItem).findByType(Touchable)
       act(() => artistSeriesButton.props.onPress())
 
       expect(trackEvent).toHaveBeenCalledWith({


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-2254]

### Description

ArtistSeriesListItem was using `TouchableOpacity` from `react-native` and not `Touchable` from palette.

Furthermore the `underlayColor` wasn't the same as other parts of the app so added "black5" to match the other Touchables.

The screenshots below show the touchable behaviour when the user is pressing the button.

Also made the `<ArtistSeriesListItem />` to take 100% width of the list and adjusted margins accordingly for consistensy as suggested from design [here](https://artsy.slack.com/archives/C9SATFLUU/p1624960749370100)

|Android|iOS|
|---|---|
|![android](https://user-images.githubusercontent.com/21178754/123755168-f07add80-d8bb-11eb-9d73-f881bc9aca61.png)|![ios](https://user-images.githubusercontent.com/21178754/123755177-f2dd3780-d8bb-11eb-9d27-f372e4d88714.png)|

#### More screenshots with all affected screens

|ArtistSeries|ArtistAbout|
|---|---|
|![Simulator Screen Shot - iPhone 8 - 2021-06-30 at 09 44 13](https://user-images.githubusercontent.com/21178754/123925300-10c59d80-d98b-11eb-86ea-71b2b632649a.png)|![Simulator Screen Shot - iPhone 8 - 2021-06-30 at 09 45 47](https://user-images.githubusercontent.com/21178754/123925307-128f6100-d98b-11eb-8066-a8201e57c746.png)|

|ArtistSeriesMoreSeries|Artwork|
|---|---|
|![Simulator Screen Shot - iPhone 8 - 2021-06-30 at 09 37 17](https://user-images.githubusercontent.com/21178754/123925316-13c08e00-d98b-11eb-80be-857b21656d82.png)|![Simulator Screen Shot - iPhone 8 - 2021-06-30 at 09 51 29](https://user-images.githubusercontent.com/21178754/123925310-1327f780-d98b-11eb-85a1-92d4b7a34418.png)|



<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Fix add touchable underlay color in ArtistSeriesListItem

<!-- end_changelog_updates -->


[FX-2254]: https://artsyproduct.atlassian.net/browse/FX-2254