### PR TITLE
fix: Double mount after delete and edit form button

### DIFF
--- a/src/lib/Scenes/SavedAddresses/SavedAddressesForm.tsx
+++ b/src/lib/Scenes/SavedAddresses/SavedAddressesForm.tsx
@@ -8,7 +8,7 @@ import { PageWithSimpleHeader } from "lib/Components/PageWithSimpleHeader"
 import { PhoneInput } from "lib/Components/PhoneInput/PhoneInput"
 import { Stack } from "lib/Components/Stack"
 import { useToast } from "lib/Components/Toast/toastHook"
-import { goBack, navigate } from "lib/navigation/navigate"
+import { goBack } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { extractNodes } from "lib/utils/extractNodes"
 import { PlaceholderBox, PlaceholderText } from "lib/utils/placeholders"
@@ -165,7 +165,7 @@ export const SavedAddressesForm: React.FC<{ me: SavedAddressesForm_me; addressId
     deleteSavedAddress(
       userAddressID,
       () => {
-        navigate("my-profile/saved-addresses")
+        goBack()
         toast.show("Address successfully deleted", "top")
       },
       (message: string) => captureMessage(message)
@@ -242,7 +242,7 @@ export const SavedAddressesForm: React.FC<{ me: SavedAddressesForm_me; addressId
 
         <AddAddressButton
           handleOnPress={isEditForm ? () => editUserAddress(addressId!) : submitAddAddress}
-          title={isEditForm ? "Add" : "Add Address"}
+          title={`${isEditForm ? "Save" : "Add"} address`}
           disabled={!state.allPresent}
         />
       </Stack>


### PR DESCRIPTION
The type of this PR is: Bugfix

This PR resolves [PURCHASE-2896] and [PURCHASE-2900]

### Description

Fixes an incorrect navigation issue that would result in a double screen mount, and corrected edit form button text while at it.
Before:
![problem](https://user-images.githubusercontent.com/7117670/131046145-8a427e23-a0e9-48c3-b002-b4cf3df34b5d.gif)


Now:
![fixes](https://user-images.githubusercontent.com/7117670/131045760-558fe972-8b07-466e-b8f6-74f287c3f757.gif)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>
