### PR TITLE
fix (CX-958): refresh artwork after purchase

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -18,6 +18,7 @@ upcoming:
     - Connect auction results for you to metaphysics endpoint - yauheni
     - Fix opening artist page after passing new onboarding on ios - dzmitry
     - Change error handling middleware & include optionalField graphql directive to home screen - ole
+    - Refresh artwork page after purchase modal dismiss - katsiaryna alshannikava
 
 releases:
   - version: 6.9.5

--- a/src/lib/Components/ArtsyReactWebView.tsx
+++ b/src/lib/Components/ArtsyReactWebView.tsx
@@ -1,7 +1,7 @@
 import { OwnerType } from "@artsy/cohesion"
 import { color } from "@artsy/palette-tokens"
 import { addBreadcrumb } from "@sentry/react-native"
-import { goBack, navigate } from "lib/navigation/navigate"
+import { dismissModal, goBack, navigate } from "lib/navigation/navigate"
 import { matchRoute } from "lib/navigation/routes"
 import { getCurrentEmissionState, GlobalStore, useEnvironment } from "lib/store/GlobalStore"
 import { Schema } from "lib/utils/track"
@@ -79,7 +79,9 @@ export const ArtsyReactWebViewPage: React.FC<
         <FancyModalHeader
           useXButton={isPresentedModally && !canGoBack}
           onLeftButtonPress={() => {
-            if (!canGoBack) {
+            if (isPresentedModally && !canGoBack) {
+              dismissModal()
+            } else if (!canGoBack) {
               goBack()
             } else {
               ref.current?.goBack()

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -6,6 +6,7 @@ import { ArtworkAboveTheFoldQuery } from "__generated__/ArtworkAboveTheFoldQuery
 import { ArtworkBelowTheFoldQuery } from "__generated__/ArtworkBelowTheFoldQuery.graphql"
 import { ArtworkMarkAsRecentlyViewedQuery } from "__generated__/ArtworkMarkAsRecentlyViewedQuery.graphql"
 import { RetryErrorBoundary } from "lib/Components/RetryErrorBoundary"
+import { navigationEvents } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { ArtistSeriesMoreSeriesFragmentContainer as ArtistSeriesMoreSeries } from "lib/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
 import { unsafe_getFeatureFlag } from "lib/store/GlobalStore"
@@ -98,6 +99,11 @@ export class Artwork extends React.Component<Props, State> {
 
   componentDidMount() {
     this.markArtworkAsRecentlyViewed()
+    navigationEvents.addListener("modalDismissed", this.handleModalDismissed)
+  }
+
+  componentWillUnmount() {
+    navigationEvents.removeListener("modalDismissed", this.handleModalDismissed)
   }
 
   // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
@@ -170,6 +176,11 @@ export class Artwork extends React.Component<Props, State> {
         force: true,
       }
     )
+  }
+
+  handleModalDismissed = () => {
+    this.onRefresh()
+    return true
   }
 
   markArtworkAsRecentlyViewed = () => {
@@ -299,18 +310,22 @@ export class Artwork extends React.Component<Props, State> {
 
     return (
       <>
-        <FlatList<ArtworkPageSection>
-          keyboardShouldPersistTaps="handled"
-          data={this.sections()}
-          ItemSeparatorComponent={() => (
-            <Box mx={2} my={3}>
-              <Separator />
-            </Box>
-          )}
-          refreshControl={<RefreshControl refreshing={this.state.refreshing} onRefresh={this.onRefresh} />}
-          contentContainerStyle={{ paddingBottom: 40 }}
-          renderItem={({ item }) => (item.excludePadding ? item.element : <Box px={2}>{item.element}</Box>)}
-        />
+        {this.state.refreshing ? (
+          <ActivityIndicator />
+        ) : (
+          <FlatList<ArtworkPageSection>
+            keyboardShouldPersistTaps="handled"
+            data={this.sections()}
+            ItemSeparatorComponent={() => (
+              <Box mx={2} my={3}>
+                <Separator />
+              </Box>
+            )}
+            refreshControl={<RefreshControl refreshing={this.state.refreshing} onRefresh={this.onRefresh} />}
+            contentContainerStyle={{ paddingBottom: 40 }}
+            renderItem={({ item }) => (item.excludePadding ? item.element : <Box px={2}>{item.element}</Box>)}
+          />
+        )}
         <QAInfo />
       </>
     )

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -5,7 +5,6 @@ import { Artwork_me } from "__generated__/Artwork_me.graphql"
 import { ArtworkAboveTheFoldQuery } from "__generated__/ArtworkAboveTheFoldQuery.graphql"
 import { ArtworkBelowTheFoldQuery } from "__generated__/ArtworkBelowTheFoldQuery.graphql"
 import { ArtworkMarkAsRecentlyViewedQuery } from "__generated__/ArtworkMarkAsRecentlyViewedQuery.graphql"
-import { Flex } from "lib/Components/Bidding/Elements/Flex"
 import { RetryErrorBoundary } from "lib/Components/RetryErrorBoundary"
 import { navigationEvents } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
@@ -21,7 +20,7 @@ import {
 import { QAInfoPanel } from "lib/utils/QAInfo"
 import { Schema, screenTrack } from "lib/utils/track"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
-import { Box, Separator, space, Spacer, Spinner } from "palette"
+import { Box, Separator, space, Spacer } from "palette"
 import React from "react"
 import { ActivityIndicator, FlatList, View } from "react-native"
 import { RefreshControl } from "react-native"
@@ -319,9 +318,9 @@ export class Artwork extends React.Component<Props, State> {
     return (
       <>
         {this.state.fetchingData ? (
-          <Flex style={{ flex: 1, height: "100%" }} flexDirection="row" justifyContent="center" alignItems="center">
-            <Spinner />
-          </Flex>
+          <ProvidePlaceholderContext>
+            <AboveTheFoldPlaceholder />
+          </ProvidePlaceholderContext>
         ) : (
           <FlatList<ArtworkPageSection>
             keyboardShouldPersistTaps="handled"

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -50,6 +50,7 @@ interface Props {
 
 interface State {
   refreshing: boolean
+  fetchingData: boolean
 }
 
 @screenTrack<Props>((props) => ({
@@ -66,6 +67,7 @@ interface State {
 export class Artwork extends React.Component<Props, State> {
   state = {
     refreshing: false,
+    fetchingData: false,
   }
 
   shouldRenderDetails = () => {
@@ -111,14 +113,7 @@ export class Artwork extends React.Component<Props, State> {
   componentDidUpdate(prevProps) {
     // If we are visible, but weren't, then we are re-appearing (not called on first render).
     if (this.props.isVisible && !prevProps.isVisible) {
-      this.props.relay.refetch(
-        { artistID: this.props.artworkAboveTheFold.internalID },
-        null,
-        () => {
-          this.markArtworkAsRecentlyViewed()
-        },
-        { force: true }
-      )
+      this.refetch()
     }
   }
 
@@ -179,8 +174,21 @@ export class Artwork extends React.Component<Props, State> {
     )
   }
 
+  refetch = () => {
+    this.setState({ fetchingData: true })
+    this.props.relay.refetch(
+      { artistID: this.props.artworkAboveTheFold.internalID },
+      null,
+      () => {
+        this.markArtworkAsRecentlyViewed()
+        this.setState({ fetchingData: false })
+      },
+      { force: true }
+    )
+  }
+
   handleModalDismissed = () => {
-    this.onRefresh()
+    this.refetch()
     return true
   }
 
@@ -311,7 +319,7 @@ export class Artwork extends React.Component<Props, State> {
 
     return (
       <>
-        {this.state.refreshing ? (
+        {this.state.fetchingData ? (
           <Flex style={{ flex: 1, height: "100%" }} flexDirection="row" justifyContent="center" alignItems="center">
             <Spinner />
           </Flex>

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -5,6 +5,7 @@ import { Artwork_me } from "__generated__/Artwork_me.graphql"
 import { ArtworkAboveTheFoldQuery } from "__generated__/ArtworkAboveTheFoldQuery.graphql"
 import { ArtworkBelowTheFoldQuery } from "__generated__/ArtworkBelowTheFoldQuery.graphql"
 import { ArtworkMarkAsRecentlyViewedQuery } from "__generated__/ArtworkMarkAsRecentlyViewedQuery.graphql"
+import { Flex } from "lib/Components/Bidding/Elements/Flex"
 import { RetryErrorBoundary } from "lib/Components/RetryErrorBoundary"
 import { navigationEvents } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
@@ -20,7 +21,7 @@ import {
 import { QAInfoPanel } from "lib/utils/QAInfo"
 import { Schema, screenTrack } from "lib/utils/track"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
-import { Box, Separator, space, Spacer } from "palette"
+import { Box, Separator, space, Spacer, Spinner } from "palette"
 import React from "react"
 import { ActivityIndicator, FlatList, View } from "react-native"
 import { RefreshControl } from "react-native"
@@ -311,7 +312,9 @@ export class Artwork extends React.Component<Props, State> {
     return (
       <>
         {this.state.refreshing ? (
-          <ActivityIndicator />
+          <Flex style={{ flex: 1, height: "100%" }} flexDirection="row" justifyContent="center" alignItems="center">
+            <Spinner />
+          </Flex>
         ) : (
           <FlatList<ArtworkPageSection>
             keyboardShouldPersistTaps="handled"

--- a/src/lib/Scenes/Artwork/Artwork.tsx
+++ b/src/lib/Scenes/Artwork/Artwork.tsx
@@ -113,7 +113,7 @@ export class Artwork extends React.Component<Props, State> {
   componentDidUpdate(prevProps) {
     // If we are visible, but weren't, then we are re-appearing (not called on first render).
     if (this.props.isVisible && !prevProps.isVisible) {
-      this.refetch()
+      this.refetch(this.markArtworkAsRecentlyViewed)
     }
   }
 
@@ -174,21 +174,20 @@ export class Artwork extends React.Component<Props, State> {
     )
   }
 
-  refetch = () => {
-    this.setState({ fetchingData: true })
+  refetch = (cb?: () => any) => {
     this.props.relay.refetch(
       { artistID: this.props.artworkAboveTheFold.internalID },
       null,
       () => {
-        this.markArtworkAsRecentlyViewed()
-        this.setState({ fetchingData: false })
+        cb?.()
       },
       { force: true }
     )
   }
 
   handleModalDismissed = () => {
-    this.refetch()
+    this.setState({ fetchingData: true })
+    this.refetch(() => this.setState({ fetchingData: false }))
     return true
   }
 


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-958]

### Description

**The issue:**
As a collector, when I buy an artwork, the artwork screen should automatically refresh to show I've purchased it so that I'm sure I bought it.
Without refresh "Buy now" button is still available and we don't display "Sold" status.

**The fix:**

https://user-images.githubusercontent.com/27921300/123959866-f00f3f00-d9ae-11eb-8527-6c626b8d80c1.mov

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->


[CX-958]: https://artsyproduct.atlassian.net/browse/CX-958