### PR TITLE
fix: move tracking into bootstrap callback, fix warnings

### DIFF
--- a/emission/Pod/Classes/EigenCommunications/ARNotificationsManager.m
+++ b/emission/Pod/Classes/EigenCommunications/ARNotificationsManager.m
@@ -100,6 +100,16 @@ RCT_EXPORT_MODULE();
     });
 }
 
+- (void)dispatchAfterBootstrap:(NSString *)eventName data:(NSDictionary *)data
+{
+    __weak typeof(self) wself = self;
+    [self afterBootstrap:^{
+        __strong typeof(self) sself = wself;
+        if (!sself) return;
+        [sself dispatch:eventName data:data];
+    }];
+}
+
 - (void)updateState:(NSDictionary *)state
 {
     @synchronized(self)
@@ -107,7 +117,7 @@ RCT_EXPORT_MODULE();
         NSMutableDictionary *nextState = [[self state] mutableCopy];
         [nextState addEntriesFromDictionary:state];
         _state = [[NSDictionary alloc] initWithDictionary:nextState];
-        [self dispatch:stateChanged data:_state];
+        [self dispatchAfterBootstrap:stateChanged data:_state];
     }
 }
 
@@ -115,12 +125,7 @@ RCT_EXPORT_MODULE();
 {
     @synchronized(self)
     {
-        __weak typeof(self) wself = self;
-        [self afterBootstrap:^{
-            __strong typeof(self) sself = wself;
-            if (!sself) return;
-            [sself dispatch:eventTracking data:traits];
-        }];
+        [self dispatchAfterBootstrap:eventTracking data:traits];
     }
 }
 
@@ -128,18 +133,18 @@ RCT_EXPORT_MODULE();
 {
     @synchronized(self)
     {
-        [self dispatch:identifyTracking data:traits];
+        [self dispatchAfterBootstrap:identifyTracking data:traits];
     }
 }
 
 - (void)notificationReceived
 {
-    [self dispatch:notificationReceived data:@{}];
+    [self dispatchAfterBootstrap:notificationReceived data:@{}];
 }
 
 - (void)modalDismissed
 {
-    [self dispatch:modalDismissed data:@{}];
+    [self dispatchAfterBootstrap:modalDismissed data:@{}];
 }
 
 - (void)requestNavigation:(NSString *)route
@@ -149,13 +154,8 @@ RCT_EXPORT_MODULE();
 
 - (void)requestNavigation:(NSString *)route withProps:(NSDictionary *)props
 {
-    __weak typeof(self) wself = self;
-    [self afterBootstrap:^{
-        __strong typeof(self) sself = wself;
-        if (!sself) return;
-        if (!route) return;
-        [sself dispatch:requestNavigation data:@{@"route": route, @"props": props}];
-    }];
+    if (!route) return;
+    [self dispatchAfterBootstrap:requestNavigation data:@{@"route": route, @"props": props}];
 }
 
 // Will be called when this module's first listener is added.


### PR DESCRIPTION
The type of this PR is: **fix**

This PR resolves [CX-1846]

### Description

After we refactored to use react-analytics for tracking our native analytics events were not being fired when triggered quickly after the app was launched from a killed state. This resulted in push taps for example being underreported. This PR uses the existing afterBootstrap method we used for a similar problem with deep linking for all our native event methods. 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Fix native analytics events not firing from killed state - Brian

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-1846]: https://artsyproduct.atlassian.net/browse/CX-1846