### PR TITLE
fix: disappearing sticky header

### DIFF
--- a/src/lib/Components/StickyHeaderPage.tsx
+++ b/src/lib/Components/StickyHeaderPage.tsx
@@ -2,7 +2,7 @@ import { useAnimatedValue } from "lib/Components/StickyTabPage/reanimatedHelpers
 import { useUpdadeShouldHideBackButton } from "lib/utils/hideBackButtonOnScroll"
 import { useAutoCollapsingMeasuredView } from "lib/utils/useAutoCollapsingMeasuredView"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
-import React, { useRef } from "react"
+import React from "react"
 import { View } from "react-native"
 import Animated from "react-native-reanimated"
 
@@ -15,9 +15,9 @@ interface StickyHeaderPageProps {
 export const StickyHeaderPage: React.FC<StickyHeaderPageProps> = (props) => {
   const { headerContent, stickyHeaderContent, footerContent, children } = props
 
-  const footerOffsetY = useRef<Animated.Value<number>>(new Animated.Value(-1))
   const { jsx: staticHeader, nativeHeight: headerHeight } = useAutoCollapsingMeasuredView(headerContent)
   const { jsx: stickyHeader, nativeHeight: stickyHeaderHeight } = useAutoCollapsingMeasuredView(stickyHeaderContent)
+  const footerOffsetY = useAnimatedValue(-1)
   const scrollOffsetY = useAnimatedValue(0)
   const { width: screenWidth } = useScreenDimensions()
   const updateShouldHideBackButton = useUpdadeShouldHideBackButton()
@@ -35,8 +35,8 @@ export const StickyHeaderPage: React.FC<StickyHeaderPageProps> = (props) => {
   const scrollOffsetYAndStickyHeaderHeight = Animated.add(scrollOffsetY, stickyHeaderHeightRendered)
   // If we have the starting position of the footer and the user scrolled to it
   const nearToTheFooter = Animated.and(
-    Animated.greaterThan(footerOffsetY.current, 0),
-    Animated.greaterThan(scrollOffsetYAndStickyHeaderHeight, footerOffsetY.current)
+    Animated.greaterThan(footerOffsetY, 0),
+    Animated.greaterThan(scrollOffsetYAndStickyHeaderHeight, footerOffsetY)
   )
 
   const translateY = Animated.cond(
@@ -45,7 +45,7 @@ export const StickyHeaderPage: React.FC<StickyHeaderPageProps> = (props) => {
     // So we move the sticky header up by 10 on translateY until it is fully hidden
     Animated.max(
       Animated.multiply(-1, stickyHeaderHeightRendered),
-      Animated.sub(footerOffsetY.current, scrollOffsetYAndStickyHeaderHeight)
+      Animated.sub(footerOffsetY, scrollOffsetYAndStickyHeaderHeight)
     ),
     stickyHeaderOffsetY
   )
@@ -83,9 +83,9 @@ export const StickyHeaderPage: React.FC<StickyHeaderPageProps> = (props) => {
         <Animated.View style={{ width: screenWidth, height: stickyHeaderHeightRendered }} />
         {children}
         {!!footerContent && (
-          <View onLayout={(event) => (footerOffsetY.current = new Animated.Value(event.nativeEvent.layout.y))}>
+          <Animated.View onLayout={Animated.event([{ nativeEvent: { layout: { y: footerOffsetY } } }])}>
             {footerContent}
-          </View>
+          </Animated.View>
         )}
       </Animated.ScrollView>
       <Animated.View


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-2907]

### Description
Some fixes for #4951. Fixed the problem of the sticky header disappearing when the user fetched the next portion of data, and the header also remained sticky in the footer area

#### Initial problems

https://user-images.githubusercontent.com/3513494/124199886-b177a280-dadc-11eb-9493-73498b41b1f6.mp4

https://user-images.githubusercontent.com/3513494/124200199-64480080-dadd-11eb-82a4-065d52baa7ec.mp4


#### Fixed problems
https://user-images.githubusercontent.com/3513494/124199599-f51ddc80-dadb-11eb-985f-1dc639fb62f0.mp4


https://user-images.githubusercontent.com/3513494/124199955-db30c980-dadc-11eb-9942-207fe35bab1c.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->


[FX-2907]: https://artsyproduct.atlassian.net/browse/FX-2907