### PR TITLE
feat: reorder artwork for sale filters on artist screen

### DIFF
--- a/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -508,13 +508,13 @@ const CollectionFiltersSorted: FilterScreen[] = [
 ]
 const ArtistArtworksFiltersSorted: FilterScreen[] = [
   "sort",
+  "attributionClass",
   "medium",
   "additionalGeneIDs",
-  "materialsTerms",
   "priceRange",
-  "attributionClass",
   "dimensionRange",
   "waysToBuy",
+  "materialsTerms",
   "locationCities",
   "majorPeriods",
   "colors",

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/AdditionalGeneIDsOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/AdditionalGeneIDsOptions-tests.tsx
@@ -100,7 +100,7 @@ describe("AdditionalGeneIDsOptions Screen", () => {
     const tree = renderWithWrappers(<MockFilterScreen initialState={injectedState} />)
     const items = tree.root.findAllByType(FilterModalOptionListItem)
 
-    expect(extractText(items[1])).toContain("Prints, Sculpture")
+    expect(extractText(items[2])).toContain("Prints, Sculpture")
   })
 
   it("toggles selected filters 'ON' and unselected filters 'OFF", () => {

--- a/src/lib/Components/ArtworkFilter/__tests__/FilterModal-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/FilterModal-tests.tsx
@@ -263,7 +263,7 @@ describe("Filter modal states", () => {
 
     const filterScreen = mount(<MockFilterScreen initialState={injectedState} />)
 
-    expect(filterScreen.find(CurrentOption).at(1).text()).toEqual("Performance Art")
+    expect(filterScreen.find(CurrentOption).at(2).text()).toEqual("Performance Art")
   })
 
   it("displays the filter screen apply button correctly when no filters are selected", () => {
@@ -328,9 +328,9 @@ describe("Filter modal states", () => {
     const filterScreen = renderWithWrappers(<MockFilterScreen initialState={injectedState} />)
 
     expect(extractText(filterScreen.root.findAllByType(CurrentOption)[0])).toEqual("Price (low to high)")
-    expect(extractText(filterScreen.root.findAllByType(CurrentOption)[1])).toEqual("Drawing")
-    expect(extractText(filterScreen.root.findAllByType(CurrentOption)[2])).toEqual("$10,000-20,000")
-    expect(extractText(filterScreen.root.findAllByType(CurrentOption)[3])).toEqual("")
+    expect(extractText(filterScreen.root.findAllByType(CurrentOption)[1])).toEqual("")
+    expect(extractText(filterScreen.root.findAllByType(CurrentOption)[2])).toEqual("Drawing")
+    expect(extractText(filterScreen.root.findAllByType(CurrentOption)[3])).toEqual("$10,000-20,000")
     expect(extractText(filterScreen.root.findAllByType(CurrentOption)[4])).toEqual("Bid")
     expect(extractText(filterScreen.root.findAllByType(CurrentOption)[5])).toEqual("")
     expect(filterScreen.root.findAllByType(CurrentOption)).toHaveLength(6)


### PR DESCRIPTION
The type of this PR is: enhancement 

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3162]

### Description

<!-- Implementation description -->
Reorder artwork for sale filters to remain consistent with desired order.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Reorder artwork for sale filters on artist screen for iOS and Android apps - rquartararo

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

### Screenshots

![Simulator Screen Shot - iPhone 12 Pro - 2021-08-11 at 15 23 54](https://user-images.githubusercontent.com/50849237/129036772-bafd54d6-3d5d-4502-b9c4-73a1fcd2accc.png)



[FX-2613]: https://artsyproduct.atlassian.net/browse/FX-2613

[FX-3162]: https://artsyproduct.atlassian.net/browse/FX-3162