### PR TITLE
fix: refetch only when applying new filters

### DIFF
--- a/src/lib/Components/ArtworkFilter/useArtworkFilters.ts
+++ b/src/lib/Components/ArtworkFilter/useArtworkFilters.ts
@@ -35,8 +35,6 @@ export const useArtworkFilters = ({
   const applyFilters = ArtworksFiltersStore.useStoreState((state) => state.applyFilters)
   const filterType = ArtworksFiltersStore.useStoreState((state) => state.filterType)
 
-  const filterParams = filterArtworksParams(appliedFilters, filterType)
-
   useEffect(() => {
     if (!aggregations) {
       return
@@ -46,6 +44,8 @@ export const useArtworkFilters = ({
 
   useEffect(() => {
     if (relay !== undefined && applyFilters) {
+      const filterParams = filterArtworksParams(appliedFilters, filterType)
+
       relay.refetchConnection(
         pageSize,
         (error) => {
@@ -63,7 +63,7 @@ export const useArtworkFilters = ({
         onApply()
       }
     }
-  }, [relay, appliedFilters, filterParams])
+  }, [relay, appliedFilters])
 }
 
 export const useArtworkFiltersAggregation = ({ paramName }: { paramName: FilterParamName }) => {


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description
Refetch was executed every time the component was re-rendered, since `filterParams` had a new reference type each time

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- refetch artworks only when applying new filters – dimatretyak

<!-- end_changelog_updates -->

</details>
