### PR TITLE
fix(FX-3255): disabled options cannot clicked

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -85,7 +85,7 @@ PODS:
     - react-native-cameraroll (= 1.3.0)
     - react-native-geolocation (= 2.0.2)
     - react-native-mapbox-gl (= 8.2.0-beta2)
-    - react-native-netinfo (= 4.6.1)
+    - react-native-netinfo (= 6.0.1)
     - React-RCTActionSheet (= 0.63.3)
     - React-RCTAnimation (= 0.63.3)
     - React-RCTImage (= 0.63.3)
@@ -519,8 +519,8 @@ PODS:
     - Mapbox-iOS-SDK (~> 6.3)
     - React
     - React-Core
-  - react-native-netinfo (4.6.1):
-    - React
+  - react-native-netinfo (6.0.1):
+    - React-Core
   - react-native-safe-area-context (3.3.0):
     - React-Core
   - react-native-view-shot (3.1.2):
@@ -1088,7 +1088,7 @@ SPEC CHECKSUMS:
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
   DoubleConversion: cde416483dac037923206447da6e1454df403714
   EDColor: c83f9a61f9f9b3c23d541f1feb561558e29cb088
-  Emission: d1ca04d191776a641ee1224cd26da9eeec5d52ff
+  Emission: 10e56f88dd6fc9dceebf7300d17b157dd4b77869
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   "Expecta+Snapshots": dcff217eef506dabd6dfdc7864ea2da321fafbb8
   Extraction: 2be993a17f8f8c4fac988ebecaed93a409181faf
@@ -1163,7 +1163,7 @@ SPEC CHECKSUMS:
   react-native-flipper: e3da3457a7cb984b4beaddecb587674a8545b71d
   react-native-geolocation: c956aeb136625c23e0dce0467664af2c437888c9
   react-native-mapbox-gl: 28350f5f43df85fdb6b85398821a96db1fab0c76
-  react-native-netinfo: a59d8426a8484f739fe3a95dd6ad5af1435db05f
+  react-native-netinfo: 7cb7877ff31ebeb3d03ce0b4fbb616f121ddd859
   react-native-safe-area-context: 61c8c484a3a9e7d1fda19f7b1794b35bbfd2262a
   react-native-view-shot: 4475fde003fe8a210053d1f98fb9e06c1d834e1c
   react-native-viewpager: ea945e2881ce9a4a8bcdc84de4ec65ff23c90f6e

--- a/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
@@ -85,6 +85,8 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
           keyExtractor={(_item, index) => String(index)}
           data={filteredOptions}
           renderItem={({ item }) => {
+            const disabled = itemIsDisabled(item)
+
             return (
               <Box ml={0.5}>
                 <TouchableRow
@@ -92,13 +94,14 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
                     const currentParamValue = item.paramValue as boolean
                     onSelect(item, !currentParamValue)
                   }}
+                  disabled={disabled}
                 >
                   <OptionListItem>
                     <Text variant="caption" color="black100">
                       {item.displayText}
                     </Text>
 
-                    <Check selected={itemIsSelected(item)} disabled={itemIsDisabled(item)} />
+                    <Check selected={itemIsSelected(item)} disabled={disabled} />
                   </OptionListItem>
                 </TouchableRow>
               </Box>

--- a/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
@@ -68,7 +68,7 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
       {!!searchable && (
         <>
           <Flex m={2}>
-            <SearchInput onChangeText={setQuery} placeholder="Filter results" />
+            <SearchInput onChangeText={setQuery} testID="multi-select-search-input" placeholder="Filter results" />
           </Flex>
 
           {filteredOptions.length === 0 && (
@@ -95,6 +95,7 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
                     onSelect(item, !currentParamValue)
                   }}
                   disabled={disabled}
+                  testID="multi-select-option-button"
                 >
                   <OptionListItem>
                     <Text variant="caption" color="black100">

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/MultiSelectOption-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/MultiSelectOption-tests.tsx
@@ -1,6 +1,6 @@
-import { SearchInput } from "lib/Components/SearchInput"
+import { fireEvent } from "@testing-library/react-native"
 import { extractText } from "lib/tests/extractText"
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { FilterData, FilterParamName } from "../../ArtworkFilterHelpers"
 import { MultiSelectOptionScreen } from "../MultiSelectOption"
@@ -14,36 +14,64 @@ const EXAMPLE_FILTER_OPTIONS: FilterData[] = [
 
 describe("MultiSelectOption", () => {
   it("renders the options", () => {
-    const tree = renderWithWrappers(
+    const { getAllByTestId } = renderWithWrappersTL(
       <MultiSelectOptionScreen filterOptions={EXAMPLE_FILTER_OPTIONS} searchable {...getEssentialProps()} />
     )
 
-    expect(extractText(tree.root)).toEqual("First ExampleAnother OneThe Third")
+    expect(getAllByTestId("multi-select-option-button").map(extractText)).toEqual([
+      "First Example",
+      "Another One",
+      "The Third",
+    ])
+  })
+
+  it("a disabled option cannot be clicked", () => {
+    const onSelectMock = jest.fn()
+    const { getAllByTestId } = renderWithWrappersTL(
+      <MultiSelectOptionScreen
+        filterOptions={EXAMPLE_FILTER_OPTIONS}
+        onSelect={onSelectMock}
+        isDisabled={() => true}
+        {...getEssentialProps()}
+      />
+    )
+
+    fireEvent.press(getAllByTestId("multi-select-option-button")[0])
+
+    expect(onSelectMock).not.toBeCalled()
   })
 
   describe("searchable", () => {
     it("filters the options with searchable", () => {
-      const tree = renderWithWrappers(
+      const { getAllByTestId, getByTestId } = renderWithWrappersTL(
         <MultiSelectOptionScreen filterOptions={EXAMPLE_FILTER_OPTIONS} searchable {...getEssentialProps()} />
       )
 
-      expect(extractText(tree.root)).toEqual("First ExampleAnother OneThe Third")
+      expect(getAllByTestId("multi-select-option-button").map(extractText)).toEqual([
+        "First Example",
+        "Another One",
+        "The Third",
+      ])
 
-      tree.root.findByType(SearchInput).props.onChangeText("another")
+      fireEvent.changeText(getByTestId("multi-select-search-input"), "another")
 
-      expect(extractText(tree.root)).toEqual("Another One")
+      expect(getAllByTestId("multi-select-option-button").map(extractText)).toEqual(["Another One"])
     })
 
     it("displays a message indicating no results when nothing matches the search input", () => {
-      const tree = renderWithWrappers(
+      const { getAllByTestId, getByTestId, getByText } = renderWithWrappersTL(
         <MultiSelectOptionScreen filterOptions={EXAMPLE_FILTER_OPTIONS} searchable {...getEssentialProps()} />
       )
 
-      expect(extractText(tree.root)).toEqual("First ExampleAnother OneThe Third")
+      expect(getAllByTestId("multi-select-option-button").map(extractText)).toEqual([
+        "First Example",
+        "Another One",
+        "The Third",
+      ])
 
-      tree.root.findByType(SearchInput).props.onChangeText("garbage")
+      fireEvent.changeText(getByTestId("multi-select-search-input"), "garbage")
 
-      expect(extractText(tree.root)).toEqual("No results")
+      expect(getByText("No results")).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3255]

### Description
Previously, it was possible to select a filter option that was disabled (there were only visual changes). This bug is fixed in this PR and the user cannot click on the disabled element


### Demo
#### Before
https://user-images.githubusercontent.com/3513494/131998152-039b2811-1340-4791-be51-2ed6791091bf.mp4

#### After
https://user-images.githubusercontent.com/3513494/131997542-c9a215d0-7506-4e49-b6e1-1134f216b009.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Disabled filter options cannot clicked - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3255]: https://artsyproduct.atlassian.net/browse/FX-3255