### PR TITLE
fix: Align context grid CTA text with icon

### DIFF
--- a/src/lib/Scenes/Artwork/Components/OtherWorks/ContextGridCTA.tsx
+++ b/src/lib/Scenes/Artwork/Components/OtherWorks/ContextGridCTA.tsx
@@ -31,10 +31,14 @@ export class ContextGridCTA extends React.Component<ContextGridCTAProps> {
       return (
         <TouchableWithoutFeedback onPress={() => this.openLink()}>
           <Flex flexDirection="row" alignContent="center">
-            <Sans size="3" textAlign="left" weight="medium">
-              {label}
-            </Sans>
-            <ArrowRightIcon fill="black30" ml={1} mt={0.3} />
+            <Flex justifyContent="center">
+              <Sans size="3" textAlign="left" weight="medium">
+                {label}
+              </Sans>
+            </Flex>
+            <Flex justifyContent="center">
+              <ArrowRightIcon fill="black30" ml={1} />
+            </Flex>
           </Flex>
         </TouchableWithoutFeedback>
       )

--- a/src/lib/Scenes/Artwork/Components/OtherWorks/ContextGridCTA.tsx
+++ b/src/lib/Scenes/Artwork/Components/OtherWorks/ContextGridCTA.tsx
@@ -31,12 +31,10 @@ export class ContextGridCTA extends React.Component<ContextGridCTAProps> {
       return (
         <TouchableWithoutFeedback onPress={() => this.openLink()}>
           <Flex flexDirection="row" alignContent="center">
-            <Flex justifyContent="center">
-              <Sans size="3" textAlign="left" weight="medium">
-                {label}
-              </Sans>
-            </Flex>
-            <Flex justifyContent="center">
+            <Sans size="3" textAlign="left" weight="medium">
+              {label}
+            </Sans>
+            <Flex alignSelf="center">
               <ArrowRightIcon fill="black30" ml={1} />
             </Flex>
           </Flex>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1918]

### Description

Aligns context grid CTA text with icon.

|Before |small font |normal font | big font |
|---|---|---|---|
|![Simulator Screen Shot - iPhone 12 mini - 2021-09-10 at 11 58 19](https://user-images.githubusercontent.com/4691889/132838162-45d4bbd0-d290-4351-ac21-4bc7a3758478.png) |![Simulator Screen Shot - iPhone 12 mini - 2021-09-10 at 12 04 44](https://user-images.githubusercontent.com/4691889/132838171-30a6b9e8-48ad-4736-96b6-983494c93670.png) |![Simulator Screen Shot - iPhone 12 mini - 2021-09-10 at 12 04 56](https://user-images.githubusercontent.com/4691889/132838181-b1a7ca81-8625-4191-ad26-1be1614789d2.png) |![Simulator Screen Shot - iPhone 12 mini - 2021-09-10 at 12 04 30](https://user-images.githubusercontent.com/4691889/132838195-8edc2eca-7ff8-4c18-8c17-9588e2b8562e.png)|









### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Align context grid CTA text with icon - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-1918]: https://artsyproduct.atlassian.net/browse/CX-1918