### PR TITLE
feat(FX-3202): add analytic events for saved search M2

### DIFF
--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -112,8 +112,6 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
   const artworks = artist.artworks
   const artworksCount = artworks?.edges?.length
   const artworksTotal = artworks?.counts?.total ?? 0
-  const artistName = artist.name
-  const artistInternalId = artist.internalID
 
   useEffect(() => {
     if (applyFilters) {
@@ -177,12 +175,12 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
             {!!enableSavedSearchV2 ? (
               <SavedSearchButtonQueryRenderer
                 filters={appliedFilters as FilterData[]}
-                artist={{ id: artistInternalId, name: artistName! }}
+                artist={{ id: artist.internalID, name: artist.name!, slug: artist.slug }}
                 aggregations={aggregations}
               />
             ) : (
               <SavedSearchBannerQueryRender
-                artistId={artistInternalId}
+                artistId={artist.internalID}
                 filters={filterParams}
                 artistSlug={artist.slug}
               />
@@ -194,16 +192,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
         <Separator />
       </Box>
     )
-  }, [
-    artworksTotal,
-    artistName,
-    artistInternalId,
-    filterParams,
-    enableSavedSearch,
-    enableSavedSearchV2,
-    appliedFilters,
-    aggregations,
-  ])
+  }, [artworksTotal, filterParams, enableSavedSearch, enableSavedSearchV2, appliedFilters, aggregations])
 
   const filteredArtworks = () => {
     if (artworksCount === 0) {

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -175,7 +175,9 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
             {!!enableSavedSearchV2 ? (
               <SavedSearchButtonQueryRenderer
                 filters={appliedFilters as FilterData[]}
-                artist={{ id: artist.internalID, name: artist.name!, slug: artist.slug }}
+                artistId={artist.internalID}
+                artistName={artist.name!}
+                artistSlug={artist.slug}
                 aggregations={aggregations}
               />
             ) : (

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
@@ -22,12 +22,19 @@ interface SavedSearchButtonProps extends SavedSearchAlertFormPropsBase {
   loading?: boolean
   relay: RelayRefetchProp
   criteria: SearchCriteriaAttributes
+  artistSlug: string
+}
+
+interface SavedSearchButtonQueryRendererProps extends SavedSearchAlertFormPropsBase {
+  artistSlug: string
 }
 
 export const SavedSearchButton: React.FC<SavedSearchButtonProps> = ({
   me,
   loading,
-  artist,
+  artistId,
+  artistName,
+  artistSlug,
   filters,
   aggregations,
   relay,
@@ -71,7 +78,7 @@ export const SavedSearchButton: React.FC<SavedSearchButtonProps> = ({
 
   const handleCreateAlertPress = () => {
     handleOpenForm()
-    tracking.trackEvent(tracks.tappedCreateAlert(artist.id, artist.slug))
+    tracking.trackEvent(tracks.tappedCreateAlert(artistId, artistSlug))
   }
 
   return (
@@ -89,7 +96,8 @@ export const SavedSearchButton: React.FC<SavedSearchButtonProps> = ({
         Create Alert
       </Button>
       <CreateSavedSearchAlert
-        artist={artist}
+        artistId={artistId}
+        artistName={artistName}
         visible={visibleForm}
         onClosePress={handleCloseForm}
         onComplete={handleComplete}
@@ -120,11 +128,11 @@ export const SavedSearchButtonRefetchContainer = createRefetchContainer(
   `
 )
 
-export const SavedSearchButtonQueryRenderer: React.FC<SavedSearchAlertFormPropsBase> = (props) => {
-  const { filters, artist } = props
+export const SavedSearchButtonQueryRenderer: React.FC<SavedSearchButtonQueryRendererProps> = (props) => {
+  const { filters, artistId } = props
   const allowedFilters = getAllowedFiltersForSavedSearchInput(filters)
   const isEmptyCriteria = allowedFilters.length === 0
-  const criteria = getSearchCriteriaFromFilters(artist.id, filters)
+  const criteria = getSearchCriteriaFromFilters(artistId, filters)
 
   if (isEmptyCriteria) {
     return <SavedSearchButtonRefetchContainer {...props} me={null} loading={false} criteria={criteria} filters={[]} />

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
@@ -1,3 +1,4 @@
+import { ActionType, OwnerType, TappedCreateAlert } from "@artsy/cohesion"
 import { captureMessage } from "@sentry/react-native"
 import { SavedSearchButton_me } from "__generated__/SavedSearchButton_me.graphql"
 import { SavedSearchButtonQuery } from "__generated__/SavedSearchButtonQuery.graphql"
@@ -14,6 +15,7 @@ import { SavedSearchAlertFormPropsBase } from "lib/Scenes/SavedSearchAlert/Saved
 import { BellIcon, Box, Button } from "palette"
 import React, { useState } from "react"
 import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
+import { useTracking } from "react-tracking"
 
 interface SavedSearchButtonProps extends SavedSearchAlertFormPropsBase {
   me?: SavedSearchButton_me | null
@@ -31,6 +33,7 @@ export const SavedSearchButton: React.FC<SavedSearchButtonProps> = ({
   relay,
   criteria,
 }) => {
+  const tracking = useTracking()
   const [visibleForm, setVisibleForm] = useState(false)
   const [refetching, setRefetching] = useState(false)
   const popover = usePopoverMessage()
@@ -66,6 +69,11 @@ export const SavedSearchButton: React.FC<SavedSearchButtonProps> = ({
     })
   }
 
+  const handleCreateAlertPress = () => {
+    handleOpenForm()
+    tracking.trackEvent(tracks.tappedCreateAlert(artist.id, artist.slug))
+  }
+
   return (
     <Box>
       <Button
@@ -74,7 +82,7 @@ export const SavedSearchButton: React.FC<SavedSearchButtonProps> = ({
         icon={<BellIcon fill="white100" mr={0.5} width="16px" height="16px" />}
         disabled={isSavedSearch || filters.length === 0}
         loading={loading || refetching}
-        onPress={handleOpenForm}
+        onPress={handleCreateAlertPress}
         testID="create-saved-search-button"
         haptic
       >
@@ -156,4 +164,13 @@ export const SavedSearchButtonQueryRenderer: React.FC<SavedSearchAlertFormPropsB
       }}
     />
   )
+}
+
+export const tracks = {
+  tappedCreateAlert: (artistId: string, artistSlug: string): TappedCreateAlert => ({
+    action: ActionType.tappedCreateAlert,
+    context_screen_owner_type: OwnerType.artist,
+    context_screen_owner_id: artistId,
+    context_screen_owner_slug: artistSlug,
+  }),
 }

--- a/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchButton-tests.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchButton-tests.tsx
@@ -10,8 +10,9 @@ import { Button } from "palette"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { act } from "react-test-renderer"
+import { useTracking } from "react-tracking"
 import { createMockEnvironment } from "relay-test-utils"
-import { SavedSearchButtonRefetchContainer as SavedSearchButton } from "../SavedSearchButton"
+import { SavedSearchButtonRefetchContainer as SavedSearchButton, tracks } from "../SavedSearchButton"
 
 jest.unmock("react-relay")
 
@@ -29,9 +30,19 @@ const mockedFilters = [
 
 describe("SavedSearchButton", () => {
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
+  const trackEvent = jest.fn()
 
   beforeEach(() => {
     mockEnvironment = createMockEnvironment()
+    ;(useTracking as jest.Mock).mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
+  })
+
+  afterEach(() => {
+    trackEvent.mockClear()
   })
 
   const TestRenderer = ({ attributes = mockedAttributes }) => {
@@ -55,6 +66,7 @@ describe("SavedSearchButton", () => {
             artist={{
               id: "artistID",
               name: "artistName",
+              slug: "artistSlug",
             }}
           />
         )}
@@ -109,6 +121,20 @@ describe("SavedSearchButton", () => {
     act(() => tree.root.findByType(Button).props.onPress())
 
     expect(tree.root.findByType(CreateSavedSearchAlert).props.visible).toBeTruthy()
+  })
+
+  it("tracks clicks when the create alert button is pressed", () => {
+    const tree = renderWithWrappers(<TestRenderer />)
+
+    mockEnvironmentPayload(mockEnvironment, {
+      Me: () => ({
+        savedSearch: null,
+      }),
+    })
+
+    act(() => tree.root.findByType(Button).props.onPress())
+
+    expect(trackEvent).toHaveBeenCalledWith(tracks.tappedCreateAlert("artistID", "artistSlug"))
   })
 
   it("should navigate to the saved search alerts list when popover is pressed", async () => {

--- a/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchButton-tests.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchButton-tests.tsx
@@ -63,11 +63,9 @@ describe("SavedSearchButton", () => {
             filters={mockedFilters}
             criteria={attributes}
             aggregations={[]}
-            artist={{
-              id: "artistID",
-              name: "artistName",
-              slug: "artistSlug",
-            }}
+            artistId="artistID"
+            artistName="artistName"
+            artistSlug="artistSlug"
           />
         )}
         variables={{

--- a/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -5,17 +5,19 @@ import { navigate } from "lib/navigation/navigate"
 import { Box, Button, Flex, Pill, Spacer, Text, Touchable } from "palette"
 import React from "react"
 import { getNamePlaceholder } from "../helpers"
-import { SavedSearchAlertFormValues, SavedSearchArtistProp } from "../SavedSearchAlertModel"
+import { SavedSearchAlertFormValues } from "../SavedSearchAlertModel"
 
-interface FormProps extends SavedSearchArtistProp {
+interface FormProps {
   pills: string[]
   savedSearchAlertId?: string
+  artistId: string
+  artistName: string
   onDeletePress?: () => void
   onSubmitPress?: () => void
 }
 
 export const Form: React.FC<FormProps> = (props) => {
-  const { pills, artist, savedSearchAlertId, onDeletePress, onSubmitPress } = props
+  const { pills, artistId, artistName, savedSearchAlertId, onDeletePress, onSubmitPress } = props
   const {
     isSubmitting,
     values,
@@ -24,7 +26,7 @@ export const Form: React.FC<FormProps> = (props) => {
     handleBlur,
     handleChange,
   } = useFormikContext<SavedSearchAlertFormValues>()
-  const namePlaceholder = getNamePlaceholder(artist.name, pills)
+  const namePlaceholder = getNamePlaceholder(artistName, pills)
 
   return (
     <Box>
@@ -47,7 +49,7 @@ export const Form: React.FC<FormProps> = (props) => {
             testID="view-artworks-button"
             hitSlop={{ top: 20, left: 20, right: 20, bottom: 20 }}
             onPress={() =>
-              navigate(`artist/${artist.id}`, {
+              navigate(`artist/${artistId}`, {
                 passProps: {
                   searchCriteriaID: savedSearchAlertId,
                 },

--- a/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
@@ -1,3 +1,4 @@
+import { OwnerType } from "@artsy/cohesion"
 import { EditSavedSearchAlert_artist } from "__generated__/EditSavedSearchAlert_artist.graphql"
 import { EditSavedSearchAlert_artworksConnection } from "__generated__/EditSavedSearchAlert_artworksConnection.graphql"
 import { EditSavedSearchAlertQuery } from "__generated__/EditSavedSearchAlertQuery.graphql"
@@ -10,6 +11,7 @@ import { PageWithSimpleHeader } from "lib/Components/PageWithSimpleHeader"
 import { goBack } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
+import { ProvideScreenTracking, Schema } from "lib/utils/track"
 import { useTheme } from "palette"
 import React from "react"
 import { ScrollView } from "react-native"
@@ -44,26 +46,34 @@ export const EditSavedSearchAlert: React.FC<EditSavedSearchAlertProps> = (props)
   }
 
   return (
-    <ArtsyKeyboardAvoidingView>
-      <PageWithSimpleHeader title="Edit your Alert">
-        <ScrollView
-          keyboardDismissMode="on-drag"
-          keyboardShouldPersistTaps="handled"
-          contentContainerStyle={{ padding: space(2) }}
-        >
-          <SavedSearchAlertForm
-            initialValues={{ name: userAlertSettings?.name ?? "" }}
-            artistId={artist.internalID}
-            artistName={artist.name!}
-            filters={filters}
-            aggregations={aggregations}
-            savedSearchAlertId={savedSearchAlertId}
-            onComplete={onComplete}
-            onDeleteComplete={onComplete}
-          />
-        </ScrollView>
-      </PageWithSimpleHeader>
-    </ArtsyKeyboardAvoidingView>
+    <ProvideScreenTracking
+      info={{
+        context_screen: Schema.PageNames.SavedSearchEdit,
+        context_screen_owner_id: savedSearchAlertId,
+        context_screen_owner_type: OwnerType.savedSearch,
+      }}
+    >
+      <ArtsyKeyboardAvoidingView>
+        <PageWithSimpleHeader title="Edit your Alert">
+          <ScrollView
+            keyboardDismissMode="on-drag"
+            keyboardShouldPersistTaps="handled"
+            contentContainerStyle={{ padding: space(2) }}
+          >
+            <SavedSearchAlertForm
+              initialValues={{ name: userAlertSettings?.name ?? "" }}
+              artistId={artist.internalID}
+              artistName={artist.name!}
+              filters={filters}
+              aggregations={aggregations}
+              savedSearchAlertId={savedSearchAlertId}
+              onComplete={onComplete}
+              onDeleteComplete={onComplete}
+            />
+          </ScrollView>
+        </PageWithSimpleHeader>
+      </ArtsyKeyboardAvoidingView>
+    </ProvideScreenTracking>
   )
 }
 

--- a/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
@@ -53,7 +53,8 @@ export const EditSavedSearchAlert: React.FC<EditSavedSearchAlertProps> = (props)
         >
           <SavedSearchAlertForm
             initialValues={{ name: userAlertSettings?.name ?? "" }}
-            artist={{ name: artist.name!, id: artist.internalID }}
+            artistId={artist.internalID}
+            artistName={artist.name!}
             filters={filters}
             aggregations={aggregations}
             savedSearchAlertId={savedSearchAlertId}

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -49,8 +49,8 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
 
       try {
         if (isUpdateForm) {
-          tracking.trackEvent(tracks.editedSavedSearch(artistId, initialValues, values))
           await updateSavedSearchAlert(alertName, savedSearchAlertId!)
+          tracking.trackEvent(tracks.editedSavedSearch(artistId, initialValues, values))
         } else {
           const criteria = getSearchCriteriaFromFilters(artistId, filters)
           await createSavedSearchAlert(alertName, criteria)
@@ -133,6 +133,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
   const onDelete = async () => {
     try {
       await deleteSavedSearchMutation(savedSearchAlertId!)
+      tracking.trackEvent(tracks.deletedSavedSearch(artistId))
       onDeleteComplete?.()
     } catch (error) {
       console.error(error)
@@ -148,7 +149,6 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
         { text: "Delete", style: "destructive", onPress: onDelete },
       ]
     )
-    tracking.trackEvent(tracks.deletedSavedSearch(artistId))
   }
 
   return (

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -23,7 +23,17 @@ export interface SavedSearchAlertFormProps extends SavedSearchAlertFormPropsBase
 }
 
 export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props) => {
-  const { filters, aggregations, initialValues, savedSearchAlertId, onComplete, onDeleteComplete, ...other } = props
+  const {
+    filters,
+    aggregations,
+    initialValues,
+    savedSearchAlertId,
+    artistId,
+    artistName,
+    onComplete,
+    onDeleteComplete,
+    ...other
+  } = props
   const isUpdateForm = !!savedSearchAlertId
   const pills = extractPills(filters, aggregations)
   const tracking = useTracking()
@@ -34,15 +44,15 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
       let alertName = values.name
 
       if (alertName.length === 0) {
-        alertName = getNamePlaceholder(props.artist.name, pills)
+        alertName = getNamePlaceholder(artistName, pills)
       }
 
       try {
         if (isUpdateForm) {
-          tracking.trackEvent(tracks.editedSavedSearch(props.artist.id, initialValues, values))
+          tracking.trackEvent(tracks.editedSavedSearch(artistId, initialValues, values))
           await updateSavedSearchAlert(alertName, savedSearchAlertId!)
         } else {
-          const criteria = getSearchCriteriaFromFilters(props.artist.id, filters)
+          const criteria = getSearchCriteriaFromFilters(artistId, filters)
           await createSavedSearchAlert(alertName, criteria)
         }
 
@@ -138,7 +148,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
         { text: "Delete", style: "destructive", onPress: onDelete },
       ]
     )
-    tracking.trackEvent(tracks.deletedSavedSearch(props.artist.id))
+    tracking.trackEvent(tracks.deletedSavedSearch(artistId))
   }
 
   return (
@@ -146,6 +156,8 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
       <Form
         pills={pills}
         savedSearchAlertId={savedSearchAlertId}
+        artistId={artistId}
+        artistName={artistName}
         onDeletePress={handleDeletePress}
         onSubmitPress={handleSubmit}
         {...other}

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -50,7 +50,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
       try {
         if (isUpdateForm) {
           await updateSavedSearchAlert(alertName, savedSearchAlertId!)
-          tracking.trackEvent(tracks.editedSavedSearch(artistId, initialValues, values))
+          tracking.trackEvent(tracks.editedSavedSearch(savedSearchAlertId!, initialValues, values))
         } else {
           const criteria = getSearchCriteriaFromFilters(artistId, filters)
           await createSavedSearchAlert(alertName, criteria)
@@ -133,7 +133,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
   const onDelete = async () => {
     try {
       await deleteSavedSearchMutation(savedSearchAlertId!)
-      tracking.trackEvent(tracks.deletedSavedSearch(artistId))
+      tracking.trackEvent(tracks.deletedSavedSearch(savedSearchAlertId!))
       onDeleteComplete?.()
     } catch (error) {
       console.error(error)
@@ -167,19 +167,19 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
 }
 
 export const tracks = {
-  deletedSavedSearch: (artistId: string): DeletedSavedSearch => ({
+  deletedSavedSearch: (savedSearchAlertId: string): DeletedSavedSearch => ({
     action: ActionType.deletedSavedSearch,
-    context_screen_owner_type: OwnerType.artist,
-    context_screen_owner_id: artistId,
+    context_screen_owner_type: OwnerType.savedSearch,
+    context_screen_owner_id: savedSearchAlertId,
   }),
   editedSavedSearch: (
-    artistId: string,
+    savedSearchAlertId: string,
     currentValues: SavedSearchAlertFormValues,
     modifiesValues: SavedSearchAlertFormValues
   ): EditedSavedSearch => ({
     action: ActionType.editedSavedSearch,
-    context_screen_owner_type: OwnerType.artist,
-    context_screen_owner_id: artistId,
+    context_screen_owner_type: OwnerType.savedSearch,
+    context_screen_owner_id: savedSearchAlertId,
     current: JSON.stringify(currentValues),
     changed: JSON.stringify(modifiesValues),
   }),

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
@@ -4,15 +4,9 @@ export interface SavedSearchAlertFormValues {
   name: string
 }
 
-export interface SavedSearchArtistProp {
-  artist: {
-    id: string
-    name: string
-    slug: string
-  }
-}
-
-export interface SavedSearchAlertFormPropsBase extends SavedSearchArtistProp {
+export interface SavedSearchAlertFormPropsBase {
   filters: FilterData[]
   aggregations: Aggregations
+  artistId: string
+  artistName: string
 }

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
@@ -8,6 +8,7 @@ export interface SavedSearchArtistProp {
   artist: {
     id: string
     name: string
+    slug: string
   }
 }
 

--- a/src/lib/Scenes/SavedSearchAlert/__tests__/CreateSavedSearchAlert-tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/__tests__/CreateSavedSearchAlert-tests.tsx
@@ -22,10 +22,8 @@ const defaultProps: CreateSavedSearchAlertProps = {
     },
   ],
   aggregations: [],
-  artist: {
-    id: "artistID",
-    name: "artistName",
-  },
+  artistId: "artistID",
+  artistName: "artistName",
   onComplete: jest.fn(),
   onClosePress: jest.fn(),
 }

--- a/src/lib/Scenes/SavedSearchAlert/__tests__/SavedSearchAlertForm-tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/__tests__/SavedSearchAlertForm-tests.tsx
@@ -96,10 +96,12 @@ describe("Saved search alert form", () => {
     fireEvent.press(getByTestId("save-alert-button"))
 
     await waitFor(() => {
-      expect(trackEvent).toHaveBeenCalledWith(
-        tracks.editedSavedSearch("artistID", { name: "" }, { name: "something new" })
-      )
+      mockEnvironmentPayload(mockEnvironment)
     })
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      tracks.editedSavedSearch("artistID", { name: "" }, { name: "something new" })
+    )
   })
 
   it("calls create mutation when form is submitted", async () => {
@@ -193,6 +195,13 @@ describe("Saved search alert form", () => {
     )
 
     fireEvent.press(getByTestId("delete-alert-button"))
+
+    // @ts-ignore
+    spyAlert.mock.calls[0][2][1].onPress()
+
+    await waitFor(() => {
+      mockEnvironmentPayload(mockEnvironment)
+    })
 
     expect(trackEvent).toHaveBeenCalledWith(tracks.deletedSavedSearch("artistID"))
   })

--- a/src/lib/Scenes/SavedSearchAlert/__tests__/SavedSearchAlertForm-tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/__tests__/SavedSearchAlertForm-tests.tsx
@@ -100,7 +100,7 @@ describe("Saved search alert form", () => {
     })
 
     expect(trackEvent).toHaveBeenCalledWith(
-      tracks.editedSavedSearch("artistID", { name: "" }, { name: "something new" })
+      tracks.editedSavedSearch("savedSearchAlertId", { name: "" }, { name: "something new" })
     )
   })
 
@@ -203,7 +203,7 @@ describe("Saved search alert form", () => {
       mockEnvironmentPayload(mockEnvironment)
     })
 
-    expect(trackEvent).toHaveBeenCalledWith(tracks.deletedSavedSearch("artistID"))
+    expect(trackEvent).toHaveBeenCalledWith(tracks.deletedSavedSearch("savedSearchAlertId"))
   })
 
   it("should auto populate alert name for the create mutation", async () => {

--- a/src/lib/Scenes/SavedSearchAlert/__tests__/SavedSearchAlertForm-tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/__tests__/SavedSearchAlertForm-tests.tsx
@@ -319,9 +319,6 @@ const baseProps: SavedSearchAlertFormProps = {
   },
   filters,
   aggregations,
-  artist: {
-    id: "artistID",
-    name: "artistName",
-    slug: "artistSlug",
-  },
+  artistId: "artistID",
+  artistName: "artistName",
 }

--- a/src/lib/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tsx
+++ b/src/lib/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tsx
@@ -1,8 +1,10 @@
+import { OwnerType } from "@artsy/cohesion"
 import { SavedSearchesList_me } from "__generated__/SavedSearchesList_me.graphql"
 import { SAVED_SERCHES_PAGE_SIZE } from "lib/data/constants"
 import { navigate, navigationEvents } from "lib/navigation/navigate"
 import { extractNodes } from "lib/utils/extractNodes"
 import { ProvidePlaceholderContext } from "lib/utils/placeholders"
+import { ProvideScreenTracking, Schema } from "lib/utils/track"
 import { Flex, Spinner, useTheme } from "palette"
 import React, { useEffect, useRef, useState } from "react"
 import { FlatList } from "react-native"
@@ -93,8 +95,21 @@ export const SavedSearchesList: React.FC<SavedSearchesListProps> = (props) => {
   )
 }
 
+export const SavedSearchesListWrapper: React.FC<SavedSearchesListProps> = (props) => {
+  return (
+    <ProvideScreenTracking
+      info={{
+        context_screen: Schema.PageNames.SavedSearchList,
+        context_screen_owner_type: OwnerType.savedSearch,
+      }}
+    >
+      <SavedSearchesList {...props} />
+    </ProvideScreenTracking>
+  )
+}
+
 export const SavedSearchesListContainer = createPaginationContainer(
-  SavedSearchesList,
+  SavedSearchesListWrapper,
   {
     me: graphql`
       fragment SavedSearchesList_me on Me

--- a/src/lib/utils/track/schema.ts
+++ b/src/lib/utils/track/schema.ts
@@ -138,6 +138,7 @@ export enum PageNames {
   ShowPage = "Show",
   ShowMoreInfoPage = "moreInfo",
   SavedSearchEdit = "SavedSearchEdit",
+  SavedSearchList = "SavedSearchList",
 }
 
 export enum OwnerEntityTypes {

--- a/src/lib/utils/track/schema.ts
+++ b/src/lib/utils/track/schema.ts
@@ -137,6 +137,7 @@ export enum PageNames {
   FairMoreInfoPage = "Fair",
   ShowPage = "Show",
   ShowMoreInfoPage = "moreInfo",
+  SavedSearchEdit = "SavedSearchEdit",
 }
 
 export enum OwnerEntityTypes {


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3202]

### Description
#### Criteria:
* `tappedCreateAlert` → initial tap to record the interest/intent
* `editedSavedSearch` → when the edit action is performed
* `deletedSavedSearch` → when the delete action is performed
* `SavedSearchEdit` → User views a Saved Search Edit screen
* `SavedSearchList` → User views the Saved Search List view

Add support for the following events:
* `editedSavedSearch`
* `deletedSavedSearch`
* `tappedCreateAlert`
* `SavedSearchEdit`
* `SavedSearchList`

### Demo
<img width="577" alt="Screenshot 2021-08-18 at 14 01 49" src="https://user-images.githubusercontent.com/3513494/129941474-81efb5b6-356a-402e-94a3-7b427c2a5ceb.png">

<img width="688" alt="Screenshot 2021-08-19 at 16 34 53" src="https://user-images.githubusercontent.com/3513494/130078037-e2440bd7-4845-4367-b7d9-c1dea300afcf.png">

<img width="676" alt="Screenshot 2021-08-19 at 16 35 07" src="https://user-images.githubusercontent.com/3513494/130078049-134e8ee5-1e91-4619-a5c5-59b66663aa5e.png">

<img width="697" alt="Screenshot 2021-08-20 at 19 07 52" src="https://user-images.githubusercontent.com/3513494/130262126-d8c1504a-39ac-4871-85d4-f5e90bd17b8c.png">

<img width="456" alt="Screenshot 2021-08-20 at 19 43 34" src="https://user-images.githubusercontent.com/3513494/130266450-c3f7bdc6-199d-446c-8fbd-0f39e3c3c352.png">

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Add analytics for saved search M2 - dzmitry tratsiak

<!-- end_changelog_updates -->

</details>


[FX-3202]: https://artsyproduct.atlassian.net/browse/FX-3202