### PR TITLE
feat(FX-3104): ability to use ScrollView instead of FlatList

### DIFF
--- a/src/lib/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
@@ -122,6 +122,7 @@ export const PriceRangeOptionsScreen: React.FC<PriceRangeOptionsScreenProps> = (
     <SingleSelectOptionScreen
       onSelect={selectOption}
       filterHeaderText={FilterDisplayName.priceRange}
+      useScrollView={true}
       filterOptions={[
         ...PRICE_RANGE_OPTIONS,
         ...(shouldShowCustomPrice

--- a/src/lib/Components/ArtworkFilter/Filters/SingleSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/SingleSelectOption.tsx
@@ -4,8 +4,8 @@ import { FilterData } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
 import { TouchableRow } from "lib/Components/TouchableRow"
 import { Flex, RadioDot, Text } from "palette"
-import React from "react"
-import { FlatList } from "react-native"
+import React, { Fragment } from "react"
+import { FlatList, ScrollView } from "react-native"
 import styled from "styled-components/native"
 
 interface SingleSelectOptionScreenProps {
@@ -16,6 +16,7 @@ interface SingleSelectOptionScreenProps {
   filterOptions: Array<FilterData | JSX.Element>
   ListHeaderComponent?: JSX.Element
   withExtraPadding?: boolean
+  useScrollView?: boolean
 }
 
 const isFilterData = (item: any): item is FilterData => {
@@ -30,9 +31,21 @@ export const SingleSelectOptionScreen: React.FC<SingleSelectOptionScreenProps> =
   navigation,
   ListHeaderComponent,
   withExtraPadding = false,
+  useScrollView = false,
 }) => {
   const handleBackNavigation = () => {
     navigation.goBack()
+  }
+  const keyExtractor = (_item: FilterData | JSX.Element, index: number) => String(index)
+  const renderItem = (item: FilterData | JSX.Element) => {
+    if (isFilterData(item)) {
+      return (
+        <ListItem item={item} selectedOption={selectedOption} onSelect={onSelect} withExtraPadding={withExtraPadding} />
+      )
+    }
+
+    // Otherwise just return JSX.Element
+    return item
   }
 
   return (
@@ -40,29 +53,24 @@ export const SingleSelectOptionScreen: React.FC<SingleSelectOptionScreenProps> =
       <FancyModalHeader onLeftButtonPress={handleBackNavigation}>{filterHeaderText}</FancyModalHeader>
 
       <Flex flexGrow={1}>
-        <FlatList
-          style={{ flex: 1 }}
-          initialNumToRender={100}
-          ListHeaderComponent={ListHeaderComponent}
-          keyExtractor={(_item, index) => String(index)}
-          data={filterOptions}
-          ItemSeparatorComponent={null}
-          renderItem={({ item }) => {
-            if (isFilterData(item)) {
-              return (
-                <ListItem
-                  item={item}
-                  selectedOption={selectedOption}
-                  onSelect={onSelect}
-                  withExtraPadding={withExtraPadding}
-                />
-              )
-            }
-
-            // Otherwise just return JSX.Element
-            return item
-          }}
-        />
+        {useScrollView ? (
+          <ScrollView style={{ flex: 1 }}>
+            {ListHeaderComponent}
+            {filterOptions.map((item, index) => {
+              return <Fragment key={keyExtractor(item, index)}>{renderItem(item)}</Fragment>
+            })}
+          </ScrollView>
+        ) : (
+          <FlatList
+            style={{ flex: 1 }}
+            initialNumToRender={100}
+            ListHeaderComponent={ListHeaderComponent}
+            keyExtractor={keyExtractor}
+            data={filterOptions}
+            ItemSeparatorComponent={null}
+            renderItem={({ item }) => renderItem(item)}
+          />
+        )}
       </Flex>
     </Flex>
   )

--- a/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
@@ -195,6 +195,7 @@ export const SizeOptionsScreen: React.FC<SizeOptionsScreenProps> = ({ navigation
       filterHeaderText={FilterDisplayName.size}
       selectedOption={selectedOption}
       navigation={navigation}
+      useScrollView={true}
       filterOptions={[
         ...SIZE_OPTIONS,
         ...(shouldShowCustomSize


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3104]

### Description
The user is not able to type any amount in the USD minimum and USD maximum and when the user taps on the USD minimum or maximum the custom is not staying there.

#### Problem
The problem is that we have a `FlatList` rendered inside the `ArtsyKeyboardAvoidingView`

https://user-images.githubusercontent.com/3513494/126776743-c5084d27-aac2-4831-b3ce-b93c55adbd27.mp4

If we render the `ScrollView` inside the `ArtsyKeyboardAvoidingView` (as it happens in most places in the code), there are no such problems

https://user-images.githubusercontent.com/3513494/126776856-37b52072-c156-45f6-8800-2824d21e4257.mp4

#### Solution
Added the ability to use `ScrollView` instead of `FlatList` for `SingleSelectOption`. In our case, the `Size` and `Price` filters will have a small number of elements to render, so there will be no performance problems

### Demo

https://user-images.githubusercontent.com/3513494/126777767-18f3ca87-ed28-4877-99a8-a28f1b4c0337.mp4



<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- User able to type any price in custom price – dzmitry tratsiak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3104]: https://artsyproduct.atlassian.net/browse/FX-3104