### PR TITLE
fix: Dont show home collections rail spinner

### DIFF
--- a/CHANGELOG.yml
+++ b/CHANGELOG.yml
@@ -36,6 +36,7 @@ upcoming:
     - Fix visual bug on auction result list item on artist insights screen - ole
     - Fix auction result home rail loading spinner issue - ole
     - Fix share button on BNMO Flow - ole, mounir, sam, george
+    - Fix collection home rail loading spinner issue - ole
 
 releases:
   - version: 6.9.5

--- a/src/lib/Scenes/Home/Components/CollectionsRail.tsx
+++ b/src/lib/Scenes/Home/Components/CollectionsRail.tsx
@@ -36,6 +36,10 @@ const CollectionsRail: React.FC<Props & RailScrollProps> = (props) => {
     scrollToTop: () => listRef.current?.scrollToOffset({ offset: 0, animated: false }),
   }))
 
+  // if (!props.collectionsModule.results?.length) {
+  //   return null
+  // }
+
   return (
     <View>
       <Flex pl="2" pr="2">

--- a/src/lib/Scenes/Home/Components/CollectionsRail.tsx
+++ b/src/lib/Scenes/Home/Components/CollectionsRail.tsx
@@ -36,9 +36,9 @@ const CollectionsRail: React.FC<Props & RailScrollProps> = (props) => {
     scrollToTop: () => listRef.current?.scrollToOffset({ offset: 0, animated: false }),
   }))
 
-  // if (!props.collectionsModule.results?.length) {
-  //   return null
-  // }
+  if (!props.collectionsModule.results?.length) {
+    return null
+  }
 
   return (
     <View>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1677]

### Description

Prevents the collections home rail from showing a spinner if no collections are available.

![Simulator Screen Shot - iPhone 8 - 2021-07-06 at 09 31 09](https://user-images.githubusercontent.com/4691889/124560760-760f0800-de3d-11eb-817f-82d62c4cab20.png)


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->


[CX-1677]: https://artsyproduct.atlassian.net/browse/CX-1677