### PR TITLE
feat: (PURCHASE-2758) add refetch to saved addresses

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -113,7 +113,6 @@
                 <data android:pathPrefix="/my-profile" />
                 <data android:pathPrefix="/my-profile/saved-addresses" />
                 <data android:pathPrefix="/orders" />
-                <data android:pathPrefix="/orders" />
                 <data android:pathPrefix="/privacy-request" />
                 <data android:pathPrefix="/privacy" />
                 <data android:pathPrefix="/sales" />

--- a/src/__generated__/SavedAddressesQuery.graphql.ts
+++ b/src/__generated__/SavedAddressesQuery.graphql.ts
@@ -1,0 +1,212 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash 9ddb6c03faad6d7c8e94247cf90fe156 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SavedAddressesQueryVariables = {};
+export type SavedAddressesQueryResponse = {
+    readonly me: {
+        readonly " $fragmentRefs": FragmentRefs<"SavedAddresses_me">;
+    } | null;
+};
+export type SavedAddressesQuery = {
+    readonly response: SavedAddressesQueryResponse;
+    readonly variables: SavedAddressesQueryVariables;
+};
+
+
+
+/*
+query SavedAddressesQuery {
+  me {
+    ...SavedAddresses_me
+    id
+  }
+}
+
+fragment SavedAddresses_me on Me {
+  name
+  addressConnection(first: 3) {
+    edges {
+      node {
+        internalID
+        name
+        addressLine1
+        addressLine2
+        addressLine3
+        city
+        region
+        postalCode
+        id
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SavedAddressesQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "SavedAddresses_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "SavedAddressesQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          (v0/*: any*/),
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 3
+              }
+            ],
+            "concreteType": "UserAddressConnection",
+            "kind": "LinkedField",
+            "name": "addressConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "UserAddressEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "UserAddress",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      (v0/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "addressLine1",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "addressLine2",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "addressLine3",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "city",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "region",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "postalCode",
+                        "storageKey": null
+                      },
+                      (v1/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "addressConnection(first:3)"
+          },
+          (v1/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "9ddb6c03faad6d7c8e94247cf90fe156",
+    "metadata": {},
+    "name": "SavedAddressesQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = 'cc91a2e091841a6dc019ad34cf94d847';
+export default node;

--- a/src/__generated__/SavedAddressesRefetchQuery.graphql.ts
+++ b/src/__generated__/SavedAddressesRefetchQuery.graphql.ts
@@ -1,0 +1,212 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash 5b700e24a86eb1addb0eb9b398c8b12c */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SavedAddressesRefetchQueryVariables = {};
+export type SavedAddressesRefetchQueryResponse = {
+    readonly me: {
+        readonly " $fragmentRefs": FragmentRefs<"SavedAddresses_me">;
+    } | null;
+};
+export type SavedAddressesRefetchQuery = {
+    readonly response: SavedAddressesRefetchQueryResponse;
+    readonly variables: SavedAddressesRefetchQueryVariables;
+};
+
+
+
+/*
+query SavedAddressesRefetchQuery {
+  me {
+    ...SavedAddresses_me
+    id
+  }
+}
+
+fragment SavedAddresses_me on Me {
+  name
+  addressConnection(first: 3) {
+    edges {
+      node {
+        internalID
+        name
+        addressLine1
+        addressLine2
+        addressLine3
+        city
+        region
+        postalCode
+        id
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SavedAddressesRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "SavedAddresses_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "SavedAddressesRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          (v0/*: any*/),
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 3
+              }
+            ],
+            "concreteType": "UserAddressConnection",
+            "kind": "LinkedField",
+            "name": "addressConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "UserAddressEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "UserAddress",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      (v0/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "addressLine1",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "addressLine2",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "addressLine3",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "city",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "region",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "postalCode",
+                        "storageKey": null
+                      },
+                      (v1/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "addressConnection(first:3)"
+          },
+          (v1/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "5b700e24a86eb1addb0eb9b398c8b12c",
+    "metadata": {},
+    "name": "SavedAddressesRefetchQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = 'e164d0b484f2f5634549c612711904c8';
+export default node;

--- a/src/__generated__/SavedAddressesTestsQuery.graphql.ts
+++ b/src/__generated__/SavedAddressesTestsQuery.graphql.ts
@@ -1,0 +1,212 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash 7f6d4b1bdf86e3c4ac94110579448304 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SavedAddressesTestsQueryVariables = {};
+export type SavedAddressesTestsQueryResponse = {
+    readonly me: {
+        readonly " $fragmentRefs": FragmentRefs<"SavedAddresses_me">;
+    } | null;
+};
+export type SavedAddressesTestsQuery = {
+    readonly response: SavedAddressesTestsQueryResponse;
+    readonly variables: SavedAddressesTestsQueryVariables;
+};
+
+
+
+/*
+query SavedAddressesTestsQuery {
+  me {
+    ...SavedAddresses_me
+    id
+  }
+}
+
+fragment SavedAddresses_me on Me {
+  name
+  addressConnection(first: 3) {
+    edges {
+      node {
+        internalID
+        name
+        addressLine1
+        addressLine2
+        addressLine3
+        city
+        region
+        postalCode
+        id
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SavedAddressesTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "SavedAddresses_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "SavedAddressesTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          (v0/*: any*/),
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 3
+              }
+            ],
+            "concreteType": "UserAddressConnection",
+            "kind": "LinkedField",
+            "name": "addressConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "UserAddressEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "UserAddress",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      (v0/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "addressLine1",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "addressLine2",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "addressLine3",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "city",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "region",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "postalCode",
+                        "storageKey": null
+                      },
+                      (v1/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "addressConnection(first:3)"
+          },
+          (v1/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "7f6d4b1bdf86e3c4ac94110579448304",
+    "metadata": {},
+    "name": "SavedAddressesTestsQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = 'de5170f448285c24d405b4988d2d2e69';
+export default node;

--- a/src/__generated__/SavedAddresses_me.graphql.ts
+++ b/src/__generated__/SavedAddresses_me.graphql.ts
@@ -1,0 +1,143 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SavedAddresses_me = {
+    readonly name: string | null;
+    readonly addressConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly internalID: string;
+                readonly name: string | null;
+                readonly addressLine1: string;
+                readonly addressLine2: string | null;
+                readonly addressLine3: string | null;
+                readonly city: string;
+                readonly region: string | null;
+                readonly postalCode: string | null;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "SavedAddresses_me";
+};
+export type SavedAddresses_me$data = SavedAddresses_me;
+export type SavedAddresses_me$key = {
+    readonly " $data"?: SavedAddresses_me$data;
+    readonly " $fragmentRefs": FragmentRefs<"SavedAddresses_me">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "SavedAddresses_me",
+  "selections": [
+    (v0/*: any*/),
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 3
+        }
+      ],
+      "concreteType": "UserAddressConnection",
+      "kind": "LinkedField",
+      "name": "addressConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "UserAddressEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "UserAddress",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "internalID",
+                  "storageKey": null
+                },
+                (v0/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "addressLine1",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "addressLine2",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "addressLine3",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "city",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "region",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "postalCode",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "addressConnection(first:3)"
+    }
+  ],
+  "type": "Me",
+  "abstractKey": null
+};
+})();
+(node as any).hash = 'e94b0eeebba5f97af4e7e3e7f566178c';
+export default node;

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -62,7 +62,7 @@ import { PrivacyRequest } from "./Scenes/PrivacyRequest"
 import { SaleQueryRenderer } from "./Scenes/Sale"
 import { SaleFAQ } from "./Scenes/SaleFAQ/SaleFAQ"
 import { SaleInfoQueryRenderer } from "./Scenes/SaleInfo"
-import { SavedAddresses } from "./Scenes/SavedAddresses/SavedAddresses"
+import { SavedAddressesQueryRenderer } from "./Scenes/SavedAddresses/SavedAddresses"
 
 import { SalesQueryRenderer } from "./Scenes/Sales"
 import { Search } from "./Scenes/Search"
@@ -362,7 +362,7 @@ export const modules = defineModules({
   Search: reactModule(SearchWithTracking, { isRootViewForTabName: "search" }),
   Show: reactModule(ShowQueryRenderer, { fullBleed: true }),
   ShowMoreInfo: reactModule(ShowMoreInfoQueryRenderer),
-  SavedAddresses: reactModule(SavedAddresses),
+  SavedAddresses: reactModule(SavedAddressesQueryRenderer),
   VanityURLEntity: reactModule(VanityURLEntityRenderer, { fullBleed: true }),
   ViewingRoom: reactModule(ViewingRoomQueryRenderer, { fullBleed: true }),
   ViewingRoomArtwork: reactModule(ViewingRoomArtworkQueryRenderer),

--- a/src/lib/Scenes/SavedAddresses/SavedAddresses.tsx
+++ b/src/lib/Scenes/SavedAddresses/SavedAddresses.tsx
@@ -1,21 +1,126 @@
+import { SavedAddresses_me } from "__generated__/SavedAddresses_me.graphql"
+import { SavedAddressesQuery } from "__generated__/SavedAddressesQuery.graphql"
 import { PageWithSimpleHeader } from "lib/Components/PageWithSimpleHeader"
+import { defaultEnvironment } from "lib/relay/createEnvironment"
+import { extractNodes } from "lib/utils/extractNodes"
+import { PlaceholderText } from "lib/utils/placeholders"
+import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
+import { times } from "lodash"
 import { Button, Flex, Text } from "palette"
-import React from "react"
+import React, { useCallback, useState } from "react"
+import { FlatList, RefreshControl } from "react-native"
+import { createRefetchContainer, QueryRenderer, RelayRefetchProp } from "react-relay"
+import { graphql } from "relay-runtime"
 
-export const SavedAddresses: React.FC = () => {
+const SavedAddresses: React.FC<{ me: SavedAddresses_me; relay: RelayRefetchProp }> = ({ me, relay }) => {
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const addresses = extractNodes(me.addressConnection)
+  const onRefresh = useCallback(() => {
+    setIsRefreshing(true)
+    relay.refetch(
+      {},
+      null,
+      () => {
+        setIsRefreshing(false)
+      },
+      { force: true }
+    )
+  }, [])
   return (
     <PageWithSimpleHeader title="Saved Addresses">
-      <Flex py={3} px={2} alignItems="center" height="100%" justifyContent="center">
-        <Text variant="title" mb={2}>
-          No Saved Addresses
-        </Text>
-        <Text variant="caption" textAlign="center" mb={3}>
-          Please add an address for a faster checkout experience in the future.
-        </Text>
-        <Button block variant="primaryBlack" width={100}>
-          Add New Address
-        </Button>
+      <FlatList
+        refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />}
+        data={addresses}
+        keyExtractor={(address) => address.internalID}
+        contentContainerStyle={{ flexGrow: 0.8, paddingTop: addresses.length === 0 ? 10 : 20 }}
+        renderItem={({ item }) => (
+          <Flex py={3} px={2} alignItems="center">
+            <Text>
+              {item.name},{item.addressLine1},{item.city}
+            </Text>
+          </Flex>
+        )}
+        ListEmptyComponent={
+          <Flex py={3} px={2} alignItems="center" height="100%" justifyContent="center">
+            <Text variant="title" mb={2}>
+              No Saved Addresses
+            </Text>
+            <Text variant="caption" textAlign="center" mb={3}>
+              Please add an address for a faster checkout experience in the future.
+            </Text>
+            <Button block variant="primaryBlack" width={100}>
+              Add New Address
+            </Button>
+          </Flex>
+        }
+      />
+    </PageWithSimpleHeader>
+  )
+}
+
+export const SavedAddressesPlaceholder: React.FC = () => {
+  return (
+    <PageWithSimpleHeader title="Saved Addresses">
+      <Flex px={2} py={15}>
+        {times(2).map((index: number) => (
+          <Flex key={index} py={1}>
+            <PlaceholderText width={100 + Math.random() * 100} />
+          </Flex>
+        ))}
       </Flex>
     </PageWithSimpleHeader>
+  )
+}
+
+export const SavedAddressesContainer = createRefetchContainer(
+  SavedAddresses,
+  {
+    me: graphql`
+      fragment SavedAddresses_me on Me {
+        name
+        addressConnection(first: 3) {
+          edges {
+            node {
+              internalID
+              name
+              addressLine1
+              addressLine2
+              addressLine3
+              city
+              region
+              postalCode
+            }
+          }
+        }
+      }
+    `,
+  },
+  graphql`
+    query SavedAddressesRefetchQuery {
+      me {
+        ...SavedAddresses_me
+      }
+    }
+  `
+)
+
+export const SavedAddressesQueryRenderer: React.FC<{}> = ({}) => {
+  return (
+    <QueryRenderer<SavedAddressesQuery>
+      environment={defaultEnvironment}
+      query={graphql`
+        query SavedAddressesQuery {
+          me {
+            ...SavedAddresses_me
+          }
+        }
+      `}
+      render={renderWithPlaceholder({
+        Container: SavedAddressesContainer,
+        renderPlaceholder: () => <SavedAddressesPlaceholder />,
+      })}
+      variables={{}}
+      cacheConfig={{ force: true }}
+    />
   )
 }

--- a/src/lib/Scenes/SavedAddresses/__tests__/SavedAddresses-tests.tsx
+++ b/src/lib/Scenes/SavedAddresses/__tests__/SavedAddresses-tests.tsx
@@ -1,11 +1,53 @@
-import { extractText } from "lib/tests/extractText"
+import { SavedAddressesTestsQuery } from "__generated__/SavedAddressesTestsQuery.graphql"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { Flex } from "palette"
 import React from "react"
-import { SavedAddresses } from "../SavedAddresses"
+import { graphql, QueryRenderer } from "react-relay"
+import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { SavedAddressesContainer, SavedAddressesQueryRenderer } from "../SavedAddresses"
 
-describe("Saved Addresses container", () => {
-  const tree = renderWithWrappers(<SavedAddresses />)
-  it("renders a saved addresses screen", () => {
-    expect(extractText(tree.root)).toContain("No Saved Addresses")
+jest.unmock("react-relay")
+
+describe(SavedAddressesQueryRenderer, () => {
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+  const TestRenderer = () => (
+    <QueryRenderer<SavedAddressesTestsQuery>
+      environment={mockEnvironment}
+      query={graphql`
+        query SavedAddressesTestsQuery {
+          me {
+            ...SavedAddresses_me
+          }
+        }
+      `}
+      render={({ props, error }) => {
+        if (props?.me) {
+          return <SavedAddressesContainer me={props.me} />
+        } else if (error) {
+          console.log(error)
+        }
+      }}
+      variables={{}}
+    />
+  )
+  beforeEach(() => {
+    mockEnvironment = createMockEnvironment()
+  })
+
+  it("renders no saved addresses screen", () => {
+    const tree = renderWithWrappers(<TestRenderer />).root
+    mockEnvironment.mock.resolveMostRecentOperation((operation) => {
+      const result = MockPayloadGenerator.generate(operation, {
+        Me: () => ({
+          name: "saver",
+          addressConnection: {
+            edges: [],
+          },
+        }),
+      })
+      return result
+    })
+
+    expect(tree.findAllByType(Flex)[4].props.children[0].props.children).toEqual("No Saved Addresses")
   })
 })


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [PURCHASE-2758](https://artsyproduct.atlassian.net/browse/PURCHASE-2758)

### Description

<!-- Implementation description -->

Most of this work was already merged via [#5087](https://github.com/artsy/eigen/pull/5087) and [#5070](https://github.com/artsy/eigen/pull/5070). This PR adds the `refetchContainer` which was explicitly mentioned in the ticket. As discussed, this satisfies the ask and will likely be replaced by `paginationContainer` in the work that follows.

> Note that I ended up [forcing the refetch](https://github.com/artsy/eigen/compare/ovasdi/PURCHASE-2758/saved-addresses-refetch?expand=1#diff-e7e6e031fb7544333964ce2fc7419c4b965c7c48bea7cc6470bc17d464ebac05R26) as relay was holding on to and serving cached values during development. Since this will likely be changed soon, I thought it was fine for now.

https://user-images.githubusercontent.com/29984068/124830155-7a274c80-df47-11eb-81ce-2a587d176dd6.mov

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a [CHANGELOG.yml](/CHANGELOG.yml) entry or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

Since this is behind a feature flag and an entry for _Saved Addresses_ work [already exists](https://github.com/artsy/eigen/blob/master/CHANGELOG.yml#L37), I don't think this change warrants a changelog update.
