### PR TITLE
feat(FX-3191):  add “View artworks” button for edit saved search alert screen

### DIFF
--- a/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
+++ b/src/__generated__/ArtistAboveTheFoldQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash f291072a2b3d2c59383fb5d84b6e340f */
+/* @relayHash d74797e1d61502554354eaf9da6af6aa */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -113,7 +113,7 @@ fragment ArtistArtworks_artist_2VV6jB on Artist {
   slug
   name
   internalID
-  artworks: filterArtworksConnection(first: 10, input: $input, aggregations: [COLOR, DIMENSION_RANGE, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE]) {
+  aggregations: filterArtworksConnection(first: 0, aggregations: [COLOR, DIMENSION_RANGE, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -122,6 +122,9 @@ fragment ArtistArtworks_artist_2VV6jB on Artist {
         value
       }
     }
+    id
+  }
+  artworks: filterArtworksConnection(first: 10, input: $input) {
     edges {
       node {
         id
@@ -324,20 +327,6 @@ v12 = {
 v13 = [
   {
     "kind": "Literal",
-    "name": "aggregations",
-    "value": [
-      "COLOR",
-      "DIMENSION_RANGE",
-      "LOCATION_CITY",
-      "MAJOR_PERIOD",
-      "MATERIALS_TERMS",
-      "MEDIUM",
-      "PARTNER",
-      "PRICE_RANGE"
-    ]
-  },
-  {
-    "kind": "Literal",
     "name": "first",
     "value": 10
   },
@@ -466,8 +455,28 @@ return {
             "storageKey": null
           },
           {
-            "alias": "artworks",
-            "args": (v13/*: any*/),
+            "alias": "aggregations",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "aggregations",
+                "value": [
+                  "COLOR",
+                  "DIMENSION_RANGE",
+                  "LOCATION_CITY",
+                  "MAJOR_PERIOD",
+                  "MATERIALS_TERMS",
+                  "MEDIUM",
+                  "PARTNER",
+                  "PRICE_RANGE"
+                ]
+              },
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 0
+              }
+            ],
             "concreteType": "FilterArtworksConnection",
             "kind": "LinkedField",
             "name": "filterArtworksConnection",
@@ -517,6 +526,18 @@ return {
                 ],
                 "storageKey": null
               },
+              (v11/*: any*/)
+            ],
+            "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"LOCATION_CITY\",\"MAJOR_PERIOD\",\"MATERIALS_TERMS\",\"MEDIUM\",\"PARTNER\",\"PRICE_RANGE\"],first:0)"
+          },
+          {
+            "alias": "artworks",
+            "args": (v13/*: any*/),
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
               {
                 "alias": null,
                 "args": null,
@@ -831,8 +852,7 @@ return {
             "alias": "artworks",
             "args": (v13/*: any*/),
             "filters": [
-              "input",
-              "aggregations"
+              "input"
             ],
             "handle": "connection",
             "key": "ArtistArtworksGrid_artworks",
@@ -846,7 +866,7 @@ return {
     ]
   },
   "params": {
-    "id": "f291072a2b3d2c59383fb5d84b6e340f",
+    "id": "d74797e1d61502554354eaf9da6af6aa",
     "metadata": {},
     "name": "ArtistAboveTheFoldQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistArtworksQuery.graphql.ts
+++ b/src/__generated__/ArtistArtworksQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash bd32e6475fe0f471b66cbf6562a048ae */
+/* @relayHash 2dca1fe40a7ce954d07e00de47f776e5 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -95,7 +95,7 @@ fragment ArtistArtworks_artist_YCAiB on Artist {
   slug
   name
   internalID
-  artworks: filterArtworksConnection(first: $count, after: $cursor, input: $input, aggregations: [COLOR, DIMENSION_RANGE, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE]) {
+  aggregations: filterArtworksConnection(first: 0, aggregations: [COLOR, DIMENSION_RANGE, LOCATION_CITY, MAJOR_PERIOD, MATERIALS_TERMS, MEDIUM, PARTNER, PRICE_RANGE]) {
     aggregations {
       slice
       counts {
@@ -104,6 +104,9 @@ fragment ArtistArtworks_artist_YCAiB on Artist {
         value
       }
     }
+    id
+  }
+  artworks: filterArtworksConnection(first: $count, after: $cursor, input: $input) {
     edges {
       node {
         id
@@ -258,20 +261,6 @@ v11 = [
     "variableName": "cursor"
   },
   {
-    "kind": "Literal",
-    "name": "aggregations",
-    "value": [
-      "COLOR",
-      "DIMENSION_RANGE",
-      "LOCATION_CITY",
-      "MAJOR_PERIOD",
-      "MATERIALS_TERMS",
-      "MEDIUM",
-      "PARTNER",
-      "PRICE_RANGE"
-    ]
-  },
-  {
     "kind": "Variable",
     "name": "first",
     "variableName": "count"
@@ -357,8 +346,28 @@ return {
               (v9/*: any*/),
               (v10/*: any*/),
               {
-                "alias": "artworks",
-                "args": (v11/*: any*/),
+                "alias": "aggregations",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "aggregations",
+                    "value": [
+                      "COLOR",
+                      "DIMENSION_RANGE",
+                      "LOCATION_CITY",
+                      "MAJOR_PERIOD",
+                      "MATERIALS_TERMS",
+                      "MEDIUM",
+                      "PARTNER",
+                      "PRICE_RANGE"
+                    ]
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 0
+                  }
+                ],
                 "concreteType": "FilterArtworksConnection",
                 "kind": "LinkedField",
                 "name": "filterArtworksConnection",
@@ -408,6 +417,18 @@ return {
                     ],
                     "storageKey": null
                   },
+                  (v7/*: any*/)
+                ],
+                "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"LOCATION_CITY\",\"MAJOR_PERIOD\",\"MATERIALS_TERMS\",\"MEDIUM\",\"PARTNER\",\"PRICE_RANGE\"],first:0)"
+              },
+              {
+                "alias": "artworks",
+                "args": (v11/*: any*/),
+                "concreteType": "FilterArtworksConnection",
+                "kind": "LinkedField",
+                "name": "filterArtworksConnection",
+                "plural": false,
+                "selections": [
                   {
                     "alias": null,
                     "args": null,
@@ -722,8 +743,7 @@ return {
                 "alias": "artworks",
                 "args": (v11/*: any*/),
                 "filters": [
-                  "input",
-                  "aggregations"
+                  "input"
                 ],
                 "handle": "connection",
                 "key": "ArtistArtworksGrid_artworks",
@@ -740,7 +760,7 @@ return {
     ]
   },
   "params": {
-    "id": "bd32e6475fe0f471b66cbf6562a048ae",
+    "id": "2dca1fe40a7ce954d07e00de47f776e5",
     "metadata": {},
     "name": "ArtistArtworksQuery",
     "operationKind": "query",

--- a/src/__generated__/ArtistArtworks_artist.graphql.ts
+++ b/src/__generated__/ArtistArtworks_artist.graphql.ts
@@ -10,7 +10,7 @@ export type ArtistArtworks_artist = {
     readonly slug: string;
     readonly name: string | null;
     readonly internalID: string;
-    readonly artworks: {
+    readonly aggregations: {
         readonly aggregations: ReadonlyArray<{
             readonly slice: ArtworkAggregation | null;
             readonly counts: ReadonlyArray<{
@@ -19,6 +19,8 @@ export type ArtistArtworks_artist = {
                 readonly value: string;
             } | null> | null;
         } | null> | null;
+    } | null;
+    readonly artworks: {
         readonly edges: ReadonlyArray<{
             readonly node: {
                 readonly id: string;
@@ -104,7 +106,7 @@ return {
       "storageKey": null
     },
     {
-      "alias": "artworks",
+      "alias": "aggregations",
       "args": [
         {
           "kind": "Literal",
@@ -121,14 +123,14 @@ return {
           ]
         },
         {
-          "kind": "Variable",
-          "name": "input",
-          "variableName": "input"
+          "kind": "Literal",
+          "name": "first",
+          "value": 0
         }
       ],
       "concreteType": "FilterArtworksConnection",
       "kind": "LinkedField",
-      "name": "__ArtistArtworksGrid_artworks_connection",
+      "name": "filterArtworksConnection",
       "plural": false,
       "selections": [
         {
@@ -174,7 +176,24 @@ return {
             }
           ],
           "storageKey": null
-        },
+        }
+      ],
+      "storageKey": "filterArtworksConnection(aggregations:[\"COLOR\",\"DIMENSION_RANGE\",\"LOCATION_CITY\",\"MAJOR_PERIOD\",\"MATERIALS_TERMS\",\"MEDIUM\",\"PARTNER\",\"PRICE_RANGE\"],first:0)"
+    },
+    {
+      "alias": "artworks",
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "input",
+          "variableName": "input"
+        }
+      ],
+      "concreteType": "FilterArtworksConnection",
+      "kind": "LinkedField",
+      "name": "__ArtistArtworksGrid_artworks_connection",
+      "plural": false,
+      "selections": [
         {
           "alias": null,
           "args": null,
@@ -268,5 +287,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = 'c1c6bedae2f8f85aeeca5518db4a4fdb';
+(node as any).hash = 'd75c83cfdcffbddc7d230323b368c5bd';
 export default node;

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -130,10 +130,13 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
   }, [appliedFilters])
 
   useEffect(() => {
-    setAggregationsAction(artworks?.aggregations)
+    setAggregationsAction(artist.aggregations?.aggregations)
 
-    if (searchCriteria && artworks?.aggregations) {
-      const params = convertSavedSearchCriteriaToFilterParams(searchCriteria, artworks.aggregations as Aggregations)
+    if (searchCriteria && artist.aggregations?.aggregations) {
+      const params = convertSavedSearchCriteriaToFilterParams(
+        searchCriteria,
+        artist.aggregations.aggregations as Aggregations
+      )
       const sortFilterItem = ORDERED_ARTWORK_SORTS.find((sortEntity) => sortEntity.paramValue === "-published_at")
 
       setInitialFilterStateAction([...params, sortFilterItem!])
@@ -244,10 +247,8 @@ export default createPaginationContainer(
         slug
         name
         internalID
-        artworks: filterArtworksConnection(
-          first: $count
-          after: $cursor
-          input: $input
+        aggregations: filterArtworksConnection(
+          first: 0
           aggregations: [
             COLOR
             DIMENSION_RANGE
@@ -258,7 +259,7 @@ export default createPaginationContainer(
             PARTNER
             PRICE_RANGE
           ]
-        ) @connection(key: "ArtistArtworksGrid_artworks") {
+        ) {
           aggregations {
             slice
             counts {
@@ -267,6 +268,9 @@ export default createPaginationContainer(
               value
             }
           }
+        }
+        artworks: filterArtworksConnection(first: $count, after: $cursor, input: $input)
+          @connection(key: "ArtistArtworksGrid_artworks") {
           edges {
             node {
               id

--- a/src/lib/Scenes/Artist/SearchCriteria.tsx
+++ b/src/lib/Scenes/Artist/SearchCriteria.tsx
@@ -26,8 +26,9 @@ export const SearchCriteriaQueryRenderer: React.FC<SearchCriteriaQueryRendererPr
   const { renderComponent, renderPlaceholder } = render
   const enableSavedSearch =
     Platform.OS === "ios" ? useFeatureFlag("AREnableSavedSearch") : useFeatureFlag("AREnableSavedSearchAndroid")
+  const enableSavedSearchV2 = useFeatureFlag("AREnableSavedSearchV2")
 
-  if (enableSavedSearch && searchCriteriaId) {
+  if ((enableSavedSearch || enableSavedSearchV2) && searchCriteriaId) {
     return (
       <QueryRenderer<SearchCriteriaQuery>
         environment={environment}

--- a/src/lib/Scenes/SavedSearchAlert/Components/EditSavedSearchAlertPlaceholder.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/Components/EditSavedSearchAlertPlaceholder.tsx
@@ -14,6 +14,10 @@ export const EditSavedSearchFormPlaceholder = () => {
           <PlaceholderText height={40} />
         </Box>
 
+        <Box mb={2} height={40} justifyContent="center" alignItems="center">
+          <PlaceholderText width={100} height={18} />
+        </Box>
+
         {/* Filter pills */}
         <Box mb={2}>
           <PlaceholderText width={50} height={18} />

--- a/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -1,7 +1,8 @@
 import { useFormikContext } from "formik"
 import { Input } from "lib/Components/Input/Input"
 import { InputTitle } from "lib/Components/Input/InputTitle"
-import { Box, Button, Flex, Pill, Spacer } from "palette"
+import { navigate } from "lib/navigation/navigate"
+import { Box, Button, Flex, Pill, Spacer, Text, Touchable } from "palette"
 import React from "react"
 import { getNamePlaceholder } from "../helpers"
 import { SavedSearchAlertFormValues, SavedSearchArtistProp } from "../SavedSearchAlertModel"
@@ -9,11 +10,12 @@ import { SavedSearchAlertFormValues, SavedSearchArtistProp } from "../SavedSearc
 interface FormProps extends SavedSearchArtistProp {
   pills: string[]
   isUpdateForm: boolean
+  savedSearchAlertId?: string
   onDeletePress?: () => void
 }
 
 export const Form: React.FC<FormProps> = (props) => {
-  const { pills, artist, isUpdateForm, onDeletePress } = props
+  const { pills, artist, isUpdateForm, savedSearchAlertId, onDeletePress } = props
   const {
     isSubmitting,
     values,
@@ -39,6 +41,26 @@ export const Form: React.FC<FormProps> = (props) => {
           maxLength={75}
         />
       </Box>
+      {!!savedSearchAlertId && (
+        <Box mb={2} height={40} justifyContent="center" alignItems="center">
+          <Touchable
+            haptic
+            testID="view-artworks-button"
+            hitSlop={{ top: 20, left: 20, right: 20, bottom: 20 }}
+            onPress={() =>
+              navigate(`/artist/${artist.id}`, {
+                passProps: {
+                  searchCriteriaID: savedSearchAlertId,
+                },
+              })
+            }
+          >
+            <Text variant="small" color="blue100" style={{ textDecorationLine: "underline" }}>
+              View Artworks
+            </Text>
+          </Touchable>
+        </Box>
+      )}
       <Box mb={2}>
         <InputTitle>Filters</InputTitle>
         <Flex flexDirection="row" flexWrap="wrap" mt={1} mx={-0.5}>

--- a/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -9,13 +9,12 @@ import { SavedSearchAlertFormValues, SavedSearchArtistProp } from "../SavedSearc
 
 interface FormProps extends SavedSearchArtistProp {
   pills: string[]
-  isUpdateForm: boolean
   savedSearchAlertId?: string
   onDeletePress?: () => void
 }
 
 export const Form: React.FC<FormProps> = (props) => {
-  const { pills, artist, isUpdateForm, savedSearchAlertId, onDeletePress } = props
+  const { pills, artist, savedSearchAlertId, onDeletePress } = props
   const {
     isSubmitting,
     values,
@@ -48,7 +47,7 @@ export const Form: React.FC<FormProps> = (props) => {
             testID="view-artworks-button"
             hitSlop={{ top: 20, left: 20, right: 20, bottom: 20 }}
             onPress={() =>
-              navigate(`/artist/${artist.id}`, {
+              navigate(`artist/${artist.id}`, {
                 passProps: {
                   searchCriteriaID: savedSearchAlertId,
                 },
@@ -74,7 +73,7 @@ export const Form: React.FC<FormProps> = (props) => {
       <Spacer mt={4} />
       <Button
         testID="save-alert-button"
-        disabled={isUpdateForm && !dirty}
+        disabled={!!savedSearchAlertId && !dirty}
         loading={isSubmitting}
         size="large"
         block
@@ -82,7 +81,7 @@ export const Form: React.FC<FormProps> = (props) => {
       >
         Save Alert
       </Button>
-      {!!isUpdateForm && (
+      {!!savedSearchAlertId && (
         <Button
           testID="delete-alert-button"
           variant="secondaryOutline"

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -69,13 +69,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
 
   return (
     <FormikProvider value={formik}>
-      <Form
-        pills={pills}
-        isUpdateForm={isUpdateForm}
-        savedSearchAlertId={savedSearchAlertId}
-        onDeletePress={handleDeletePress}
-        {...other}
-      />
+      <Form pills={pills} savedSearchAlertId={savedSearchAlertId} onDeletePress={handleDeletePress} {...other} />
     </FormikProvider>
   )
 }

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -69,7 +69,13 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
 
   return (
     <FormikProvider value={formik}>
-      <Form pills={pills} isUpdateForm={isUpdateForm} onDeletePress={handleDeletePress} {...other} />
+      <Form
+        pills={pills}
+        isUpdateForm={isUpdateForm}
+        savedSearchAlertId={savedSearchAlertId}
+        onDeletePress={handleDeletePress}
+        {...other}
+      />
     </FormikProvider>
   )
 }

--- a/src/lib/Scenes/SavedSearchAlert/__tests__/EditSavedSearchAlert-tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/__tests__/EditSavedSearchAlert-tests.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, waitFor } from "@testing-library/react-native"
-import { goBack } from "lib/navigation/navigate"
+import { goBack, navigate } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { extractText } from "lib/tests/extractText"
 import { mockEnvironmentPayload } from "lib/tests/mockEnvironmentPayload"
@@ -59,6 +59,28 @@ describe("EditSavedSearchAlert", () => {
     })
 
     expect(goBack).toHaveBeenCalled()
+  })
+
+  it("should navigate to artworks grid when the view artworks is pressed", async () => {
+    const { getByTestId } = renderWithWrappersTL(<TestRenderer />)
+
+    mockEnvironmentPayload(mockEnvironment, {
+      SearchCriteria: () => searchCriteria,
+    })
+    mockEnvironmentPayload(mockEnvironment, {
+      Artist: () => ({
+        internalID: "artistID",
+      }),
+      FilterArtworksConnection: () => filterArtworks,
+    })
+
+    fireEvent.press(getByTestId("view-artworks-button"))
+
+    expect(navigate).toBeCalledWith("artist/artistID", {
+      passProps: {
+        searchCriteriaID: "savedSearchAlertId",
+      },
+    })
   })
 })
 


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3191]

### Description
* As an user with the saved search M2 feature flag enabled,
* After opening a edit saved search alert form
* And if I tap “view artworks“ button,
* I am taken to the artist screen
* And I see the artworks grid with the saved search filters applied

### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/129351066-0f220fd5-2100-451e-9028-b7a8251314ca.mp4

#### Android
https://user-images.githubusercontent.com/3513494/129351096-f8577034-c3cc-43a2-bf23-dcae2c8a78e0.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-  Add “View artworks” button for edit saved search alert screen - dzmitry tratsiak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3191]: https://artsyproduct.atlassian.net/browse/FX-3191