### PR TITLE
fix(CX-1776): Dont show broken image when auction result screen loads

### DIFF
--- a/src/lib/Scenes/AuctionResult/AuctionResult.tsx
+++ b/src/lib/Scenes/AuctionResult/AuctionResult.tsx
@@ -174,7 +174,7 @@ const AuctionResult: React.FC<Props> = ({ artist, auctionResult }) => {
                 alignItems="center"
                 justifyContent="center"
               >
-                <NoArtworkIcon width={28} height={28} opacity={0.3} />
+                {!auctionResult.images?.thumbnail?.url && <NoArtworkIcon width={28} height={28} opacity={0.3} />}
               </Box>
             )}
             <Flex justifyContent="center" flex={1} ml={2}>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1776]

### Description

This PR prevents the auction result screen from showing a `NoArtworkIcon` while the image size is being calculated. With this change, we just show the NoArtworkIcon when the auction result doesn't have an image.

![Simulator Screen Shot - iPhone 8 - 2021-08-09 at 10 32 33](https://user-images.githubusercontent.com/4691889/128679023-620456ee-9829-4f81-b5f8-74dd235c1739.png)


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Don't show broken image when auction result screen loads - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-1776]: https://artsyproduct.atlassian.net/browse/CX-1776