### PR TITLE
fix: remove extra notification delegate handling

### DIFF
--- a/Artsy/App/ARAppDelegate.m
+++ b/Artsy/App/ARAppDelegate.m
@@ -178,8 +178,6 @@ static ARAppDelegate *_sharedInstance = nil;
 
 - (void)setupAnalytics:(UIApplication *)application withLaunchOptions:(NSDictionary *)launchOptions
 {
-    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-    center.delegate = [self remoteNotificationsDelegate];
     NSString *brazeAppKey = [ReactNativeConfig envFor:@"BRAZE_STAGING_APP_KEY_IOS"];
     if (![ARAppStatus isDev]) {
         brazeAppKey = [ReactNativeConfig envFor:@"BRAZE_PRODUCTION_APP_KEY_IOS"];

--- a/Artsy/App/ARAppNotificationsDelegate.h
+++ b/Artsy/App/ARAppNotificationsDelegate.h
@@ -4,7 +4,7 @@
 #import <React/RCTDevSettings.h>
 #import <UserNotifications/UNUserNotificationCenter.h>
 
-@interface ARAppNotificationsDelegate : NSObject <JSApplicationRemoteNotificationsDelegate, UNUserNotificationCenterDelegate>
+@interface ARAppNotificationsDelegate : NSObject <JSApplicationRemoteNotificationsDelegate>
 
 typedef NS_ENUM(NSInteger, ARAppNotificationsRequestContext) {
     ARAppNotificationsRequestContextLaunch,

--- a/Artsy/App/ARAppNotificationsDelegate.m
+++ b/Artsy/App/ARAppNotificationsDelegate.m
@@ -360,22 +360,4 @@
     }
 }
 
-#pragma mark - UNUserNotificationCenterDelegate
-
-- (void)userNotificationCenter:(UNUserNotificationCenter *)center
-       willPresentNotification:(UNNotification *)notification
-         withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler {
-  if (@available(iOS 14.0, *)) {
-    completionHandler(UNNotificationPresentationOptionList | UNNotificationPresentationOptionBanner);
-  } else {
-    completionHandler(UNNotificationPresentationOptionAlert);
-  }
-}
-
-- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler {
-    [[Appboy sharedInstance] userNotificationCenter:center
-                     didReceiveNotificationResponse:response
-                              withCompletionHandler:completionHandler];
-}
-
 @end


### PR DESCRIPTION
The type of this PR is: **fix**

### Description

Fixes an issue with our push notifications not deeplinking correctly, this was due to us implementing some new notification center delegate methods as part of the braze integration and as a result our old delegate methods were not getting called. Tested both braze push and a local push and both seem to be working now.


### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- Fix push notification deeplinking - Brian

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>
