### PR TITLE
fix(FX-3072): jerky popover message

### DIFF
--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -56,7 +56,6 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({
     popoverMessage.show({
       title: "Sorry, an error occured.",
       message: "Please try again.",
-      placement: "top",
       type: "error",
     })
   }
@@ -85,7 +84,6 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({
         popoverMessage.show({
           title: "Your alert has been set.",
           message: "We will send you a push notification once new works are added.",
-          placement: "top",
         })
         trackToggledSavedSearchEvent(true, response.createSavedSearch?.savedSearchOrErrors.internalID)
       },
@@ -120,7 +118,6 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({
         popoverMessage.show({
           title: "Your alert has been removed.",
           message: "Don't worry, you can always create a new one.",
-          placement: "top",
         })
         trackToggledSavedSearchEvent(false, response.disableSavedSearch?.savedSearchOrErrors.internalID)
       },

--- a/src/lib/Components/PopoverMessage/PopoverMessage.tsx
+++ b/src/lib/Components/PopoverMessage/PopoverMessage.tsx
@@ -14,7 +14,7 @@ export type PopoverMessageType = "info" | "success" | "error" | "default"
 export type PopoverMessageItem = Omit<PopoverMessageProps, "translateYAnimation" | "opacityAnimation">
 
 export interface PopoverMessageProps {
-  placement: PopoverMessagePlacement
+  placement?: PopoverMessagePlacement
   title: string
   translateYAnimation: Animated.Value
   opacityAnimation: Animated.Value
@@ -42,7 +42,7 @@ export const getTitleColorByType = (type?: PopoverMessageType): Color => {
 // TODO: Remove NAVBAR_HEIGHT when a new design without a floating back button is added
 export const PopoverMessage: React.FC<PopoverMessageProps> = (props) => {
   const {
-    placement,
+    placement = "top",
     title,
     message,
     showCloseIcon = true,

--- a/src/lib/Components/PopoverMessage/PopoverMessage.tsx
+++ b/src/lib/Components/PopoverMessage/PopoverMessage.tsx
@@ -1,20 +1,31 @@
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { Box, CloseIcon, Color, color, Flex, Text, Touchable } from "palette"
-import React, { useEffect, useRef, useState } from "react"
-import { Animated, Platform } from "react-native"
-import useTimeoutFn from "react-use/lib/useTimeoutFn"
+import React from "react"
+import { Animated } from "react-native"
 import { usePopoverMessage } from "./popoverMessageHooks"
 
 export const AnimatedFlex = Animated.createAnimatedComponent(Flex)
 
-const EDGE_POPOVER_MESSAGE_HEIGHT = Platform.OS === "ios" ? 80 : 90
 const EDGE_POPOVER_MESSAGE_PADDING = 10
-const FRICTION = 20
 const NAVBAR_HEIGHT = 44
 
 export type PopoverMessagePlacement = "top" | "bottom"
 export type PopoverMessageType = "info" | "success" | "error" | "default"
-export type PopoverMessageOptions = Omit<PopoverMessageProps, "id" | "positionIndex">
+export type PopoverMessageItem = Omit<PopoverMessageProps, "translateYAnimation" | "opacityAnimation">
+
+export interface PopoverMessageProps {
+  placement: PopoverMessagePlacement
+  title: string
+  translateYAnimation: Animated.Value
+  opacityAnimation: Animated.Value
+  message?: string
+  autoHide?: boolean
+  hideTimeout?: number
+  showCloseIcon?: boolean
+  type?: PopoverMessageType
+  onPress?: () => void
+  onClose?: () => void
+}
 
 export const getTitleColorByType = (type?: PopoverMessageType): Color => {
   if (type === "success") {
@@ -28,95 +39,37 @@ export const getTitleColorByType = (type?: PopoverMessageType): Color => {
   return "black100"
 }
 
-export interface PopoverMessageProps {
-  id: string
-  positionIndex: number
-  placement: PopoverMessagePlacement
-  title: string
-  message?: string
-  autoHide?: boolean
-  hideTimeout?: number
-  showCloseIcon?: boolean
-  type?: PopoverMessageType
-  onPress?: () => void
-  onClose?: () => void
-}
-
 // TODO: Remove NAVBAR_HEIGHT when a new design without a floating back button is added
 export const PopoverMessage: React.FC<PopoverMessageProps> = (props) => {
   const {
-    id,
-    positionIndex,
     placement,
     title,
     message,
-    autoHide = true,
-    hideTimeout = 3500,
     showCloseIcon = true,
     type,
+    translateYAnimation,
+    opacityAnimation,
     onPress,
     onClose,
   } = props
   const { safeAreaInsets } = useScreenDimensions()
   const { hide } = usePopoverMessage()
-  const [opacityAnim] = useState(new Animated.Value(0))
-  const [translateYAnim] = useState(new Animated.Value(0))
-  const isClosed = useRef<boolean>(false)
   const titleColor = getTitleColorByType(type)
 
-  useEffect(() => {
-    Animated.parallel([
-      Animated.spring(translateYAnim, {
-        toValue: 1,
-        useNativeDriver: true,
-        friction: FRICTION,
-      }),
-      Animated.timing(opacityAnim, {
-        toValue: 1,
-        useNativeDriver: true,
-        duration: 450,
-      }),
-    ]).start()
-  }, [])
-
-  const hideAnimation = () => {
-    isClosed.current = true
-    Animated.parallel([
-      Animated.spring(translateYAnim, {
-        toValue: 0,
-        useNativeDriver: true,
-        friction: FRICTION,
-      }),
-      Animated.timing(opacityAnim, {
-        toValue: 0,
-        useNativeDriver: true,
-        duration: 250,
-      }),
-    ]).start(() => hide(id))
-  }
-
   const handlePopoverMessagePress = () => {
-    hideAnimation()
+    hide()
     onPress?.()
   }
 
   const handlePopoverMessageClosePress = () => {
-    hideAnimation()
+    hide()
     onClose?.()
   }
 
-  useTimeoutFn(() => {
-    if (autoHide && !isClosed.current) {
-      hideAnimation()
-    }
-  }, hideTimeout)
-
-  const range = [-EDGE_POPOVER_MESSAGE_HEIGHT, 0]
+  const range = [-150, 0]
   const outputRange = placement === "top" ? range : range.map((item) => item * -1)
-  const translateY = translateYAnim.interpolate({ inputRange: [0, 1], outputRange })
-  const opacity = opacityAnim.interpolate({ inputRange: [0, 1], outputRange: [0, 1] })
-  const offset =
-    EDGE_POPOVER_MESSAGE_PADDING + positionIndex * (EDGE_POPOVER_MESSAGE_HEIGHT + EDGE_POPOVER_MESSAGE_PADDING)
+  const translateY = translateYAnimation.interpolate({ inputRange: [0, 1], outputRange })
+  const opacity = opacityAnimation.interpolate({ inputRange: [0, 1], outputRange: [0, 1] })
 
   const content = (
     <Flex p={1}>
@@ -126,7 +79,7 @@ export const PopoverMessage: React.FC<PopoverMessageProps> = (props) => {
             {title}
           </Text>
           {!!message && (
-            <Text numberOfLines={2} color="black60" variant="small">
+            <Text color="black60" variant="small">
               {message}
             </Text>
           )}
@@ -147,9 +100,8 @@ export const PopoverMessage: React.FC<PopoverMessageProps> = (props) => {
       position="absolute"
       left="1"
       right="1"
-      height={EDGE_POPOVER_MESSAGE_HEIGHT}
-      bottom={placement === "bottom" ? safeAreaInsets.bottom + offset : undefined}
-      top={placement === "top" ? safeAreaInsets.top + offset + NAVBAR_HEIGHT : undefined}
+      bottom={placement === "bottom" ? safeAreaInsets.bottom + EDGE_POPOVER_MESSAGE_PADDING : undefined}
+      top={placement === "top" ? safeAreaInsets.top + EDGE_POPOVER_MESSAGE_PADDING + NAVBAR_HEIGHT : undefined}
       style={{
         opacity,
         transform: [{ translateY }],

--- a/src/lib/Components/PopoverMessage/__tests__/PopoverMessage-tests.tsx
+++ b/src/lib/Components/PopoverMessage/__tests__/PopoverMessage-tests.tsx
@@ -1,12 +1,13 @@
+import { flushPromiseQueue } from 'lib/tests/flushPromiseQueue'
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { Touchable } from "palette"
 import React from "react"
 import { Text } from "react-native"
 import { act } from "react-test-renderer"
-import { AnimatedFlex, PopoverMessage, PopoverMessageOptions } from "../PopoverMessage"
+import { AnimatedFlex, PopoverMessage, PopoverMessageItem } from "../PopoverMessage"
 import { usePopoverMessage } from "../popoverMessageHooks"
 
-const TestRenderer: React.FC<{ options: PopoverMessageOptions }> = (props) => {
+const TestRenderer: React.FC<{ options: PopoverMessageItem }> = (props) => {
   const popoverMessage = usePopoverMessage()
 
   return (
@@ -17,15 +18,6 @@ const TestRenderer: React.FC<{ options: PopoverMessageOptions }> = (props) => {
 }
 
 describe("PopoverMessage", () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-    jest.useFakeTimers()
-  })
-
-  afterEach(() => {
-    jest.useRealTimers()
-  })
-
   it("renders when `show` is called", async () => {
     const tree = renderWithWrappers(
       <TestRenderer
@@ -43,13 +35,9 @@ describe("PopoverMessage", () => {
     act(() => buttonInstance.props.onPress())
 
     expect(tree.root.findAllByType(PopoverMessage)).toHaveLength(1)
-
-    jest.advanceTimersByTime(3500)
-
-    expect(tree.root.findAllByType(PopoverMessage)).toHaveLength(0)
   })
 
-  it("renders 2 popover messages when `show` is called twice", async () => {
+  it("renders 1 popover message when `show` is called twice", async () => {
     const tree = renderWithWrappers(
       <TestRenderer
         options={{
@@ -66,7 +54,7 @@ describe("PopoverMessage", () => {
     act(() => buttonInstance.props.onPress())
     act(() => buttonInstance.props.onPress())
 
-    expect(tree.root.findAllByType(PopoverMessage)).toHaveLength(2)
+    expect(tree.root.findAllByType(PopoverMessage)).toHaveLength(1)
   })
 
   it("renders with title and message", async () => {
@@ -150,6 +138,7 @@ describe("PopoverMessage", () => {
   })
 
   it("does not hide after timeout if autoHide is set to false", async () => {
+    jest.useFakeTimers()
     const tree = renderWithWrappers(
       <TestRenderer
         options={{
@@ -172,6 +161,7 @@ describe("PopoverMessage", () => {
   })
 
   it("should hide after `hideTimeout` time", async () => {
+    jest.useFakeTimers()
     const tree = renderWithWrappers(
       <TestRenderer
         options={{
@@ -189,7 +179,11 @@ describe("PopoverMessage", () => {
     jest.advanceTimersByTime(3500)
     expect(tree.root.findAllByType(PopoverMessage)).toHaveLength(1)
 
-    jest.advanceTimersByTime(5000)
+    jest.advanceTimersByTime(2000)
+    jest.useRealTimers()
+
+    await flushPromiseQueue()
+
     expect(tree.root.findAllByType(PopoverMessage)).toHaveLength(0)
   })
 
@@ -208,7 +202,8 @@ describe("PopoverMessage", () => {
     act(() => buttonInstance.props.onPress())
     act(() => tree.root.findByType(PopoverMessage).findByType(Touchable).props.onPress())
 
-    jest.advanceTimersByTime(1000)
+    jest.useRealTimers()
+    await flushPromiseQueue()
 
     expect(tree.root.findAllByType(PopoverMessage)).toHaveLength(0)
   })

--- a/src/lib/Components/PopoverMessage/__tests__/PopoverMessage-tests.tsx
+++ b/src/lib/Components/PopoverMessage/__tests__/PopoverMessage-tests.tsx
@@ -24,7 +24,6 @@ describe("PopoverMessage", () => {
         options={{
           title: "Some title",
           message: "Some message",
-          placement: "top",
         }}
       />
     )
@@ -43,7 +42,6 @@ describe("PopoverMessage", () => {
         options={{
           title: "Some title",
           message: "Some message",
-          placement: "top",
         }}
       />
     )
@@ -63,7 +61,6 @@ describe("PopoverMessage", () => {
         options={{
           title: "Some title",
           message: "Some message",
-          placement: "top",
         }}
       />
     )
@@ -84,7 +81,6 @@ describe("PopoverMessage", () => {
         options={{
           title: "Some title",
           message: "Some message",
-          placement: "top",
           type: "error",
         }}
       />
@@ -103,7 +99,6 @@ describe("PopoverMessage", () => {
         options={{
           title: "Some title",
           message: "Some message",
-          placement: "top",
         }}
       />
     )
@@ -144,7 +139,6 @@ describe("PopoverMessage", () => {
         options={{
           title: "Some title",
           message: "Some message",
-          placement: "bottom",
           autoHide: false,
         }}
       />
@@ -167,7 +161,6 @@ describe("PopoverMessage", () => {
         options={{
           title: "Some title",
           message: "Some message",
-          placement: "bottom",
           hideTimeout: 5000,
         }}
       />
@@ -193,7 +186,6 @@ describe("PopoverMessage", () => {
         options={{
           title: "Some title",
           message: "Some message",
-          placement: "top",
         }}
       />
     )
@@ -215,7 +207,6 @@ describe("PopoverMessage", () => {
         options={{
           title: "Some title",
           message: "Some message",
-          placement: "top",
           onClose,
         }}
       />
@@ -234,7 +225,6 @@ describe("PopoverMessage", () => {
         options={{
           title: "Some title",
           message: "Some message",
-          placement: "top",
           showCloseIcon: false,
         }}
       />
@@ -253,7 +243,6 @@ describe("PopoverMessage", () => {
         options={{
           title: "Some title",
           message: "Some message",
-          placement: "top",
           onPress,
         }}
       />


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3072]

### Description
* Multiple toasts onscreen at the same time results in somewhat jerky movement of the toasts when one disappears. We would like to prevent this movement so that the user has a smooth experience. 
* We only need one single toasts as its a toggle and should reflect the last action for clarity. So a new toast would move in and replace the current.

#### iOS

https://user-images.githubusercontent.com/3513494/125271415-67c85c80-e313-11eb-82bd-47994ad255fc.mp4

#### Android

https://user-images.githubusercontent.com/3513494/125272300-5b90cf00-e314-11eb-9c7b-b052a7ed60be.mp4


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a CHANGELOG.yml entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Stop jerky movement of multiple toasts - dzmitry tratsiak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3072]: https://artsyproduct.atlassian.net/browse/FX-3072