### PR TITLE
feat(FX-3210): show SS only when applied filters

### DIFF
--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchBanner.tsx
@@ -260,22 +260,9 @@ export const SavedSearchBannerQueryRender: React.FC<{
   artistSlug: string
 }> = ({ filters, artistId, artistSlug }) => {
   const input = prepareFilterParamsForSaveSearchInput(filters)
-  const isEmptyCriteria = Object.keys(input).length === 0
   const attributes: SearchCriteriaAttributes = {
     artistID: artistId,
     ...input,
-  }
-
-  if (isEmptyCriteria) {
-    return (
-      <SavedSearchBannerRefetchContainer
-        me={null}
-        attributes={attributes}
-        artistId={artistId}
-        artistSlug={artistSlug}
-        disabled
-      />
-    )
   }
 
   return (

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
@@ -2,10 +2,7 @@ import { ActionType, OwnerType, TappedCreateAlert } from "@artsy/cohesion"
 import { captureMessage } from "@sentry/react-native"
 import { SavedSearchButton_me } from "__generated__/SavedSearchButton_me.graphql"
 import { SavedSearchButtonQuery } from "__generated__/SavedSearchButtonQuery.graphql"
-import {
-  getAllowedFiltersForSavedSearchInput,
-  getSearchCriteriaFromFilters,
-} from "lib/Components/ArtworkFilter/SavedSearch/searchCriteriaHelpers"
+import { getSearchCriteriaFromFilters } from "lib/Components/ArtworkFilter/SavedSearch/searchCriteriaHelpers"
 import { SearchCriteriaAttributes } from "lib/Components/ArtworkFilter/SavedSearch/types"
 import { usePopoverMessage } from "lib/Components/PopoverMessage/popoverMessageHooks"
 import { navigate } from "lib/navigation/navigate"
@@ -130,13 +127,7 @@ export const SavedSearchButtonRefetchContainer = createRefetchContainer(
 
 export const SavedSearchButtonQueryRenderer: React.FC<SavedSearchButtonQueryRendererProps> = (props) => {
   const { filters, artistId } = props
-  const allowedFilters = getAllowedFiltersForSavedSearchInput(filters)
-  const isEmptyCriteria = allowedFilters.length === 0
   const criteria = getSearchCriteriaFromFilters(artistId, filters)
-
-  if (isEmptyCriteria) {
-    return <SavedSearchButtonRefetchContainer {...props} me={null} loading={false} criteria={criteria} filters={[]} />
-  }
 
   return (
     <QueryRenderer<SavedSearchButtonQuery>
@@ -163,7 +154,7 @@ export const SavedSearchButtonQueryRenderer: React.FC<SavedSearchButtonQueryRend
             me={relayProps?.me ?? null}
             loading={relayProps === null && error === null}
             criteria={criteria}
-            filters={allowedFilters}
+            filters={filters}
           />
         )
       }}

--- a/src/lib/Scenes/Artist/__tests__/ArtistSavedSearch-tests.tsx
+++ b/src/lib/Scenes/Artist/__tests__/ArtistSavedSearch-tests.tsx
@@ -107,8 +107,9 @@ describe("Saved search banner on artist screen", () => {
   it("should render new saved search component if AREnableSavedSearchV2 flag set to true", async () => {
     __globalStoreTestUtils__?.injectFeatureFlags({ AREnableSavedSearchV2: true })
 
-    const tree = getTree()
+    const tree = getTree("search-criteria-id")
 
+    mockMostRecentOperation("SearchCriteriaQuery", MockSearchCriteriaQuery)
     mockMostRecentOperation("ArtistAboveTheFoldQuery", MockArtistAboveTheFoldQuery)
 
     await flushPromiseQueue()


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3210]

### Description
We’d like to hiding the "Create Alert" button until a filter has been applied, at which point the button would appear and be clickable.

### Demo
#### Saved search button M1
https://user-images.githubusercontent.com/3513494/130491642-194f1618-3573-45c3-9c91-a84c8b2dc7e8.mp4

#### Saved search button M2
https://user-images.githubusercontent.com/3513494/130491664-52ec81a0-7e01-4201-bd73-5eb8b2f34f81.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Show the saved search button only when there are applied filters - dzmitry tratsiak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

[FX-3210]: https://artsyproduct.atlassian.net/browse/FX-3210