### PR TITLE
feat(FX-3274): fallback name for saved search alert without name

### DIFF
--- a/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -75,7 +75,7 @@ export const Form: React.FC<FormProps> = (props) => {
       <Spacer mt={4} />
       <Button
         testID="save-alert-button"
-        disabled={!!savedSearchAlertId && !dirty}
+        disabled={!!savedSearchAlertId && !(dirty || values.name.length === 0)}
         loading={isSubmitting}
         size="large"
         block

--- a/src/lib/Scenes/SavedSearchAlertsList/Components/SavedSearchListItem.tsx
+++ b/src/lib/Scenes/SavedSearchAlertsList/Components/SavedSearchListItem.tsx
@@ -6,6 +6,8 @@ interface SavedSearchListItemProps {
   onPress?: () => void
 }
 
+const FALLBACK_TITLE = "Untitled Alert"
+
 export const SavedSearchListItem: React.FC<SavedSearchListItemProps> = (props) => {
   const { title, onPress } = props
   const color = useColor()
@@ -15,7 +17,7 @@ export const SavedSearchListItem: React.FC<SavedSearchListItemProps> = (props) =
       <Box px={2} py={1.5}>
         <Flex flexDirection="row" alignItems="center" justifyContent="space-between">
           <Flex flex={1} flexDirection="row" mr="2">
-            <Text variant="text">{title}</Text>
+            <Text variant="text">{title ?? FALLBACK_TITLE}</Text>
           </Flex>
           <ChevronIcon direction="right" fill="black60" />
         </Flex>

--- a/src/lib/Scenes/SavedSearchAlertsList/Components/__tests__/SavedSearchesList-tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlertsList/Components/__tests__/SavedSearchesList-tests.tsx
@@ -83,4 +83,35 @@ describe("SavedSearches", () => {
 
     expect(tree.root.findAllByType(EmptyMessage)).toHaveLength(1)
   })
+
+  it("renders an empty message if there is no name for saved search alert", () => {
+    const tree = renderWithWrappers(<TestRenderer />)
+
+    mockEnvironmentPayload(mockEnvironment, {
+      SearchCriteriaConnection: () => ({
+        edges: [
+          {
+            node: {
+              userAlertSettings: {
+                name: "one",
+              },
+            },
+          },
+          {
+            node: {
+              userAlertSettings: {
+                name: null,
+              },
+            },
+          },
+        ],
+      }),
+    })
+
+    const items = tree.root.findAllByType(SavedSearchListItem)
+
+    expect(items.length).toBe(2)
+    expect(extractText(items[0])).toBe("one")
+    expect(extractText(items[1])).toBe("Untitled Alert")
+  })
 })


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3274]

### Demo
<img width="361" alt="iPhone 8 – 14 4 2021-09-02 19-30-41" src="https://user-images.githubusercontent.com/3513494/131888850-7d38bf1a-92d6-4e2b-8de4-10bbd41538bf.png">

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Display fallback name for saved search alert without name - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3274]: https://artsyproduct.atlassian.net/browse/FX-3274