### PR TITLE
feat(FX-3144): saved search name input is limited to 75 characters

### DIFF
--- a/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -36,6 +36,7 @@ export const Form: React.FC<FormProps> = (props) => {
           onBlur={handleBlur("name")}
           error={errors.name}
           testID="alert-input-name"
+          maxLength={75}
         />
       </Box>
       <Box mb={2}>

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -3,7 +3,7 @@ import { getSearchCriteriaFromFilters } from "lib/Components/ArtworkFilter/Saved
 import React from "react"
 import { Alert } from "react-native"
 import { Form } from "./Components/Form"
-import { extractPills } from "./helpers"
+import { extractPills, getNamePlaceholder } from "./helpers"
 import { createSavedSearchAlert } from "./mutations/createSavedSearchAlert"
 import { deleteSavedSearchMutation } from "./mutations/deleteSavedSearchAlert"
 import { updateSavedSearchAlert } from "./mutations/updateSavedSearchAlert"
@@ -21,17 +21,23 @@ export interface SavedSearchAlertFormProps extends SavedSearchAlertFormPropsBase
 export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props) => {
   const { filters, aggregations, initialValues, savedSearchAlertId, onComplete, onDeleteComplete, ...other } = props
   const isUpdateForm = !!savedSearchAlertId
+  const pills = extractPills(filters, aggregations)
   const formik = useFormik<SavedSearchAlertFormValues>({
     initialValues,
     initialErrors: {},
     onSubmit: async (values) => {
+      let alertName = values.name
+
+      if (alertName.length === 0) {
+        alertName = getNamePlaceholder(props.artist.name, pills)
+      }
+
       try {
         if (isUpdateForm) {
-          await updateSavedSearchAlert(savedSearchAlertId!, values)
+          await updateSavedSearchAlert(alertName, savedSearchAlertId!)
         } else {
           const criteria = getSearchCriteriaFromFilters(props.artist.id, filters)
-
-          await createSavedSearchAlert(values.name, criteria)
+          await createSavedSearchAlert(alertName, criteria)
         }
 
         onComplete?.()
@@ -60,8 +66,6 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
       ]
     )
   }
-
-  const pills = extractPills(filters, aggregations)
 
   return (
     <FormikProvider value={formik}>

--- a/src/lib/Scenes/SavedSearchAlert/__tests__/SavedSearchAlertForm-tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/__tests__/SavedSearchAlertForm-tests.tsx
@@ -156,6 +156,45 @@ describe("Saved search alert form", () => {
 
     expect(onDeletePressMock).toHaveBeenCalled()
   })
+
+  it("should auto populate alert name for the create mutation", async () => {
+    const { getByTestId } = renderWithWrappersTL(<SavedSearchAlertForm {...baseProps} />)
+
+    fireEvent.press(getByTestId("save-alert-button"))
+
+    await waitFor(() => {
+      expect(mockEnvironment.mock.getMostRecentOperation().request.variables).toMatchObject({
+        input: {
+          userAlertSettings: {
+            name: "artistName • 5 filters",
+          },
+        },
+      })
+    })
+  })
+
+  it("should auto populate alert name for the update mutation", async () => {
+    const { getByTestId } = renderWithWrappersTL(
+      <SavedSearchAlertForm
+        {...baseProps}
+        savedSearchAlertId="savedSearchAlertId"
+        initialValues={{ name: "update value" }}
+      />
+    )
+
+    fireEvent.changeText(getByTestId("alert-input-name"), "")
+    fireEvent.press(getByTestId("save-alert-button"))
+
+    await waitFor(() => {
+      expect(mockEnvironment.mock.getMostRecentOperation().request.variables).toMatchObject({
+        input: {
+          userAlertSettings: {
+            name: "artistName • 5 filters",
+          },
+        },
+      })
+    })
+  })
 })
 
 const filters: FilterData[] = [

--- a/src/lib/Scenes/SavedSearchAlert/mutations/updateSavedSearchAlert.ts
+++ b/src/lib/Scenes/SavedSearchAlert/mutations/updateSavedSearchAlert.ts
@@ -1,9 +1,8 @@
 import { updateSavedSearchAlertMutation } from "__generated__/updateSavedSearchAlertMutation.graphql"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { commitMutation, graphql } from "relay-runtime"
-import { SavedSearchAlertFormValues } from "../SavedSearchAlertModel"
 
-export const updateSavedSearchAlert = (savedSearchAlertId: string, values: SavedSearchAlertFormValues) => {
+export const updateSavedSearchAlert = (name: string, savedSearchAlertId: string) => {
   return new Promise((resolve, reject) => {
     commitMutation<updateSavedSearchAlertMutation>(defaultEnvironment, {
       mutation: graphql`
@@ -24,7 +23,7 @@ export const updateSavedSearchAlert = (savedSearchAlertId: string, values: Saved
         input: {
           searchCriteriaID: savedSearchAlertId,
           userAlertSettings: {
-            name: values.name,
+            name,
           },
         },
       },

--- a/src/lib/Scenes/SavedSearchAlertsList/Components/EmptyMessage.tsx
+++ b/src/lib/Scenes/SavedSearchAlertsList/Components/EmptyMessage.tsx
@@ -8,7 +8,9 @@ export const EmptyMessage: React.FC = () => {
     <ScrollView contentContainerStyle={{ flex: 1 }}>
       <Flex px={2} py={4} justifyContent="center" alignItems="center" height="100%">
         <Box maxWidth="80%" alignItems="center">
-          <Text variant="title">You haven’t created any Alerts yet.</Text>
+          <Text variant="title" textAlign="center">
+            You haven’t created any Alerts yet.
+          </Text>
           <Spacer mb={1} />
           <Text textAlign="center" variant="caption" color="black60">
             Filter for the artworks you love on an Artist Page and tap ‘Create Alert’ to be notified when new works are


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3144]

### Description
* As a user,
* When I am creating or updating the name of a saved search
* I cannot save the form with over 75 characters in the name field
* Additional discussion of the [task implementation](https://artsy.slack.com/archives/C9SATFLUU/p1628689788332800)

### Acceptance criteria
* User cannot enter characters beyond the limit
* Without a counter of the entered characters (at the moment)
* If the name field is blank on-submit, auto populate it with a generated (placeholder) name (in grey) and continue with submission

### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/129060966-fca878b5-a1a7-4d12-9037-e991731db554.mp4

#### Android
https://user-images.githubusercontent.com/3513494/129061032-fc6a4451-025e-459f-a5eb-4d4131046951.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Saved search name input is limited to 75 characters - dzmitry tratsiak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3144]: https://artsyproduct.atlassian.net/browse/FX-3144