### PR TITLE
feat: Use correct Braze app id for android prod GRO-262

### DIFF
--- a/android/app/src/main/res/values/braze.xml
+++ b/android/app/src/main/res/values/braze.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="com_appboy_api_key">a011388c-984b-441f-8ad7-3cc2feec0321</string>
+    <string name="com_appboy_api_key">3afa6308-dbf9-47c0-89e9-b9aed60f35ae</string>
     <string translatable="false" name="com_appboy_custom_endpoint">sdk.iad-06.braze.com</string>
 </resources>


### PR DESCRIPTION
This is a follow up to https://github.com/artsy/eigen/pull/4952 that updates the Braze app id for Android production builds. We did this as sort of an experiment and used the staging key but it's working so this PR updates it to the production key.

Updating like this is good because it properly attributes production sessions BUT it also means that dev and beta builds will also phone home to Braze as if they were the production app. What would be better would be to switch this key depending on the build we're making but I don't really know how to do that.

There was some chatter on Slack here about ways to do this:

https://artsy.slack.com/archives/C02BAQ5K7/p1623248720272400?thread_ts=1623248529.271200&cid=C02BAQ5K7

So if doing that is easier/faster than what I've got here, happy to close this PR in favor of another one, but wanted to fix the lack of session data asap.

https://artsyproduct.atlassian.net/browse/GRO-262

/cc @artsy/grow-devs