### PR TITLE
feat: add artwork pill and show artwork grid when selected

### DIFF
--- a/src/__generated__/SearchArtworksGridQuery.graphql.ts
+++ b/src/__generated__/SearchArtworksGridQuery.graphql.ts
@@ -1,0 +1,413 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash 651e7baa557924fafba7f549b7c6af0d */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SearchArtworksGridQueryVariables = {};
+export type SearchArtworksGridQueryResponse = {
+    readonly artworksConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly id: string;
+                readonly image: {
+                    readonly aspect_ratio: number;
+                } | null;
+                readonly " $fragmentRefs": FragmentRefs<"ArtworkGridItem_artwork">;
+            } | null;
+        } | null> | null;
+    } | null;
+};
+export type SearchArtworksGridQuery = {
+    readonly response: SearchArtworksGridQueryResponse;
+    readonly variables: SearchArtworksGridQueryVariables;
+};
+
+
+
+/*
+query SearchArtworksGridQuery {
+  artworksConnection(first: 10) {
+    edges {
+      node {
+        id
+        image {
+          aspect_ratio: aspectRatio
+        }
+        ...ArtworkGridItem_artwork
+      }
+    }
+    id
+  }
+}
+
+fragment ArtworkGridItem_artwork on Artwork {
+  title
+  date
+  saleMessage
+  slug
+  internalID
+  artistNames
+  href
+  sale {
+    isAuction
+    isClosed
+    displayTimelyAt
+    endAt
+    id
+  }
+  saleArtwork {
+    counts {
+      bidderPositions
+    }
+    currentBid {
+      display
+    }
+    lotLabel
+    id
+  }
+  partner {
+    name
+    id
+  }
+  image {
+    url(version: "large")
+    aspectRatio
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "alias": "aspect_ratio",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "aspectRatio",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SearchArtworksGridQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "FilterArtworksConnection",
+        "kind": "LinkedField",
+        "name": "artworksConnection",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "FilterArtworksEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Artwork",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v1/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Image",
+                    "kind": "LinkedField",
+                    "name": "image",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
+                    "name": "ArtworkGridItem_artwork"
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "artworksConnection(first:10)"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "SearchArtworksGridQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "FilterArtworksConnection",
+        "kind": "LinkedField",
+        "name": "artworksConnection",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "FilterArtworksEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Artwork",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v1/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Image",
+                    "kind": "LinkedField",
+                    "name": "image",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": "large"
+                          }
+                        ],
+                        "kind": "ScalarField",
+                        "name": "url",
+                        "storageKey": "url(version:\"large\")"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "aspectRatio",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "title",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "date",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "saleMessage",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "slug",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "internalID",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "artistNames",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "href",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Sale",
+                    "kind": "LinkedField",
+                    "name": "sale",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isAuction",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isClosed",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "displayTimelyAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endAt",
+                        "storageKey": null
+                      },
+                      (v1/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "SaleArtwork",
+                    "kind": "LinkedField",
+                    "name": "saleArtwork",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "SaleArtworkCounts",
+                        "kind": "LinkedField",
+                        "name": "counts",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "bidderPositions",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "SaleArtworkCurrentBid",
+                        "kind": "LinkedField",
+                        "name": "currentBid",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "display",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lotLabel",
+                        "storageKey": null
+                      },
+                      (v1/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Partner",
+                    "kind": "LinkedField",
+                    "name": "partner",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      (v1/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          (v1/*: any*/)
+        ],
+        "storageKey": "artworksConnection(first:10)"
+      }
+    ]
+  },
+  "params": {
+    "id": "651e7baa557924fafba7f549b7c6af0d",
+    "metadata": {},
+    "name": "SearchArtworksGridQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = 'ac65d0089b81b624b92fc79326ed8052';
+export default node;

--- a/src/__generated__/SearchArtworksGridRefetchQuery.graphql.ts
+++ b/src/__generated__/SearchArtworksGridRefetchQuery.graphql.ts
@@ -1,0 +1,400 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash acb250efe638ffbf5d1dbca2ef1fc71a */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SearchArtworksGridRefetchQueryVariables = {};
+export type SearchArtworksGridRefetchQueryResponse = {
+    readonly artworksConnection: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly " $fragmentRefs": FragmentRefs<"SearchArtworksGrid_artworks">;
+            } | null;
+        } | null> | null;
+    } | null;
+};
+export type SearchArtworksGridRefetchQuery = {
+    readonly response: SearchArtworksGridRefetchQueryResponse;
+    readonly variables: SearchArtworksGridRefetchQueryVariables;
+};
+
+
+
+/*
+query SearchArtworksGridRefetchQuery {
+  artworksConnection(first: 10) {
+    edges {
+      node {
+        ...SearchArtworksGrid_artworks
+        id
+      }
+    }
+    id
+  }
+}
+
+fragment ArtworkGridItem_artwork on Artwork {
+  title
+  date
+  saleMessage
+  slug
+  internalID
+  artistNames
+  href
+  sale {
+    isAuction
+    isClosed
+    displayTimelyAt
+    endAt
+    id
+  }
+  saleArtwork {
+    counts {
+      bidderPositions
+    }
+    currentBid {
+      display
+    }
+    lotLabel
+    id
+  }
+  partner {
+    name
+    id
+  }
+  image {
+    url(version: "large")
+    aspectRatio
+  }
+}
+
+fragment SearchArtworksGrid_artworks on Artwork {
+  id
+  image {
+    aspect_ratio: aspectRatio
+  }
+  ...ArtworkGridItem_artwork
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SearchArtworksGridRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "FilterArtworksConnection",
+        "kind": "LinkedField",
+        "name": "artworksConnection",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "FilterArtworksEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Artwork",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
+                    "name": "SearchArtworksGrid_artworks"
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "artworksConnection(first:10)"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "SearchArtworksGridRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "FilterArtworksConnection",
+        "kind": "LinkedField",
+        "name": "artworksConnection",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "FilterArtworksEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Artwork",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v1/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Image",
+                    "kind": "LinkedField",
+                    "name": "image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": "aspect_ratio",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "aspectRatio",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": "large"
+                          }
+                        ],
+                        "kind": "ScalarField",
+                        "name": "url",
+                        "storageKey": "url(version:\"large\")"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "aspectRatio",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "title",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "date",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "saleMessage",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "slug",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "internalID",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "artistNames",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "href",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Sale",
+                    "kind": "LinkedField",
+                    "name": "sale",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isAuction",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isClosed",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "displayTimelyAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endAt",
+                        "storageKey": null
+                      },
+                      (v1/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "SaleArtwork",
+                    "kind": "LinkedField",
+                    "name": "saleArtwork",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "SaleArtworkCounts",
+                        "kind": "LinkedField",
+                        "name": "counts",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "bidderPositions",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "SaleArtworkCurrentBid",
+                        "kind": "LinkedField",
+                        "name": "currentBid",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "display",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lotLabel",
+                        "storageKey": null
+                      },
+                      (v1/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Partner",
+                    "kind": "LinkedField",
+                    "name": "partner",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      (v1/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          (v1/*: any*/)
+        ],
+        "storageKey": "artworksConnection(first:10)"
+      }
+    ]
+  },
+  "params": {
+    "id": "acb250efe638ffbf5d1dbca2ef1fc71a",
+    "metadata": {},
+    "name": "SearchArtworksGridRefetchQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = '3eb9c80f11882a1253f865a32c716204';
+export default node;

--- a/src/__generated__/SearchArtworksGrid_artworks.graphql.ts
+++ b/src/__generated__/SearchArtworksGrid_artworks.graphql.ts
@@ -1,0 +1,66 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type SearchArtworksGrid_artworks = ReadonlyArray<{
+    readonly id: string;
+    readonly image: {
+        readonly aspect_ratio: number;
+    } | null;
+    readonly " $fragmentRefs": FragmentRefs<"ArtworkGridItem_artwork">;
+    readonly " $refType": "SearchArtworksGrid_artworks";
+}>;
+export type SearchArtworksGrid_artworks$data = SearchArtworksGrid_artworks;
+export type SearchArtworksGrid_artworks$key = ReadonlyArray<{
+    readonly " $data"?: SearchArtworksGrid_artworks$data;
+    readonly " $fragmentRefs": FragmentRefs<"SearchArtworksGrid_artworks">;
+}>;
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "SearchArtworksGrid_artworks",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "image",
+      "plural": false,
+      "selections": [
+        {
+          "alias": "aspect_ratio",
+          "args": null,
+          "kind": "ScalarField",
+          "name": "aspectRatio",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "ArtworkGridItem_artwork"
+    }
+  ],
+  "type": "Artwork",
+  "abstractKey": null
+};
+(node as any).hash = '7d9f73429d23691fd24fa6b2e8806da7';
+export default node;

--- a/src/lib/Scenes/Search2/Search2.tsx
+++ b/src/lib/Scenes/Search2/Search2.tsx
@@ -10,7 +10,7 @@ import { isPad } from "lib/utils/hardware"
 import { Schema } from "lib/utils/track"
 import { useAlgoliaClient } from "lib/utils/useAlgoliaClient"
 import { Flex, Pill, Spacer, Spinner, Text, Touchable, useSpace } from "palette"
-import React, { useEffect, useRef, useState } from "react"
+import React, { useEffect, useMemo, useRef, useState } from "react"
 import { InfiniteHitsProvided, StateResultsProvided } from "react-instantsearch-core"
 import {
   connectHighlight,
@@ -180,13 +180,16 @@ export const Search2: React.FC<Search2QueryResponse> = (props) => {
   const [elasticSearchEntity, setElasticSearchEntity] = useState("")
   const searchProviderValues = useSearchProviderValues(searchState?.query ?? "")
   const { system } = props
-  const [pillsArray, setPillsArray] = useState(pills)
   const { searchClient } = useAlgoliaClient(system?.algolia?.appID!, system?.algolia?.apiKey!)
 
-  useEffect(() => {
-    if (system?.algolia?.indices !== undefined && system?.algolia?.indices.length > 0) {
-      setPillsArray([...pills, ...system.algolia.indices!])
+  const pillsArray = useMemo(() => {
+    const indices = system?.algolia?.indices
+
+    if (Array.isArray(indices) && indices.length > 0) {
+      return [...pills, ...indices]
     }
+
+    return pills
   }, [system?.algolia?.indices])
 
   if (!searchClient) {
@@ -232,17 +235,19 @@ export const Search2: React.FC<Search2QueryResponse> = (props) => {
           {!!shouldStartQuering ? (
             <>
               <Flex p={2} pb={1} flexDirection="row">
-                {pillsArray.map(({ name, displayName }) => (
-                  <Pill
-                    mr={1}
-                    key={name}
-                    rounded
-                    selected={selectedAlgoliaIndex === name || elasticSearchEntity === name}
-                    onPress={() => handlePillPress(name)}
-                  >
-                    {displayName}
-                  </Pill>
-                ))}
+                <ScrollView horizontal>
+                  {pillsArray.map(({ name, displayName }) => (
+                    <Pill
+                      mr={1}
+                      key={name}
+                      rounded
+                      selected={selectedAlgoliaIndex === name || elasticSearchEntity === name}
+                      onPress={() => handlePillPress(name)}
+                    >
+                      {displayName}
+                    </Pill>
+                  ))}
+                </ScrollView>
               </Flex>
               {renderResults()}
             </>

--- a/src/lib/Scenes/Search2/Search2.tsx
+++ b/src/lib/Scenes/Search2/Search2.tsx
@@ -233,17 +233,15 @@ export const Search2: React.FC<Search2QueryResponse> = (props) => {
             <>
               <Flex p={2} pb={1} flexDirection="row">
                 {pillsArray.map(({ name, displayName }) => (
-                  <>
-                    <Pill
-                      mr={0.5}
-                      key={name}
-                      rounded
-                      selected={selectedAlgoliaIndex === name || elasticSearchEntity === name}
-                      onPress={() => handlePillPress(name)}
-                    >
-                      {displayName}
-                    </Pill>
-                  </>
+                  <Pill
+                    mr={1}
+                    key={name}
+                    rounded
+                    selected={selectedAlgoliaIndex === name || elasticSearchEntity === name}
+                    onPress={() => handlePillPress(name)}
+                  >
+                    {displayName}
+                  </Pill>
                 ))}
               </Flex>
               {renderResults()}

--- a/src/lib/Scenes/Search2/Search2.tsx
+++ b/src/lib/Scenes/Search2/Search2.tsx
@@ -27,6 +27,7 @@ import { AutosuggestResults } from "../Search/AutosuggestResults"
 import { CityGuideCTA } from "../Search/CityGuideCTA"
 import { RecentSearches } from "../Search/RecentSearches"
 import { SearchContext, useSearchProviderValues } from "../Search/SearchContext"
+import { SearchArtworksGridQueryRenderer } from "./SearchArtworksGrid"
 
 interface SearchInputProps {
   refine: (value: string) => any
@@ -171,27 +172,50 @@ interface SearchState {
   page?: number
 }
 
+const pills = [{ name: "ARTWORK", displayName: "Artworks" }]
+
 export const Search2: React.FC<Search2QueryResponse> = (props) => {
   const [searchState, setSearchState] = useState<SearchState>({})
   const [selectedAlgoliaIndex, setSelectedAlgoliaIndex] = useState("")
+  const [elasticSearchEntity, setElasticSearchEntity] = useState("")
   const searchProviderValues = useSearchProviderValues(searchState?.query ?? "")
   const { system } = props
-
+  const [pillsArray, setPillsArray] = useState(pills)
   const { searchClient } = useAlgoliaClient(system?.algolia?.appID!, system?.algolia?.apiKey!)
+
+  useEffect(() => {
+    if (system?.algolia?.indices !== undefined && system?.algolia?.indices.length > 0) {
+      setPillsArray([...pills, ...system.algolia.indices!])
+    }
+  }, [system?.algolia?.indices])
 
   if (!searchClient) {
     // error handling in case appID or apiKey is not set ??
     return null
   }
 
-  const renderResults = () =>
-    !!selectedAlgoliaIndex ? (
-      <SearchResultsContainer indexName={selectedAlgoliaIndex} />
-    ) : (
-      <AutosuggestResults query={searchState.query!} />
-    )
+  const renderResults = () => {
+    if (!!selectedAlgoliaIndex) {
+      return <SearchResultsContainer />
+    }
+    if (!!elasticSearchEntity) {
+      return <SearchArtworksGridQueryRenderer />
+    }
+    return <AutosuggestResults query={searchState.query!} />
+  }
 
   const shouldStartQuering = !!searchState?.query?.length && searchState?.query.length >= 2
+
+  const handlePillPress = (name: string) => {
+    setSearchState((prevState) => ({ ...prevState, page: 1 }))
+    if (name === "ARTWORK") {
+      setSelectedAlgoliaIndex("")
+      setElasticSearchEntity(elasticSearchEntity === name ? "" : name)
+      return
+    }
+    setElasticSearchEntity("")
+    setSelectedAlgoliaIndex(selectedAlgoliaIndex === name ? "" : name)
+  }
 
   return (
     <SearchContext.Provider value={searchProviderValues}>
@@ -205,23 +229,21 @@ export const Search2: React.FC<Search2QueryResponse> = (props) => {
           <Flex p={2} pb={1}>
             <SearchInputContainer placeholder="Search artists, artworks, galleries, etc" />
           </Flex>
-
           {!!shouldStartQuering ? (
             <>
               <Flex p={2} pb={1} flexDirection="row">
-                {system?.algolia?.indices.map(({ name, displayName }) => (
-                  <Pill
-                    ml={0.5}
-                    key={name}
-                    rounded
-                    selected={selectedAlgoliaIndex === name}
-                    onPress={() => {
-                      setSelectedAlgoliaIndex(selectedAlgoliaIndex === name ? "" : name)
-                      setSearchState((prevState) => ({ ...prevState, page: 1 }))
-                    }}
-                  >
-                    {displayName}
-                  </Pill>
+                {pillsArray.map(({ name, displayName }) => (
+                  <>
+                    <Pill
+                      mr={0.5}
+                      key={name}
+                      rounded
+                      selected={selectedAlgoliaIndex === name || elasticSearchEntity === name}
+                      onPress={() => handlePillPress(name)}
+                    >
+                      {displayName}
+                    </Pill>
+                  </>
                 ))}
               </Flex>
               {renderResults()}

--- a/src/lib/Scenes/Search2/Search2.tsx
+++ b/src/lib/Scenes/Search2/Search2.tsx
@@ -199,7 +199,7 @@ export const Search2: React.FC<Search2QueryResponse> = (props) => {
 
   const renderResults = () => {
     if (!!selectedAlgoliaIndex) {
-      return <SearchResultsContainer />
+      return <SearchResultsContainer indexName={selectedAlgoliaIndex} />
     }
     if (!!elasticSearchEntity) {
       return <SearchArtworksGridQueryRenderer />

--- a/src/lib/Scenes/Search2/Search2.tsx
+++ b/src/lib/Scenes/Search2/Search2.tsx
@@ -234,8 +234,8 @@ export const Search2: React.FC<Search2QueryResponse> = (props) => {
           </Flex>
           {!!shouldStartQuering ? (
             <>
-              <Flex p={2} pb={1} flexDirection="row">
-                <ScrollView horizontal>
+              <Flex p={2} pb={1}>
+                <ScrollView horizontal showsHorizontalScrollIndicator={false}>
                   {pillsArray.map(({ name, displayName }) => (
                     <Pill
                       mr={1}

--- a/src/lib/Scenes/Search2/SearchArtworksGrid.tsx
+++ b/src/lib/Scenes/Search2/SearchArtworksGrid.tsx
@@ -1,0 +1,70 @@
+import { SearchArtworksGridQuery } from "__generated__/SearchArtworksGridQuery.graphql"
+import { InfiniteScrollArtworksGridContainer } from "lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
+import { defaultEnvironment } from "lib/relay/createEnvironment"
+import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
+import { Flex } from "palette"
+import React from "react"
+import { createRefetchContainer, graphql, QueryRenderer } from "react-relay"
+
+const SearchArtworksGrid = (props: any) => {
+  return (
+    <Flex p={2} pb={0}>
+      <InfiniteScrollArtworksGridContainer connection={props?.artworksConnection ?? null} {...props} />
+    </Flex>
+  )
+}
+
+export const SearchArtworksGridQueryRenderer: React.FC<{}> = ({}) => {
+  return (
+    <QueryRenderer<SearchArtworksGridQuery>
+      environment={defaultEnvironment}
+      query={graphql`
+        query SearchArtworksGridQuery {
+          artworksConnection(first: 10) {
+            edges {
+              node {
+                id
+                image {
+                  aspect_ratio: aspectRatio
+                }
+                ...ArtworkGridItem_artwork
+              }
+            }
+          }
+        }
+      `}
+      render={renderWithPlaceholder({
+        Container: SearchArtworksGridContainer,
+        renderPlaceholder: () => <SearchArtworksGrid />,
+      })}
+      variables={{}}
+      cacheConfig={{ force: true }}
+    />
+  )
+}
+
+export const SearchArtworksGridContainer = createRefetchContainer(
+  SearchArtworksGrid,
+  {
+    artworks: graphql`
+      fragment SearchArtworksGrid_artworks on Artwork @relay(plural: true) {
+        id
+        image {
+          aspect_ratio: aspectRatio
+        }
+        ...ArtworkGridItem_artwork
+      }
+    `,
+  },
+  graphql`
+    query SearchArtworksGridRefetchQuery {
+      artworksConnection(first: 10) {
+        edges {
+          node {
+            ...SearchArtworksGrid_artworks
+          }
+        }
+      }
+    }
+  `
+)


### PR DESCRIPTION
The type of this PR is: **TYPE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3283]

### Description

This is the initial implementation including:
- showing the artwork pill (independed from algolia indices since we're getting the artworks from metaphysics)
- will add to the component keyword as input to filter through the artworks afterwards but this is why I added the refetch container.

> **note:** This is hidden behind a feature flag 

### Screenshots
|Android|iOS|
|---|---|
|<img width="383" alt="Screenshot 2021-09-09 at 10 46 29" src="https://user-images.githubusercontent.com/21178754/132653990-39ddb48c-397a-4bf2-ace5-879465d14a11.png">|![Simulator Screen Shot - iPhone 8 - 2021-09-09 at 10 40 40](https://user-images.githubusercontent.com/21178754/132653254-3d6831b6-337d-4eb5-bdc4-ccec86be41b1.png)|

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- introducing artwork pill and grid in improved search screen - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3283]: https://artsyproduct.atlassian.net/browse/FX-3283