### PR TITLE
fix: artwork filter helpers increment and "All" issue 

### DIFF
--- a/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -1,5 +1,6 @@
 import { FilterScreen } from "lib/Components/ArtworkFilter"
 import { capitalize, compact, groupBy, isEqual, isUndefined, pick, pickBy, sortBy } from "lodash"
+import { isEmpty } from "lodash"
 import { LOCALIZED_UNIT } from "./Filters/helpers"
 
 export enum FilterDisplayName {
@@ -415,7 +416,9 @@ export const selectedOption = ({
     }
 
     return waysToBuyOptions.join(", ")
-  } else if (filterScreen === "artistIDs") {
+  }
+
+  if (filterScreen === "artistIDs") {
     const hasArtistsIFollowChecked = !!selectedOptions.find(({ paramName, paramValue }) => {
       return paramName === FilterParamName.artistsIFollow && paramValue === true
     })
@@ -438,7 +441,8 @@ export const selectedOption = ({
       }
     } else {
       selectedArtistNames = selectedOptions
-        .filter((filter) => filter.paramName === FilterParamName.artistIDs)
+        // Filtering out paramValue with an empty array to remove delfault option "All"
+        .filter((filter) => filter.paramName === FilterParamName.artistIDs && !isEmpty(filter.paramValue))
         .map(({ displayText }) => displayText)
     }
 

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -441,7 +441,7 @@ export const selectedOption = ({
       }
     } else {
       selectedArtistNames = selectedOptions
-        // Filtering out paramValue with an empty array to remove delfault option "All"
+        // Filtering out paramValue with an empty array to remove default option "All"
         .filter((filter) => filter.paramName === FilterParamName.artistIDs && !isEmpty(filter.paramValue))
         .map(({ displayText }) => displayText)
     }


### PR DESCRIPTION
Co-authored-by: George Kartalis <g.kartalis7@gmail.com>

The type of this PR is: **fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-2936] and [FX-3199]

### Description

This PR fixes the "All" showing up in the filter helpers and the incrementing issue when selected more than one Artist. Eg. when only one artist was selected the helper would show "Selected Artist, 1 more". 

Note: This was a quick fix, however the artwork filter helpers and filter selection logic does eventually need to be refactored as defined here: [FX-3205]

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- The artwork filter helpers increment and "All" issue has been fixed -rquartararo 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-2936]: https://artsyproduct.atlassian.net/browse/FX-2936
[FX-3199]: https://artsyproduct.atlassian.net/browse/FX-3199
[FX-3205]: https://artsyproduct.atlassian.net/browse/FX-3205