### PR TITLE
fix: Add horizontal padding to auciton confirmation step bottom text

### DIFF
--- a/src/lib/Components/Bidding/Screens/ConfirmBid/index.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid/index.tsx
@@ -540,10 +540,9 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
               />
             </Box>
           </ScrollView>
+          <Divider />
 
-          <Box mx={4}>
-            <Divider />
-
+          <Box px={4}>
             {requiresCheckbox ? (
               <Checkbox
                 mt={4}

--- a/src/lib/Components/Bidding/Screens/ConfirmBid/index.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid/index.tsx
@@ -541,7 +541,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
             </Box>
           </ScrollView>
 
-          <Box>
+          <Box mx={4}>
             <Divider />
 
             {requiresCheckbox ? (
@@ -561,7 +561,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
                 </Serif>
               </Checkbox>
             ) : (
-              <Flex alignItems="center">
+              <Flex>
                 <Serif size="2" mt={2} color="black60">
                   You agree to{" "}
                   <LinkText onPress={isLoading ? undefined : () => this.onConditionsOfSaleLinkPressed()}>

--- a/src/lib/Components/Bidding/Screens/ConfirmBid/index.tsx
+++ b/src/lib/Components/Bidding/Screens/ConfirmBid/index.tsx
@@ -27,7 +27,7 @@ import { unsafe_getFeatureFlag } from "lib/store/GlobalStore"
 import NavigatorIOS from "lib/utils/__legacy_do_not_use__navigator-ios-shim"
 import { Schema, screenTrack, track } from "lib/utils/track"
 import { get, isEmpty } from "lodash"
-import { Box, Button, Serif, Theme } from "palette"
+import { Box, Button, Serif, Text, Theme } from "palette"
 import { Checkbox } from "palette/elements/Checkbox"
 import React from "react"
 import { Image, ScrollView, ViewProps } from "react-native"
@@ -542,29 +542,29 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
           </ScrollView>
           <Divider />
 
-          <Box px={4}>
+          <Box>
             {requiresCheckbox ? (
               <Checkbox
                 mt={4}
-                mx={5}
+                mx={3}
                 justifyContent="center"
                 onPress={() => this.onConditionsOfSaleCheckboxPressed()}
                 disabled={isLoading}
               >
-                <Serif size="2" mt={2} color="black60">
+                <Text color="black60">
                   You agree to{" "}
                   <LinkText onPress={isLoading ? undefined : () => this.onConditionsOfSaleLinkPressed()}>
-                    {partnerName(sale! /* STRICTNESS_MIGRATION */)} Conditions of Sale
+                    {partnerName(sale!)} Conditions of Sale
                   </LinkText>
                   .
-                </Serif>
+                </Text>
               </Checkbox>
             ) : (
-              <Flex>
+              <Flex alignItems="center" px={4}>
                 <Serif size="2" mt={2} color="black60">
                   You agree to{" "}
                   <LinkText onPress={isLoading ? undefined : () => this.onConditionsOfSaleLinkPressed()}>
-                    {partnerName(sale! /* STRICTNESS_MIGRATION */)} Conditions of Sale
+                    {partnerName(sale!)} Conditions of Sale
                   </LinkText>
                   .
                 </Serif>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1907]

### Description

Adds horizontal padding to the auction confirmation step bottom text.

**Palette V3**

| Before | After |
| --- | --- | 
| ![Simulator Screen Shot - iPhone 8 - 2021-09-09 at 15 55 37](https://user-images.githubusercontent.com/4691889/132701281-3ebd3d8a-e077-49d2-ba3d-efa2c7a651e2.png) |  ![Simulator Screen Shot - iPhone 8 - 2021-09-09 at 16 06 31](https://user-images.githubusercontent.com/4691889/132701209-2c50dc96-5b41-45da-bd04-2acf50645443.png) |

**Palette V2**





| Before | After |
| --- | --- | 
| ![Simulator Screen Shot - iPhone 8 - 2021-09-10 at 08 58 08](https://user-images.githubusercontent.com/4691889/132813123-657cece0-688c-489c-aec0-6526c6d4ed76.png) |  ![Simulator Screen Shot - iPhone 8 - 2021-09-10 at 08 58 36](https://user-images.githubusercontent.com/4691889/132813134-f9de695a-e1d0-4f62-b7c8-8f9b05cd4638.png) |




### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Add horizontal padding to the auction confirmation step bottom text - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-1907]: https://artsyproduct.atlassian.net/browse/CX-1907