### PR TITLE
chore: standardize ampersands in filter titles

### DIFF
--- a/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -16,7 +16,7 @@ export enum FilterDisplayName {
   materialsTerms = "Material",
   medium = "Medium",
   organizations = "Auction House",
-  partnerIDs = "Galleries and Institutions",
+  partnerIDs = "Galleries & Institutions",
   priceRange = "Price",
   size = "Size",
   sizes = "Size",

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/GalleriesAndInstitutionsOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/GalleriesAndInstitutionsOptions-tests.tsx
@@ -85,7 +85,7 @@ describe("Galleries and Institutions Options Screen", () => {
       const tree = renderWithWrappers(<MockFilterScreen initialState={state} />)
 
       const items = tree.root.findAllByType(FilterModalOptionListItem)
-      const item = items.find((i) => extractText(i).startsWith("Galleries and Institutions"))
+      const item = items.find((i) => extractText(i).startsWith("Galleries & Institutions"))
 
       expect(item).not.toBeUndefined()
       if (item) {


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3196]

### Description

<!-- Implementation description -->

 This PR standardises the use of ampersands in filter names, specifically changing "Galleries **and** Institutions" to "Galleries **&** Institutions"

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes


#### iOS user-facing changes

- "Galleries and Institutions" filter renamed to "Galleries & Institutions" - rquartararo

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

###Screenshots

![Simulator Screen Shot - iPhone 12 Pro - 2021-08-16 at 15 09 51](https://user-images.githubusercontent.com/50849237/129569868-116f3c58-e297-4d57-a21e-c6bf220d01e3.png)



[FX-3196]: https://artsyproduct.atlassian.net/browse/FX-3196