### PR TITLE
enhancement(button): easy to use v2 and v3 props

### DIFF
--- a/src/lib/Scenes/Partner/Components/PartnerFollowButton.tsx
+++ b/src/lib/Scenes/Partner/Components/PartnerFollowButton.tsx
@@ -1,14 +1,14 @@
 import { PartnerFollowButton_partner } from "__generated__/PartnerFollowButton_partner.graphql"
 import { PartnerFollowButtonFollowMutation } from "__generated__/PartnerFollowButtonFollowMutation.graphql"
 import { Schema, Track, track as _track } from "lib/utils/track"
-import { Button, ButtonSize } from "palette"
+import { Button, ButtonProps } from "palette"
 import React from "react"
 import { commitMutation, createFragmentContainer, graphql, RelayProp } from "react-relay"
 
 interface Props {
   partner: PartnerFollowButton_partner
   relay: RelayProp
-  size?: ButtonSize
+  size?: ButtonProps["size"]
 }
 
 interface State {

--- a/src/palette/elements/Button/Button.stories.tsx
+++ b/src/palette/elements/Button/Button.stories.tsx
@@ -2,14 +2,15 @@ import { action } from "@storybook/addon-actions"
 import { storiesOf } from "@storybook/react-native"
 import { LinkIcon } from "palette"
 import React from "react"
+import { withThemeV3 } from "storybook/decorators"
 import { DList, List } from "storybook/helpers"
-import { Button, ButtonSize, ButtonVariant } from "./Button"
+import { Button, ButtonV3Props } from "."
 
-const sizes: ButtonSize[] = ["small", "large"]
-
-const variants: ButtonVariant[] = ["fillDark", "fillLight", "fillGray", "outline", "text"]
+const sizes: Array<ButtonV3Props["size"]> = ["small", "large"]
+const variants: Array<ButtonV3Props["variant"]> = ["fillDark", "fillLight", "fillGray", "outline", "text"]
 
 storiesOf("ButtonV3", module)
+  .addDecorator(withThemeV3)
   .add("Sizes", () => (
     <DList
       data={sizes}

--- a/src/palette/elements/Button/Button.tsx
+++ b/src/palette/elements/Button/Button.tsx
@@ -20,15 +20,15 @@ import { Spinner } from "../Spinner"
 
 export type ButtonVariant = "fillDark" | "fillLight" | "fillGray" | "outline" | "text"
 
-export const defaultVariant: ButtonVariant = "fillDark"
+const defaultVariant: ButtonVariant = "fillDark"
 
-export type ButtonSize = "small" | "large"
+type ButtonSize = "small" | "large"
 
-export type ButtonIconPosition = "left" | "right"
+type ButtonIconPosition = "left" | "right"
 
-export const defaultSize: ButtonSize = "large"
+const defaultSize: ButtonSize = "large"
 
-export const defaultIconPosition: ButtonIconPosition = "left"
+const defaultIconPosition: ButtonIconPosition = "left"
 
 export interface ButtonProps extends ButtonBaseProps {
   children: ReactNode

--- a/src/palette/elements/Button/Button.tsx
+++ b/src/palette/elements/Button/Button.tsx
@@ -1,46 +1,42 @@
+import { Text } from "palette"
 import { useColor } from "palette/hooks"
 import React, { ReactNode, useState } from "react"
-import { GestureResponderEvent, TextStyle, TouchableWithoutFeedback, ViewStyle } from "react-native"
+import {
+  GestureResponderEvent,
+  TextStyle,
+  TouchableWithoutFeedback,
+  TouchableWithoutFeedbackProps,
+  ViewStyle,
+} from "react-native"
 import Haptic, { HapticFeedbackTypes } from "react-native-haptic-feedback"
+import { config } from "react-spring"
 // @ts-ignore
 import { animated, Spring } from "react-spring/renderprops-native.cjs"
 import styled from "styled-components/native"
-import { SansSize, ThemeV3 } from "../../Theme"
+import { ThemeV3 } from "../../Theme"
 import { Box, BoxProps } from "../Box"
 import { Flex } from "../Flex"
 import { Spinner } from "../Spinner"
-import { Text } from "../Text"
 
-/** Different theme variations */
 export type ButtonVariant = "fillDark" | "fillLight" | "fillGray" | "outline" | "text"
 
-/** Default button color variant */
 export const defaultVariant: ButtonVariant = "fillDark"
 
-/** The size of the button */
 export type ButtonSize = "small" | "large"
 
-/** Icon position */
 export type ButtonIconPosition = "left" | "right"
 
-/** Default button size */
 export const defaultSize: ButtonSize = "large"
 
-/** Default icon position */
 export const defaultIconPosition: ButtonIconPosition = "left"
 
 export interface ButtonProps extends ButtonBaseProps {
   children: ReactNode
-  /** The icon component */
   icon?: ReactNode
-  /** Icon position */
   iconPosition?: ButtonIconPosition
-  /** The size of the button */
   size?: ButtonSize
-  /** The theme of the button */
   variant?: ButtonVariant
-  /** React Native only, Callback on press, use instead of onClick */
-  onPress?: (event: GestureResponderEvent) => void
+  onPress?: TouchableWithoutFeedbackProps["onPress"]
 
   /**
    * `haptic` can be used like:
@@ -61,8 +57,6 @@ export interface ButtonBaseProps extends BoxProps {
   disabled?: boolean
   /** Makes button full width */
   block?: boolean
-  /** Additional styles to apply to the variant */
-  variantStyles?: any // FIXME
   /** Pass the longest text to the button for the button to keep longest text width */
   longestText?: string
 }
@@ -90,15 +84,14 @@ const PureButton: React.FC<ButtonProps> = ({
 }) => {
   const color = useColor()
 
-  const [previous, setPrevious] = useState(DisplayState.Enabled)
   const [current, setCurrent] = useState(DisplayState.Enabled)
 
-  const getSize = (): { height: number; size: SansSize; px: number } => {
+  const getSize = (): { height: number; px: number } => {
     switch (size) {
       case "small":
-        return { height: 30, size: "2", px: 15 }
+        return { height: 30, px: 15 }
       case "large":
-        return { height: 50, size: "3t", px: 30 }
+        return { height: 50, px: 30 }
     }
   }
 
@@ -107,7 +100,6 @@ const PureButton: React.FC<ButtonProps> = ({
         backgroundColor: variant === "text" ? color("black10") : disabled ? color("black30") : color("blue100"),
         color: color("white100"),
         borderWidth: 0,
-        textColor: "transparent",
       }
     : {}
 
@@ -124,10 +116,8 @@ const PureButton: React.FC<ButtonProps> = ({
 
     // Did someone tap really fast? Flick the highlighted state
     if (current === DisplayState.Enabled) {
-      setPrevious(current)
       setCurrent(DisplayState.Highlighted)
       setTimeout(() => {
-        setPrevious(current)
         setCurrent(DisplayState.Enabled)
       }, 0.3)
     } else {
@@ -145,21 +135,18 @@ const PureButton: React.FC<ButtonProps> = ({
   const containerSize = getSize()
   const variantColors = getColorsForVariant(variant, disabled)
 
-  const from = variantColors[previous]
   const to = variantColors[current]
   const iconBox = <Box opacity={loading ? 0 : 1}>{icon}</Box>
 
   return (
-    <Spring native from={from} to={to}>
+    <Spring native to={to} config={{ config: config.stiff }}>
       {(springProps: ViewStyle & TextStyle) => (
         <TouchableWithoutFeedback
           onPress={handlePress}
           onPressIn={() => {
-            setPrevious(DisplayState.Enabled)
             setCurrent(DisplayState.Highlighted)
           }}
           onPressOut={() => {
-            setPrevious(DisplayState.Highlighted)
             setCurrent(DisplayState.Enabled)
           }}
           disabled={disabled}
@@ -202,11 +189,7 @@ const PureButton: React.FC<ButtonProps> = ({
   )
 }
 
-/**
- * Returns various colors for each state given a button variant
- * @param variant
- */
-export function getColorsForVariant(variant: ButtonVariant, disabled: boolean = false) {
+function getColorsForVariant(variant: ButtonVariant, disabled: boolean = false) {
   const color = useColor()
 
   const blackWithOpacity = disabled ? color("black30") : color("black100")
@@ -222,13 +205,11 @@ export function getColorsForVariant(variant: ButtonVariant, disabled: boolean = 
           backgroundColor: blackWithOpacity,
           borderColor: blackWithOpacity,
           color: color("white100"),
-          textColor: color("white100"),
         },
         hover: {
           backgroundColor: blueWithOpacity,
           borderColor: blueWithOpacity,
           color: whiteWithOpacity,
-          textColor: whiteWithOpacity,
         },
       }
     case "fillLight":
@@ -237,13 +218,11 @@ export function getColorsForVariant(variant: ButtonVariant, disabled: boolean = 
           backgroundColor: whiteWithOpacity,
           borderColor: whiteWithOpacity,
           color: blackWithFullOpacity,
-          textColor: blackWithFullOpacity,
         },
         hover: {
           backgroundColor: blueWithOpacity,
           borderColor: blueWithOpacity,
           color: color("white100"),
-          textColor: color("white100"),
         },
       }
     case "fillGray":
@@ -252,13 +231,11 @@ export function getColorsForVariant(variant: ButtonVariant, disabled: boolean = 
           backgroundColor: black10WithOpacity,
           borderColor: black10WithOpacity,
           color: blackWithFullOpacity,
-          textColor: blackWithFullOpacity,
         },
         hover: {
           backgroundColor: blueWithOpacity,
           borderColor: blueWithOpacity,
           color: color("white100"),
-          textColor: color("white100"),
         },
       }
     case "outline":
@@ -267,13 +244,11 @@ export function getColorsForVariant(variant: ButtonVariant, disabled: boolean = 
           backgroundColor: color("white100"),
           borderColor: blackWithOpacity,
           color: blackWithOpacity,
-          textColor: blackWithOpacity,
         },
         hover: {
           backgroundColor: blueWithOpacity,
           borderColor: blueWithOpacity,
           color: color("white100"),
-          textColor: color("white100"),
         },
       }
     case "text":
@@ -282,13 +257,11 @@ export function getColorsForVariant(variant: ButtonVariant, disabled: boolean = 
           backgroundColor: color("white100"),
           borderColor: color("white100"),
           color: blackWithOpacity,
-          textColor: blackWithOpacity,
         },
         hover: {
           backgroundColor: color("black10"),
           borderColor: color("black10"),
           color: blueWithOpacity,
-          textColor: blueWithOpacity,
         },
       }
   }

--- a/src/palette/elements/Button/ButtonV2.stories.tsx
+++ b/src/palette/elements/Button/ButtonV2.stories.tsx
@@ -1,13 +1,14 @@
 import { action } from "@storybook/addon-actions"
 import { storiesOf } from "@storybook/react-native"
 import { LinkIcon } from "palette"
-import { ButtonSize, ButtonV2 as Button, ButtonVariant } from "palette/elements/Button/ButtonV2"
 import React from "react"
+import { withThemeV2 } from "storybook/decorators"
 import { DList, List } from "storybook/helpers"
+import { ButtonV2, ButtonV2Props } from "."
 
-const sizes: ButtonSize[] = ["small", "medium", "large"]
+const sizes: Array<ButtonV2Props["size"]> = ["small", "medium", "large"]
 
-const variants: ButtonVariant[] = [
+const variants: Array<ButtonV2Props["variant"]> = [
   "primaryBlack",
   "primaryWhite",
   "secondaryGray",
@@ -17,13 +18,14 @@ const variants: ButtonVariant[] = [
 ]
 
 storiesOf("ButtonV2", module)
+  .addDecorator(withThemeV2)
   .add("Sizes", () => (
     <DList
       data={sizes}
       renderItem={({ item: size }) => (
-        <Button size={size} onPress={() => action(`tapped ${size}`)}>
+        <ButtonV2 size={size} onPress={() => action(`tapped ${size}`)}>
           {size}
-        </Button>
+        </ButtonV2>
       )}
     />
   ))
@@ -31,20 +33,20 @@ storiesOf("ButtonV2", module)
     <DList
       data={variants}
       renderItem={({ item: variant }) => (
-        <Button variant={variant} onPress={() => action(`tapped ${variant}`)}>
+        <ButtonV2 variant={variant} onPress={() => action(`tapped ${variant}`)}>
           {variant}
-        </Button>
+        </ButtonV2>
       )}
     />
   ))
   .add("Miscellaneous", () => (
     <List>
-      <Button loading>loading</Button>
-      <Button disabled>disabled</Button>
-      <Button block>block</Button>
-      <Button icon={<LinkIcon />}>with icon</Button>
-      <Button icon={<LinkIcon />} iconPosition="right">
+      <ButtonV2 loading>loading</ButtonV2>
+      <ButtonV2 disabled>disabled</ButtonV2>
+      <ButtonV2 block>block</ButtonV2>
+      <ButtonV2 icon={<LinkIcon />}>with icon</ButtonV2>
+      <ButtonV2 icon={<LinkIcon />} iconPosition="right">
         with icon
-      </Button>
+      </ButtonV2>
     </List>
   ))

--- a/src/palette/elements/Button/ButtonV2.tsx
+++ b/src/palette/elements/Button/ButtonV2.tsx
@@ -24,16 +24,16 @@ export type ButtonVariant =
 export const defaultVariant: ButtonVariant = "primaryBlack"
 
 /** The size of the button */
-export type ButtonSize = "small" | "medium" | "large"
+type ButtonSize = "small" | "medium" | "large"
 
 /** Icon position */
-export type ButtonIconPosition = "left" | "right"
+type ButtonIconPosition = "left" | "right"
 
 /** Default button size */
-export const defaultSize: ButtonSize = "medium"
+const defaultSize: ButtonSize = "medium"
 
 /** Default icon position */
-export const defaultIconPosition: ButtonIconPosition = "left"
+const defaultIconPosition: ButtonIconPosition = "left"
 
 export interface ButtonProps extends ButtonBaseProps {
   children: ReactNode

--- a/src/palette/elements/Button/index.tsx
+++ b/src/palette/elements/Button/index.tsx
@@ -2,14 +2,15 @@ import { usePaletteFlagStore } from "palette/PaletteFlag"
 import React from "react"
 
 // v3
-import { Button as ButtonV3, ButtonProps as ButtonV3Props } from "./Button"
+import { Button as ButtonV3, ButtonProps as ButtonV3Props, ButtonVariant as ButtonV3Variant } from "./Button"
 export { ButtonV3, ButtonV3Props }
 
 // v2
-import { ButtonProps as ButtonV2Props, ButtonV2 } from "./ButtonV2"
+import { ButtonProps as ButtonV2Props, ButtonV2, ButtonVariant as ButtonV2Variant } from "./ButtonV2"
 export { ButtonV2, ButtonV2Props }
 
 export type ButtonProps = ButtonV2Props | ButtonV3Props
+export type ButtonVariant = ButtonV2Variant | ButtonV3Variant
 
 const isV2Props = (props: ButtonProps): props is ButtonV2Props => {
   const v2Variants: Array<ButtonV2Props["variant"]> = [

--- a/src/palette/elements/Button/index.tsx
+++ b/src/palette/elements/Button/index.tsx
@@ -1,30 +1,67 @@
 import { usePaletteFlagStore } from "palette/PaletteFlag"
 import React from "react"
 
-import { Button as ButtonV3, ButtonProps as ButtonPropsV3, ButtonSize, ButtonVariant } from "./Button"
-import { ButtonProps as ButtonPropsV2, ButtonV2 } from "./ButtonV2"
-export * from "./Button"
+// v3
+import { Button as ButtonV3, ButtonProps as ButtonV3Props } from "./Button"
+export { ButtonV3, ButtonV3Props }
 
-export { ButtonV2, ButtonVariant } from "./ButtonV2"
+// v2
+import { ButtonProps as ButtonV2Props, ButtonV2 } from "./ButtonV2"
+export { ButtonV2, ButtonV2Props }
 
-export const Button: React.FC<ButtonPropsV2> = (props) => {
+export type ButtonProps = ButtonV2Props | ButtonV3Props
+
+const isV2Props = (props: ButtonProps): props is ButtonV2Props => {
+  const v2Variants: Array<ButtonV2Props["variant"]> = [
+    "primaryBlack",
+    "primaryWhite",
+    "secondaryGray",
+    "secondaryOutline",
+    "secondaryOutlineWarning",
+    "noOutline",
+  ]
+  if (v2Variants.includes(props.variant as any)) {
+    return true
+  }
+
+  const v3Variants: Array<ButtonV3Props["variant"]> = ["fillDark", "fillLight", "fillGray", "outline", "text"]
+  if (v3Variants.includes(props.variant as any)) {
+    return false
+  }
+
+  if (props.size === "medium") {
+    return true
+  }
+
+  // if nothing is obviously v2 or v3, assume v2
+  return true
+}
+
+export const Button: React.FC<ButtonProps> = (props) => {
   const allowV3 = usePaletteFlagStore((state) => state.allowV3)
 
   if (allowV3) {
-    return <ButtonV3 {...transformV3Props(props)} />
+    if (isV2Props(props)) {
+      return <ButtonV3 {...transformV3Props(props)} />
+    } else {
+      return <ButtonV3 {...props} />
+    }
   }
 
-  return <ButtonV2 {...(props as ButtonPropsV2)} />
+  if (isV2Props(props)) {
+    return <ButtonV2 {...props} />
+  }
+  throw new Error("ButtonV2 used with v3 props. Don't do that.")
 }
 
-const transformV3Props = (props: ButtonPropsV2): ButtonPropsV3 => {
-  const sizeMap: { [key: string]: ButtonSize } = {
+const transformV3Props = (props: ButtonV2Props): ButtonV3Props => {
+  const sizeMap: { [key: string]: ButtonV3Props["size"] } = {
     small: "small",
     medium: "small",
     large: "large",
   }
 
-  const variantMap: { [key: string]: ButtonVariant } = {
+  const variantMap: { [key: string]: ButtonV3Props["variant"] } = {
     primaryBlack: "fillDark",
     primaryWhite: "fillLight",
     secondaryGray: "fillGray",
@@ -36,5 +73,5 @@ const transformV3Props = (props: ButtonPropsV2): ButtonPropsV3 => {
   const size = props.size && sizeMap[props.size]
   const variant = props.variant && variantMap[props.variant]
 
-  return { ...props, size, variant } as ButtonPropsV3
+  return { ...props, size, variant } as ButtonV3Props
 }


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves []

### Description

<!-- Implementation description -->


Small PR to simplify the way Button works.

- Removed the `from` part from the animation, since it's not needed. `to` is enough, and it's reversed on untap.
- unexport some things that we don't use, like default variants etc.
- remove `textColor` from variants since it's not used. same for `size` for the `getSize` func.
- make the main `Button` wrapper accept v2 or v3 props, and try to guess the right ones and use that button.

To explain this a bit better:
- If the palette v3 flag is off, Button will point to v2, nothing to worry about.
- If flag is on, Button will point to v3. If it gets v3 props, it will use them. If it gets v2 props, it will convert them to v3 based on the mappings we have.
- If flag is on and we want to use a v2 button, we need to do it by specifically importing and using `ButtonV2`. We should rework any code that needs to do that, since v2 is going away soon.
- In the weird case that flag is off, and we specifically use v3 props on a button, which should not happen, then we get an error thrown.


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Button v2 and v3 simplify - pavlos

<!-- end_changelog_updates -->

</details>
