### PR TITLE
feat: Track separate event for auction screen view GRO-363

### DIFF
--- a/src/lib/Scenes/Sale/Sale.tsx
+++ b/src/lib/Scenes/Sale/Sale.tsx
@@ -237,6 +237,12 @@ export const tracks = {
       context_screen_owner_slug: slug,
     }
   },
+  pageView: (slug: string) => {
+    return {
+      auction_slug: slug,
+      name: "Auctions Pageview",
+    }
+  },
   openFilter: (id: string, slug: string) => {
     return {
       action_name: "filter",
@@ -328,6 +334,12 @@ export const SaleQueryRenderer: React.FC<{ saleID: string; environment?: RelayMo
   saleID,
   environment,
 }) => {
+  const { trackEvent } = useTracking()
+
+  useEffect(() => {
+    trackEvent(tracks.pageView(saleID))
+  }, [])
+
   return (
     <RetryErrorBoundary
       render={({ isRetry }) => {


### PR DESCRIPTION
This is likely the wrong way to do this because it's not using Cohesion, but what I'm trying to match is this event in Force:

https://github.com/artsy/force/blob/master/src/lib/analytics/trackPageView.ts#L52

https://artsyproduct.atlassian.net/browse/GRO-363

/cc @artsy/grow-devs