### PR TITLE
fix(palette flag): separated the temporary palette flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,8 @@
     "supercluster": "6.0.1",
     "tipsi-stripe": "https://github.com/artsy/tipsi-stripe.git#fix-infinite-loop",
     "url": "^0.11.0",
-    "yup": "0.29.1"
+    "yup": "0.29.1",
+    "zustand": "^3.5.7"
   },
   "devDependencies": {
     "@artsy/update-repo": "0.2.1",

--- a/src/lib/Components/ArtistListItem.tsx
+++ b/src/lib/Components/ArtistListItem.tsx
@@ -5,7 +5,7 @@ import { PlaceholderBox, PlaceholderText } from "lib/utils/placeholders"
 import { Schema, track } from "lib/utils/track"
 import { Button, ClassTheme, EntityHeader, Flex, Touchable } from "palette"
 import React from "react"
-import { StyleProp, TouchableWithoutFeedback, ViewStyle } from "react-native"
+import { StyleProp, ViewStyle } from "react-native"
 import { commitMutation, createFragmentContainer, graphql, RelayProp } from "react-relay"
 import { RelayModernEnvironment } from "relay-runtime/lib/store/RelayModernEnvironment"
 
@@ -109,8 +109,6 @@ export class ArtistListItem extends React.Component<Props, State> {
     const { is_followed, initials, image, href, name, nationality, birthday, deathday } = artist
     const imageURl = image && image.url
 
-    const TouchableComponent = withFeedback ? Touchable : TouchableWithoutFeedback
-
     if (!name) {
       return null
     }
@@ -118,7 +116,8 @@ export class ArtistListItem extends React.Component<Props, State> {
     return (
       <ClassTheme>
         {({ color }) => (
-          <TouchableComponent
+          <Touchable
+            noFeedback={!withFeedback}
             onPress={() => {
               if (href && !disableNavigation) {
                 this.handleTap(href)
@@ -150,7 +149,7 @@ export class ArtistListItem extends React.Component<Props, State> {
                 </Button>
               </Flex>
             </Flex>
-          </TouchableComponent>
+          </Touchable>
         )}
       </ClassTheme>
     )

--- a/src/lib/Components/__tests__/ArtistListItem-tests.tsx
+++ b/src/lib/Components/__tests__/ArtistListItem-tests.tsx
@@ -1,9 +1,8 @@
 import { ArtistListItemTestsQuery } from "__generated__/ArtistListItemTestsQuery.graphql"
+import { Touchable } from "palette"
 import React from "react"
-import { TouchableWithoutFeedback } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment } from "relay-test-utils"
-import { Touchable } from "../../../palette/elements/Touchable"
 import { mockEnvironmentPayload } from "../../tests/mockEnvironmentPayload"
 import { renderWithWrappers } from "../../tests/renderWithWrappers"
 import { ArtistListItemContainer, formatTombstoneText } from "../ArtistListItem"
@@ -38,15 +37,15 @@ describe("ArtistListItem", () => {
   })
 
   it("renders without feedback without throwing an error", () => {
-    const tree = renderWithWrappers(<TestRenderer />)
+    const tree = renderWithWrappers(<TestRenderer />).root
     mockEnvironmentPayload(mockEnvironment)
-    expect(tree.root.findAllByType(TouchableWithoutFeedback)).toHaveLength(2)
+    expect(tree.findByType(Touchable).props.noFeedback).toBe(true)
   })
 
   it("renders with feedback without throwing an error", () => {
-    const tree = renderWithWrappers(<TestRenderer withFeedback />)
+    const tree = renderWithWrappers(<TestRenderer withFeedback />).root
     mockEnvironmentPayload(mockEnvironment)
-    expect(tree.root.findAllByType(Touchable)).toHaveLength(1)
+    expect(tree.findByType(Touchable).props.noFeedback).toBe(false)
   })
 })
 

--- a/src/lib/store/config/features.ts
+++ b/src/lib/store/config/features.ts
@@ -172,7 +172,7 @@ export const devToggles = defineDevToggles({
       }
     },
   },
-  DTDShowAnalyticsVisualiser: {
+  DTShowAnalyticsVisualiser: {
     description: "Show analytics visualiser",
   },
 })

--- a/src/lib/utils/AdminMenu.tsx
+++ b/src/lib/utils/AdminMenu.tsx
@@ -10,6 +10,7 @@ import { DevToggleName, devToggles, FeatureName, features } from "lib/store/conf
 import { GlobalStore } from "lib/store/GlobalStore"
 import { capitalize, compact, sortBy } from "lodash"
 import { ChevronIcon, CloseIcon, Flex, ReloadIcon, Separator, Spacer, Text, useColor } from "palette"
+import { DevTogglePaletteFlag } from "palette/PaletteFlag"
 import React, { useEffect, useState } from "react"
 import {
   Alert,
@@ -122,6 +123,7 @@ export const AdminMenu: React.FC<{ onClose(): void }> = ({ onClose = dismissModa
         {configurableDevToggleKeys.map((devToggleKey) => {
           return <DevToggleItem key={devToggleKey} toggleKey={devToggleKey} />
         })}
+        <DevTogglePaletteFlag />
         <MenuItem
           title="Clear AsyncStorage"
           chevron={null}

--- a/src/lib/utils/track/SegmentTrackingProvider.ts
+++ b/src/lib/utils/track/SegmentTrackingProvider.ts
@@ -96,7 +96,7 @@ export const SegmentTrackingProvider: TrackingProvider = {
 }
 
 const visualize = (type: string, name: string, info: { [key: string]: any }) => {
-  if (!unsafe_getDevToggle("DTDShowAnalyticsVisualiser")) {
+  if (!unsafe_getDevToggle("DTShowAnalyticsVisualiser")) {
     return
   }
 

--- a/src/palette/PaletteFlag.tsx
+++ b/src/palette/PaletteFlag.tsx
@@ -14,7 +14,7 @@ interface PaletteFlagState {
 export const usePaletteFlagStore = create<PaletteFlagState>(
   persist(
     (set) => ({
-      allowV3: false,
+      allowV3: __TEST__,
       setAllowV3: (value) => set((_state) => ({ allowV3: value })),
     }),
     { name: "z-devtoggle-palette", getStorage: () => AsyncStorage }

--- a/src/palette/PaletteFlag.tsx
+++ b/src/palette/PaletteFlag.tsx
@@ -1,0 +1,59 @@
+import AsyncStorage from "@react-native-community/async-storage"
+import { MenuItem } from "lib/Components/MenuItem"
+import { Text } from "palette"
+import React from "react"
+import { Alert } from "react-native"
+import create from "zustand"
+import { persist } from "zustand/middleware"
+
+interface PaletteFlagState {
+  allowV3: boolean
+  setAllowV3: (value: boolean) => void
+}
+
+export const usePaletteFlagStore = create<PaletteFlagState>(
+  persist(
+    (set) => ({
+      allowV3: false,
+      setAllowV3: (value) => set((_state) => ({ allowV3: value })),
+    }),
+    { name: "z-devtoggle-palette", getStorage: () => AsyncStorage }
+  )
+)
+
+export const DevTogglePaletteFlag = () => {
+  const currentValue = usePaletteFlagStore((state) => state.allowV3)
+  const setValue = usePaletteFlagStore((state) => state.setAllowV3)
+
+  const description = "Allow Palette V3"
+  const valText = currentValue ? "Yes" : "No"
+
+  return (
+    <MenuItem
+      title={description}
+      onPress={() => {
+        Alert.alert(description, undefined, [
+          {
+            text: currentValue ? "Keep turned ON" : "Turn ON",
+            onPress: () => setValue(true),
+          },
+          {
+            text: currentValue ? "Turn OFF" : "Keep turned OFF",
+            onPress: () => setValue(false),
+          },
+        ])
+      }}
+      value={
+        currentValue ? (
+          <Text variant="subtitle" color="black100" fontWeight="bold">
+            {valText}
+          </Text>
+        ) : (
+          <Text variant="subtitle" color="black100">
+            {valText}
+          </Text>
+        )
+      }
+    />
+  )
+}

--- a/src/palette/Theme.tsx
+++ b/src/palette/Theme.tsx
@@ -1,9 +1,9 @@
 import { THEME_V2, THEME_V3 } from "@artsy/palette-tokens"
-import { useFeatureFlag } from "lib/store/GlobalStore"
 import _ from "lodash"
 import React, { useContext } from "react"
 import { ThemeContext, ThemeProvider } from "styled-components/native"
 import { TEXT_FONTS_V2, TEXT_FONTS_V3 } from "./elements/Text/tokens"
+import { usePaletteFlagStore } from "./PaletteFlag"
 import { fontFamily } from "./platform/fonts/fontFamily"
 
 /**
@@ -97,14 +97,16 @@ type ThemeV2Type = typeof THEMES.v2
 type ThemeV3Type = typeof THEMES.v3
 type ThemeType = ThemeV2Type | ThemeV3Type
 
-// stop using this!! use any of the hooks in this file instead.
+/**
+ * Do not use this!! Use any the hooks instead!
+ */
 export const themeProps = THEMES.v2
 
 export const Theme: React.FC<{
   theme?: keyof typeof THEMES | ThemeType
   override?: DeepPartial<ThemeV2Type> | DeepPartial<ThemeV3Type>
 }> = ({ children, theme = "v2", override = {} }) => {
-  const allowV3 = useFeatureFlag("ARAllowPaletteV3")
+  const allowV3 = usePaletteFlagStore((state) => state.allowV3)
 
   let actualTheme: ThemeType
   if (_.isString(theme)) {

--- a/src/palette/elements/Avatar/Avatar.tsx
+++ b/src/palette/elements/Avatar/Avatar.tsx
@@ -1,8 +1,8 @@
 import { themeGet } from "@styled-system/theme-get"
 import React, { FunctionComponent, ImgHTMLAttributes } from "react"
 import { Image } from "react-native"
+import styled from "styled-components/native"
 import { borderRadius } from "styled-system"
-import { styledWrapper } from "../../platform/primitives"
 import { Flex } from "../Flex"
 import { Text, TextFontSize } from "../Text"
 
@@ -92,7 +92,7 @@ export const BaseAvatar = ({ src, initials, size = "md", renderAvatar }: BaseAva
 }
 
 /** InitialsHolder */
-export const InitialsHolder = styledWrapper(Flex)`
+export const InitialsHolder = styled(Flex)`
   background-color: ${themeGet("colors.black10")};
   text-align: center;
   overflow: hidden;

--- a/src/palette/elements/BorderBox/BorderBox.tsx
+++ b/src/palette/elements/BorderBox/BorderBox.tsx
@@ -1,8 +1,8 @@
 import { themeGet } from "@styled-system/theme-get"
 // @ts-ignore
 import React from "react"
+import styled from "styled-components/native"
 import { border, BorderProps, space as styledSpace, SpaceProps } from "styled-system"
-import { styledWrapper } from "../../platform/primitives"
 import { Flex, FlexProps } from "../Flex"
 
 export interface BorderBoxProps extends FlexProps, BorderProps, SpaceProps {
@@ -13,7 +13,7 @@ export interface BorderBoxProps extends FlexProps, BorderProps, SpaceProps {
  * A `View` or `div` (depending on the platform) that has a common border
  * and padding set by default
  */
-export const BorderBox = styledWrapper(Flex)<BorderBoxProps>`
+export const BorderBox = styled(Flex)<BorderBoxProps>`
   border: 1px solid ${themeGet("colors.black10")};
   border-radius: 2px;
   padding: ${themeGet("space.2")}px;

--- a/src/palette/elements/Flex/Flex.tsx
+++ b/src/palette/elements/Flex/Flex.tsx
@@ -1,4 +1,4 @@
-import { styledWrapper } from "../../platform/primitives"
+import styled from "styled-components/native"
 import { Box, BoxProps } from "../Box"
 
 /**
@@ -9,7 +9,7 @@ export type FlexProps = BoxProps
 /**
  * Flex is Box with display: flex
  */
-export const Flex = styledWrapper(Box)<FlexProps>``
+export const Flex = styled(Box)<FlexProps>``
 
 Flex.defaultProps = {
   display: "flex",

--- a/src/palette/elements/Message/Message.tsx
+++ b/src/palette/elements/Message/Message.tsx
@@ -1,7 +1,7 @@
 import { themeGet } from "@styled-system/theme-get"
 import React from "react"
+import styled from "styled-components/native"
 import { useColor } from "../../hooks"
-import { styledWrapper } from "../../platform/primitives"
 import { SansSize } from "../../Theme"
 import { Flex, FlexProps } from "../Flex"
 import { Sans } from "../Typography"
@@ -14,7 +14,7 @@ interface MessageProps extends FlexProps {
   textSize?: SansSize
 }
 
-const StyledFlex = styledWrapper(Flex)`
+const StyledFlex = styled(Flex)`
   background-color: ${themeGet("colors.black5")};
   border-radius: 2px;
 `

--- a/src/palette/elements/Typography/Typography.tsx
+++ b/src/palette/elements/Typography/Typography.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import styled from "styled-components/native"
-import { styledWrapper } from "../../platform/primitives"
 
 import { SansSize, SerifSize, themeProps, TypeSizes } from "../../Theme"
 
@@ -88,24 +87,22 @@ interface StyledTextProps extends Partial<FullTextProps> {
  *        An optional function that maps weight+italic to a font-family.
  */
 function createStyledText<P extends StyledTextProps>(fontType: keyof FontFamily) {
-  return styledWrapper<React.ComponentType<P>>(
-    ({ size, weight, italic, style: _style, ...textProps }: StyledTextProps) => {
-      const fontFamilyString = fontFamily[fontType][weight ?? "regular"][italic ? "italic" : "normal"]
-      if (fontFamilyString === null) {
-        throw new Error(
-          `Incompatible text style combination: {type: ${fontType}, weight: ${weight}, italic: ${!!italic}}`
-        )
-      }
-
-      const fontMetrics = themeProps.typeSizes[fontType as "sans"][size as "4"]
-
-      if (fontMetrics == null) {
-        throw new Error(`"${size}" is not a valid size for ${fontType}`)
-      }
-
-      return <BaseText style={[_style, { fontFamily: fontFamilyString, ...stripPx(fontMetrics) }]} {...textProps} />
+  return styled<React.ComponentType<P>>(({ size, weight, italic, style: _style, ...textProps }: StyledTextProps) => {
+    const fontFamilyString = fontFamily[fontType][weight ?? "regular"][italic ? "italic" : "normal"]
+    if (fontFamilyString === null) {
+      throw new Error(
+        `Incompatible text style combination: {type: ${fontType}, weight: ${weight}, italic: ${!!italic}}`
+      )
     }
-  )``
+
+    const fontMetrics = themeProps.typeSizes[fontType as "sans"][size as "4"]
+
+    if (fontMetrics == null) {
+      throw new Error(`"${size}" is not a valid size for ${fontType}`)
+    }
+
+    return <BaseText style={[_style, { fontFamily: fontFamilyString, ...stripPx(fontMetrics) }]} {...textProps} />
+  })``
 }
 
 function stripPx(fontMetrics: { fontSize: string; lineHeight: string }): { fontSize: number; lineHeight: number } {

--- a/src/palette/hooks.ts
+++ b/src/palette/hooks.ts
@@ -1,4 +1,4 @@
-import { useFeatureFlag } from "lib/store/GlobalStore"
+import { usePaletteFlagStore } from "./PaletteFlag"
 import { useTheme } from "./Theme"
 
 export const useColor = () => useTheme().color
@@ -7,6 +7,6 @@ export const useSpace = () => useTheme().space
 /** Returns a config specific to the current theme. */
 export const useThemeConfig = <T, U>({ v2, v3 }: { v2: T; v3: U }): U | T => {
   const { theme = { id: "v2" } } = useTheme()
-  const allowV3 = useFeatureFlag("ARAllowPaletteV3")
+  const allowV3 = usePaletteFlagStore((state) => state.allowV3)
   return theme.id === "v2" ? v2 : allowV3 ? v3 : v2
 }

--- a/src/palette/platform/primitives.ts
+++ b/src/palette/platform/primitives.ts
@@ -1,3 +1,0 @@
-import styles from "styled-components/native"
-
-export const styledWrapper = styles as typeof styles

--- a/yarn.lock
+++ b/yarn.lock
@@ -19550,3 +19550,8 @@ zen-observable-ts@^0.8.10:
 zen-observable@^0.8.0:
   version "0.8.11"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.11.tgz#d3415885eeeb42ee5abb9821c95bb518fcd6d199"
+
+zustand@^3.5.7:
+  version "3.5.7"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-3.5.7.tgz#add5e8d0ba031ce6e0ddf9cb76ef15306efb665f"
+  integrity sha512-DlVFXJavIHyXTOGz6dB+8QHZsPyJcGJSEBtlp2Ivmd5SwtlCnhPo3L8LB6YRfAOJC2PbqzgoD8NMjk+y+vIF0g==


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves the issue here https://artsy.slack.com/archives/C02BAQ5K7/p1627387196273400.


### Description


easy-peasy/redux cause a lot of require cycles, but usually they don't cause problems. The latest flag for palette v3 just broke that limit. iOS was ok with that but not Android.

The main problem was that, starting from `Theme`, we have a hook that needs to check a flag. That flag lives in GlobalStore, that requires NativeModel. NativeModel needs `navigate`, and that needs `AppRegistry`. That file imports all screens, and of course a lot of them use Theme. And this is a nice require cycle that breaks our stuff.

One of the two possible solutions was to remove the flag, but I didn't want that. Code listens to me, not the other way around 😆. So the other solution was to not use redux in the "global way" it works, which causes the cycles. I thought I'll try `zustand`, which is kinda redux-but-only-the-good-parts, and also it allows/prefers many small stores, instead of one humongous one, which helps alleviate cycles.

So yea, that's what this PR here is, plus two other small things:
- `DTDShowAnalyticsVisualiser` -> `DTShowAnalyticsVisualiser`
- removing `styledWrapper` to just `styled`


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- use a separate store for the temporary palette flag

<!-- end_changelog_updates -->

</details>
