### PR TITLE
fix: don't show spinner when user has no auction results by followed artists

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -33,7 +33,7 @@ upcoming:
     - Fix empty search for consignment submissions - dzmitry
     - Release order history view - sweir
     - Fix visual bug on auction result list item on artist insights screen - ole
-
+    - Fix artist home rail loading spinner issue - ole
 releases:
   - version: 6.9.5
   - date: June 24, 2021

--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -33,7 +33,7 @@ upcoming:
     - Fix empty search for consignment submissions - dzmitry
     - Release order history view - sweir
     - Fix visual bug on auction result list item on artist insights screen - ole
-    - Fix artist home rail loading spinner issue - ole
+    - Fix auction result home rail loading spinner issue - ole
 releases:
   - version: 6.9.5
   - date: June 24, 2021

--- a/src/lib/Components/Lists/AuctionResultListItem.tsx
+++ b/src/lib/Components/Lists/AuctionResultListItem.tsx
@@ -55,7 +55,7 @@ const AuctionResultListItem: React.FC<Props> = ({ auctionResult, onPress, showAr
         <Flex pl={15} flex={1} flexDirection="row" justifyContent="space-between">
           <Flex flex={3}>
             <Flex>
-              {!!showArtistName && (
+              {!!showArtistName && !!auctionResult.artist?.name && (
                 <Text variant="caption" ellipsizeMode="middle" numberOfLines={2} fontWeight="bold">
                   {auctionResult.artist?.name}
                 </Text>

--- a/src/lib/Scenes/Home/Components/AuctionResultsRail.tsx
+++ b/src/lib/Scenes/Home/Components/AuctionResultsRail.tsx
@@ -26,6 +26,10 @@ const AuctionResultsRail: React.FC<{ me: AuctionResultsRail_me } & RailScrollPro
     scrollToTop: () => listRef.current?.scrollToOffset({ offset: 0, animated: false }),
   }))
 
+  if (!auctionResultsByFollowedArtists?.length) {
+    return null
+  }
+
   return (
     <View>
       <Flex pl="2" pr="2">

--- a/src/lib/Scenes/Home/Components/__tests__/AuctionResultsRail-tests.tsx
+++ b/src/lib/Scenes/Home/Components/__tests__/AuctionResultsRail-tests.tsx
@@ -2,8 +2,7 @@ import { cloneDeep, first } from "lodash"
 import React from "react"
 import "react-native"
 import { graphql, QueryRenderer } from "react-relay"
-import { act } from "react-test-renderer"
-import { createMockEnvironment } from "relay-test-utils"
+import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 
 import { navigate } from "lib/navigation/navigate"
 
@@ -45,14 +44,13 @@ describe("AuctionResultsRailFragmentContainer", () => {
 
   it("doesn't throw when rendered", () => {
     renderWithWrappers(<TestRenderer />)
-    act(() => {
-      env.mock.resolveMostRecentOperation({
-        errors: [],
-        data: {
+    env.mock.resolveMostRecentOperation((operation) =>
+      MockPayloadGenerator.generate(operation, {
+        Query: () => ({
           me: meResponseMock,
-        },
+        }),
       })
-    })
+    )
   })
 
   it("looks correct when rendered with sales missing auctionResultsByFollowedArtists", () => {
@@ -60,29 +58,28 @@ describe("AuctionResultsRailFragmentContainer", () => {
     auctionResultsCopy.results.forEach((result) => {
       result.auctionResultsByFollowedArtists.edges = []
     })
+
     renderWithWrappers(<TestRenderer />)
-    act(() => {
-      env.mock.resolveMostRecentOperation({
-        errors: [],
-        data: {
-          me: meResponseMock,
-        },
+    env.mock.resolveMostRecentOperation((operation) =>
+      MockPayloadGenerator.generate(operation, {
+        Query: () => ({
+          me: auctionResultsCopy,
+        }),
       })
-    })
+    )
   })
 
   it("routes to auction-results-for-you URL", () => {
     const tree = renderWithWrappers(<TestRenderer />)
-    act(() => {
-      env.mock.resolveMostRecentOperation({
-        errors: [],
-        data: {
+    env.mock.resolveMostRecentOperation((operation) =>
+      MockPayloadGenerator.generate(operation, {
+        Query: () => ({
           me: meResponseMock,
-        },
+        }),
       })
-    })
-    // @ts-ignore
-    first(tree.root.findAllByType(SectionTitle)).props.onPress()
+    )
+
+    first(tree.root.findAllByType(SectionTitle))?.props.onPress()
     expect(navigate).toHaveBeenCalledWith("/auction-results-for-you")
   })
 })


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1674]

### Description

- Prevents auctionResultsRail from showing a spinner if there are no auction results
- Checks if artist name is not null 

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->


[CX-1674]: https://artsyproduct.atlassian.net/browse/CX-1674