### PR TITLE
fix(viewing room): dont show artwork rail if 0 artworks

### DIFF
--- a/src/__generated__/ViewingRoomQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash a029ad570b605553ac8f2d18794e7062 */
+/* @relayHash 5f4199c1cb0a65502a2288021d0a1f85 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -119,6 +119,9 @@ fragment ViewingRoom_viewingRoom on ViewingRoom {
   slug
   status
   title
+  artworks: artworksConnection(first: 10) {
+    totalCount
+  }
   ...ViewingRoomViewWorksButton_viewingRoom
   ...ViewingRoomSubsections_viewingRoom
   ...ViewingRoomArtworkRail_viewingRoom
@@ -331,70 +334,6 @@ return {
           },
           (v7/*: any*/),
           {
-            "alias": "artworksForCount",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 1
-              }
-            ],
-            "concreteType": "ArtworkConnection",
-            "kind": "LinkedField",
-            "name": "artworksConnection",
-            "plural": false,
-            "selections": [
-              (v8/*: any*/)
-            ],
-            "storageKey": "artworksConnection(first:1)"
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "ViewingRoomSubsection",
-            "kind": "LinkedField",
-            "name": "subsections",
-            "plural": true,
-            "selections": [
-              (v2/*: any*/),
-              (v7/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "caption",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "ARImage",
-                "kind": "LinkedField",
-                "name": "image",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "width",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "height",
-                    "storageKey": null
-                  },
-                  (v9/*: any*/)
-                ],
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
-          },
-          {
             "alias": "artworks",
             "args": [
               {
@@ -493,6 +432,70 @@ return {
             "storageKey": "artworksConnection(first:10)"
           },
           {
+            "alias": "artworksForCount",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 1
+              }
+            ],
+            "concreteType": "ArtworkConnection",
+            "kind": "LinkedField",
+            "name": "artworksConnection",
+            "plural": false,
+            "selections": [
+              (v8/*: any*/)
+            ],
+            "storageKey": "artworksConnection(first:1)"
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ViewingRoomSubsection",
+            "kind": "LinkedField",
+            "name": "subsections",
+            "plural": true,
+            "selections": [
+              (v2/*: any*/),
+              (v7/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "caption",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ARImage",
+                "kind": "LinkedField",
+                "name": "image",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "width",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "height",
+                    "storageKey": null
+                  },
+                  (v9/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
@@ -524,7 +527,7 @@ return {
     ]
   },
   "params": {
-    "id": "a029ad570b605553ac8f2d18794e7062",
+    "id": "5f4199c1cb0a65502a2288021d0a1f85",
     "metadata": {},
     "name": "ViewingRoomQuery",
     "operationKind": "query",

--- a/src/__generated__/ViewingRoomTestsQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 4e04606ba38a03327cd00b5df769c3ff */
+/* @relayHash 895a204ad09fff20ffd6096e38410704 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -115,6 +115,9 @@ fragment ViewingRoom_viewingRoom on ViewingRoom {
   slug
   status
   title
+  artworks: artworksConnection(first: 10) {
+    totalCount
+  }
   ...ViewingRoomViewWorksButton_viewingRoom
   ...ViewingRoomSubsections_viewingRoom
   ...ViewingRoomArtworkRail_viewingRoom
@@ -320,70 +323,6 @@ return {
           },
           (v6/*: any*/),
           {
-            "alias": "artworksForCount",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 1
-              }
-            ],
-            "concreteType": "ArtworkConnection",
-            "kind": "LinkedField",
-            "name": "artworksConnection",
-            "plural": false,
-            "selections": [
-              (v7/*: any*/)
-            ],
-            "storageKey": "artworksConnection(first:1)"
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "ViewingRoomSubsection",
-            "kind": "LinkedField",
-            "name": "subsections",
-            "plural": true,
-            "selections": [
-              (v1/*: any*/),
-              (v6/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "caption",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "ARImage",
-                "kind": "LinkedField",
-                "name": "image",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "width",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "height",
-                    "storageKey": null
-                  },
-                  (v8/*: any*/)
-                ],
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
-          },
-          {
             "alias": "artworks",
             "args": [
               {
@@ -482,6 +421,70 @@ return {
             "storageKey": "artworksConnection(first:10)"
           },
           {
+            "alias": "artworksForCount",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 1
+              }
+            ],
+            "concreteType": "ArtworkConnection",
+            "kind": "LinkedField",
+            "name": "artworksConnection",
+            "plural": false,
+            "selections": [
+              (v7/*: any*/)
+            ],
+            "storageKey": "artworksConnection(first:1)"
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ViewingRoomSubsection",
+            "kind": "LinkedField",
+            "name": "subsections",
+            "plural": true,
+            "selections": [
+              (v1/*: any*/),
+              (v6/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "caption",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ARImage",
+                "kind": "LinkedField",
+                "name": "image",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "width",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "height",
+                    "storageKey": null
+                  },
+                  (v8/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
@@ -513,7 +516,7 @@ return {
     ]
   },
   "params": {
-    "id": "4e04606ba38a03327cd00b5df769c3ff",
+    "id": "895a204ad09fff20ffd6096e38410704",
     "metadata": {},
     "name": "ViewingRoomTestsQuery",
     "operationKind": "query",

--- a/src/__generated__/ViewingRoom_viewingRoom.graphql.ts
+++ b/src/__generated__/ViewingRoom_viewingRoom.graphql.ts
@@ -16,6 +16,9 @@ export type ViewingRoom_viewingRoom = {
     readonly slug: string;
     readonly status: string;
     readonly title: string;
+    readonly artworks: {
+        readonly totalCount: number | null;
+    } | null;
     readonly " $fragmentRefs": FragmentRefs<"ViewingRoomViewWorksButton_viewingRoom" | "ViewingRoomSubsections_viewingRoom" | "ViewingRoomArtworkRail_viewingRoom" | "ViewingRoomHeader_viewingRoom">;
     readonly " $refType": "ViewingRoom_viewingRoom";
 };
@@ -108,6 +111,30 @@ const node: ReaderFragment = {
       "storageKey": null
     },
     {
+      "alias": "artworks",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 10
+        }
+      ],
+      "concreteType": "ArtworkConnection",
+      "kind": "LinkedField",
+      "name": "artworksConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "totalCount",
+          "storageKey": null
+        }
+      ],
+      "storageKey": "artworksConnection(first:10)"
+    },
+    {
       "args": null,
       "kind": "FragmentSpread",
       "name": "ViewingRoomViewWorksButton_viewingRoom"
@@ -131,5 +158,5 @@ const node: ReaderFragment = {
   "type": "ViewingRoom",
   "abstractKey": null
 };
-(node as any).hash = 'df57f83b52fa8a39e1e6cdfd48be20fb';
+(node as any).hash = '2868de706326992d349d98839e9e0e85';
 export default node;

--- a/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
+++ b/src/lib/Scenes/ViewingRoom/ViewingRoom.tsx
@@ -85,21 +85,23 @@ export const ViewingRoom: React.FC<ViewingRoomProps> = (props) => {
       content: <ClosedNotice status={viewingRoom.status} partnerHref={viewingRoom.partner!.href!} />,
     })
   } else if (viewingRoom.status === ViewingRoomStatus.LIVE) {
-    sections.push(
-      {
-        key: "introStatement",
-        content: (
-          <Flex mt="2" mx="2">
-            <Text data-test-id="intro-statement" mt="2" variant="text" mx="2" style={maxWidth}>
-              {viewingRoom.introStatement}
-            </Text>
-          </Flex>
-        ),
-      },
-      {
+    sections.push({
+      key: "introStatement",
+      content: (
+        <Flex mt="2" mx="2">
+          <Text data-test-id="intro-statement" mt="2" variant="text" mx="2" style={maxWidth}>
+            {viewingRoom.introStatement}
+          </Text>
+        </Flex>
+      ),
+    })
+    if ((viewingRoom.artworks?.totalCount ?? 0) > 0) {
+      sections.push({
         key: "artworkRail",
         content: <ViewingRoomArtworkRailContainer viewingRoom={viewingRoom} />,
-      },
+      })
+    }
+    sections.push(
       {
         key: "pullQuote",
         content: (
@@ -221,6 +223,9 @@ export const ViewingRoomFragmentContainer = createFragmentContainer(ViewingRoom,
       slug
       status
       title
+      artworks: artworksConnection(first: 10) {
+        totalCount
+      }
       ...ViewingRoomViewWorksButton_viewingRoom
       ...ViewingRoomSubsections_viewingRoom
       ...ViewingRoomArtworkRail_viewingRoom


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves []

### Description

This came from https://artsy.slack.com/archives/C020VBMEJC8/p1629034697186700 and the message above.

It just feels wrong.

before
<img width="373" alt="Screenshot 2021-08-16 at 20 43 07" src="https://user-images.githubusercontent.com/100233/129620510-71fcce27-9297-449f-ba1a-b72caca23998.png">


after
<img width="387" alt="Screenshot 2021-08-16 at 20 42 10" src="https://user-images.githubusercontent.com/100233/129620464-df97a26b-9ece-4542-a1cd-8c1918823a23.png">


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- remove viewing room artworks rail if 0 artworks - pavlos

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>
