### PR TITLE
fix(FX-3257): Enable "Create Alert" button after deleting an alert

### DIFF
--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
@@ -2,6 +2,7 @@ import { ActionType, OwnerType, TappedCreateAlert, ToggledSavedSearch } from "@a
 import { captureMessage } from "@sentry/react-native"
 import { SavedSearchButton_me } from "__generated__/SavedSearchButton_me.graphql"
 import { SavedSearchButtonQuery } from "__generated__/SavedSearchButtonQuery.graphql"
+import { EventEmitter } from "events"
 import { getSearchCriteriaFromFilters } from "lib/Components/ArtworkFilter/SavedSearch/searchCriteriaHelpers"
 import { SearchCriteriaAttributes } from "lib/Components/ArtworkFilter/SavedSearch/types"
 import { usePopoverMessage } from "lib/Components/PopoverMessage/popoverMessageHooks"
@@ -13,7 +14,7 @@ import {
   SavedSearchAlertMutationResult,
 } from "lib/Scenes/SavedSearchAlert/SavedSearchAlertModel"
 import { BellIcon, Box, Button } from "palette"
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
 import { useTracking } from "react-tracking"
 
@@ -27,6 +28,12 @@ interface SavedSearchButtonProps extends SavedSearchAlertFormPropsBase {
 
 interface SavedSearchButtonQueryRendererProps extends SavedSearchAlertFormPropsBase {
   artistSlug: string
+}
+
+export const savedSearchEvents = new EventEmitter()
+
+export const emitSavedSearchRefetchEvent = () => {
+  savedSearchEvents.emit("refetch")
 }
 
 export const SavedSearchButton: React.FC<SavedSearchButtonProps> = ({
@@ -82,6 +89,13 @@ export const SavedSearchButton: React.FC<SavedSearchButtonProps> = ({
     handleOpenForm()
     tracking.trackEvent(tracks.tappedCreateAlert(artistId, artistSlug))
   }
+
+  useEffect(() => {
+    savedSearchEvents.addListener("refetch", refetch)
+    return () => {
+      savedSearchEvents.removeListener("refetch", refetch)
+    }
+  }, [])
 
   return (
     <Box>

--- a/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
@@ -4,6 +4,7 @@ import { EditSavedSearchAlert_artworksConnection } from "__generated__/EditSaved
 import { EditSavedSearchAlertQuery } from "__generated__/EditSavedSearchAlertQuery.graphql"
 import { SavedSearchAlertQueryResponse } from "__generated__/SavedSearchAlertQuery.graphql"
 import { SearchCriteriaAttributes } from "__generated__/SavedSearchBannerCreateSavedSearchMutation.graphql"
+import { emitSavedSearchRefetchEvent } from "lib/Components/Artist/ArtistArtworks/SavedSearchButton"
 import { ArtsyKeyboardAvoidingView } from "lib/Components/ArtsyKeyboardAvoidingView"
 import { Aggregations } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { convertSavedSearchCriteriaToFilterParams } from "lib/Components/ArtworkFilter/SavedSearch/convertersToFilterParams"
@@ -43,6 +44,7 @@ export const EditSavedSearchAlert: React.FC<EditSavedSearchAlertProps> = (props)
 
   const onComplete = () => {
     goBack()
+    emitSavedSearchRefetchEvent()
   }
 
   return (

--- a/src/lib/Scenes/SavedSearchAlert/__tests__/EditSavedSearchAlert-tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/__tests__/EditSavedSearchAlert-tests.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, waitFor } from "@testing-library/react-native"
+import * as savedSearchButton from "lib/Components/Artist/ArtistArtworks/SavedSearchButton"
 import { goBack, navigate } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { extractText } from "lib/tests/extractText"
@@ -11,6 +12,8 @@ import { createMockEnvironment } from "relay-test-utils"
 import { EditSavedSearchAlertQueryRenderer } from "../EditSavedSearchAlert"
 
 jest.unmock("react-relay")
+
+const emitSavedSearchRefetchEventSpy = jest.spyOn(savedSearchButton, "emitSavedSearchRefetchEvent")
 
 describe("EditSavedSearchAlert", () => {
   const mockEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
@@ -63,6 +66,7 @@ describe("EditSavedSearchAlert", () => {
     })
 
     expect(goBack).toHaveBeenCalled()
+    expect(emitSavedSearchRefetchEventSpy).toHaveBeenCalled()
   })
 
   it("should navigate to artworks grid when the view artworks is pressed", async () => {


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [FX-3257]

### Description

If user deletes an alert and then comes back to artist page with the same filters applied, "Create Alert" button is disabled, the alert doesn't exist anymore though.

This fixes current behavior via emitting `refetch` event after editing an alert and refetching fresh data on this event

**Before**

![before](https://user-images.githubusercontent.com/44819355/133400538-6ff0f37a-4ce8-4d4d-8ed2-05cbd41f578b.gif)


**After**

![after](https://user-images.githubusercontent.com/44819355/133400101-e79c3ac8-b784-4f38-8020-76acb5b69453.gif)



### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Enable "Create Alert" button if alert doesn't exist - anastasiapyzhik

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3257]: https://artsyproduct.atlassian.net/browse/FX-3257