### PR TITLE
refactor(FX-3246, FX-3275): keep `artistIDs` in one filter entity

### DIFF
--- a/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -1,18 +1,5 @@
 import { FilterScreen } from "lib/Components/ArtworkFilter"
-import {
-  capitalize,
-  compact,
-  filter,
-  groupBy,
-  isArray,
-  isEmpty,
-  isEqual,
-  isUndefined,
-  pick,
-  pickBy,
-  sortBy,
-  unionBy,
-} from "lodash"
+import { capitalize, compact, filter, isArray, isEqual, isUndefined, pick, pickBy, sortBy, unionBy } from "lodash"
 import { LOCALIZED_UNIT } from "./Filters/helpers"
 
 export enum FilterDisplayName {
@@ -276,24 +263,6 @@ const waysToBuyFilterNames = [
   FilterParamName.waysToBuyInquire,
 ]
 
-const paramsFromAppliedFilters = (appliedFilters: FilterArray, filterParams: FilterParams, filterType: FilterType) => {
-  const groupedFilters = groupBy(appliedFilters, "paramName")
-
-  Object.keys(groupedFilters).forEach((paramName) => {
-    const paramValues = groupedFilters[paramName].map((item) => item.paramValue)
-    // If we add more filter options that can take arrays, we would include them here.
-    if (paramName === FilterParamName.artistIDs && filterType === "artwork") {
-      // For the artistIDs param, we want to return an array
-      filterParams[paramName] = paramValues as string[]
-    } else {
-      // For other params, we just want to return the first value
-      filterParams[paramName as FilterParamName] = paramValues[0]
-    }
-  })
-
-  return filterParams
-}
-
 const getDefaultParamsByType = (filterType: FilterType) => {
   return {
     artwork: DEFAULT_ARTWORKS_PARAMS,
@@ -324,7 +293,16 @@ export const changedFiltersParams = (currentFilterParams: FilterParams, selected
 
 export const filterArtworksParams = (appliedFilters: FilterArray, filterType: FilterType = "artwork") => {
   const defaultFilterParams = getDefaultParamsByType(filterType)
-  return paramsFromAppliedFilters(appliedFilters, { ...defaultFilterParams }, filterType)
+  const appliedFilterParams: Partial<FilterParams> = {}
+
+  appliedFilters.forEach((filterParam) => {
+    appliedFilterParams[filterParam.paramName] = filterParam.paramValue
+  })
+
+  return {
+    ...defaultFilterParams,
+    ...appliedFilterParams,
+  }
 }
 
 export const extractCustomSizeLabel = (selectedOptions: FilterArray) => {
@@ -348,12 +326,10 @@ export const extractCustomSizeLabel = (selectedOptions: FilterArray) => {
 export const selectedOption = ({
   selectedOptions,
   filterScreen,
-  filterType = "artwork",
   aggregations,
 }: {
   selectedOptions: FilterArray
   filterScreen: FilterScreen
-  filterType?: FilterType
   aggregations: Aggregations
 }) => {
   if (filterScreen === "dimensionRange") {
@@ -441,30 +417,24 @@ export const selectedOption = ({
       return paramName === FilterParamName.artistsIFollow && paramValue === true
     })
 
-    let selectedArtistNames: string[]
+    let selectedArtistNames: string[] = []
+    const artistIDsFilter = selectedOptions.find(({ paramName }) => paramName === FilterParamName.artistIDs)
 
-    if (filterType === "saleArtwork") {
-      const saleArtworksArtistIDs = selectedOptions.find(({ paramName }) => paramName === FilterParamName.artistIDs)
-      // The user has selected one or more artist ids
-      if (saleArtworksArtistIDs && Array.isArray(saleArtworksArtistIDs?.paramValue)) {
-        const artistIDsAggregation = aggregationForFilter(FilterParamName.artistIDs, aggregations)
-
-        selectedArtistNames = compact(
-          saleArtworksArtistIDs.paramValue.map((artistID: string) => {
-            return artistIDsAggregation?.counts.find((artistAggregation) => artistAggregation.value === artistID)?.name
-          })
+    // The user has selected one or more artist ids
+    if (Array.isArray(artistIDsFilter?.paramValue)) {
+      const artistIDsAggregation = aggregationForFilter(FilterParamName.artistIDs, aggregations)
+      const artistNames = artistIDsFilter!.paramValue.map((artistID: string) => {
+        const aggregation = artistIDsAggregation?.counts.find(
+          (artistAggregation) => artistAggregation.value === artistID
         )
-      } else {
-        selectedArtistNames = []
-      }
-    } else {
-      selectedArtistNames = selectedOptions
-        // Filtering out paramValue with an empty array to remove default option "All"
-        .filter(({ paramName, paramValue }) => paramName === FilterParamName.artistIDs && !isEmpty(paramValue))
-        .map(({ displayText }) => displayText)
+
+        return aggregation?.name
+      })
+
+      selectedArtistNames = compact(artistNames)
     }
 
-    const alphabetizedArtistNames = sortBy(selectedArtistNames, (name) => name)
+    const alphabetizedArtistNames = sortBy(selectedArtistNames)
     const allArtistDisplayNames = hasArtistsIFollowChecked
       ? ["All Artists I Follow", ...alphabetizedArtistNames]
       : alphabetizedArtistNames
@@ -635,36 +605,9 @@ export const getUnitedSelectedAndAppliedFilters = ({
   }
 
   // replace previously applied options with currently selected options
-  const filtersToUnite = unionBy(selectedFilters, previouslyAppliedFilters, ({ paramValue, paramName }) => {
-    // We don't want to union the artistID params, as each entry corresponds to a
-    // different artist that may be selected. Instead we de-dupe based on the paramValue.
-    if (paramName === FilterParamName.artistIDs && filterType === "artwork") {
-      return paramValue
-    } else {
-      return paramName
-    }
-  })
+  const filtersToUnite = unionBy(selectedFilters, previouslyAppliedFilters, "paramName")
 
   const unitedFilters = filter(filtersToUnite, ({ paramName, paramValue }) => {
-    // This logic is specific to filters that allow for multiple options. Right now
-    // it only applies to the artist filter, but this will likely change.
-    if (paramName === FilterParamName.artistIDs && filterType === "artwork") {
-      // See if we have an existing entry in previouslyAppliedFilters
-      const hasExistingPreviouslyAppliedFilter = previouslyAppliedFilters.find(
-        (previouslyAppliedFilter) =>
-          paramName === previouslyAppliedFilter.paramName && paramValue === previouslyAppliedFilter.paramValue
-      )
-
-      const hasExistingSelectedAppliedFilter = selectedFilters.find(
-        (selectedFilter) => paramName === selectedFilter.paramName && paramValue === selectedFilter.paramValue
-      )
-
-      // If so, it means that this filter had been previously applied and is now being de-selected.
-      // We need it to exist in the "selectedFilters" array so that our counts, etc. are correct,
-      // but it's technically de-selected.
-      return !(hasExistingPreviouslyAppliedFilter && hasExistingSelectedAppliedFilter)
-    }
-
     // The default sorting and lot ascending sorting at the saleArtwork filterType has the same paramValue
     // with a different displayText, we want to make sure that the user can still switch between the two.
     if (paramName === FilterParamName.sort && filterType === "saleArtwork") {
@@ -679,9 +622,7 @@ export const getUnitedSelectedAndAppliedFilters = ({
 export const getSelectedFiltersCounts = (selectedFilters: FilterArray) => {
   const counts: Partial<SelectedFiltersCounts> = {}
   selectedFilters.forEach(({ paramName, paramValue }: FilterData) => {
-    if (paramName === FilterParamName.artistIDs) {
-      counts.artistIDs = (counts.artistIDs ?? 0) + 1
-    } else if (waysToBuyFilterNames.includes(paramName)) {
+    if (waysToBuyFilterNames.includes(paramName)) {
       counts.waysToBuy = (counts.waysToBuy ?? 0) + 1
     } else if (createdYearsFilterNames.includes(paramName)) {
       counts.year = 1

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -188,7 +188,6 @@ export const ArtworkFilterOptionsScreen: React.FC<
           const selectedCurrentOption = selectedOption({
             selectedOptions,
             filterScreen: item.filterType,
-            filterType: filterTypeState,
             aggregations: aggregationsState,
           })
 

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/ArtistIDsArtworksOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/ArtistIDsArtworksOptions-tests.tsx
@@ -96,7 +96,7 @@ describe("Artist options screen", () => {
         selectedFilters: [
           {
             paramName: FilterParamName.artistIDs,
-            paramValue: "artist-2",
+            paramValue: ["artist-2"],
             displayText: "Artist 2",
           },
         ],
@@ -153,7 +153,7 @@ describe("Artist options screen", () => {
         selectedFilters: [
           {
             paramName: FilterParamName.artistIDs,
-            paramValue: "artist-2",
+            paramValue: ["artist-2"],
             displayText: "Artist 2",
           },
         ],

--- a/src/lib/Components/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
@@ -90,7 +90,7 @@ describe("Select Filters", () => {
     const filterArtworksStore = getFilterArtworksStore(filterState)
     filterArtworksStore.getActions().selectFiltersAction({
       paramName: FilterParamName.artistIDs,
-      paramValue: "artist-1",
+      paramValue: ["artist-1"],
       displayText: "Artist 1",
     })
 
@@ -101,7 +101,7 @@ describe("Select Filters", () => {
       selectedFilters: [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
+          paramValue: ["artist-1"],
           displayText: "Artist 1",
         },
       ],
@@ -122,7 +122,7 @@ describe("Select Filters", () => {
       selectedFilters: [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
+          paramValue: ["artist-1"],
           displayText: "Artist 1",
         },
       ],
@@ -137,8 +137,8 @@ describe("Select Filters", () => {
     const filterArtworksStore = getFilterArtworksStore(filterState)
     filterArtworksStore.getActions().selectFiltersAction({
       paramName: FilterParamName.artistIDs,
-      paramValue: "artist-2",
-      displayText: "Artist 2",
+      paramValue: ["artist-1", "artist-2"],
+      displayText: "Artist 1, Artist 2",
     })
 
     expect(filterArtworksStore.getState()).toEqual({
@@ -148,13 +148,8 @@ describe("Select Filters", () => {
       selectedFilters: [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
-          displayText: "Artist 1",
-        },
-        {
-          paramName: FilterParamName.artistIDs,
-          paramValue: "artist-2",
-          displayText: "Artist 2",
+          paramValue: ["artist-1", "artist-2"],
+          displayText: "Artist 1, Artist 2",
         },
       ],
       aggregations: [],
@@ -174,13 +169,8 @@ describe("Select Filters", () => {
       selectedFilters: [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
-          displayText: "Artist 1",
-        },
-        {
-          paramName: FilterParamName.artistIDs,
-          paramValue: "artist-2",
-          displayText: "Artist 2",
+          paramValue: ["artist-1", "artist-2"],
+          displayText: "Artist 1, Artist 2",
         },
         {
           paramName: FilterParamName.waysToBuyBid,
@@ -199,7 +189,7 @@ describe("Select Filters", () => {
     const filterArtworksStore = getFilterArtworksStore(filterState)
     filterArtworksStore.getActions().selectFiltersAction({
       paramName: FilterParamName.artistIDs,
-      paramValue: "artist-2",
+      paramValue: ["artist-2"],
       displayText: "Artist 2",
     })
 
@@ -210,8 +200,8 @@ describe("Select Filters", () => {
       selectedFilters: [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
-          displayText: "Artist 1",
+          paramValue: ["artist-2"],
+          displayText: "Artist 2",
         },
         {
           paramName: FilterParamName.waysToBuyBid,
@@ -234,14 +224,14 @@ describe("Select Filters", () => {
       appliedFilters: [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
+          paramValue: ["artist-1"],
           displayText: "Artist 1",
         },
       ],
       previouslyAppliedFilters: [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
+          paramValue: ["artist-1"],
           displayText: "Artist 1",
         },
       ],
@@ -257,7 +247,7 @@ describe("Select Filters", () => {
     const filterArtworksStore = getFilterArtworksStore(filterState)
     filterArtworksStore.getActions().selectFiltersAction({
       paramName: FilterParamName.artistIDs,
-      paramValue: "artist-1",
+      paramValue: ["artist-1"],
       displayText: "Artist 1",
     })
 
@@ -266,21 +256,21 @@ describe("Select Filters", () => {
       appliedFilters: [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
+          paramValue: ["artist-1"],
           displayText: "Artist 1",
         },
       ],
       previouslyAppliedFilters: [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
+          paramValue: ["artist-1"],
           displayText: "Artist 1",
         },
       ],
       selectedFilters: [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
+          paramValue: ["artist-1"],
           displayText: "Artist 1",
         },
       ],
@@ -798,7 +788,7 @@ describe("Apply Filters", () => {
       selectedFilters: [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
+          paramValue: ["artist-1"],
           displayText: "Artist 1",
         },
       ],
@@ -818,14 +808,14 @@ describe("Apply Filters", () => {
       appliedFilters: [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
+          paramValue: ["artist-1"],
           displayText: "Artist 1",
         },
       ],
       previouslyAppliedFilters: [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
+          paramValue: ["artist-1"],
           displayText: "Artist 1",
         },
       ],
@@ -847,13 +837,8 @@ describe("Apply Filters", () => {
       selectedFilters: [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
-          displayText: "Artist 1",
-        },
-        {
-          paramName: FilterParamName.artistIDs,
-          paramValue: "artist-2",
-          displayText: "Artist 2",
+          paramValue: ["artist-1", "artist-2"],
+          displayText: "Artist 1, Artist 2",
         },
       ],
       aggregations: [],
@@ -877,25 +862,15 @@ describe("Apply Filters", () => {
       appliedFilters: [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
-          displayText: "Artist 1",
-        },
-        {
-          paramName: FilterParamName.artistIDs,
-          paramValue: "artist-2",
-          displayText: "Artist 2",
+          paramValue: ["artist-1", "artist-2"],
+          displayText: "Artist 1, Artist 2",
         },
       ],
       previouslyAppliedFilters: [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
-          displayText: "Artist 1",
-        },
-        {
-          paramName: FilterParamName.artistIDs,
-          paramValue: "artist-2",
-          displayText: "Artist 2",
+          paramValue: ["artist-1", "artist-2"],
+          displayText: "Artist 1, Artist 2",
         },
       ],
       selectedFilters: [],
@@ -910,20 +885,15 @@ describe("Apply Filters", () => {
       previouslyAppliedFilters: [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
+          paramValue: ["artist-1"],
           displayText: "Artist 1",
         },
       ],
       selectedFilters: [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
-          displayText: "Artist 1",
-        },
-        {
-          paramName: FilterParamName.artistIDs,
-          paramValue: "artist-2",
-          displayText: "Artist 2",
+          paramValue: ["artist-1", "artist-2"],
+          displayText: "Artist 1, Artist 2",
         },
       ],
       aggregations: [],
@@ -947,15 +917,15 @@ describe("Apply Filters", () => {
       appliedFilters: [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-2",
-          displayText: "Artist 2",
+          paramValue: ["artist-1", "artist-2"],
+          displayText: "Artist 1, Artist 2",
         },
       ],
       previouslyAppliedFilters: [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-2",
-          displayText: "Artist 2",
+          paramValue: ["artist-1", "artist-2"],
+          displayText: "Artist 1, Artist 2",
         },
       ],
       selectedFilters: [],
@@ -1068,7 +1038,7 @@ describe("SetInitialFilterState", () => {
 
 describe("selectedOptionsUnion", () => {
   describe("artworks", () => {
-    it("correctly unions non-artistID params", () => {
+    it("correctly unions params", () => {
       const previouslyAppliedFilters = [{ displayText: "Recently Updated", paramName: FilterParamName.sort }]
       const selectedFilters = [{ displayText: "Artwork Year (Descending)", paramName: FilterParamName.sort }]
 
@@ -1171,12 +1141,12 @@ describe("selectedOptionsUnion", () => {
       ])
     })
 
-    it("correctly unions with a single artistID param", () => {
+    it("correctly unions with a single selected artist", () => {
       const previouslyAppliedFilters = [] as FilterArray
       const selectedFilters = [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
+          paramValue: ["artist-1"],
           displayText: "Artist 1",
         },
       ]
@@ -1184,7 +1154,7 @@ describe("selectedOptionsUnion", () => {
       expect(selectedOptionsUnion({ selectedFilters, previouslyAppliedFilters })).toEqual([
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
+          paramValue: ["artist-1"],
           displayText: "Artist 1",
         },
         {
@@ -1272,11 +1242,6 @@ describe("selectedOptionsUnion", () => {
           paramValue: false,
         },
         {
-          displayText: "All",
-          paramName: "artistIDs",
-          paramValue: [],
-        },
-        {
           displayText: "Grid",
           paramName: "viewAs",
           paramValue: false,
@@ -1289,31 +1254,21 @@ describe("selectedOptionsUnion", () => {
       ])
     })
 
-    it("correctly unions with a multiple artistID params", () => {
+    it("correctly unions with multiple selected artists", () => {
       const previouslyAppliedFilters = [] as FilterArray
       const selectedFilters = [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
-          displayText: "Artist 1",
-        },
-        {
-          paramName: FilterParamName.artistIDs,
-          paramValue: "artist-2",
-          displayText: "Artist 2",
+          paramValue: ["artist-1", "artist-2"],
+          displayText: "Artist 1, Artist 2",
         },
       ]
 
       expect(selectedOptionsUnion({ selectedFilters, previouslyAppliedFilters })).toEqual([
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
-          displayText: "Artist 1",
-        },
-        {
-          paramName: FilterParamName.artistIDs,
-          paramValue: "artist-2",
-          displayText: "Artist 2",
+          paramValue: ["artist-1", "artist-2"],
+          displayText: "Artist 1, Artist 2",
         },
         {
           displayText: "Default",
@@ -1400,11 +1355,6 @@ describe("selectedOptionsUnion", () => {
           paramValue: false,
         },
         {
-          displayText: "All",
-          paramName: "artistIDs",
-          paramValue: [],
-        },
-        {
           displayText: "Grid",
           paramName: "viewAs",
           paramValue: false,
@@ -1417,42 +1367,27 @@ describe("selectedOptionsUnion", () => {
       ])
     })
 
-    it("correctly unions with a multiple artistID params when an artistID has been previously applied", () => {
+    it("correctly unions with multiple selected artists when an artist has been previously applied", () => {
       const previouslyAppliedFilters = [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-3",
+          paramValue: ["artist-3"],
           displayText: "Artist 3",
         },
       ] as FilterArray
       const selectedFilters = [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
-          displayText: "Artist 1",
-        },
-        {
-          paramName: FilterParamName.artistIDs,
-          paramValue: "artist-2",
-          displayText: "Artist 2",
+          paramValue: ["artist-1", "artist-2"],
+          displayText: "Artist 1, Artist 2",
         },
       ]
 
       expect(selectedOptionsUnion({ selectedFilters, previouslyAppliedFilters })).toEqual([
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
-          displayText: "Artist 1",
-        },
-        {
-          paramName: FilterParamName.artistIDs,
-          paramValue: "artist-2",
-          displayText: "Artist 2",
-        },
-        {
-          paramName: FilterParamName.artistIDs,
-          paramValue: "artist-3",
-          displayText: "Artist 3",
+          paramValue: ["artist-1", "artist-2"],
+          displayText: "Artist 1, Artist 2",
         },
         {
           displayText: "Default",
@@ -1537,11 +1472,6 @@ describe("selectedOptionsUnion", () => {
           displayText: "All Artists I Follow",
           paramName: "includeArtworksByFollowedArtists",
           paramValue: false,
-        },
-        {
-          displayText: "All",
-          paramName: "artistIDs",
-          paramValue: [],
         },
         {
           displayText: "Grid",
@@ -1556,32 +1486,27 @@ describe("selectedOptionsUnion", () => {
       ])
     })
 
-    it("correctly unions with a multiple artistID params when a duplicate artistID has been previously applied", () => {
+    it("correctly unions with multiple selected artists when a duplicate artist has been previously applied", () => {
       const previouslyAppliedFilters = [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-2",
+          paramValue: ["artist-2"],
           displayText: "Artist 2",
         },
       ] as FilterArray
       const selectedFilters = [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
-          displayText: "Artist 1",
-        },
-        {
-          paramName: FilterParamName.artistIDs,
-          paramValue: "artist-2",
-          displayText: "Artist 2",
+          paramValue: ["artist-1", "artist-2"],
+          displayText: "Artist 1, Artist 2",
         },
       ]
 
       expect(selectedOptionsUnion({ selectedFilters, previouslyAppliedFilters })).toEqual([
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
-          displayText: "Artist 1",
+          paramValue: ["artist-1", "artist-2"],
+          displayText: "Artist 1, Artist 2",
         },
         {
           displayText: "Default",
@@ -1666,11 +1591,6 @@ describe("selectedOptionsUnion", () => {
           displayText: "All Artists I Follow",
           paramName: "includeArtworksByFollowedArtists",
           paramValue: false,
-        },
-        {
-          displayText: "All",
-          paramName: "artistIDs",
-          paramValue: [],
         },
         {
           displayText: "Grid",
@@ -1689,7 +1609,7 @@ describe("selectedOptionsUnion", () => {
       const previouslyAppliedFilters = [
         {
           paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
+          paramValue: ["artist-1"],
           displayText: "Artist 1",
         },
       ] as FilterArray
@@ -1718,8 +1638,8 @@ describe("selectedOptionsUnion", () => {
           paramValue: true,
         },
         {
-          paramName: FilterParamName.artistIDs,
-          paramValue: "artist-1",
+          paramName: "artistIDs",
+          paramValue: ["artist-1"],
           displayText: "Artist 1",
         },
         {
@@ -1795,11 +1715,6 @@ describe("selectedOptionsUnion", () => {
           displayText: "All Artists I Follow",
           paramName: "includeArtworksByFollowedArtists",
           paramValue: false,
-        },
-        {
-          displayText: "All",
-          paramName: "artistIDs",
-          paramValue: [],
         },
         {
           displayText: "Grid",

--- a/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/FilterArtworksHelpers-tests.tsx
@@ -330,7 +330,7 @@ describe("filterArtworksParams helper", () => {
     appliedFilters = [
       {
         displayText: "Artist 1",
-        paramValue: "artist-1",
+        paramValue: ["artist-1"],
         paramName: FilterParamName.artistIDs,
       },
       {
@@ -357,13 +357,8 @@ describe("filterArtworksParams helper", () => {
   it("maps correct applied filters when there are multiple artistID params", () => {
     appliedFilters = [
       {
-        displayText: "Artist 1",
-        paramValue: "artist-1",
-        paramName: FilterParamName.artistIDs,
-      },
-      {
-        displayText: "Artist 2",
-        paramValue: "artist-2",
+        displayText: "Artist 1, Artist 2",
+        paramValue: ["artist-1", "artist-2"],
         paramName: FilterParamName.artistIDs,
       },
     ]
@@ -539,54 +534,52 @@ describe("selectedOption", () => {
 
   describe("artists", () => {
     describe("artworks", () => {
+      const aggregations: Aggregations = [
+        {
+          slice: "ARTIST",
+          counts: [
+            { count: 21, name: "Artist 1", value: "artist-1" },
+            { count: 21, name: "Artist 2", value: "artist-2" },
+          ],
+        },
+      ]
+
       it("returns the correct value in the default case", () => {
         const selectedOptions = [] as FilterArray
 
-        expect(selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations: [] })).toEqual("All")
+        expect(selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations })).toEqual("All")
       })
 
       it("returns the correct value when one artist is selected", () => {
         const selectedOptions = [
           {
             paramName: FilterParamName.artistIDs,
-            paramValue: "artist-1",
+            paramValue: ["artist-1"],
             displayText: "Artist 1",
           },
         ]
 
-        expect(selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations: [] })).toEqual("Artist 1")
+        expect(selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations })).toEqual("Artist 1")
       })
 
       it("returns the correct value when multiple artists are selected", () => {
         const selectedOptions = [
           {
             paramName: FilterParamName.artistIDs,
-            paramValue: "artist-1",
-            displayText: "Z Artist 1",
-          },
-          {
-            paramName: FilterParamName.artistIDs,
-            paramValue: "artist-2",
-            displayText: "Artist 2",
+            paramValue: ["artist-1", "artist-2"],
+            displayText: "Artist 1, Artist 2",
           },
         ]
 
-        expect(selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations: [] })).toEqual(
-          "Artist 2, 1 more"
-        )
+        expect(selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations })).toEqual("Artist 1, 1 more")
       })
 
       it("returns the correct value when multiple artists and Artist I follow are selected", () => {
         const selectedOptions = [
           {
             paramName: FilterParamName.artistIDs,
-            paramValue: "artist-1",
-            displayText: "Z Artist 1",
-          },
-          {
-            paramName: FilterParamName.artistIDs,
-            paramValue: "artist-2",
-            displayText: "Artist 2",
+            paramValue: ["artist-1", "artist-2"],
+            displayText: "Artist 1, Artist 2",
           },
           {
             paramName: FilterParamName.artistsIFollow,
@@ -595,7 +588,7 @@ describe("selectedOption", () => {
           },
         ]
 
-        expect(selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations: [] })).toEqual(
+        expect(selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations })).toEqual(
           "All Artists I Follow, 2 more"
         )
       })
@@ -615,9 +608,7 @@ describe("selectedOption", () => {
       it("returns the correct value in the default case", () => {
         const selectedOptions = [] as FilterArray
 
-        expect(
-          selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations, filterType: "saleArtwork" })
-        ).toEqual("All")
+        expect(selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations })).toEqual("All")
       })
 
       it("returns the correct value when one artist is selected", () => {
@@ -629,9 +620,7 @@ describe("selectedOption", () => {
           },
         ]
 
-        expect(
-          selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations, filterType: "saleArtwork" })
-        ).toEqual("Banksy")
+        expect(selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations })).toEqual("Banksy")
       })
 
       it("returns the correct value when multiple artists are selected", () => {
@@ -643,9 +632,9 @@ describe("selectedOption", () => {
           },
         ]
 
-        expect(
-          selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations, filterType: "saleArtwork" })
-        ).toEqual("Andy Warhol, 1 more")
+        expect(selectedOption({ selectedOptions, filterScreen: "artistIDs", aggregations })).toEqual(
+          "Andy Warhol, 1 more"
+        )
       })
     })
   })
@@ -967,32 +956,7 @@ describe("getSelectedFiltersCounts helper", () => {
     {
       displayText: "Artists",
       paramName: FilterParamName.artistIDs,
-      paramValue: "alex-katz",
-    },
-    {
-      displayText: "Artists",
-      paramName: FilterParamName.artistIDs,
-      paramValue: "anne-siems",
-    },
-    {
-      displayText: "Artists",
-      paramName: FilterParamName.artistIDs,
-      paramValue: "cat-sirot",
-    },
-    {
-      displayText: "Artists",
-      paramName: FilterParamName.artistIDs,
-      paramValue: "brian-rutenberg",
-    },
-    {
-      displayText: "Artists",
-      paramName: FilterParamName.artistIDs,
-      paramValue: "ceravolo",
-    },
-    {
-      displayText: "Artists",
-      paramName: FilterParamName.artistIDs,
-      paramValue: "andy-warhol",
+      paramValue: ["alex-katz", "anne-siems", "cat-sirot", "brian-rutenberg", "ceravolo", "andy-warhol"],
     },
   ]
 
@@ -1221,22 +1185,7 @@ describe("getUnitedSelectedAndAppliedFilters helper", () => {
       {
         displayText: "Artists",
         paramName: FilterParamName.artistIDs,
-        paramValue: "alex-katz",
-      },
-      {
-        displayText: "Artists",
-        paramName: FilterParamName.artistIDs,
-        paramValue: "anne-siems",
-      },
-      {
-        displayText: "Artists",
-        paramName: FilterParamName.artistIDs,
-        paramValue: "cat-sirot",
-      },
-      {
-        displayText: "Artists",
-        paramName: FilterParamName.artistIDs,
-        paramValue: "ceravolo",
+        paramValue: ["alex-katz", "anne-siems", "cat-sirot", "ceravolo"],
       },
     ]
 
@@ -1244,17 +1193,7 @@ describe("getUnitedSelectedAndAppliedFilters helper", () => {
       {
         displayText: "Artists",
         paramName: FilterParamName.artistIDs,
-        paramValue: "anne-siems",
-      },
-      {
-        displayText: "Artists",
-        paramName: FilterParamName.artistIDs,
-        paramValue: "brian-rutenberg",
-      },
-      {
-        displayText: "Artists",
-        paramName: FilterParamName.artistIDs,
-        paramValue: "ceravolo",
+        paramValue: ["anne-siems", "brian-rutenberg", "ceravolo"],
       },
     ]
 
@@ -1269,17 +1208,7 @@ describe("getUnitedSelectedAndAppliedFilters helper", () => {
         {
           displayText: "Artists",
           paramName: FilterParamName.artistIDs,
-          paramValue: "alex-katz",
-        },
-        {
-          displayText: "Artists",
-          paramName: FilterParamName.artistIDs,
-          paramValue: "brian-rutenberg",
-        },
-        {
-          displayText: "Artists",
-          paramName: FilterParamName.artistIDs,
-          paramValue: "cat-sirot",
+          paramValue: ["anne-siems", "brian-rutenberg", "ceravolo"],
         },
       ])
     )


### PR DESCRIPTION
The type of this PR is: **Refactor**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3246], [FX-3275]

### Description
In the current implementation, each selected artist is stored as a separate filter entity, which complicates the readability of the code, its support, and so on. @iskounen [suggested](https://github.com/artsy/eigen/pull/5351#pullrequestreview-743174613) refactoring the artists filter to work as other multi-select filters do. 

### Expected filters format
```javascript
[
  {
    paramName: "artistIDs",
    displayText: "Alex Katz, Alex Merritt, Amze Emmons",
    paramValue: ["alex-katz", "alex-merritt", "amze-emmons"],
  },
  {
    displayText: "All Artists I Follow",
    paramName: "includeArtworksByFollowedArtists",
    paramValue: true,
  },
]
```

### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/131716377-6ff1bae8-a494-46c5-8e66-a2b9c2c771b0.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Refactor the artists filter to work like other multi-select filters - dimatretyak

<!-- end_changelog_updates -->

</details>


[FX-3246]: https://artsyproduct.atlassian.net/browse/FX-3246

[FX-3275]: https://artsyproduct.atlassian.net/browse/FX-3275