### PR TITLE
fix(FX-3075): apply default sort for saved search

### DIFF
--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -8,6 +8,7 @@ import {
   prepareFilterArtworksParamsForInput,
 } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworkFiltersStoreProvider, ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
+import { ORDERED_ARTWORK_SORTS } from 'lib/Components/ArtworkFilter/Filters/SortOptions'
 import { convertSavedSearchCriteriaToFilterParams } from "lib/Components/ArtworkFilter/SavedSearch/convertersToFilterParams"
 import { SearchCriteriaAttributes } from "lib/Components/ArtworkFilter/SavedSearch/types"
 import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
@@ -130,7 +131,12 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
 
     if (searchCriteria && artworks?.aggregations) {
       const params = convertSavedSearchCriteriaToFilterParams(searchCriteria, artworks.aggregations as Aggregations)
-      setInitialFilterStateAction(params)
+      const sortFilterItem = ORDERED_ARTWORK_SORTS.find(sortEntity => sortEntity.paramValue === "-published_at")
+
+      setInitialFilterStateAction([
+        ...params,
+        sortFilterItem!,
+      ])
     }
   }, [])
 

--- a/src/lib/Components/ArtworkFilter/Filters/SortOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/SortOptions.tsx
@@ -21,7 +21,7 @@ enum ArtworkSorts {
 
 export type SortOption = keyof typeof ArtworkSorts
 
-const DEFAULT_ARTWORK_SORT = {
+export const DEFAULT_ARTWORK_SORT = {
   displayText: "Default",
   paramName: FilterParamName.sort,
   paramValue: "-decayed_merch",

--- a/src/lib/Scenes/Artist/Artist.tsx
+++ b/src/lib/Scenes/Artist/Artist.tsx
@@ -10,6 +10,7 @@ import { ArtistAboutContainer } from "lib/Components/Artist/ArtistAbout/ArtistAb
 import ArtistArtworks from "lib/Components/Artist/ArtistArtworks/ArtistArtworks"
 import { ArtistHeaderFragmentContainer } from "lib/Components/Artist/ArtistHeader"
 import { ArtistInsightsFragmentContainer } from "lib/Components/Artist/ArtistInsights/ArtistInsights"
+import { DEFAULT_ARTWORK_SORT } from 'lib/Components/ArtworkFilter/Filters/SortOptions'
 import { getOnlyFilledSearchCriteriaValues } from "lib/Components/ArtworkFilter/SavedSearch/searchCriteriaHelpers"
 import { SearchCriteriaAttributes } from "lib/Components/ArtworkFilter/SavedSearch/types"
 import { HeaderTabsGridPlaceholder } from "lib/Components/HeaderTabGridPlaceholder"
@@ -143,7 +144,7 @@ export const ArtistQueryRenderer: React.FC<ArtistQueryRendererProps> = (props) =
           const preparedSavedSearchCriteria = getOnlyFilledSearchCriteriaValues(savedSearchCriteria ?? {})
           const initialArtworksInput = {
             dimensionRange: "*-*",
-            sort: !!savedSearchCriteria ? "-published_at" : "-decayed_merch",
+            sort: !!savedSearchCriteria ? "-published_at" : DEFAULT_ARTWORK_SORT.paramValue,
             ...preparedSavedSearchCriteria,
           }
 

--- a/src/lib/Scenes/Artist/__tests__/ArtistSavedSearch-tests.tsx
+++ b/src/lib/Scenes/Artist/__tests__/ArtistSavedSearch-tests.tsx
@@ -104,6 +104,7 @@ describe("Saved search banner on artist screen", () => {
 
     const filterTextValues = tree.root.findAllByType(CurrentOption).map(extractText)
 
+    expect(filterTextValues).toContain("Recently added")
     expect(filterTextValues).toContain("Buy now, Inquire")
     expect(filterTextValues).toContain("Limited Edition, Open Edition")
   })


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3075]

### Description
- As a user
- When I receive a saved search push notification
- And tap on that notification
- I am taken to the artist artworks tab
- And after a brief load,
- And if I tap the sort & filter button
- I see that the sort by filter is applied to the “Recently added“

#### Demo

https://user-images.githubusercontent.com/3513494/125116758-daf48780-e0f5-11eb-89a6-6ffac7b4dfd0.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a CHANGELOG.yml entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Display "Recently added" sort by filter value when tap open saved search notification - dzmitry tratsiak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3075]: https://artsyproduct.atlassian.net/browse/FX-3075