### PR TITLE
refactor(FX-3288): Refactor useArtworkFilters and use it on artwork pages

### DIFF
--- a/src/lib/Components/ArtworkFilter/useArtworkFilters.ts
+++ b/src/lib/Components/ArtworkFilter/useArtworkFilters.ts
@@ -1,5 +1,6 @@
+import { PAGE_SIZE } from "lib/data/constants"
 import { useEffect } from "react"
-import { RelayPaginationProp } from "react-relay"
+import { RelayPaginationProp, Variables } from "react-relay"
 import {
   aggregationForFilter,
   filterArtworksParams,
@@ -8,10 +9,27 @@ import {
 } from "./ArtworkFilterHelpers"
 import { ArtworksFiltersStore, selectedOptionsUnion } from "./ArtworkFilterStore"
 
+interface UseArtworkFiltersOptions {
+  relay?: RelayPaginationProp
+  aggregations?: unknown
+  pageSize?: number
+  componentPath?: string
+  type?: "filter" | "sort"
+  refetchVariables?: Variables | null
+  onApply?: () => void
+  onRefetch?: () => void
+}
+
 export const useArtworkFilters = ({
   relay,
   aggregations,
-}: { relay?: RelayPaginationProp; aggregations?: unknown } = {}) => {
+  pageSize = PAGE_SIZE,
+  componentPath,
+  refetchVariables,
+  onApply,
+  onRefetch,
+  type = "filter",
+}: UseArtworkFiltersOptions) => {
   const setAggregationsAction = ArtworksFiltersStore.useStoreActions((state) => state.setAggregationsAction)
   const appliedFilters = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
   const applyFilters = ArtworksFiltersStore.useStoreState((state) => state.applyFilters)
@@ -23,27 +41,29 @@ export const useArtworkFilters = ({
     if (!aggregations) {
       return
     }
-
     setAggregationsAction(aggregations)
-  }, [aggregations])
+  }, [])
 
   useEffect(() => {
     if (relay !== undefined && applyFilters) {
       relay.refetchConnection(
-        30,
+        pageSize,
         (error) => {
+          if (onRefetch) {
+            onRefetch()
+          }
           if (error) {
-            throw error
+            const errorMessage = componentPath ? `${componentPath} ${type} error: ${error.message}` : error.message
+            throw new Error(errorMessage)
           }
         },
-        { input: prepareFilterArtworksParamsForInput(filterParams) }
+        refetchVariables ?? { input: prepareFilterArtworksParamsForInput(filterParams) }
       )
+      if (onApply) {
+        onApply()
+      }
     }
   }, [relay, appliedFilters, filterParams])
-
-  return {
-    filterParams,
-  }
 }
 
 export const useArtworkFiltersAggregation = ({ paramName }: { paramName: FilterParamName }) => {

--- a/src/lib/Components/ArtworkFilter/useArtworkFilters.ts
+++ b/src/lib/Components/ArtworkFilter/useArtworkFilters.ts
@@ -17,7 +17,7 @@ interface UseArtworkFiltersOptions {
   type?: "filter" | "sort"
   refetchVariables?: Variables | null
   onApply?: () => void
-  onRefetch?: () => void
+  onRefetch?: (error?: Error | null) => void
 }
 
 export const useArtworkFilters = ({
@@ -50,7 +50,7 @@ export const useArtworkFilters = ({
         pageSize,
         (error) => {
           if (onRefetch) {
-            onRefetch()
+            onRefetch(error)
           }
           if (error) {
             const errorMessage = componentPath ? `${componentPath} ${type} error: ${error.message}` : error.message

--- a/src/lib/Scenes/Partner/Components/PartnerArtwork.tsx
+++ b/src/lib/Scenes/Partner/Components/PartnerArtwork.tsx
@@ -13,7 +13,12 @@ export const PartnerArtwork: React.FC<{
   partner: PartnerArtwork_partner
   relay: RelayPaginationProp
 }> = ({ partner, relay }) => {
-  useArtworkFilters({ relay, aggregations: partner.artworks?.aggregations })
+  useArtworkFilters({
+    relay,
+    aggregations: partner.artworks?.aggregations,
+    componentPath: "PartnerArtwork/PartnerArtwork",
+    pageSize: 30,
+  })
 
   const [isFilterArtworksModalVisible, setIsFilterArtworksModalVisible] = useState(false)
 


### PR DESCRIPTION
The type of this PR is: **Refactor**

This PR resolves [FX-3288]

### Description

In the current implementation, each artworks page (except partner page) duplicates logic of remembering aggregations on first request and refetching data

### Expected format of hook usage:

Instead of

```
useEffect(() => {
  setAggregationsAction(artworks?.aggregations)
}, [])

useEffect(() => {
  if (relay !== undefined && applyFilters) {
    relay.refetchConnection(
      10,
      (error) => {
        if (error) {
            throw new Error("ArtistSeries/ArtistSeriesArtworks filter error: " + error.message)
        }
      },
      { input: prepareFilterArtworksParamsForInput(filterParams) }
    )
  }
}, [appliedFilters])
```

in each artworks page component we can (in most cases) use

```
useArtworkFilters({
  relay,
  aggregations: artworks?.aggregations,
  componentPath: "ArtistSeries/ArtistSeriesArtworks",
  pageSize: 10,
})
```

Refactored hook also takes such optional parameters as custom `refetchVariables`, `onApply` and `onRefetch` callbacks

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- refactored artwork pages - anastasiapyzhik

<!-- end_changelog_updates -->

</details>


[FX-3288]: https://artsyproduct.atlassian.net/browse/FX-3288