### PR TITLE
feat(FX-3089): create saved search alert button

### DIFF
--- a/src/__generated__/SavedSearchButtonQuery.graphql.ts
+++ b/src/__generated__/SavedSearchButtonQuery.graphql.ts
@@ -1,9 +1,10 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 0e4f0773764f0453f181d81d21ed4882 */
+/* @relayHash 28d5a3a40691a84f69881d0cf92d2132 */
 
 import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
 export type SearchCriteriaAttributes = {
     acquireable?: boolean | null;
     additionalGeneIDs?: Array<string> | null;
@@ -27,9 +28,7 @@ export type SavedSearchButtonQueryVariables = {
 };
 export type SavedSearchButtonQueryResponse = {
     readonly me: {
-        readonly savedSearch: {
-            readonly internalID: string;
-        } | null;
+        readonly " $fragmentRefs": FragmentRefs<"SavedSearchButton_me">;
     } | null;
 };
 export type SavedSearchButtonQuery = {
@@ -44,10 +43,14 @@ query SavedSearchButtonQuery(
   $criteria: SearchCriteriaAttributes!
 ) {
   me {
-    savedSearch(criteria: $criteria) {
-      internalID
-    }
+    ...SavedSearchButton_me_1ff8oJ
     id
+  }
+}
+
+fragment SavedSearchButton_me_1ff8oJ on Me {
+  savedSearch(criteria: $criteria) {
+    internalID
   }
 }
 */
@@ -60,30 +63,13 @@ var v0 = [
     "name": "criteria"
   }
 ],
-v1 = {
-  "alias": null,
-  "args": [
-    {
-      "kind": "Variable",
-      "name": "criteria",
-      "variableName": "criteria"
-    }
-  ],
-  "concreteType": "SearchCriteria",
-  "kind": "LinkedField",
-  "name": "savedSearch",
-  "plural": false,
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "internalID",
-      "storageKey": null
-    }
-  ],
-  "storageKey": null
-};
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "criteria",
+    "variableName": "criteria"
+  }
+];
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -99,7 +85,11 @@ return {
         "name": "me",
         "plural": false,
         "selections": [
-          (v1/*: any*/)
+          {
+            "args": (v1/*: any*/),
+            "kind": "FragmentSpread",
+            "name": "SavedSearchButton_me"
+          }
         ],
         "storageKey": null
       }
@@ -121,7 +111,24 @@ return {
         "name": "me",
         "plural": false,
         "selections": [
-          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": (v1/*: any*/),
+            "concreteType": "SearchCriteria",
+            "kind": "LinkedField",
+            "name": "savedSearch",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "internalID",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
           {
             "alias": null,
             "args": null,
@@ -135,7 +142,7 @@ return {
     ]
   },
   "params": {
-    "id": "0e4f0773764f0453f181d81d21ed4882",
+    "id": "28d5a3a40691a84f69881d0cf92d2132",
     "metadata": {},
     "name": "SavedSearchButtonQuery",
     "operationKind": "query",
@@ -143,5 +150,5 @@ return {
   }
 };
 })();
-(node as any).hash = 'f0dd7ec6b20568c11ae92595c1350cf3';
+(node as any).hash = '449e4412d84929d7c547ad86d3657c1b';
 export default node;

--- a/src/__generated__/SavedSearchButtonQuery.graphql.ts
+++ b/src/__generated__/SavedSearchButtonQuery.graphql.ts
@@ -1,0 +1,147 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash 0e4f0773764f0453f181d81d21ed4882 */
+
+import { ConcreteRequest } from "relay-runtime";
+export type SearchCriteriaAttributes = {
+    acquireable?: boolean | null;
+    additionalGeneIDs?: Array<string> | null;
+    artistID?: string | null;
+    atAuction?: boolean | null;
+    attributionClass?: Array<string> | null;
+    colors?: Array<string> | null;
+    dimensionRange?: string | null;
+    height?: string | null;
+    inquireableOnly?: boolean | null;
+    locationCities?: Array<string> | null;
+    majorPeriods?: Array<string> | null;
+    materialsTerms?: Array<string> | null;
+    offerable?: boolean | null;
+    partnerIDs?: Array<string> | null;
+    priceRange?: string | null;
+    width?: string | null;
+};
+export type SavedSearchButtonQueryVariables = {
+    criteria: SearchCriteriaAttributes;
+};
+export type SavedSearchButtonQueryResponse = {
+    readonly me: {
+        readonly savedSearch: {
+            readonly internalID: string;
+        } | null;
+    } | null;
+};
+export type SavedSearchButtonQuery = {
+    readonly response: SavedSearchButtonQueryResponse;
+    readonly variables: SavedSearchButtonQueryVariables;
+};
+
+
+
+/*
+query SavedSearchButtonQuery(
+  $criteria: SearchCriteriaAttributes!
+) {
+  me {
+    savedSearch(criteria: $criteria) {
+      internalID
+    }
+    id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "criteria"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "criteria",
+      "variableName": "criteria"
+    }
+  ],
+  "concreteType": "SearchCriteria",
+  "kind": "LinkedField",
+  "name": "savedSearch",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SavedSearchButtonQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SavedSearchButtonQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "0e4f0773764f0453f181d81d21ed4882",
+    "metadata": {},
+    "name": "SavedSearchButtonQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = 'f0dd7ec6b20568c11ae92595c1350cf3';
+export default node;

--- a/src/__generated__/SavedSearchButtonTestsQuery.graphql.ts
+++ b/src/__generated__/SavedSearchButtonTestsQuery.graphql.ts
@@ -1,0 +1,177 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash 12121ce84504f77f46b0c4522e5bab66 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SearchCriteriaAttributes = {
+    acquireable?: boolean | null;
+    additionalGeneIDs?: Array<string> | null;
+    artistID?: string | null;
+    atAuction?: boolean | null;
+    attributionClass?: Array<string> | null;
+    colors?: Array<string> | null;
+    dimensionRange?: string | null;
+    height?: string | null;
+    inquireableOnly?: boolean | null;
+    locationCities?: Array<string> | null;
+    majorPeriods?: Array<string> | null;
+    materialsTerms?: Array<string> | null;
+    offerable?: boolean | null;
+    partnerIDs?: Array<string> | null;
+    priceRange?: string | null;
+    width?: string | null;
+};
+export type SavedSearchButtonTestsQueryVariables = {
+    criteria: SearchCriteriaAttributes;
+};
+export type SavedSearchButtonTestsQueryResponse = {
+    readonly me: {
+        readonly " $fragmentRefs": FragmentRefs<"SavedSearchButton_me">;
+    } | null;
+};
+export type SavedSearchButtonTestsQuery = {
+    readonly response: SavedSearchButtonTestsQueryResponse;
+    readonly variables: SavedSearchButtonTestsQueryVariables;
+};
+
+
+
+/*
+query SavedSearchButtonTestsQuery(
+  $criteria: SearchCriteriaAttributes!
+) {
+  me {
+    ...SavedSearchButton_me_1ff8oJ
+    id
+  }
+}
+
+fragment SavedSearchButton_me_1ff8oJ on Me {
+  savedSearch(criteria: $criteria) {
+    internalID
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "criteria"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "criteria",
+    "variableName": "criteria"
+  }
+],
+v2 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SavedSearchButtonTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": (v1/*: any*/),
+            "kind": "FragmentSpread",
+            "name": "SavedSearchButton_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SavedSearchButtonTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v1/*: any*/),
+            "concreteType": "SearchCriteria",
+            "kind": "LinkedField",
+            "name": "savedSearch",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "internalID",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "12121ce84504f77f46b0c4522e5bab66",
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "me": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Me"
+        },
+        "me.id": (v2/*: any*/),
+        "me.savedSearch": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SearchCriteria"
+        },
+        "me.savedSearch.internalID": (v2/*: any*/)
+      }
+    },
+    "name": "SavedSearchButtonTestsQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = 'd369f95a141fe0bd2f24bf5249e083ba';
+export default node;

--- a/src/__generated__/SavedSearchButton_me.graphql.ts
+++ b/src/__generated__/SavedSearchButton_me.graphql.ts
@@ -1,0 +1,62 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SavedSearchButton_me = {
+    readonly savedSearch: {
+        readonly internalID: string;
+    } | null;
+    readonly " $refType": "SavedSearchButton_me";
+};
+export type SavedSearchButton_me$data = SavedSearchButton_me;
+export type SavedSearchButton_me$key = {
+    readonly " $data"?: SavedSearchButton_me$data;
+    readonly " $fragmentRefs": FragmentRefs<"SavedSearchButton_me">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "criteria"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "SavedSearchButton_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "criteria",
+          "variableName": "criteria"
+        }
+      ],
+      "concreteType": "SearchCriteria",
+      "kind": "LinkedField",
+      "name": "savedSearch",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "internalID",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Me",
+  "abstractKey": null
+};
+(node as any).hash = '47929e285b919e81f21a8625678edd09';
+export default node;

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -29,7 +29,7 @@ import { Platform } from "react-native"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import { useTracking } from "react-tracking"
 import { SavedSearchBannerQueryRender } from "./SavedSearchBanner"
-import { SavedSearchButtonQueryRender } from './SavedSearchButton'
+import { SavedSearchButtonQueryRenderer } from "./SavedSearchButton"
 
 interface ArtworksGridProps extends InfiniteScrollGridProps {
   artist: ArtistArtworks_artist
@@ -174,7 +174,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
                   </Flex>
                 )}
               />
-              <SavedSearchButtonQueryRender artistId={artistInternalId} filters={filterParams} />
+              <SavedSearchButtonQueryRenderer artistId={artistInternalId} filters={filterParams} />
             </Flex>
             <Separator />
           </>

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -23,12 +23,13 @@ import { PAGE_SIZE } from "lib/data/constants"
 import { useFeatureFlag } from "lib/store/GlobalStore"
 import { Schema } from "lib/utils/track"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
-import { Box, Separator, Spacer } from "palette"
+import { Box, FilterIcon, Flex, Separator, Spacer, Text, TouchableHighlightColor } from "palette"
 import React, { useContext, useEffect, useMemo, useState } from "react"
 import { Platform } from "react-native"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import { useTracking } from "react-tracking"
 import { SavedSearchBannerQueryRender } from "./SavedSearchBanner"
+import { SavedSearchButtonQueryRender } from './SavedSearchButton'
 
 interface ArtworksGridProps extends InfiniteScrollGridProps {
   artist: ArtistArtworks_artist
@@ -98,6 +99,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
   const tracking = useTracking()
   const enableSavedSearch =
     Platform.OS === "ios" ? useFeatureFlag("AREnableSavedSearch") : useFeatureFlag("AREnableSavedSearchAndroid")
+  const enableSavedSearchV2 = useFeatureFlag("AREnableSavedSearchV2")
   const appliedFilters = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
 
   const setInitialFilterStateAction = ArtworksFiltersStore.useStoreActions((state) => state.setInitialFilterStateAction)
@@ -157,17 +159,44 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
   useEffect(() => {
     setJSX(
       <Box backgroundColor="white">
-        <ArtworksFilterHeader count={artworksTotal} onFilterPress={openFilterModal} />
-        <Separator />
-        {!!shouldShowSavedSearchBanner && (
-          <Box px={2}>
-            <SavedSearchBannerQueryRender artistId={artistInternalId} filters={filterParams} artistSlug={artist.slug} />
-            <Separator ml={-2} width={screenWidth} />
-          </Box>
+        {enableSavedSearchV2 ? (
+          <>
+            <Flex flexDirection="row" my={1} px={2} justifyContent="space-between" alignItems="center">
+              <TouchableHighlightColor
+                haptic
+                onPress={openFilterModal}
+                render={({ color }) => (
+                  <Flex flexDirection="row" alignItems="center">
+                    <FilterIcon fill={color} width="20px" height="20px" />
+                    <Text variant="small" color={color} ml={0.5}>
+                      Sort & Filter
+                    </Text>
+                  </Flex>
+                )}
+              />
+              <SavedSearchButtonQueryRender artistId={artistInternalId} filters={filterParams} />
+            </Flex>
+            <Separator />
+          </>
+        ) : (
+          <>
+            <ArtworksFilterHeader count={artworksTotal} onFilterPress={openFilterModal} />
+            <Separator />
+            {!!shouldShowSavedSearchBanner && (
+              <Box px={2}>
+                <SavedSearchBannerQueryRender
+                  artistId={artistInternalId}
+                  filters={filterParams}
+                  artistSlug={artist.slug}
+                />
+                <Separator ml={-2} width={screenWidth} />
+              </Box>
+            )}
+          </>
         )}
       </Box>
     )
-  }, [artworksTotal, shouldShowSavedSearchBanner, artistInternalId, filterParams])
+  }, [artworksTotal, shouldShowSavedSearchBanner, artistInternalId, filterParams, enableSavedSearchV2])
 
   const filteredArtworks = () => {
     if (artworksCount === 0) {

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
@@ -42,7 +42,7 @@ export const SavedSearchButton: React.FC<SavedSearchButtonProps> = ({ me, loadin
   )
 }
 
-export const SavedSeearchButtonFragmentContainer = createFragmentContainer(SavedSearchButton, {
+export const SavedSearchButtonFragmentContainer = createFragmentContainer(SavedSearchButton, {
   me: graphql`
     fragment SavedSearchButton_me on Me @argumentDefinitions(criteria: { type: "SearchCriteriaAttributes" }) {
       savedSearch(criteria: $criteria) {
@@ -80,7 +80,7 @@ export const SavedSearchButtonQueryRender: React.FC<SavedSearchButtonQueryRender
         }
 
         return (
-          <SavedSeearchButtonFragmentContainer
+          <SavedSearchButtonFragmentContainer
             me={relayProps?.me ?? null}
             loading={relayProps === null && error === null}
             attributes={input}

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
@@ -1,0 +1,94 @@
+import { captureMessage } from "@sentry/react-native"
+import { SavedSearchButtonQuery } from "__generated__/SavedSearchButtonQuery.graphql"
+import { FilterParams, prepareFilterParamsForSaveSearchInput } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { SearchCriteriaAttributes } from "lib/Components/ArtworkFilter/SavedSearch/types"
+import { defaultEnvironment } from "lib/relay/createEnvironment"
+import { BellIcon, Button } from "palette"
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+
+interface SavedSearchButtonProps {
+  isSavedSearch: boolean
+  loading?: boolean
+  attributes: SearchCriteriaAttributes
+}
+
+interface SavedSearchButtonQueryRenderProps {
+  filters: FilterParams
+  artistId: string
+}
+
+export const SavedSearchButton: React.FC<SavedSearchButtonProps> = ({
+  isSavedSearch,
+  loading,
+  attributes,
+}) => {
+  console.log('[debug] attributes', attributes)
+  console.log('[debug] isSavedSearch', isSavedSearch)
+  console.log('[debug] loading', loading)
+
+  const emptyAttributes = Object.keys(attributes).length === 0
+
+  const handlePress = () => {
+    console.log('saved search button pressed')
+  }
+
+  return (
+    <Button
+      variant="primaryBlack"
+      size="small"
+      icon={<BellIcon fill="white100" mr={0.5} width="16px" height="16px" />}
+      disabled={isSavedSearch || emptyAttributes}
+      loading={loading}
+      onPress={handlePress}
+      haptic
+    >
+      Create Alert
+    </Button>
+  )
+}
+
+export const SavedSearchButtonQueryRender: React.FC<SavedSearchButtonQueryRenderProps> = (props) => {
+  const { filters, artistId } = props
+  const input = prepareFilterParamsForSaveSearchInput(filters)
+  const attributes: SearchCriteriaAttributes = {
+    artistID: artistId,
+    ...input,
+  }
+
+  return (
+    <QueryRenderer<SavedSearchButtonQuery>
+      environment={defaultEnvironment}
+      query={graphql`
+        query SavedSearchButtonQuery($criteria: SearchCriteriaAttributes!) {
+          me {
+            savedSearch(criteria: $criteria) {
+              internalID
+            }
+          }
+        }
+      `}
+      render={({ props: relayProps, error }) => {
+        if (error) {
+          if (__DEV__) {
+            console.error(error)
+          } else {
+            captureMessage(error.stack!)
+          }
+        }
+
+        return (
+          <SavedSearchButton
+            isSavedSearch={!!relayProps?.me?.savedSearch?.internalID ?? false}
+            loading={relayProps === null && error === null}
+            attributes={input}
+          />
+        )
+      }}
+      variables={{
+        criteria: attributes,
+      }}
+    />
+  )
+}
+

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
@@ -14,7 +14,7 @@ interface SavedSearchButtonProps {
   attributes: SearchCriteriaAttributes
 }
 
-interface SavedSearchButtonQueryRenderProps {
+interface SavedSearchButtonQueryRendererProps {
   filters: FilterParams
   artistId: string
 }
@@ -52,7 +52,7 @@ export const SavedSearchButtonFragmentContainer = createFragmentContainer(SavedS
   `,
 })
 
-export const SavedSearchButtonQueryRender: React.FC<SavedSearchButtonQueryRenderProps> = (props) => {
+export const SavedSearchButtonQueryRenderer: React.FC<SavedSearchButtonQueryRendererProps> = (props) => {
   const { filters, artistId } = props
   const input = prepareFilterParamsForSaveSearchInput(filters)
   const attributes: SearchCriteriaAttributes = {

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
@@ -60,6 +60,10 @@ export const SavedSearchButtonQueryRenderer: React.FC<SavedSearchButtonQueryRend
     ...input,
   }
 
+  if (Object.keys(input).length === 0) {
+    return <SavedSearchButton loading={false} attributes={input} />
+  }
+
   return (
     <QueryRenderer<SavedSearchButtonQuery>
       environment={defaultEnvironment}

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
@@ -20,7 +20,7 @@ interface SavedSearchButtonQueryRendererProps {
 }
 
 export const SavedSearchButton: React.FC<SavedSearchButtonProps> = ({ me, loading, attributes }) => {
-  const isSavedSearch = !!me?.savedSearch?.internalID ?? false
+  const isSavedSearch = !!me?.savedSearch?.internalID
   const emptyAttributes = Object.keys(attributes).length === 0
 
   const handlePress = () => {

--- a/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchButton-tests.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchButton-tests.tsx
@@ -6,7 +6,7 @@ import { Button } from 'palette'
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment } from "relay-test-utils"
-import { SavedSeearchButtonFragmentContainer as SavedSearchButton } from "../SavedSearchButton"
+import { SavedSearchButtonFragmentContainer as SavedSearchButton } from "../SavedSearchButton"
 
 jest.unmock("react-relay")
 

--- a/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchButton-tests.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchButton-tests.tsx
@@ -1,0 +1,80 @@
+import { SearchCriteriaAttributes } from "__generated__/SavedSearchBannerQuery.graphql"
+import { SavedSearchButtonTestsQuery } from "__generated__/SavedSearchButtonTestsQuery.graphql"
+import { mockEnvironmentPayload } from 'lib/tests/mockEnvironmentPayload'
+import { renderWithWrappers } from 'lib/tests/renderWithWrappers'
+import { Button } from 'palette'
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import { createMockEnvironment } from "relay-test-utils"
+import { SavedSeearchButtonFragmentContainer as SavedSearchButton } from "../SavedSearchButton"
+
+jest.unmock("react-relay")
+
+const mockedAttributes: SearchCriteriaAttributes = {
+  acquireable: true,
+}
+
+describe("SavedSearchButton", () => {
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => {
+    mockEnvironment = createMockEnvironment()
+  })
+
+  const TestRenderer = ({ attributes = mockedAttributes }) => {
+    return (
+      <QueryRenderer<SavedSearchButtonTestsQuery>
+        environment={mockEnvironment}
+        query={graphql`
+          query SavedSearchButtonTestsQuery($criteria: SearchCriteriaAttributes!) @relay_test_operation {
+            me {
+              ...SavedSearchButton_me @arguments(criteria: $criteria)
+            }
+          }
+        `}
+        render={({ props, error }) => (
+          <SavedSearchButton
+            {...props}
+            loading={props === null && error === null}
+            attributes={attributes}
+          />
+        )}
+        variables={{
+          criteria: attributes,
+        }}
+      />
+    )
+  }
+
+  it("renders loading state if request didn't return data and an error", () => {
+    const tree = renderWithWrappers(<TestRenderer />)
+
+    expect(tree.root.findByType(Button).props.loading).toBe(true)
+  })
+
+  it("renders enabled button if criteria are not saved", () => {
+    const tree = renderWithWrappers(<TestRenderer />)
+
+    mockEnvironmentPayload(mockEnvironment, {
+      Me: () => ({
+        savedSearch: null,
+      }),
+    })
+
+    expect(tree.root.findByType(Button).props.disabled).toBe(false)
+  })
+
+  it("renders disabled button if criteria are saved", () => {
+    const tree = renderWithWrappers(<TestRenderer />)
+
+    mockEnvironmentPayload(mockEnvironment, {
+      Me: () => ({
+        savedSearch: {
+          internalID: 'internalID'
+        },
+      }),
+    })
+
+    expect(tree.root.findByType(Button).props.disabled).toBe(true)
+  })
+})

--- a/src/lib/Scenes/Artist/__tests__/ArtistSavedSearch-tests.tsx
+++ b/src/lib/Scenes/Artist/__tests__/ArtistSavedSearch-tests.tsx
@@ -1,5 +1,5 @@
 import { SavedSearchBanner } from "lib/Components/Artist/ArtistArtworks/SavedSearchBanner"
-import { SavedSearchButtonQueryRender } from 'lib/Components/Artist/ArtistArtworks/SavedSearchButton'
+import { SavedSearchButtonQueryRenderer } from 'lib/Components/Artist/ArtistArtworks/SavedSearchButton'
 import { CurrentOption } from "lib/Components/ArtworkFilter"
 import { PopoverMessage } from "lib/Components/PopoverMessage/PopoverMessage"
 import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
@@ -134,7 +134,7 @@ describe("Saved search banner on artist screen", () => {
 
     await flushPromiseQueue()
 
-    expect(tree.root.findAllByType(SavedSearchButtonQueryRender)).toHaveLength(1)
+    expect(tree.root.findAllByType(SavedSearchButtonQueryRenderer)).toHaveLength(1)
     expect(tree.root.findAllByType(SavedSearchBanner)).toHaveLength(0)
   })
 })

--- a/src/lib/Scenes/Artist/__tests__/ArtistSavedSearch-tests.tsx
+++ b/src/lib/Scenes/Artist/__tests__/ArtistSavedSearch-tests.tsx
@@ -1,4 +1,5 @@
 import { SavedSearchBanner } from "lib/Components/Artist/ArtistArtworks/SavedSearchBanner"
+import { SavedSearchButtonQueryRender } from 'lib/Components/Artist/ArtistArtworks/SavedSearchButton'
 import { CurrentOption } from "lib/Components/ArtworkFilter"
 import { PopoverMessage } from "lib/Components/PopoverMessage/PopoverMessage"
 import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
@@ -122,6 +123,19 @@ describe("Saved search banner on artist screen", () => {
 
     expect(textInstances[0].props.children).toEqual("Sorry, an error occured")
     expect(textInstances[1].props.children).toEqual("Failed to get saved search criteria")
+  })
+
+  it("should render new saved search component if AREnableSavedSearchV2 flag set to true", async () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableSavedSearchV2: true })
+
+    const tree = getTree()
+
+    mockMostRecentOperation("ArtistAboveTheFoldQuery", MockArtistAboveTheFoldQuery)
+
+    await flushPromiseQueue()
+
+    expect(tree.root.findAllByType(SavedSearchButtonQueryRender)).toHaveLength(1)
+    expect(tree.root.findAllByType(SavedSearchBanner)).toHaveLength(0)
   })
 })
 

--- a/src/lib/store/config/features.ts
+++ b/src/lib/store/config/features.ts
@@ -112,6 +112,11 @@ export const features = defineFeatures({
     description: "Enable Saved Search: Android",
     showInAdminMenu: true,
   },
+  AREnableSavedSearchV2: {
+    readyForRelease: false,
+    description: "Enable Saved Search V2",
+    showInAdminMenu: true,
+  },
   AREnableNewOnboardingFlow: {
     readyForRelease: false,
     description: "Enable new onboarding flow",

--- a/src/palette/elements/Button/Button.tsx
+++ b/src/palette/elements/Button/Button.tsx
@@ -25,11 +25,21 @@ export const defaultVariant: ButtonVariant = "primaryBlack"
 /** The size of the button */
 export type ButtonSize = "small" | "medium" | "large"
 
+/** Icon position */
+export type ButtonIconPosition = "left" | "right"
+
 /** Default button size */
 export const defaultSize: ButtonSize = "medium"
 
+/** Default icon position */
+export const defaultIconPosition: ButtonIconPosition = "left"
+
 export interface ButtonProps extends ButtonBaseProps {
   children: ReactNode
+  /** The icon component */
+  icon?: ReactNode
+  /** Icon position */
+  iconPosition?: ButtonIconPosition
   /** The size of the button */
   size?: ButtonSize
   /** The theme of the button */
@@ -185,6 +195,7 @@ enum DisplayState {
 export const Button: React.FC<ButtonProps> = (props) => {
   const size = props.size ?? defaultSize
   const variant = props.variant ?? defaultVariant
+  const iconPosition = props.iconPosition ?? defaultIconPosition
 
   const [previous, setPrevious] = useState(DisplayState.Enabled)
   const [current, setCurrent] = useState(DisplayState.Enabled)
@@ -257,12 +268,13 @@ export const Button: React.FC<ButtonProps> = (props) => {
     props.onPress(event)
   }
 
-  const { children, loading, disabled, inline, longestText, ...rest } = props
+  const { children, loading, disabled, inline, longestText, style, icon, ...rest } = props
   const s = getSize()
   const variantColors = getColorsForVariant(variant, disabled)
 
   const from = variantColors[previous]
   const to = variantColors[current]
+  const iconBox = <Box opacity={loading ? 0 : 1}>{icon}</Box>
 
   return (
     <Spring native from={from} to={to}>
@@ -290,13 +302,18 @@ export const Button: React.FC<ButtonProps> = (props) => {
                 px={s.px}
               >
                 <VisibleTextContainer>
+                  {iconPosition === "left" && iconBox}
                   <Sans weight="medium" color={loadingStyles.textColor || to.textColor} size={s.size}>
                     {children}
                   </Sans>
+                  {iconPosition === "right" && iconBox}
                 </VisibleTextContainer>
-                <HiddenText role="presentation" weight="medium" size={s.size}>
-                  {longestText ? longestText : children}
-                </HiddenText>
+                <HiddenContainer>
+                  {icon}
+                  <LongestText role="presentation" weight="medium" size={s.size}>
+                    {longestText ? longestText : children}
+                  </LongestText>
+                </HiddenContainer>
 
                 {!!loading && <Spinner size={size} color={spinnerColor} />}
               </AnimatedContainer>
@@ -320,9 +337,13 @@ const VisibleTextContainer = styled(Box)`
   height: 100%;
 `
 
-const HiddenText = styled(Sans)`
+const HiddenContainer = styled(Box)<ButtonProps>`
+  display: flex;
+  flex-direction: row;
   opacity: 0;
 `
+
+const LongestText = styled(Sans)``
 
 const Container = styled(Box)<ButtonProps>`
   align-items: center;


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3089]

### Description
As an admin with the saved search M2 feature flag enabled,
If I am viewing an artist artworks grid,
I always see the "create alert" button

#### Acceptance criteria:
* This ticket includes introduction of a feature flag for M2 and hides these changes behind it
* Button is disabled when no filters are applied
* Button is enabled when filters are applied but no search criteria with those filters exists
* Button is disabled when search criteria with existing filters exists

#### iOS

https://user-images.githubusercontent.com/3513494/126628736-b7733313-3b04-44b1-bc3a-f9deddb20a8d.mp4

#### Android
https://user-images.githubusercontent.com/3513494/126629723-bf05d0f3-7c2b-489e-bcd9-7c8d5d29c980.mp4


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Saved search banner M2 – dzmitry tratsiak

<!-- end_changelog_updates -->

</details>


[FX-3089]: https://artsyproduct.atlassian.net/browse/FX-3089