### PR TITLE
feat(FX-3214): apply custom Dialog for confirm saved search delete

### DIFF
--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -3,7 +3,8 @@ import { FormikProvider, useFormik } from "formik"
 import { getSearchCriteriaFromFilters } from "lib/Components/ArtworkFilter/SavedSearch/searchCriteriaHelpers"
 import { LegacyNativeModules } from "lib/NativeModules/LegacyNativeModules"
 import { getNotificationPermissionsStatus, PushAuthorizationStatus } from "lib/utils/PushNotification"
-import React from "react"
+import { Dialog } from "palette"
+import React, { useState } from "react"
 import { Alert, AlertButton, Linking, Platform } from "react-native"
 import { useTracking } from "react-tracking"
 import { Form } from "./Components/Form"
@@ -37,6 +38,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
   const isUpdateForm = !!savedSearchAlertId
   const pills = extractPills(filters, aggregations)
   const tracking = useTracking()
+  const [visibleDeleteDialog, setVisibleDeleteDialog] = useState(false)
   const formik = useFormik<SavedSearchAlertFormValues>({
     initialValues,
     initialErrors: {},
@@ -141,14 +143,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
   }
 
   const handleDeletePress = () => {
-    Alert.alert(
-      "Delete Alert",
-      "Once you delete this alert, you will have to recreate it to continue receiving alerts on your favorite artworks.",
-      [
-        { text: "Cancel", style: "cancel" },
-        { text: "Delete", style: "destructive", onPress: onDelete },
-      ]
-    )
+    setVisibleDeleteDialog(true)
   }
 
   return (
@@ -162,6 +157,26 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
         onSubmitPress={handleSubmit}
         {...other}
       />
+      {!!savedSearchAlertId && (
+        <Dialog
+          isVisible={visibleDeleteDialog}
+          title="Delete Alert"
+          detail="Once deleted, you will no longer receive notifications for these filter criteria."
+          primaryCta={{
+            text: "Delete",
+            onPress: () => {
+              onDelete()
+              setVisibleDeleteDialog(false)
+            },
+          }}
+          secondaryCta={{
+            text: "Cancel",
+            onPress: () => {
+              setVisibleDeleteDialog(false)
+            },
+          }}
+        />
+      )}
     </FormikProvider>
   )
 }

--- a/src/lib/Scenes/SavedSearchAlert/__tests__/SavedSearchAlertForm-tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/__tests__/SavedSearchAlertForm-tests.tsx
@@ -7,12 +7,9 @@ import { mockFetchNotificationPermissions } from "lib/tests/mockFetchNotificatio
 import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import { PushAuthorizationStatus } from "lib/utils/PushNotification"
 import React from "react"
-import { Alert } from "react-native"
 import { useTracking } from "react-tracking"
 import { createMockEnvironment } from "relay-test-utils"
 import { SavedSearchAlertForm, SavedSearchAlertFormProps, tracks } from "../SavedSearchAlertForm"
-
-const spyAlert = jest.spyOn(Alert, "alert")
 
 describe("Saved search alert form", () => {
   const mockEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
@@ -22,7 +19,6 @@ describe("Saved search alert form", () => {
   beforeEach(() => {
     mockEnvironment.mockClear()
     notificationPermissions.mockImplementationOnce((cb) => cb(null, PushAuthorizationStatus.Authorized))
-    ;(Alert.alert as jest.Mock).mockClear()
     ;(useTracking as jest.Mock).mockImplementation(() => {
       return {
         trackEvent,
@@ -158,25 +154,7 @@ describe("Saved search alert form", () => {
     )
 
     fireEvent.press(getByTestId("delete-alert-button"))
-
-    /**
-     * Click confirm button in Alert
-     *
-     * The first call of the function
-     * calls[0] === [
-     *  [
-     *    'Title', === calls[0][0]
-     *    'Description' === calls[0][1],
-     *    [
-     *      ['cancel button'], === calls[0][2][0]
-     *      ['confirm button'] === calls[0][2][1]
-     *    ]
-     *  ]
-     * ]
-     */
-
-    // @ts-ignore
-    spyAlert.mock.calls[0][2][1].onPress()
+    fireEvent.press(getByTestId("dialog-primary-action-button"))
 
     expect(mockEnvironment.mock.getMostRecentOperation().request.node.operation.name).toBe(
       "deleteSavedSearchAlertMutation"
@@ -195,9 +173,7 @@ describe("Saved search alert form", () => {
     )
 
     fireEvent.press(getByTestId("delete-alert-button"))
-
-    // @ts-ignore
-    spyAlert.mock.calls[0][2][1].onPress()
+    fireEvent.press(getByTestId("dialog-primary-action-button"))
 
     await waitFor(() => {
       mockEnvironmentPayload(mockEnvironment)


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3214]

### Description
* When a user
* Clicks the "delete alert" button on the edit saved search page
* Delete modal should be displayed with the following params:
  * title: Delete Alert
  * description: Once deleted, you will no longer receive notifications for these filter criteria.
  * buttons:
    * Cancel - close modal
    * Delete – must perform a deletion operation

### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/130479557-109998e5-0946-42ca-ba89-5e980071d297.mp4

#### Android
https://user-images.githubusercontent.com/3513494/130483347-f2061103-0e1d-4ca7-9379-1329f8b3a52d.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Apply custom Dialog for confirm saved search delete - dzmitry tratsiak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3214]: https://artsyproduct.atlassian.net/browse/FX-3214