### PR TITLE
Fix: Phone number doesn't populate field on edit

### DIFF
--- a/CHANGELOG.legacy.yml
+++ b/CHANGELOG.legacy.yml
@@ -26,6 +26,7 @@ upcoming:
     - Replace ios native analytics with segment analytics - kizito
   user_facing:
     - Add keyword search to artist auction reults - ole
+    - Prepopulate phone number field in edit address form - lily
 
 releases:
   - version: 6.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -820,14 +820,7 @@ DEPENDENCIES:
   - Yoga (from `./node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/artsy/Specs.git:
-    - Aerodramus
-    - "Artsy+UIColors"
-    - "Artsy+UIFonts"
-    - "Artsy+UILabels"
-    - Artsy-UIButtons
-    - Extraction
-  trunk:
+  https://cdn.cocoapods.org/:
     - Adjust
     - AFNetworkActivityLogger
     - AFNetworking
@@ -899,6 +892,13 @@ SPEC REPOS:
     - "UIView+BooleanAnimations"
     - "XCTest+OHHTTPStubSuiteCleanUp"
     - YogaKit
+  https://github.com/artsy/Specs.git:
+    - Aerodramus
+    - "Artsy+UIColors"
+    - "Artsy+UIFonts"
+    - "Artsy+UILabels"
+    - Artsy-UIButtons
+    - Extraction
 
 EXTERNAL SOURCES:
   AFOAuth1Client:

--- a/src/__generated__/SavedAddressesFormQuery.graphql.ts
+++ b/src/__generated__/SavedAddressesFormQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 4882c50bcdba5ef0707c728f8c12da46 */
+/* @relayHash 030e5e211cd3ad7645df9020a4145d31 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -41,6 +41,7 @@ fragment SavedAddressesForm_me on Me {
         city
         region
         postalCode
+        phoneNumber
         isDefault
         id
       }
@@ -203,6 +204,13 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
+                        "name": "phoneNumber",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
                         "name": "isDefault",
                         "storageKey": null
                       },
@@ -222,7 +230,7 @@ return {
     ]
   },
   "params": {
-    "id": "4882c50bcdba5ef0707c728f8c12da46",
+    "id": "030e5e211cd3ad7645df9020a4145d31",
     "metadata": {},
     "name": "SavedAddressesFormQuery",
     "operationKind": "query",

--- a/src/__generated__/SavedAddressesFormTestsQuery.graphql.ts
+++ b/src/__generated__/SavedAddressesFormTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash c1731f4f53b8c1a40f580d23f8235ef4 */
+/* @relayHash 04251a3982fac431e790ad94a9d954ed */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -41,6 +41,7 @@ fragment SavedAddressesForm_me on Me {
         city
         region
         postalCode
+        phoneNumber
         isDefault
         id
       }
@@ -203,6 +204,13 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
+                        "name": "phoneNumber",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
                         "name": "isDefault",
                         "storageKey": null
                       },
@@ -222,7 +230,7 @@ return {
     ]
   },
   "params": {
-    "id": "c1731f4f53b8c1a40f580d23f8235ef4",
+    "id": "04251a3982fac431e790ad94a9d954ed",
     "metadata": {},
     "name": "SavedAddressesFormTestsQuery",
     "operationKind": "query",

--- a/src/__generated__/SavedAddressesForm_me.graphql.ts
+++ b/src/__generated__/SavedAddressesForm_me.graphql.ts
@@ -19,6 +19,7 @@ export type SavedAddressesForm_me = {
                 readonly city: string;
                 readonly region: string | null;
                 readonly postalCode: string | null;
+                readonly phoneNumber: string | null;
                 readonly isDefault: boolean;
             } | null;
         } | null> | null;
@@ -150,6 +151,13 @@ const node: ReaderFragment = {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
+                  "name": "phoneNumber",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
                   "name": "isDefault",
                   "storageKey": null
                 }
@@ -166,5 +174,5 @@ const node: ReaderFragment = {
   "type": "Me",
   "abstractKey": null
 };
-(node as any).hash = 'b8dc20f08a969820d3a2cd8dc6b674ba';
+(node as any).hash = '8ff0c0d27e5344b9c9a750dfea54c8fc';
 export default node;

--- a/src/lib/Components/PhoneInput/PhoneInput.tsx
+++ b/src/lib/Components/PhoneInput/PhoneInput.tsx
@@ -37,6 +37,10 @@ export const PhoneInput = React.forwardRef<
   const phoneUtil = PhoneNumberUtil.getInstance()
 
   useEffect(() => {
+    if (isFirstRun.current) {
+      return
+    }
+
     const cleanPhoneNumber = cleanUserPhoneNumber(value ?? "")
     const formattedPhoneNumber = formatPhoneNumber({
       current: cleanPhoneNumber.phoneNumber,
@@ -44,11 +48,7 @@ export const PhoneInput = React.forwardRef<
       countryCode: cleanPhoneNumber.countryCode,
     })
 
-    if (formattedPhoneNumber?.match(/[\D]$/)) {
-      return;
-    }
-
-    setPhoneNumber(formattedPhoneNumber)
+    setPhoneNumber(formattedPhoneNumber.replace(/[\D]$/, ""))
     setCountryCode(cleanPhoneNumber.countryCode);
   }, [value])
 

--- a/src/lib/Components/PhoneInput/PhoneInput.tsx
+++ b/src/lib/Components/PhoneInput/PhoneInput.tsx
@@ -27,7 +27,7 @@ export const PhoneInput = React.forwardRef<
   const initialValues = cleanUserPhoneNumber(value ?? "")
   const showPhoneValidationMessage = useFeatureFlag("ARPhoneValidation")
 
-  const [countryCode, setCountryCode] = useState(initialValues.countryCode)
+  const [countryCode, setCountryCode] = useState<string>(initialValues.countryCode)
   const [phoneNumber, setPhoneNumber] = useState(
     formatPhoneNumber({ current: initialValues.phoneNumber, previous: initialValues.phoneNumber, countryCode })
   )
@@ -41,9 +41,15 @@ export const PhoneInput = React.forwardRef<
     const formattedPhoneNumber = formatPhoneNumber({
       current: cleanPhoneNumber.phoneNumber,
       previous: initialValues.phoneNumber,
-      countryCode,
+      countryCode: cleanPhoneNumber.countryCode,
     })
+
+    if (formattedPhoneNumber?.match(/[\D]$/)) {
+      return;
+    }
+
     setPhoneNumber(formattedPhoneNumber)
+    setCountryCode(cleanPhoneNumber.countryCode);
   }, [value])
 
   const isValidNumber = (number: string, code: string) => {

--- a/src/lib/Components/PhoneInput/PhoneInput.tsx
+++ b/src/lib/Components/PhoneInput/PhoneInput.tsx
@@ -36,6 +36,16 @@ export const PhoneInput = React.forwardRef<
   const countryISO2Code = countryIndex[countryCode].iso2
   const phoneUtil = PhoneNumberUtil.getInstance()
 
+  useEffect(() => {
+    const cleanPhoneNumber = cleanUserPhoneNumber(value ?? "")
+    const formattedPhoneNumber = formatPhoneNumber({
+      current: cleanPhoneNumber.phoneNumber,
+      previous: initialValues.phoneNumber,
+      countryCode,
+    })
+    setPhoneNumber(formattedPhoneNumber)
+  }, [value])
+
   const isValidNumber = (number: string, code: string) => {
     try {
       number = replace(number, /[+()-\s]/g, "")

--- a/src/lib/Scenes/Consignments/Screens/__tests__/ConfirmContactInfo-tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/__tests__/ConfirmContactInfo-tests.tsx
@@ -83,7 +83,7 @@ describe("ConfirmContactInfo", () => {
     tree.root.findByType(Button).props.onPress()
     expect(env.mock.getAllOperations()).toHaveLength(1)
     expect(env.mock.getMostRecentOperation().request.node.operation.name).toBe("updateMyUserProfileMutation")
-    expect(env.mock.getMostRecentOperation().request.variables).toEqual({ input: { phone: "+15558902345" } })
+    expect(env.mock.getMostRecentOperation().request.variables).toEqual({ input: { phone: "+1 (555) 890-2345" } })
   })
 
   it("shows an alert if something went wrong", async () => {

--- a/src/lib/Scenes/SavedAddresses/SavedAddressesForm.tsx
+++ b/src/lib/Scenes/SavedAddresses/SavedAddressesForm.tsx
@@ -86,19 +86,16 @@ export const SavedAddressesForm: React.FC<{ me: SavedAddressesForm_me; addressId
   const toast = useToast()
 
   const [state, actions] = useStore()
-  const [phoneNumber, setPhoneNumber] = useState(me?.phone)
+  const [phoneNumber, setPhoneNumber] = useState("")
   const [isDefaultAddress, setIsDefaultAddress] = useState(false)
   const { height } = useScreenDimensions()
   const offSetTop = 0.75
 
   useEffect(() => {
-    setPhoneNumber(me?.phone)
-  }, [me?.phone])
-
-  useEffect(() => {
     if (isEditForm) {
       const addresses = extractNodes(me.addressConnection)
       const selectedAddress = addresses!.find((address) => address.internalID === addressId)
+      setPhoneNumber(selectedAddress?.phoneNumber!)
       Object.keys(actions.fields).forEach((field) => {
         const fieldValue = selectedAddress?.[field as keyof FormFields] ?? ""
         actions.fields[field as keyof FormFields].setValue(fieldValue)
@@ -267,6 +264,7 @@ export const SavedAddressesFormContainer = createFragmentContainer(SavedAddresse
             city
             region
             postalCode
+            phoneNumber
             isDefault
           }
         }


### PR DESCRIPTION
The type of this PR is: BUGFIX

[PURCHASE-2898]

Paired with @copperkraft 

When editing an address, the phone input is always empty and with the incorrect country code, even if there’s an existing phone number. So, saving, even if there were no changes, overrides the existing one with an empty one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- fix populating phone number on editing saving adress - lilyfromseattle

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-


<!-- end_changelog_updates -->

</details>

[PURCHASE-2898]: https://artsyproduct.atlassian.net/browse/PURCHASE-2898