### PR TITLE
fix: Use correct name of auction event GRO-363

### DIFF
--- a/src/lib/Scenes/Sale/Sale.tsx
+++ b/src/lib/Scenes/Sale/Sale.tsx
@@ -240,7 +240,7 @@ export const tracks = {
   pageView: (slug: string) => {
     return {
       auction_slug: slug,
-      name: "Auctions Pageview",
+      name: "Auction Screenview",
     }
   },
   openFilter: (id: string, slug: string) => {


### PR DESCRIPTION
This is a placeholder - please update with an awesome PR description!

https://artsyproduct.atlassian.net/browse/GRO-363

/cc @artsy/grow-devs @abhitip