### PR TITLE
feat(FX-3302): Move custom price filter to top and default expand

### DIFF
--- a/src/lib/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
@@ -18,22 +18,12 @@ interface PriceRangeOptionsScreenProps
 
 const PARAM_NAME = FilterParamName.priceRange
 
-export const CUSTOM_PRICE_OPTION = {
-  displayText: "Custom Price",
-  // Values need to be unique and we can't use "*-*" which is used by "All."
-  // This essentially means the same thing.
-  paramValue: "0-*",
-  paramName: PARAM_NAME,
-}
-
 const PRICE_RANGE_OPTIONS: FilterData[] = [
-  { displayText: "All", paramValue: "*-*", paramName: PARAM_NAME },
   { displayText: "$50,000+", paramValue: "50000-*", paramName: PARAM_NAME },
   { displayText: "$10,000–50,000", paramValue: "10000-50000", paramName: PARAM_NAME },
   { displayText: "$5,000–10,000", paramValue: "5000-10000", paramName: PARAM_NAME },
   { displayText: "$1,000–5,000", paramValue: "1000-5000", paramName: PARAM_NAME },
   { displayText: "$0–1,000", paramValue: "*-1000", paramName: PARAM_NAME },
-  CUSTOM_PRICE_OPTION,
 ]
 
 interface CustomPriceInputProps {
@@ -65,7 +55,7 @@ export const CustomPriceInput: React.FC<CustomPriceInputProps> = ({
   }, [state])
 
   return (
-    <Flex flexDirection="row" alignItems="center" mt={1} mx={2} mb={2}>
+    <Flex flexDirection="row" alignItems="center" mt={2} mb={1} mx={2}>
       <Input
         placeholder="$ USD minimum"
         defaultValue={state.min === "*" || state.min === 0 ? undefined : String(state.min)}
@@ -92,17 +82,7 @@ export const PriceRangeOptionsScreen: React.FC<PriceRangeOptionsScreenProps> = (
   const selectedOptions = useSelectedOptionsDisplay()
   const selectedOption = selectedOptions.find((option) => option.paramName === PARAM_NAME)!
 
-  const isCustomPrice =
-    // Is the placeholder custom price option
-    selectedOption.displayText === CUSTOM_PRICE_OPTION.displayText ||
-    // Isn't a pre-defined price range option
-    PRICE_RANGE_OPTIONS.find((option) => option.paramValue === selectedOption.paramValue) === undefined
-
-  const [shouldShowCustomPrice, showCustomPrice] = useState(isCustomPrice)
-
   const selectOption = (option: AggregateOption) => {
-    showCustomPrice(option.displayText === CUSTOM_PRICE_OPTION.displayText)
-
     selectFiltersAction({
       displayText: option.displayText,
       paramValue: option.paramValue,
@@ -124,17 +104,13 @@ export const PriceRangeOptionsScreen: React.FC<PriceRangeOptionsScreenProps> = (
       filterHeaderText={FilterDisplayName.priceRange}
       useScrollView={true}
       filterOptions={[
+        <CustomPriceInput
+          initialValue={parseRange(selectedOption.paramValue as string)}
+          onChange={handleCustomPriceChange}
+        />,
         ...PRICE_RANGE_OPTIONS,
-        ...(shouldShowCustomPrice
-          ? [
-              <CustomPriceInput
-                initialValue={parseRange(selectedOption.paramValue as string)}
-                onChange={handleCustomPriceChange}
-              />,
-            ]
-          : []),
       ]}
-      selectedOption={isCustomPrice ? CUSTOM_PRICE_OPTION : selectedOption}
+      selectedOption={selectedOption}
       navigation={navigation}
     />
   )

--- a/src/lib/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
@@ -18,7 +18,7 @@ interface PriceRangeOptionsScreenProps
 
 const PARAM_NAME = FilterParamName.priceRange
 
-const CUSTOM_PRICE_OPTION = {
+const DEFAULT_PRICE_OPTION = {
   displayText: "Custom",
   paramValue: "*-*",
   paramName: PARAM_NAME,
@@ -95,10 +95,11 @@ export const PriceRangeOptionsScreen: React.FC<PriceRangeOptionsScreenProps> = (
   const isCustomOption =
     PRICE_RANGE_OPTIONS.find((option) => option.paramValue === selectedFilterOption.paramValue) === undefined
   const [customPriceValue, setCustomPriceValue] = useState(
-    parseRange(isCustomOption ? (selectedFilterOption.paramValue as string) : CUSTOM_PRICE_OPTION.paramValue)
+    parseRange(isCustomOption ? (selectedFilterOption.paramValue as string) : DEFAULT_PRICE_OPTION.paramValue)
   )
   const [customSelected, setCustomSelected] = useState(isCustomOption)
-  const selectedOption = customSelected ? CUSTOM_PRICE_OPTION : selectedFilterOption
+  const selectedOption = customSelected ? DEFAULT_PRICE_OPTION : selectedFilterOption
+  const isActive = selectedFilterOption.paramValue !== DEFAULT_PRICE_OPTION.paramValue
 
   const selectOption = (option: AggregateOption) => {
     setCustomSelected(false)
@@ -123,13 +124,18 @@ export const PriceRangeOptionsScreen: React.FC<PriceRangeOptionsScreenProps> = (
     })
   }
 
+  const handleClear = () => {
+    const defaultRangeValue = parseRange(DEFAULT_PRICE_OPTION.paramValue)
+    handleCustomPriceChange(defaultRangeValue)
+  }
+
   return (
     <SingleSelectOptionScreen
       onSelect={selectOption}
       filterHeaderText={FilterDisplayName.priceRange}
       useScrollView={true}
       filterOptions={[
-        <ListItem item={CUSTOM_PRICE_OPTION} selectedOption={selectedOption} onSelect={handleSelectCustomOption} />,
+        <ListItem item={DEFAULT_PRICE_OPTION} selectedOption={selectedOption} onSelect={handleSelectCustomOption} />,
         <CustomPriceInput
           value={customPriceValue}
           onChange={handleCustomPriceChange}
@@ -139,6 +145,7 @@ export const PriceRangeOptionsScreen: React.FC<PriceRangeOptionsScreenProps> = (
       ]}
       selectedOption={selectedOption}
       navigation={navigation}
+      {...(isActive ? { rightButtonText: "Clear", onRightButtonPress: handleClear } : {})}
     />
   )
 }

--- a/src/lib/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
@@ -45,7 +45,6 @@ export const CustomPriceInput: React.FC<CustomPriceInputProps> = ({ value = { mi
         value={value.min === "*" || value.min === 0 ? undefined : String(value.min)}
         keyboardType="number-pad"
         onChangeText={handleChange("min")}
-        autoFocus
       />
 
       <Text mx={2}>to</Text>

--- a/src/lib/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
@@ -7,8 +7,8 @@ import {
   FilterParamName,
 } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworksFiltersStore, useSelectedOptionsDisplay } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
-import { Input } from "lib/Components/Input/Input"
-import { Flex, Text } from "palette"
+import { Input, InputProps } from "lib/Components/Input/Input"
+import { Flex, Spacer, Text } from "palette"
 import React, { useState } from "react"
 import { parsePriceRangeLabel, parseRange, Range } from "./helpers"
 import { ListItem, SingleSelectOptionScreen } from "./SingleSelectOption"
@@ -38,6 +38,21 @@ interface CustomPriceInputProps {
   onFocus: () => void
 }
 
+interface InputLabelProps extends InputProps {
+  label: string
+}
+
+const InputLabel: React.FC<InputLabelProps> = ({ label, ...other }) => {
+  return (
+    <Flex flex={1}>
+      <Text color="black60" variant="small" mb={0.5}>
+        {label}
+      </Text>
+      <Input {...other} />
+    </Flex>
+  )
+}
+
 export const CustomPriceInput: React.FC<CustomPriceInputProps> = ({ value, onChange, onFocus }) => {
   const handleChange = (key: "min" | "max") => (text: string) => {
     const parsed = parseInt(text, 10)
@@ -47,18 +62,20 @@ export const CustomPriceInput: React.FC<CustomPriceInputProps> = ({ value, onCha
 
   return (
     <Flex flexDirection="row" alignItems="center" mb={1} mx={2}>
-      <Input
-        placeholder="$ USD minimum"
+      <InputLabel
+        label="Min"
+        placeholder="$USD"
         value={value.min === "*" ? undefined : String(value.min)}
         keyboardType="number-pad"
         onChangeText={handleChange("min")}
         onFocus={onFocus}
       />
 
-      <Text mx={2}>to</Text>
+      <Spacer mx={2} />
 
-      <Input
-        placeholder="$ USD maximum"
+      <InputLabel
+        label="Max"
+        placeholder="$USD"
         value={value.max === "*" ? undefined : String(value.max)}
         keyboardType="number-pad"
         onChangeText={handleChange("max")}

--- a/src/lib/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
@@ -69,6 +69,7 @@ export const CustomPriceInput: React.FC<CustomPriceInputProps> = ({ value, onCha
         keyboardType="number-pad"
         onChangeText={handleChange("min")}
         onFocus={onFocus}
+        testID="price-min-input"
       />
 
       <Spacer mx={2} />
@@ -80,6 +81,7 @@ export const CustomPriceInput: React.FC<CustomPriceInputProps> = ({ value, onCha
         keyboardType="number-pad"
         onChangeText={handleChange("max")}
         onFocus={onFocus}
+        testID="price-max-input"
       />
     </Flex>
   )

--- a/src/lib/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
@@ -19,7 +19,7 @@ interface PriceRangeOptionsScreenProps
 const PARAM_NAME = FilterParamName.priceRange
 
 const CUSTOM_PRICE_OPTION = {
-  displayText: "Custom Price",
+  displayText: "Custom",
   paramValue: "*-*",
   paramName: PARAM_NAME,
 }

--- a/src/lib/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
@@ -92,8 +92,7 @@ export const PriceRangeOptionsScreen: React.FC<PriceRangeOptionsScreenProps> = (
 
   const selectedOptions = useSelectedOptionsDisplay()
   const selectedFilterOption = selectedOptions.find((option) => option.paramName === PARAM_NAME)!
-  const isCustomOption =
-    PRICE_RANGE_OPTIONS.find((option) => option.paramValue === selectedFilterOption.paramValue) === undefined
+  const isCustomOption = PRICE_RANGE_OPTIONS.every((option) => option.paramValue !== selectedFilterOption.paramValue)
   const [customPriceValue, setCustomPriceValue] = useState(
     parseRange(isCustomOption ? (selectedFilterOption.paramValue as string) : DEFAULT_PRICE_OPTION.paramValue)
   )

--- a/src/lib/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
@@ -19,7 +19,7 @@ interface PriceRangeOptionsScreenProps
 const PARAM_NAME = FilterParamName.priceRange
 
 const DEFAULT_PRICE_OPTION = {
-  displayText: "Custom",
+  displayText: "Choose Your Price",
   paramValue: "*-*",
   paramName: PARAM_NAME,
 }

--- a/src/lib/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
@@ -9,7 +9,7 @@ import {
 import { ArtworksFiltersStore, useSelectedOptionsDisplay } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { Input } from "lib/Components/Input/Input"
 import { Flex, Text } from "palette"
-import React, { useEffect, useRef, useState } from "react"
+import React from "react"
 import { parsePriceRangeLabel, parseRange, Range } from "./helpers"
 import { SingleSelectOptionScreen } from "./SingleSelectOption"
 
@@ -27,38 +27,22 @@ const PRICE_RANGE_OPTIONS: FilterData[] = [
 ]
 
 interface CustomPriceInputProps {
-  initialValue: Range
+  value: Range
   onChange(value: Range): void
 }
 
-export const CustomPriceInput: React.FC<CustomPriceInputProps> = ({
-  initialValue = { min: "*", max: "*" },
-  onChange,
-}) => {
-  const isMounted = useRef(false)
-  const [state, setState] = useState<Range>(initialValue)
-
+export const CustomPriceInput: React.FC<CustomPriceInputProps> = ({ value = { min: "*", max: "*" }, onChange }) => {
   const handleChange = (key: "min" | "max") => (text: string) => {
     const parsed = parseInt(text, 10)
-    const value = isNaN(parsed) ? "*" : parsed
-    setState((prevState) => ({ ...prevState, [key]: value }))
+    const parsedValue = isNaN(parsed) ? "*" : parsed
+    onChange({ ...value, [key]: parsedValue })
   }
-
-  useEffect(() => {
-    // Ignore initial mount
-    if (!isMounted.current) {
-      isMounted.current = true
-      return
-    }
-
-    onChange(state)
-  }, [state])
 
   return (
     <Flex flexDirection="row" alignItems="center" mt={2} mb={1} mx={2}>
       <Input
         placeholder="$ USD minimum"
-        defaultValue={state.min === "*" || state.min === 0 ? undefined : String(state.min)}
+        value={value.min === "*" || value.min === 0 ? undefined : String(value.min)}
         keyboardType="number-pad"
         onChangeText={handleChange("min")}
         autoFocus
@@ -68,7 +52,7 @@ export const CustomPriceInput: React.FC<CustomPriceInputProps> = ({
 
       <Input
         placeholder="$ USD maximum"
-        defaultValue={state.max === "*" ? undefined : String(state.max)}
+        value={value.max === "*" ? undefined : String(value.max)}
         keyboardType="number-pad"
         onChangeText={handleChange("max")}
       />
@@ -81,6 +65,7 @@ export const PriceRangeOptionsScreen: React.FC<PriceRangeOptionsScreenProps> = (
 
   const selectedOptions = useSelectedOptionsDisplay()
   const selectedOption = selectedOptions.find((option) => option.paramName === PARAM_NAME)!
+  const customPriceValue = parseRange(selectedOption.paramValue as string)
 
   const selectOption = (option: AggregateOption) => {
     selectFiltersAction({
@@ -104,10 +89,7 @@ export const PriceRangeOptionsScreen: React.FC<PriceRangeOptionsScreenProps> = (
       filterHeaderText={FilterDisplayName.priceRange}
       useScrollView={true}
       filterOptions={[
-        <CustomPriceInput
-          initialValue={parseRange(selectedOption.paramValue as string)}
-          onChange={handleCustomPriceChange}
-        />,
+        <CustomPriceInput value={customPriceValue} onChange={handleCustomPriceChange} />,
         ...PRICE_RANGE_OPTIONS,
       ]}
       selectedOption={selectedOption}

--- a/src/lib/Components/ArtworkFilter/Filters/SingleSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/SingleSelectOption.tsx
@@ -76,7 +76,7 @@ export const SingleSelectOptionScreen: React.FC<SingleSelectOptionScreenProps> =
   )
 }
 
-const ListItem = ({
+export const ListItem = ({
   item,
   onSelect,
   selectedOption,
@@ -85,7 +85,7 @@ const ListItem = ({
   item: FilterData
   onSelect: (any: any) => void
   selectedOption: FilterData
-  withExtraPadding: boolean
+  withExtraPadding?: boolean
 }) => {
   const selected = item.displayText === selectedOption.displayText
 

--- a/src/lib/Components/ArtworkFilter/Filters/SingleSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/SingleSelectOption.tsx
@@ -1,14 +1,14 @@
 import { ParamListBase } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"
 import { FilterData } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
-import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
+import { FancyModalHeader, FancyModalHeaderProps } from "lib/Components/FancyModal/FancyModalHeader"
 import { TouchableRow } from "lib/Components/TouchableRow"
 import { Flex, RadioDot, Text } from "palette"
 import React, { Fragment } from "react"
 import { FlatList, ScrollView } from "react-native"
 import styled from "styled-components/native"
 
-interface SingleSelectOptionScreenProps {
+interface SingleSelectOptionScreenProps extends FancyModalHeaderProps {
   navigation: StackNavigationProp<ParamListBase>
   filterHeaderText: string
   onSelect: (any: any) => void
@@ -32,6 +32,7 @@ export const SingleSelectOptionScreen: React.FC<SingleSelectOptionScreenProps> =
   ListHeaderComponent,
   withExtraPadding = false,
   useScrollView = false,
+  ...rest
 }) => {
   const handleBackNavigation = () => {
     navigation.goBack()
@@ -50,7 +51,9 @@ export const SingleSelectOptionScreen: React.FC<SingleSelectOptionScreenProps> =
 
   return (
     <Flex flexGrow={1}>
-      <FancyModalHeader onLeftButtonPress={handleBackNavigation}>{filterHeaderText}</FancyModalHeader>
+      <FancyModalHeader onLeftButtonPress={handleBackNavigation} {...rest}>
+        {filterHeaderText}
+      </FancyModalHeader>
 
       <Flex flexGrow={1}>
         {useScrollView ? (

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/PriceRangeOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/PriceRangeOptions-tests.tsx
@@ -135,6 +135,29 @@ describe("PriceRangeOptions", () => {
     )
   })
 
+  it("dispatches the last entered price", () => {
+    const { getByTestId, getByText } = getTree()
+
+    fireEvent.changeText(getByTestId("price-min-input"), "1111")
+    fireEvent.press(getByText("$10,000–50,000"))
+    fireEvent.changeText(getByTestId("price-min-input"), "2222")
+
+    expect(extractText(getByTestId("debug"))).toContain(
+      `{"displayText":"$2,222+","paramValue":"2222-*","paramName":"priceRange"}`
+    )
+  })
+
+  it("dispatches the last selected price", () => {
+    const { getByTestId, getByText } = getTree()
+
+    fireEvent.press(getByText("$10,000–50,000"))
+    fireEvent.press(getByText("$1,000–5,000"))
+
+    expect(extractText(getByTestId("debug"))).toContain(
+      `{"displayText":"$1,000–5,000","paramValue":"1000-5000","paramName":"priceRange"}`
+    )
+  })
+
   it('should display the "clear" button if a custom price is entered', () => {
     const { getByTestId, getByText } = getTree()
 

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/PriceRangeOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/PriceRangeOptions-tests.tsx
@@ -134,4 +134,39 @@ describe("PriceRangeOptions", () => {
       `{"displayText":"$1,111–98,765","paramValue":"1111-98765","paramName":"priceRange"}`
     )
   })
+
+  it('should display the "clear" button if a custom price is entered', () => {
+    const { getByTestId, getByText } = getTree()
+
+    fireEvent.changeText(getByTestId("price-min-input"), "1111")
+
+    expect(getByText("Clear")).toBeTruthy()
+  })
+
+  it('should display the "clear" button if a predefined value is selected', () => {
+    const { getByText } = getTree()
+
+    fireEvent.press(getByText("$10,000–50,000"))
+
+    expect(getByText("Clear")).toBeTruthy()
+  })
+
+  it('should not display the "clear" button if the default value is selected', () => {
+    const { queryByText, getByText } = getTree()
+
+    fireEvent.press(getByText("$10,000–50,000"))
+    fireEvent.press(getByText("Custom"))
+
+    expect(queryByText("Clear")).toBeNull()
+  })
+
+  it('selected value should be cleared when the "clear" button is pressed', () => {
+    const { getByTestId, getByText } = getTree()
+    const minInput = getByTestId("price-min-input")
+
+    fireEvent.changeText(minInput, "1111")
+    fireEvent.press(getByText("Clear"))
+
+    expect(minInput.props.value).toBeUndefined()
+  })
 })

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/PriceRangeOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/PriceRangeOptions-tests.tsx
@@ -96,7 +96,7 @@ describe("PriceRangeOptions", () => {
   it("renders the options", () => {
     const { getByText } = getTree()
 
-    expect(getByText("Custom")).toBeTruthy()
+    expect(getByText("Choose Your Price")).toBeTruthy()
     expect(getByText("$50,000+")).toBeTruthy()
     expect(getByText("$10,000–50,000")).toBeTruthy()
     expect(getByText("$5,000–10,000")).toBeTruthy()
@@ -178,7 +178,7 @@ describe("PriceRangeOptions", () => {
     const { queryByText, getByText } = getTree()
 
     fireEvent.press(getByText("$10,000–50,000"))
-    fireEvent.press(getByText("Custom"))
+    fireEvent.press(getByText("Choose Your Price"))
 
     expect(queryByText("Clear")).toBeNull()
   })


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3302]

### Description
* More context you can find in [Slack](https://artsy.slack.com/archives/C9SATFLUU/p1631633628141600)
* Figma [design](https://www.figma.com/file/zG9cduJdOaTQAw886QcOwn/Filters?node-id=3114%3A31607)
- [x] Move the custom price filter to the top of the list of radio buttons
- [x] Ensure that custom price is default expanded so that user can input range right away
- [x] Remove the “All” radio button so that a blank custom range implies all by default
- [x] Leave input values as typed, so they are not over-written if a user selects another value
- [x] Should display the "clear" button if a price is entered/selected

### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/133614212-e8bab4a4-4b2d-4981-85b9-f861c67611b5.mp4

#### Android
https://user-images.githubusercontent.com/3513494/133616295-1c7abfc6-03a4-4c2c-97f9-5125deac109c.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Move custom price filter to top and default expand - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3302]: https://artsyproduct.atlassian.net/browse/FX-3302