### PR TITLE
fix(FX-3235): track toggle saved search event

### DIFF
--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
@@ -1,4 +1,4 @@
-import { ActionType, OwnerType, TappedCreateAlert } from "@artsy/cohesion"
+import { ActionType, OwnerType, TappedCreateAlert, ToggledSavedSearch } from "@artsy/cohesion"
 import { captureMessage } from "@sentry/react-native"
 import { SavedSearchButton_me } from "__generated__/SavedSearchButton_me.graphql"
 import { SavedSearchButtonQuery } from "__generated__/SavedSearchButtonQuery.graphql"
@@ -8,7 +8,10 @@ import { usePopoverMessage } from "lib/Components/PopoverMessage/popoverMessageH
 import { navigate } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { CreateSavedSearchAlert } from "lib/Scenes/SavedSearchAlert/CreateSavedSearchAlert"
-import { SavedSearchAlertFormPropsBase } from "lib/Scenes/SavedSearchAlert/SavedSearchAlertModel"
+import {
+  SavedSearchAlertFormPropsBase,
+  SavedSearchAlertMutationResult,
+} from "lib/Scenes/SavedSearchAlert/SavedSearchAlertModel"
 import { BellIcon, Box, Button } from "palette"
 import React, { useState } from "react"
 import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
@@ -58,7 +61,9 @@ export const SavedSearchButton: React.FC<SavedSearchButtonProps> = ({
   const handleOpenForm = () => setVisibleForm(true)
   const handleCloseForm = () => setVisibleForm(false)
 
-  const handleComplete = () => {
+  const handleComplete = (result: SavedSearchAlertMutationResult) => {
+    tracking.trackEvent(tracks.toggleSavedSearch(true, artistId, artistSlug, result.id))
+
     refetch()
     handleCloseForm()
 
@@ -171,5 +176,19 @@ export const tracks = {
     context_screen_owner_type: OwnerType.artist,
     context_screen_owner_id: artistId,
     context_screen_owner_slug: artistSlug,
+  }),
+  toggleSavedSearch: (
+    enabled: boolean,
+    artistId: string,
+    artistSlug: string,
+    searchCriteriaId: string
+  ): ToggledSavedSearch => ({
+    action: ActionType.toggledSavedSearch,
+    context_screen_owner_type: OwnerType.artist,
+    context_screen_owner_id: artistId,
+    context_screen_owner_slug: artistSlug,
+    modified: enabled,
+    original: !enabled,
+    search_criteria_id: searchCriteriaId,
   }),
 }

--- a/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchButton-tests.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/__tests__/SavedSearchButton-tests.tsx
@@ -4,6 +4,7 @@ import { SearchCriteriaAttributes } from "lib/Components/ArtworkFilter/SavedSear
 import { PopoverMessage } from "lib/Components/PopoverMessage/PopoverMessage"
 import { navigate } from "lib/navigation/navigate"
 import { CreateSavedSearchAlert } from "lib/Scenes/SavedSearchAlert/CreateSavedSearchAlert"
+import { SavedSearchAlertMutationResult } from "lib/Scenes/SavedSearchAlert/SavedSearchAlertModel"
 import { mockEnvironmentPayload } from "lib/tests/mockEnvironmentPayload"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { Button } from "palette"
@@ -18,6 +19,10 @@ jest.unmock("react-relay")
 
 const mockedAttributes: SearchCriteriaAttributes = {
   atAuction: true,
+}
+
+const mockedMutationResult: SavedSearchAlertMutationResult = {
+  id: "savedSearchAlertId",
 }
 
 const mockedFilters = [
@@ -138,9 +143,19 @@ describe("SavedSearchButton", () => {
   it("should navigate to the saved search alerts list when popover is pressed", async () => {
     const tree = renderWithWrappers(<TestRenderer />)
 
-    act(() => tree.root.findByType(CreateSavedSearchAlert).props.onComplete())
+    act(() => tree.root.findByType(CreateSavedSearchAlert).props.onComplete(mockedMutationResult))
     act(() => tree.root.findByType(PopoverMessage).props.onPress())
 
     expect(navigate).toHaveBeenCalled()
+  })
+
+  it("tracks clicks when the create alert button is pressed", async () => {
+    const tree = renderWithWrappers(<TestRenderer />)
+
+    act(() => tree.root.findByType(CreateSavedSearchAlert).props.onComplete(mockedMutationResult))
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      tracks.toggleSavedSearch(true, "artistID", "artistSlug", "savedSearchAlertId")
+    )
   })
 })

--- a/src/lib/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
@@ -5,22 +5,22 @@ import { Sans, Text, useTheme } from "palette"
 import React from "react"
 import { ScrollView } from "react-native"
 import { SavedSearchAlertForm } from "./SavedSearchAlertForm"
-import { SavedSearchAlertFormPropsBase } from "./SavedSearchAlertModel"
+import { SavedSearchAlertFormPropsBase, SavedSearchAlertMutationResult } from "./SavedSearchAlertModel"
 
 export interface CreateSavedSearchAlertProps extends SavedSearchAlertFormPropsBase {
   visible: boolean
   filters: FilterData[]
   aggregations: Aggregations
   onClosePress: () => void
-  onComplete: () => void
+  onComplete: (response: SavedSearchAlertMutationResult) => void
 }
 
 export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (props) => {
   const { visible, filters, aggregations, onClosePress, onComplete, ...other } = props
   const { space } = useTheme()
 
-  const handleComplete = async () => {
-    onComplete()
+  const handleComplete = async (result: SavedSearchAlertMutationResult) => {
+    onComplete(result)
   }
 
   return (

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -12,14 +12,18 @@ import { extractPills, getNamePlaceholder } from "./helpers"
 import { createSavedSearchAlert } from "./mutations/createSavedSearchAlert"
 import { deleteSavedSearchMutation } from "./mutations/deleteSavedSearchAlert"
 import { updateSavedSearchAlert } from "./mutations/updateSavedSearchAlert"
-import { SavedSearchAlertFormPropsBase, SavedSearchAlertFormValues } from "./SavedSearchAlertModel"
+import {
+  SavedSearchAlertFormPropsBase,
+  SavedSearchAlertFormValues,
+  SavedSearchAlertMutationResult,
+} from "./SavedSearchAlertModel"
 
 export interface SavedSearchAlertFormProps extends SavedSearchAlertFormPropsBase {
   initialValues: {
     name: string
   }
   savedSearchAlertId?: string
-  onComplete?: () => void
+  onComplete?: (result: SavedSearchAlertMutationResult) => void
   onDeleteComplete?: () => void
 }
 
@@ -50,15 +54,25 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
       }
 
       try {
+        let result: SavedSearchAlertMutationResult
+
         if (isUpdateForm) {
-          await updateSavedSearchAlert(alertName, savedSearchAlertId!)
+          const response = await updateSavedSearchAlert(alertName, savedSearchAlertId!)
           tracking.trackEvent(tracks.editedSavedSearch(savedSearchAlertId!, initialValues, values))
+
+          result = {
+            id: response.updateSavedSearch?.savedSearchOrErrors.internalID!,
+          }
         } else {
           const criteria = getSearchCriteriaFromFilters(artistId, filters)
-          await createSavedSearchAlert(alertName, criteria)
+          const response = await createSavedSearchAlert(alertName, criteria)
+
+          result = {
+            id: response.createSavedSearch?.savedSearchOrErrors.internalID!,
+          }
         }
 
-        onComplete?.()
+        onComplete?.(result)
       } catch (error) {
         console.error(error)
       }

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
@@ -10,3 +10,7 @@ export interface SavedSearchAlertFormPropsBase {
   artistId: string
   artistName: string
 }
+
+export interface SavedSearchAlertMutationResult {
+  id: string
+}

--- a/src/lib/Scenes/SavedSearchAlert/__tests__/CreateSavedSearchAlert-tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/__tests__/CreateSavedSearchAlert-tests.tsx
@@ -64,9 +64,15 @@ describe("CreateSavedSearchAlert", () => {
     fireEvent.press(getByTestId("save-alert-button"))
 
     await waitFor(() => {
-      mockEnvironmentPayload(mockEnvironment)
+      mockEnvironmentPayload(mockEnvironment, {
+        SearchCriteria: () => ({
+          internalID: "internalID",
+        }),
+      })
     })
 
-    expect(onCompleteMock).toBeCalled()
+    expect(onCompleteMock).toHaveBeenCalledWith({
+      id: "internalID",
+    })
   })
 })

--- a/src/lib/Scenes/SavedSearchAlert/mutations/createSavedSearchAlert.ts
+++ b/src/lib/Scenes/SavedSearchAlert/mutations/createSavedSearchAlert.ts
@@ -1,9 +1,15 @@
-import { createSavedSearchAlertMutation } from "__generated__/createSavedSearchAlertMutation.graphql"
+import {
+  createSavedSearchAlertMutation,
+  createSavedSearchAlertMutationResponse,
+} from "__generated__/createSavedSearchAlertMutation.graphql"
 import { SearchCriteriaAttributes } from "lib/Components/ArtworkFilter/SavedSearch/types"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { commitMutation, graphql } from "relay-runtime"
 
-export const createSavedSearchAlert = (name: string, attributes: SearchCriteriaAttributes) => {
+export const createSavedSearchAlert = (
+  name: string,
+  attributes: SearchCriteriaAttributes
+): Promise<createSavedSearchAlertMutationResponse> => {
   return new Promise((resolve, reject) => {
     commitMutation<createSavedSearchAlertMutation>(defaultEnvironment, {
       mutation: graphql`

--- a/src/lib/Scenes/SavedSearchAlert/mutations/updateSavedSearchAlert.ts
+++ b/src/lib/Scenes/SavedSearchAlert/mutations/updateSavedSearchAlert.ts
@@ -1,8 +1,14 @@
-import { updateSavedSearchAlertMutation } from "__generated__/updateSavedSearchAlertMutation.graphql"
+import {
+  updateSavedSearchAlertMutation,
+  updateSavedSearchAlertMutationResponse,
+} from "__generated__/updateSavedSearchAlertMutation.graphql"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { commitMutation, graphql } from "relay-runtime"
 
-export const updateSavedSearchAlert = (name: string, savedSearchAlertId: string) => {
+export const updateSavedSearchAlert = (
+  name: string,
+  savedSearchAlertId: string
+): Promise<updateSavedSearchAlertMutationResponse> => {
   return new Promise((resolve, reject) => {
     commitMutation<updateSavedSearchAlertMutation>(defaultEnvironment, {
       mutation: graphql`


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3235]

### Description
Track the `toggleSavedSearch` event when the user clicks the "create alert" button in the form of creating a new saved search alert

### Demo
![image](https://user-images.githubusercontent.com/3513494/131193022-2c98f376-9c55-4d4c-83df-0e0cb1ce7724.png)


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Fix saved search m2 analytics to properly track alert creation - dzmitry tratsiak

<!-- end_changelog_updates -->

</details>


[FX-3235]: https://artsyproduct.atlassian.net/browse/FX-3235