### PR TITLE
feat(FX-3190): use saved search banner M2 design for M1

### DIFF
--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -5,7 +5,6 @@ import {
   Aggregations,
   filterArtworksParams,
   FilterData,
-  FilterParamName,
   prepareFilterArtworksParamsForInput,
 } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworkFiltersStoreProvider, ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
@@ -23,7 +22,6 @@ import { StickyTabPageScrollView } from "lib/Components/StickyTabPage/StickyTabP
 import { PAGE_SIZE } from "lib/data/constants"
 import { useFeatureFlag } from "lib/store/GlobalStore"
 import { Schema } from "lib/utils/track"
-import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { Box, FilterIcon, Flex, Separator, Spacer, Text, TouchableHighlightColor } from "palette"
 import React, { useContext, useEffect, useMemo, useState } from "react"
 import { Platform } from "react-native"
@@ -72,12 +70,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) 
   return (
     <ArtworkFiltersStoreProvider>
       <StickyTabPageScrollView>
-        <ArtistArtworksContainer
-          {...props}
-          artist={artist}
-          relay={relay}
-          openFilterModal={openFilterArtworksModal}
-        />
+        <ArtistArtworksContainer {...props} artist={artist} relay={relay} openFilterModal={openFilterArtworksModal} />
         <ArtworkFilterNavigator
           {...props}
           id={artist.internalID}
@@ -112,8 +105,6 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
 
   const applyFilters = ArtworksFiltersStore.useStoreState((state) => state.applyFilters)
   const aggregations = ArtworksFiltersStore.useStoreState((state) => state.aggregations)
-  const relevantFiltersForSavedSearch = appliedFilters.filter((filter) => !(filter.paramName === FilterParamName.sort))
-  const shouldShowSavedSearchBanner = enableSavedSearch && relevantFiltersForSavedSearch.length > 0
 
   const setAggregationsAction = ArtworksFiltersStore.useStoreActions((state) => state.setAggregationsAction)
 
@@ -162,58 +153,50 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
   }
 
   const setJSX = useContext(StickyTabPageFlatListContext).setJSX
-  const screenWidth = useScreenDimensions().width
 
   useEffect(() => {
     setJSX(
       <Box backgroundColor="white">
-        {enableSavedSearchV2 ? (
-          <>
-            <Flex flexDirection="row" my={1} px={2} justifyContent="space-between" alignItems="center">
-              <TouchableHighlightColor
-                haptic
-                onPress={openFilterModal}
-                render={({ color }) => (
-                  <Flex flexDirection="row" alignItems="center">
-                    <FilterIcon fill={color} width="20px" height="20px" />
-                    <Text variant="small" color={color} ml={0.5}>
-                      Sort & Filter
-                    </Text>
-                  </Flex>
-                )}
-              />
+        {enableSavedSearchV2 || enableSavedSearch ? (
+          <Flex flexDirection="row" my={1} px={2} justifyContent="space-between" alignItems="center">
+            <TouchableHighlightColor
+              haptic
+              onPress={openFilterModal}
+              render={({ color }) => (
+                <Flex flexDirection="row" alignItems="center">
+                  <FilterIcon fill={color} width="20px" height="20px" />
+                  <Text variant="small" color={color} ml={0.5}>
+                    Sort & Filter
+                  </Text>
+                </Flex>
+              )}
+            />
+            {!!enableSavedSearchV2 ? (
               <SavedSearchButtonQueryRenderer
                 filters={appliedFilters as FilterData[]}
                 artist={{ id: artistInternalId, name: artistName! }}
                 aggregations={aggregations}
               />
-            </Flex>
-            <Separator />
-          </>
-        ) : (
-          <>
-            <ArtworksFilterHeader count={artworksTotal} onFilterPress={openFilterModal} />
-            <Separator />
-            {!!shouldShowSavedSearchBanner && (
-              <Box px={2}>
-                <SavedSearchBannerQueryRender
-                  artistId={artistInternalId}
-                  filters={filterParams}
-                  artistSlug={artist.slug}
-                />
-                <Separator ml={-2} width={screenWidth} />
-              </Box>
+            ) : (
+              <SavedSearchBannerQueryRender
+                artistId={artistInternalId}
+                filters={filterParams}
+                artistSlug={artist.slug}
+              />
             )}
-          </>
+          </Flex>
+        ) : (
+          <ArtworksFilterHeader count={artworksTotal} onFilterPress={openFilterModal} />
         )}
+        <Separator />
       </Box>
     )
   }, [
     artworksTotal,
-    shouldShowSavedSearchBanner,
     artistName,
     artistInternalId,
     filterParams,
+    enableSavedSearch,
     enableSavedSearchV2,
     appliedFilters,
     aggregations,

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -11,7 +11,7 @@ import { usePopoverMessage } from "lib/Components/PopoverMessage/popoverMessageH
 import { LegacyNativeModules } from "lib/NativeModules/LegacyNativeModules"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { PushAuthorizationStatus } from "lib/Scenes/MyProfile/MyProfilePushNotifications"
-import { Button, Flex, Text } from "palette"
+import { BellIcon, Button } from "palette"
 import React, { useState } from "react"
 import { Alert, AlertButton, Linking, Platform } from "react-native"
 import PushNotification from "react-native-push-notification"
@@ -25,6 +25,7 @@ interface SavedSearchBannerProps {
   attributes: SearchCriteriaAttributes
   loading?: boolean
   relay: RelayRefetchProp
+  disabled?: boolean
 }
 
 export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({
@@ -33,6 +34,7 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({
   artistSlug,
   attributes,
   loading,
+  disabled,
   relay,
 }) => {
   const [saving, setSaving] = useState(false)
@@ -217,29 +219,18 @@ export const SavedSearchBanner: React.FC<SavedSearchBannerProps> = ({
   }
 
   return (
-    <Flex
-      backgroundColor="white"
-      flexDirection="row"
-      mx={-2}
-      px={2}
-      py={11}
-      justifyContent="space-between"
-      alignItems="center"
+    <Button
+      variant={enabled ? "secondaryOutline" : "primaryBlack"}
+      disabled={disabled}
+      onPress={handleSaveSearchFiltersPress}
+      icon={<BellIcon fill={enabled ? "black100" : "white100"} mr={0.5} width="16px" height="16px" />}
+      size="small"
+      loading={inProcess}
+      longestText="Remove Alert"
+      haptic
     >
-      <Text variant="small" color="black">
-        {enabled ? "Remove alert with these filters" : "Set alert with these filters"}
-      </Text>
-      <Button
-        variant={enabled ? "secondaryOutline" : "primaryBlack"}
-        onPress={handleSaveSearchFiltersPress}
-        size="small"
-        loading={inProcess}
-        longestText="Disable"
-        haptic
-      >
-        {enabled ? "Disable" : "Enable"}
-      </Button>
-    </Flex>
+      {enabled ? "Remove Alert" : "Create Alert"}
+    </Button>
   )
 }
 
@@ -269,9 +260,22 @@ export const SavedSearchBannerQueryRender: React.FC<{
   artistSlug: string
 }> = ({ filters, artistId, artistSlug }) => {
   const input = prepareFilterParamsForSaveSearchInput(filters)
+  const isEmptyCriteria = Object.keys(input).length === 0
   const attributes: SearchCriteriaAttributes = {
     artistID: artistId,
     ...input,
+  }
+
+  if (isEmptyCriteria) {
+    return (
+      <SavedSearchBannerRefetchContainer
+        me={null}
+        attributes={attributes}
+        artistId={artistId}
+        artistSlug={artistSlug}
+        disabled
+      />
+    )
   }
 
   return (

--- a/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchBanner-tests.tsx
@@ -122,7 +122,7 @@ describe("SavedSearchBanner", () => {
 
     const buttonComponent = tree.root.findByType(Button)
 
-    expect(buttonComponent.props.children).toEqual("Enable")
+    expect(buttonComponent.props.children).toEqual("Create Alert")
     expect(buttonComponent.props.variant).toBe("primaryBlack")
     expect(buttonComponent.props.loading).toBe(false)
   })
@@ -133,7 +133,7 @@ describe("SavedSearchBanner", () => {
 
     const buttonComponent = tree.root.findByType(Button)
 
-    expect(buttonComponent.props.children).toEqual("Disable")
+    expect(buttonComponent.props.children).toEqual("Remove Alert")
     expect(buttonComponent.props.variant).toBe("secondaryOutline")
     expect(buttonComponent.props.loading).toBe(false)
   })

--- a/src/lib/Scenes/Artist/__tests__/ArtistSavedSearch-tests.tsx
+++ b/src/lib/Scenes/Artist/__tests__/ArtistSavedSearch-tests.tsx
@@ -1,5 +1,5 @@
 import { SavedSearchBanner } from "lib/Components/Artist/ArtistArtworks/SavedSearchBanner"
-import { SavedSearchButtonQueryRenderer } from 'lib/Components/Artist/ArtistArtworks/SavedSearchButton'
+import { SavedSearchButtonQueryRenderer } from "lib/Components/Artist/ArtistArtworks/SavedSearchButton"
 import { CurrentOption } from "lib/Components/ArtworkFilter"
 import { PopoverMessage } from "lib/Components/PopoverMessage/PopoverMessage"
 import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
@@ -60,7 +60,7 @@ describe("Saved search banner on artist screen", () => {
     )
   }
 
-  it("should not render banner when criteria attributes passed and AREnableSavedSearch flag set to false", () => {
+  it("should not render saved search button when AREnableSavedSearch flag set to false", () => {
     __globalStoreTestUtils__?.injectFeatureFlags({ AREnableSavedSearch: false })
 
     const tree = getTree("search-criteria-id")
@@ -68,27 +68,6 @@ describe("Saved search banner on artist screen", () => {
     mockMostRecentOperation("ArtistAboveTheFoldQuery", MockArtistAboveTheFoldQuery)
 
     expect(tree.root.findAllByType(SavedSearchBanner)).toHaveLength(0)
-  })
-
-  it("should not render banner when the criteria attributes not passed", () => {
-    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableSavedSearch: true })
-
-    const tree = getTree()
-
-    mockMostRecentOperation("ArtistAboveTheFoldQuery", MockArtistAboveTheFoldQuery)
-
-    expect(tree.root.findAllByType(SavedSearchBanner)).toHaveLength(0)
-  })
-
-  it("should render banner when the criteria attributes passed", () => {
-    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableSavedSearch: true })
-
-    const tree = getTree("search-criteria-id")
-
-    mockMostRecentOperation("SearchCriteriaQuery", MockSearchCriteriaQuery)
-    mockMostRecentOperation("ArtistAboveTheFoldQuery", MockArtistAboveTheFoldQuery)
-
-    expect(tree.root.findAllByType(SavedSearchBanner)).toHaveLength(1)
   })
 
   it("should convert the criteria attributes to the filter params format", async () => {


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3190]
### Description
* Use the Saved Search M2 banner design for the M1 version
* This is necessary in order to see if it increases engagement to see the button visible before any filters are applied.
* For Android saved search banner, the old version of the banner will be displayed

### Acceptance criteria
* User lands on artist screen
* Sees “Create alert” button disabled/gray
* Apply filters
* User sees “Create alert” button tappable/black
* User can tap button to enable alert
  * toast appears
  * button updates to “Remove alert” (white outline)
* User can tap button again to disable alert
  * toast appears
  * button reverts to “Create alert”

### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/129233637-03953e86-dd4b-471c-b503-a4282ba7528c.mp4

#### Android
https://user-images.githubusercontent.com/3513494/129234860-bd5f0971-a100-44a1-872e-916920cde1e5.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Use the Saved Search M2 banner design for the M1 version - dzmitry tratsiak

#### iOS user-facing changes

- use saved search banner M2 design for M1 - dimatretyak

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3190]: https://artsyproduct.atlassian.net/browse/FX-3190