### PR TITLE
chore: do not run ci on update-changelog branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -503,12 +503,14 @@ workflows:
                 - beta-android
                 - app_store_submission
                 - play_store_submission
+                - update-changelog
       - build-test-js:
           filters:
             branches:
               ignore:
                 - app_store_submission
                 - play_store_submission
+                - update-changelog
       - horizon/block:
           context: horizon
           project_id: 37
@@ -524,6 +526,7 @@ workflows:
                 - app_store_submission
                 - play_store_submission
                 - beta-android
+                - update-changelog
           requires:
             - build-test-js
             - horizon/block
@@ -534,6 +537,7 @@ workflows:
                 - app_store_submission
                 - play_store_submission
                 - beta-ios
+                - update-changelog
           requires:
             - build-test-js
             - horizon/block
@@ -543,6 +547,8 @@ workflows:
               only:
                 - beta-ios
                 - beta-android
+              ignore:
+                - update-changelog
           requires:
             - build-test-app-ios
             - build-test-app-android


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->


### Description
- do not run ci on update-changelog branch


<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Do not run ci on update-changelog branch

<!-- end_changelog_updates -->

</details>
