### PR TITLE
Add padding between items on auction results for you screen

### DIFF
--- a/src/lib/Scenes/AuctionResultsForArtistsYouFollow/AuctionResultsForArtistsYouFollow.tsx
+++ b/src/lib/Scenes/AuctionResultsForArtistsYouFollow/AuctionResultsForArtistsYouFollow.tsx
@@ -76,18 +76,18 @@ export const AuctionResultsForArtistsYouFollow: React.FC<Props> = ({ me, relay }
                 <Text my="2" variant="title">
                   {sectionTitle}
                 </Text>
-                <Separator borderColor={"black5"} />
+                <Separator borderColor={"black10"} />
               </Flex>
             )}
             renderSectionFooter={() => <Flex mt="2" />}
             ItemSeparatorComponent={() => (
               <Flex px={2}>
-                <Separator borderColor={"black5"} />
+                <Separator borderColor={"black10"} />
               </Flex>
             )}
             renderItem={({ item }) =>
               item ? (
-                <Flex px={1}>
+                <Flex px={1} py={2}>
                   <AuctionResultFragmentContainer
                     auctionResult={item}
                     showArtistName
@@ -229,7 +229,7 @@ const LoadingSkeleton = () => {
           </Flex>
         </Flex>
         <Spacer height={10} />
-        <Separator borderColor={"black5"} />
+        <Separator borderColor={"black10"} />
       </React.Fragment>
     )
   }
@@ -240,7 +240,7 @@ const LoadingSkeleton = () => {
         <Spacer height={20} />
         <PlaceholderText height={24} width={100 + Math.random() * 50} />
         <Spacer height={10} />
-        <Separator borderColor={"black5"} />
+        <Separator borderColor={"black10"} />
         {placeholderResults}
       </Flex>
     </PageWithSimpleHeader>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1922]

### Description

Adds padding between items on "Auction Results for Artists You Follow" screen.

![simulator_screenshot_50B42009-EC1D-4549-8FDA-4B3A5264B5F0](https://user-images.githubusercontent.com/4691889/132877667-49209912-5b1b-4e4d-91ac-dc8ad7412569.png)


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-1922]: https://artsyproduct.atlassian.net/browse/CX-1922