### PR TITLE
fix(FX-3223): correct logic for displaying the selected insight filters

### DIFF
--- a/src/lib/Components/ArtworkFilter/Filters/AuctionHouseOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/AuctionHouseOptions.tsx
@@ -1,10 +1,9 @@
 import { StackScreenProps } from "@react-navigation/stack"
 import { ArtworkFilterNavigationStack } from "lib/Components/ArtworkFilter"
 import { FilterData, FilterDisplayName, FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
-import { ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
-import { xor } from "lodash"
-import React, { useState } from "react"
+import React from "react"
 import { MultiSelectCheckOptionScreen } from "./MultiSelectCheckOption"
+import { useMultiSelect } from "./useMultiSelect"
 
 export const AUCTION_HOUSE_OPTIONS: FilterData[] = [
   {
@@ -28,47 +27,18 @@ interface AuctionHouseOptionsScreenProps
   extends StackScreenProps<ArtworkFilterNavigationStack, "AuctionHouseOptionsScreen"> {}
 
 export const AuctionHouseOptionsScreen: React.FC<AuctionHouseOptionsScreenProps> = ({ navigation }) => {
-  const appliedFilters = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
-  const selectedFilters = ArtworksFiltersStore.useStoreState((state) => state.selectedFilters)
-  const selectFiltersAction = ArtworksFiltersStore.useStoreActions((state) => state.selectFiltersAction)
+  const { handleSelect, isSelected } = useMultiSelect({
+    options: AUCTION_HOUSE_OPTIONS,
+    paramName: FilterParamName.organizations,
+  })
 
-  const oldAppliedFilterAuctionHouses = appliedFilters.find(
-    (filter) => filter.paramName === FilterParamName.organizations
-  )?.paramValue as string[] | undefined
-
-  const oldSelectedFilterAuctionHouses = selectedFilters.find(
-    (filter) => filter.paramName === FilterParamName.organizations
-  )?.paramValue as string[] | undefined
-
-  const initialState = xor(oldAppliedFilterAuctionHouses, oldSelectedFilterAuctionHouses)
-
-  const [selectedOptions, setSelectedOptions] = useState(initialState)
-
-  const toggleOption = (option: FilterData) => {
-    let updatedParamValue: string[]
-
-    // The user is trying to uncheck the auction house
-    if (typeof option.paramValue === "string" && selectedOptions?.includes(option.paramValue)) {
-      updatedParamValue = selectedOptions.filter((paramValue) => paramValue !== option.paramValue)
-    } else {
-      // The user is trying to check the auction house
-      updatedParamValue = [...(selectedOptions || []), option.paramValue as string]
-    }
-
-    setSelectedOptions(updatedParamValue)
-    selectFiltersAction({
-      displayText: option.displayText,
-      paramValue: updatedParamValue,
-      paramName: FilterParamName.organizations,
-    })
-  }
+  const filterOptions = AUCTION_HOUSE_OPTIONS.map((option) => ({ ...option, paramValue: isSelected(option) }))
 
   return (
     <MultiSelectCheckOptionScreen
-      onSelect={toggleOption}
+      onSelect={handleSelect}
       filterHeaderText={FilterDisplayName.organizations}
-      filterOptions={AUCTION_HOUSE_OPTIONS}
-      selectedOptions={selectedOptions}
+      filterOptions={filterOptions}
       navigation={navigation}
     />
   )

--- a/src/lib/Components/ArtworkFilter/Filters/CategoriesOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/CategoriesOptions.tsx
@@ -1,10 +1,9 @@
 import { StackScreenProps } from "@react-navigation/stack"
 import { ArtworkFilterNavigationStack } from "lib/Components/ArtworkFilter"
 import { FilterData, FilterDisplayName, FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
-import { ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
-import { xor } from "lodash"
-import React, { useState } from "react"
+import React from "react"
 import { MultiSelectCheckOptionScreen } from "./MultiSelectCheckOption"
+import { useMultiSelect } from "./useMultiSelect"
 
 interface ArtistIDsArtworksOptionsScreenProps
   extends StackScreenProps<ArtworkFilterNavigationStack, "CategoriesOptionsScreen"> {}
@@ -43,48 +42,18 @@ export const CATEGORIES_OPTIONS: FilterData[] = [
 ]
 
 export const CategoriesOptionsScreen: React.FC<ArtistIDsArtworksOptionsScreenProps> = ({ navigation }) => {
-  const selectFiltersAction = ArtworksFiltersStore.useStoreActions((state) => state.selectFiltersAction)
+  const { handleSelect, isSelected } = useMultiSelect({
+    options: CATEGORIES_OPTIONS,
+    paramName: FilterParamName.categories,
+  })
 
-  const appliedFilters = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
-  const selectedFilters = ArtworksFiltersStore.useStoreState((state) => state.selectedFilters)
-
-  const oldAppliedFilterCategories = appliedFilters.find((filter) => filter.paramName === FilterParamName.categories)
-    ?.paramValue as string[] | undefined
-
-  const oldSelectedFilterCategories = selectedFilters.find((filter) => filter.paramName === FilterParamName.categories)
-    ?.paramValue as string[] | undefined
-
-  // Get the Symmetric difference of the previously applied filters and the ones that were selected but not yet applied
-  // Read more about Symmetric difference here https://en.wikipedia.org/wiki/Symmetric_difference
-  const initialState = xor(oldAppliedFilterCategories, oldSelectedFilterCategories)
-  const [selectedOptions, setSelectedOptions] = useState(initialState)
-
-  const toggleOption = (option: FilterData) => {
-    let updatedParamValue: string[]
-
-    // The user is trying to uncheck the category
-    if (typeof option.paramValue === "string" && selectedOptions?.includes(option.paramValue)) {
-      updatedParamValue = selectedOptions.filter((paramValue) => paramValue !== option.paramValue)
-    } else {
-      // The user is trying to check the category
-      updatedParamValue = [...(selectedOptions || []), option.paramValue as string]
-    }
-
-    setSelectedOptions(updatedParamValue)
-
-    selectFiltersAction({
-      displayText: option.displayText,
-      paramValue: updatedParamValue,
-      paramName: FilterParamName.categories,
-    })
-  }
+  const filterOptions = CATEGORIES_OPTIONS.map((option) => ({ ...option, paramValue: isSelected(option) }))
 
   return (
     <MultiSelectCheckOptionScreen
-      onSelect={toggleOption}
+      onSelect={handleSelect}
       filterHeaderText={FilterDisplayName.categories}
-      filterOptions={CATEGORIES_OPTIONS}
-      selectedOptions={selectedOptions}
+      filterOptions={filterOptions}
       navigation={navigation}
     />
   )

--- a/src/lib/Components/ArtworkFilter/Filters/MultiSelectCheckOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/MultiSelectCheckOption.tsx
@@ -13,7 +13,7 @@ interface MultiSelectOptionScreenProps {
   ListHeaderComponent?: React.ReactElement
   navigation: StackNavigationProp<ParamListBase>
   onSelect: (filterData: FilterData, updatedValue: boolean) => void
-  selectedOptions: string[] | undefined
+  selectedOptions?: string[]
   withIndent?: boolean
 }
 
@@ -34,6 +34,11 @@ export const MultiSelectCheckOptionScreen: React.FC<MultiSelectOptionScreenProps
     if (typeof item?.paramValue === "string") {
       return selectedOptions?.includes(item.paramValue)
     }
+
+    if (typeof item.paramValue === "boolean") {
+      return item.paramValue
+    }
+
     return false
   }
 

--- a/src/lib/Components/ArtworkFilter/Filters/SizesOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/SizesOptions.tsx
@@ -1,10 +1,10 @@
 import { StackScreenProps } from "@react-navigation/stack"
 import { ArtworkFilterNavigationStack } from "lib/Components/ArtworkFilter"
 import { FilterData, FilterDisplayName, FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
-import { ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { Separator, Text } from "palette"
-import React, { useRef, useState } from "react"
+import React from "react"
 import { MultiSelectCheckOptionScreen } from "./MultiSelectCheckOption"
+import { useMultiSelect } from "./useMultiSelect"
 
 interface SizesOptionsScreenProps extends StackScreenProps<ArtworkFilterNavigationStack, "SizesOptionsScreen"> {}
 
@@ -27,41 +27,16 @@ export const SIZES_OPTIONS: FilterData[] = [
 ]
 
 export const SizesOptionsScreen: React.FC<SizesOptionsScreenProps> = ({ navigation }) => {
-  const appliedFilters = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
-  const selectedFilters = ArtworksFiltersStore.useStoreState((state) => state.selectedFilters)
-  const selectFiltersAction = ArtworksFiltersStore.useStoreActions((state) => state.selectFiltersAction)
+  const { handleSelect, isSelected } = useMultiSelect({
+    options: SIZES_OPTIONS,
+    paramName: FilterParamName.sizes,
+  })
 
-  const oldAppliedFilterSizs = useRef(
-    appliedFilters.find((filter) => filter.paramName === FilterParamName.sizes)?.paramValue as string[] | undefined
-  )
-
-  const oldSelectedFilterSizs = useRef(
-    selectedFilters.find((filter) => filter.paramName === FilterParamName.sizes)?.paramValue as string[] | undefined
-  )
-  const [selectedOptions, setSelectedOptions] = useState(oldSelectedFilterSizs.current || oldAppliedFilterSizs.current)
-
-  const toggleOption = (option: FilterData) => {
-    let updatedParamValue: string[]
-
-    // The user is trying to uncheck the size
-    if (typeof option.paramValue === "string" && selectedOptions?.includes(option.paramValue)) {
-      updatedParamValue = selectedOptions.filter((paramValue) => paramValue !== option.paramValue)
-    } else {
-      // The user is trying to check the size
-      updatedParamValue = [...(selectedOptions || []), option.paramValue as string]
-    }
-
-    setSelectedOptions(updatedParamValue)
-    selectFiltersAction({
-      displayText: option.displayText,
-      paramValue: updatedParamValue,
-      paramName: FilterParamName.sizes,
-    })
-  }
+  const filterOptions = SIZES_OPTIONS.map((option) => ({ ...option, paramValue: isSelected(option) }))
 
   return (
     <MultiSelectCheckOptionScreen
-      onSelect={toggleOption}
+      onSelect={handleSelect}
       ListHeaderComponent={
         <>
           <Text variant="caption" color="black60" textAlign="center" my={15}>
@@ -71,8 +46,7 @@ export const SizesOptionsScreen: React.FC<SizesOptionsScreenProps> = ({ navigati
         </>
       }
       filterHeaderText={FilterDisplayName.sizes}
-      filterOptions={SIZES_OPTIONS}
-      selectedOptions={selectedOptions}
+      filterOptions={filterOptions}
       navigation={navigation}
     />
   )


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3223]

### Description
PR contains an error fix when the previously selected auction house/medium filter values were not visually marked as selected

### Demo
#### Before
https://user-images.githubusercontent.com/3513494/131489683-00d6b514-333a-460c-886b-305e120aa79c.mp4

#### After
https://user-images.githubusercontent.com/3513494/131489124-58ec9968-41f6-436b-8f62-bb29f6a95a7d.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Correct logic for displaying the selected insight filters - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3223]: https://artsyproduct.atlassian.net/browse/FX-3223