### PR TITLE
fix: Multiple edition works with Radiobutton V3

### DIFF
--- a/src/lib/Scenes/Artwork/Components/CommercialEditionSetInformation.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialEditionSetInformation.tsx
@@ -1,11 +1,9 @@
-import { themeGet } from "@styled-system/theme-get"
 import { CommercialEditionSetInformation_artwork } from "__generated__/CommercialEditionSetInformation_artwork.graphql"
 import { LegacyNativeModules } from "lib/NativeModules/LegacyNativeModules"
-import { Box, Flex, Sans, Spacer } from "palette"
+import { Box, Flex, RadioButton, Sans, Spacer } from "palette"
 import React from "react"
 import { TouchableWithoutFeedback } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
-import styled from "styled-components/native"
 import { CommercialPartnerInformationFragmentContainer as CommercialPartnerInformation } from "./CommercialPartnerInformation"
 
 // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
@@ -72,13 +70,14 @@ export class CommercialEditionSetInformation extends React.Component<Props, Stat
             const selected = internalID === selectedEdition.internalID
             return (
               <TouchableWithoutFeedback key={id} onPress={() => this.selectEdition(internalID)}>
-                <EditionSelector px={2} height={26} mt={1} mr={1} selected={selected}>
+                <Box height={26} mt={1} mr={2} flexDirection="row">
+                  <RadioButton selected={selected} onPress={() => this.selectEdition(internalID)} />
                   <Sans size="2" weight="medium" color="black100">
                     {LegacyNativeModules.ARCocoaConstantsModule.CurrentLocale === "en_US"
                       ? dimensions.in
                       : dimensions.cm}
                   </Sans>
-                </EditionSelector>
+                </Box>
               </TouchableWithoutFeedback>
             )
           })}
@@ -134,15 +133,3 @@ export const CommercialEditionSetInformationFragmentContainer = createFragmentCo
     `,
   }
 )
-
-interface EditionSelectorProps {
-  selected: boolean
-}
-
-const EditionSelector = styled(Box)<EditionSelectorProps>`
-  border-radius: 3;
-  align-items: center;
-  justify-content: center;
-  border: ${(props: any /* STRICTNESS_MIGRATION */) =>
-    props.selected ? `2px solid ${themeGet("colors.black100")}` : `2px solid ${themeGet("colors.black30")}`};
-`

--- a/src/lib/Scenes/Artwork/Components/__tests__/CommercialEditionSetInformation-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/CommercialEditionSetInformation-tests.tsx
@@ -57,7 +57,7 @@ describe("CommercialEditionSetInformation", () => {
       </GlobalStoreProvider>
     )
 
-    const secondEditionSelect = component.find(TouchableWithoutFeedback).at(1)
+    const secondEditionSelect = component.find(TouchableWithoutFeedback).at(2)
     secondEditionSelect.props().onPress()
     expect(component.html()).toContain("$2")
   })

--- a/src/lib/Scenes/Artwork/Components/__tests__/CommercialInformation-tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/__tests__/CommercialInformation-tests.tsx
@@ -271,7 +271,7 @@ describe("CommercialInformation", () => {
     // Expect the component to default to first edition set's internalID
     expect(component.find(CommercialButtons).props().editionSetID).toEqual("5bbb9777ce2fc3002c179013")
 
-    const secondEditionButton = component.find(CommercialEditionSetInformation).find(TouchableWithoutFeedback).at(1)
+    const secondEditionButton = component.find(CommercialEditionSetInformation).find(TouchableWithoutFeedback).at(2)
     secondEditionButton.props().onPress()
     component.update()
 


### PR DESCRIPTION
The type of this PR is: Bugfix

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1912]

### Description

Artworks with V3 Radiobutton to choose between multiple editions size.  

![image](https://user-images.githubusercontent.com/17421923/132833669-f65407e3-d934-4a0d-80bd-8789d2b3f05e.png)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Add V3 Radio button component for multiple edition artworks- rajsam003

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-1912]: https://artsyproduct.atlassian.net/browse/CX-1912