### PR TITLE
feat: add context_screen_owner_slug to toggleSavedSearch analytics payload

### DIFF
--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -171,7 +171,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
         <Separator mt={2} ml={-2} width={screenWidth} />
         {!!shouldShowSavedSearchBanner && (
           <>
-            <SavedSearchBannerQueryRender artistId={artistInternalId} filters={filterParams} slug={artist.slug} />
+            <SavedSearchBannerQueryRender artistId={artistInternalId} filters={filterParams} artistSlug={artist.slug} />
             <Separator ml={-2} width={screenWidth} />
           </>
         )}

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -9,7 +9,7 @@ import {
 } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworkFiltersStoreProvider, ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { convertSavedSearchCriteriaToFilterParams } from "lib/Components/ArtworkFilter/SavedSearch/convertersToFilterParams"
-import { SearchCriteriaAttributes } from 'lib/Components/ArtworkFilter/SavedSearch/types'
+import { SearchCriteriaAttributes } from "lib/Components/ArtworkFilter/SavedSearch/types"
 import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
 import {
   InfiniteScrollArtworksGridContainer as InfiniteScrollArtworksGrid,
@@ -128,10 +128,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
     setAggregationsAction(artworks?.aggregations)
 
     if (searchCriteria && artworks?.aggregations) {
-      const params = convertSavedSearchCriteriaToFilterParams(
-        searchCriteria,
-        artworks.aggregations as Aggregations
-      )
+      const params = convertSavedSearchCriteriaToFilterParams(searchCriteria, artworks.aggregations as Aggregations)
       setInitialFilterStateAction(params)
     }
   }, [])
@@ -174,7 +171,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
         <Separator mt={2} ml={-2} width={screenWidth} />
         {!!shouldShowSavedSearchBanner && (
           <>
-            <SavedSearchBannerQueryRender artistId={artistInternalId} filters={filterParams} />
+            <SavedSearchBannerQueryRender artistId={artistInternalId} filters={filterParams} slug={artist.slug} />
             <Separator ml={-2} width={screenWidth} />
           </>
         )}

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -5,8 +5,8 @@ import { SavedSearchBannerCreateSavedSearchMutation } from "__generated__/SavedS
 import { SavedSearchBannerDeleteSavedSearchMutation } from "__generated__/SavedSearchBannerDeleteSavedSearchMutation.graphql"
 import { SavedSearchBannerQuery } from "__generated__/SavedSearchBannerQuery.graphql"
 import { FilterParams, prepareFilterParamsForSaveSearchInput } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
-import { SearchCriteriaAttributes } from 'lib/Components/ArtworkFilter/SavedSearch/types'
-import { usePopoverMessage } from 'lib/Components/PopoverMessage/popoverMessageHooks'
+import { SearchCriteriaAttributes } from "lib/Components/ArtworkFilter/SavedSearch/types"
+import { usePopoverMessage } from "lib/Components/PopoverMessage/popoverMessageHooks"
 import { LegacyNativeModules } from "lib/NativeModules/LegacyNativeModules"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { PushAuthorizationStatus } from "lib/Scenes/MyProfile/MyProfilePushNotifications"
@@ -19,12 +19,20 @@ import { useTracking } from "react-tracking"
 interface SavedSearchBannerProps {
   me?: SavedSearchBanner_me | null
   artistId: string
+  slug: string
   attributes: SearchCriteriaAttributes
   loading?: boolean
   relay: RelayRefetchProp
 }
 
-export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({ me, artistId, attributes, loading, relay }) => {
+export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({
+  me,
+  artistId,
+  slug,
+  attributes,
+  loading,
+  relay,
+}) => {
   const [saving, setSaving] = useState(false)
   const popoverMessage = usePopoverMessage()
   const enabled = !!me?.savedSearch?.internalID
@@ -184,7 +192,7 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({ me, artist
 
   const trackToggledSavedSearchEvent = (modified: boolean, searchCriteriaId: string | undefined) => {
     if (searchCriteriaId) {
-      tracking.trackEvent(tracks.toggleSavedSearch(modified, artistId, searchCriteriaId))
+      tracking.trackEvent(tracks.toggleSavedSearch(modified, artistId, slug, searchCriteriaId))
     }
   }
 
@@ -235,9 +243,10 @@ export const SavedSearchBannerRefetchContainer = createRefetchContainer(
   `
 )
 
-export const SavedSearchBannerQueryRender: React.FC<{ filters: FilterParams; artistId: string }> = ({
+export const SavedSearchBannerQueryRender: React.FC<{ filters: FilterParams; artistId: string; slug: string }> = ({
   filters,
   artistId,
+  slug,
 }) => {
   const input = prepareFilterParamsForSaveSearchInput(filters)
   const attributes: SearchCriteriaAttributes = {
@@ -270,6 +279,7 @@ export const SavedSearchBannerQueryRender: React.FC<{ filters: FilterParams; art
             loading={props === null && error === null}
             attributes={attributes}
             artistId={artistId}
+            slug={slug}
           />
         )
       }}
@@ -281,10 +291,16 @@ export const SavedSearchBannerQueryRender: React.FC<{ filters: FilterParams; art
 }
 
 export const tracks = {
-  toggleSavedSearch: (enabled: boolean, artistId: string, searchCriteriaId: string): ToggledSavedSearch => ({
+  toggleSavedSearch: (
+    enabled: boolean,
+    artistId: string,
+    slug: string,
+    searchCriteriaId: string
+  ): ToggledSavedSearch => ({
     action: ActionType.toggledSavedSearch,
     context_screen_owner_type: OwnerType.artist,
     context_screen_owner_id: artistId,
+    context_screen_owner_slug: slug,
     modified: enabled,
     original: !enabled,
     search_criteria_id: searchCriteriaId,

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -19,7 +19,7 @@ import { useTracking } from "react-tracking"
 interface SavedSearchBannerProps {
   me?: SavedSearchBanner_me | null
   artistId: string
-  slug: string
+  artistSlug: string
   attributes: SearchCriteriaAttributes
   loading?: boolean
   relay: RelayRefetchProp
@@ -28,7 +28,7 @@ interface SavedSearchBannerProps {
 export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({
   me,
   artistId,
-  slug,
+  artistSlug,
   attributes,
   loading,
   relay,
@@ -192,7 +192,7 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({
 
   const trackToggledSavedSearchEvent = (modified: boolean, searchCriteriaId: string | undefined) => {
     if (searchCriteriaId) {
-      tracking.trackEvent(tracks.toggleSavedSearch(modified, artistId, slug, searchCriteriaId))
+      tracking.trackEvent(tracks.toggleSavedSearch(modified, artistId, artistSlug, searchCriteriaId))
     }
   }
 
@@ -243,11 +243,11 @@ export const SavedSearchBannerRefetchContainer = createRefetchContainer(
   `
 )
 
-export const SavedSearchBannerQueryRender: React.FC<{ filters: FilterParams; artistId: string; slug: string }> = ({
-  filters,
-  artistId,
-  slug,
-}) => {
+export const SavedSearchBannerQueryRender: React.FC<{
+  filters: FilterParams
+  artistId: string
+  artistSlug: string
+}> = ({ filters, artistId, artistSlug }) => {
   const input = prepareFilterParamsForSaveSearchInput(filters)
   const attributes: SearchCriteriaAttributes = {
     artistID: artistId,
@@ -279,7 +279,7 @@ export const SavedSearchBannerQueryRender: React.FC<{ filters: FilterParams; art
             loading={props === null && error === null}
             attributes={attributes}
             artistId={artistId}
-            slug={slug}
+            artistSlug={artistSlug}
           />
         )
       }}
@@ -294,13 +294,13 @@ export const tracks = {
   toggleSavedSearch: (
     enabled: boolean,
     artistId: string,
-    slug: string,
+    artistSlug: string,
     searchCriteriaId: string
   ): ToggledSavedSearch => ({
     action: ActionType.toggledSavedSearch,
     context_screen_owner_type: OwnerType.artist,
     context_screen_owner_id: artistId,
-    context_screen_owner_slug: slug,
+    context_screen_owner_slug: artistSlug,
     modified: enabled,
     original: !enabled,
     search_criteria_id: searchCriteriaId,

--- a/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
@@ -65,7 +65,7 @@ describe("SavedSearchBanner", () => {
             loading={props === null}
             attributes={attributes}
             artistId="banksy"
-            slug="some-slug"
+            artistSlug="some-slug"
           />
         )}
         variables={{

--- a/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
@@ -65,6 +65,7 @@ describe("SavedSearchBanner", () => {
             loading={props === null}
             attributes={attributes}
             artistId="banksy"
+            slug="some-slug"
           />
         )}
         variables={{
@@ -163,7 +164,12 @@ describe("SavedSearchBanner", () => {
       message: "We will send you a push notification once new works are added.",
     }
 
-    const analyticsPayload = tracks.toggleSavedSearch(true, "banksy", '<mock-value-for-field-"internalID">')
+    const analyticsPayload = tracks.toggleSavedSearch(
+      true,
+      "banksy",
+      "some-slug",
+      '<mock-value-for-field-"internalID">'
+    )
     checkLogicForMutations(mockResolvers, mutation, popover, analyticsPayload)
   })
 
@@ -189,7 +195,12 @@ describe("SavedSearchBanner", () => {
       message: "Don't worry, you can always create a new one.",
     }
 
-    const analyticsPayload = tracks.toggleSavedSearch(false, "banksy", '<mock-value-for-field-"internalID">')
+    const analyticsPayload = tracks.toggleSavedSearch(
+      false,
+      "banksy",
+      "some-slug",
+      '<mock-value-for-field-"internalID">'
+    )
     checkLogicForMutations(mockResolvers, mutation, popover, analyticsPayload)
   })
 })


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3040]

### Description

Added `context_screen_owner_slug` to `toggleSavedSearch`

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

#nochangelog

[FX-3040]: https://artsyproduct.atlassian.net/browse/FX-3040