### PR TITLE
feat: Use optimistic response for all follow buttons

### DIFF
--- a/src/lib/Components/Artist/ArtistHeader.tsx
+++ b/src/lib/Components/Artist/ArtistHeader.tsx
@@ -136,7 +136,6 @@ export const ArtistHeader: React.FC<Props> = ({ artist, relay }) => {
           <Flex>
             <Button
               variant={artist.isFollowed ? "secondaryOutline" : "primaryBlack"}
-              loading={isFollowedChanging}
               onPress={handleFollowChange}
               size="small"
               longestText="Following"

--- a/src/lib/Components/ArtistListItem.tsx
+++ b/src/lib/Components/ArtistListItem.tsx
@@ -104,7 +104,6 @@ export class ArtistListItem extends React.Component<Props, State> {
   }
 
   render() {
-    const { isFollowedChanging } = this.state
     const { artist, withFeedback, containerStyle, disableNavigation } = this.props
     const { is_followed, initials, image, href, name, nationality, birthday, deathday } = artist
     const imageURl = image && image.url
@@ -141,7 +140,6 @@ export class ArtistListItem extends React.Component<Props, State> {
                   variant={is_followed ? "secondaryOutline" : "secondaryGray"}
                   onPress={this.handleFollowArtist.bind(this)}
                   size="small"
-                  loading={isFollowedChanging}
                   longestText="Following"
                   haptic
                 >

--- a/src/lib/Components/Gene/Header.tsx
+++ b/src/lib/Components/Gene/Header.tsx
@@ -135,7 +135,6 @@ class Header extends React.Component<Props, State> {
           variant={gene.isFollowed ? "secondaryOutline" : "primaryBlack"}
           block
           width={100}
-          loading={this.state.isFollowedChanging}
           onPress={() => this.handleFollowChange()}
         >
           {gene.isFollowed ? "Following" : "Follow"}

--- a/src/lib/Components/Home/ArtistRails/ArtistCard.tsx
+++ b/src/lib/Components/Home/ArtistRails/ArtistCard.tsx
@@ -113,7 +113,6 @@ export class ArtistCard extends React.Component<Props, State> {
                 onPress={this.handleFollowChange}
                 size="small"
                 block
-                loading={this.state.processingChange}
                 haptic
               >
                 {this.state.following ? "Following" : "Follow"}

--- a/src/lib/Scenes/Artwork/Components/ContextCard.tsx
+++ b/src/lib/Scenes/Artwork/Components/ContextCard.tsx
@@ -102,7 +102,6 @@ export class ContextCard extends React.Component<ContextCardProps, ContextCardSt
 
   followButton = (show: Show) => {
     const { isFollowed } = show
-    const { isSaving } = this.state
 
     return (
       <Button
@@ -110,7 +109,6 @@ export class ContextCard extends React.Component<ContextCardProps, ContextCardSt
         onPress={() => this.handleFollowShow(show)}
         size="small"
         longestText="Following"
-        loading={isSaving}
         haptic
       >
         {isFollowed ? "Following" : "Follow"}

--- a/src/lib/Scenes/Artwork/Components/PartnerCard.tsx
+++ b/src/lib/Scenes/Artwork/Components/PartnerCard.tsx
@@ -90,7 +90,6 @@ export class PartnerCard extends React.Component<Props, State> {
     if (partner.type === "Auction House" || galleryOrBenefitAuction) {
       return null
     }
-    const { isFollowedChanging } = this.state
     let locationNames = null
     const imageUrl = partner.profile && partner.profile.icon ? partner.profile.icon.url : null
     if (partner.cities) {
@@ -121,7 +120,6 @@ export class PartnerCard extends React.Component<Props, State> {
                   onPress={this.handleFollowPartner.bind(this)}
                   size="small"
                   longestText="Following"
-                  loading={isFollowedChanging}
                   haptic
                 >
                   {partner!.profile.is_followed ? "Following" : "Follow"}

--- a/src/lib/Scenes/Partner/Components/PartnerFollowButton.tsx
+++ b/src/lib/Scenes/Partner/Components/PartnerFollowButton.tsx
@@ -83,13 +83,12 @@ export class PartnerFollowButton extends React.Component<Props, State> {
 
   render() {
     const { partner } = this.props
-    const { isFollowedChanging } = this.state
+
     return (
       <Button
         variant={partner.profile?.isFollowed ? "secondaryOutline" : "primaryBlack"}
         onPress={this.handleFollowPartner.bind(this)}
         longestText="Following"
-        loading={isFollowedChanging}
         size="small"
         haptic
       >


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1939]

### Description

Use optimistic response for all follow buttons and don't show a loading spinner anymore.

**Screens/Components:**

- Artist Screen Header
- Artist List Item Component
- Gene Screen Header
- Artist Rail Component
- Artwork Context Card Component
- Partner Card Component
- Partner Screen

| Succeeding | Not Succeeding |
| --- | --- |
| <video src="https://user-images.githubusercontent.com/4691889/133433484-efaef5e8-fc4d-40ee-8b80-cf47fa392721.mp4"/> | <video src="https://user-images.githubusercontent.com/4691889/133433602-48ba431e-87f7-459f-83ad-7dcde81ea9e5.mp4"/> |







### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Use optimistic response instead of loading spinner for all follow buttons - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-1939]: https://artsyproduct.atlassian.net/browse/CX-1939

